### PR TITLE
[ui] Fix tags on backfill table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
@@ -250,15 +250,33 @@ export const VirtualizedBackfillPartitionsRow = ({
             <RowCell>-</RowCell>
             <RowCell>
               {inProgress ? (
-                <Tag icon="spinner" intent="primary">
-                  In progress
-                </Tag>
+                <div>
+                  <Tag icon="spinner" intent="primary">
+                    In progress
+                  </Tag>
+                </div>
               ) : (
                 '-'
               )}
             </RowCell>
-            <RowCell>{completed ? <Tag intent="success">Completed</Tag> : '-'}</RowCell>
-            <RowCell>{failed ? <Tag intent="danger">Failed</Tag> : '-'}</RowCell>
+            <RowCell>
+              {completed ? (
+                <div>
+                  <Tag intent="success">Completed</Tag>
+                </div>
+              ) : (
+                '-'
+              )}
+            </RowCell>
+            <RowCell>
+              {failed ? (
+                <div>
+                  <Tag intent="danger">Failed</Tag>
+                </div>
+              ) : (
+                '-'
+              )}
+            </RowCell>
           </>
         )}
       </RowGrid>


### PR DESCRIPTION
## Summary & Motivation

Fix stretched tags on Backfill table.

The row cells are flex column containers with no `alignItems` value set, so the children stretch, causing `Tag` elements to occupy the entire cell width.

It's not really safe to change `RowCell` to have `align-items: flex-start` since that would have broader/riskier impact on other table views, so the simple thing to do here is just wrap the `Tag` elements in `div`s.

## How I Tested These Changes

View a backfill table with tags, verify that they no longer stretch.

## Changelog

[ui] Fix stretched tags in backfill table view for non-partitioned assets.
