### PR TITLE
[dagster-azure] Generate URL from compute log manager

### DIFF
--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
@@ -4,34 +4,69 @@ from typing import Generator
 
 import pytest
 from azure.identity import ClientSecretCredential
-from azure.storage.blob import ContainerClient
+from azure.storage.blob import BlobClient, ContainerClient
+from dagster import (
+    DagsterEventType,
+    DagsterInstance,
+    EventRecordsFilter,
+    _check as check,
+)
 from dagster_azure.blob.utils import create_blob_client
 
 
 @pytest.fixture
-def container_client() -> Generator[ContainerClient, None, None]:
+def credentials() -> ClientSecretCredential:
+    return ClientSecretCredential(
+        tenant_id=os.environ["TEST_AZURE_TENANT_ID"],
+        client_id=os.environ["TEST_AZURE_CLIENT_ID"],
+        client_secret=os.environ["TEST_AZURE_CLIENT_SECRET"],
+    )
+
+
+@pytest.fixture
+def container_client(credentials: ClientSecretCredential) -> Generator[ContainerClient, None, None]:
     yield create_blob_client(
         storage_account="chriscomplogmngr",
-        credential=ClientSecretCredential(
-            tenant_id=os.environ["TEST_AZURE_TENANT_ID"],
-            client_id=os.environ["TEST_AZURE_CLIENT_ID"],
-            client_secret=os.environ["TEST_AZURE_CLIENT_SECRET"],
-        ),
+        credential=credentials,
     ).get_container_client("mycontainer")
 
 
 def test_compute_log_manager(
-    dagster_dev: subprocess.Popen, container_client: ContainerClient, prefix_env: str
+    dagster_dev: subprocess.Popen,
+    container_client: ContainerClient,
+    prefix_env: str,
+    credentials: ClientSecretCredential,
 ) -> None:
     subprocess.run(
         ["dagster", "asset", "materialize", "--select", "my_asset", "-m", "azure_test_proj.defs"],
         check=True,
     )
-    blobs = list(container_client.list_blobs(name_starts_with=f"{prefix_env}/storage"))
-    assert len(blobs) == 2
-    assert len([blob for blob in blobs if blob.name.endswith(".err")]) == 1
-    assert len([blob for blob in blobs if blob.name.endswith(".out")]) == 1
-    stdout = container_client.download_blob(blob=blobs[0].name).readall().decode()
-    stderr = container_client.download_blob(blob=blobs[1].name).readall().decode()
-    assert stdout.count("Logging using context") == 10
-    assert stderr.count("Printing without context") == 10
+    logs_captured_data = check.not_none(
+        DagsterInstance.get()
+        .get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.LOGS_CAPTURED,
+            )
+        )[0]
+        .event_log_entry.dagster_event
+    ).logs_captured_data
+
+    assert logs_captured_data.external_stderr_url
+    assert logs_captured_data.external_stdout_url
+
+    stderr = (
+        BlobClient.from_blob_url(logs_captured_data.external_stderr_url, credential=credentials)
+        .download_blob()
+        .readall()
+        .decode()
+    )
+
+    stdout = (
+        BlobClient.from_blob_url(logs_captured_data.external_stdout_url, credential=credentials)
+        .download_blob()
+        .readall()
+        .decode()
+    )
+
+    assert stdout.count("Printing without context") == 10
+    assert stderr.count("Logging using context") == 10

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -1,7 +1,7 @@
 import os
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Iterator, Mapping, Optional, Sequence
 
 import dagster._seven as seven
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
@@ -18,7 +18,7 @@ from dagster._core.storage.cloud_storage_compute_log_manager import (
     CloudStorageComputeLogManager,
     PollingComputeLogSubscriptionManager,
 )
-from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._core.storage.compute_log_manager import CapturedLogContext, ComputeIOType
 from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
@@ -81,7 +81,9 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         prefix="dagster",
         upload_interval=None,
         default_azure_credential=None,
+        show_url_only=True,
     ):
+        self._show_url_only = check.bool_param(show_url_only, "show_url_only")
         self._storage_account = check.str_param(storage_account, "storage_account")
         self._container = check.str_param(container, "container")
         self._blob_prefix = self._clean_prefix(check.str_param(prefix, "prefix"))
@@ -110,12 +112,6 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         self._subscription_manager = PollingComputeLogSubscriptionManager(self)
         self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-
-    @contextmanager
-    def _watch_logs(self, dagster_run, step_key=None):
-        # proxy watching to the local compute log manager, interacting with the filesystem
-        with self.local_manager._watch_logs(dagster_run, step_key):  # noqa: SLF001
-            yield
 
     @property
     def inst_data(self):
@@ -240,6 +236,21 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         url = blob.url + "?" + sas
         self._download_urls[blob_key] = url
         return url
+
+    @contextmanager
+    def capture_logs(self, log_key: Sequence[str]) -> Iterator[CapturedLogContext]:
+        with super().capture_logs(log_key) as local_context:
+            if not self._show_url_only:
+                yield local_context
+            else:
+                out_key = self._blob_key(log_key, ComputeIOType.STDOUT)
+                err_key = self._blob_key(log_key, ComputeIOType.STDERR)
+                azure_base_url = self._container_client.url
+                out_url = f"{azure_base_url}/{out_key}"
+                err_url = f"{azure_base_url}/{err_key}"
+                yield CapturedLogContext(
+                    local_context.log_key, external_stdout_url=out_url, external_stderr_url=err_url
+                )
 
     def _request_user_delegation_key(
         self,

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
@@ -66,6 +66,10 @@ class FakeBlobContainerClient:
     def container_name(self):
         return self._container_name
 
+    @property
+    def url(self):
+        return f"https://{self.account_name}.blob.core.windows.net/{self.container_name}"
+
     def keys(self):
         return self._container.keys()
 


### PR DESCRIPTION
## Summary & Motivation

See comments for additional context.

This PR changes the Azure compute log manager to generate a URL by default instead of capturing the logs.

There's a few considerations here:
- If the blob storage is private, the url will not be publicly accessible. Instead you'll have to go to the azure portal and type in the url - I think this is fine to start.
- We need to make this configurable.

## How I Tested These Changes
Switches the tests to pull out the stdout/stderr urls and read the results.
**This changes the test behavior from the previous PR**.  We were previously reading stdout and stderr in reverse (pulling them out of a list of arbitrary order instead of ensuring we were reading the correct file). So the stdout and stderr readouts flip in this PR, as is to be expected.