### PR TITLE
[components] Remove class hierarchy from components for now

### DIFF
--- a/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
+++ b/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from dagster._components import ComponentRegistry, build_defs_from_toplevel_components_folder
 from dagster._components.impls.python_script_component import PythonScriptCollection
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 defs = build_defs_from_toplevel_components_folder(
@@ -9,3 +10,6 @@ defs = build_defs_from_toplevel_components_folder(
     registry=ComponentRegistry({"python_script_collection": PythonScriptCollection}),
     resources={"pipes_client": PipesSubprocessClient()},
 )
+
+if __name__ == "__main__":
+    Definitions.validate_loadable(defs)


### PR DESCRIPTION
## Summary & Motivation

Removing `LoadableComponent` and `FileCollectionComponent` as I think these are quite overfit right now and just add layers of indirection for little value. I think we need to get more variants of components implemented before we build layers of abstractions.

## How I Tested These Changes

Load hello world

## Changelog
