### PR TITLE
[components] Silence experimental warnings in components code paths in development

### DIFF
--- a/python_modules/dagster/dagster/_components/__init__.py
+++ b/python_modules/dagster/dagster/_components/__init__.py
@@ -276,7 +276,9 @@ def build_defs_from_component_folder(
     init_context = ComponentInitContext(path=path, registry=registry)
     components = init_context.load()
 
-    return Definitions.merge(*[c.build_defs(ComponentLoadContext(resources)) for c in components])
+    return Definitions.merge_internal(
+        *[c.build_defs(ComponentLoadContext(resources)) for c in components]
+    )
 
 
 def register_components_in_module(registry: ComponentRegistry, root_module: ModuleType) -> None:
@@ -311,4 +313,4 @@ def build_defs_from_toplevel_components_folder(
             resources=resources or {},
         )
         all_defs.append(defs)
-    return Definitions.merge(*all_defs)
+    return Definitions.merge_internal(*all_defs)

--- a/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
@@ -1,4 +1,5 @@
 import shutil
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
@@ -10,6 +11,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster._utils.warnings import ExperimentalWarning
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -27,12 +29,14 @@ class AssetSpecModel(BaseModel):
     tags: Mapping[str, str] = {}
 
     def to_asset_spec(self) -> AssetSpec:
-        return AssetSpec(
-            **{
-                **self.__dict__,
-                "key": AssetKey.from_user_string(self.key),
-            },
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=ExperimentalWarning)
+            return AssetSpec(
+                **{
+                    **self.__dict__,
+                    "key": AssetKey.from_user_string(self.key),
+                },
+            )
 
 
 class PipesSubprocessScriptParams(BaseModel):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -636,7 +636,11 @@ class Definitions(IHaveNew):
             Definitions: The merged definitions.
         """
         check.sequence_param(def_sets, "def_sets", of_type=Definitions)
+        return Definitions.merge_internal(*def_sets)
 
+    @staticmethod
+    def merge_internal(*def_sets: "Definitions") -> "Definitions":
+        check.sequence_param(def_sets, "def_sets", of_type=Definitions)
         assets = []
         schedules = []
         sensors = []


### PR DESCRIPTION
## Summary & Motivation

While we are developing this thing I want to silence experimental warnings.

* Added scoped warning filter around `AssetSpec` construction
* Added `Definitions.merge_internal` for internal use cases.

## How I Tested These Changes

`dagster dev` in hello world. no warnings seen.
