### PR TITLE
[4/n][dagster-airbyte] Implement connection and destination methods in AirbyteClient

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -32,8 +32,8 @@ from dagster_airbyte.types import AirbyteOutput
 AIRBYTE_REST_API_BASE = "https://api.airbyte.com"
 AIRBYTE_REST_API_VERSION = "v1"
 
-AIRBYTE_SERVER_API_BASE = "https://cloud.airbyte.com/api"
-AIRBYTE_SERVER_API_VERSION = "v1"
+AIRBYTE_CONFIGURATION_API_BASE = "https://cloud.airbyte.com/api"
+AIRBYTE_CONFIGURATION_API_VERSION = "v1"
 
 DEFAULT_POLL_INTERVAL_SECONDS = 10
 
@@ -843,8 +843,8 @@ class AirbyteCloudClient(DagsterModel):
         return f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}"
 
     @property
-    def server_api_base_url(self) -> str:
-        return f"{AIRBYTE_SERVER_API_BASE}/{AIRBYTE_SERVER_API_VERSION}"
+    def configuration_api_base_url(self) -> str:
+        return f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}"
 
     @property
     def all_additional_request_params(self) -> Mapping[str, Any]:
@@ -960,13 +960,13 @@ class AirbyteCloudClient(DagsterModel):
         )
 
     def get_connection_details(self, connection_id) -> Mapping[str, Any]:
-        """Fetches details about a given connection from the Airbyte Server API."""
-        # Using the Server API to get the connection details, including streams and their configs.
+        """Fetches details about a given connection from the Airbyte Configuration API."""
+        # Using the Airbyte Configuration API to get the connection details, including streams and their configs.
         # https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
         return self._make_request(
             method="POST",
             endpoint="connections/get",
-            base_url=self.server_api_base_url,
+            base_url=self.configuration_api_base_url,
             data={"connectionId": connection_id},
         )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -960,9 +960,12 @@ class AirbyteCloudClient(DagsterModel):
         )
 
     def get_connection_details(self, connection_id) -> Mapping[str, Any]:
-        """Fetches details about a given connection from the Airbyte Configuration API."""
+        """Fetches details about a given connection from the Airbyte Configuration API.
+        The Airbyte Configuration API is an internal and may change in the future.
+        """
         # Using the Airbyte Configuration API to get the connection details, including streams and their configs.
         # https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
+        # https://github.com/airbytehq/airbyte-platform/blob/v1.0.0/airbyte-api/server-api/src/main/openapi/config.yaml
         return self._make_request(
             method="POST",
             endpoint="connections/get",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -960,7 +960,7 @@ class AirbyteCloudClient(DagsterModel):
         )
 
     def get_connection_details(self, connection_id) -> Mapping[str, Any]:
-        """Fetches all connections of an Airbyte workspace from the Airbyte Server API."""
+        """Fetches details about a given connection from the Airbyte Server API."""
         # Using the Server API to get the connection details, including streams and their configs.
         # https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
         return self._make_request(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -943,23 +943,19 @@ class AirbyteCloudClient(DagsterModel):
 
     def get_connections(self) -> Mapping[str, Any]:
         """Fetches all connections of an Airbyte workspace from the Airbyte API."""
-        return check.not_none(
-            self._make_request(
-                method="GET",
-                endpoint="connections",
-                base_url=self.api_base_url,
-                data={"workspaceIds": [self.workspace_id]},
-            )
+        return self._make_request(
+            method="GET",
+            endpoint="connections",
+            base_url=self.api_base_url,
+            data={"workspaceIds": [self.workspace_id]},
         )
 
     def get_destination_details(self, destination_id: str) -> Mapping[str, Any]:
         """Fetches details about a given destination from the Airbyte API."""
-        return check.not_none(
-            self._make_request(
-                method="GET",
-                endpoint=f"destinations/{destination_id}",
-                base_url=self.api_base_url,
-            )
+        return self._make_request(
+            method="GET",
+            endpoint=f"destinations/{destination_id}",
+            base_url=self.api_base_url,
         )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -862,7 +862,7 @@ class AirbyteCloudClient(DagsterModel):
         response = check.not_none(
             self._make_request(
                 method="POST",
-                endpoint="/applications/token",
+                endpoint="applications/token",
                 base_url=self.api_base_url,
                 data={
                     "client_id": self.client_id,
@@ -917,7 +917,7 @@ class AirbyteCloudClient(DagsterModel):
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request
         """
-        url = base_url + endpoint
+        url = f"{base_url}/{endpoint}"
 
         num_retries = 0
         while True:
@@ -943,11 +943,24 @@ class AirbyteCloudClient(DagsterModel):
 
     def get_connections(self) -> Mapping[str, Any]:
         """Fetches all connections of an Airbyte workspace from the Airbyte API."""
-        raise NotImplementedError()
+        return check.not_none(
+            self._make_request(
+                method="GET",
+                endpoint="connections",
+                base_url=self.api_base_url,
+                data={"workspaceIds": [self.workspace_id]},
+            )
+        )
 
     def get_destination_details(self, destination_id: str) -> Mapping[str, Any]:
         """Fetches details about a given destination from the Airbyte API."""
-        raise NotImplementedError()
+        return check.not_none(
+            self._make_request(
+                method="GET",
+                endpoint=f"destinations/{destination_id}",
+                base_url=self.api_base_url,
+            )
+        )
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -3,10 +3,10 @@ from typing import Iterator
 import pytest
 import responses
 from dagster_airbyte.resources import (
+    AIRBYTE_CONFIGURATION_API_BASE,
+    AIRBYTE_CONFIGURATION_API_VERSION,
     AIRBYTE_REST_API_BASE,
     AIRBYTE_REST_API_VERSION,
-    AIRBYTE_SERVER_API_BASE,
-    AIRBYTE_SERVER_API_VERSION,
 )
 
 TEST_WORKSPACE_ID = "some_workspace_id"
@@ -45,7 +45,7 @@ SAMPLE_CONNECTIONS = {
 }
 
 
-# Taken from Airbyte Server API documentation
+# Taken from Airbyte Configuration API documentation
 # https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
 SAMPLE_CONNECTION_DETAILS = {
     "connectionId": TEST_CONNECTION_ID,
@@ -165,7 +165,7 @@ def fetch_workspace_data_api_mocks_fixture(
     )
     base_api_mocks.add(
         method=responses.POST,
-        url=f"{AIRBYTE_SERVER_API_BASE}/{AIRBYTE_SERVER_API_VERSION}/connections/get",
+        url=f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/connections/get",
         json=SAMPLE_CONNECTION_DETAILS,
         status=200,
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -15,6 +15,7 @@ TEST_CLIENT_SECRET = "some_client_secret"
 
 TEST_ACCESS_TOKEN = "some_access_token"
 
+# Taken from the examples in the Airbyte REST API documentation
 TEST_DESTINATION_ID = "18dccc91-0ab1-4f72-9ed7-0b8fc27c5826"
 TEST_CONNECTION_ID = "9924bcd0-99be-453d-ba47-c2c9766f7da5"
 
@@ -47,6 +48,7 @@ SAMPLE_CONNECTIONS = {
 
 # Taken from Airbyte Configuration API documentation
 # https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
+# https://github.com/airbytehq/airbyte-platform/blob/v1.0.0/airbyte-api/server-api/src/main/openapi/config.yaml
 SAMPLE_CONNECTION_DETAILS = {
     "connectionId": TEST_CONNECTION_ID,
     "name": "string",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -15,6 +15,48 @@ TEST_ACCESS_TOKEN = "some_access_token"
 SAMPLE_ACCESS_TOKEN = {"access_token": TEST_ACCESS_TOKEN}
 
 
+# Taken from Airbyte API documentation
+# https://reference.airbyte.com/reference/listconnections
+SAMPLE_CONNECTIONS = {
+    "next": "https://api.airbyte.com/v1/connections?limit=5&offset=10",
+    "previous": "https://api.airbyte.com/v1/connections?limit=5&offset=0",
+    "data": [
+        {
+            "connectionId": "9924bcd0-99be-453d-ba47-c2c9766f7da5",
+            "workspaceId": "744cc0ed-7f05-4949-9e60-2a814f90c035",
+            "name": "Postgres To Snowflake",
+            "sourceId": "0c31738c-0b2d-4887-b506-e2cd1c39cc35",
+            "destinationId": "18dccc91-0ab1-4f72-9ed7-0b8fc27c5826",
+            "status": "active",
+            "schedule": {
+                "schedule_type": "cron",
+            },
+        }
+    ],
+}
+
+
+# Taken from Airbyte API documentation
+# https://reference.airbyte.com/reference/getdestination
+SAMPLE_DESTINATION_DETAILS = {
+    "destinationId": "18dccc91-0ab1-4f72-9ed7-0b8fc27c5826",
+    "name": "My Destination",
+    "sourceType": "postgres",
+    "workspaceId": "744cc0ed-7f05-4949-9e60-2a814f90c035",
+    "configuration": {
+        "conversion_window_days": 14,
+        "customer_id": "1234567890",
+        "start_date": "2023-01-01",
+        "end_date": "2024-01-01",
+    },
+}
+
+
+@pytest.fixture(name="destination_id")
+def destination_id_fixture() -> str:
+    return "18dccc91-0ab1-4f72-9ed7-0b8fc27c5826"
+
+
 @pytest.fixture(
     name="base_api_mocks",
 )
@@ -27,3 +69,25 @@ def base_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
             status=201,
         )
         yield response
+
+
+@pytest.fixture(
+    name="fetch_workspace_data_api_mocks",
+)
+def fetch_workspace_data_api_mocks_fixture(
+    destination_id: str,
+    base_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{AIRBYTE_API_BASE}/{AIRBYTE_API_VERSION}/connections",
+        json=SAMPLE_CONNECTIONS,
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{AIRBYTE_API_BASE}/{AIRBYTE_API_VERSION}/destinations/{destination_id}",
+        json=SAMPLE_DESTINATION_DETAILS,
+        status=200,
+    )
+    yield base_api_mocks

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -9,6 +9,8 @@ from dagster_airbyte_tests.experimental.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_CLIENT_ID,
     TEST_CLIENT_SECRET,
+    TEST_CONNECTION_ID,
+    TEST_DESTINATION_ID,
     TEST_WORKSPACE_ID,
 )
 
@@ -29,7 +31,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
     base_api_mocks.add(
         method=responses.GET,
-        url=f"{client.api_base_url}/test",
+        url=f"{client.rest_api_base_url}/test",
         json={},
         status=200,
     )
@@ -40,7 +42,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
     with mock.patch("dagster_airbyte.resources.datetime", wraps=datetime) as dt:
         # Test first call, must get the access token before calling the jobs api
         dt.now.return_value = test_time_first_call
-        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.rest_api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]
@@ -56,7 +58,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
         # Test second call, occurs before the access token expiration, only the jobs api is called
         dt.now.return_value = test_time_before_expiration
-        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.rest_api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 1
         jobs_api_call = base_api_mocks.calls[0]
@@ -68,7 +70,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
         # Test third call, occurs after the token expiration,
         # must refresh the access token before calling the jobs api
         dt.now.return_value = test_time_after_expiration
-        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.rest_api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]
@@ -82,7 +84,6 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
 
 def test_basic_resource_request(
-    destination_id: str,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     resource = AirbyteCloudWorkspace(
@@ -94,11 +95,16 @@ def test_basic_resource_request(
 
     # fetch workspace data calls
     client.get_connections()
-    client.get_destination_details(destination_id=destination_id)
+    client.get_connection_details(connection_id=TEST_CONNECTION_ID)
+    client.get_destination_details(destination_id=TEST_DESTINATION_ID)
 
-    assert len(fetch_workspace_data_api_mocks.calls) == 3
+    assert len(fetch_workspace_data_api_mocks.calls) == 4
     # The first call is to create the access token
     assert "Authorization" not in fetch_workspace_data_api_mocks.calls[0].request.headers
     # The two next calls are actual API calls
     assert "connections" in fetch_workspace_data_api_mocks.calls[1].request.url
-    assert f"destinations/{destination_id}" in fetch_workspace_data_api_mocks.calls[2].request.url
+    assert "connections/get" in fetch_workspace_data_api_mocks.calls[2].request.url
+    assert TEST_CONNECTION_ID in fetch_workspace_data_api_mocks.calls[2].request.body.decode()
+    assert (
+        f"destinations/{TEST_DESTINATION_ID}" in fetch_workspace_data_api_mocks.calls[3].request.url
+    )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -1,16 +1,15 @@
 import json
 from datetime import datetime
-from unittest import mock
 from typing import Optional
+from unittest import mock
 
 import responses
 from dagster_airbyte import AirbyteCloudWorkspace
-
 from dagster_airbyte.resources import (
-    AIRBYTE_REST_API_BASE,
-    AIRBYTE_REST_API_VERSION,
     AIRBYTE_CONFIGURATION_API_BASE,
     AIRBYTE_CONFIGURATION_API_VERSION,
+    AIRBYTE_REST_API_BASE,
+    AIRBYTE_REST_API_VERSION,
 )
 
 from dagster_airbyte_tests.experimental.conftest import (
@@ -29,7 +28,10 @@ def assert_token_call_and_split_calls(calls: responses.CallList):
     access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
     assert access_token_call_body["client_id"] == TEST_CLIENT_ID
     assert access_token_call_body["client_secret"] == TEST_CLIENT_SECRET
-    assert access_token_call.request.url == f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/applications/token"
+    assert (
+        access_token_call.request.url
+        == f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/applications/token"
+    )
     return calls[1:]
 
 
@@ -39,8 +41,13 @@ def assert_rest_api_call(call: responses.Call, endpoint: str):
     assert call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
 
 
-def assert_configuration_api_call(call: responses.Call, endpoint: str, object_id: Optional[str] = None):
-    assert call.request.url == f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/{endpoint}"
+def assert_configuration_api_call(
+    call: responses.Call, endpoint: str, object_id: Optional[str] = None
+):
+    assert (
+        call.request.url
+        == f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/{endpoint}"
+    )
     if object_id:
         assert object_id in call.request.body.decode()
     assert call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
@@ -124,5 +131,7 @@ def test_basic_resource_request(
     api_calls = assert_token_call_and_split_calls(calls=fetch_workspace_data_api_mocks.calls)
     # The next calls are actual API calls
     assert_rest_api_call(call=api_calls[0], endpoint="connections")
-    assert_configuration_api_call(call=api_calls[1], endpoint="connections/get", object_id=TEST_CONNECTION_ID)
+    assert_configuration_api_call(
+        call=api_calls[1], endpoint="connections/get", object_id=TEST_CONNECTION_ID
+    )
     assert_rest_api_call(call=api_calls[2], endpoint=f"destinations/{TEST_DESTINATION_ID}")

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -40,7 +40,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
     with mock.patch("dagster_airbyte.resources.datetime", wraps=datetime) as dt:
         # Test first call, must get the access token before calling the jobs api
         dt.now.return_value = test_time_first_call
-        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]
@@ -56,7 +56,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
 
         # Test second call, occurs before the access token expiration, only the jobs api is called
         dt.now.return_value = test_time_before_expiration
-        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 1
         jobs_api_call = base_api_mocks.calls[0]
@@ -68,7 +68,7 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
         # Test third call, occurs after the token expiration,
         # must refresh the access token before calling the jobs api
         dt.now.return_value = test_time_after_expiration
-        client._make_request(method="GET", endpoint="/test", base_url=client.api_base_url)  # noqa
+        client._make_request(method="GET", endpoint="test", base_url=client.api_base_url)  # noqa
 
         assert len(base_api_mocks.calls) == 2
         access_token_call = base_api_mocks.calls[0]
@@ -79,3 +79,26 @@ def test_refresh_access_token(base_api_mocks: responses.RequestsMock) -> None:
         assert access_token_call_body["client_id"] == TEST_CLIENT_ID
         assert access_token_call_body["client_secret"] == TEST_CLIENT_SECRET
         assert jobs_api_call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
+
+
+def test_basic_resource_request(
+    destination_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = AirbyteCloudWorkspace(
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    client = resource.get_client()
+
+    # fetch workspace data calls
+    client.get_connections()
+    client.get_destination_details(destination_id=destination_id)
+
+    assert len(fetch_workspace_data_api_mocks.calls) == 3
+    # The first call is to create the access token
+    assert "Authorization" not in fetch_workspace_data_api_mocks.calls[0].request.headers
+    # The two next calls are actual API calls
+    assert "connections" in fetch_workspace_data_api_mocks.calls[1].request.url
+    assert f"destinations/{destination_id}" in fetch_workspace_data_api_mocks.calls[2].request.url


### PR DESCRIPTION
## Summary & Motivation

This PR implements the `get_connections`, `get_connection_details` and `get_destination_destails` in the `AirbyteCloudClient`.

Note that we need to use the [internal Airbyte Configuration API](https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#overview) to get the stream configs in the connection details. The other methods are using the public REST API.

## How I Tested These Changes

Additional unit tests with BK
