### PR TITLE
[dagster-aws] fix flaky PipesCloudWatchMessageReader test

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -487,6 +487,8 @@ def test_cloudwatch_logs_reader(cloudwatch_client: "CloudWatchLogsClient", capsy
 
     is_session_closed.set()
 
+    time.sleep(1)
+
     reader.stop()
 
     time.sleep(1)


### PR DESCRIPTION
## Summary & Motivation

Fixing a flaky `PipesCloudWatchMessageReader` which fails sometimes due to race conditions in writing and reading cloud watch events