### PR TITLE
[dagster-dbt] updates `default_code_version_fn` to take from dbt checksum if available

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -613,12 +613,16 @@ def default_asset_check_fn(
     )
 
 
-def default_code_version_fn(dbt_resource_props: Mapping[str, Any]) -> str:
-    return hashlib.sha1(
-        (dbt_resource_props.get("raw_sql") or dbt_resource_props.get("raw_code", "")).encode(
-            "utf-8"
-        )
-    ).hexdigest()
+def default_code_version_fn(dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+    code: Optional[str] = dbt_resource_props.get("raw_sql") or dbt_resource_props.get("raw_code")
+    checksum: Optional[str] = (
+        dbt_resource_props["checksum"]["checksum"]
+        if "checksum" in dbt_resource_props and "checksum" in dbt_resource_props["checksum"]
+        else None
+    )
+    if code:
+        return hashlib.sha1(code.encode("utf-8")).hexdigest()
+    return checksum
 
 
 def _attach_sql_model_code_reference(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -618,11 +618,7 @@ def default_code_version_fn(dbt_resource_props: Mapping[str, Any]) -> Optional[s
     if code:
         return hashlib.sha1(code.encode("utf-8")).hexdigest()
 
-    return (
-        dbt_resource_props["checksum"]["checksum"]
-        if "checksum" in dbt_resource_props and "checksum" in dbt_resource_props["checksum"]
-        else None
-    )
+    return dbt_resource_props.get("checksum", {}).get("checksum")
 
 
 def _attach_sql_model_code_reference(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -615,14 +615,14 @@ def default_asset_check_fn(
 
 def default_code_version_fn(dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
     code: Optional[str] = dbt_resource_props.get("raw_sql") or dbt_resource_props.get("raw_code")
-    checksum: Optional[str] = (
+    if code:
+        return hashlib.sha1(code.encode("utf-8")).hexdigest()
+
+    return (
         dbt_resource_props["checksum"]["checksum"]
         if "checksum" in dbt_resource_props and "checksum" in dbt_resource_props["checksum"]
         else None
     )
-    if code:
-        return hashlib.sha1(code.encode("utf-8")).hexdigest()
-    return checksum
 
 
 def _attach_sql_model_code_reference(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -691,6 +691,17 @@ def test_with_code_version_replacements(test_jaffle_shop_manifest: Dict[str, Any
         assert code_version == expected_code_version
 
 
+def test_all_assets_have_a_distinct_code_version(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        dagster_dbt_translator=DagsterDbtTranslator(),
+    )
+    def my_dbt_assets(): ...
+
+    code_versions = list(my_dbt_assets.code_versions_by_key.values())
+    assert len(code_versions) == len(set(code_versions))
+
+
 def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
 


### PR DESCRIPTION
## Summary & Motivation

This updates the `default_code_version_fn` in `dagster-dbt` to read from `dbt_resource_props["checksum"]["checksum"]` if available (suggested [here](https://github.com/dagster-io/dagster/pull/25387#issuecomment-2474701457)). This gives dbt seeds a valid model version.

An alternative implementation could be to always read from the checksum field and ignore the `raw_sql` and `raw_code` fields. This would simplify the code version getter, but this would cause all current code versions of dbt models to be updated. Perhaps something for a breaking release?

Closes https://github.com/dagster-io/dagster/issues/25947

## How I Tested These Changes

Added test

## Changelog

`dagster-dbt` now gives dbt seeds a valid code version
