### PR TITLE
[dagster-webserver] fix platform agnostic paths

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -90,7 +90,7 @@ class DagsterWebserver(
         }
 
     def make_csp_header(self, nonce: str) -> str:
-        csp_conf_path = self.relative_path("webapp/build/csp-header.txt")
+        csp_conf_path = self.relative_path(path.sep.join(["webapp", "build", "csp-header.txt"]))
         try:
             with open(csp_conf_path, encoding="utf8") as f:
                 csp_template = f.read()
@@ -201,7 +201,7 @@ class DagsterWebserver(
 
     def index_html_endpoint(self, request: Request):
         """Serves root html."""
-        index_path = self.relative_path("webapp/build/index.html")
+        index_path = self.relative_path(path.sep.join(["webapp", "build", "index.html"]))
 
         context = self.make_request_context(request)
 
@@ -257,7 +257,7 @@ class DagsterWebserver(
         mimetypes.add_type("image/svg+xml", ".svg")
 
         routes = []
-        base_dir = self.relative_path("webapp/build/")
+        base_dir = self.relative_path(path.sep.join(["webapp", "build"]))
         for subdir, _, files in walk(base_dir):
             for file in files:
                 full_path = path.join(subdir, file)


### PR DESCRIPTION
## Summary & Motivation

User ran into an issue with the web server not working on Windows. The current _theory_ is that it's due to path separates being hard coded.

Still waiting for user to respond if this is applicable; keeping as draft until then.

```
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\github\\dagster\\python_modules\\dagster-webserver\\dagster_webserver\\webapp/build/index.html'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\mt255026\AppData\Local\Programs\Python\Python311\Lib\site-packages\uvicorn\protocols\http\httptools_impl.py", line 401, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\mt255026\AppData\Local\Programs\Python\Python311\Lib\site-packages\uvicorn\middleware\proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\mt255026\AppData\Local\Programs\Python\Python311\Lib\site-packages\starlette\applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "C:\Users\mt255026\AppData\Local\Programs\Python\Python311\Lib\site-packages\starlette\middleware\errors.py", line 187, in __call__
    raise exc
  File "C:\Users\mt255026\AppData\Local\Programs\Python\Python311\Lib\site-packages\starlette\middleware\errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "c:\github\dagster\python_modules\dagster-webserver\dagster_webserver\webserver.py", line 378
```

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
