### PR TITLE
Change the default implementation to calculate step stats more efficiently

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/stats.py
+++ b/python_modules/dagster/dagster/_core/execution/stats.py
@@ -9,6 +9,19 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._serdes import whitelist_for_serdes
 
+STEP_STATS_EVENT_TYPES = {
+    DagsterEventType.STEP_START,
+    DagsterEventType.STEP_FAILURE,
+    DagsterEventType.STEP_RESTARTED,
+    DagsterEventType.STEP_SUCCESS,
+    DagsterEventType.STEP_SKIPPED,
+    DagsterEventType.ASSET_MATERIALIZATION,
+    DagsterEventType.STEP_EXPECTATION_RESULT,
+    DagsterEventType.STEP_UP_FOR_RETRY,
+    DagsterEventType.STEP_RESTARTED,
+    *MARKER_EVENTS,
+}
+
 
 def build_run_stats_from_events(
     run_id: str, entries: Iterable[EventLogEntry]
@@ -91,6 +104,9 @@ def build_run_step_stats_from_events(
 
         step_key = dagster_event.step_key
         if not step_key:
+            continue
+
+        if dagster_event.event_type not in STEP_STATS_EVENT_TYPES:
             continue
 
         if dagster_event.event_type == DagsterEventType.STEP_START:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -28,6 +28,7 @@ from dagster._core.event_api import (
 )
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.stats import (
+    STEP_STATS_EVENT_TYPES,
     RunStepKeyStatsSnapshot,
     build_run_stats_from_events,
     build_run_step_stats_from_events,
@@ -88,7 +89,9 @@ class AssetEntry(
             cls,
             asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
             last_materialization_record=check.opt_inst_param(
-                last_materialization_record, "last_materialization_record", EventLogRecord
+                last_materialization_record,
+                "last_materialization_record",
+                EventLogRecord,
             ),
             last_run_id=check.opt_str_param(last_run_id, "last_run_id"),
             asset_details=check.opt_inst_param(asset_details, "asset_details", AssetDetails),
@@ -245,7 +248,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         self, run_id: str, step_keys: Optional[Sequence[str]] = None
     ) -> Sequence[RunStepKeyStatsSnapshot]:
         """Get per-step stats for a pipeline run."""
-        logs = self.get_logs_for_run(run_id)
+        logs = self.get_logs_for_run(run_id, of_type=STEP_STATS_EVENT_TYPES)
         if step_keys:
             logs = [
                 event
@@ -556,7 +559,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def claim_concurrency_slot(
-        self, concurrency_key: str, run_id: str, step_key: str, priority: Optional[int] = None
+        self,
+        concurrency_key: str,
+        run_id: str,
+        step_key: str,
+        priority: Optional[int] = None,
     ) -> ConcurrencyClaimStatus:
         """Claim concurrency slots for step."""
         raise NotImplementedError()


### PR DESCRIPTION
## Summary & Motivation
By default, we calculate step stats by fetching all of the events and filtering in-memory to construct the step stat summary.

This PR changes the event fetch to pass in an event type filter.

This has the biggest impact for runs that have a lot of unstructured events and that do not directly inherit from the SqlEventLogStorage (e.g. some Cloud storage implementations)

## How I Tested These Changes
BK