### PR TITLE
[components] Change registered component name to just Component.registered_name

### DIFF
--- a/python_modules/dagster/dagster/_components/__init__.py
+++ b/python_modules/dagster/dagster/_components/__init__.py
@@ -248,6 +248,8 @@ class ComponentRegistry:
         self._components: Dict[str, Type[Component]] = {}
 
     def register(self, name: str, component: Type[Component]) -> None:
+        if name in self._components:
+            raise DagsterError(f"There is an existing component registered under {name}")
         self._components[name] = component
 
     def has(self, name: str) -> bool:
@@ -329,5 +331,4 @@ def register_components_in_module(registry: ComponentRegistry, root_module: Modu
         for component in find_subclasses_in_module(module, (Component,)):
             if component is Component:
                 continue
-            name = f"{module.__name__}[{component.registered_name()}]"
-            registry.register(name, component)
+            registry.register(component.registered_name(), component)

--- a/python_modules/dagster/dagster/_components/cli/generate.py
+++ b/python_modules/dagster/dagster/_components/cli/generate.py
@@ -68,7 +68,7 @@ def generate_component_type_command(name: str) -> None:
         sys.exit(1)
 
     context = CodeLocationProjectContext.from_path(os.getcwd())
-    if context.has_component_type(f"{context.component_types_root_module}.{name}[{name}]"):
+    if context.has_component_type(name):
         click.echo(click.style(f"A component type named `{name}` already exists.", fg="red"))
         sys.exit(1)
 

--- a/python_modules/dagster/dagster/_generate/generate.py
+++ b/python_modules/dagster/dagster/_generate/generate.py
@@ -62,7 +62,15 @@ def generate_component_instance(root_path: str, name: str, component_type: Type[
     click.echo(f"Creating a Dagster component instance at {root_path}/{name}.py.")
 
     component_instance_root_path = os.path.join(root_path, name)
-    os.mkdir(component_instance_root_path)
+    generate_project(
+        path=component_instance_root_path,
+        name_placeholder="COMPONENT_INSTANCE_NAME_PLACEHOLDER",
+        templates_path=os.path.join(
+            os.path.dirname(__file__), "templates", "COMPONENT_INSTANCE_NAME_PLACEHOLDER"
+        ),
+        project_name=name,
+        component_type=component_type.registered_name(),
+    )
     with pushd(component_instance_root_path):
         component_type.generate_files()
 

--- a/python_modules/dagster/dagster_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_generate_commands.py
@@ -153,7 +153,7 @@ def test_generate_component_type_success():
         assert Path("bar/lib/baz.py").exists()
         _assert_module_imports("bar.lib.baz")
         context = CodeLocationProjectContext.from_path(os.getcwd())
-        assert context.has_component_type("bar.lib.baz[baz]")
+        assert context.has_component_type("baz")
 
 
 def test_generate_component_type_outside_code_location_fails():
@@ -178,7 +178,7 @@ def test_generate_component_success():
     runner = CliRunner()
     _ensure_cwd_on_sys_path()
     with isolated_example_code_location_bar_with_component_type_baz(runner):
-        result = runner.invoke(generate_component_command, ["bar.lib.baz[baz]", "qux"])
+        result = runner.invoke(generate_component_command, ["baz", "qux"])
         assert result.exit_code == 0
         assert Path("bar/components/qux").exists()
         assert Path("bar/components/qux/sample.py").exists()
@@ -187,7 +187,7 @@ def test_generate_component_success():
 def test_generate_component_outside_code_location_fails():
     runner = CliRunner()
     with isolated_example_deployment_foo(runner):
-        result = runner.invoke(generate_component_command, ["bar.lib.baz[baz]", "qux"])
+        result = runner.invoke(generate_component_command, ["baz", "qux"])
         assert result.exit_code != 0
         assert "must be run inside a Dagster code location project" in result.output
 
@@ -196,8 +196,8 @@ def test_generate_component_already_exists_fails():
     runner = CliRunner()
     _ensure_cwd_on_sys_path()
     with isolated_example_code_location_bar_with_component_type_baz(runner):
-        result = runner.invoke(generate_component_command, ["bar.lib.baz[baz]", "qux"])
+        result = runner.invoke(generate_component_command, ["baz", "qux"])
         assert result.exit_code == 0
-        result = runner.invoke(generate_component_command, ["bar.lib.baz[baz]", "qux"])
+        result = runner.invoke(generate_component_command, ["baz", "qux"])
         assert result.exit_code != 0
         assert "already exists" in result.output


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, component types would get registered as `module.path[component-type-name]`. This PR changes it to just `component-type-name`. I don't think this is a final decision, but this is a useful simplification for now since it allows us to punt on decisions about the module name for locally defined components.

## How I Tested These Changes

Existing test suite.