### PR TITLE
[components] Rename to be pipes-specific and provide resource out of the box

### DIFF
--- a/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/components/a_script_collection/defs.yml
+++ b/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/components/a_script_collection/defs.yml
@@ -1,4 +1,4 @@
-component_type: python_script_collection
+component_type: pipes_subprocess_script_collection
 
 component_params:
   script_one:

--- a/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
+++ b/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
@@ -1,14 +1,16 @@
 from pathlib import Path
 
 from dagster._components import ComponentRegistry, build_defs_from_toplevel_components_folder
-from dagster._components.impls.python_script_component import PythonScriptCollection
+from dagster._components.impls.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollection,
+)
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 defs = build_defs_from_toplevel_components_folder(
     path=Path(__file__).parent,
-    registry=ComponentRegistry({"python_script_collection": PythonScriptCollection}),
-    resources={"pipes_client": PipesSubprocessClient()},
+    registry=ComponentRegistry(
+        {"pipes_subprocess_script_collection": PipesSubprocessScriptCollection}
+    ),
 )
 
 if __name__ == "__main__":

--- a/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
@@ -35,12 +35,12 @@ class AssetSpecModel(BaseModel):
         )
 
 
-class PythonScriptParams(BaseModel):
+class PipesSubprocessScriptParams(BaseModel):
     assets: Sequence[AssetSpecModel]
 
 
-class PythonScriptCollection(Component):
-    params_schema = Mapping[str, PythonScriptParams]
+class PipesSubprocessScriptCollection(Component):
+    params_schema = Mapping[str, PipesSubprocessScriptParams]
 
     def __init__(
         self, dirpath: Path, path_specs: Optional[Mapping[str, Sequence[AssetSpec]]] = None
@@ -53,7 +53,7 @@ class PythonScriptCollection(Component):
     @classmethod
     def from_component_params(
         cls, init_context: ComponentInitContext, component_params: object
-    ) -> "PythonScriptCollection":
+    ) -> "PipesSubprocessScriptCollection":
         loaded_params = TypeAdapter(cls.params_schema).validate_python(component_params)
         return cls(
             dirpath=init_context.path,
@@ -69,7 +69,7 @@ class PythonScriptCollection(Component):
 
         return Definitions(
             assets=[self._create_asset_def(path) for path in list(self.dirpath.rglob("*.py"))],
-            resources=load_context.resources,
+            resources={"pipes_client": PipesSubprocessClient()},
         )
 
     def _create_asset_def(self, path: Path):

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/scripts/defs.yaml
@@ -1,4 +1,4 @@
-component_type: python_script_collection
+component_type: pipes_subprocess_script_collection
 
 component_params:
   script_one:

--- a/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
@@ -6,28 +6,32 @@ from dagster._components import (
     ComponentLoadContext,
     build_defs_from_component_folder,
 )
-from dagster._components.impls.python_script_component import PythonScriptCollection
+from dagster._components.impls.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollection,
+)
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
 init_context = ComponentInitContext(path=LOCATION_PATH / "scripts")
-init_context.registry.register("python_script_collection", PythonScriptCollection)
+init_context.registry.register(
+    "pipes_subprocess_script_collection", PipesSubprocessScriptCollection
+)
 
 
 def _assert_assets(component: Component, expected_assets: int) -> None:
-    defs = component.build_defs(ComponentLoadContext({"pipes_client": PipesSubprocessClient()}))
+    defs = component.build_defs(ComponentLoadContext())
     assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
     result = defs.get_implicit_global_asset_job_def().execute_in_process()
     assert result.success
 
 
 def test_python_native() -> None:
-    component = PythonScriptCollection(LOCATION_PATH / "scripts")
+    component = PipesSubprocessScriptCollection(LOCATION_PATH / "scripts")
     _assert_assets(component, 3)
 
 
 def test_python_params() -> None:
-    component = PythonScriptCollection.from_component_params(
+    component = PipesSubprocessScriptCollection.from_component_params(
         init_context=init_context,
         component_params={
             "script_one": {


### PR DESCRIPTION
## Summary & Motivation

Renames PythonScriptCollection to PipesSubprocessScriptCollection which is more accurate and specific. Also have it provide its own pipes client for now for convenience.

## How I Tested These Changes

dagster dev hello and BK

