### PR TITLE
Fix issue where when user provides a custom task definition, the image is not provided via config, and this check fails

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -487,8 +487,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         )
         command = self._get_command_args(args, context)
         image = self._get_image_for_run(context)
-        if image is None:
-            raise ValueError("Could not determine image for run")
 
         run_task_kwargs = self._run_task_kwargs(run, image, container_context)
 


### PR DESCRIPTION
## Summary & Motivation
User reported an issue in the community Slack channel about the ECS run launcher throwing an error at runtime due to this check failing when providing a custom task definition to the run launcher. This PR just rolls back the check I added that is throwing the exception - still need to check whether that actually fixes the issue

## How I Tested These Changes


## Changelog

> Insert changelog entry or delete this section.
