### PR TITLE
[components] [rfc] Python-based components

### DIFF
--- a/python_modules/dagster/dagster/_components/core/component_decl_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_decl_builder.py
@@ -20,9 +20,14 @@ class YamlComponentDecl(ComponentDeclNode):
 
 
 @record
+class PythonComponentDecl(ComponentDeclNode):
+    path: Path
+
+
+@record
 class ComponentFolder(ComponentDeclNode):
     path: Path
-    sub_decls: Sequence[Union[YamlComponentDecl, "ComponentFolder"]]
+    sub_decls: Sequence[Union[YamlComponentDecl, "ComponentFolder", PythonComponentDecl]]
 
 
 def find_component_decl(path: Path) -> Optional[ComponentDeclNode]:
@@ -33,13 +38,18 @@ def find_component_decl(path: Path) -> Optional[ComponentDeclNode]:
     if not path.is_dir():
         return None
 
-    defs_path = path / "defs.yml"
+    defs_yml_path = path / "defs.yml"
 
-    if defs_path.exists():
+    if defs_yml_path.exists():
         defs_file_model = parse_yaml_file_to_pydantic(
-            DefsFileModel, defs_path.read_text(), str(path)
+            DefsFileModel, defs_yml_path.read_text(), str(path)
         )
         return YamlComponentDecl(path=path, defs_file_model=defs_file_model)
+
+    defs_py_path = path / "defs.py"
+
+    if defs_py_path.exists():
+        return PythonComponentDecl(path=path)
 
     subs = []
     for subpath in path.iterdir():

--- a/python_modules/dagster/dagster/_components/core/component_decl_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_decl_builder.py
@@ -49,7 +49,7 @@ def find_component_decl(path: Path) -> Optional[ComponentDeclNode]:
     defs_py_path = path / "defs.py"
 
     if defs_py_path.exists():
-        return PythonComponentDecl(path=path)
+        return PythonComponentDecl(path=defs_py_path)
 
     subs = []
     for subpath in path.iterdir():

--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -31,11 +31,11 @@ def build_component_hierarchy(
                 module_name=decl_node.path.parent.stem, path_to_file=str(decl_node.path)
             )
 
-            assert hasattr(module, "component_instance")
+            assert hasattr(module, "component_loader")
 
-            if "component_instance" in module.__dict__:
-                component_instance_fn = module.__dict__["component_instance"]
-                component = component_instance_fn(context)
+            if "component_loader" in module.__dict__:
+                component_loader_fn = module.__dict__["component_loader"]
+                component = component_loader_fn(context)
                 to_return.append(component)
         elif isinstance(decl_node, ComponentFolder):
             to_return.extend(build_component_hierarchy(context, decl_node))

--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
 from dagster._components.core.component import Component, ComponentLoadContext, ComponentRegistry
 from dagster._components.core.component_decl_builder import (
     ComponentFolder,
+    PythonComponentDecl,
     YamlComponentDecl,
     find_component_decl,
 )
 from dagster._components.core.deployment import CodeLocationProjectContext
+from dagster._seven import import_module_from_path
 from dagster._utils.warnings import suppress_dagster_warnings
 
 if TYPE_CHECKING:
@@ -23,6 +25,14 @@ def build_component_hierarchy(
             parsed_defs = decl_node.defs_file_model
             component_type = context.registry.get(parsed_defs.component_type)
             to_return.append(component_type.from_decl_node(context, decl_node))
+        elif isinstance(decl_node, PythonComponentDecl):
+            module = import_module_from_path(
+                module_name="something", path_to_file=str(decl_node.path)
+            )
+            import code
+
+            code.interact(local=locals())
+            ...
         elif isinstance(decl_node, ComponentFolder):
             to_return.extend(build_component_hierarchy(context, decl_node))
         else:

--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -27,12 +27,15 @@ def build_component_hierarchy(
             to_return.append(component_type.from_decl_node(context, decl_node))
         elif isinstance(decl_node, PythonComponentDecl):
             module = import_module_from_path(
-                module_name="something", path_to_file=str(decl_node.path)
+                module_name="something", path_to_file=str(decl_node.path / "defs.py")
             )
-            import code
 
-            code.interact(local=locals())
-            ...
+            assert hasattr(module, "component_instance")
+
+            if "component_instance" in module.__dict__:
+                component_instance_fn = module.__dict__["component_instance"]
+                component = component_instance_fn(context)
+                to_return.append(component)
         elif isinstance(decl_node, ComponentFolder):
             to_return.extend(build_component_hierarchy(context, decl_node))
         else:

--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -31,6 +31,7 @@ def build_component_hierarchy(
                 module_name=decl_node.path.parent.stem, path_to_file=str(decl_node.path)
             )
 
+            # TODO make this more robust via a component_loader decorator or something
             assert hasattr(module, "component_loader")
 
             if "component_loader" in module.__dict__:

--- a/python_modules/dagster/dagster/_components/core/component_defs_builder.py
+++ b/python_modules/dagster/dagster/_components/core/component_defs_builder.py
@@ -26,8 +26,9 @@ def build_component_hierarchy(
             component_type = context.registry.get(parsed_defs.component_type)
             to_return.append(component_type.from_decl_node(context, decl_node))
         elif isinstance(decl_node, PythonComponentDecl):
+            # TODO need a coherent scheme for determining the module name
             module = import_module_from_path(
-                module_name="something", path_to_file=str(decl_node.path / "defs.py")
+                module_name=decl_node.path.parent.stem, path_to_file=str(decl_node.path)
             )
 
             assert hasattr(module, "component_instance")

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/defs.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/defs.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from dagster._components.core.component_defs_builder import ComponentLoadContext
+from dagster._components.impls.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollection,
+)
+from dagster._core.definitions.asset_spec import AssetSpec
+
+
+def component_path() -> Path:
+    return Path(__file__).parent
+
+
+# component = PipesSubprocessScriptCollection(
+#     dirpath=component_path(),
+#     path_specs={
+#         component_path() / "script_one.py": [AssetSpec("asset_one")],
+#         component_path() / "script_two.py": [AssetSpec("asset_two")],
+#     },
+# )
+
+# defs = component.build_defs(
+#     load_context=ComponentLoadContext(resources={}, registry=ComponentRegistry({}))
+# )
+
+
+def component_instance(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
+    return PipesSubprocessScriptCollection(
+        dirpath=component_path(),
+        path_specs={
+            component_path() / "script_one.py": [AssetSpec("asset_one")],
+            component_path() / "script_two.py": [AssetSpec("asset_two")],
+        },
+    )

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/defs.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/defs.py
@@ -11,20 +11,7 @@ def component_path() -> Path:
     return Path(__file__).parent
 
 
-# component = PipesSubprocessScriptCollection(
-#     dirpath=component_path(),
-#     path_specs={
-#         component_path() / "script_one.py": [AssetSpec("asset_one")],
-#         component_path() / "script_two.py": [AssetSpec("asset_two")],
-#     },
-# )
-
-# defs = component.build_defs(
-#     load_context=ComponentLoadContext(resources={}, registry=ComponentRegistry({}))
-# )
-
-
-def component_instance(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
+def component_loader(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
     return PipesSubprocessScriptCollection(
         dirpath=component_path(),
         path_specs={

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/script_one.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/script_one.py
@@ -1,0 +1,6 @@
+def do_thing() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    do_thing()

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/script_two.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_python_script_location/components/scripts/script_two.py
@@ -1,0 +1,6 @@
+def do_thing() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    do_thing()

--- a/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
@@ -13,7 +13,7 @@ from dagster._components.impls.pipes_subprocess_script_collection import (
 )
 from dagster._core.instance import DagsterInstance
 
-LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
+YAML_BASED_LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
 
 
 def registry() -> ComponentRegistry:
@@ -46,7 +46,7 @@ def _assert_assets(component: Component, expected_assets: int) -> None:
 
 def test_python_native() -> None:
     component = PipesSubprocessScriptCollection.introspect_from_path(
-        LOCATION_PATH / "components" / "scripts"
+        YAML_BASED_LOCATION_PATH / "components" / "scripts"
     )
     _assert_assets(component, 3)
 
@@ -55,7 +55,7 @@ def test_python_params() -> None:
     component = PipesSubprocessScriptCollection.from_decl_node(
         load_context=script_load_context(),
         component_decl=YamlComponentDecl(
-            path=LOCATION_PATH / "components" / "scripts",
+            path=YAML_BASED_LOCATION_PATH / "components" / "scripts",
             defs_file_model=DefsFileModel(
                 component_type="pipes_subprocess_script_collection",
                 component_params={
@@ -81,7 +81,7 @@ def test_python_params() -> None:
 
 def test_load_from_path() -> None:
     components = build_components_from_component_folder(
-        script_load_context(), LOCATION_PATH / "components"
+        script_load_context(), YAML_BASED_LOCATION_PATH / "components"
     )
     assert len(components) == 1
     assert _asset_keys(components[0]) == {
@@ -109,3 +109,15 @@ def test_load_from_path() -> None:
         AssetKey("up2"),
         AssetKey("override_key"),
     }
+
+
+PYTHON_BASED_LOCATION_PATH = (
+    Path(__file__).parent / "code_locations" / "python_python_script_location"
+)
+
+
+def test_load_py_component_from_path() -> None:
+    components = build_components_from_component_folder(
+        script_load_context(), PYTHON_BASED_LOCATION_PATH / "components"
+    )
+    assert len(components) == 1


### PR DESCRIPTION
## Summary & Motivation

API for discovering and loading purely Python-based components. This is a hacky proof of concept not meant for commit.

Idea is that instead of a yaml file the user would define, in Python, a function the returns an instance of a component.

e.g.

```python
def component_loader(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
    return PipesSubprocessScriptCollection(
        dirpath=component_path(),
        path_specs={
            component_path() / "script_one.py": [AssetSpec("asset_one")],
            component_path() / "script_two.py": [AssetSpec("asset_two")],
        },
    )
```

We would not repeat the mistake we made with `Definitions` that relied on creating the object at import time. This would always be within a function.

It would also be straightforward to define a component subclass directly in this file and instantiate it.

## How I Tested These Changes

BK