### PR TITLE
[record] allow iteration in debugger

### DIFF
--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -128,8 +128,11 @@ def _namedtuple_record_transform(
     # parents if both are records
     base.__repr__ = _repr
     nt_iter = base.__iter__
-    base.__iter__ = _banned_iter
-    base.__getitem__ = _banned_idx
+
+    # disable iteration unless the debugger is running which uses iteration to display values
+    if not os.getenv("DEBUGPY_RUNNING"):
+        base.__iter__ = _banned_iter
+        base.__getitem__ = _banned_idx
 
     # these will override an implementation on the class if it exists
     new_class_dict = {


### PR DESCRIPTION
Currently `@record` objects do not display nicely in the vscode debugger since it tries to iterate over namedtuples to display all their fields. 

To fix that this PR just leaves iteration on when a debugger env var is present. 

## How I Tested These Changes

pause in the VSCode debugger and be able to see the values inside a `@record` 
