### PR TITLE
fix owners not propogated to graph_multi_asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1096,6 +1096,12 @@ def graph_multi_asset(
             if isinstance(out, AssetOut) and out.tags is not None
         }
 
+        owners_by_output_name = {
+            output_name: out.owners
+            for output_name, out in outs.items()
+            if isinstance(out, AssetOut) and out.owners is not None
+        }
+
         return AssetsDefinition.from_graph(
             op_graph,
             keys_by_input_name=keys_by_input_name,
@@ -1115,6 +1121,7 @@ def graph_multi_asset(
             check_specs=check_specs,
             code_versions_by_output_name=code_versions_by_output_name,
             tags_by_output_name=tags_by_output_name,
+            owners_by_output_name=owners_by_output_name,
         )
 
     return inner

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -1321,6 +1321,36 @@ def test_multi_asset_graph_asset_w_tags():
     assert the_asset.tags_by_key[AssetKey("no_tags")] == {}
 
 
+@ignore_warning("Parameter `owners` of initializer `AssetOut.__init__` is experimental")
+def test_multi_asset_graph_asset_w_owners():
+    @op
+    def return_1():
+        return 1
+
+    @op
+    def plus_1(x):
+        return x + 1
+
+    @graph_multi_asset(
+        outs={
+            "first_asset": AssetOut(owners=["team:team_name1"]),
+            "second_asset": AssetOut(owners=["team:team_name2"]),
+            "no_owner": AssetOut(),
+        }
+    )
+    def the_asset():
+        one = return_1()
+        two = plus_1(one)
+        three = plus_1(two)
+        return {"first_asset": one, "second_asset": two, "no_owner": three}
+
+    result = materialize_to_memory([the_asset])
+    assert result.success
+    assert the_asset.owners_by_key[AssetKey("first_asset")] == ["team:team_name1"]
+    assert the_asset.owners_by_key[AssetKey("second_asset")] == ["team:team_name2"]
+    assert the_asset.owners_by_key[AssetKey("no_owner")] == []
+
+
 def test_graph_asset_w_ins_and_kwargs():
     @asset
     def upstream():


### PR DESCRIPTION
## Summary & Motivation
when defining a `@graph_multi_asset`, the `owners` added to `AssetOuts` were not being pulled out and passed to the underlying AssetsDefinition. 

## How I Tested These Changes
unit test 

Tested that owners is shown in the UI  for this graph multi asset 
```python
import dagster as dg

@dg.op
def op1():
    return 1

@dg.op
def op2(input1):
    return input1 + 1

@dg.op
def op3(input2):
    return input2 + 1


@dg.graph_multi_asset(
    outs={
        "asset1": dg.AssetOut(owners=["team:team_name1"]),
        "asset2": dg.AssetOut(owners=["team:team_name2"])
    }
)
def my_graph_multi_asset():
    result1 = op1()
    result2 = op2(result1)
    result3 = op3(result2)
    return {"asset1": result2, "asset2": result3}

```
<img width="452" alt="Screenshot 2024-11-22 at 4 58 30 PM" src="https://github.com/user-attachments/assets/2d1217c3-0258-4ac5-bda1-3928090f0929">



## Changelog

Fixed a bug where `owners` added to `AssetOut`s when defining a `@graph_multi_asset` were not added to the underlying `AssetsDefinition`