### PR TITLE
Make dagster-dbt project scaffold compatible with uv

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/pyproject.toml.jinja
@@ -1,3 +1,23 @@
+[project]
+name = "{{ project_name }}"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.9,<3.13"
+dependencies = [
+    "dagster",
+    "dagster-cloud",
+    "dagster-dbt",
+    {%- for dbt_adapter in dbt_adapter_packages %}
+    "{{ dbt_adapter }}<{{ dbt_core_version_upper_bound }}",
+    {%- endfor %}
+]
+
+[project.optional-dependencies]
+dev = [
+    "dagster-webserver", 
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary & Motivation

This PR modifies the `dagster-dbt` to compatible with uv by modify a `pyproject.toml`. The pyproject.toml that generated by `dagster-dbt` is a bit different from the `dagster` is that the pyproject.toml didn't include `pytest` as an dev dependency.

Closes #26224 

## How I Tested These Changes

1. Clone the jaffle_shop and follow the profile setup from https://docs.dagster.io/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.
2. In `python_modules/libraries/dagster-dbt`, run `typer dagster_dbt/cli/app.py run project scaffold --project-name hello_dbt --dbt-project-dir jaffle-shop-classic`. The `hello_dbt` should be generated successfully.
3. Open the `pyproject.toml` in `hello_dbt`, the dependencies (and optional-dependencies) and project information should be added.
4. Run the pipeline with `uv run --extra dev dagster run`. The dbt assets will be presents on assets pipeline page.

## Changelog

[dagster-dbt] Update dagster-dbt scaffold template to be compatible with uv
