### PR TITLE
[ui] backfill preview modal - if an asset won't launch any partitions show a message instead of a spinner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
@@ -57,7 +57,7 @@ export const BackfillPreviewModal = ({
       skip: !isOpen,
     },
   );
-  const {data} = queryResult;
+  const {data, loading} = queryResult;
 
   const partitionsByAssetToken = useMemo(() => {
     return Object.fromEntries(
@@ -107,8 +107,10 @@ export const BackfillPreviewModal = ({
                   <RowCell style={{color: Colors.textDefault(), alignItems: 'flex-start'}}>
                     {partitions ? (
                       <TargetPartitionsDisplay targetPartitions={partitions} />
-                    ) : (
+                    ) : loading ? (
                       <Spinner purpose="body-text" />
+                    ) : (
+                      'No partitions available to materialize'
                     )}
                   </RowCell>
                 </RowGrid>


### PR DESCRIPTION
## Summary & Motivation
If you select a group of assets to backfill and select a range such that a subset of the assets have no partitions in that range, the Backfill Preview modal shows spinners for those assets 

For example - for the following asset graph 
<img width="743" alt="Screenshot 2024-11-21 at 11 46 09 AM" src="https://github.com/user-attachments/assets/08b3c5c5-9c32-417d-b2ea-4daaf716417d">

If you select only the latest hour to materialize, the daily asset will have no valid partitions to materialize (materializing today's asset isn't available until tomorrow)

If you then click the "Backfill Preview" button, we show an infinite spinner for the daily asset 
![image (19)](https://github.com/user-attachments/assets/ef08731b-8b8e-4f28-a53a-3eca5ad2b648)

This PR adds a message when we know an asset wont have any partitions targeted by the backfill
<img width="1113" alt="Screenshot 2024-11-21 at 11 41 39 AM" src="https://github.com/user-attachments/assets/6cbcd0d3-1444-4235-be7f-f229e9e41edc">


## How I Tested These Changes

## Changelog

[ui] Fixed a bug in the Backfill Preview where a loading spinner would spin forever if an asset had no valid partitions targeted by the backfill
