### PR TITLE
RFC: allow load_assets_from_x to load asset specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.utils import (
+    DEFAULT_GROUP_NAME,
     resolve_automation_condition,
     validate_asset_owner,
     validate_group_name,
@@ -383,6 +384,36 @@ class AssetSpec(
                 owners=[*self.owners, *(owners if owners is not ... else [])],
                 tags={**current_tags_without_kinds, **(tags if tags is not ... else {})},
                 kinds={*self.kinds, *(kinds if kinds is not ... else {})},
+                partitions_def=self.partitions_def,
+            )
+
+    def with_attributes(
+        self, group_name: Optional[str] = None, key: Optional[AssetKey] = None
+    ) -> "AssetSpec":
+        if (
+            self.group_name is not None
+            and self.group_name != DEFAULT_GROUP_NAME  # group name already set
+            and group_name is not None  # group name being set
+        ):
+            raise DagsterInvalidDefinitionError(
+                "A group name has already been provided to asset spec"
+                f" {self.key.to_user_string()}"
+            )
+
+        with disable_dagster_warnings():
+            return self.dagster_internal_init(
+                key=self.key,
+                deps=self.deps,
+                description=self.description,
+                metadata=self.metadata,
+                skippable=self.skippable,
+                group_name=group_name,
+                code_version=self.code_version,
+                freshness_policy=self.freshness_policy,
+                automation_condition=self.automation_condition,
+                owners=self.owners,
+                tags=self.tags,
+                kinds=self.kinds,
                 partitions_def=self.partitions_def,
             )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/__init__.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/__init__.py
@@ -1,4 +1,4 @@
-from dagster import AssetKey, SourceAsset, asset
+from dagster import AssetKey, AssetSpec, SourceAsset, asset
 
 
 @asset
@@ -29,4 +29,13 @@ def make_list_of_source_assets():
     return [buddy_holly, jerry_lee_lewis]
 
 
-list_of_assets_and_source_assets = [*make_list_of_assets(), *make_list_of_source_assets()]
+def make_list_of_asset_specs():
+    my_asset_spec = AssetSpec(key=AssetKey("my_asset_spec"))
+    return [my_asset_spec]
+
+
+list_of_assets_and_source_assets = [
+    *make_list_of_assets(),
+    *make_list_of_source_assets(),
+    *make_list_of_asset_specs(),
+]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -14,6 +14,7 @@ from dagster import (
     load_assets_from_package_module,
     load_assets_from_package_name,
 )
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 
@@ -90,12 +91,12 @@ def test_load_assets_from_package_name():
     from dagster_tests.asset_defs_tests import asset_package
 
     assets_defs = load_assets_from_package_name(asset_package.__name__)
-    assert len(assets_defs) == 11
+    assert len(assets_defs) == 12
 
     assets_1 = [get_unique_asset_identifier(asset) for asset in assets_defs]
 
     assets_defs_2 = load_assets_from_package_name(asset_package.__name__)
-    assert len(assets_defs_2) == 11
+    assert len(assets_defs_2) == 12
 
     assets_2 = [get_unique_asset_identifier(asset) for asset in assets_defs]
 
@@ -106,12 +107,12 @@ def test_load_assets_from_package_module():
     from dagster_tests.asset_defs_tests import asset_package
 
     assets_1 = load_assets_from_package_module(asset_package)
-    assert len(assets_1) == 11
+    assert len(assets_1) == 12
 
     assets_1 = [get_unique_asset_identifier(asset) for asset in assets_1]
 
     assets_2 = load_assets_from_package_module(asset_package)
-    assert len(assets_2) == 11
+    assert len(assets_2) == 12
 
     assets_2 = [get_unique_asset_identifier(asset) for asset in assets_2]
 
@@ -157,11 +158,18 @@ def asset_in_current_module():
 source_asset_in_current_module = SourceAsset(AssetKey("source_asset_in_current_module"))
 
 
+asset_spec_in_current_module = AssetSpec(key=AssetKey("asset_spec_in_current_module"))
+
+
 def test_load_assets_from_current_module():
     assets = load_assets_from_current_module()
     assets = [get_unique_asset_identifier(asset) for asset in assets]
-    assert assets == ["asset_in_current_module", AssetKey("source_asset_in_current_module")]
-    assert len(assets) == 2
+    assert assets == [
+        "asset_in_current_module",
+        AssetKey("source_asset_in_current_module"),
+        AssetKey("asset_spec_in_current_module"),
+    ]
+    assert len(assets) == 3
 
 
 def test_load_assets_from_modules_with_group_name():


### PR DESCRIPTION
## Summary & Motivation
disclaimer: i haven't touched the core codebase for a long time, so this might be a naive approach and please feel free to push back on this!


why: as we push more on using asset spec to handle "observe" use cases, people will use asset specs more. so we want to make the loading convenient.
- note: this might be relevant to [an open discussion in the "bulk editing asset specs" work](https://www.notion.so/dagster/Bulk-editing-asset-specs-13f18b92e4628020bd6fd3ac45f28af0) around "making it easier to deal with Union[AssetSpec, AssetsDefinition]". my primary goal is to make the loading part easier and make asset specs feel similar to assets. this change does not intent to enable bulk edits, except for group_name.

how:
- this PR allows `load_assets_from_x` to load `AssetSpec`, so users no longer need to manually add asset specs to `Definitions(assets=[...])`.
- an alternative approach would be to introduce a separate `load_asset_specs_from_x` to avoid worrying about backcompat. this addition might break current users, and i haven't thought through the implications (e.g. our docs snippet fails, so users will be broken by this)

## How I Tested These Changes
unit test & local dummy project loads asset specs
## Changelog
load_assets_from_modules, load_assets_from_current_module, load_assets_from_package_module, load_assets_from_package_name now loads AssetSpec automatically.
