### PR TITLE
[11/n] [RFC] add jest tests

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
@@ -52,6 +52,7 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
             </td>
             <td style={{width: '7.5%', verticalAlign: 'middle', textAlign: 'center'}}>
               <PreviewButton
+                request={request}
                 onClick={() => {
                   setSelectedRequest(request);
                   setVisibleDialog('config');
@@ -91,10 +92,14 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
   );
 };
 
-function PreviewButton({onClick}: {onClick: () => void}) {
+function PreviewButton({request, onClick}: {request: RunRequestFragment; onClick: () => void}) {
   return (
     <Tooltip content="Preview run config and tags" placement="left-start">
-      <Button icon={<Icon name="data_object" />} onClick={onClick} />
+      <Button
+        icon={<Icon name="data_object" />}
+        onClick={onClick}
+        data-testid={testId(`preview-${request.runKey || ''}`)}
+      />
     </Tooltip>
   );
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
@@ -4,8 +4,12 @@ import {
   RunStatus,
   buildDryRunInstigationTick,
   buildErrorChainLink,
+  buildLaunchMultipleRunsResult,
+  buildLaunchRunSuccess,
+  buildPipelineSnapshot,
   buildPipelineTag,
   buildPythonError,
+  buildRun,
   buildRunRequest,
   buildSchedule,
   buildTickEvaluation,
@@ -211,18 +215,14 @@ export const ScheduleLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutatio
   result: {
     data: {
       __typename: 'Mutation',
-      launchMultipleRuns: {
-        __typename: 'LaunchMultipleRunsResult',
+      launchMultipleRuns: buildLaunchMultipleRunsResult({
         launchMultipleRunsResult: [
-          {
-            __typename: 'LaunchRunSuccess',
-            run: {
-              __typename: 'Run',
+          buildLaunchRunSuccess({
+            run: buildRun({
               id: '504b3a77-d6c4-440c-a128-7f59c9d75d59',
-              pipeline: {
-                __typename: 'PipelineSnapshot',
+              pipeline: buildPipelineSnapshot({
                 name: 'saepe',
-              },
+              }),
               tags: [
                 buildPipelineTag({
                   key: 'dagster/schedule_name',
@@ -246,10 +246,10 @@ export const ScheduleLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutatio
                 'ops:\n  configurable_op:\n    config:\n      scheduled_date: 2023-01-29',
               mode: 'default',
               resolvedOpSelection: null,
-            },
-          },
+            }),
+          }),
         ],
-      },
+      }),
     },
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
@@ -1,6 +1,7 @@
 import {MockedResponse} from '@apollo/client/testing';
 
 import {
+  RunStatus,
   buildDryRunInstigationTick,
   buildErrorChainLink,
   buildPipelineTag,
@@ -9,6 +10,8 @@ import {
   buildSchedule,
   buildTickEvaluation,
 } from '../../graphql/types';
+import {LAUNCH_MULTIPLE_RUNS_MUTATION} from '../../runs/RunUtils';
+import {LaunchMultipleRunsMutation} from '../../runs/types/RunUtils.types';
 import {GET_SCHEDULE_QUERY, SCHEDULE_DRY_RUN_MUTATION} from '../EvaluateScheduleDialog';
 import {GetScheduleQuery, ScheduleDryRunMutation} from '../types/EvaluateScheduleDialog.types';
 
@@ -63,7 +66,7 @@ export const scheduleDryWithWithRunRequest = {
               value: 'okay',
             }),
           ],
-          runKey: null,
+          runKey: 'EvaluateScheduleDialog.test.tsx:1675705668.993122345',
         }),
       ],
       skipReason: null,
@@ -161,6 +164,92 @@ export const ScheduleDryRunMutationSkipped: MockedResponse<ScheduleDryRunMutatio
           error: null,
         }),
       }),
+    },
+  },
+};
+
+export const ScheduleLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation> = {
+  request: {
+    query: LAUNCH_MULTIPLE_RUNS_MUTATION,
+    variables: {
+      executionParamsList: [
+        {
+          runConfigData: 'ops:\n  configurable_op:\n    config:\n      scheduled_date: 2023-01-29',
+          selector: {
+            jobName: 'saepe',
+            repositoryLocationName: 'testLocation',
+            repositoryName: 'testName',
+            assetSelection: [],
+            assetCheckSelection: [],
+            solidSelection: undefined,
+          },
+          mode: 'default',
+          executionMetadata: {
+            tags: [
+              {
+                key: 'dagster/schedule_name',
+                value: 'configurable_job_schedule',
+              },
+              {
+                key: 'date',
+                value: '2023-01-29',
+              },
+              {
+                key: 'github_test',
+                value: 'test',
+              },
+              {
+                key: 'okay_t2',
+                value: 'okay',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  result: {
+    data: {
+      __typename: 'Mutation',
+      launchMultipleRuns: {
+        __typename: 'LaunchMultipleRunsResult',
+        launchMultipleRunsResult: [
+          {
+            __typename: 'LaunchRunSuccess',
+            run: {
+              __typename: 'Run',
+              id: '504b3a77-d6c4-440c-a128-7f59c9d75d59',
+              pipeline: {
+                __typename: 'PipelineSnapshot',
+                name: 'saepe',
+              },
+              tags: [
+                buildPipelineTag({
+                  key: 'dagster/schedule_name',
+                  value: 'configurable_job_schedule',
+                }),
+                buildPipelineTag({
+                  key: 'date',
+                  value: '2023-01-29',
+                }),
+                buildPipelineTag({
+                  key: 'github_test',
+                  value: 'test',
+                }),
+                buildPipelineTag({
+                  key: 'okay_t2',
+                  value: 'okay',
+                }),
+              ],
+              status: RunStatus.QUEUED,
+              runConfigYaml:
+                'ops:\n  configurable_op:\n    config:\n      scheduled_date: 2023-01-29',
+              mode: 'default',
+              resolvedOpSelection: null,
+            },
+          },
+        ],
+      },
     },
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
@@ -7,8 +7,12 @@ import {
   buildDryRunInstigationTick,
   buildErrorChainLink,
   buildInstigationState,
+  buildLaunchMultipleRunsResult,
+  buildLaunchRunSuccess,
+  buildPipelineSnapshot,
   buildPipelineTag,
   buildPythonError,
+  buildRun,
   buildRunRequest,
   buildSensor,
   buildSensorData,
@@ -267,18 +271,16 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
   result: {
     data: {
       __typename: 'Mutation',
-      launchMultipleRuns: {
-        __typename: 'LaunchMultipleRunsResult',
+      launchMultipleRuns: buildLaunchMultipleRunsResult({
         launchMultipleRunsResult: [
-          {
+          buildLaunchRunSuccess({
             __typename: 'LaunchRunSuccess',
-            run: {
+            run: buildRun({
               __typename: 'Run',
               id: '504b3a77-d6c4-440c-a128-7f59c9d75d59',
-              pipeline: {
-                __typename: 'PipelineSnapshot',
+              pipeline: buildPipelineSnapshot({
                 name: 'saepe',
-              },
+              }),
               tags: [
                 buildPipelineTag({key: 'dagster2', value: 'test'}),
                 buildPipelineTag({key: 'marco2', value: 'salazar2'}),
@@ -288,17 +290,16 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
                 'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx\n',
               mode: 'default',
               resolvedOpSelection: null,
-            },
-          },
-          {
+            }),
+          }),
+          buildLaunchRunSuccess({
             __typename: 'LaunchRunSuccess',
-            run: {
+            run: buildRun({
               __typename: 'Run',
               id: '6745cd03-3d89-4fd2-a41f-6b9d9ffdc134',
-              pipeline: {
-                __typename: 'PipelineSnapshot',
+              pipeline: buildPipelineSnapshot({
                 name: 'saepe',
-              },
+              }),
               tags: [
                 buildPipelineTag({key: 'dagster3', value: 'test'}),
                 buildPipelineTag({key: 'marco3', value: 'salazar3'}),
@@ -307,20 +308,16 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
               status: RunStatus.QUEUED,
               runConfigYaml:
                 'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx\n',
-
               mode: 'default',
               resolvedOpSelection: null,
-            },
-          },
-          {
-            __typename: 'LaunchRunSuccess',
-            run: {
-              __typename: 'Run',
+            }),
+          }),
+          buildLaunchRunSuccess({
+            run: buildRun({
               id: '7ed35f69-42cf-4518-84a4-c97d0551a56b',
-              pipeline: {
-                __typename: 'PipelineSnapshot',
+              pipeline: buildPipelineSnapshot({
                 name: 'simple_config_job',
-              },
+              }),
               tags: [
                 buildPipelineTag({key: 'dagster6', value: 'test'}),
                 buildPipelineTag({key: 'marco6', value: 'salazar6'}),
@@ -331,10 +328,10 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
 
               mode: 'default',
               resolvedOpSelection: null,
-            },
-          },
+            }),
+          }),
         ],
-      },
+      }),
     },
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
@@ -3,6 +3,7 @@ import {MockedResponse} from '@apollo/client/testing';
 import {
   InstigationStatus,
   RunRequest,
+  RunStatus,
   buildDryRunInstigationTick,
   buildErrorChainLink,
   buildInstigationState,
@@ -13,6 +14,8 @@ import {
   buildSensorData,
   buildTickEvaluation,
 } from '../../graphql/types';
+import {LAUNCH_MULTIPLE_RUNS_MUTATION} from '../../runs/RunUtils';
+import {LaunchMultipleRunsMutation} from '../../runs/types/RunUtils.types';
 import {SET_CURSOR_MUTATION} from '../../sensors/EditCursorDialog';
 import {SetSensorCursorMutation} from '../../sensors/types/EditCursorDialog.types';
 import {EVALUATE_SENSOR_MUTATION} from '../SensorDryRunDialog';
@@ -174,6 +177,164 @@ export const PersistCursorValueMock: MockedResponse<SetSensorCursorMutation> = {
           }),
         }),
       }),
+    },
+  },
+};
+
+export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation> = {
+  request: {
+    query: LAUNCH_MULTIPLE_RUNS_MUTATION,
+    variables: {
+      executionParamsList: [
+        {
+          runConfigData:
+            'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx',
+          selector: {
+            jobName: 'saepe',
+            repositoryLocationName: 'testLocation',
+            repositoryName: 'testName',
+            assetSelection: [],
+            assetCheckSelection: [],
+            solidSelection: undefined,
+          },
+          mode: 'default',
+          executionMetadata: {
+            tags: [
+              {
+                key: 'dagster2',
+                value: 'test',
+              },
+              {
+                key: 'marco2',
+                value: 'salazar2',
+              },
+            ],
+          },
+        },
+        {
+          runConfigData:
+            'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx',
+          selector: {
+            jobName: 'saepe',
+            repositoryLocationName: 'testLocation',
+            repositoryName: 'testName',
+            assetSelection: [],
+            assetCheckSelection: [],
+            solidSelection: undefined,
+          },
+          mode: 'default',
+          executionMetadata: {
+            tags: [
+              {
+                key: 'dagster3',
+                value: 'test',
+              },
+              {
+                key: 'marco3',
+                value: 'salazar3',
+              },
+            ],
+          },
+        },
+        {
+          runConfigData:
+            'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx',
+          selector: {
+            jobName: 'saepe',
+            repositoryLocationName: 'testLocation',
+            repositoryName: 'testName',
+            assetSelection: [],
+            assetCheckSelection: [],
+            solidSelection: undefined,
+          },
+          mode: 'default',
+          executionMetadata: {
+            tags: [
+              {
+                key: 'dagster6',
+                value: 'test',
+              },
+              {
+                key: 'marco6',
+                value: 'salazar6',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  result: {
+    data: {
+      __typename: 'Mutation',
+      launchMultipleRuns: {
+        __typename: 'LaunchMultipleRunsResult',
+        launchMultipleRunsResult: [
+          {
+            __typename: 'LaunchRunSuccess',
+            run: {
+              __typename: 'Run',
+              id: '504b3a77-d6c4-440c-a128-7f59c9d75d59',
+              pipeline: {
+                __typename: 'PipelineSnapshot',
+                name: 'saepe',
+              },
+              tags: [
+                buildPipelineTag({key: 'dagster2', value: 'test'}),
+                buildPipelineTag({key: 'marco2', value: 'salazar2'}),
+              ],
+              status: RunStatus.QUEUED,
+              runConfigYaml:
+                'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx\n',
+              mode: 'default',
+              resolvedOpSelection: null,
+            },
+          },
+          {
+            __typename: 'LaunchRunSuccess',
+            run: {
+              __typename: 'Run',
+              id: '6745cd03-3d89-4fd2-a41f-6b9d9ffdc134',
+              pipeline: {
+                __typename: 'PipelineSnapshot',
+                name: 'saepe',
+              },
+              tags: [
+                buildPipelineTag({key: 'dagster3', value: 'test'}),
+                buildPipelineTag({key: 'marco3', value: 'salazar3'}),
+              ],
+
+              status: RunStatus.QUEUED,
+              runConfigYaml:
+                'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx\n',
+
+              mode: 'default',
+              resolvedOpSelection: null,
+            },
+          },
+          {
+            __typename: 'LaunchRunSuccess',
+            run: {
+              __typename: 'Run',
+              id: '7ed35f69-42cf-4518-84a4-c97d0551a56b',
+              pipeline: {
+                __typename: 'PipelineSnapshot',
+                name: 'simple_config_job',
+              },
+              tags: [
+                buildPipelineTag({key: 'dagster6', value: 'test'}),
+                buildPipelineTag({key: 'marco6', value: 'salazar6'}),
+              ],
+              status: RunStatus.QUEUED,
+              runConfigYaml:
+                'solids:\n  read_file:\n    config:\n      directory: /Users/marcosalazar/code/dagster/js_modules/dagster-ui/packages/ui-core/src/ticks/tests\n      filename: DryRunRequestTable.test.tsx\n',
+
+              mode: 'default',
+              resolvedOpSelection: null,
+            },
+          },
+        ],
+      },
     },
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/DryRunRequestTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/DryRunRequestTable.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import {BrowserRouter} from 'react-router-dom';
 
 import {RunRequestTable} from '../DryRunRequestTable';
@@ -7,6 +7,10 @@ import {runRequests} from '../__fixtures__/SensorDryRunDialog.fixtures';
 jest.mock('../../workspace/WorkspaceContext/util', () => ({
   ...jest.requireActual('../../workspace/WorkspaceContext/util'),
   useRepository: jest.fn(() => null),
+}));
+
+jest.mock('../../runs/RunConfigDialog', () => ({
+  RunConfigDialog: () => <div>RunConfigDialog</div>,
 }));
 
 function TestComponent() {
@@ -31,10 +35,19 @@ describe('RunRequestTableTest', () => {
     render(<TestComponent />);
 
     runRequests.forEach((req) => {
-      req.tags.forEach(({key, value}) => {
-        expect(screen.getByText(`${key}: ${value}`)).toBeVisible();
-      });
       expect(screen.getByTestId(req.runKey!)).toBeVisible();
+    });
+  });
+
+  it('renders preview button and opens dialog on click', async () => {
+    render(<TestComponent />);
+
+    const previewButton = screen.getByTestId(`preview-${runRequests[0]!.runKey || ''}`);
+    expect(previewButton).toBeVisible();
+    previewButton.click();
+
+    await waitFor(() => {
+      expect(screen.getByText(/RunConfigDialog/i)).toBeVisible();
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -84,4 +84,42 @@ describe('EvaluateScheduleTest', () => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });
   });
+
+  it('allows you to test again', async () => {
+    render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationSkipped]} />);
+    const selectButton = await screen.findByTestId('tick-selection');
+    await userEvent.click(selectButton);
+    await waitFor(() => {
+      expect(screen.getByTestId('tick-5')).toBeVisible();
+    });
+    await userEvent.click(screen.getByTestId('tick-5'));
+    await userEvent.click(screen.getByTestId('continue'));
+    await waitFor(() => {
+      expect(screen.getByText('Skipped')).toBeVisible();
+    });
+    await userEvent.click(screen.getByTestId('try-again'));
+    expect(screen.queryByText('Failed')).toBe(null);
+    expect(screen.queryByText('Skipped')).toBe(null);
+  });
+
+  it('launches all runs', async () => {
+    render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationRunRequests]} />);
+    const selectButton = await screen.findByTestId('tick-selection');
+    await userEvent.click(selectButton);
+    await waitFor(() => {
+      expect(screen.getByTestId('tick-5')).toBeVisible();
+    });
+    await userEvent.click(screen.getByTestId('tick-5'));
+    await userEvent.click(screen.getByTestId('continue'));
+    await waitFor(() => {
+      expect(screen.getByText(/1\s+run request/i)).toBeVisible();
+      expect(screen.getByTestId('launch-all')).not.toBeDisabled();
+    });
+
+    userEvent.click(screen.getByTestId('launch-all'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Launching runs/i)).toBeVisible();
+    });
+  }, 10000);
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -57,6 +57,16 @@ describe('SensorDryRunTest', () => {
     });
   });
 
+  it('renders skip reason', async () => {
+    render(<Test mocks={[Mocks.SensorDryRunMutationSkipped]} />);
+    const cursorInput = await screen.findByTestId('cursor-input');
+    await userEvent.type(cursorInput, 'testing123');
+    await userEvent.click(screen.getByTestId('continue'));
+    await waitFor(() => {
+      expect(screen.getByText('Skipped')).toBeVisible();
+    });
+  });
+
   it('allows you to test again', async () => {
     render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
@@ -72,13 +82,25 @@ describe('SensorDryRunTest', () => {
     expect(screen.getByTestId('cursor-input')).toBeVisible();
   });
 
-  it('renders skip reason', async () => {
-    render(<Test mocks={[Mocks.SensorDryRunMutationSkipped]} />);
+  it('launches all runs', async () => {
+    render(<Test mocks={[Mocks.SensorDryRunMutationRunRequests, Mocks.PersistCursorValueMock]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
     await userEvent.type(cursorInput, 'testing123');
     await userEvent.click(screen.getByTestId('continue'));
     await waitFor(() => {
-      expect(screen.getByText('Skipped')).toBeVisible();
+      expect(screen.getByText(/3\srun requests/g)).toBeVisible();
+      expect(screen.queryByText('Skipped')).toBe(null);
+      expect(screen.queryByText('Failed')).toBe(null);
     });
-  });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('launch-all')).not.toBeDisabled();
+    });
+
+    userEvent.click(screen.getByTestId('launch-all'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Launching runs/i)).toBeVisible();
+    });
+  }, 10000);
 });

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
@@ -272,7 +272,7 @@ class TestSuccessAndFailureMultipleLaunch(BaseTestSuite):
         launchSuccessExecutionParams = [
             {
                 "selector": {
-                    "repositoryLocationName": "test",
+                    "repositoryLocationName": "test_location",
                     "repositoryName": "test_repo",
                     "pipelineName": "no_config_job",
                     "solidSelection": None,
@@ -283,7 +283,7 @@ class TestSuccessAndFailureMultipleLaunch(BaseTestSuite):
             },
             {
                 "selector": {
-                    "repositoryLocationName": "test",
+                    "repositoryLocationName": "test_location",
                     "repositoryName": "test_repo",
                     "pipelineName": "no_config_job",
                     "solidSelection": None,
@@ -297,7 +297,7 @@ class TestSuccessAndFailureMultipleLaunch(BaseTestSuite):
         pipelineNotFoundExecutionParams = [
             {
                 "selector": {
-                    "repositoryLocationName": "test",
+                    "repositoryLocationName": "test_location",
                     "repositoryName": "test_dict_repo",
                     "pipelineName": "no_config_job",
                     "solidSelection": None,
@@ -308,7 +308,7 @@ class TestSuccessAndFailureMultipleLaunch(BaseTestSuite):
             },
             {
                 "selector": {
-                    "repositoryLocationName": "test",
+                    "repositoryLocationName": "test_location",
                     "repositoryName": "test_dict_repo",
                     "pipelineName": "no_config_job",
                     "solidSelection": None,


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-713/add-jest-tests-for-sensors-and-schedules

Adds jest tests for launch all

## How I Tested These Changes
yarn jest, ts, lint