### PR TITLE
[dagster-embedded-elt][dlt] remove forced double-underscore in transformer

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
@@ -52,8 +52,6 @@ def pipeline(month: Optional[str] = None):
         primary_key=["repo_id", "issue_id"],
         write_disposition="merge",
         data_from=repos,
-        # Test the case where source identifier 'Repo__Issues' differs from destination identifier 'repo_issues'.
-        table_name="Repo__Issues",
     )
     def repo_issues(repo):
         """Extracted list of issues from repositories."""

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,8 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
-    # pin dlt<1.4.1 due to breaking change in table naming convention with double underscores; pending support response from dltHub team members
-    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4,<1.4.1"],
+    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4"],
     zip_safe=False,
     extras_require={
         "test": [

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
-    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4"],
+    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4,<1.4.1"],
     zip_safe=False,
     extras_require={
         "test": [

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,6 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
+    # pin dlt<1.4.1 due to breaking change in table naming convention with double underscores; pending support response from dltHub team members
     install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4,<1.4.1"],
     zip_safe=False,
     extras_require={


### PR DESCRIPTION
## Summary & Motivation

Removes hard-coded double underscore `table_name` in example `@transformer`; this is a reserved naming convention for children tables by `dlt` and causes unwanted behavior in metadata extraction for primary tables. This will likely, or should not, exist in real-world scenarios.

## How I Tested These Changes

pytest / bk

## Changelog

> Insert changelog entry or delete this section.
