### PR TITLE
[dagster-embedded-elt][dlt] pin dlt <1.4.1 due to breaking schema change used in row counts

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
-    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4"],
+    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4,<1.4.1"],
     zip_safe=False,
     extras_require={
         "test": [

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,6 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
+    # pin dlt<1.4.1 due to breaking change in table naming convention with double underscores; pending support response from dltHub team members
     install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4,<1.4.1"],
     zip_safe=False,
     extras_require={


### PR DESCRIPTION
## Summary & Motivation

Temporary pin until breaking change in schema is made more robust.

## How I Tested These Changes

local pytest / bk

## Changelog

- Pins dlt to <1.4.1 due to breaking schema change used in row counts
