### PR TITLE
[components] Add ability to load a component using config

### DIFF
--- a/python_modules/dagster/dagster/_components/__init__.py
+++ b/python_modules/dagster/dagster/_components/__init__.py
@@ -2,12 +2,27 @@ import importlib.util
 import os
 import sys
 from abc import ABC, abstractmethod
+from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, ClassVar, Dict, Final, Iterable, Mapping, Optional, Sequence, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Final,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+)
 
+from pydantic import BaseModel
 from typing_extensions import Self
 
 import dagster._check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import DagsterError
 from dagster._utils import snakecase
 
@@ -28,6 +43,14 @@ class Component(ABC):
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> "Definitions": ...
+
+
+class LoadableComponent(Component):
+    params_schema: ClassVar[Optional[Type[BaseModel]]] = None
+
+    @classmethod
+    @abstractmethod
+    def from_component_params(cls, path: Path, component_params: object) -> Self: ...
 
 
 class ComponentCollection(Component):

--- a/python_modules/dagster/dagster/_components/impls/python_script_component.py
+++ b/python_modules/dagster/dagster/_components/impls/python_script_component.py
@@ -1,8 +1,12 @@
 import shutil
 from pathlib import Path
-from typing import Optional, Sequence, Union
+from typing import Any, ClassVar, Mapping, Optional, Sequence, Type, Union
 
-from dagster._components import Component, ComponentLoadContext
+from pydantic import BaseModel, TypeAdapter
+from typing_extensions import Self
+
+from dagster._components import ComponentLoadContext, LoadableComponent
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
@@ -10,13 +14,42 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
-class PythonScript(Component):
+class AssetSpecModel(BaseModel):
+    key: str
+    deps: Sequence[str] = []
+    description: Optional[str] = None
+    metadata: Mapping[str, Any] = {}
+    group_name: Optional[str] = None
+    skippable: bool = False
+    code_version: Optional[str] = None
+    owners: Sequence[str] = []
+    tags: Mapping[str, str] = {}
+
+    def to_asset_spec(self) -> AssetSpec:
+        return AssetSpec(
+            **{
+                **self.__dict__,
+                "key": AssetKey.from_user_string(self.key),
+            },
+        )
+
+
+class PythonScript(LoadableComponent):
+    params_schema: ClassVar[Type[Optional[Sequence[AssetSpecModel]]]] = Optional[
+        Sequence[AssetSpecModel]
+    ]
     path: Path
     specs: Sequence[AssetSpec]
 
     def __init__(self, path: Union[str, Path], specs: Optional[Sequence[AssetSpec]] = None):
         self.path = Path(path)
         self.specs = specs or [AssetSpec(key=self.path.stem)]
+
+    @classmethod
+    def from_component_params(cls, path: Path, component_params: object) -> Self:
+        models = TypeAdapter(cls.params_schema).validate_python(component_params)
+        specs = [s.to_asset_spec() for s in models] if models else None
+        return cls(path=path, specs=specs)
 
     def build_defs(self, load_context: ComponentLoadContext) -> Definitions:
         @multi_asset(specs=self.specs, name=f"script_{self.path.stem}")

--- a/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
@@ -8,25 +8,42 @@ from dagster._core.pipes.subprocess import PipesSubprocessClient
 LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
 
 
-def test_individual() -> None:
-    component = PythonScript(LOCATION_PATH / "scripts" / "script_one.py")
+def _assert_assets(component: PythonScript, expected_assets: int) -> None:
     defs = component.build_defs(ComponentLoadContext({"pipes_client": PipesSubprocessClient()}))
-
-    assert len(defs.get_asset_graph().get_all_asset_keys()) == 1
+    assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
     result = defs.get_implicit_global_asset_job_def().execute_in_process()
     assert result.success
 
 
-def test_individual_spec_override() -> None:
+def test_individual_python() -> None:
+    component = PythonScript(LOCATION_PATH / "scripts" / "script_one.py")
+    _assert_assets(component, 1)
+
+
+def test_individual_spec_override_python() -> None:
     component = PythonScript(
         path=LOCATION_PATH / "scripts" / "script_one.py",
         specs=[AssetSpec("a"), AssetSpec("b", deps=["up1", "up2"])],
     )
-    defs = component.build_defs(ComponentLoadContext({"pipes_client": PipesSubprocessClient()}))
+    _assert_assets(component, 4)
 
-    assert len(defs.get_asset_graph().get_all_asset_keys()) == 4
-    result = defs.get_implicit_global_asset_job_def().execute_in_process()
-    assert result.success
+
+def test_individual_config() -> None:
+    component = PythonScript.from_component_params(
+        LOCATION_PATH / "scripts" / "script_one.py", component_params=None
+    )
+    _assert_assets(component, 1)
+
+
+def test_individual_spec_override_config() -> None:
+    component = PythonScript.from_component_params(
+        LOCATION_PATH / "scripts" / "script_one.py",
+        component_params=[
+            {"key": "a"},
+            {"key": "b", "deps": ["up1", "up2"]},
+        ],
+    )
+    _assert_assets(component, 4)
 
 
 def test_collection() -> None:


### PR DESCRIPTION
## Summary & Motivation

This adds a separate construction path for Components, which takes a dictionary of config that conforms to the class's config schema.

Because there's no generalized way to auto-generate a config schema or a conversion function, I think we'll end up relying in most cases on users subclassing an iniital simple implementation that just allows for some configured specs and maybe some unstrctured params, hence the AssetsComponent.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
