### PR TITLE
[ui] Automation bar chart

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AnimationBarChartTooltip.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AnimationBarChartTooltip.tsx
@@ -1,0 +1,31 @@
+import {Box, Colors} from '@dagster-io/ui-components';
+
+import {TooltipCard} from '../../insights/InsightsChartShared';
+import {formatMetric} from '../../insights/formatMetric';
+import {ReportingUnitType} from '../../insights/types';
+
+interface Props {
+  dateTimeString: string;
+  formattedValue: string;
+  metricLabel: string;
+}
+
+export const AnimationBarChartTooltip = (props: Props) => {
+  const {dateTimeString, formattedValue, metricLabel} = props;
+
+  return (
+    <TooltipCard>
+      <Box padding={{vertical: 8, horizontal: 12}} flex={{direction: 'column', gap: 4}}>
+        <div style={{fontWeight: 600, fontSize: '12px', color: Colors.textLight()}}>
+          {dateTimeString}
+        </div>
+        <div style={{fontSize: '12px', color: Colors.textLight()}}>
+          {metricLabel}:{' '}
+          {formatMetric(formattedValue, ReportingUnitType.INTEGER, {
+            floatPrecision: 'maximum-precision',
+          })}
+        </div>
+      </Box>
+    </TooltipCard>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomationBarChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomationBarChart.tsx
@@ -1,0 +1,248 @@
+import {Colors, FontFamily, NonIdealState, SpinnerWithText} from '@dagster-io/ui-components';
+import {ActiveElement, ChartOptions} from 'chart.js';
+import {useCallback, useMemo} from 'react';
+import {Bar} from 'react-chartjs-2';
+
+import {AnimationBarChartTooltip} from './AnimationBarChartTooltip';
+import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
+import {EmptyStateContainer, LoadingStateContainer} from '../../insights/InsightsChartShared';
+import {formatMetric} from '../../insights/formatMetric';
+import {
+  RenderTooltipFn,
+  renderInsightsChartTooltip,
+} from '../../insights/renderInsightsChartTooltip';
+import {ReportingUnitType} from '../../insights/types';
+import {useFormatDateTime} from '../../ui/useFormatDateTime';
+
+interface Props {
+  loading: boolean;
+  timestamps: number[];
+  values: {value: number | null; evaluationID: string}[];
+  onClickEvaluation: (evaluationID: string) => void;
+}
+
+export const AutomationBarChart = ({loading, timestamps, values, onClickEvaluation}: Props) => {
+  const numValues = values.length;
+  const numTimestamps = timestamps.length;
+
+  const rgbColors = useRGBColorsForTheme();
+  const formatDateTime = useFormatDateTime();
+
+  const yMax = useMemo(() => {
+    if (values.length === 0) {
+      return 1;
+    }
+
+    const allValues = values
+      .map(({value}) => value)
+      .filter((value): value is number => value !== null);
+    const maxValue = Math.max(...allValues);
+    return Math.ceil(maxValue * 1.05);
+  }, [values]);
+
+  // Don't show the y axis while loading datapoints, to avoid jumping renders.
+  // const showYAxis = values.length > 0;
+
+  const barColorRGB = rgbColors[Colors.accentBlue()]!;
+  const keylineDefaultRGB = rgbColors[Colors.keylineDefault()];
+  const textLighterRGB = rgbColors[Colors.textLighter()];
+
+  const data = useMemo(() => {
+    return {
+      labels: timestamps,
+      datasets: [
+        {
+          data: values.map(({value}) => value),
+          backgroundColor: barColorRGB.replace(/, 1\)/, ', 0.6)'),
+          hoverBackgroundColor: barColorRGB,
+        },
+      ],
+    };
+  }, [timestamps, values, barColorRGB]);
+
+  const yAxis = useMemo(() => {
+    return {
+      display: true,
+      border: {
+        display: true,
+        color: keylineDefaultRGB,
+      },
+      grid: {
+        display: true,
+        color: keylineDefaultRGB,
+      },
+      title: {
+        display: true,
+        text: 'Run requests',
+        color: textLighterRGB,
+        font: {
+          weight: '700',
+          size: 12,
+        },
+      },
+      ticks: {
+        color: textLighterRGB,
+        font: {
+          size: 12,
+          family: FontFamily.monospace,
+        },
+        autoSkip: true,
+        autoSkipPadding: 20,
+        callback(value: string | number) {
+          return formatMetric(value, ReportingUnitType.INTEGER, {
+            integerFormat: 'compact',
+            floatPrecision: 'maximum-precision',
+            floatFormat: 'compact-above-threshold',
+          });
+        },
+      },
+      min: 0,
+      suggestedMax: yMax,
+    };
+  }, [keylineDefaultRGB, textLighterRGB, yMax]);
+
+  const onClick = useCallback(
+    (element: ActiveElement | null) => {
+      if (element) {
+        const whichBar = values[element.index];
+        if (whichBar?.evaluationID) {
+          onClickEvaluation(whichBar.evaluationID);
+        }
+        return;
+      }
+    },
+    [values, onClickEvaluation],
+  );
+
+  const renderTooltipFn: RenderTooltipFn = useCallback(
+    (config) => {
+      const {date, formattedValue} = config;
+      return (
+        <AnimationBarChartTooltip
+          dateTimeString={formatDateTime(date, {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+          })}
+          formattedValue={formattedValue}
+          metricLabel="Run requests"
+        />
+      );
+    },
+    [formatDateTime],
+  );
+
+  const options: ChartOptions<'bar'> = useMemo(() => {
+    return {
+      // dish: Disable animation until I can figure out why it's acting crazy.
+      // When rendering a responsive grid of charts, it's doing a distracting
+      // zoom-like animation on initial render.
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      onClick: (_event, elements) => onClick(elements[0] || null),
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          enabled: false,
+          external: (context) => {
+            return renderInsightsChartTooltip({
+              ...context,
+              // Place the tooltip on the bottom of the chart.
+              tooltip: {...context.tooltip, caretY: 260},
+              renderFn: renderTooltipFn,
+            });
+          },
+        },
+      },
+      interaction: {
+        intersect: false,
+        mode: 'x',
+      },
+      scales: {
+        x: {
+          display: true,
+          border: {
+            display: true,
+            color: keylineDefaultRGB,
+          },
+          grid: {
+            color: keylineDefaultRGB,
+          },
+          title: {
+            display: true,
+          },
+          ticks: {
+            font: {
+              size: 12,
+              family: FontFamily.monospace,
+            },
+            color: textLighterRGB,
+            maxRotation: 0,
+            autoSkip: true,
+            autoSkipPadding: 20,
+            callback(timestamp, index) {
+              if (index > 0 && index < numTimestamps - 1) {
+                return '';
+              }
+              const label = this.getLabelForValue(Number(timestamp));
+              return formatDateTime(new Date(label), {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric',
+              });
+            },
+          },
+        },
+        y: yAxis,
+      },
+    };
+  }, [
+    keylineDefaultRGB,
+    textLighterRGB,
+    yAxis,
+    onClick,
+    renderTooltipFn,
+    numTimestamps,
+    formatDateTime,
+  ]);
+
+  const emptyContent = () => {
+    // If there is some data, we don't want to show a loading or empty state.
+    // Or, if we shouldn't show the spinner yet (due to the delay) we also shouldn't
+    // show anything yet.
+    if (numValues) {
+      return null;
+    }
+
+    if (loading) {
+      return (
+        <LoadingStateContainer>
+          <SpinnerWithText label="Loading…" />
+        </LoadingStateContainer>
+      );
+    }
+
+    return (
+      <EmptyStateContainer>
+        <NonIdealState
+          icon="search"
+          title="No evaluations found"
+          description="No evaluations were found for this asset"
+        />
+      </EmptyStateContainer>
+    );
+  };
+
+  return (
+    <div style={{height: '100%', position: 'relative'}}>
+      {emptyContent()}
+      <Bar key="materializations" data={data} options={options} />
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/AutomationBarChart.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/AutomationBarChart.stories.tsx
@@ -1,0 +1,77 @@
+import {useRef} from 'react';
+
+import {AutomationBarChart} from '../AutomationBarChart';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/AutomationBarChart',
+};
+
+const ONE_MINUTE_MS = 60 * 1000;
+const PER_PAGE = 25;
+const EMPTY_PER_PAGE = 25;
+
+export const Default = () => {
+  const now = useRef(Date.now());
+  const timestamps = new Array(PER_PAGE).fill(null).map((_, ii) => {
+    return new Date(now.current + ONE_MINUTE_MS * ii).getTime();
+  });
+
+  const values = new Array(PER_PAGE).fill(null).map((_, ii) => {
+    return {
+      value: Math.floor(Math.random() * 5),
+      evaluationID: `evaluation-${ii}`,
+    };
+  });
+
+  return (
+    <div style={{height: '240px'}}>
+      <AutomationBarChart
+        timestamps={timestamps}
+        values={values}
+        loading={false}
+        onClickEvaluation={(evaluationID) => {
+          console.log('evaluationID', evaluationID);
+        }}
+      />
+    </div>
+  );
+};
+
+export const NoData = () => {
+  const now = useRef(Date.now());
+  const timestamps: number[] = new Array(EMPTY_PER_PAGE).fill(null).map((_, ii) => {
+    return new Date(now.current + ONE_MINUTE_MS * ii).getTime();
+  });
+  const values: {value: number | null; evaluationID: string}[] = [];
+
+  return (
+    <div style={{height: '240px'}}>
+      <AutomationBarChart
+        timestamps={timestamps}
+        values={values}
+        loading={false}
+        onClickEvaluation={() => {}}
+      />
+    </div>
+  );
+};
+
+export const Loading = () => {
+  const now = useRef(Date.now());
+  const timestamps: number[] = new Array(EMPTY_PER_PAGE).fill(null).map((_, ii) => {
+    return new Date(now.current + ONE_MINUTE_MS * ii).getTime();
+  });
+  const values: {value: number | null; evaluationID: string}[] = [];
+
+  return (
+    <div style={{height: '240px'}}>
+      <AutomationBarChart
+        timestamps={timestamps}
+        values={values}
+        loading={true}
+        onClickEvaluation={() => {}}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Create `AutomationBarChart`, which will display run requests over time on the updated Automation tab.

With data, hovering on a bar.

<img width="1244" alt="Screenshot 2024-11-22 at 11 43 02" src="https://github.com/user-attachments/assets/1d37a472-e3bc-46a1-9c61-75a99757f3f7">

<img width="1245" alt="Screenshot 2024-11-22 at 11 43 09" src="https://github.com/user-attachments/assets/5475657f-146b-4e3f-b400-f9068fe56a4d">

<img width="1240" alt="Screenshot 2024-11-22 at 11 43 17" src="https://github.com/user-attachments/assets/6ba12b7b-99e7-494a-8f55-4460e888d7d8">

## How I Tested These Changes

Storybook example. Test hover and clicking on individual bars to verify correct behavior.