### PR TITLE
[dagster-databricks] forward logs from shared clusters

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -12,7 +12,7 @@ from dagster_databricks._test_utils import (
     temp_dbfs_script,
     upload_dagster_pipes_whl,
 )
-from dagster_databricks.pipes import PipesDatabricksClient
+from dagster_databricks.pipes import PipesDatabricksClient, PipesDbfsMessageReader
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import compute, jobs
 
@@ -146,12 +146,18 @@ def test_pipes_client(
     use_existing_cluster: bool,
 ):
     if use_existing_cluster and forward_logs:
-        # Two reasons for this: (a) logs are flushed every 5 minutes or on cluster termination.
+        # Log forwarding from existing clusters requires using Pipes messages as log transport. This has to be done because:
+        # (a) logs are flushed every 5 minutes or on cluster termination.
         # If cluster termination is not tied to the end of the launched job, there is no mechanism
         # to wait for logs to be flushed. (b) The logs reader functions by forwarding stdout/stderr,
         # which is shared across all jobs on the cluster-- so there is no way to scope the
         # forwarding to just the target job.
-        pytest.skip("Testing existing cluster with log forwarding currently does not work.")
+        #
+        message_reader = PipesDbfsMessageReader(
+            client=databricks_client, include_stdio_in_messages=True
+        )
+    else:
+        message_reader = None
 
     @asset
     def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksClient):
@@ -180,9 +186,7 @@ def test_pipes_client(
     result = materialize(
         [number_x],
         resources={
-            "pipes_client": PipesDatabricksClient(
-                databricks_client,
-            )
+            "pipes_client": PipesDatabricksClient(databricks_client, message_reader=message_reader)
         },
         raise_on_error=False,
     )


### PR DESCRIPTION
## Summary & Motivation

Currently we do not support log forwarding in Databricks Pipes in the case where the job is being executed on a shared Databricks cluster. 

This PR makes this possible by adding an option for enabling log forwarding via Pipes messages with the  `PipesDefaultLogWriter` in the remote Pipes session. 

## How I Tested These Changes

Added a test

## Changelog

[dagster-databricks] Databricks Pipes now support log forwarding when running on existing clusters. It can be enabled by setting `PipesDbfsMessageReader(include_stdio_in_messages=True)`. 
