### PR TITLE
[components] [easy] Use ephemeral instance in test

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_pipes_subprocess_script_collection.py
@@ -11,6 +11,7 @@ from dagster._components.core.component_defs_builder import (
 from dagster._components.impls.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollection,
 )
+from dagster._core.instance import DagsterInstance
 
 LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
 
@@ -37,7 +38,9 @@ def _asset_keys(component: Component) -> set[AssetKey]:
 def _assert_assets(component: Component, expected_assets: int) -> None:
     defs = component.build_defs(ComponentLoadContext.for_test())
     assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
-    result = defs.get_implicit_global_asset_job_def().execute_in_process()
+    result = defs.get_implicit_global_asset_job_def().execute_in_process(
+        instance=DagsterInstance.ephemeral()
+    )
     assert result.success
 
 


### PR DESCRIPTION
## Summary & Motivation

Changing this test to run against ephemeral instance. It was running against the default system before which leaves file system turds if you do not have DAGSTER_HOME set

## How I Tested These Changes

Local test run. Saw no file system turds.
