### PR TITLE
[dagster-azure] live tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
@@ -64,6 +64,17 @@ def build_dagster_oss_nightly_steps() -> List[BuildkiteStep]:
                     "KS_DBT_CLOUD_DISCOVERY_API_URL",
                 ],
             ),
+            PackageSpec(
+                "integration_tests/test_suites/dagster-azure-live-tests",
+                name="azure-live-tests",
+                env_vars=[
+                    "TEST_AZURE_TENANT_ID",
+                    "TEST_AZURE_CLIENT_ID",
+                    "TEST_AZURE_CLIENT_SECRET",
+                    "TEST_AZURE_STORAGE_ACCOUNT_ID",
+                    "TEST_AZURE_CONTAINER_ID",
+                ],
+            ),
         ]
     )
 

--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -600,7 +600,10 @@ compute_logs:
   config:
     storage_account: mycorp-dagster
     container: compute-logs
-    secret_key: foo
+    secret_credential:
+      client_id: ...
+      tenant_id: ...
+      client_secret: ...
     local_dir: /tmp/bar
     prefix: dagster-test-
 
@@ -613,8 +616,10 @@ compute_logs:
       env: MYCORP_DAGSTER_STORAGE_ACCOUNT_NAME
     container:
       env: CONTAINER_NAME
-    secret_key:
-      env: SECRET_KEY
+    secret_credential:
+      client_id: ...
+      tenant_id: ...
+      client_secret: ...
     local_dir:
       env: LOCAL_DIR_PATH
     prefix:

--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -245,7 +245,10 @@ compute_logs:
   config:
     storage_account: mycorp-dagster
     container: compute-logs
-    secret_key: foo
+    secret_credential:
+      client_id: ...
+      tenant_id: ...
+      client_secret: ... 
     local_dir: /tmp/bar
     prefix: dagster-test-
 
@@ -258,8 +261,10 @@ compute_logs:
       env: MYCORP_DAGSTER_STORAGE_ACCOUNT_NAME
     container:
       env: CONTAINER_NAME
-    secret_key:
-      env: SECRET_KEY
+    secret_credential:
+      client_id: ...
+      tenant_id: ...
+      client_secret: ...
     local_dir:
       env: LOCAL_DIR_PATH
     prefix:

--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -18,7 +18,7 @@ class ComputeLogManagerType(str, Enum):
 class AzureBlobComputeLogManager(BaseModel):
     storageAccount: StringSource
     container: StringSource
-    secretKey: Optional[StringSource] = None
+    secretCredential: Optional[dict] = None
     defaultAzureCredential: Optional[dict] = None
     localDir: Optional[StringSource] = None
     prefix: Optional[StringSource] = None

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -694,7 +694,7 @@ def test_noop_compute_log_manager(template: HelmTemplate):
 def test_azure_blob_compute_log_manager(template: HelmTemplate):
     storage_account = "account"
     container = "container"
-    secret_key = "secret_key"
+    secret_credential = {"client_id": "id", "client_secret": "secret", "tenant_id": "tenant"}
     default_azure_credential = {"exclude_cli_credential": True}
     local_dir = "/dir"
     prefix = "prefix"
@@ -706,7 +706,7 @@ def test_azure_blob_compute_log_manager(template: HelmTemplate):
                 azureBlobComputeLogManager=AzureBlobComputeLogManagerModel(
                     storageAccount=storage_account,
                     container=container,
-                    secretKey=secret_key,
+                    secretCredential=secret_credential,
                     defaultAzureCredential=default_azure_credential,
                     localDir=local_dir,
                     prefix=prefix,
@@ -726,7 +726,7 @@ def test_azure_blob_compute_log_manager(template: HelmTemplate):
     assert compute_logs_config["config"] == {
         "storage_account": storage_account,
         "container": container,
-        "secret_key": secret_key,
+        "secret_credential": secret_credential,
         "default_azure_credential": default_azure_credential,
         "local_dir": local_dir,
         "prefix": prefix,

--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -21,8 +21,8 @@ config:
   storage_account: {{ include "stringSource" $azureBlobComputeLogManagerConfig.storageAccount }}
   container: {{ include "stringSource" $azureBlobComputeLogManagerConfig.container }}
 
-  {{- if $azureBlobComputeLogManagerConfig.secretKey }}
-  secret_key: {{ include "stringSource" $azureBlobComputeLogManagerConfig.secretKey }}
+  {{- if $azureBlobComputeLogManagerConfig.secretCredential }}
+  secret_credential: {{ $azureBlobComputeLogManagerConfig.secretCredential | toYaml | nindent 4 }}
   {{- end }}
 
   {{- if $azureBlobComputeLogManagerConfig.localDir }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -37,20 +37,17 @@
                     ],
                     "title": "Container"
                 },
-                "secretKey": {
+                "secretCredential": {
                     "anyOf": [
                         {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/$defs/Source"
+                            "type": "object"
                         },
                         {
                             "type": "null"
                         }
                     ],
                     "default": null,
-                    "title": "Secretkey"
+                    "title": "Secretcredential"
                 },
                 "defaultAzureCredential": {
                     "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -216,7 +216,7 @@ computeLogManager:
   #   azureBlobComputeLogManager:
   #     storageAccount: ~
   #     container: ~
-  #     secretKey: ~
+  #     secretCredential: ~
   #     defaultAzureCredential: ~
   #     localDir: ~
   #     prefix: ~

--- a/integration_tests/test_suites/dagster-azure-live-tests/azure_test_proj/defs.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/azure_test_proj/defs.py
@@ -1,0 +1,12 @@
+from dagster import AssetExecutionContext, asset
+
+
+@asset
+def my_asset(context: AssetExecutionContext) -> None:
+    for i in range(10):
+        print(f"Printing without context {i}")  # noqa: T201
+        context.log.info(f"Logging using context {i}")
+    try:
+        raise Exception("This is an exception")
+    except:
+        return

--- a/integration_tests/test_suites/dagster-azure-live-tests/dagster.yaml
+++ b/integration_tests/test_suites/dagster-azure-live-tests/dagster.yaml
@@ -1,0 +1,19 @@
+compute_logs:
+  module: dagster_azure.blob.compute_log_manager
+  class: AzureBlobComputeLogManager
+  config:
+    storage_account:
+      env: TEST_AZURE_STORAGE_ACCOUNT_ID
+    container: 
+      env: TEST_AZURE_CONTAINER_ID 
+    secret_credential: 
+      client_id: 
+        env: TEST_AZURE_CLIENT_ID
+      tenant_id: 
+        env: TEST_AZURE_TENANT_ID
+      client_secret: 
+        env: TEST_AZURE_CLIENT_SECRET
+    prefix: 
+      env: TEST_AZURE_LOG_PREFIX
+    local_dir: "/tmp/cool"
+    upload_interval: 30    

--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/conftest.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/conftest.py
@@ -1,0 +1,78 @@
+import os
+import shutil
+import signal
+import subprocess
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Generator, List
+
+import pytest
+import requests
+from dagster._core.test_utils import environ
+from dagster._time import get_current_timestamp
+
+
+def integration_test_dir() -> Path:
+    return Path(__file__).parent.parent
+
+
+def _dagster_is_ready(port: int) -> bool:
+    try:
+        response = requests.get(f"http://localhost:{port}")
+        return response.status_code == 200
+    except:
+        return False
+
+
+@pytest.fixture(name="dagster_home")
+def setup_dagster_home() -> Generator[str, None, None]:
+    """Instantiate a temporary directory to serve as the DAGSTER_HOME."""
+    with TemporaryDirectory() as tmpdir:
+        # Copy over dagster.yaml
+        shutil.copy2(integration_test_dir() / "dagster.yaml", tmpdir)
+        with environ({"DAGSTER_HOME": tmpdir}):
+            yield tmpdir
+
+
+@pytest.fixture
+def prefix_env() -> Generator[str, None, None]:
+    prefix = f"prefix_{uuid.uuid4().hex}"
+    with environ({"TEST_AZURE_LOG_PREFIX": prefix}):
+        yield prefix
+
+
+@pytest.fixture(name="dagster_dev")
+def setup_dagster(dagster_home: str, prefix_env: str) -> Generator[Any, None, None]:
+    with stand_up_dagster(["dagster", "dev", "-m", "azure_test_proj.defs"]) as process:
+        yield process
+
+
+@contextmanager
+def stand_up_dagster(
+    dagster_dev_cmd: List[str], port: int = 3000
+) -> Generator[subprocess.Popen, None, None]:
+    """Stands up a dagster instance using the dagster dev CLI. dagster_defs_path must be provided
+    by a fixture included in the callsite.
+    """
+    process = subprocess.Popen(
+        dagster_dev_cmd,
+        env=os.environ.copy(),
+        shell=False,
+        preexec_fn=os.setsid,  # noqa
+    )
+    try:
+        dagster_ready = False
+        initial_time = get_current_timestamp()
+        while get_current_timestamp() - initial_time < 60:
+            if _dagster_is_ready(port):
+                dagster_ready = True
+                break
+            time.sleep(1)
+
+        assert dagster_ready, "Dagster did not start within 30 seconds..."
+        yield process
+    finally:
+        os.killpg(process.pid, signal.SIGKILL)

--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+from typing import Generator
+
+import pytest
+from azure.identity import ClientSecretCredential
+from azure.storage.blob import ContainerClient
+from dagster_azure.blob.utils import create_blob_client
+
+
+@pytest.fixture
+def container_client() -> Generator[ContainerClient, None, None]:
+    yield create_blob_client(
+        storage_account="chriscomplogmngr",
+        credential=ClientSecretCredential(
+            tenant_id=os.environ["TEST_AZURE_TENANT_ID"],
+            client_id=os.environ["TEST_AZURE_CLIENT_ID"],
+            client_secret=os.environ["TEST_AZURE_CLIENT_SECRET"],
+        ),
+    ).get_container_client("mycontainer")
+
+
+def test_compute_log_manager(
+    dagster_dev: subprocess.Popen, container_client: ContainerClient, prefix_env: str
+) -> None:
+    subprocess.run(
+        ["dagster", "asset", "materialize", "--select", "my_asset", "-m", "azure_test_proj.defs"],
+        check=True,
+    )
+    blobs = list(container_client.list_blobs(name_starts_with=f"{prefix_env}/storage"))
+    assert len(blobs) == 2
+    assert len([blob for blob in blobs if blob.name.endswith(".err")]) == 1
+    assert len([blob for blob in blobs if blob.name.endswith(".out")]) == 1
+    stdout = container_client.download_blob(blob=blobs[0].name).readall().decode()
+    stderr = container_client.download_blob(blob=blobs[1].name).readall().decode()
+    assert stdout.count("Logging using context") == 10
+    assert stderr.count("Printing without context") == 10

--- a/integration_tests/test_suites/dagster-azure-live-tests/setup.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/setup.py
@@ -1,0 +1,12 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="azure-test-proj",
+    packages=find_packages(),
+    install_requires=[
+        "dagster",
+        "dagster-webserver",
+        "dagster-azure",
+    ],
+    extras_require={"test": ["pytest"]},
+)

--- a/integration_tests/test_suites/dagster-azure-live-tests/tox.ini
+++ b/integration_tests/test_suites/dagster-azure-live-tests/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+skipsdist = true
+
+[testenv]
+download = True
+passenv =
+    CI_*
+    COVERALLS_REPO_TOKEN
+    BUILDKITE*
+    TEST_AZURE*
+install_command = uv pip install {opts} {packages}
+deps =
+  -e ../../../python_modules/dagster[test]
+  -e ../../../python_modules/dagster-webserver
+  -e ../../../python_modules/dagster-test
+  -e ../../../python_modules/dagster-pipes
+  -e ../../../python_modules/dagster-graphql
+  -e ../../../python_modules/libraries/dagster-azure
+  -e .
+allowlist_externals =
+  /bin/bash
+  uv
+commands =
+  # We need to rebuild the UI to ensure that the dagster-webserver can run
+  make -C ../../.. rebuild_ui
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
+  pytest ./integration_tests --snapshot-warn-unused -vv -s {posargs}

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
@@ -31,6 +31,10 @@ class FakeBlobServiceClient:
     def containers(self):
         return self._containers
 
+    @property
+    def url(self):
+        return f"https://{self.account_name}.blob.core.windows.net"
+
     def get_container_client(self, container):
         return self._containers.setdefault(
             container, FakeBlobContainerClient(self.account_name, container)

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -57,7 +57,7 @@ def test_compute_log_manager(
                 container=container,
                 prefix="my_prefix",
                 local_dir=temp_dir,
-                secret_key=credential,
+                secret_credential=credential,
             )
             instance = DagsterInstance(
                 instance_type=InstanceType.PERSISTENT,
@@ -122,7 +122,10 @@ compute_logs:
   config:
     storage_account: "{storage_account}"
     container: {container}
-    secret_key: {credential}
+    secret_credential:
+        client_id: "{credential['client_id']}"
+        client_secret: "{credential['client_secret']}"
+        tenant_id: "{credential['tenant_id']}"
     local_dir: "/tmp/cool"
     prefix: "{prefix}"
 """
@@ -149,7 +152,7 @@ def test_prefix_filter(mock_create_blob_client, storage_account, container, cred
             container=container,
             prefix=blob_prefix,
             local_dir=temp_dir,
-            secret_key=credential,
+            secret_credential=credential,
         )
         log_key = ["arbitrary", "log", "key"]
         with manager.open_log_stream(log_key, ComputeIOType.STDERR) as write_stream:
@@ -178,7 +181,7 @@ def test_get_log_keys_for_log_key_prefix(
             container=container,
             prefix=blob_prefix,
             local_dir=temp_dir,
-            secret_key=credential,
+            secret_credential=credential,
         )
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 
@@ -254,7 +257,7 @@ class TestAzureComputeLogManager(TestComputeLogManager):
                 container=container,
                 prefix="my_prefix",
                 local_dir=temp_dir,
-                secret_key=credential,
+                secret_credential=credential,
             )
 
     # for streaming tests
@@ -283,7 +286,7 @@ class TestAzureComputeLogManager(TestComputeLogManager):
                 container=container,
                 prefix="my_prefix",
                 local_dir=temp_dir,
-                secret_key=credential,
+                secret_credential=credential,
                 upload_interval=1,
             )
 


### PR DESCRIPTION
## Summary & Motivation
Azure integrations aren't under live test anywhere. This fixes by introducing a test suite for running against live azure.

To start, test the compute log manager against live azure. 

I based a lot of these components on what we built for airlift/dlift - specifically fixtures for standing up airflow, dagster, etc. that could probably live in a shared module somewhere. 

An important consideration here is we don't want to take a dependency across all our builds on azure. So **this new test suite will only run when on a branch that touches dagster-azure, or on the nightly oss build.** 

## How I Tested These Changes
New tests
