### PR TITLE
[components] Add @global_component decorator to register globally available components

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -625,6 +625,11 @@ from dagster.version import __version__ as __version__
 
 # ruff: isort: split
 
+# Ensure that global components are available. They need to be loaded in order to register.
+import dagster._components.impls  # noqa: F401
+
+# ruff: isort: split
+
 # ########################
 # ##### DYNAMIC IMPORTS
 # ########################

--- a/python_modules/dagster/dagster/_components/impls/__init__.py
+++ b/python_modules/dagster/dagster/_components/impls/__init__.py
@@ -1,0 +1,3 @@
+from dagster._components.impls.python_script_component import (
+    PythonScriptCollection as PythonScriptCollection,
+)

--- a/python_modules/dagster/dagster/_components/impls/python_script_component.py
+++ b/python_modules/dagster/dagster/_components/impls/python_script_component.py
@@ -4,7 +4,12 @@ from typing import Any, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, TypeAdapter
 
-from dagster._components import ComponentInitContext, ComponentLoadContext, FileCollectionComponent
+from dagster._components import (
+    ComponentInitContext,
+    ComponentLoadContext,
+    FileCollectionComponent,
+    global_component,
+)
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
@@ -37,6 +42,7 @@ class PythonScriptParams(BaseModel):
     assets: Sequence[AssetSpecModel]
 
 
+@global_component
 class PythonScriptCollection(FileCollectionComponent):
     params_schema = Mapping[str, PythonScriptParams]
 

--- a/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_python_script_component.py
@@ -22,7 +22,7 @@ def _assert_assets(component: Component, expected_assets: int) -> None:
 
 
 def test_python_native() -> None:
-    component = PythonScriptCollection(LOCATION_PATH / "scripts")
+    component = PythonScriptCollection(dirpath=LOCATION_PATH / "scripts")
     _assert_assets(component, 3)
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/test_registration.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_registration.py
@@ -1,0 +1,30 @@
+import pytest
+from dagster._components import Component, ComponentRegistry, global_component
+from dagster._components.impls.python_script_component import PythonScriptCollection
+from dagster._core.errors import DagsterInvalidDefinitionError
+
+
+def test_global_component_registration():
+    global_registry = ComponentRegistry.get_global()
+    try:
+
+        @global_component
+        class MyGlobalComponent(Component):
+            pass
+
+        assert global_registry.get(MyGlobalComponent.registered_name()) is MyGlobalComponent
+    finally:
+        ComponentRegistry.get_global().unregister(MyGlobalComponent.registered_name())
+
+
+def test_global_component_registration_fails_not_a_component():
+    with pytest.raises(DagsterInvalidDefinitionError, match="is not a subclass of Component"):
+
+        @global_component  # type: ignore
+        class NotAComponent:
+            pass
+
+
+def test_known_global_components():
+    global_registry = ComponentRegistry.get_global()
+    assert global_registry.get("python_script_collection") is PythonScriptCollection


### PR DESCRIPTION
## Summary & Motivation

This adds a `@global_component` decorator that registers components in the global component registry. This has the effect of globally registering a component when the module containing it is loaded.

Fro third party non-local components, we'll want to use entry point registration, but this is an appropriate mechanism to make any built-in components we want to define always available. For now I've attached it to the `PythonScriptCollection` component added by @OwenKephart.

## How I Tested These Changes

New unit tests.