### PR TITLE
[dagster-fivetran] Implement sync_and_poll method in FivetranClient

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -397,6 +397,12 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
 SAMPLE_SUCCESS_MESSAGE = {"code": "Success", "message": "Operation performed."}
 
 
+def get_fivetran_connector_api_url(connector_id: str) -> str:
+    return (
+        f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}"
+    )
+
+
 @pytest.fixture(name="connector_id")
 def connector_id_fixture() -> str:
     return "connector_id"
@@ -442,7 +448,7 @@ def fetch_workspace_data_api_mocks_fixture(
 
         response.add(
             method=responses.GET,
-            url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}/schemas",
+            url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
             json=SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR,
             status=200,
         )
@@ -461,7 +467,7 @@ def all_api_mocks_fixture(
 ) -> Iterator[responses.RequestsMock]:
     fetch_workspace_data_api_mocks.add(
         method=responses.GET,
-        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}",
+        url=get_fivetran_connector_api_url(connector_id),
         json=get_sample_connection_details(
             succeeded_at=TEST_MAX_TIME_STR, failed_at=TEST_PREVIOUS_MAX_TIME_STR
         ),
@@ -469,7 +475,7 @@ def all_api_mocks_fixture(
     )
     fetch_workspace_data_api_mocks.add(
         method=responses.PATCH,
-        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}",
+        url=get_fivetran_connector_api_url(connector_id),
         json=get_sample_connection_details(
             succeeded_at=TEST_MAX_TIME_STR, failed_at=TEST_PREVIOUS_MAX_TIME_STR
         ),
@@ -477,19 +483,19 @@ def all_api_mocks_fixture(
     )
     fetch_workspace_data_api_mocks.add(
         method=responses.POST,
-        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}/force",
+        url=f"{get_fivetran_connector_api_url(connector_id)}/force",
         json=SAMPLE_SUCCESS_MESSAGE,
         status=200,
     )
     fetch_workspace_data_api_mocks.add(
         method=responses.POST,
-        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}/resync",
+        url=f"{get_fivetran_connector_api_url(connector_id)}/resync",
         json=SAMPLE_SUCCESS_MESSAGE,
         status=200,
     )
     fetch_workspace_data_api_mocks.add(
         method=responses.POST,
-        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/{FIVETRAN_CONNECTOR_ENDPOINT}/{connector_id}/schemas/tables/resync",
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas/tables/resync",
         json=SAMPLE_SUCCESS_MESSAGE,
         status=200,
     )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -132,7 +132,7 @@ def test_sync_and_poll(n_polls, succeed_at_end, connector_id):
     if not succeed_at_end:
         test_succeeded_at, test_failed_at = test_failed_at, test_succeeded_at
 
-    # Create mock responses to mock poll behavior, used only in this test
+    # Create mock responses to mock full sync and poll behavior, used only in this test
     def _mock_interaction():
         with responses.RequestsMock() as response:
             response.add(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -132,7 +132,7 @@ def test_sync_and_poll(n_polls, succeed_at_end, connector_id):
     if not succeed_at_end:
         test_succeeded_at, test_failed_at = test_failed_at, test_succeeded_at
 
-    # Create mock responses to mock poll behavior
+    # Create mock responses to mock poll behavior, used only in this test
     def _mock_interaction():
         with responses.RequestsMock() as response:
             response.add(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -113,6 +113,7 @@ def test_basic_resource_request(
 @pytest.mark.parametrize(
     "n_polls, succeed_at_end",
     [(0, True), (0, False), (4, True), (4, False), (30, True)],
+    ids=["short_success", "short_failure", "medium_success", "medium_failure", "long_success"],
 )
 def test_sync_and_poll(n_polls, succeed_at_end, connector_id):
     resource = FivetranWorkspace(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -126,7 +126,8 @@ def test_sync_and_poll(n_polls, succeed_at_end, connector_id):
     test_failed_at = TEST_PREVIOUS_MAX_TIME_STR
     # Set `failed_at` as more recent that `succeeded_at` if the sync and poll process is expected to fail
     if not succeed_at_end:
-        test_succeeded_at, test_failed_at = test_failed_at, test_succeeded_at
+        test_succeeded_at = TEST_PREVIOUS_MAX_TIME_STR
+        test_failed_at = TEST_MAX_TIME_STR
 
     # Create mock responses to mock full sync and poll behavior, used only in this test
     def _mock_interaction():


### PR DESCRIPTION
## Summary & Motivation

This PR uses the sync and poll methods implemented in previous PRs to implement `sync_and_poll` in `FivetranClient`. This method will be used in a subsequent PR to materialize Fivetran assets.

Tests are added to test the full sync and poll behavior.

## How I Tested These Changes

Additional unit tests with BK