### PR TITLE
[components] [rfc] Eval-based automation conditions

### DIFF
--- a/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
@@ -1,14 +1,20 @@
 import shutil
 import warnings
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, TypeAdapter
 
+from dagster import _check as check
+from dagster._annotations import is_public
 from dagster._components.core.component import Component, ComponentDeclNode, ComponentLoadContext
 from dagster._components.core.component_decl_builder import YamlComponentDecl
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
@@ -16,6 +22,44 @@ from dagster._utils.warnings import ExperimentalWarning
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
+
+
+class AutomationConditionInterpreter:
+    @cache
+    @staticmethod
+    def allowed_operations() -> Mapping[str, Any]:
+        def is_allowed_operation(obj: Any) -> bool:
+            # Probably will need to make this an explicit annotation
+            return callable(obj) and is_public(obj) and isinstance(obj, staticmethod)
+
+        return {
+            name: method
+            for name, method in AutomationCondition.__dict__.items()
+            if is_allowed_operation(method)
+        }
+
+    @staticmethod
+    def eval(code: str) -> AutomationCondition:
+        """Executes a string of Python code, restricting the context to only public static methods
+        of the AutomationCondition class. The class name is not required in the code.
+
+        Args:
+            code (str): The Python code to execute.
+
+        Returns:
+            Any: The result of the executed code.
+
+        Raises:
+            Exception: If the code is invalid or contains unauthorized functions.
+        """
+        # # Restrict the context to only public static methods of AutomationCondition
+        # Evaluate the code in the restricted context
+        result = eval(
+            code,
+            {"__builtins__": __builtins__},  # TODO subset this
+            AutomationConditionInterpreter.allowed_operations(),
+        )
+        return check.inst(result, AutomationCondition)
 
 
 class AssetSpecModel(BaseModel):
@@ -28,6 +72,7 @@ class AssetSpecModel(BaseModel):
     code_version: Optional[str] = None
     owners: Sequence[str] = []
     tags: Mapping[str, str] = {}
+    automation_condition: Optional[str] = None
 
     def to_asset_spec(self) -> AssetSpec:
         with warnings.catch_warnings():
@@ -36,6 +81,11 @@ class AssetSpecModel(BaseModel):
                 **{
                     **self.__dict__,
                     "key": AssetKey.from_user_string(self.key),
+                    "automation_condition": AutomationConditionInterpreter.eval(
+                        self.automation_condition
+                    )
+                    if self.automation_condition
+                    else None,
                 },
             )
 

--- a/python_modules/dagster/dagster_tests/components_tests/test_automation_condition_interpreter.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_automation_condition_interpreter.py
@@ -1,0 +1,34 @@
+from dagster._components.impls.pipes_subprocess_script_collection import (
+    AutomationConditionInterpreter,
+)
+from dagster_dbt.asset_utils import AutomationCondition
+
+
+def test_allowed_operations() -> None:
+    operations = AutomationConditionInterpreter.allowed_operations()
+    assert "eager" in operations
+    assert "requires_cursor" not in operations
+
+
+def test_interpret_eager() -> None:
+    condition = AutomationConditionInterpreter.eval("eager()")
+    assert condition.get_label() == "eager"
+
+
+def test_using_since() -> None:
+    condition = AutomationConditionInterpreter.eval(
+        "code_version_changed().since(newly_requested())"
+    )
+    assert isinstance(condition, AutomationCondition)
+
+
+def test_using_or() -> None:
+    condition = AutomationConditionInterpreter.eval(
+        "newly_requested() | newly_updated() | initial_evaluation()"
+    )
+    assert isinstance(condition, AutomationCondition)
+
+
+def test_with_label() -> None:
+    condition = AutomationConditionInterpreter.eval("eager().with_label('test')")
+    assert condition.get_label() == "test"

--- a/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
@@ -143,14 +143,6 @@ def test_eager_automation_condition() -> None:
 
 
 def test_more_complex_condition() -> None:
-    # in_progress_or_failed_parents = AutomationCondition.any_deps_match(
-    # AutomationCondition.in_progress() | AutomationCondition.failed()
-
-    # methods = AutomationConditionInterpreter.methods()
-    # import code
-
-    # code.interact(local=locals())
-
     component = load_component_with_params(
         component_params={
             "script_one": {


### PR DESCRIPTION
## Summary & Motivation

This diff proposes uses `eval` in the YAML DSL to process evaluation conditions.

It places all the public static methods on `AutomationCondition` into context and evals it.

That means you can do things like:

```yaml
assets:
  - key: a
    automation_condition: "on_cron('0 0 0 * * ')" 
```

In yaml

or 

```yaml
assets:
  - key: a
    automation_condition: "any_deps_match(in_progress() | execution_failed())"
```

There are downsides to this. It can be a big footgun. Debugging can be hard. However it does open up a lot of flexibility to DSL users.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
