### PR TITLE
[components] Remove Definitions.merge_internal. Use suppress_dagster_warnings

### DIFF
--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -8,6 +8,7 @@ from dagster._components.core.component_decl_builder import (
     find_component_decl,
 )
 from dagster._components.core.deployment import CodeLocationProjectContext
+from dagster._utils.warnings import suppress_dagster_warnings
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -51,6 +52,7 @@ def build_defs_from_component_folder(
     return defs_from_components(resources=resources, context=context, components=components)
 
 
+@suppress_dagster_warnings
 def defs_from_components(
     *,
     context: ComponentLoadContext,
@@ -59,12 +61,13 @@ def defs_from_components(
 ) -> "Definitions":
     from dagster._core.definitions.definitions_class import Definitions
 
-    return Definitions.merge_internal(
-        [*[c.build_defs(context) for c in components], Definitions(resources=resources)]
+    return Definitions.merge(
+        *[*[c.build_defs(context) for c in components], Definitions(resources=resources)]
     )
 
 
 # Public method so optional Nones are fine
+@suppress_dagster_warnings
 def build_defs_from_toplevel_components_folder(
     path: Path,
     resources: Optional[Mapping[str, object]] = None,
@@ -84,4 +87,4 @@ def build_defs_from_toplevel_components_folder(
             resources=resources or {},
         )
         all_defs.append(defs)
-    return Definitions.merge_internal(all_defs)
+    return Definitions.merge(*all_defs)

--- a/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster/_components/impls/pipes_subprocess_script_collection.py
@@ -1,5 +1,4 @@
 import shutil
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
@@ -13,7 +12,7 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
-from dagster._utils.warnings import ExperimentalWarning
+from dagster._utils.warnings import suppress_dagster_warnings
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -30,15 +29,14 @@ class AssetSpecModel(BaseModel):
     owners: Sequence[str] = []
     tags: Mapping[str, str] = {}
 
+    @suppress_dagster_warnings
     def to_asset_spec(self) -> AssetSpec:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-            return AssetSpec(
-                **{
-                    **self.__dict__,
-                    "key": AssetKey.from_user_string(self.key),
-                },
-            )
+        return AssetSpec(
+            **{
+                **self.__dict__,
+                "key": AssetKey.from_user_string(self.key),
+            },
+        )
 
 
 class PipesSubprocessScriptParams(BaseModel):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -636,11 +636,6 @@ class Definitions(IHaveNew):
             Definitions: The merged definitions.
         """
         check.sequence_param(def_sets, "def_sets", of_type=Definitions)
-        return Definitions.merge_internal(def_sets)
-
-    @staticmethod
-    def merge_internal(def_sets: Sequence["Definitions"]) -> "Definitions":
-        check.sequence_param(def_sets, "def_sets", of_type=Definitions)
         assets = []
         schedules = []
         sensors = []


### PR DESCRIPTION
## Summary & Motivation

Addressing feedback in https://github.com/dagster-io/dagster/pull/26201

* Use `suppress_dagster_warnings` instead of `warnings`
* Do not have `Definitions.merge_internal`.

## How I Tested These Changes

BK
