### PR TITLE
Add pod logging

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -1,7 +1,6 @@
 import os
 import time
 from typing import Any, Dict, List, Optional
-import traceback
 
 import kubernetes.config
 import kubernetes.watch
@@ -421,9 +420,7 @@ def execute_k8s_job(
             pods = api_client.get_pod_names_in_job(job_name=job_name, namespace=namespace)
             pod_debug_info = "\n\n".join([api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods])
         except Exception:
-            context.log.error(
-                f"Error trying to get pod debug information for failed k8s job {job_name}:\n\n{traceback.format_exc()}"
-            )
+            context.log.exception(f"Error trying to get pod debug information for failed k8s job {job_name}")
         else:
             context.log.error(f"Debug information for failed k8s job {job_name}:\n\n{pod_debug_info}")
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any, Dict, List, Optional
+import traceback
 
 import kubernetes.config
 import kubernetes.watch
@@ -418,13 +419,13 @@ def execute_k8s_job(
     except (DagsterExecutionInterruptedError, Exception) as e:
         try:
             pods = api_client.get_pod_names_in_job(job_name=job_name, namespace=namespace)
-            pod_debug_info = "\n\n\n\n".join([api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods])
+            pod_debug_info = "\n\n".join([api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods])
         except Exception:
-            context.log.info(
-                f"Error trying to get pod debug information for failed k8s job {job_name}"
+            context.log.error(
+                f"Error trying to get pod debug information for failed k8s job {job_name}:\n\n{traceback.format_exc()}"
             )
         else:
-            context.log.error(f"Pod debug info:\n\n{pod_debug_info}")
+            context.log.error(f"Debug information for failed k8s job {job_name}:\n\n{pod_debug_info}")
 
         if delete_failed_k8s_jobs:
             context.log.info(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -418,11 +418,17 @@ def execute_k8s_job(
     except (DagsterExecutionInterruptedError, Exception) as e:
         try:
             pods = api_client.get_pod_names_in_job(job_name=job_name, namespace=namespace)
-            pod_debug_info = "\n\n".join([api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods])
+            pod_debug_info = "\n\n".join(
+                [api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods]
+            )
         except Exception:
-            context.log.exception(f"Error trying to get pod debug information for failed k8s job {job_name}")
+            context.log.exception(
+                f"Error trying to get pod debug information for failed k8s job {job_name}"
+            )
         else:
-            context.log.error(f"Debug information for failed k8s job {job_name}:\n\n{pod_debug_info}")
+            context.log.error(
+                f"Debug information for failed k8s job {job_name}:\n\n{pod_debug_info}"
+            )
 
         if delete_failed_k8s_jobs:
             context.log.info(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -416,6 +416,16 @@ def execute_k8s_job(
             num_pods_to_wait_for=num_pods_to_wait_for,
         )
     except (DagsterExecutionInterruptedError, Exception) as e:
+        try:
+            pods = api_client.get_pod_names_in_job(job_name=job_name, namespace=namespace)
+            pod_debug_info = "\n\n\n\n".join([api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pods])
+        except Exception:
+            context.log.info(
+                f"Error trying to get pod debug information for failed k8s job {job_name}"
+            )
+        else:
+            context.log.error(f"Pod debug info:\n\n{pod_debug_info}")
+
         if delete_failed_k8s_jobs:
             context.log.info(
                 f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"


### PR DESCRIPTION
## Summary & Motivation
This is a follow up of https://github.com/dagster-io/dagster/pull/22784
Such logging is still necessary to have even after `delete_failed_k8s_jobs` implementation, because such option isn't feasible in production or/and highly dynamic environments.

Addressed previous comments of @gibsondan 

## How I Tested These Changes
Tested locally by inducing an error. Logging was successful as expected.

## Changelog

Output k8s pod logs when pods fail.