### PR TITLE
[dagster-airlift] Handle sensor existing in multiple code locations

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -99,12 +99,14 @@ def get_timestamp_from_materialization(event: AssetEvent) -> float:
 
 
 def synthetic_mats_for_peered_dag_asset_keys(
-    dag_run: DagRun, airflow_data: AirflowDefinitionsData, already_materialized_asset_keys: AbstractSet[AssetKey]
+    dag_run: DagRun,
+    airflow_data: AirflowDefinitionsData,
+    peered_dags_already_materialized: AbstractSet[AssetKey],
 ) -> Sequence[AssetMaterialization]:
     return [
         dag_synthetic_mat(dag_run, airflow_data, asset_key)
         for asset_key in airflow_data.peered_dag_asset_keys_by_dag_handle[DagHandle(dag_run.dag_id)]
-        if asset_key not in already_materialized_asset_keys
+        if asset_key not in peered_dags_already_materialized
     ]
 
 
@@ -120,9 +122,10 @@ def synthetic_mats_for_mapped_dag_asset_keys(
 def dag_synthetic_mat(
     dag_run: DagRun, airflow_data: AirflowDefinitionsData, asset_key: AssetKey
 ) -> AssetMaterialization:
-    print("entered dag_synthetic_mat")
     return AssetMaterialization(
-        asset_key=asset_key, description=dag_run.note, metadata=get_dag_run_metadata(dag_run), tags={"dagster-airlift/dag_run_id": dag_run.run_id.replace(":", "__").replace("+", "__")}
+        asset_key=asset_key,
+        description=dag_run.note,
+        metadata=get_dag_run_metadata(dag_run),
     )
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -99,11 +99,12 @@ def get_timestamp_from_materialization(event: AssetEvent) -> float:
 
 
 def synthetic_mats_for_peered_dag_asset_keys(
-    dag_run: DagRun, airflow_data: AirflowDefinitionsData
+    dag_run: DagRun, airflow_data: AirflowDefinitionsData, already_materialized_asset_keys: AbstractSet[AssetKey]
 ) -> Sequence[AssetMaterialization]:
     return [
         dag_synthetic_mat(dag_run, airflow_data, asset_key)
         for asset_key in airflow_data.peered_dag_asset_keys_by_dag_handle[DagHandle(dag_run.dag_id)]
+        if asset_key not in already_materialized_asset_keys
     ]
 
 
@@ -119,8 +120,9 @@ def synthetic_mats_for_mapped_dag_asset_keys(
 def dag_synthetic_mat(
     dag_run: DagRun, airflow_data: AirflowDefinitionsData, asset_key: AssetKey
 ) -> AssetMaterialization:
+    print("entered dag_synthetic_mat")
     return AssetMaterialization(
-        asset_key=asset_key, description=dag_run.note, metadata=get_dag_run_metadata(dag_run)
+        asset_key=asset_key, description=dag_run.note, metadata=get_dag_run_metadata(dag_run), tags={"dagster-airlift/dag_run_id": dag_run.run_id.replace(":", "__").replace("+", "__")}
     )
 
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/multi_location_dags.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/multi_location_dags.py
@@ -42,7 +42,7 @@ with DAG(
 ) as shared_dag:
     a = PythonOperator(task_id="first_task", python_callable=print_hello)
     b = PythonOperator(task_id="second_task", python_callable=print_hello)
-    a >> b
+    a >> b  # type: ignore
 
 
 proxying_to_dagster(

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/multi_location_dags.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/multi_location_dags.py
@@ -34,6 +34,16 @@ with DAG(
 ) as second_dag:
     PythonOperator(task_id="task", python_callable=print_hello)
 
+with DAG(
+    "dag_shared_between_code_locations",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as shared_dag:
+    a = PythonOperator(task_id="first_task", python_callable=print_hello)
+    b = PythonOperator(task_id="second_task", python_callable=print_hello)
+    a >> b
+
 
 proxying_to_dagster(
     proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
@@ -3,15 +3,24 @@ from dagster_airlift.core import assets_with_task_mappings, build_defs_from_airf
 
 from kitchen_sink.airflow_instance import local_airflow_instance
 
+dags_to_include = {
+    "dag_first_code_location",
+    "dag_shared_between_code_locations",
+}
 defs = build_defs_from_airflow_instance(
     airflow_instance=local_airflow_instance(),
     defs=Definitions(
-        assets=assets_with_task_mappings(
+        assets=[*assets_with_task_mappings(
             dag_id="dag_first_code_location",
             task_mappings={
                 "task": [AssetSpec(key="dag_first_code_location__asset")],
             },
-        ),
+        ), *assets_with_task_mappings(
+            dag_id="dag_shared_between_code_locations",
+            task_mappings={
+                "first_task": [AssetSpec(key="dag_shared_between_code_locations__first_asset")],
+            },
+        )],
     ),
-    dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_first_code_location",
+    dag_selector_fn=lambda dag_info: dag_info.dag_id in dags_to_include,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
@@ -10,17 +10,20 @@ dags_to_include = {
 defs = build_defs_from_airflow_instance(
     airflow_instance=local_airflow_instance(),
     defs=Definitions(
-        assets=[*assets_with_task_mappings(
-            dag_id="dag_first_code_location",
-            task_mappings={
-                "task": [AssetSpec(key="dag_first_code_location__asset")],
-            },
-        ), *assets_with_task_mappings(
-            dag_id="dag_shared_between_code_locations",
-            task_mappings={
-                "first_task": [AssetSpec(key="dag_shared_between_code_locations__first_asset")],
-            },
-        )],
+        assets=[
+            *assets_with_task_mappings(
+                dag_id="dag_first_code_location",
+                task_mappings={
+                    "task": [AssetSpec(key="dag_first_code_location__asset")],
+                },
+            ),
+            *assets_with_task_mappings(
+                dag_id="dag_shared_between_code_locations",
+                task_mappings={
+                    "first_task": [AssetSpec(key="dag_shared_between_code_locations__first_asset")],
+                },
+            ),
+        ],
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id in dags_to_include,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
@@ -3,15 +3,27 @@ from dagster_airlift.core import assets_with_task_mappings, build_defs_from_airf
 
 from kitchen_sink.airflow_instance import local_airflow_instance
 
+dags_to_include = {
+    "dag_second_code_location",
+    "dag_shared_between_code_locations",
+}
+
 defs = build_defs_from_airflow_instance(
     airflow_instance=local_airflow_instance(),
     defs=Definitions(
-        assets=assets_with_task_mappings(
+        assets=[*assets_with_task_mappings(
             dag_id="dag_second_code_location",
             task_mappings={
                 "task": [AssetSpec(key="dag_second_code_location__asset")],
             },
         ),
+        *assets_with_task_mappings(
+            dag_id="dag_shared_between_code_locations",
+            task_mappings={
+                "second_task": [AssetSpec(key="dag_shared_between_code_locations__second_asset")],
+            },
+        )],
+        
     ),
-    dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_second_code_location",
+    dag_selector_fn=lambda dag_info: dag_info.dag_id in dags_to_include,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
@@ -11,19 +11,22 @@ dags_to_include = {
 defs = build_defs_from_airflow_instance(
     airflow_instance=local_airflow_instance(),
     defs=Definitions(
-        assets=[*assets_with_task_mappings(
-            dag_id="dag_second_code_location",
-            task_mappings={
-                "task": [AssetSpec(key="dag_second_code_location__asset")],
-            },
-        ),
-        *assets_with_task_mappings(
-            dag_id="dag_shared_between_code_locations",
-            task_mappings={
-                "second_task": [AssetSpec(key="dag_shared_between_code_locations__second_asset")],
-            },
-        )],
-        
+        assets=[
+            *assets_with_task_mappings(
+                dag_id="dag_second_code_location",
+                task_mappings={
+                    "task": [AssetSpec(key="dag_second_code_location__asset")],
+                },
+            ),
+            *assets_with_task_mappings(
+                dag_id="dag_shared_between_code_locations",
+                task_mappings={
+                    "second_task": [
+                        AssetSpec(key="dag_shared_between_code_locations__second_asset")
+                    ],
+                },
+            ),
+        ],
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id in dags_to_include,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_multi_code_location.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_multi_code_location.py
@@ -32,6 +32,14 @@ def test_multiple_code_locations_materialize(
         "dag_second_code_location": [
             ExpectedMat(AssetKey("dag_first_code_location__asset"), runs_in_dagster=False)
         ],
+        "dag_shared_between_code_locations": [
+            ExpectedMat(
+                AssetKey("dag_shared_between_code_locations__first_asset"), runs_in_dagster=False
+            ),
+            ExpectedMat(
+                AssetKey("dag_shared_between_code_locations__second_asset"), runs_in_dagster=False
+            ),
+        ],
     }
 
     poll_for_expected_mats(af_instance, expected_mats_per_dag)


### PR DESCRIPTION
## Summary & Motivation
Users might want to use Airlift to split a dag into multiple code locations.
Currently, the Airlift sensor assumes that there is only one sensor polling the dag for a given location, this gracefully handles the case where there might be multiple copies of the sensor polling the same dag asset.

## How I Tested These Changes
Added a new test which has a dag split apart into multiple code locations, but polls the same dag asset in those code locations.