### PR TITLE
[dagster-fivetran] Use Fivetran translator instance in load specs fn and state-backed defs

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -1,7 +1,13 @@
 import responses
 from dagster._config.field_utils import EnvVar
+from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
 from dagster._core.test_utils import environ
-from dagster_fivetran import FivetranWorkspace, load_fivetran_asset_specs
+from dagster_fivetran import (
+    DagsterFivetranTranslator,
+    FivetranConnectorTableProps,
+    FivetranWorkspace,
+    load_fivetran_asset_specs,
+)
 from dagster_fivetran.asset_defs import build_fivetran_assets_definitions
 from dagster_fivetran.translator import FivetranMetadataSet
 
@@ -112,3 +118,38 @@ def test_cached_load_spec_with_asset_factory(
         # then load_fivetran_asset_specs is called once per connector ID in fivetran_assets
         build_fivetran_assets_definitions(workspace=resource)
         assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+
+class MyCustomTranslator(DagsterFivetranTranslator):
+    def get_asset_spec(self, data: FivetranConnectorTableProps) -> AssetSpec:
+        default_spec = super().get_asset_spec(data)
+        return replace_attributes(
+            default_spec,
+            key=default_spec.key.with_prefix("prefix"),
+            metadata={**default_spec.metadata, "custom": "metadata"},
+        )
+
+
+def test_translator_custom_metadata(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        workspace = FivetranWorkspace(
+            account_id=TEST_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        all_asset_specs = load_fivetran_asset_specs(
+            workspace=workspace, dagster_fivetran_translator=MyCustomTranslator()
+        )
+        asset_spec = next(spec for spec in all_asset_specs)
+
+        assert "custom" in asset_spec.metadata
+        assert asset_spec.metadata["custom"] == "metadata"
+        assert asset_spec.key.path == [
+            "prefix",
+            "schema_name_in_destination_1",
+            "table_name_in_destination_1",
+        ]
+        assert "dagster/kind/fivetran" in asset_spec.tags

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -1,6 +1,6 @@
 import responses
 from dagster._config.field_utils import EnvVar
-from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.test_utils import environ
 from dagster_fivetran import (
     DagsterFivetranTranslator,
@@ -123,8 +123,7 @@ def test_cached_load_spec_with_asset_factory(
 class MyCustomTranslator(DagsterFivetranTranslator):
     def get_asset_spec(self, data: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(data)
-        return replace_attributes(
-            default_spec,
+        return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
         )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import responses
 from dagster._config.field_utils import EnvVar
-from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.test_utils import environ
 from dagster_fivetran import (
     DagsterFivetranTranslator,
@@ -36,8 +36,7 @@ def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
 class MyCustomTranslator(DagsterFivetranTranslator):
     def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(props)
-        return replace_attributes(
-            default_spec,
+        return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
         )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -1,6 +1,14 @@
 from typing import Callable
 
-from dagster_fivetran import FivetranWorkspace
+import responses
+from dagster._config.field_utils import EnvVar
+from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
+from dagster._core.test_utils import environ
+from dagster_fivetran import (
+    DagsterFivetranTranslator,
+    FivetranConnectorTableProps,
+    FivetranWorkspace,
+)
 
 from dagster_fivetran_tests.experimental.conftest import (
     TEST_ACCOUNT_ID,
@@ -23,3 +31,40 @@ def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
     assert table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
     assert table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
     assert table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"
+
+
+class MyCustomTranslator(DagsterFivetranTranslator):
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
+        default_spec = super().get_asset_spec(props)
+        return replace_attributes(
+            default_spec,
+            key=default_spec.key.with_prefix("prefix"),
+            metadata={**default_spec.metadata, "custom": "metadata"},
+        )
+
+
+def test_translator_custom_metadata(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        resource = FivetranWorkspace(
+            account_id=TEST_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        actual_workspace_data = resource.fetch_fivetran_workspace_data()
+        table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()
+
+        first_table_props_data = next(props for props in table_props_data)
+
+        asset_spec = MyCustomTranslator().get_asset_spec(first_table_props_data)
+
+        assert "custom" in asset_spec.metadata
+        assert asset_spec.metadata["custom"] == "metadata"
+        assert asset_spec.key.path == [
+            "prefix",
+            "schema_name_in_destination_1",
+            "table_name_in_destination_1",
+        ]
+        assert "dagster/kind/fivetran" in asset_spec.tags


### PR DESCRIPTION
## Summary & Motivation

Updates load_fivetran_asset_specs() and state-backed definitions to accept an instance of `DagsterFivetranTranslator`.

See more about the motivation in the original thread [here](https://github.com/dagster-io/dagster/pull/25944#issuecomment-2495112807).

## How I Tested These Changes

Additional unit tests to test custom translators with BK

## Changelog

[dagster-fivetran] `load_fivetran_asset_specs` is updated to accept an instance of `DagsterFivetranTranslator` or custom subclass.
