### PR TITLE
[ui] FIx backfill partition range coloring, clarify meaning of progress bars

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOpJobPartitionsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOpJobPartitionsTable.tsx
@@ -59,12 +59,12 @@ export const BackfillOpJobPartitionsTable = ({
       <tbody>
         <tr>
           <td>
-            <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
+            <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'baseline'}}>
               <BackfillTarget backfill={backfill} repoAddress={repoAddress} />
               <StatusBar
                 targeted={results.length}
                 inProgress={inProgress.length}
-                completed={succeeded.length}
+                succeeded={succeeded.length}
                 failed={failed.length}
               />
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -175,7 +175,7 @@ describe('BackfillPage', () => {
 
     const assetBRow = await screen.findByTestId('backfill-asset-row-assetB');
     expect(getByTitle(assetBRow, 'assetB')).toBeVisible();
-    expect(getByText(assetBRow, 'Completed')).toBeVisible();
+    expect(getByText(assetBRow, 'Succeeded')).toBeVisible();
     expect(getAllByText(assetBRow, '-').length).toBe(3);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -387,9 +387,9 @@ function assetHealthToColorSegments(ranges: Range[]) {
 
 const statusToBackgroundColor = (status: RunStatus | undefined) => {
   if (status === undefined) {
-    return Colors.accentGray();
+    return Colors.backgroundDisabled();
   }
-  return status === RunStatus.NOT_STARTED ? Colors.accentGrayHover() : RUN_STATUS_COLORS[status];
+  return status === RunStatus.NOT_STARTED ? Colors.backgroundDisabled() : RUN_STATUS_COLORS[status];
 };
 
 function opRunStatusToColorRanges(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -188,7 +188,7 @@ export const RunsFeedRow = ({
 };
 
 const TEMPLATE_COLUMNS =
-  '60px minmax(0, 2fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 150px 120px 132px';
+  '60px minmax(0, 2fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 170px 120px 132px';
 
 export const RunsFeedTableHeader = ({checkbox}: {checkbox: React.ReactNode}) => {
   return (


### PR DESCRIPTION
## Summary & Motivation

Related: https://linear.app/dagster-labs/issue/FE-689/backfill-ui-partition-range-display-issue

This is a handful of small fixes for the backfill partitions pages:

- These tags were rendering full-width, and the terminology (succeeded vs completed) was inconsistent. Clicking it takes you to a view of Succeeded runs, so I changed both to succeeded:
![image](https://github.com/user-attachments/assets/a244071f-b390-4f72-ab7e-035a9186ab30)

- On this page, the two gray colors used in the bars were very similar, which was confusing - now using `backgroundDisabled()`:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ecad8b04-876c-46cb-ad9b-831378a5dc51">

- When viewing a backfill, there is a color bar that is not related to the color bars above - it indicates the success or failure of the _subset of partitions you chose to backfill_. This can be sorta confusing (why does this bar not have the gray bands from the previous screenshot?).  I added a small caption: "100% complete" that clarifies that this bar relates to the backfill, not the partition set:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/e82ec42b-752e-4be8-a81c-5303c3b8ee0f">

- The centering of these two items looked odd - aligned them to the top text baseline:

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/cd8bc111-9c1d-418b-bacf-158afe84f700">

- Dates from previous years were wrapping in the new Runs Feed table - needed slightly more space:

<img width="631" alt="image" src="https://github.com/user-attachments/assets/f885a32d-490c-4e10-925a-f3579f23f910">

## How I Tested These Changes

I tested these changes manually using both op and asset backfills!
