### PR TITLE
[6/n] [RFC] add launch all frontend functionality for schedules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -25,23 +25,26 @@ export function useLaunchMultipleRunsWithTelemetry() {
 
   return useCallback(
     async (variables: LaunchMultipleRunsMutationVariables, behavior: LaunchBehavior) => {
-      const executionParamsList = Array.isArray(variables.executionParamsList)
-        ? variables.executionParamsList
-        : [variables.executionParamsList];
-      const jobNames = executionParamsList.map((params) => params.selector?.jobName);
-
-      if (jobNames.length !== executionParamsList.length || jobNames.includes(undefined)) {
-        return;
-      }
-
-      const metadata: {[key: string]: string | string[] | null | undefined} = {
-        jobNames: jobNames.filter((name): name is string => name !== undefined),
-        opSelection: undefined,
-      };
-
-      let result;
       try {
-        result = (await launchMultipleRuns({variables})).data?.launchMultipleRuns;
+        const executionParamsList = Array.isArray(variables.executionParamsList)
+          ? variables.executionParamsList
+          : [variables.executionParamsList];
+        const jobNames = executionParamsList.map((params) => params.selector?.jobName);
+
+        if (
+          jobNames.length !== executionParamsList.length ||
+          jobNames.includes(undefined) ||
+          jobNames.includes(null)
+        ) {
+          throw new Error('Invalid job names');
+        }
+
+        const metadata: {[key: string]: string | string[] | null | undefined} = {
+          jobNames: jobNames.filter((name): name is string => name !== undefined),
+          opSelection: undefined,
+        };
+
+        const result = (await launchMultipleRuns({variables})).data?.launchMultipleRuns;
         if (result) {
           handleLaunchMultipleResult(result, history, {behavior});
           logTelemetry(

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSchedule.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSchedule.tsx
@@ -27,7 +27,6 @@ export const EvaluateTickButtonSchedule = ({
         Evaluate tick
       </Button>
       <EvaluateScheduleDialog
-        key={showTestTickDialog ? '1' : '0'} // change key to reset dialog state
         isOpen={showTestTickDialog}
         onClose={() => {
           setShowTestTickDialog(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -61,6 +61,9 @@ describe('EvaluateScheduleTest', () => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
     await userEvent.click(screen.getByTestId('tick-5'));
+    await waitFor(() => {
+      expect(screen.getByTestId('evaluate')).not.toBeDisabled();
+    });
     await userEvent.click(screen.getByTestId('evaluate'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-654/[fe]-implement-launch-all-frontend-schedule

Adds the frontend for 'launch all' for manual tick schedules

Video:

https://github.com/user-attachments/assets/1d3a9315-cc05-4142-8964-5e86e077403b


## How I Tested These Changes
tested the launch all runs flow locally

yarn lint, ts, jest, generate-graphql in ui-core

## Changelog
