### PR TITLE
Disallow 2/30 and 2/31 cronstrings

### DIFF
--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -6,6 +6,7 @@ from dagster._time import create_datetime, get_timezone
 from dagster._utils.schedules import (
     _croniter_string_iterator,
     cron_string_iterator,
+    is_valid_cron_string,
     reverse_cron_string_iterator,
 )
 
@@ -645,3 +646,21 @@ def test_weekend_cron_schedule_with_sunday_as_7():
 
         for i in range(len(expected_datetimes)):
             assert next(cron_iter) == expected_datetimes[-(i + 1)]
+
+
+def test_invalid_cron_strings():
+    assert is_valid_cron_string("0 0 27 2 *")
+    assert is_valid_cron_string("0 0 28 2 *")
+    assert is_valid_cron_string("0 0 29 2 *")
+    assert is_valid_cron_string("0 0 29 2 3")
+
+    assert not is_valid_cron_string("0 0 30 2 *")
+    assert not is_valid_cron_string("0 0 30 2 3")
+
+    assert not is_valid_cron_string("0 0 31 2 *")
+    assert not is_valid_cron_string("0 0 31 2 3")
+
+    assert not is_valid_cron_string("0 0 32 2 *")
+
+    assert is_valid_cron_string("0 0 31 1 *")
+    assert not is_valid_cron_string("0 0 32 1 *")


### PR DESCRIPTION
## Summary & Motivation
Croniter validates these strings but they error when you try to iterate them, since they produce no dates. Instead, fail them at definition time.

## How I Tested These Changes
BK

## Changelog
Fixed an issue where invalid cron strings like "0 0 30 2 *" that represented invalid dates in February were still allowed as Dagster cron strings, but then failed during schedule execution. Now, these invalid cronstrings will raise an exception when they are first loaded.

