### PR TITLE
Add a thread pool to process backfills in parallel

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -992,6 +993,7 @@ def execute_asset_backfill_iteration(
     logger: logging.Logger,
     workspace_process_context: IWorkspaceProcessContext,
     instance: DagsterInstance,
+    submit_threadpool_executor: Optional[ThreadPoolExecutor],
 ) -> Iterable[None]:
     """Runs an iteration of the backfill, including submitting runs and updating the backfill object
     in the DB.

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -3,7 +3,6 @@ import logging
 import os
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -993,7 +992,6 @@ def execute_asset_backfill_iteration(
     logger: logging.Logger,
     workspace_process_context: IWorkspaceProcessContext,
     instance: DagsterInstance,
-    submit_threadpool_executor: Optional[ThreadPoolExecutor],
 ) -> Iterable[None]:
     """Runs an iteration of the backfill, including submitting runs and updating the backfill object
     in the DB.

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -831,6 +831,9 @@ class DagsterInstance(DynamicPartitionsStore):
             return self._settings.get(settings_key)
         return {}
 
+    def get_backfill_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("backfills")
+
     def get_scheduler_settings(self) -> Mapping[str, Any]:
         return self.get_settings("schedules")
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2,7 +2,6 @@ import logging
 import logging.config
 import os
 import sys
-import threading
 import warnings
 import weakref
 from abc import abstractmethod
@@ -103,8 +102,6 @@ IS_AIRFLOW_INGEST_PIPELINE_STR = "is_airflow_ingest_pipeline"
 # actually using this constants.
 RUNLESS_RUN_ID = ""
 RUNLESS_JOB_NAME = ""
-
-_RUN_LOCK = threading.Lock()
 
 if TYPE_CHECKING:
     from dagster._core.debug import DebugRunPayload
@@ -2692,10 +2689,9 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
         try:
-            with _RUN_LOCK:
-                submitted_run = self.run_coordinator.submit_run(
-                    SubmitRunContext(run, workspace=workspace)
-                )
+            submitted_run = self.run_coordinator.submit_run(
+                SubmitRunContext(run, workspace=workspace)
+            )
         except:
             from dagster._core.events import EngineEventData
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2,6 +2,7 @@ import logging
 import logging.config
 import os
 import sys
+import threading
 import warnings
 import weakref
 from abc import abstractmethod
@@ -102,6 +103,8 @@ IS_AIRFLOW_INGEST_PIPELINE_STR = "is_airflow_ingest_pipeline"
 # actually using this constants.
 RUNLESS_RUN_ID = ""
 RUNLESS_JOB_NAME = ""
+
+_RUN_LOCK = threading.Lock()
 
 if TYPE_CHECKING:
     from dagster._core.debug import DebugRunPayload
@@ -2689,9 +2692,10 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
         try:
-            submitted_run = self.run_coordinator.submit_run(
-                SubmitRunContext(run, workspace=workspace)
-            )
+            with _RUN_LOCK:
+                submitted_run = self.run_coordinator.submit_run(
+                    SubmitRunContext(run, workspace=workspace)
+                )
         except:
             from dagster._core.events import EngineEventData
 

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -267,6 +267,20 @@ def get_tick_retention_settings(
         return default_retention_settings
 
 
+def backfills_daemon_config() -> Field:
+    return Field(
+        {
+            "use_threads": Field(Bool, is_required=False, default_value=False),
+            "num_workers": Field(
+                int,
+                is_required=False,
+                description="How many threads to use to process multiple backfills in parallel",
+            ),
+        },
+        is_required=False,
+    )
+
+
 def sensors_daemon_config() -> Field:
     return Field(
         {
@@ -389,6 +403,7 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         ),
         "secrets": secrets_loader_config_schema(),
         "retention": retention_config_schema(),
+        "backfills": backfills_daemon_config(),
         "sensors": sensors_daemon_config(),
         "schedules": schedules_daemon_config(),
         "auto_materialize": Field(

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -451,6 +451,7 @@ class InstanceRef(
             "run_retries",
             "code_servers",
             "retention",
+            "backfills",
             "sensors",
             "schedules",
             "nux",

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -72,7 +72,7 @@ from dagster._daemon.utils import DaemonErrorCapture
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._time import get_current_datetime, get_current_timestamp
-from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash
+from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash, materialize
 
 _LEGACY_PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR_NEW"
@@ -655,24 +655,6 @@ class AssetDaemon(DagsterDaemon):
 
         return result
 
-    def _process_auto_materialize_tick(
-        self,
-        workspace_process_context: IWorkspaceProcessContext,
-        repository: Optional[RemoteRepository],
-        sensor: Optional[RemoteSensor],
-        debug_crash_flags: SingleInstigatorDebugCrashFlags,
-        submit_threadpool_executor: Optional[ThreadPoolExecutor],
-    ):
-        return list(
-            self._process_auto_materialize_tick_generator(
-                workspace_process_context,
-                repository,
-                sensor,
-                debug_crash_flags,
-                submit_threadpool_executor=submit_threadpool_executor,
-            )
-        )
-
     def _process_auto_materialize_tick_generator(
         self,
         workspace_process_context: IWorkspaceProcessContext,
@@ -877,6 +859,8 @@ class AssetDaemon(DagsterDaemon):
             )
 
         yield error_info
+
+    _process_auto_materialize_tick = materialize(_process_auto_materialize_tick_generator)
 
     def _evaluate_auto_materialize_tick(
         self,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -72,7 +72,7 @@ from dagster._daemon.utils import DaemonErrorCapture
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._time import get_current_datetime, get_current_timestamp
-from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash, materialize
+from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash, return_as_list
 
 _LEGACY_PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR_NEW"
@@ -860,7 +860,7 @@ class AssetDaemon(DagsterDaemon):
 
         yield error_info
 
-    _process_auto_materialize_tick = materialize(_process_auto_materialize_tick_generator)
+    _process_auto_materialize_tick = return_as_list(_process_auto_materialize_tick_generator)
 
     def _evaluate_auto_materialize_tick(
         self,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -19,6 +19,7 @@ from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._time import get_current_datetime, get_current_timestamp
+from dagster._utils import materialize
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -173,7 +174,7 @@ def execute_backfill_jobs(
 
                     if backfill.is_asset_backfill:
                         future = threadpool_executor.submit(
-                            execute_asset_backfill_iteration,
+                            materialize(execute_asset_backfill_iteration),
                             backfill,
                             backfill_logger,
                             workspace_process_context,
@@ -181,7 +182,7 @@ def execute_backfill_jobs(
                         )
                     else:
                         future = threadpool_executor.submit(
-                            execute_job_backfill_iteration,
+                            materialize(execute_job_backfill_iteration),
                             backfill,
                             backfill_logger,
                             workspace_process_context,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -167,6 +167,10 @@ def execute_backfill_jobs(
                             "backfill_futures dict must be passed with threadpool_executor"
                         )
 
+                    # only allow one backfill per backfill job to be in flight
+                    if backfill_id in backfill_futures and not backfill_futures[backfill_id].done():
+                        continue
+
                     if backfill.is_asset_backfill:
                         future = threadpool_executor.submit(
                             execute_asset_backfill_iteration,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -57,7 +57,6 @@ def execute_backfill_iteration_loop(
     shutdown_event: threading.Event,
     until: Optional[float] = None,
     threadpool_executor: Optional[ThreadPoolExecutor] = None,
-    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
 ) -> "DaemonIterator":
     from dagster._daemon.controller import DEFAULT_DAEMON_INTERVAL_SECONDS
     from dagster._daemon.daemon import SpanMarker
@@ -76,7 +75,6 @@ def execute_backfill_iteration_loop(
                 workspace_process_context,
                 logger,
                 threadpool_executor=threadpool_executor,
-                submit_threadpool_executor=submit_threadpool_executor,
                 backfill_futures=backfill_futures,
             )
         except Exception:
@@ -101,7 +99,6 @@ def execute_backfill_iteration(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
     threadpool_executor: Optional[ThreadPoolExecutor] = None,
-    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
     backfill_futures: Optional[Dict[str, Future]] = None,
     debug_crash_flags: Optional[Mapping[str, int]] = None,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
@@ -141,7 +138,6 @@ def execute_backfill_jobs(
     logger: logging.Logger,
     backfill_jobs: Sequence[PartitionBackfill],
     threadpool_executor: Optional[ThreadPoolExecutor] = None,
-    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
     backfill_futures: Optional[Dict[str, Future]] = None,
     debug_crash_flags: Optional[Mapping[str, int]] = None,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
@@ -175,7 +171,6 @@ def execute_backfill_jobs(
                         workspace_process_context,
                         debug_crash_flags,
                         instance,
-                        submit_threadpool_executor=submit_threadpool_executor,
                     )
                     backfill_futures[backfill_id] = future
                     yield

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -119,7 +119,12 @@ def execute_backfill_iteration(
     backfill_jobs = [*in_progress_backfills, *canceling_backfills]
 
     yield from execute_backfill_jobs(
-        workspace_process_context, logger, backfill_jobs, debug_crash_flags
+        workspace_process_context,
+        logger,
+        backfill_jobs,
+        threadpool_executor,
+        backfill_futures,
+        debug_crash_flags,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -19,7 +19,7 @@ from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._time import get_current_datetime, get_current_timestamp
-from dagster._utils import materialize
+from dagster._utils import return_as_list
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -174,7 +174,7 @@ def execute_backfill_jobs(
 
                     if backfill.is_asset_backfill:
                         future = threadpool_executor.submit(
-                            materialize(execute_asset_backfill_iteration),
+                            return_as_list(execute_asset_backfill_iteration),
                             backfill,
                             backfill_logger,
                             workspace_process_context,
@@ -182,7 +182,7 @@ def execute_backfill_jobs(
                         )
                     else:
                         future = threadpool_executor.submit(
-                            materialize(execute_job_backfill_iteration),
+                            return_as_list(execute_job_backfill_iteration),
                             backfill,
                             backfill_logger,
                             workspace_process_context,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -162,16 +162,23 @@ def execute_backfill_jobs(
                             "backfill_futures dict must be passed with threadpool_executor"
                         )
 
-                    future = threadpool_executor.submit(
-                        execute_asset_backfill_iteration
-                        if backfill.is_asset_backfill
-                        else execute_job_backfill_iteration,
-                        backfill,
-                        backfill_logger,
-                        workspace_process_context,
-                        debug_crash_flags,
-                        instance,
-                    )
+                    if backfill.is_asset_backfill:
+                        future = threadpool_executor.submit(
+                            execute_asset_backfill_iteration,
+                            backfill,
+                            backfill_logger,
+                            workspace_process_context,
+                            instance,
+                        )
+                    else:
+                        future = threadpool_executor.submit(
+                            execute_job_backfill_iteration,
+                            backfill,
+                            backfill_logger,
+                            workspace_process_context,
+                            debug_crash_flags,
+                            instance,
+                        )
                     backfill_futures[backfill_id] = future
                     yield
 

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import sys
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Iterable, Mapping, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Sequence, cast
 
 import dagster._check as check
 from dagster._core.definitions.instigation_logger import InstigationLogger
@@ -16,8 +18,11 @@ from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
-from dagster._time import get_current_datetime
+from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo
+
+if TYPE_CHECKING:
+    from dagster._daemon.daemon import DaemonIterator
 
 
 @contextmanager
@@ -46,9 +51,58 @@ def _get_max_asset_backfill_retries():
     return int(os.getenv("DAGSTER_MAX_ASSET_BACKFILL_RETRIES", "5"))
 
 
+def execute_backfill_iteration_loop(
+    workspace_process_context: IWorkspaceProcessContext,
+    logger: logging.Logger,
+    shutdown_event: threading.Event,
+    until: Optional[float] = None,
+    threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
+) -> "DaemonIterator":
+    from dagster._daemon.controller import DEFAULT_DAEMON_INTERVAL_SECONDS
+    from dagster._daemon.daemon import SpanMarker
+
+    backfill_futures: Dict[str, Future] = {}
+    while True:
+        start_time = get_current_timestamp()
+        if until and start_time >= until:
+            # provide a way of organically ending the loop to support test environment
+            break
+
+        yield SpanMarker.START_SPAN
+
+        try:
+            yield from execute_backfill_iteration(
+                workspace_process_context,
+                logger,
+                threadpool_executor=threadpool_executor,
+                submit_threadpool_executor=submit_threadpool_executor,
+                backfill_futures=backfill_futures,
+            )
+        except Exception:
+            error_info = DaemonErrorCapture.on_exception(
+                exc_info=sys.exc_info(),
+                logger=logger,
+                log_message="BackfillDaemon caught an error",
+            )
+            yield error_info
+
+        yield SpanMarker.END_SPAN
+
+        end_time = get_current_timestamp()
+        loop_duration = end_time - start_time
+        sleep_time = max(0, DEFAULT_DAEMON_INTERVAL_SECONDS - loop_duration)
+        shutdown_event.wait(sleep_time)
+
+        yield None
+
+
 def execute_backfill_iteration(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
+    threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    backfill_futures: Optional[Dict[str, Future]] = None,
     debug_crash_flags: Optional[Mapping[str, int]] = None,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
@@ -86,6 +140,9 @@ def execute_backfill_jobs(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
     backfill_jobs: Sequence[PartitionBackfill],
+    threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
+    backfill_futures: Optional[Dict[str, Future]] = None,
     debug_crash_flags: Optional[Mapping[str, int]] = None,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
@@ -103,18 +160,39 @@ def execute_backfill_jobs(
             )
 
             try:
-                if backfill.is_asset_backfill:
-                    yield from execute_asset_backfill_iteration(
-                        backfill, backfill_logger, workspace_process_context, instance
-                    )
-                else:
-                    yield from execute_job_backfill_iteration(
+                if threadpool_executor:
+                    if backfill_futures is None:
+                        check.failed(
+                            "backfill_futures dict must be passed with threadpool_executor"
+                        )
+
+                    future = threadpool_executor.submit(
+                        execute_asset_backfill_iteration
+                        if backfill.is_asset_backfill
+                        else execute_job_backfill_iteration,
                         backfill,
                         backfill_logger,
                         workspace_process_context,
                         debug_crash_flags,
                         instance,
+                        submit_threadpool_executor=submit_threadpool_executor,
                     )
+                    backfill_futures[backfill_id] = future
+                    yield
+
+                else:
+                    if backfill.is_asset_backfill:
+                        yield from execute_asset_backfill_iteration(
+                            backfill, backfill_logger, workspace_process_context, instance
+                        )
+                    else:
+                        yield from execute_job_backfill_iteration(
+                            backfill,
+                            backfill_logger,
+                            workspace_process_context,
+                            debug_crash_flags,
+                            instance,
+                        )
             except Exception as e:
                 backfill = check.not_none(instance.get_backfill(backfill.backfill_id))
                 if (

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -362,7 +362,7 @@ def create_daemon_of_type(daemon_type: str, instance: DagsterInstance) -> Dagste
             interval_seconds=instance.run_coordinator.dequeue_interval_seconds  # type: ignore  # (??)
         )
     elif daemon_type == BackfillDaemon.daemon_type():
-        return BackfillDaemon(interval_seconds=DEFAULT_DAEMON_INTERVAL_SECONDS)
+        return BackfillDaemon(settings=instance.get_backfill_settings())
     elif daemon_type == MonitoringDaemon.daemon_type():
         return MonitoringDaemon(interval_seconds=instance.run_monitoring_poll_interval_seconds)
     elif daemon_type == EventLogConsumerDaemon.daemon_type():

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -338,7 +338,6 @@ class BackfillDaemon(DagsterDaemon):
         super().__init__()
         self._exit_stack = ExitStack()
         self._threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
-        self._submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
 
         if settings.get("use_threads"):
             self._threadpool_executor = self._exit_stack.enter_context(
@@ -347,14 +346,6 @@ class BackfillDaemon(DagsterDaemon):
                     thread_name_prefix="backfill_daemon_worker",
                 )
             )
-            num_submit_workers = settings.get("num_submit_workers")
-            if num_submit_workers:
-                self._submit_threadpool_executor = self._exit_stack.enter_context(
-                    InheritContextThreadPoolExecutor(
-                        max_workers=settings.get("num_submit_workers"),
-                        thread_name_prefix="backfill_submit_worker",
-                    )
-                )
 
     @classmethod
     def daemon_type(cls) -> str:
@@ -374,7 +365,6 @@ class BackfillDaemon(DagsterDaemon):
             self._logger,
             shutdown_event,
             threadpool_executor=self._threadpool_executor,
-            submit_threadpool_executor=self._submit_threadpool_executor,
         )
 
 

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -22,7 +22,7 @@ from dagster._core.scheduler.scheduler import DagsterDaemonScheduler
 from dagster._core.telemetry import DAEMON_ALIVE, log_action
 from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._daemon.backfill import execute_backfill_iteration
+from dagster._daemon.backfill import execute_backfill_iteration_loop
 from dagster._daemon.monitoring import (
     execute_concurrency_slots_iteration,
     execute_run_monitoring_iteration,
@@ -333,16 +333,49 @@ class SensorDaemon(DagsterDaemon):
         )
 
 
-class BackfillDaemon(IntervalDaemon):
+class BackfillDaemon(DagsterDaemon):
+    def __init__(self, settings: Mapping[str, Any]) -> None:
+        super().__init__()
+        self._exit_stack = ExitStack()
+        self._threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
+        self._submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
+
+        if settings.get("use_threads"):
+            self._threadpool_executor = self._exit_stack.enter_context(
+                InheritContextThreadPoolExecutor(
+                    max_workers=settings.get("num_workers"),
+                    thread_name_prefix="backfill_daemon_worker",
+                )
+            )
+            num_submit_workers = settings.get("num_submit_workers")
+            if num_submit_workers:
+                self._submit_threadpool_executor = self._exit_stack.enter_context(
+                    InheritContextThreadPoolExecutor(
+                        max_workers=settings.get("num_submit_workers"),
+                        thread_name_prefix="backfill_submit_worker",
+                    )
+                )
+
     @classmethod
     def daemon_type(cls) -> str:
         return "BACKFILL"
 
-    def run_iteration(
+    def __exit__(self, _exception_type, _exception_value, _traceback):
+        self._exit_stack.close()
+        super().__exit__(_exception_type, _exception_value, _traceback)
+
+    def core_loop(
         self,
         workspace_process_context: IWorkspaceProcessContext,
+        shutdown_event: Event,
     ) -> DaemonIterator:
-        yield from execute_backfill_iteration(workspace_process_context, self._logger)
+        yield from execute_backfill_iteration_loop(
+            workspace_process_context,
+            self._logger,
+            shutdown_event,
+            threadpool_executor=self._threadpool_executor,
+            submit_threadpool_executor=self._submit_threadpool_executor,
+        )
 
 
 class MonitoringDaemon(IntervalDaemon):

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -344,7 +344,6 @@ def execute_sensor_iteration_loop(
         yield SpanMarker.END_SPAN
 
         end_time = get_current_timestamp()
-
         loop_duration = end_time - start_time
         sleep_time = max(0, MIN_INTERVAL_LOOP_TIME - loop_duration)
         shutdown_event.wait(sleep_time)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -70,7 +70,7 @@ from dagster._utils import (
     DebugCrashFlags,
     SingleInstigatorDebugCrashFlags,
     check_for_debug_crash,
-    materialize,
+    return_as_list,
 )
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
@@ -612,7 +612,7 @@ def _process_tick_generator(
 
 # evaluate the tick immediately, but from within a thread.  The main thread should be able to
 # heartbeat to keep the daemon alive
-_process_tick = materialize(_process_tick_generator)
+_process_tick = return_as_list(_process_tick_generator)
 
 
 def _sensor_instigator_data(state: InstigatorState) -> Optional[SensorInstigatorData]:

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -197,8 +197,8 @@ def execute_scheduler_iteration_loop(
     scheduler_run_futures: Dict[str, Future] = {}
     iteration_times: Dict[str, ScheduleIterationTimes] = {}
 
-    submit_threadpool_executor = None
     threadpool_executor = None
+    submit_threadpool_executor = None
 
     with ExitStack() as stack:
         settings = workspace_process_context.instance.get_scheduler_settings()
@@ -225,6 +225,7 @@ def execute_scheduler_iteration_loop(
             next_interval_time = _get_next_scheduler_iteration_time(start_time)
 
             yield SpanMarker.START_SPAN
+
             try:
                 yield from launch_scheduled_runs(
                     workspace_process_context,
@@ -248,8 +249,8 @@ def execute_scheduler_iteration_loop(
                 next_interval_time = min(start_time + ERROR_INTERVAL_TIME, next_interval_time)
 
             yield SpanMarker.END_SPAN
-            end_time = get_current_timestamp()
 
+            end_time = get_current_timestamp()
             if next_interval_time > end_time:
                 # Sleep until the beginning of the next minute, plus a small epsilon to
                 # be sure that we're past the start of the minute

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -846,7 +846,7 @@ def run_with_concurrent_update_guard(
         return
 
 
-def materialize(func: Callable[..., Iterable[T]]) -> Callable[..., List[T]]:
+def return_as_list(func: Callable[..., Iterable[T]]) -> Callable[..., List[T]]:
     """A decorator that returns a list from the output of a function."""
 
     @functools.wraps(func)

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -846,11 +846,11 @@ def run_with_concurrent_update_guard(
         return
 
 
-def materialize(func: Callable[..., Generator[T, Any, None]]) -> Callable[..., List[T]]:
-    """A decorator that materializes the result from a function call."""
+def materialize(func: Callable[..., Iterable[T]]) -> Callable[..., List[T]]:
+    """A decorator that returns a list from the output of a function."""
 
     @functools.wraps(func)
     def inner(*args, **kwargs):
         return list(func(*args, **kwargs))
 
-    return cast(Callable[..., List[T]], inner)
+    return inner

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -844,3 +844,13 @@ def run_with_concurrent_update_guard(
             return
         update_fn(**kwargs)
         return
+
+
+def materialize(func: Callable[..., Generator[T, Any, None]]) -> Callable[..., List[T]]:
+    """A decorator that materializes the result from a function call."""
+
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+        return list(func(*args, **kwargs))
+
+    return inner

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -853,4 +853,4 @@ def materialize(func: Callable[..., Generator[T, Any, None]]) -> Callable[..., L
     def inner(*args, **kwargs):
         return list(func(*args, **kwargs))
 
-    return inner
+    return cast(Callable[..., List[T]], inner)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2908,10 +2908,11 @@ def test_repository_namespacing(executor):
             assert len(ticks) == 2
 
 
-def test_settings():
+@pytest.mark.parametrize("daemon", ["backfills", "schedules", "sensors"])
+def test_settings(daemon):
     settings = {"use_threads": True, "num_workers": 4}
-    with instance_for_test(overrides={"sensors": settings}) as thread_inst:
-        assert thread_inst.get_settings("sensors") == settings
+    with instance_for_test(overrides={daemon: settings}) as thread_inst:
+        assert thread_inst.get_settings(daemon) == settings
 
 
 @pytest.mark.parametrize("sensor_name", ["logging_sensor", "multi_asset_logging_sensor"])

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2908,13 +2908,6 @@ def test_repository_namespacing(executor):
             assert len(ticks) == 2
 
 
-@pytest.mark.parametrize("daemon", ["backfills", "schedules", "sensors"])
-def test_settings(daemon):
-    settings = {"use_threads": True, "num_workers": 4}
-    with instance_for_test(overrides={daemon: settings}) as thread_inst:
-        assert thread_inst.get_settings(daemon) == settings
-
-
 @pytest.mark.parametrize("sensor_name", ["logging_sensor", "multi_asset_logging_sensor"])
 def test_sensor_logging(executor, instance, workspace_context, remote_repo, sensor_name) -> None:
     sensor = remote_repo.get_sensor(sensor_name)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -691,6 +691,7 @@ def test_two_backfills(
             )
         )
 
+        time.sleep(0.5)
         wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -644,6 +644,10 @@ def test_two_backfills_at_the_same_time(
     tmp_path: Path,
     parallel: bool,
 ):
+    # In order to avoid deadlock, we need to ensure that the instance we
+    # are using will launch runs in separate subprocesses rather than in
+    # the same in-memory process. This is akin to the context created in
+    # https://github.com/dagster-io/dagster/blob/a116c44/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py#L53-L71
     with instance_for_test(
         overrides={
             "event_log_storage": {

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -636,7 +636,7 @@ def test_simple_backfill(
 
 
 @pytest.mark.parametrize("parallel", [True, False])
-def test_two_backfills(
+def test_two_backfills_at_the_same_time(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
     remote_repo: RemoteRepository,
@@ -702,6 +702,17 @@ def test_two_backfills(
         )
 
     assert instance.get_runs_count() == 6
+
+    *runs, one, two, three = reversed(list(instance.get_runs()))
+    assert one.tags[BACKFILL_ID_TAG] == "simple"
+    assert one.tags[PARTITION_NAME_TAG] == "one"
+    assert two.tags[BACKFILL_ID_TAG] == "simple"
+    assert two.tags[PARTITION_NAME_TAG] == "two"
+    assert three.tags[BACKFILL_ID_TAG] == "simple"
+    assert three.tags[PARTITION_NAME_TAG] == "three"
+    for idx, run in enumerate(runs):
+        assert run.tags[BACKFILL_ID_TAG] == "partition_schedule_from_job"
+        assert run.tags[PARTITION_NAME_TAG] == second_partition_keys[idx]
 
 
 def test_canceled_backfill(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -86,7 +86,6 @@ from dagster._core.test_utils import (
     step_did_not_run,
     step_failed,
     step_succeeded,
-    wait_for_futures,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -615,7 +614,6 @@ def test_simple_backfill(
             )
         )
 
-        wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:
         list(
@@ -683,8 +681,6 @@ def test_two_backfills_at_the_same_time(
             )
         )
 
-        time.sleep(0.5)
-        wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:
         list(
@@ -778,7 +774,6 @@ def test_failure_backfill(
                 )
             )
 
-            wait_for_futures(backfill_daemon_futures)
             [list(future.result()) for future in backfill_daemon_futures.values()]
         else:
             list(
@@ -840,7 +835,6 @@ def test_failure_backfill(
             )
         )
 
-        wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:
         list(
@@ -3003,7 +2997,6 @@ def test_asset_backfill_from_asset_graph_subset(
             )
         )
 
-        wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:
         list(
@@ -3036,7 +3029,6 @@ def test_asset_backfill_from_asset_graph_subset(
             )
         )
 
-        wait_for_futures(backfill_daemon_futures)
         [list(future.result()) for future in backfill_daemon_futures.values()]
     else:
         list(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -634,7 +634,7 @@ def test_simple_backfill(
     assert three.tags[PARTITION_NAME_TAG] == "three"
 
 
-@pytest.mark.parametrize("parallel", [True, False])
+@pytest.mark.parametrize("parallel", [False])
 def test_two_backfills_at_the_same_time(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2886,10 +2886,12 @@ def test_asset_backfill_logs(
         assert record_dict.get("msg")
 
 
+@pytest.mark.parametrize("parallel", [True, False])
 def test_asset_backfill_from_asset_graph_subset(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
     remote_repo: RemoteRepository,
+    parallel: bool,
 ):
     del remote_repo
 
@@ -2918,7 +2920,25 @@ def test_asset_backfill_from_asset_graph_subset(
     assert backfill
     assert backfill.status == BulkActionStatus.REQUESTED
 
-    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    if parallel:
+        backfill_daemon_futures = {}
+        list(
+            execute_backfill_iteration(
+                workspace_context,
+                get_default_daemon_logger("BackfillDaemon"),
+                threadpool_executor=ThreadPoolExecutor(2),
+                backfill_futures=backfill_daemon_futures,
+            )
+        )
+
+        wait_for_futures(backfill_daemon_futures)
+        [list(future.result()) for future in backfill_daemon_futures.values()]
+    else:
+        list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
     assert instance.get_runs_count() == 3
     wait_for_all_runs_to_start(instance, timeout=30)
     assert instance.get_runs_count() == 3
@@ -2933,7 +2953,25 @@ def test_asset_backfill_from_asset_graph_subset(
         assert step_succeeded(instance, run, "reusable")
         assert step_succeeded(instance, run, "bar")
 
-    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    if parallel:
+        backfill_daemon_futures = {}
+        list(
+            execute_backfill_iteration(
+                workspace_context,
+                get_default_daemon_logger("BackfillDaemon"),
+                threadpool_executor=ThreadPoolExecutor(2),
+                backfill_futures=backfill_daemon_futures,
+            )
+        )
+
+        wait_for_futures(backfill_daemon_futures)
+        [list(future.result()) for future in backfill_daemon_futures.values()]
+    else:
+        list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
     backfill = instance.get_backfill("backfill_from_asset_graph_subset")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -682,14 +682,6 @@ def test_two_backfills_at_the_same_time(
                 backfill_futures=backfill_daemon_futures,
             )
         )
-        list(
-            execute_backfill_iteration(
-                workspace_context,
-                get_default_daemon_logger("BackfillDaemon"),
-                threadpool_executor=threadpool_executor,
-                backfill_futures=backfill_daemon_futures,
-            )
-        )
 
         time.sleep(0.5)
         wait_for_futures(backfill_daemon_futures)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1085,14 +1085,17 @@ def test_backfill_is_processed_only_once(
     assert instance.get_runs_count() == 0
     future = backfill_daemon_futures[backfill_id]
 
-    list(
-        execute_backfill_iteration(
-            workspace_context,
-            get_default_daemon_logger("BackfillDaemon"),
-            threadpool_executor=threadpool_executor,
-            backfill_futures=backfill_daemon_futures,
+    with mock.patch.object(
+        threadpool_executor, "submit", side_effect=AssertionError("Should not be called")
+    ):
+        list(
+            execute_backfill_iteration(
+                workspace_context,
+                get_default_daemon_logger("BackfillDaemon"),
+                threadpool_executor=threadpool_executor,
+                backfill_futures=backfill_daemon_futures,
+            )
         )
-    )
 
     assert instance.get_runs_count() == 0
     assert backfill_daemon_futures[backfill_id] is future

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -11,6 +11,13 @@ from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import Queued
 from dagster._utils.log import get_structlog_json_formatter
 
 
+@pytest.mark.parametrize("daemon", ["backfills", "schedules", "sensors"])
+def test_settings(daemon):
+    settings = {"use_threads": True, "num_workers": 4}
+    with instance_for_test(overrides={daemon: settings}) as thread_inst:
+        assert thread_inst.get_settings(daemon) == settings
+
+
 def test_scheduler_instance():
     with instance_for_test(
         overrides={

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -176,15 +176,20 @@ def _execute_ticks(
         )
     )
 
+    backfill_daemon_futures = {}
     list(
         execute_backfill_iteration(
             context,
             get_default_daemon_logger("BackfillDaemon"),
+            threadpool_executor=threadpool_executor,
+            backfill_futures=backfill_daemon_futures,
+            debug_crash_flags=debug_crash_flags or {},
         )
     )
 
     wait_for_futures(asset_daemon_futures)
     wait_for_futures(sensor_daemon_futures)
+    wait_for_futures(backfill_daemon_futures)
 
 
 def _get_current_state(context: WorkspaceRequestContext) -> Mapping[str, InstigatorState]:

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -1,10 +1,10 @@
 import os
 import sys
-from typing import Iterator, Optional
+from typing import Iterator, Optional, cast
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import RemoteRepository
+from dagster._core.remote_representation import CodeLocation, RemoteRepository
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
@@ -73,11 +73,12 @@ def workspace_fixture(
 
 @pytest.fixture(name="remote_repo", scope="session")
 def remote_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
-    return next(
-        iter(workspace_context.create_request_context().get_code_location_entries().values())
-    ).code_location.get_repository(  # type: ignore  # (possible none)
-        "the_repo"
-    )
+    return cast(
+        CodeLocation,
+        next(
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
+        ).code_location,
+    ).get_repository("the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:


### PR DESCRIPTION
## Summary & Motivation

Some users are running into situations where they kick off a backfill that takes hours to process and it holds up every other backfill until it finishes. Adding a thread pool can alleviate this in most situations, where there is one of a handful of long-running backfills; in the unlikely case where all of the backfills being executed in parallel take hours, this still won't help.

## How I Tested These Changes

Existing tests, plus changing e2e tests to use thread pool for backfills.

## Changelog

Added the option to use a thread pool to process backfills in parallel.
