### PR TITLE
[fix] Allow a backfill to target a selection of assets of which only a subset have backfill policies

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -197,19 +197,6 @@ _PartitionsDefKeyMapping = Dict[
 ]
 
 
-def _get_mapping_from_asset_partitions(
-    asset_partitions: AbstractSet[AssetKeyPartitionKey], asset_graph: BaseAssetGraph
-) -> _PartitionsDefKeyMapping:
-    mapping: _PartitionsDefKeyMapping = defaultdict(set)
-
-    for asset_partition in asset_partitions:
-        mapping[
-            asset_graph.get(asset_partition.asset_key).partitions_def, asset_partition.partition_key
-        ].add(asset_partition.asset_key)
-
-    return mapping
-
-
 def _get_mapping_from_entity_subsets(
     entity_subsets: Iterable[EntitySubset], asset_graph: BaseAssetGraph
 ) -> _PartitionsDefKeyMapping:
@@ -234,18 +221,6 @@ def _get_mapping_from_entity_subsets(
             mapping[partitions_def, None].add(key)
 
     return mapping
-
-
-def build_run_requests_from_asset_partitions(
-    asset_partitions: AbstractSet[AssetKeyPartitionKey],
-    asset_graph: BaseAssetGraph,
-    run_tags: Optional[Mapping[str, str]],
-) -> Sequence[RunRequest]:
-    return _build_run_requests_from_partitions_def_mapping(
-        _get_mapping_from_asset_partitions(asset_partitions, asset_graph),
-        asset_graph,
-        run_tags,
-    )
 
 
 def _build_backfill_request(
@@ -373,9 +348,7 @@ def build_run_requests_with_backfill_policies(
     asset_graph: BaseAssetGraph,
     dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
-    """If all assets have backfill policies, we should respect them and materialize them according
-    to their backfill policies.
-    """
+    """Build run requests for a selection of asset partitions based on the associated BackfillPolicies."""
     run_requests = []
 
     asset_partition_keys: Mapping[AssetKey, Set[str]] = {
@@ -406,9 +379,9 @@ def build_run_requests_with_backfill_policies(
         asset_check_keys = asset_graph.get_check_keys_for_assets(asset_keys)
         if partitions_def is None and partition_keys is not None:
             check.failed("Partition key provided for unpartitioned asset")
-        if partitions_def is not None and partition_keys is None:
+        elif partitions_def is not None and partition_keys is None:
             check.failed("Partition key missing for partitioned asset")
-        if partitions_def is None and partition_keys is None:
+        elif partitions_def is None and partition_keys is None:
             # non partitioned assets will be backfilled in a single run
             run_requests.append(
                 RunRequest(
@@ -416,6 +389,15 @@ def build_run_requests_with_backfill_policies(
                     asset_check_keys=list(asset_check_keys),
                     tags={},
                 )
+            )
+        elif backfill_policy is None:
+            # just use the normal single-partition behavior
+            entity_keys = cast(Set[EntityKey], asset_keys)
+            mapping: _PartitionsDefKeyMapping = {
+                (partitions_def, pk): entity_keys for pk in (partition_keys or [None])
+            }
+            run_requests.extend(
+                _build_run_requests_from_partitions_def_mapping(mapping, asset_graph, run_tags={})
             )
         else:
             run_requests.extend(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -25,7 +25,6 @@ import dagster._check as check
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import KeysAssetSelection
 from dagster._core.definitions.automation_tick_evaluation_context import (
-    build_run_requests_from_asset_partitions,
     build_run_requests_with_backfill_policies,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
@@ -1486,37 +1485,11 @@ def execute_asset_backfill_iteration_inner(
             f"The following assets were considered for materialization but not requested:\n\n{not_requested_str}"
         )
 
-    # check if all assets have backfill policies if any of them do, otherwise, raise error
-    asset_backfill_policies = [
-        asset_graph.get(asset_key).backfill_policy
-        for asset_key in {
-            asset_partition.asset_key for asset_partition in asset_partitions_to_request
-        }
-    ]
-    all_assets_have_backfill_policies = all(
-        backfill_policy is not None for backfill_policy in asset_backfill_policies
+    run_requests = build_run_requests_with_backfill_policies(
+        asset_partitions=asset_partitions_to_request,
+        asset_graph=asset_graph,
+        dynamic_partitions_store=instance_queryer,
     )
-    if all_assets_have_backfill_policies:
-        run_requests = build_run_requests_with_backfill_policies(
-            asset_partitions=asset_partitions_to_request,
-            asset_graph=asset_graph,
-            dynamic_partitions_store=instance_queryer,
-        )
-    else:
-        if not all(backfill_policy is None for backfill_policy in asset_backfill_policies):
-            # if some assets have backfill policies, but not all of them, raise error
-            raise DagsterBackfillFailedError(
-                "Either all assets must have backfill policies or none of them must have backfill"
-                " policies. To backfill these assets together, either add backfill policies to all"
-                " assets, or remove backfill policies from all assets."
-            )
-        # When any of the assets do not have backfill policies, we fall back to the default behavior of
-        # backfilling them partition by partition.
-        run_requests = build_run_requests_from_asset_partitions(
-            asset_partitions=asset_partitions_to_request,
-            asset_graph=asset_graph,
-            run_tags={},
-        )
 
     if request_roots:
         check.invariant(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -15,7 +15,6 @@ from dagster import (
     asset,
 )
 from dagster._core.definitions.partition import StaticPartitionsDefinition
-from dagster._core.errors import DagsterBackfillFailedError
 from dagster._core.execution.asset_backfill import AssetBackfillData, AssetBackfillStatus
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.tags import (
@@ -37,7 +36,7 @@ from dagster_tests.core_tests.execution_tests.test_asset_backfill import (
 )
 
 
-def test_asset_backfill_not_all_asset_have_backfill_policy():
+def test_asset_backfill_not_all_asset_have_backfill_policy() -> None:
     @asset(backfill_policy=None)
     def unpartitioned_upstream_of_partitioned():
         return 1
@@ -45,6 +44,7 @@ def test_asset_backfill_not_all_asset_have_backfill_policy():
     @asset(
         partitions_def=DailyPartitionsDefinition("2023-01-01"),
         backfill_policy=BackfillPolicy.single_run(),
+        deps=[unpartitioned_upstream_of_partitioned],
     )
     def upstream_daily_partitioned_asset():
         return 1
@@ -69,19 +69,35 @@ def test_asset_backfill_not_all_asset_have_backfill_policy():
         backfill_start_timestamp=get_current_timestamp(),
     )
 
-    with pytest.raises(
-        DagsterBackfillFailedError,
-        match=(
-            "Either all assets must have backfill policies or none of them must have backfill"
-            " policies"
-        ),
-    ):
-        execute_asset_backfill_iteration_consume_generator(
-            backfill_id="test_backfill_id",
-            asset_backfill_data=backfill_data,
-            asset_graph=asset_graph,
-            instance=DagsterInstance.ephemeral(),
-        )
+    instance = DagsterInstance.ephemeral()
+    _, materialized, failed = run_backfill_to_completion(
+        asset_graph,
+        assets_by_repo_name,
+        backfill_data=backfill_data,
+        fail_asset_partitions=set(),
+        instance=instance,
+    )
+
+    assert len(failed) == 0
+    assert {akpk.asset_key for akpk in materialized} == {
+        unpartitioned_upstream_of_partitioned.key,
+        upstream_daily_partitioned_asset.key,
+    }
+
+    runs = instance.get_runs(ascending=True)
+
+    # separate runs for the assets (different partitions_def / backfill policy)
+    assert len(runs) == 2
+
+    unpartitioned = runs[0]
+    assert unpartitioned.tags == {"dagster/backfill": "backfillid_x"}
+
+    partitioned = runs[1]
+    assert partitioned.tags.keys() == {
+        "dagster/asset_partition_range_end",
+        "dagster/asset_partition_range_start",
+        "dagster/backfill",
+    }
 
 
 def test_asset_backfill_parent_and_children_have_different_backfill_policy():


### PR DESCRIPTION
## Summary & Motivation

As title -- we were unnecessarily forking these code paths, which limited a pretty easy to support bit of functionality

## How I Tested These Changes

## Changelog

Previously, asset backfills could only target selections of assets in which all assets had a `BackfillPolicy`, or none of them did. Mixed selections are now supported.
