### PR TITLE
[dagster-fivetran] Implement resync_and_poll method in FivetranClient

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -749,6 +749,36 @@ class FivetranClient:
             poll_timeout=poll_timeout,
         )
 
+    def resync_and_poll(
+        self,
+        connector_id: str,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        poll_timeout: Optional[float] = None,
+        resync_parameters: Optional[Mapping[str, Sequence[str]]] = None,
+    ) -> FivetranOutput:
+        """Initializes a historical resync operation for the given connector, and polls until it completes.
+
+        Args:
+            connector_id (str): The Fivetran Connector ID. You can retrieve this value from the
+                "Setup" tab of a given connector in the Fivetran UI.
+            resync_parameters (Dict[str, List[str]]): The payload to send to the Fivetran API.
+                This should be a dictionary with schema names as the keys and a list of tables
+                to resync as the values.
+            poll_interval (float): The time (in seconds) that will be waited between successive polls.
+            poll_timeout (float): The maximum time that will wait before this operation is timed
+                out. By default, this will never time out.
+
+        Returns:
+            :py:class:`~FivetranOutput`:
+                Object containing details about the connector and the tables it updates
+        """
+        return self._sync_and_poll(
+            sync_fn=partial(self.start_resync, resync_parameters=resync_parameters),
+            connector_id=connector_id,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
+        )
+
     def _sync_and_poll(
         self,
         sync_fn: Callable,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -124,7 +124,18 @@ def test_basic_resource_request(
         ("resync_and_poll", 4, False),
         ("resync_and_poll", 30, True),
     ],
-    ids=["short_success", "short_failure", "medium_success", "medium_failure", "long_success"],
+    ids=[
+        "sync_short_success",
+        "sync_short_failure",
+        "sync_medium_success",
+        "sync_medium_failure",
+        "sync_long_success",
+        "resync_short_success",
+        "resync_short_failure",
+        "resync_medium_success",
+        "resync_medium_failure",
+        "resync_long_success",
+    ],
 )
 def test_sync_and_poll_methods(method, n_polls, succeed_at_end, connector_id):
     resource = FivetranWorkspace(


### PR DESCRIPTION
## Summary & Motivation

This PR uses the resync and poll methods implemented in previous PRs to implement `resync_and_poll` in `FivetranClient`. This method will be used in a subsequent PR to materialize Fivetran assets.

Tests are added to test the full sync and poll behavior.

## How I Tested These Changes

Additional unit tests with BK