### PR TITLE
[ui] Separate sensor logs into their own dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -7,14 +7,13 @@ import {
   DialogFooter,
   DialogHeader,
   MiddleTruncate,
-  Spinner,
+  NonIdealState,
+  SpinnerWithText,
   Subtitle2,
-  Tab,
   Table,
-  Tabs,
   Tag,
 } from '@dagster-io/ui-components';
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 
 import {RunList, TargetedRunList} from './InstigationTick';
 import {HISTORY_TICK_FRAGMENT} from './InstigationUtils';
@@ -35,7 +34,6 @@ import {
   InstigationTickStatus,
 } from '../graphql/types';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {QueryfulTickLogsTable} from '../ticks/TickLogDialog';
 import {TickResultType} from '../ticks/TickStatusTag';
 
 interface DialogProps extends InnerProps {
@@ -61,13 +59,9 @@ export const TickDetailsDialog = ({
         tickResultType={tickResultType}
         instigationSelector={instigationSelector}
       />
-      {/* The logs table uses z-index for the column lines. Create a new stacking index
-      for the footer so that the lines don't sit above it. */}
-      <div style={{zIndex: 1}}>
-        <DialogFooter topBorder>
-          <Button onClick={onClose}>Close</Button>
-        </DialogFooter>
-      </div>
+      <DialogFooter topBorder>
+        <Button onClick={onClose}>Close</Button>
+      </DialogFooter>
     </Dialog>
   );
 };
@@ -79,12 +73,13 @@ interface InnerProps {
 }
 
 const TickDetailsDialogImpl = ({tickId, tickResultType, instigationSelector}: InnerProps) => {
-  const [activeTab, setActiveTab] = useState<'result' | 'logs'>('result');
-
-  const {data} = useQuery<SelectedTickQuery, SelectedTickQueryVariables>(JOB_SELECTED_TICK_QUERY, {
-    variables: {instigationSelector, tickId: tickId || ''},
-    skip: !tickId,
-  });
+  const {data, loading} = useQuery<SelectedTickQuery, SelectedTickQueryVariables>(
+    JOB_SELECTED_TICK_QUERY,
+    {
+      variables: {instigationSelector, tickId: tickId || ''},
+      skip: !tickId,
+    },
+  );
 
   const tick =
     data?.instigationStateOrError.__typename === 'InstigationState'
@@ -105,11 +100,29 @@ const TickDetailsDialogImpl = ({tickId, tickResultType, instigationSelector}: In
     return [added, deleted];
   }, [tick?.dynamicPartitionsRequestResults]);
 
+  if (loading) {
+    return (
+      <>
+        <DialogHeader label={`Tick for ${instigationSelector.name}`} />
+        <Box style={{padding: 64}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+          <SpinnerWithText label="Loading tick details…" />
+        </Box>
+      </>
+    );
+  }
+
   if (!tick) {
     return (
-      <Box style={{padding: 32}} flex={{alignItems: 'center', justifyContent: 'center'}}>
-        <Spinner purpose="section" />
-      </Box>
+      <>
+        <DialogHeader label={`Tick for ${instigationSelector.name}`} />
+        <Box style={{padding: 64}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+          <NonIdealState
+            icon="no-results"
+            title="Tick details not found"
+            description="Details for this tick could not be found."
+          />
+        </Box>
+      </>
     );
   }
 
@@ -117,25 +130,20 @@ const TickDetailsDialogImpl = ({tickId, tickResultType, instigationSelector}: In
     <>
       <DialogHeader
         label={
-          <TimestampDisplay
-            timestamp={tick.timestamp}
-            timeFormat={{showTimezone: false, showSeconds: true}}
-          />
+          <>
+            <span>Tick for {instigationSelector.name}: </span>
+            <TimestampDisplay
+              timestamp={tick.timestamp}
+              timeFormat={{showTimezone: false, showSeconds: true}}
+            />
+          </>
         }
       />
       <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
         <TickDetailSummary tick={tick} tickResultType={tickResultType} />
       </Box>
-      <Box padding={{horizontal: 24}} border="bottom">
-        <Tabs selectedTabId={activeTab} onChange={setActiveTab}>
-          <Tab id="result" title="Result" />
-          <Tab id="logs" title="Logs" />
-        </Tabs>
-      </Box>
-      {tickResultType === 'materializations' && activeTab === 'result' ? (
-        <TickMaterializationsTable tick={tick} />
-      ) : null}
-      {tickResultType === 'runs' && activeTab === 'result' ? (
+      {tickResultType === 'materializations' ? <TickMaterializationsTable tick={tick} /> : null}
+      {tickResultType === 'runs' ? (
         <div style={{height: '500px', overflowY: 'auto'}}>
           {tick.runIds.length ? (
             <>
@@ -174,9 +182,6 @@ const TickDetailsDialogImpl = ({tickId, tickResultType, instigationSelector}: In
             </Box>
           ) : null}
         </div>
-      ) : null}
-      {activeTab === 'logs' ? (
-        <QueryfulTickLogsTable instigationSelector={instigationSelector} tick={tick} />
       ) : null}
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
@@ -1,9 +1,13 @@
-import {Box, ButtonLink, MiddleTruncate, Tag} from '@dagster-io/ui-components';
+import {Box, MiddleTruncate, Tag} from '@dagster-io/ui-components';
 import {useState} from 'react';
 
 import {DagsterTag} from './RunTag';
 import {InstigationSelector} from '../graphql/types';
 import {TickDetailsDialog} from '../instigation/TickDetailsDialog';
+import {TickLogDialog} from '../ticks/TickLogDialog';
+import {TagActionsPopover} from '../ui/TagActions';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 interface Props {
   instigationSelector: InstigationSelector;
@@ -12,26 +16,52 @@ interface Props {
 }
 
 export const TickTagForRun = ({instigationSelector, instigationType, tickId}: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+  const [showLogs, setShowLogs] = useState(false);
   const icon = instigationType === DagsterTag.ScheduleName ? 'schedule' : 'sensors';
-  const {name} = instigationSelector;
+  const {name, repositoryName, repositoryLocationName} = instigationSelector;
+  const repoAddress = buildRepoAddress(repositoryName, repositoryLocationName);
+
+  const actions = [
+    {
+      label: `View ${instigationType === DagsterTag.ScheduleName ? 'schedule' : 'sensor'}`,
+      to: workspacePathFromAddress(
+        repoAddress,
+        `${instigationType === DagsterTag.ScheduleName ? '/schedules' : '/sensors'}/${name}`,
+      ),
+    },
+    {
+      label: 'View tick details',
+      onClick: () => setShowDetails(true),
+    },
+    {
+      label: 'View tick logs',
+      onClick: () => setShowLogs(true),
+    },
+  ];
 
   return (
     <>
-      <Tag icon={icon}>
-        <Box flex={{direction: 'row'}}>
-          <span>Launched by&nbsp;</span>
-          <ButtonLink onClick={() => setIsOpen(true)}>
+      <TagActionsPopover actions={actions} data={{key: 'Launched by', value: name}}>
+        <Tag icon={icon}>
+          <Box flex={{direction: 'row'}}>
+            <span>Launched by&nbsp;</span>
             <div style={{maxWidth: '140px'}}>
               <MiddleTruncate text={name} />
             </div>
-          </ButtonLink>
-        </Box>
-      </Tag>
+          </Box>
+        </Tag>
+      </TagActionsPopover>
       <TickDetailsDialog
-        isOpen={isOpen}
+        isOpen={showDetails}
         tickResultType="runs"
-        onClose={() => setIsOpen(false)}
+        onClose={() => setShowDetails(false)}
+        instigationSelector={instigationSelector}
+        tickId={tickId}
+      />
+      <TickLogDialog
+        isOpen={showLogs}
+        onClose={() => setShowLogs(false)}
         instigationSelector={instigationSelector}
         tickId={tickId}
       />


### PR DESCRIPTION
## Summary & Motivation

Users have found it a bit confusing that sensor tick logs are buried under an extra click under the "N materializations requested" button-link. Move these out into their own dialog, opened via a "View logs" button in the table.

Plus a couple other changes I made while in there:

- Middle-truncate the cursor value, which is currently long and may or may not wrap, depending on its contents.
- Clean up some loading and empty states in the dialogs.

<img width="424" alt="Screenshot 2024-11-25 at 10 42 39" src="https://github.com/user-attachments/assets/7f354b07-47a4-4d50-b4f0-526efb1fc808">

## How I Tested These Changes

View a running sensor. Verify that the "View logs" button is present in the row, and opens the dialog correctly. Verify with forced dialog height that the logs table is scrollable, and that the footer sits on top of the log table lines.

Verify that the cursor is middle-truncated, and that loading and empty states look correct for various ticks.

## Changelog

[ui] Add a "View logs" button to open tick logs in the sensor tick history table.
