### PR TITLE
[5/n][dagster-airbyte] Implement fetch_airbyte_workspace_data

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1034,9 +1034,12 @@ class AirbyteCloudWorkspace(ConfigurableResource):
         client = self.get_client()
         connections = client.get_connections()["data"]
 
-        for connection_details in connections:
+        for partial_connection_details in connections:
+            full_connection_details = client.get_connection_details(
+                connection_id=partial_connection_details["connectionId"]
+            )
             connection = AirbyteConnection.from_connection_details(
-                connection_details=connection_details
+                connection_details=full_connection_details
             )
             connections_by_id[connection.id] = connection
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -26,7 +26,7 @@ from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field, PrivateAttr
 from requests.exceptions import RequestException
 
-from dagster_airbyte.translator import AirbyteWorkspaceData
+from dagster_airbyte.translator import AirbyteConnection, AirbyteDestination, AirbyteWorkspaceData
 from dagster_airbyte.types import AirbyteOutput
 
 AIRBYTE_REST_API_BASE = "https://api.airbyte.com"
@@ -1028,4 +1028,27 @@ class AirbyteCloudWorkspace(ConfigurableResource):
         Returns:
             AirbyteWorkspaceData: A snapshot of the Airbyte workspace's content.
         """
-        raise NotImplementedError()
+        connections_by_id = {}
+        destinations_by_id = {}
+
+        client = self.get_client()
+        connections = client.get_connections()["data"]
+
+        for connection_details in connections:
+            connection = AirbyteConnection.from_connection_details(
+                connection_details=connection_details
+            )
+            connections_by_id[connection.id] = connection
+
+            destination_details = client.get_destination_details(
+                destination_id=connection.destination_id
+            )
+            destination = AirbyteDestination.from_destination_details(
+                destination_details=destination_details
+            )
+            destinations_by_id[destination.id] = destination
+
+        return AirbyteWorkspaceData(
+            connections_by_id=connections_by_id,
+            destinations_by_id=destinations_by_id,
+        )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
@@ -30,10 +30,12 @@ class AirbyteConnection:
             name=connection_details["name"],
             stream_prefix=connection_details.get("prefix"),
             streams={
-                stream_details["stream"]["name"]: AirbyteStream.from_stream_details(stream_details=stream_details)
+                stream_details["stream"]["name"]: AirbyteStream.from_stream_details(
+                    stream_details=stream_details
+                )
                 for stream_details in connection_details.get("syncCatalog", {}).get("streams", [])
             },
-            destination_id=connection_details["destinationId"]
+            destination_id=connection_details["destinationId"],
         )
 
 
@@ -75,7 +77,7 @@ class AirbyteStream:
         return cls(
             name=stream_details["stream"]["name"],
             selected=stream_details["config"].get("selected", False),
-            json_schema=stream_details["stream"].get("jsonSchema", {})
+            json_schema=stream_details["stream"].get("jsonSchema", {}),
         )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
@@ -63,7 +63,9 @@ class AirbyteDestination:
 @whitelist_for_serdes
 @record
 class AirbyteStream:
-    """Represents an Airbyte stream, based on data as returned from the API."""
+    """Represents an Airbyte stream, based on data as returned from the API.
+    A stream in Airbyte corresponds to a table.
+    """
 
     name: str
     selected: bool

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
@@ -1,0 +1,18 @@
+import responses
+from dagster_airbyte import AirbyteCloudWorkspace
+
+from dagster_airbyte_tests.experimental.conftest import TEST_CLIENT_ID, TEST_CLIENT_SECRET, TEST_WORKSPACE_ID
+
+
+def test_fetch_fivetran_workspace_data(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = AirbyteCloudWorkspace(
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+
+    actual_workspace_data = resource.fetch_airbyte_workspace_data()
+    assert len(actual_workspace_data.connections_by_id) == 1
+    assert len(actual_workspace_data.destinations_by_id) == 1

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
@@ -1,7 +1,11 @@
 import responses
 from dagster_airbyte import AirbyteCloudWorkspace
 
-from dagster_airbyte_tests.experimental.conftest import TEST_CLIENT_ID, TEST_CLIENT_SECRET, TEST_WORKSPACE_ID
+from dagster_airbyte_tests.experimental.conftest import (
+    TEST_CLIENT_ID,
+    TEST_CLIENT_SECRET,
+    TEST_WORKSPACE_ID,
+)
 
 
 def test_fetch_fivetran_workspace_data(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
@@ -8,7 +8,7 @@ from dagster_airbyte_tests.experimental.conftest import (
 )
 
 
-def test_fetch_fivetran_workspace_data(
+def test_fetch_airbyte_workspace_data(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     resource = AirbyteCloudWorkspace(


### PR DESCRIPTION
## Summary & Motivation

This PR implements `AirbyteCloudWorkspace.fetch_airbyte_workspace_data`, that fetches the connections and destinations included in a given workspace.

## How I Tested These Changes

Additional unit tests with BK.