### PR TITLE
[graphql] defend against hang in backfill test

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -686,10 +686,13 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
             assert not result.errors
             assert result.data
+            assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
             # ensure the execution has happened
+            start = time.time()
             while not os.path.exists(path):
                 time.sleep(0.1)
+                assert time.time() - start < 60, "timed out waiting for file"
 
             result = execute_dagster_graphql(
                 graphql_context,
@@ -762,10 +765,13 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
             assert not result.errors
             assert result.data
+            assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
             # ensure the execution has happened
+            start = time.time()
             while not os.path.exists(path):
                 time.sleep(0.1)
+                assert time.time() - start < 60, "timed out waiting for file"
 
             result = execute_dagster_graphql(
                 graphql_context,


### PR DESCRIPTION
Had an error cause these tests to hang indefinitely, prevent that from happening again

## How I Tested These Changes

bk
