### PR TITLE
add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git/
+**/.tox/
+**/.yarn/
+**/__pycache__/
+**/*.egg-info/
+**/node_modules/
+**/*.pyc
+**/.next/
+**/venv/


### PR DESCRIPTION
## Summary & Motivation

This lets us use the dagster repo as a docker context, without having to transfer a lot of cruft through docker that would then get ignored anyway

## How I Tested These Changes

Ran a docker build locally with /code/dagster as the context, and verified that before this change the context was unmanegeable (several GB) and after it was basically immediate
