### PR TITLE
Send back the RepositoryPythonOrigin on job subset grpc calls, use it in the resulting created RemoteJob

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -96,6 +96,7 @@ from dagster._core.definitions.time_window_partitions import TimeWindowPartition
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.origin import RepositoryPythonOrigin
 from dagster._core.snap import JobSnap
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
@@ -433,6 +434,7 @@ class RemoteJobSubsetResult:
     success: bool
     error: Optional[SerializableErrorInfo] = None
     job_data_snap: Optional[JobDataSnap] = None
+    repository_python_origin: Optional[RepositoryPythonOrigin] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -27,7 +27,7 @@ from dagster._core.definitions.partition import (
     PartitionedConfig,
     PartitionsDefinition,
 )
-from dagster._core.definitions.reconstruct import ReconstructableJob
+from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.sensor_definition import SensorEvaluationContext
 from dagster._core.errors import (
@@ -274,6 +274,7 @@ def start_run_in_subprocess(
 
 def get_external_pipeline_subset_result(
     repo_def: RepositoryDefinition,
+    recon_repo: ReconstructableRepository,
     job_name: str,
     op_selection: Optional[Sequence[str]],
     asset_selection: Optional[AbstractSet[AssetKey]],
@@ -290,7 +291,11 @@ def get_external_pipeline_subset_result(
         job_data_snap = JobDataSnap.from_job_def(
             definition, include_parent_snapshot=include_parent_snapshot
         )
-        return RemoteJobSubsetResult(success=True, job_data_snap=job_data_snap)
+        return RemoteJobSubsetResult(
+            success=True,
+            job_data_snap=job_data_snap,
+            repository_python_origin=recon_repo.get_python_origin(),
+        )
     except Exception:
         return RemoteJobSubsetResult(
             success=False, error=serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -1,10 +1,13 @@
+import json
 import sys
 
+import dagster._check as check
 import pytest
 from dagster._api.snapshot_job import sync_get_external_job_subset_grpc
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.remote_representation.external_data import RemoteJobSubsetResult
 from dagster._core.remote_representation.handle import JobHandle
+from dagster._core.test_utils import environ
 from dagster._grpc.types import JobSubsetSnapshotArgs
 from dagster._serdes import deserialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -30,6 +33,32 @@ def test_job_snapshot_api_grpc(instance):
         assert isinstance(remote_job_subset_result, RemoteJobSubsetResult)
         assert remote_job_subset_result.success is True
         assert remote_job_subset_result.job_data_snap.name == "foo"  # pyright: ignore[reportOptionalMemberAccess]
+        assert (
+            remote_job_subset_result.repository_python_origin
+            == code_location.get_repository("bar_repo").handle.repository_python_origin
+        )
+
+
+def test_job_snapshot_api_grpc_with_container_context(instance):
+    container_context = {"k8s": {"namespace": "foo"}}
+    with environ({"DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT": json.dumps(container_context)}):
+        with get_bar_repo_code_location(instance) as code_location:
+            assert code_location.container_context == container_context
+            job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
+            api_client = code_location.client
+
+            remote_job_subset_result = _test_job_subset_grpc(job_handle, api_client)
+            assert isinstance(remote_job_subset_result, RemoteJobSubsetResult)
+            assert remote_job_subset_result.success is True
+            assert check.not_none(remote_job_subset_result.job_data_snap).name == "foo"
+            assert (
+                remote_job_subset_result.repository_python_origin
+                == code_location.get_repository("bar_repo").handle.repository_python_origin
+            )
+            assert (
+                check.not_none(remote_job_subset_result.repository_python_origin).container_context
+                == container_context
+            )
 
 
 def test_job_snapshot_deserialize_error(instance):


### PR DESCRIPTION
Summary:
This is intended to guard against a class of issues where you make a change to your code that introduces a new asset but the daemon is using slightly out of date snapshots - so we might end up launching a run on the previous image targeting assets or asset checks that don't exist yet

It doesn't perfectly guard against all classes of issues (for example, the code updating between generating the job snapshot and the execution plan snapshot, or jobs without subsets) but should help in many cases.

## How I Tested These Changes
BK, manually test going from one asset to two assets with a sensor targeting them and see the image change immediately.

## Changelog

Fixed an race condition where immediately after adding a new asset to the graph, a freshness check sensor targeting that asset might raise an InvalidSubsetError in its first one.
