### PR TITLE
Avoid unnecessary pyenv usage in environment setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ graphql:
 sanity_check:
 #NOTE:  fails on nonPOSIX-compliant shells (e.g. CMD, powershell)
 #NOTE:  dagster-hex is an external package
-	@echo Checking for prod installs - if any are listed below reinstall with 'pip -e'
-	@! (pip list --exclude-editable | grep -e dagster | grep -v dagster-hex | grep -v dagster-hightouch)
+	@echo Checking for prod installs - if any are listed below reinstall with 'uv pip install -e'
+	@! (uv pip list --exclude-editable | grep -e dagster | grep -v dagster-hex | grep -v dagster-hightouch)
 
 rebuild_ui: sanity_check
 	cd js_modules/dagster-ui/; yarn install && yarn build

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install_dev_python_modules_verbose:
 	python scripts/install_dev_python_modules.py
 
 install_dev_python_modules_verbose_m1:
-	python scripts/install_dev_python_modules.py -q --include-prebuilt-grpcio-wheel
+	python scripts/install_dev_python_modules.py --include-prebuilt-grpcio-wheel
 
 graphql:
 	cd js_modules/dagster-ui/; make generate-graphql; make generate-perms

--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -36,7 +36,7 @@ We love to see our community members get involved! If you are planning to contri
    git clone git@github.com:dagster-io/dagster.git
    ```
 
-5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (sanity_check, which is part of `rebuild_ui`) require POSIX compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended. Note also that if this command fails while installing python packages, the problem might be resolved by ensuring you are running an up-to-date version of `pip` (upgrade with `pip install -U pip`).
+5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (`sanity_check`, which is part of `rebuild_ui`) require POSIX-compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended.
 
    ```bash
    make dev_install

--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -9,28 +9,20 @@ We love to see our community members get involved! If you are planning to contri
 
 ## Environment setup
 
-1. Install a version of Python that Dagster supports. <DagsterVersion />
-
-2. Create and activate a virtualenv, using the tool of your choice. On macOS you can install `pyenv` with Homebrew:
+1. [Install uv](https://docs.astral.sh/uv/getting-started/installation/). On macOS, you can use `curl` to download the script and execute it with `sh`:
 
    ```bash
-   brew install pyenv pyenv-virtualenv
+   curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
 
-   Then add the following commands to your shell profile:
+2. Create and activate a virtual environment using uv with a Python version that Dagster supports:
 
    ```bash
-   eval "$(pyenv init -)"
-   eval "$(pyenv virtualenv-init -)"
+   uv venv --python 3.12
+   source .venv/bin/activate
    ```
 
-   and finally create and activate the virtualenev:
-
-   ```bash
-   pyenv install 3.10.14
-   pyenv virtualenv 3.10.14 dagster310
-   pyenv activate dagster310
-   ```
+   <DagsterVersion />
 
 3. Ensure that you have node installed by running `node -v`, and that you have [yarn](https://yarnpkg.com/lang/en/) installed. If you are on macOS, you can install yarn with Homebrew:
 
@@ -44,7 +36,7 @@ We love to see our community members get involved! If you are planning to contri
    git clone git@github.com:dagster-io/dagster.git
    ```
 
-5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (sanity_check, which is part of `rebuild_ui`) require POSIX compliant shells and will fail on CMD and powershell -- if developing on windows, using something like WSL or git-bash is recommended. Note also that if this command fails while installing python packages, the problem might be resolved by ensuring you are running an up-to-date version of `pip` (upgrade with `pip install -U pip`).
+5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (sanity_check, which is part of `rebuild_ui`) require POSIX compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended. Note also that if this command fails while installing python packages, the problem might be resolved by ensuring you are running an up-to-date version of `pip` (upgrade with `pip install -U pip`).
 
    ```bash
    make dev_install
@@ -132,7 +124,7 @@ make mdx-format
 
 You can find more information about developing documentation in `docs/README.md`.
 
-## Picking a Github Issue
+## Picking a GitHub Issue
 
 We encourage you to start with an issue labeled with the tag [`good first issue`](https://github.com/dagster-io/dagster/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+good+first+issue%22) on the [Github issue board](https://github.com/dagster-io/dagster/issues), to get familiar with our codebase as a first-time contributor.
 
@@ -144,6 +136,6 @@ To submit your code, [fork the Dagster repository](https://help.github.com/en/ar
 
 In the PR template, please describe the change, including the motivation/context, test coverage, and any other relevant information. Please note if the PR is a breaking change or if it is related to an open GitHub issue.
 
-A Core reviewer will review your PR in around one business day and provide feedback on any changes it requires to be approved. Once approved and all the tests (including Buildkite!) pass, the reviewer will click the Squash and merge button in Github 🥳.
+A Core reviewer will review your PR in around one business day and provide feedback on any changes it requires to be approved. Once approved and all the tests (including Buildkite!) pass, the reviewer will click the Squash and merge button in GitHub 🥳.
 
 Your PR is now merged into Dagster! We’ll shout out your contribution in the weekly release notes.

--- a/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
+++ b/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
@@ -38,7 +38,8 @@ ENV LANG=en_US.UTF-8 \
     DOCKER_COMPOSE_VERSION=1.29.1 \
     KIND_VERSION=v0.14.0 \
     KUBECTL_VERSION=v1.20.1 \
-    FOSSA_VERSION=1.1.10
+    FOSSA_VERSION=1.1.10 \
+    UV_VERSION=0.5.4
 
 # Install Kubernetes tools: kubectl, kind, helm
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" \
@@ -131,8 +132,8 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | \
     && curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
-# Install Python build deps
-RUN pip install -U pip setuptools wheel
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /bin/
 
 # Install redis
 RUN wget http://download.redis.io/redis-stable.tar.gz \
@@ -159,7 +160,7 @@ WORKDIR dagster
 ENV VIRTUAL_ENV=/usr/local
 ENV UV_HTTP_TIMEOUT=300
 RUN python scripts/install_dev_python_modules.py --system awscli || exit 1
-RUN pip freeze --exclude-editable > /snapshot-reqs.txt
+RUN uv pip freeze --exclude-editable > /snapshot-reqs.txt
 
 # Final image includes both system deps and preinstalled non-Dagster python deps
 FROM system_base
@@ -168,7 +169,7 @@ COPY --from=snapshot_builder /snapshot-reqs.txt .
 
 # Preinstall non-Dagster packages in image so that the virtual environment
 # builds faster in Buildkite.
-RUN pip install -r /snapshot-reqs.txt \
+RUN uv pip install -r /snapshot-reqs.txt \
     && rm /snapshot-reqs.txt
 
 # New versions of debian require allowlisting folders where `git` can run

--- a/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
+++ b/python_modules/automation/automation/docker/images/buildkite-test/Dockerfile
@@ -38,8 +38,7 @@ ENV LANG=en_US.UTF-8 \
     DOCKER_COMPOSE_VERSION=1.29.1 \
     KIND_VERSION=v0.14.0 \
     KUBECTL_VERSION=v1.20.1 \
-    FOSSA_VERSION=1.1.10 \
-    UV_VERSION=0.5.4
+    FOSSA_VERSION=1.1.10
 
 # Install Kubernetes tools: kubectl, kind, helm
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" \
@@ -133,7 +132,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | \
     && chmod +x /usr/local/bin/docker-compose
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.5.4 /uv /bin/
 
 # Install redis
 RUN wget http://download.redis.io/redis-stable.tar.gz \
@@ -169,7 +168,7 @@ COPY --from=snapshot_builder /snapshot-reqs.txt .
 
 # Preinstall non-Dagster packages in image so that the virtual environment
 # builds faster in Buildkite.
-RUN uv pip install -r /snapshot-reqs.txt \
+RUN uv pip install --system -r /snapshot-reqs.txt \
     && rm /snapshot-reqs.txt
 
 # New versions of debian require allowlisting folders where `git` can run

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -124,9 +124,6 @@ def main(
         )
     )
 
-    if sys.version_info > (3, 6) and sys.version_info < (3, 10):
-        install_targets += []
-
     if include_prebuilt_grpcio_wheel:
         install_targets += [
             "--find-links",

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -118,9 +118,6 @@ def main(
             "python_modules/libraries/dagster-airflow",
         ]
 
-    # if sys.version_info > (3, 7):
-    #     editable_target_paths += []
-
     install_targets += list(
         itertools.chain.from_iterable(
             zip(["-e"] * len(editable_target_paths), editable_target_paths)
@@ -135,9 +132,6 @@ def main(
             "--find-links",
             "https://github.com/dagster-io/build-grpcio/wiki/Wheels",
         ]
-
-    # Ensure uv is installed which we use for faster package resolution
-    subprocess.run(["pip", "install", "-U", "uv"], check=True)
 
     # NOTE: These need to be installed as one long pip install command, otherwise pip will install
     # conflicting dependencies, which will break pip freeze snapshot creation during the integration


### PR DESCRIPTION
## Summary & Motivation

Resolve #26078

## How I Tested These Changes

The change in instructions reflects how I set up my local environment.

I verified that I can build the Buildkite image using `dagster-image build --name buildkite-test  --dagster-version unused -v 3.12`, and that dependencies are installed on the resulting image, but the CI tests are not running using the updated image.

## Changelog

Avoided unnecessary pyenv usage in environment setup step of contributing guide.