### PR TITLE
[components] Add ability to load directly from path

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yml
@@ -1,0 +1,13 @@
+component_type: collection
+
+component_params:
+  component_type: python_script
+  components:
+    script_one:
+      assets:
+        - key: a
+        - key: b
+          deps: [up1, up2]
+    script_three:
+      assets:
+        - key: override_key


### PR DESCRIPTION
## Summary & Motivation

This allows us to use the config loading system to load components from a path directly. All `defs.yaml` files conform to the same schema of:

```yaml

component_type: <component type>

component_params: <component-specific params>

```

## How I Tested These Changes

## Changelog

NOCHANGELOG
