### PR TITLE
[oss] Don't retry mutations

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -33,6 +33,7 @@ const config = {
   origin: process.env.NEXT_PUBLIC_BACKEND_ORIGIN || document.location.origin,
   telemetryEnabled,
   statusPolling: new Set<DeploymentStatusType>(['code-locations', 'daemons']),
+  idempotentMutations: false,
 };
 
 const appCache = createAppCache();


### PR DESCRIPTION
## Summary & Motivation

as titled.


## How I Tested These Changes

hardcoded mutations to return an error and saw us hit this codepath
<img width="741" alt="Screenshot 2024-11-21 at 3 40 28 PM" src="https://github.com/user-attachments/assets/4addb93f-b5ad-461d-99c1-5068effd5844">

> Insert changelog entry or delete this section.

[ui] In OSS, mutations are no longer retried.