### PR TITLE
regenerate helm schema with pydantic 2.10.0

### DIFF
--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3035,9 +3035,6 @@
                 "enabled": {
                     "const": true,
                     "default": true,
-                    "enum": [
-                        true
-                    ],
                     "title": "Enabled",
                     "type": "boolean"
                 },


### PR DESCRIPTION
Summary:
2.10.0 appears to have introduced a benign schema change when its regenerated - I guess because this field is a Literal[true] instead of a boolean in the schema.

Test Plan: BK

NOCHANGELOG

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
