### PR TITLE
[components] Remove nested component concept, pass path directly through init_context

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yml
@@ -1,13 +1,11 @@
-component_type: collection
+component_type: python_script_collection
 
 component_params:
-  component_type: python_script
-  components:
-    script_one:
-      assets:
-        - key: a
-        - key: b
-          deps: [up1, up2]
-    script_three:
-      assets:
-        - key: override_key
+  script_one:
+    assets:
+      - key: a
+      - key: b
+        deps: [up1, up2]
+  script_three:
+    assets:
+      - key: override_key

--- a/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
@@ -2,19 +2,16 @@ from pathlib import Path
 
 from dagster._components import (
     Component,
-    ComponentCollection,
     ComponentInitContext,
     ComponentLoadContext,
     build_defs_from_path,
 )
-from dagster._components.impls.python_script_component import PythonScript
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._components.impls.python_script_component import PythonScriptCollection
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
-init_context = ComponentInitContext()
-init_context.registry.register("python_script", PythonScript)
-init_context.registry.register("collection", ComponentCollection)
+init_context = ComponentInitContext(path=LOCATION_PATH / "scripts")
+init_context.registry.register("python_script_collection", PythonScriptCollection)
 
 
 def _assert_assets(component: Component, expected_assets: int) -> None:
@@ -24,75 +21,35 @@ def _assert_assets(component: Component, expected_assets: int) -> None:
     assert result.success
 
 
-def test_individual_python() -> None:
-    component = PythonScript(LOCATION_PATH / "scripts" / "script_one.py")
-    _assert_assets(component, 1)
-
-
-def test_individual_spec_override_python() -> None:
-    component = PythonScript(
-        path=LOCATION_PATH / "scripts" / "script_one.py",
-        specs=[AssetSpec("a"), AssetSpec("b", deps=["up1", "up2"])],
-    )
-    _assert_assets(component, 4)
-
-
-def test_individual_config() -> None:
-    component = PythonScript.from_component_params(
-        LOCATION_PATH / "scripts" / "script_one.py", component_params=None, context=init_context
-    )
-    _assert_assets(component, 1)
-
-
-def test_individual_spec_override_config() -> None:
-    component = PythonScript.from_component_params(
-        LOCATION_PATH / "scripts" / "script_one.py",
-        component_params={
-            "assets": [
-                {"key": "a"},
-                {"key": "b", "deps": ["up1", "up2"]},
-            ]
-        },
-        context=init_context,
-    )
-    _assert_assets(component, 4)
-
-
-def test_collection_python() -> None:
-    component = ComponentCollection(
-        PythonScript, [PythonScript(path) for path in (LOCATION_PATH / "scripts").rglob("*.py")]
-    )
+def test_python_native() -> None:
+    component = PythonScriptCollection(LOCATION_PATH / "scripts")
     _assert_assets(component, 3)
 
 
-def test_collection_config() -> None:
-    component = ComponentCollection.from_component_params(
-        path=LOCATION_PATH / "scripts",
+def test_python_params() -> None:
+    component = PythonScriptCollection.from_component_params(
+        init_context=init_context,
         component_params={
-            "component_type": "python_script",
-            "components": {
-                "script_one": {
-                    "assets": [
-                        {"key": "a"},
-                        {"key": "b", "deps": ["up1", "up2"]},
-                    ]
-                },
-                "script_three": {"assets": [{"key": "key_override"}]},
+            "script_one": {
+                "assets": [
+                    {"key": "a"},
+                    {"key": "b", "deps": ["up1", "up2"]},
+                ]
             },
+            "script_three": {"assets": [{"key": "key_override"}]},
         },
-        context=init_context,
     )
     _assert_assets(component, 6)
 
 
-def test_collection_from_path() -> None:
-    components = init_context.load(LOCATION_PATH)
+def test_load_from_path() -> None:
+    components = init_context.load()
     assert len(components) == 1
 
     _assert_assets(components[0], 6)
 
 
-def test_load_and_build_from_path() -> None:
+def test_build_from_path() -> None:
     defs = build_defs_from_path(
         path=LOCATION_PATH,
         resources={"pipes_client": PipesSubprocessClient()},


### PR DESCRIPTION
## Summary & Motivation

This removes the ComponentCollection concept, and replaces it with a FileCollectionComponent, which is just a subclass that makes it easier to do per-file operations.

My feeling was that the ComponentCollection thing was over-specified, and added a weird layer of indirection to the system. As can be seen in the diff, this change made implementation a fair amount simpler for a variety of things, while not making the PythonScript component implementation much different.

The key thing here is that it feels very unlikely that someone would want to use a given component type both within and without of a Collection wrapper (i.e. if it's designed to go inside a Collection, it will always be in a collection). If that's the case then we should just have them define the collection component directly.

## How I Tested These Changes

