### PR TITLE
[docs] remove manual set up of GitHub Actions workflows workaround for Import Dagster NUX 

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -57,7 +57,7 @@ When you create a new Dagster+ organization, you'll be prompted to choose Server
 - The repo will need to allow the [Workflow permission](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) for `Read and write permissions`. Workflow permissions settings can be found in GitHub's `Settings` > `Actions` > `General` > `Workflow permissions`. In GitHub Enterprise, these permissions [are controlled at the Organization level](https://github.com/orgs/community/discussions/57244).
 
 - An initial commit will need to be able to be merged directly to the repo's `main` branch to automatically add the GitHub Actions workflow files. If [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#about-branch-protection-rules) require changes be done through a pull request, it will prevent the automatic setup completing.
-  - You can temporarily disable the branch protection rules and then re-enable them after the automatic setup completes. Alternatively, you can manually set up the GitHub Actions workflows. You can use our ­­[dagster-cloud-serverless-quickstart​​​­ r​​​epo](https://github.com/dagster-io/dagster-cloud-serverless-quickstart) as a template and its [README](https://github.com/dagster-io/dagster-cloud-serverless-quickstart/blob/main/README.md) as a guide​​.
+  - You can temporarily disable the branch protection rules and then re-enable them after the automatic setup completes.
 
 </Note>
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/ci-cd-in-serverless.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/ci-cd-in-serverless.md
@@ -20,7 +20,7 @@ If you're a GitHub user, with a single click our GitHub app with GitHub Actions 
 
 - An initial commit will need to be able to be merged directly to the repo's `main` branch to automatically add the GitHub Actions workflow files. If [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#about-protected-branches) require changes be done through a pull request, it will prevent the automatic setup from completing.
 
-  - You can temporarily disable the branch protection rules and then re-enable them after the automatic setup completes. Alternatively, you can manually set up the GitHub Actions workflows. You can use our [dagster-cloud-serverless-quickstart repo](https://github.com/dagster-io/dagster-cloud-serverless-quickstart) as a template and its [README](https://github.com/dagster-io/dagster-cloud-serverless-quickstart/blob/main/README.md) as a guide.
+  - You can temporarily disable the branch protection rules and then re-enable them after the automatic setup completes.
 
 :::
 


### PR DESCRIPTION
## Summary & Motivation
Looking at [the code in internal,](https://github.com/dagster-io/internal/blob/1.9.2/dagster-cloud/python_modules/dagster-cloud-dagit/dagster_cloud_dagit/server/resources/github/app.py#L549) we are trying to add new CI/CD files no matter what, so as long as the branch is protected this workaround won't work.

## How I Tested These Changes
👀