### PR TITLE
[dagster-looker] Fix calling lower-level spec methods for deps

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -120,7 +120,7 @@ class DagsterLookerApiTranslator:
         additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
     )
     def get_view_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
-        return self.get_view_asset_spec(looker_structure).key
+        return self.get_asset_spec(looker_structure).key
 
     def get_view_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
         lookml_view = check.inst(looker_structure.data, LookmlView)
@@ -156,7 +156,7 @@ class DagsterLookerApiTranslator:
                 key=AssetKey(check.not_none(lookml_explore.id)),
                 deps=list(
                     {
-                        self.get_view_asset_spec(
+                        self.get_asset_spec(
                             LookerStructureData(
                                 structure_type=LookerStructureType.VIEW, data=lookml_view
                             )
@@ -186,7 +186,7 @@ class DagsterLookerApiTranslator:
         additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
     )
     def get_dashboard_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
-        return self.get_dashboard_asset_spec(looker_structure).key
+        return self.get_asset_spec(looker_structure).key
 
     def get_dashboard_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
         looker_dashboard = check.inst(looker_structure.data, Dashboard)
@@ -199,7 +199,7 @@ class DagsterLookerApiTranslator:
             key=AssetKey(f"{check.not_none(looker_dashboard.title)}_{looker_dashboard.id}"),
             deps=list(
                 {
-                    self.get_explore_asset_spec(
+                    self.get_asset_spec(
                         LookerStructureData(
                             structure_type=LookerStructureType.EXPLORE, data=dashboard_filter
                         )

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -217,3 +217,5 @@ def test_custom_asset_specs(
             assert "custom" in metadata
             assert metadata["custom"] == "metadata"
         assert all(key.path[0] == "my_prefix" for key in asset.keys)
+        for deps in asset.asset_deps.values():
+            assert all(key.path[0] == "my_prefix" for key in deps), str(deps)


### PR DESCRIPTION
## Summary

Right now, the object-specific methods of `get_asset_spec` call other object-specific methods to generate deps, meaning that if a user overrides `get_asset_spec` it is not properly called in these cases.

## How I Tested These Changes

Update unit test to ensure deps are properly prefixed
