### PR TITLE
[graphql] dont wipe instance in checks test

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -416,8 +416,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         }
 
     def test_asset_check_execution_cursoring(self, graphql_context: WorkspaceRequestContext):
-        graphql_context.instance.wipe()
-
         run_ids = [create_run_for_test(graphql_context.instance).run_id for _ in range(10)]
         for run_id in run_ids:
             graphql_context.instance.event_log_storage.store_event(
@@ -460,8 +458,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
             assert execution["runId"] == expected_run_id
 
     def test_asset_check_executions(self, graphql_context: WorkspaceRequestContext):
-        graphql_context.instance.wipe()
-
         run_id_one, run_id_two = [make_new_run_id() for _ in range(2)]
         create_run_for_test(graphql_context.instance, run_id=run_id_one)
 
@@ -535,8 +531,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         }
 
     def test_asset_check_events(self, graphql_context: WorkspaceRequestContext):
-        graphql_context.instance.wipe()
-
         run_id_one, run_id_two = [make_new_run_id() for _ in range(2)]
         create_run_for_test(graphql_context.instance, run_id=run_id_one)
 
@@ -580,8 +574,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         }
 
     def test_asset_check_failure(self, graphql_context: WorkspaceRequestContext):
-        graphql_context.instance.wipe()
-
         run = create_run_for_test(graphql_context.instance)
 
         graphql_context.instance.event_log_storage.store_event(
@@ -621,7 +613,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
 
     def test_latest_execution(self, graphql_context: WorkspaceRequestContext):
         instance = graphql_context.instance
-        instance.wipe()
 
         def new_materialization() -> EventLogRecord:
             """Stores a materialization in a new run, and asserts that latest execustion is null."""
@@ -857,7 +848,9 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+        assert (
+            result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+        ), result.data
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
@@ -1308,8 +1301,6 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         }
 
     def test_deleted_run(self, graphql_context: WorkspaceRequestContext):
-        graphql_context.instance.wipe()
-
         run_id = make_new_run_id()
         run = create_run_for_test(graphql_context.instance, run_id=run_id)
 


### PR DESCRIPTION
we already wipe in the context fixture 
https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py#L792
so this just messes up places that change that out

## How I Tested These Changes

bk