### PR TITLE
Memoize job snapshot ID when called repeatedly on the same object

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1290,13 +1290,13 @@ class DagsterInstance(DynamicPartitionsStore):
         job_snapshot: "JobSnap",
         parent_job_snapshot: "Optional[JobSnap]",
     ) -> str:
-        from dagster._core.snap import JobSnap, create_job_snapshot_id
+        from dagster._core.snap import JobSnap
 
         check.inst_param(job_snapshot, "job_snapshot", JobSnap)
         check.opt_inst_param(parent_job_snapshot, "parent_job_snapshot", JobSnap)
 
         if job_snapshot.lineage_snapshot:
-            parent_snapshot_id = create_job_snapshot_id(check.not_none(parent_job_snapshot))
+            parent_snapshot_id = check.not_none(parent_job_snapshot).snapshot_id
 
             if job_snapshot.lineage_snapshot.parent_snapshot_id != parent_snapshot_id:
                 warnings.warn(
@@ -1308,7 +1308,7 @@ class DagsterInstance(DynamicPartitionsStore):
                     check.not_none(parent_job_snapshot), parent_snapshot_id
                 )
 
-        job_snapshot_id = create_job_snapshot_id(job_snapshot)
+        job_snapshot_id = job_snapshot.snapshot_id
         if not self._run_storage.has_job_snapshot(job_snapshot_id):
             returned_job_snapshot_id = self._run_storage.add_job_snapshot(job_snapshot)
             check.invariant(job_snapshot_id == returned_job_snapshot_id)

--- a/python_modules/dagster/dagster/_core/remote_representation/job_index.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/job_index.py
@@ -1,9 +1,8 @@
-from threading import Lock
 from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._config import ConfigSchemaSnapshot
-from dagster._core.snap import DependencyStructureIndex, JobSnap, create_job_snapshot_id
+from dagster._core.snap import DependencyStructureIndex, JobSnap
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
@@ -47,9 +46,6 @@ class JobIndex:
             for comp_snap in job_snapshot.node_defs_snapshot.graph_def_snaps
         }
 
-        self._memo_lock = Lock()
-        self._job_snapshot_id = None
-
     @property
     def name(self) -> str:
         return self.job_snapshot.name
@@ -68,10 +64,7 @@ class JobIndex:
 
     @property
     def job_snapshot_id(self) -> str:
-        with self._memo_lock:
-            if not self._job_snapshot_id:
-                self._job_snapshot_id = create_job_snapshot_id(self.job_snapshot)
-            return self._job_snapshot_id
+        return self.job_snapshot.snapshot_id
 
     def has_dagster_type_name(self, type_name: str) -> bool:
         return type_name in self._dagster_type_snaps_by_name_index

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -54,10 +54,7 @@ from dagster._core.snap.execution_plan_snapshot import (
     create_execution_plan_snapshot_id as create_execution_plan_snapshot_id,
     snapshot_from_execution_plan as snapshot_from_execution_plan,
 )
-from dagster._core.snap.job_snapshot import (
-    JobSnap as JobSnap,
-    create_job_snapshot_id as create_job_snapshot_id,
-)
+from dagster._core.snap.job_snapshot import JobSnap as JobSnap
 from dagster._core.snap.mode import (
     LoggerDefSnap as LoggerDefSnap,
     ModeDefSnap as ModeDefSnap,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -40,12 +40,7 @@ from dagster._core.events import (
 )
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.remote_representation.origin import RemoteJobOrigin
-from dagster._core.snap import (
-    ExecutionPlanSnapshot,
-    JobSnap,
-    create_execution_plan_snapshot_id,
-    create_job_snapshot_id,
-)
+from dagster._core.snap import ExecutionPlanSnapshot, JobSnap, create_execution_plan_snapshot_id
 from dagster._core.storage.dagster_run import (
     DagsterRun,
     DagsterRunStatus,
@@ -580,7 +575,7 @@ class SqlRunStorage(RunStorage):
         check.opt_str_param(snapshot_id, "snapshot_id")
 
         if not snapshot_id:
-            snapshot_id = create_job_snapshot_id(job_snapshot)
+            snapshot_id = job_snapshot.snapshot_id
 
         return self._add_snapshot(
             snapshot_id=snapshot_id,

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -36,11 +36,7 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
-from dagster._core.snap import (
-    create_execution_plan_snapshot_id,
-    create_job_snapshot_id,
-    snapshot_from_execution_plan,
-)
+from dagster._core.snap import create_execution_plan_snapshot_id, snapshot_from_execution_plan
 from dagster._core.storage.partition_status_cache import AssetPartitionStatus, AssetStatusCacheValue
 from dagster._core.storage.sqlite_storage import (
     _event_logs_directory,
@@ -266,7 +262,7 @@ def test_create_job_snapshot():
 
         run = instance.get_run_by_id(result.run_id)
 
-        assert run.job_snapshot_id == create_job_snapshot_id(noop_job.get_job_snapshot())
+        assert run.job_snapshot_id == noop_job.get_job_snapshot().snapshot_id
 
 
 def test_create_execution_plan_snapshot():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
@@ -1,6 +1,6 @@
 from dagster import GraphOut, In, Out, graph, job, op
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.snap import create_job_snapshot_id, snapshot_from_execution_plan
+from dagster._core.snap import snapshot_from_execution_plan
 from dagster._serdes import serialize_pp
 
 
@@ -17,10 +17,7 @@ def test_create_noop_execution_plan(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            snapshot_from_execution_plan(
-                execution_plan,
-                create_job_snapshot_id(noop_job.get_job_snapshot()),
-            )
+            snapshot_from_execution_plan(execution_plan, noop_job.get_job_snapshot().snapshot_id)
         )
     )
 
@@ -44,7 +41,7 @@ def test_create_execution_plan_with_dep(snapshot):
         serialize_pp(
             snapshot_from_execution_plan(
                 execution_plan,
-                create_job_snapshot_id(noop_job.get_job_snapshot()),
+                noop_job.get_job_snapshot().snapshot_id,
             )
         )
     )
@@ -84,7 +81,7 @@ def test_create_with_graph(snapshot):
         serialize_pp(
             snapshot_from_execution_plan(
                 execution_plan,
-                create_job_snapshot_id(do_comps.get_job_snapshot()),
+                do_comps.get_job_snapshot().snapshot_id,
             )
         )
     )
@@ -105,7 +102,7 @@ def test_create_noop_execution_plan_with_tags(snapshot):
         serialize_pp(
             snapshot_from_execution_plan(
                 execution_plan,
-                create_job_snapshot_id(noop_job.get_job_snapshot()),
+                noop_job.get_job_snapshot().snapshot_id,
             )
         )
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -7,7 +7,6 @@ from dagster._core.snap import (
     DependencyStructureIndex,
     JobSnap,
     NodeInvocationSnap,
-    create_job_snapshot_id,
     snap_from_config_type,
 )
 from dagster._core.snap.dep_snapshot import (
@@ -51,7 +50,7 @@ def test_empty_job_snap_props(snapshot):
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
-    snapshot.assert_match(create_job_snapshot_id(job_snapshot))
+    snapshot.assert_match(job_snapshot.snapshot_id)
 
 
 def test_job_snap_all_props(snapshot):
@@ -72,7 +71,7 @@ def test_job_snap_all_props(snapshot):
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
-    snapshot.assert_match(create_job_snapshot_id(job_snapshot))
+    snapshot.assert_match(job_snapshot.snapshot_id)
 
 
 def test_noop_deps_snap():
@@ -107,7 +106,7 @@ def test_two_invocations_deps_snap(snapshot):
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
-    snapshot.assert_match(create_job_snapshot_id(job_snapshot))
+    snapshot.assert_match(job_snapshot.snapshot_id)
 
 
 def test_basic_dep():
@@ -177,7 +176,7 @@ def test_basic_dep_fan_out(snapshot):
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
-    snapshot.assert_match(create_job_snapshot_id(job_snapshot))
+    snapshot.assert_match(job_snapshot.snapshot_id)
 
 
 def test_basic_fan_in(snapshot):
@@ -218,7 +217,7 @@ def test_basic_fan_in(snapshot):
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
-    snapshot.assert_match(create_job_snapshot_id(job_snapshot))
+    snapshot.assert_match(job_snapshot.snapshot_id)
 
 
 def _dict_has_stable_hashes(hydrated_map, snapshot_config_snap_map):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -20,7 +20,7 @@ from dagster._core.origin import (
     JobPythonOrigin,
     RepositoryPythonOrigin,
 )
-from dagster._core.snap import JobSnap, create_job_snapshot_id
+from dagster._core.snap import JobSnap
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 from dagster._utils.hosted_user_process import recon_job_from_origin
@@ -52,7 +52,7 @@ lambda_version = lambda: the_job
 
 
 def pid(pipeline_def):
-    return create_job_snapshot_id(JobSnap.from_job_def(pipeline_def))
+    return JobSnap.from_job_def(pipeline_def).snapshot_id
 
 
 @job

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
@@ -1,6 +1,6 @@
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.remote_representation import RemoteExecutionPlan
-from dagster._core.snap import create_execution_plan_snapshot_id, create_job_snapshot_id
+from dagster._core.snap import create_execution_plan_snapshot_id
 from dagster._utils import file_relative_path
 from dagster._utils.test import copy_directory
 
@@ -22,7 +22,7 @@ def test_run_created_in_0_7_9_snapshot_id_change():
 
         # It is the pipeline snapshot that changed
         # Verify that snapshot ids are not equal. This changed in 0.7.10
-        created_snapshot_id = create_job_snapshot_id(job_snapshot)
+        created_snapshot_id = job_snapshot.snapshot_id
         assert created_snapshot_id != old_job_snapshot_id
 
         # verify that both are accessible off of the historical pipeline

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -24,7 +24,6 @@ from dagster._core.remote_representation import (
     RemoteRepositoryOrigin,
 )
 from dagster._core.run_coordinator import DefaultRunCoordinator
-from dagster._core.snap import create_job_snapshot_id
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log import InMemoryEventLogStorage
 from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
@@ -237,8 +236,8 @@ class TestRunStorage:
         job_def_b = GraphDefinition(name="some_other_pipeline", node_defs=[]).to_job()
         job_snapshot_a = job_def_a.get_job_snapshot()
         job_snapshot_b = job_def_b.get_job_snapshot()
-        job_snapshot_a_id = create_job_snapshot_id(job_snapshot_a)
-        job_snapshot_b_id = create_job_snapshot_id(job_snapshot_b)
+        job_snapshot_a_id = job_snapshot_a.snapshot_id
+        job_snapshot_b_id = job_snapshot_b.snapshot_id
 
         assert storage.add_job_snapshot(job_snapshot_a) == job_snapshot_a_id
         assert storage.add_job_snapshot(job_snapshot_b) == job_snapshot_b_id
@@ -1080,7 +1079,7 @@ class TestRunStorage:
     def test_add_get_snapshot(self, storage):
         job_def = GraphDefinition(name="some_pipeline", node_defs=[]).to_job()
         job_snapshot = job_def.get_job_snapshot()
-        job_snapshot_id = create_job_snapshot_id(job_snapshot)
+        job_snapshot_id = job_snapshot.snapshot_id
 
         assert storage.add_job_snapshot(job_snapshot) == job_snapshot_id
         fetch_job_snapshot = storage.get_job_snapshot(job_snapshot_id)
@@ -1100,7 +1099,7 @@ class TestRunStorage:
 
         job_snapshot = job_def.get_job_snapshot()
 
-        job_snapshot_id = create_job_snapshot_id(job_snapshot)
+        job_snapshot_id = job_snapshot.snapshot_id
 
         run_with_snapshot = DagsterRun(
             run_id=run_with_snapshot_id,
@@ -1811,7 +1810,7 @@ class TestRunStorage:
         job_def = GraphDefinition(name="some_pipeline", node_defs=[]).to_job()
 
         job_snapshot = job_def.get_job_snapshot()
-        job_snapshot_id = create_job_snapshot_id(job_snapshot)
+        job_snapshot_id = job_snapshot.snapshot_id
         new_job_snapshot_id = f"{job_snapshot_id}-new-snapshot"
 
         storage.add_snapshot(job_snapshot, snapshot_id=new_job_snapshot_id)


### PR DESCRIPTION
Test Plan: BK, verify that a daemon keeps this value across multiple runs within a single backfill (and better yet, consecutive backfill ticks when the code has not changed)

NOCHANGELOG

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
