### PR TITLE
Add pyopenssl pin to dagster-snowflake to work around breaking upstream package change

### DIFF
--- a/examples/temp_pins.txt
+++ b/examples/temp_pins.txt
@@ -14,3 +14,6 @@ responses==0.23.1
 
 # pydantic 2.9.0 release briefly broke dagster
 pydantic<2.9.0
+
+# https://github.com/snowflakedb/snowflake-connector-python/issues/2109
+pyOpenSSL>=22.1.0

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -37,6 +37,9 @@ setup(
     install_requires=[
         f"dagster{pin}",
         "snowflake-connector-python>=3.4.0",
+        # Workaround for incorrect pin in the snowflake-connector-python package
+        # See https://github.com/snowflakedb/snowflake-connector-python/issues/2109
+        "pyOpenSSL>=22.1.0",
     ],
     extras_require={
         "snowflake.sqlalchemy": [


### PR DESCRIPTION
Summary:
Workaround for breaking pin change in the snowflake-connector-python package - see linked issue

Test Plan:
BK (assets_smoke_test should now pass)

