### PR TITLE
[azure-docs][rfc] docs on setting up AKS agent

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -548,6 +548,16 @@
               {
                 "title": "Setting environment variables",
                 "path": "/dagster-plus/managing-deployments/setting-environment-variables-agents"
+              },
+              {
+                "title": "Deploying on Azure: Full guide",
+                "path": "/dagster-plus/deployment/azure/overview",
+                "children": [
+                  {
+                    "title": "Part 1: Setting up an AKS agent.",
+                    "path": "/dagster-plus/deployment/azure/aks-agent"
+                  }
+                ]
               }
             ]
           }

--- a/docs/content/dagster-plus/deployment/azure/aks-agent.mdx
+++ b/docs/content/dagster-plus/deployment/azure/aks-agent.mdx
@@ -1,0 +1,40 @@
+# Dagster+ on Azure - Quickstart Guide
+
+This guide will walk you through deploying a Dagster+ agent on an Azure Kubernetes Service (AKS) cluster.
+
+This guide is intended to be a quickstart, and you should always defer to organization-specific guidelines for creating and managing new infrastructure.
+
+We'll start from a brand new organization in Dagster+, and finish with a full hybrid deployment of Dagster+ using Azure infrastructure.
+
+## Prerequisites
+
+To complete the steps in this guide, you'll need:
+
+- The azure CLI installed on your machine. You can download it [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
+- `kubectl` installed on your machine. You can download it [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+- `helm` installed on your machine. You can download it [here](https://helm.sh/docs/intro/install/).
+- An existing AKS cluster. If you need to create a new AKS cluster, refer to the [Azure documentation](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-portal?tabs=azure-cli).
+- A Dagster+ organization, with an agent token for that organization.
+
+## Step 1: Generate a Dagster+ agent token.
+
+<GenerateAgentToken />
+
+## Step 2: Log in to your AKS cluster.
+
+We'll use the azure CLI to log in to your AKS cluster. Run the following command and follow the prompts to log in.
+
+```bash
+az login
+az aks get-credentials --resource-group <your-resource-group> --name <your-aks-cluster>
+```
+
+We should now be able to verify our installation by running a command that tells us the current context of our kubectl installation. We'd expect it to output the name of the AKS cluster.
+
+```bash
+kubectl config current-context
+```
+
+## Step 3: Install the Dagster+ agent on the AKS cluster.
+
+Next, we'll install the agent helm chart. You should be able to follow the guide [here](/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent) to install the agent on the AKS cluster.

--- a/docs/content/dagster-plus/deployment/azure/overview.mdx
+++ b/docs/content/dagster-plus/deployment/azure/overview.mdx
@@ -1,0 +1,10 @@
+# Deploying Dagster+ hybrid on Azure
+
+This guide will walk you through deploying Dagster+ on Azure. We'll start from a brand new organization in Dagster+, and finish with a full hybrid deployment of Dagster+ using Azure infrastructure.
+
+<ArticleList>
+  <ArticleListItem
+    title="Step 1: Deploy an Azure Kubernetes Service (AKS) agent"
+    href="/dagster-plus/deployment/azure/aks-agent"
+  ></ArticleListItem>
+</ArticleList>


### PR DESCRIPTION
This PR is the first in a stack creating a "zero to one" guide for deploying Dagster on azure infrastructure. The idea is to make Dagster on azure feel more first class and provide a richly linked, linear, guided experience for setting up a deployment. Everything from initial agent setup to CI/CD to compute logs.
## Summary & Motivation
Adds initial docs on setting up an AKS agent. Includes the azure specific incantations necessary to get kubectl working + stand up the helm chart on an AKS cluster (including perms).

I would like someone more knowledgeable than me on K8s best practices to vet what I've written here and make sure we're not walking people into security issues.