### PR TITLE
[ui] Fix styles for tag actions link

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
@@ -1,7 +1,7 @@
 import {Box, Caption, Colors, Popover} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 import {TagType} from '../runs/RunTag';
 
@@ -19,11 +19,9 @@ export const TagActions = ({data, actions}: {data: TagType; actions: TagAction[]
   <ActionContainer background={Colors.tooltipBackground()} flex={{direction: 'row'}}>
     {actions.map((action, ii) =>
       'to' in action ? (
-        <Link to={action.to} key={ii}>
-          <TagButton>
-            <Caption>{action.label}</Caption>
-          </TagButton>
-        </Link>
+        <TagButtonLink to={action.to} key={ii}>
+          <Caption>{action.label}</Caption>
+        </TagButtonLink>
       ) : (
         <TagButton key={ii} onClick={() => action.onClick(data)}>
           <Caption>{action.label}</Caption>
@@ -63,7 +61,7 @@ const ActionContainer = styled(Box)`
   overflow: hidden;
 `;
 
-const TagButton = styled.button`
+const TagButtonSharedStyles = css`
   border: none;
   background: ${Colors.tooltipBackground()};
   color: ${Colors.tooltipText()};
@@ -80,8 +78,22 @@ const TagButton = styled.button`
   :focus {
     outline: none;
   }
+`;
+
+const TagButton = styled.button`
+  ${TagButtonSharedStyles}
 
   :hover {
+    opacity: 1;
+  }
+`;
+
+const TagButtonLink = styled(Link)`
+  ${TagButtonSharedStyles}
+
+  :hover {
+    color: ${Colors.tooltipText()};
+    text-decoration: none;
     opacity: 1;
   }
 `;


### PR DESCRIPTION
## Summary & Motivation

Fix the structure and styles of links within the tag actions popover. Namely, links are rendered outside `button` elements, which isn't valid, and the separation border doesn't render correctly.

Before:

<img width="372" alt="Screenshot 2024-12-02 at 14 00 17" src="https://github.com/user-attachments/assets/b37a58f8-908c-443d-9d08-8878d3f9e8cf">

After:

<img width="349" alt="Screenshot 2024-12-02 at 13 57 26" src="https://github.com/user-attachments/assets/9f3a5264-c266-46dc-8656-64823f9a19a0">

## How I Tested These Changes

Hover on tag actions on a run tick tag.
