### PR TITLE
[3/n][dagster-airbyte] Implement base request method in AirbyteCloudClient

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -21,6 +21,7 @@ from dagster_airbyte.asset_defs import (
 from dagster_airbyte.ops import airbyte_sync_op as airbyte_sync_op
 from dagster_airbyte.resources import (
     AirbyteCloudResource as AirbyteCloudResource,
+    AirbyteCloudWorkspace as AirbyteCloudWorkspace,
     AirbyteResource as AirbyteResource,
     AirbyteState as AirbyteState,
     airbyte_cloud_resource as airbyte_cloud_resource,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -29,6 +29,9 @@ from requests.exceptions import RequestException
 from dagster_airbyte.translator import AirbyteWorkspaceData
 from dagster_airbyte.types import AirbyteOutput
 
+AIRBYTE_API_BASE = "https://api.airbyte.com"
+AIRBYTE_API_VERSION = "v1"
+
 DEFAULT_POLL_INTERVAL_SECONDS = 10
 
 # The access token expire every 3 minutes in Airbyte Cloud.
@@ -834,7 +837,7 @@ class AirbyteCloudClient(DagsterModel):
 
     @property
     def api_base_url(self) -> str:
-        return "https://api.airbyte.com/v1"
+        return f"{AIRBYTE_API_BASE}/{AIRBYTE_API_VERSION}"
 
     @property
     def all_additional_request_params(self) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -867,6 +867,7 @@ class AirbyteCloudClient(DagsterModel):
             self._make_request(
                 method="POST",
                 endpoint="/applications/token",
+                base_url=self.api_base_url,
                 data={
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
@@ -892,6 +893,7 @@ class AirbyteCloudClient(DagsterModel):
         self,
         method: str,
         endpoint: str,
+        base_url: str,
         data: Optional[Mapping[str, Any]] = None,
         include_additional_request_params: bool = True,
     ) -> Mapping[str, Any]:
@@ -900,6 +902,7 @@ class AirbyteCloudClient(DagsterModel):
         Args:
             method (str): The http method to use for this request (e.g. "POST", "GET", "PATCH").
             endpoint (str): The Airbyte API endpoint to send this request to.
+            base_url (str): The base url to the Airbyte API to use.
             data (Optional[Dict[str, Any]]): JSON-formatted data string to be included in the request.
             include_additional_request_params (bool): Whether to include authorization and user-agent headers
             to the request parameters. Defaults to True.
@@ -907,7 +910,7 @@ class AirbyteCloudClient(DagsterModel):
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request
         """
-        url = self.api_base_url + endpoint
+        url = base_url + endpoint
         headers = {"accept": "application/json"}
 
         num_retries = 0

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -884,9 +884,9 @@ class AirbyteCloudClient(DagsterModel):
             not self._access_token_value
             or not self._access_token_timestamp
             or self._access_token_timestamp
-            <= datetime.timestamp(
+            <= (
                 datetime.now() - timedelta(seconds=AIRBYTE_CLOUD_REFRESH_TIMEDELTA_SECONDS)
-            )
+            ).timestamp()
         )
 
     def _make_request(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -894,18 +894,18 @@ class AirbyteCloudClient(DagsterModel):
         endpoint: str,
         data: Optional[Mapping[str, Any]] = None,
         include_additional_request_params: bool = True,
-    ) -> Optional[Mapping[str, Any]]:
+    ) -> Mapping[str, Any]:
         """Creates and sends a request to the desired Airbyte REST API endpoint.
 
         Args:
             method (str): The http method to use for this request (e.g. "POST", "GET", "PATCH").
             endpoint (str): The Airbyte API endpoint to send this request to.
-            data (Optional[str]): JSON-formatted data string to be included in the request.
+            data (Optional[Dict[str, Any]]): JSON-formatted data string to be included in the request.
             include_additional_request_params (bool): Whether to include authorization and user-agent headers
             to the request parameters. Defaults to True.
 
         Returns:
-            Optional[Dict[str, Any]]: Parsed json data from the response to this request
+            Dict[str, Any]: Parsed json data from the response to this request
         """
         url = self.api_base_url + endpoint
         headers = {"accept": "application/json"}
@@ -932,8 +932,6 @@ class AirbyteCloudClient(DagsterModel):
                     **request_args,
                 )
                 response.raise_for_status()
-                if response.status_code == 204:
-                    return None
                 return response.json()
             except RequestException as e:
                 self._log.error("Request to Airbyte API failed: %s", e)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -1,0 +1,23 @@
+from typing import Iterator
+
+import pytest
+import responses
+from dagster_airbyte.resources import AIRBYTE_API_BASE, AIRBYTE_API_VERSION
+
+# Taken from Airbyte API documentation
+# https://reference.airbyte.com/reference/createaccesstoken
+SAMPLE_ACCESS_TOKEN = {"access_token": "some_access_token"}
+
+
+@pytest.fixture(
+    name="base_api_mocks",
+)
+def base_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
+    with responses.RequestsMock() as response:
+        response.add(
+            method=responses.POST,
+            url=f"{AIRBYTE_API_BASE}/{AIRBYTE_API_VERSION}/applications/token",
+            json=SAMPLE_ACCESS_TOKEN,
+            status=201,
+        )
+        yield response

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -4,9 +4,15 @@ import pytest
 import responses
 from dagster_airbyte.resources import AIRBYTE_API_BASE, AIRBYTE_API_VERSION
 
+TEST_WORKSPACE_ID = "some_workspace_id"
+TEST_CLIENT_ID = "some_client_id"
+TEST_CLIENT_SECRET = "some_client_secret"
+
+TEST_ACCESS_TOKEN = "some_access_token"
+
 # Taken from Airbyte API documentation
 # https://reference.airbyte.com/reference/createaccesstoken
-SAMPLE_ACCESS_TOKEN = {"access_token": "some_access_token"}
+SAMPLE_ACCESS_TOKEN = {"access_token": TEST_ACCESS_TOKEN}
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -14,6 +14,12 @@ from dagster_airbyte_tests.experimental.conftest import (
 
 
 def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
+    """Tests the `AirbyteCloudClient._make_request` method and how the API access token is refreshed.
+
+    Args:
+        base_api_mocks (responses.RequestsMock): The mock responses for the base API requests,
+        i.e. generating the access token.
+    """
     resource = AirbyteCloudWorkspace(
         workspace_id=TEST_WORKSPACE_ID,
         client_id=TEST_CLIENT_ID,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -5,12 +5,19 @@ from unittest import mock
 import responses
 from dagster_airbyte import AirbyteCloudWorkspace
 
+from dagster_airbyte_tests.experimental.conftest import (
+    TEST_ACCESS_TOKEN,
+    TEST_CLIENT_ID,
+    TEST_CLIENT_SECRET,
+    TEST_WORKSPACE_ID,
+)
+
 
 def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
     resource = AirbyteCloudWorkspace(
-        workspace_id="some_workspace_id",
-        client_id="some_client_id",
-        client_secret="some_client_secret",
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
     )
     client = resource.get_client()
 
@@ -35,9 +42,9 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
         assert "Authorization" not in access_token_call.request.headers
         access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
-        assert access_token_call_body["client_id"] == "some_client_id"
-        assert access_token_call_body["client_secret"] == "some_client_secret"
-        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+        assert access_token_call_body["client_id"] == TEST_CLIENT_ID
+        assert access_token_call_body["client_secret"] == TEST_CLIENT_SECRET
+        assert jobs_api_call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
 
         base_api_mocks.calls.reset()
 
@@ -48,7 +55,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
         assert len(base_api_mocks.calls) == 1
         jobs_api_call = base_api_mocks.calls[0]
 
-        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+        assert jobs_api_call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
 
         base_api_mocks.calls.reset()
 
@@ -63,6 +70,6 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
         assert "Authorization" not in access_token_call.request.headers
         access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
-        assert access_token_call_body["client_id"] == "some_client_id"
-        assert access_token_call_body["client_secret"] == "some_client_secret"
-        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+        assert access_token_call_body["client_id"] == TEST_CLIENT_ID
+        assert access_token_call_body["client_secret"] == TEST_CLIENT_SECRET
+        assert jobs_api_call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -27,7 +27,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
     with mock.patch("dagster_airbyte.resources.datetime", wraps=datetime) as dt:
         # Test first call, must get the access token before calling the jobs api
         dt.now.return_value = test_time_first_call
-        client._make_request(method="GET", endpoint="/test")  # noqa
+        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]
@@ -43,7 +43,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
         # Test second call, occurs before the access token expiration, only the jobs api is called
         dt.now.return_value = test_time_before_expiration
-        client._make_request(method="GET", endpoint="/test")  # noqa
+        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 1
         jobs_api_call = base_api_mocks.calls[0]
@@ -55,7 +55,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
         # Test third call, occurs after the token expiration,
         # must refresh the access token before calling the jobs api
         dt.now.return_value = test_time_after_expiration
-        client._make_request(method="GET", endpoint="/test")  # noqa
+        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -15,11 +15,6 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
     client = resource.get_client()
 
     base_api_mocks.add(
-        responses.POST,
-        f"{client.api_base_url}/applications/token",
-        json={"access_token": "some_access_token"},
-    )
-    base_api_mocks.add(
         method=responses.GET,
         url=f"{client.api_base_url}/test",
         json={},

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -1,0 +1,74 @@
+import json
+from datetime import datetime
+from unittest import mock
+
+import responses
+from dagster_airbyte import AirbyteCloudWorkspace
+
+
+@responses.activate
+def test_refresh_access_token() -> None:
+    resource = AirbyteCloudWorkspace(
+        workspace_id="some_workspace_id",
+        client_id="some_client_id",
+        client_secret="some_client_secret",
+    )
+    client = resource.get_client()
+
+    responses.add(
+        responses.POST,
+        f"{client.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
+    responses.add(
+        method=responses.GET,
+        url=f"{client.api_base_url}/test",
+        json={},
+        status=200,
+    )
+
+    test_time_first_call = datetime(2024, 1, 1, 0, 0, 0)
+    test_time_before_expiration = datetime(2024, 1, 1, 0, 2, 0)
+    test_time_after_expiration = datetime(2024, 1, 1, 0, 3, 0)
+    with mock.patch("dagster_airbyte.resources.datetime", wraps=datetime) as dt:
+        # Test first call, must get the access token before calling the jobs api
+        dt.now.return_value = test_time_first_call
+        client._make_request(method="GET", endpoint="/test")  # noqa
+
+        assert len(responses.calls) == 2
+        access_token_call = responses.calls[0]
+        jobs_api_call = responses.calls[1]
+
+        assert "Authorization" not in access_token_call.request.headers
+        access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
+        assert access_token_call_body["client_id"] == "some_client_id"
+        assert access_token_call_body["client_secret"] == "some_client_secret"
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+
+        responses.calls.reset()
+
+        # Test second call, occurs before the access token expiration, only the jobs api is called
+        dt.now.return_value = test_time_before_expiration
+        client._make_request(method="GET", endpoint="/test")  # noqa
+
+        assert len(responses.calls) == 1
+        jobs_api_call = responses.calls[0]
+
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+
+        responses.calls.reset()
+
+        # Test third call, occurs after the token expiration,
+        # must refresh the access token before calling the jobs api
+        dt.now.return_value = test_time_after_expiration
+        client._make_request(method="GET", endpoint="/test")  # noqa
+
+        assert len(responses.calls) == 2
+        access_token_call = responses.calls[0]
+        jobs_api_call = responses.calls[1]
+
+        assert "Authorization" not in access_token_call.request.headers
+        access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
+        assert access_token_call_body["client_id"] == "some_client_id"
+        assert access_token_call_body["client_secret"] == "some_client_secret"
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"


### PR DESCRIPTION
## Summary & Motivation

This PR implements the base `_make_request` method for AirbyteCloudClient and the methods that are required to handle the creation of the access token.

About the access token, the logic was taken and reworked from this [previous implementation](https://github.com/dagster-io/dagster/pull/23451). TL;DR, Airbyte now requires a client ID and secret to generate an access token - this access token expires every 3 minutes. See more [here](https://reference.airbyte.com/reference/portalairbytecom-deprecation).

## How I Tested These Changes

Additional tests

