### PR TITLE
add pool as top-level definition arg

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -2599,6 +2599,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2639,6 +2640,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2673,6 +2675,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2707,6 +2710,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2734,6 +2738,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2768,6 +2773,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2795,6 +2801,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2830,6 +2837,7 @@
               "name": "fourth_kinds_key"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {
             "dagster/compute_kind": "python"
@@ -2859,6 +2867,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2886,6 +2895,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2913,6 +2923,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2947,6 +2958,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2982,6 +2994,7 @@
               "name": "check_in_op_asset_my_check"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3016,6 +3029,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3050,6 +3064,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3090,6 +3105,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3124,6 +3140,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3158,6 +3175,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3192,6 +3210,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3219,6 +3238,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3253,6 +3273,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3280,6 +3301,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3314,6 +3336,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3341,6 +3364,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3381,6 +3405,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3421,6 +3446,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3455,6 +3481,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3489,6 +3516,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3523,6 +3551,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3550,6 +3579,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3577,6 +3607,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3604,6 +3635,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3638,6 +3670,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -3674,6 +3707,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -3703,6 +3737,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -3732,6 +3767,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3766,6 +3802,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3800,6 +3837,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3835,6 +3873,7 @@
               "name": "second_kinds_key"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3862,6 +3901,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3889,6 +3929,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3923,6 +3964,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3950,6 +3992,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -3977,6 +4020,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4011,6 +4055,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4045,6 +4090,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4072,6 +4118,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4099,6 +4146,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4126,6 +4174,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -4155,6 +4204,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4206,6 +4256,7 @@
               "name": "one_my_other_check"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4240,6 +4291,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4275,6 +4327,7 @@
               "name": "str_asset"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4302,6 +4355,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4329,6 +4383,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4356,6 +4411,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4383,6 +4439,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4417,6 +4474,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4451,6 +4509,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4478,6 +4537,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4512,6 +4572,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4539,6 +4600,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -4566,6 +4628,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -5450,6 +5513,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -5484,6 +5548,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -5494,7 +5559,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[101]
-  'ab8f4b864ee53d2d9304b85f7a368aad7f678f29'
+  '769fc2d8acd27f4698b2c69c4be7c28c9f12ab70'
 # ---
 # name: test_all_snapshot_ids[102]
   '''
@@ -6341,6 +6406,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -6351,7 +6417,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[103]
-  '98a8e544c66ff337c2aef1334603df0a3b1c7434'
+  '915d58f6d85c07bf073eb4a459c84cbf4fff70bc'
 # ---
 # name: test_all_snapshot_ids[104]
   '''
@@ -7376,6 +7442,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -7386,7 +7453,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[105]
-  'f53f6915917e179ab89bae44c345e79603f8d42d'
+  '2606adb830535b7009f9506f3b5fe8b2c54eb971'
 # ---
 # name: test_all_snapshot_ids[106]
   '''
@@ -8233,6 +8300,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -8243,7 +8311,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[107]
-  'd65a072229c6e8fc80db02c8d06067f3b0b48305'
+  '6ed1ee20c02e2765f51bbcc68bf9add6af5305ac'
 # ---
 # name: test_all_snapshot_ids[108]
   '''
@@ -9268,6 +9336,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -9278,7 +9347,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[109]
-  '77bb631e77718a35cfd31049d03241709f9454ea'
+  '85e2679dc3c40934668114ca0a4ef1c2dda41a57'
 # ---
 # name: test_all_snapshot_ids[10]
   '''
@@ -11012,6 +11081,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -11024,7 +11094,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[111]
-  'c5cbcfa0e6f1c8658773ba21a9a70fd1b7c517eb'
+  '4dff0f381a4c32ce934bfdad3089ca7adb6ae4a7'
 # ---
 # name: test_all_snapshot_ids[112]
   '''
@@ -12049,6 +12119,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -12059,7 +12130,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[113]
-  '8b0a6d0b6366a3178821e74b13782124ffa5d0fd'
+  '7685e700b5df952f2da8b5430c3ba3bc142d2863'
 # ---
 # name: test_all_snapshot_ids[114]
   '''
@@ -12906,6 +12977,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -12916,7 +12988,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[115]
-  '88c326b7e07c8c537ecd8086fd6429436a46c66f'
+  'e762100146993ec779a5fa784bf47d4aed7151eb'
 # ---
 # name: test_all_snapshot_ids[116]
   '''
@@ -13809,6 +13881,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -13819,7 +13892,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[117]
-  'a73f4941b2735f3a261d9617abaaed09a88aaebc'
+  '72c1d87c885853264966ae277c3d6dcdd1239d1a'
 # ---
 # name: test_all_snapshot_ids[118]
   '''
@@ -14712,6 +14785,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "R1"
           ],
@@ -14724,7 +14798,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[119]
-  '11f4785f61153adc6cca6935748af3807b59eee9'
+  'e2e8e72f3582e1a2eae7382944855471a6bc602a'
 # ---
 # name: test_all_snapshot_ids[11]
   'cd81ec29a7fde8a337dc04fb109dd707a2962d18'
@@ -15620,6 +15694,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "R1"
           ],
@@ -15632,7 +15707,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[121]
-  '2b43566d7b3de2138b12c91b6953d6f1ddde0140'
+  'c86d5fe8c2541af9f50ae935ff37aa065151dc63'
 # ---
 # name: test_all_snapshot_ids[122]
   '''
@@ -16657,6 +16732,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "disable_gc"
           ],
@@ -16693,6 +16769,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "disable_gc"
           ],
@@ -16722,6 +16799,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -16762,6 +16840,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -16772,7 +16851,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[123]
-  'b07b89c1664d4a248bc1a39974a91b31d8956c54'
+  '28b691accda6c56db71e3383fbb09c528da3d866'
 # ---
 # name: test_all_snapshot_ids[124]
   '''
@@ -17830,6 +17909,7 @@
               "name": "start_skip"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -17865,6 +17945,7 @@
               "name": "skip"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -17890,6 +17971,7 @@
           ],
           "name": "no_output",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -17924,6 +18006,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -17934,7 +18017,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[125]
-  '9a9a09da6b3a1dbab13bfde5e155c0f097dd22a5'
+  'c835b5ac4189eafef207b267f933fd97123cb365'
 # ---
 # name: test_all_snapshot_ids[126]
   '''
@@ -18857,6 +18940,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "a"
           ],
@@ -18893,6 +18977,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "b"
           ],
@@ -18905,7 +18990,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[127]
-  'b131f0bc1872f377636fbf002a3ad86049c1e8af'
+  '775a4c5ea46104e3a1ff9db07a8bd083468c2b20'
 # ---
 # name: test_all_snapshot_ids[128]
   '''
@@ -19803,6 +19888,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -19830,6 +19916,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -19857,6 +19944,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -19884,6 +19972,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -19894,7 +19983,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[129]
-  'ca68b52613bfcadc230b3dc1ec7e1045f9bc5836'
+  '70918a742d3ab528c6bcc6cd7b78e20fd6bb8e3a'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -20808,6 +20897,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -20835,6 +20925,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -20869,6 +20960,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -21723,6 +21815,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -21733,7 +21826,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[131]
-  '4fbe2b21985de715173a8d630c5d1506a0c7f040'
+  '928c0e7fa6489a9994d16215ef968ccafa0d0679'
 # ---
 # name: test_all_snapshot_ids[132]
   '''
@@ -22580,6 +22673,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -22590,7 +22684,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[133]
-  'c58bbee5967b5e43b907f2ee09bfa26b5b017899'
+  'fdde90a39d165ebd07fc39556c7a9b4af1e44f13'
 # ---
 # name: test_all_snapshot_ids[134]
   '''
@@ -23437,6 +23531,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -23447,7 +23542,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[135]
-  '9109ebc6447db70cdcd17a7bf8b90ec61ffd02fe'
+  'a23753e6c511ccff1f07d05304a6f7f0a832a116'
 # ---
 # name: test_all_snapshot_ids[136]
   '''
@@ -24294,6 +24389,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -24304,7 +24400,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[137]
-  '673ec5c1c0fce5ffec0506edd32bcdbd018e79bb'
+  'e2f9e2e1e6719a79f8bc336bac4521c8d0136655'
 # ---
 # name: test_all_snapshot_ids[138]
   '''
@@ -25451,6 +25547,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -25485,6 +25582,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -25519,6 +25617,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -25553,6 +25652,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -25563,10 +25663,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[139]
-  'ea8e78a81a6c470713834d21c023ab1d45d00394'
+  'f9ad400e36d87bf80246971be128612ea622ca2c'
 # ---
 # name: test_all_snapshot_ids[13]
-  '1f3478e419b57370edfc5959b967300b91ad776c'
+  'a86aacf9a2c9d233cab329983796e55ae6e6805c'
 # ---
 # name: test_all_snapshot_ids[140]
   '''
@@ -26413,6 +26513,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -26423,7 +26524,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[141]
-  '927cbfcff5af3bd40ebed1cae3eed1baf4c3547f'
+  '83c6ac6d0dfa042821973ee0e8c432e9cb462e11'
 # ---
 # name: test_all_snapshot_ids[142]
   '''
@@ -27273,6 +27374,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -27285,7 +27387,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[143]
-  'c3320c44d5fa6c508dfda564e67bc67747b9891c'
+  'cd65ddea2cf05735d3afd0d5a754bb480701540d'
 # ---
 # name: test_all_snapshot_ids[144]
   '''
@@ -28347,6 +28449,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -28374,6 +28477,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -28384,7 +28488,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[145]
-  '81ecba8b867d1179f0998c86b85a1176aa946456'
+  '547f39e0de84614590c1247c5c8f646696153dcd'
 # ---
 # name: test_all_snapshot_ids[146]
   '''
@@ -29439,6 +29543,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -29473,6 +29578,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -29483,7 +29589,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[147]
-  'ce839b23a887f29520c71238335886cbe80337ef'
+  'c12ff78fede2ed02f9f73a531003b65b262f85b3'
 # ---
 # name: test_all_snapshot_ids[148]
   '''
@@ -30389,6 +30495,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -30416,6 +30523,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -30456,6 +30564,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -30466,7 +30575,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[149]
-  '4b4b18dca82ef0567492f476ff2bcbbf7392206d'
+  '9c9eca490a1c758490dcd538469321bef142615f'
 # ---
 # name: test_all_snapshot_ids[14]
   '''
@@ -31538,6 +31647,7 @@
               "name": "one_my_other_check"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -32660,6 +32770,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -32695,6 +32806,7 @@
               "name": "str_asset"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -32729,6 +32841,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -32739,10 +32852,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[151]
-  'dedb9fc5a6627950d8d31dce78af887c18c25160'
+  '927ec3de2eafb5ea326d481adbfa6f108d896bca'
 # ---
 # name: test_all_snapshot_ids[15]
-  'c77559c3ffec162d2580606b6cc7aeaf8ab8d9e0'
+  'b0c06b1d19ebc1719fb97e606c97c98808173120'
 # ---
 # name: test_all_snapshot_ids[16]
   '''
@@ -33660,6 +33773,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -33670,7 +33784,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[17]
-  'ac30d35b2d3b8c25490824aaa8dac2281ad4f860'
+  '2f4a7e8dac16272a9e008a61e766b43bd473eb7e'
 # ---
 # name: test_all_snapshot_ids[18]
   '''
@@ -35005,6 +35119,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -35039,6 +35154,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -35049,10 +35165,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[19]
-  'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
+  'f726acb538de96f43dfa0335f7bc79d1b52394c1'
 # ---
 # name: test_all_snapshot_ids[1]
-  'e3c865407ca4b1623f7d29ccbdc56d77a3da497b'
+  '6c2e7891d74bdc0ff647f100a13f4a630081c2ba'
 # ---
 # name: test_all_snapshot_ids[20]
   '''
@@ -36081,6 +36197,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -36108,6 +36225,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -36118,7 +36236,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[21]
-  '9041a32e00b2c27d78e168f10272a992f819e88d'
+  'a380036718142da0ac2761aa86d24ae2c0f96f53'
 # ---
 # name: test_all_snapshot_ids[22]
   '''
@@ -37078,6 +37196,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -37112,6 +37231,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -37122,7 +37242,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[23]
-  '9d2930f7c072c5a01688d84b725c49d4ae718c65'
+  '42f2f9908dcf606a04364fd6edab7bd9a1e39aa4'
 # ---
 # name: test_all_snapshot_ids[24]
   '''
@@ -38082,6 +38202,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -38116,6 +38237,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -38126,7 +38248,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[25]
-  'a28dd9e490e08f05fab6ab1309de27da5cd3eb0f'
+  '55ca8157660c610a531746808060e545b83c6247'
 # ---
 # name: test_all_snapshot_ids[26]
   '''
@@ -39056,6 +39178,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -39066,7 +39189,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[27]
-  'a62baecf830886bfa322863f86bbd7344ef9c359'
+  '3d4925a65348e3a0560aa6b818aa958098967525'
 # ---
 # name: test_all_snapshot_ids[28]
   '''
@@ -40056,6 +40179,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -40090,6 +40214,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -40124,6 +40249,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -40134,7 +40260,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[29]
-  '2bc0dc6a7c8ccb4ec4352fde1925f82521d71675'
+  '65d1097db8175b8dccef024c87c948f207cdb11f'
 # ---
 # name: test_all_snapshot_ids[2]
   '''
@@ -41159,6 +41285,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -42013,6 +42140,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -42023,7 +42151,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[31]
-  '458a303a0e8d51f99eb8417d4be851f0b982b5a5'
+  '3ee8302845c25b0527561794e22024de90478a04'
 # ---
 # name: test_all_snapshot_ids[32]
   '''
@@ -43085,6 +43213,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -43112,6 +43241,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -43122,7 +43252,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[33]
-  '155cb67915656dd22c1d24cac01603648f423b0b'
+  '702d508e8721e8c8286c056f5a0a888c1febb1da'
 # ---
 # name: test_all_snapshot_ids[34]
   '''
@@ -44179,6 +44309,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -44206,6 +44337,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -44240,6 +44372,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -44286,6 +44419,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -44320,6 +44454,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -44330,7 +44465,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[35]
-  'db3c9e009bad031bbf9b5f278cc09b691a00eaec'
+  'e3cf4257cb43e1a09b7dbfb4878d44bd40e30798'
 # ---
 # name: test_all_snapshot_ids[36]
   '''
@@ -45392,6 +45527,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -45419,6 +45555,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -45429,7 +45566,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[37]
-  '226bfaa0b42ce356abd18ab86046686cc2c2b9b2'
+  'a1d2b3ec611aced3a1efde71401cded7594ac075'
 # ---
 # name: test_all_snapshot_ids[38]
   '''
@@ -46543,6 +46680,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -46577,6 +46715,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "retry_count"
           ],
@@ -46613,6 +46752,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -46640,6 +46780,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -46650,10 +46791,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[39]
-  'effe11fd9b8a40682bc8041fcfdaf25f68be4612'
+  'cdea9b63b71ce76a1db61539dd7040f69d52590c'
 # ---
 # name: test_all_snapshot_ids[3]
-  'fc5c2d069b423eb651fd1b8e68f1537d8ecfdd82'
+  'b3476cfa8240e1713d78897fdfec25a59b64f0df'
 # ---
 # name: test_all_snapshot_ids[40]
   '''
@@ -47692,6 +47833,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -47702,7 +47844,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[41]
-  '5c546683c0858a71f27c63a4b294926e1de6a1e1'
+  '1044db6796f43e8732d5971f0024ca36faf9885c'
 # ---
 # name: test_all_snapshot_ids[42]
   '''
@@ -48727,6 +48869,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -48737,7 +48880,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[43]
-  '39c8061a712382691a1d8203efadcec978be2173'
+  'ba40a7cc6906899c438abe67f5144f720ead2158'
 # ---
 # name: test_all_snapshot_ids[44]
   '''
@@ -49863,6 +50006,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -49903,6 +50047,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -49937,6 +50082,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -49971,6 +50117,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -49981,7 +50128,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[45]
-  'f07b5f3e9fe1aaec2d455ef01bac50f38db70300'
+  '0419f0d2bcee4b7d82c749b41ffde27d3e841669'
 # ---
 # name: test_all_snapshot_ids[46]
   '''
@@ -51112,6 +51259,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -51146,6 +51294,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -51173,6 +51322,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -51213,6 +51363,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -51240,6 +51391,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -51250,7 +51402,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[47]
-  '7ba20030eeecab26afcfd3cd5a68be1d2f48c427'
+  'cbc9b73edbfb16e68bfaea0cf9b96849bceb8768'
 # ---
 # name: test_all_snapshot_ids[48]
   '''
@@ -52397,6 +52549,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -52431,6 +52584,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -52465,6 +52619,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -52499,6 +52654,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -52509,7 +52665,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[49]
-  'a670207753e19f723023819135333b4ac71a281b'
+  '3f6c8ba6993e3c2d8ef331327dfe6bcdec3d1e39'
 # ---
 # name: test_all_snapshot_ids[4]
   '''
@@ -53534,6 +53690,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -54750,6 +54907,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -54784,6 +54942,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -54813,6 +54972,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -54847,6 +55007,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -54857,7 +55018,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[51]
-  '8d5778a9040bf5a8f2eb894cca019573f72cafb7'
+  '709d40d76a7309b11219cb331842fb349e161eb0'
 # ---
 # name: test_all_snapshot_ids[52]
   '''
@@ -55871,6 +56032,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -55905,6 +56067,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -55941,6 +56104,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -55951,7 +56115,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[53]
-  '2a4c830fed93036921f36e4ff15172e452f21460'
+  'c3aabf70377cb5b0e29bbb20fd4fcf3e19a31243'
 # ---
 # name: test_all_snapshot_ids[54]
   '''
@@ -56891,6 +57055,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -56903,7 +57068,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[55]
-  '3fcb711d337cb03bedf5ff7e5ec64b30eefc9ec8'
+  'feee923ea5fe7d6c6a32a7bcb5520580968b172b'
 # ---
 # name: test_all_snapshot_ids[56]
   '''
@@ -57856,6 +58021,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [
             "hanging_asset_resource"
           ],
@@ -57885,6 +58051,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -57895,7 +58062,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[57]
-  'b467f29b8fb76fd793f23aa1cefb10918a105f91'
+  '02b4161e051e81f1c2a6d98a9e4fd317dfdebcb6'
 # ---
 # name: test_all_snapshot_ids[58]
   '''
@@ -58818,6 +58985,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -58852,6 +59020,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -58862,10 +59031,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[59]
-  'c6b504611b1ee7582092807ac90bdd4ac64bac3b'
+  'c3ee2f13236f5c435fd35cda5130aee26f782ba6'
 # ---
 # name: test_all_snapshot_ids[5]
-  'c23e75a6d1d7a9b89528399a9d27bcc9c90a178e'
+  'caa77ddbcfcd5b19d2aa3a79f590ebdbf08d0e93'
 # ---
 # name: test_all_snapshot_ids[60]
   '''
@@ -59712,6 +59881,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -59724,7 +59894,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[61]
-  'dc190868e8887ba5ac3669da13473252cd0ab098'
+  'aa4ef476a6365f3e0580260a76a6d6d68230f1ba'
 # ---
 # name: test_all_snapshot_ids[62]
   '''
@@ -60617,6 +60787,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -60627,7 +60798,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[63]
-  '83469e8c700778e0c1e268f158672fca54d5896b'
+  'ef3bed708c084bf42ea5a6323e0956535baa4543'
 # ---
 # name: test_all_snapshot_ids[64]
   '''
@@ -61474,6 +61645,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -61484,7 +61656,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[65]
-  'c4fee3a0c56b1ef6fcea9b64ceaacd06c4d5e216'
+  'd0384ede0cce61753aaeb41ca23c890fe92056ff'
 # ---
 # name: test_all_snapshot_ids[66]
   '''
@@ -62509,6 +62681,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -62519,7 +62692,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[67]
-  '10e316cc85a348c2e9f5c5ec1a076bfe7e036ff2'
+  'd80307a63854223bed7bb3ee68a98bcc8dd1e910'
 # ---
 # name: test_all_snapshot_ids[68]
   '''
@@ -63412,6 +63585,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -63422,7 +63596,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[69]
-  '643e2b02ca69b0087d15b448a9108d39d5b35036'
+  'b7bb430ea92805bcde137dfd09f72b84d7d5e073'
 # ---
 # name: test_all_snapshot_ids[6]
   '''
@@ -64500,6 +64674,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -64540,6 +64715,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -64575,6 +64751,7 @@
               "name": "check_in_op_asset_my_check"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -65481,6 +65658,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -65491,7 +65669,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[71]
-  '158a79ab642707e63923c59c6abaf7960b36211e'
+  '000261a9954723ac0cefe107bc92adcf0e3a200b'
 # ---
 # name: test_all_snapshot_ids[72]
   '''
@@ -66363,6 +66541,7 @@
           "input_def_snaps": [],
           "name": "emit_failed_expectation",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -66381,6 +66560,7 @@
           "input_def_snaps": [],
           "name": "emit_successful_expectation",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -66399,6 +66579,7 @@
           "input_def_snaps": [],
           "name": "emit_successful_expectation_no_metadata",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -66409,7 +66590,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[73]
-  '25eed9832eef95ee97a63357e836659193775b3d'
+  '6d22707948b2ee20673d0b3108d83b1c4f3d7afd'
 # ---
 # name: test_all_snapshot_ids[74]
   '''
@@ -67347,6 +67528,7 @@
               "name": "bar"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -67357,7 +67539,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[75]
-  '6069db2378a5bcd370c5f8ce8e8ee51d997e3447'
+  'f265b9e6e67079d19d46aa0d652a879c6fbec8ef'
 # ---
 # name: test_all_snapshot_ids[76]
   '''
@@ -68255,6 +68437,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -68282,6 +68465,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -68292,7 +68476,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[77]
-  'de3cee0b30bf45c5c28b57035caff8a592cb8a99'
+  '5dd48aa61f869698d9a41066631b480e451bf4a8'
 # ---
 # name: test_all_snapshot_ids[78]
   '''
@@ -69168,6 +69352,7 @@
           "input_def_snaps": [],
           "name": "op_with_list",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -69178,10 +69363,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[79]
-  '68f90c6bc3483e01ab1317573d90e23d0efe14a9'
+  '40a335f6458b99a0e8ece9e2438437ff0851bf6c'
 # ---
 # name: test_all_snapshot_ids[7]
-  '8023256507d183317343a2f6c4703a5ac3800eaf'
+  '4cbb3779564cdebc3594f0edd5c94950ec92f778'
 # ---
 # name: test_all_snapshot_ids[80]
   '''
@@ -70074,6 +70259,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -70084,7 +70270,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[81]
-  '1c4b82d393f7eacd9a358e3d82925d2afb9afbc0'
+  '6bb72c4b253804f1387776ea54c767fd97923f0d'
 # ---
 # name: test_all_snapshot_ids[82]
   '''
@@ -70931,6 +71117,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -70941,7 +71128,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[83]
-  'ab213b2b0286d659e9d7044d7dcec9b13d5b8bc7'
+  '12f5edfb1605d122c4e3628a8481844db5d772ce'
 # ---
 # name: test_all_snapshot_ids[84]
   '''
@@ -71869,6 +72056,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -71896,6 +72084,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -71906,7 +72095,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[85]
-  '06068d3cd0c89f54330c52e56f4e72a338f19a9f'
+  '9717dc0073cae0d9772818a7097d4cf71c2892fe'
 # ---
 # name: test_all_snapshot_ids[86]
   '''
@@ -72897,6 +73086,7 @@
           "input_def_snaps": [],
           "name": "op_with_multilayered_config",
           "output_def_snaps": [],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -72907,7 +73097,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[87]
-  '10cfd966244a4e4064ff00517d3e012ad6ce4c7d'
+  '947292f5870d5ca8a8dcf99a66f9d7759f2f5646'
 # ---
 # name: test_all_snapshot_ids[88]
   '''
@@ -73784,6 +73974,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -73818,6 +74009,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -73828,7 +74020,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[89]
-  'b7499dc1851fe912eb84bbbcead7d7db511e64d8'
+  '4eb442f45da611e54320f4cc5084f41a2f1f1a86'
 # ---
 # name: test_all_snapshot_ids[8]
   '''
@@ -74675,6 +74867,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -75707,6 +75900,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -75717,7 +75911,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[91]
-  '17bea22424bd5aa8995cc8ae08cd2e0c1be7c019'
+  '65a943726ccddf0851318d8255849c6a27687b60'
 # ---
 # name: test_all_snapshot_ids[92]
   '''
@@ -76772,6 +76966,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -76806,6 +77001,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -76816,7 +77012,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[93]
-  '7fc53a5a9f9ab514b23b938f7fa68cd5fd2f464d'
+  '15eee9b4a572e4b6eddd9ed0ec8fcc34e3d96e59'
 # ---
 # name: test_all_snapshot_ids[94]
   '''
@@ -77909,6 +78105,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -77936,6 +78133,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -77963,6 +78161,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -77990,6 +78189,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -78017,6 +78217,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -78027,7 +78228,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[95]
-  'f08d1a06b69649912ba8b056d76b8c7809954c31'
+  '11b9c9be70b3ce0434a5ea9aca6a52547da2ed73'
 # ---
 # name: test_all_snapshot_ids[96]
   '''
@@ -78874,6 +79075,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -78884,7 +79086,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[97]
-  '913c310b609478d52a81ee83bdd4b095d0f2932d'
+  '2de4122175e786573bf2870c54af3189990ceb77'
 # ---
 # name: test_all_snapshot_ids[98]
   '''
@@ -79950,6 +80152,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -79977,6 +80180,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -80004,6 +80208,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -80038,6 +80243,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -80048,8 +80254,8 @@
   '''
 # ---
 # name: test_all_snapshot_ids[99]
-  '8e137c24b2245e55025e1cc7b71a42b99425dbec'
+  'cf140114fda778cc12c11ba13f7e26cd0fbccb3c'
 # ---
 # name: test_all_snapshot_ids[9]
-  '9699a524d810d89264bf60d01dab3c751fe47461'
+  'cf67ad5622d23845499daf2adba4a11f6b23f9eb'
 # ---

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -2571,6 +2571,9 @@
               "mapped_solid_name": "never_runs_op"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         }
       ],
@@ -33745,6 +33748,9 @@
           "name": "simple_graph",
           "output_def_snaps": [],
           "output_mapping_snaps": [],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         }
       ],
@@ -33784,7 +33790,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[17]
-  '2f4a7e8dac16272a9e008a61e766b43bd473eb7e'
+  'cfb767a61be6a485474582ec75fc6834cd314c08'
 # ---
 # name: test_all_snapshot_ids[18]
   '''
@@ -34920,6 +34926,9 @@
               "mapped_solid_name": "adder_2"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         },
         {
@@ -35002,6 +35011,9 @@
               "mapped_solid_name": "adder_2"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         },
         {
@@ -35084,6 +35096,9 @@
               "mapped_solid_name": "div_2"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         }
       ],
@@ -35165,10 +35180,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[19]
-  'f726acb538de96f43dfa0335f7bc79d1b52394c1'
+  'b336066bf8dc411b162f9869dd08da0b18057896'
 # ---
 # name: test_all_snapshot_ids[1]
-  '6c2e7891d74bdc0ff647f100a13f4a630081c2ba'
+  'fb54440831226acbda6ad87d0d7599c4f3424168'
 # ---
 # name: test_all_snapshot_ids[20]
   '''
@@ -54872,6 +54887,9 @@
               "mapped_solid_name": "never_runs_op"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         }
       ],
@@ -55018,7 +55036,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[51]
-  '709d40d76a7309b11219cb331842fb349e161eb0'
+  '200c1bc946100875b19e0c6b7f26fbb9edab070b'
 # ---
 # name: test_all_snapshot_ids[52]
   '''
@@ -80111,6 +80129,9 @@
               "mapped_solid_name": "plus_one"
             }
           ],
+          "pools": {
+            "__set__": []
+          },
           "tags": {}
         }
       ],
@@ -80254,7 +80275,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[99]
-  'cf140114fda778cc12c11ba13f7e26cd0fbccb3c'
+  '1959e3612cf7d53844928fff25df04128d1b15ff'
 # ---
 # name: test_all_snapshot_ids[9]
   'cf67ad5622d23845499daf2adba4a11f6b23f9eb'

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_pipeline_snapshot.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_pipeline_snapshot.ambr
@@ -40,7 +40,7 @@
         }
       ],
       "name": "tagged_job",
-      "pipelineSnapshotId": "c3320c44d5fa6c508dfda564e67bc67747b9891c",
+      "pipelineSnapshotId": "cd65ddea2cf05735d3afd0d5a754bb480701540d",
       "runTags": [
         {
           "key": "baz",
@@ -109,7 +109,7 @@
         }
       ],
       "name": "noop_job",
-      "pipelineSnapshotId": "dbc0d71fefa48d56ff94e517235980f1bbf0d8e8",
+      "pipelineSnapshotId": "8d26314f29636d538a81739b645f46241b8373d4",
       "runTags": [],
       "solidHandles": [
         {

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -246,7 +246,7 @@ def asset_check(
             asset_in_map={},
             asset_out_map={},
             execution_type=None,
-            concurrency_group=None,
+            pool=None,
         )
 
         builder = DecoratorAssetsDefinitionBuilder(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -246,7 +246,7 @@ def asset_check(
             asset_in_map={},
             asset_out_map={},
             execution_type=None,
-            concurrency_key=None,
+            concurrency_group=None,
         )
 
         builder = DecoratorAssetsDefinitionBuilder(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -246,6 +246,7 @@ def asset_check(
             asset_in_map={},
             asset_out_map={},
             execution_type=None,
+            concurrency_key=None,
         )
 
         builder = DecoratorAssetsDefinitionBuilder(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -93,7 +93,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = ...,
     owners: Optional[Sequence[str]] = ...,
     kinds: Optional[AbstractSet[str]] = ...,
-    concurrency_group: Optional[str] = ...,
+    pool: Optional[str] = ...,
     **kwargs,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
@@ -171,7 +171,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
-    concurrency_group: Optional[str] = None,
+    pool: Optional[str] = None,
     **kwargs,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
@@ -248,7 +248,7 @@ def asset(
             e.g. `team:finops`.
         kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
             will be made visible in the Dagster UI.
-        concurrency_group (Optional[str]): A string that identifies the concurrency limit group that governs
+        pool (Optional[str]): A string that identifies the concurrency limit group that governs
             this asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
@@ -310,7 +310,7 @@ def asset(
         check_specs=check_specs,
         key=key,
         owners=owners,
-        concurrency_group=concurrency_group,
+        pool=pool,
     )
 
     if compute_fn is not None:
@@ -383,7 +383,7 @@ class AssetDecoratorArgs(NamedTuple):
     key: Optional[CoercibleToAssetKey]
     check_specs: Optional[Sequence[AssetCheckSpec]]
     owners: Optional[Sequence[str]]
-    concurrency_group: Optional[str]
+    pool: Optional[str]
 
 
 class ResourceRelatedState(NamedTuple):
@@ -508,7 +508,7 @@ def create_assets_def_from_fn_and_decorator_args(
             can_subset=False,
             decorator_name="@asset",
             execution_type=AssetExecutionType.MATERIALIZATION,
-            concurrency_group=args.concurrency_group,
+            pool=args.pool,
         )
 
         builder = DecoratorAssetsDefinitionBuilder.from_asset_outs_in_asset_centric_decorator(
@@ -555,7 +555,7 @@ def multi_asset(
     code_version: Optional[str] = None,
     specs: Optional[Sequence[AssetSpec]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
-    concurrency_group: Optional[str] = None,
+    pool: Optional[str] = None,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
@@ -610,7 +610,7 @@ def multi_asset(
             by this function.
         check_specs (Optional[Sequence[AssetCheckSpec]]): Specs for asset checks that
             execute in the decorated function after materializing the assets.
-        concurrency_group (Optional[str]): A string that identifies the concurrency limit group that
+        pool (Optional[str]): A string that identifies the concurrency limit group that
             governs this multi-asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the
@@ -687,7 +687,7 @@ def multi_asset(
         backfill_policy=backfill_policy,
         decorator_name="@multi_asset",
         execution_type=AssetExecutionType.MATERIALIZATION,
-        concurrency_group=concurrency_group,
+        pool=pool,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -171,7 +171,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
-    concurrency_key: Optional[str] = ...,
+    concurrency_key: Optional[str] = None,
     **kwargs,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -248,8 +248,7 @@ def asset(
             e.g. `team:finops`.
         kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
             will be made visible in the Dagster UI.
-        pool (Optional[str]): A string that identifies the concurrency limit group that governs
-            this asset's execution.
+        pool (Optional[str]): A string that identifies the concurrency pool that governs this asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
             Hidden parameter not exposed in the decorator signature, but passed in kwargs.
@@ -610,8 +609,8 @@ def multi_asset(
             by this function.
         check_specs (Optional[Sequence[AssetCheckSpec]]): Specs for asset checks that
             execute in the decorated function after materializing the assets.
-        pool (Optional[str]): A string that identifies the concurrency limit group that
-            governs this multi-asset's execution.
+        pool (Optional[str]): A string that identifies the concurrency pool that governs this
+            multi-asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the
             multi_asset.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -93,6 +93,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = ...,
     owners: Optional[Sequence[str]] = ...,
     kinds: Optional[AbstractSet[str]] = ...,
+    concurrency_key: Optional[str] = ...,
     **kwargs,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
@@ -170,6 +171,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
+    concurrency_key: Optional[str] = ...,
     **kwargs,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
@@ -246,6 +248,8 @@ def asset(
             e.g. `team:finops`.
         kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
             will be made visible in the Dagster UI.
+        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that governs
+            this asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
             Hidden parameter not exposed in the decorator signature, but passed in kwargs.
@@ -306,6 +310,7 @@ def asset(
         check_specs=check_specs,
         key=key,
         owners=owners,
+        concurrency_key=concurrency_key,
     )
 
     if compute_fn is not None:
@@ -378,6 +383,7 @@ class AssetDecoratorArgs(NamedTuple):
     key: Optional[CoercibleToAssetKey]
     check_specs: Optional[Sequence[AssetCheckSpec]]
     owners: Optional[Sequence[str]]
+    concurrency_key: Optional[str]
 
 
 class ResourceRelatedState(NamedTuple):
@@ -502,6 +508,7 @@ def create_assets_def_from_fn_and_decorator_args(
             can_subset=False,
             decorator_name="@asset",
             execution_type=AssetExecutionType.MATERIALIZATION,
+            concurrency_key=args.concurrency_key,
         )
 
         builder = DecoratorAssetsDefinitionBuilder.from_asset_outs_in_asset_centric_decorator(
@@ -548,6 +555,7 @@ def multi_asset(
     code_version: Optional[str] = None,
     specs: Optional[Sequence[AssetSpec]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
+    concurrency_key: Optional[str] = None,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
@@ -602,6 +610,8 @@ def multi_asset(
             by this function.
         check_specs (Optional[Sequence[AssetCheckSpec]]): Specs for asset checks that
             execute in the decorated function after materializing the assets.
+        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that
+            governs this multi-asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the
             multi_asset.
@@ -677,6 +687,7 @@ def multi_asset(
         backfill_policy=backfill_policy,
         decorator_name="@multi_asset",
         execution_type=AssetExecutionType.MATERIALIZATION,
+        concurrency_key=concurrency_key,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -93,7 +93,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = ...,
     owners: Optional[Sequence[str]] = ...,
     kinds: Optional[AbstractSet[str]] = ...,
-    concurrency_key: Optional[str] = ...,
+    concurrency_group: Optional[str] = ...,
     **kwargs,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
@@ -171,7 +171,7 @@ def asset(
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
-    concurrency_key: Optional[str] = None,
+    concurrency_group: Optional[str] = None,
     **kwargs,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
@@ -248,7 +248,7 @@ def asset(
             e.g. `team:finops`.
         kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
             will be made visible in the Dagster UI.
-        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that governs
+        concurrency_group (Optional[str]): A string that identifies the concurrency limit group that governs
             this asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
@@ -310,7 +310,7 @@ def asset(
         check_specs=check_specs,
         key=key,
         owners=owners,
-        concurrency_key=concurrency_key,
+        concurrency_group=concurrency_group,
     )
 
     if compute_fn is not None:
@@ -383,7 +383,7 @@ class AssetDecoratorArgs(NamedTuple):
     key: Optional[CoercibleToAssetKey]
     check_specs: Optional[Sequence[AssetCheckSpec]]
     owners: Optional[Sequence[str]]
-    concurrency_key: Optional[str]
+    concurrency_group: Optional[str]
 
 
 class ResourceRelatedState(NamedTuple):
@@ -508,7 +508,7 @@ def create_assets_def_from_fn_and_decorator_args(
             can_subset=False,
             decorator_name="@asset",
             execution_type=AssetExecutionType.MATERIALIZATION,
-            concurrency_key=args.concurrency_key,
+            concurrency_group=args.concurrency_group,
         )
 
         builder = DecoratorAssetsDefinitionBuilder.from_asset_outs_in_asset_centric_decorator(
@@ -555,7 +555,7 @@ def multi_asset(
     code_version: Optional[str] = None,
     specs: Optional[Sequence[AssetSpec]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
-    concurrency_key: Optional[str] = None,
+    concurrency_group: Optional[str] = None,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
@@ -610,7 +610,7 @@ def multi_asset(
             by this function.
         check_specs (Optional[Sequence[AssetCheckSpec]]): Specs for asset checks that
             execute in the decorated function after materializing the assets.
-        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that
+        concurrency_group (Optional[str]): A string that identifies the concurrency limit group that
             governs this multi-asset's execution.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the
@@ -687,7 +687,7 @@ def multi_asset(
         backfill_policy=backfill_policy,
         decorator_name="@multi_asset",
         execution_type=AssetExecutionType.MATERIALIZATION,
-        concurrency_key=concurrency_key,
+        concurrency_group=concurrency_group,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -243,6 +243,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     specs: Sequence[AssetSpec]
     upstream_asset_deps: Optional[Iterable[AssetDep]]
     execution_type: Optional[AssetExecutionType]
+    concurrency_key: Optional[str]
 
     @property
     def check_specs(self) -> Sequence[AssetCheckSpec]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -561,6 +561,7 @@ class DecoratorAssetsDefinitionBuilder:
             config_schema=self.args.config_schema,
             retry_policy=self.args.retry_policy,
             code_version=self.args.code_version,
+            concurrency_group=self.args.concurrency_group,
         )(self.fn)
 
     def create_assets_definition(self) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -243,7 +243,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     specs: Sequence[AssetSpec]
     upstream_asset_deps: Optional[Iterable[AssetDep]]
     execution_type: Optional[AssetExecutionType]
-    concurrency_key: Optional[str]
+    concurrency_group: Optional[str]
 
     @property
     def check_specs(self) -> Sequence[AssetCheckSpec]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -243,7 +243,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     specs: Sequence[AssetSpec]
     upstream_asset_deps: Optional[Iterable[AssetDep]]
     execution_type: Optional[AssetExecutionType]
-    concurrency_group: Optional[str]
+    pool: Optional[str]
 
     @property
     def check_specs(self) -> Sequence[AssetCheckSpec]:
@@ -561,7 +561,7 @@ class DecoratorAssetsDefinitionBuilder:
             config_schema=self.args.config_schema,
             retry_policy=self.args.retry_policy,
             code_version=self.args.code_version,
-            concurrency_group=self.args.concurrency_group,
+            pool=self.args.pool,
         )(self.fn)
 
     def create_assets_definition(self) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -50,6 +50,7 @@ class _Op:
         retry_policy: Optional[RetryPolicy] = None,
         ins: Optional[Mapping[str, In]] = None,
         out: Optional[Union[Out, Mapping[str, Out]]] = None,
+        concurrency_key: Optional[str] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.decorator_takes_context = check.bool_param(
@@ -63,6 +64,7 @@ class _Op:
         self.tags = tags
         self.code_version = code_version
         self.retry_policy = retry_policy
+        self.concurrency_key = concurrency_key
 
         # config will be checked within OpDefinition
         self.config_schema = config_schema
@@ -130,6 +132,7 @@ class _Op:
             code_version=self.code_version,
             retry_policy=self.retry_policy,
             version=None,  # code_version has replaced version
+            concurrency_key=self.concurrency_key,
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
@@ -152,6 +155,7 @@ def op(
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
     code_version: Optional[str] = ...,
+    concurrency_key: Optional[str] = None,
 ) -> _Op: ...
 
 
@@ -171,6 +175,7 @@ def op(
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
     code_version: Optional[str] = None,
+    concurrency_key: Optional[str] = None,
 ) -> Union["OpDefinition", _Op]:
     """Create an op with the specified parameters from the decorated function.
 
@@ -264,6 +269,7 @@ def op(
         retry_policy=retry_policy,
         ins=ins,
         out=out,
+        concurrency_key=concurrency_key,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -50,7 +50,7 @@ class _Op:
         retry_policy: Optional[RetryPolicy] = None,
         ins: Optional[Mapping[str, In]] = None,
         out: Optional[Union[Out, Mapping[str, Out]]] = None,
-        concurrency_key: Optional[str] = None,
+        concurrency_group: Optional[str] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.decorator_takes_context = check.bool_param(
@@ -64,7 +64,7 @@ class _Op:
         self.tags = tags
         self.code_version = code_version
         self.retry_policy = retry_policy
-        self.concurrency_key = concurrency_key
+        self.concurrency_group = concurrency_group
 
         # config will be checked within OpDefinition
         self.config_schema = config_schema
@@ -132,7 +132,7 @@ class _Op:
             code_version=self.code_version,
             retry_policy=self.retry_policy,
             version=None,  # code_version has replaced version
-            concurrency_key=self.concurrency_key,
+            concurrency_group=self.concurrency_group,
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
@@ -155,7 +155,7 @@ def op(
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
     code_version: Optional[str] = ...,
-    concurrency_key: Optional[str] = None,
+    concurrency_group: Optional[str] = None,
 ) -> _Op: ...
 
 
@@ -175,7 +175,7 @@ def op(
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
     code_version: Optional[str] = None,
-    concurrency_key: Optional[str] = None,
+    concurrency_group: Optional[str] = None,
 ) -> Union["OpDefinition", _Op]:
     """Create an op with the specified parameters from the decorated function.
 
@@ -269,7 +269,7 @@ def op(
         retry_policy=retry_policy,
         ins=ins,
         out=out,
-        concurrency_key=concurrency_key,
+        concurrency_group=concurrency_group,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -50,7 +50,7 @@ class _Op:
         retry_policy: Optional[RetryPolicy] = None,
         ins: Optional[Mapping[str, In]] = None,
         out: Optional[Union[Out, Mapping[str, Out]]] = None,
-        concurrency_group: Optional[str] = None,
+        pool: Optional[str] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.decorator_takes_context = check.bool_param(
@@ -64,7 +64,7 @@ class _Op:
         self.tags = tags
         self.code_version = code_version
         self.retry_policy = retry_policy
-        self.concurrency_group = concurrency_group
+        self.pool = pool
 
         # config will be checked within OpDefinition
         self.config_schema = config_schema
@@ -132,7 +132,7 @@ class _Op:
             code_version=self.code_version,
             retry_policy=self.retry_policy,
             version=None,  # code_version has replaced version
-            concurrency_group=self.concurrency_group,
+            pool=self.pool,
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
@@ -155,7 +155,7 @@ def op(
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
     code_version: Optional[str] = ...,
-    concurrency_group: Optional[str] = None,
+    pool: Optional[str] = None,
 ) -> _Op: ...
 
 
@@ -175,7 +175,7 @@ def op(
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
     code_version: Optional[str] = None,
-    concurrency_group: Optional[str] = None,
+    pool: Optional[str] = None,
 ) -> Union["OpDefinition", _Op]:
     """Create an op with the specified parameters from the decorated function.
 
@@ -269,7 +269,7 @@ def op(
         retry_policy=retry_policy,
         ins=ins,
         out=out,
-        concurrency_group=concurrency_group,
+        pool=pool,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -301,6 +301,7 @@ def multi_observable_source_asset(
         backfill_policy=None,
         decorator_name="@multi_observable_source_asset",
         execution_type=AssetExecutionType.OBSERVATION,
+        concurrency_key=None,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -301,7 +301,7 @@ def multi_observable_source_asset(
         backfill_policy=None,
         decorator_name="@multi_observable_source_asset",
         execution_type=AssetExecutionType.OBSERVATION,
-        concurrency_group=None,
+        pool=None,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -301,7 +301,7 @@ def multi_observable_source_asset(
         backfill_policy=None,
         decorator_name="@multi_observable_source_asset",
         execution_type=AssetExecutionType.OBSERVATION,
-        concurrency_key=None,
+        concurrency_group=None,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -808,6 +808,13 @@ class GraphDefinition(NodeDefinition):
         """The tags associated with the graph."""
         return super().tags
 
+    @property
+    def pools(self) -> set[str]:
+        pools = set()
+        for node_def in self.node_defs:
+            pools.update(node_def.pools)
+        return pools
+
     @public
     def alias(self, name: str) -> "PendingNodeInvocation":
         """Aliases the graph with a new name.

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from typing import (  # noqa: UP035
     TYPE_CHECKING,
     AbstractSet,
@@ -809,7 +809,7 @@ class GraphDefinition(NodeDefinition):
         return super().tags
 
     @property
-    def pools(self) -> set[str]:
+    def pools(self) -> Set[str]:
         pools = set()
         for node_def in self.node_defs:
             pools.update(node_def.pools)
@@ -1050,7 +1050,7 @@ def _validate_in_mappings(
     from dagster._core.definitions.composition import MappedInputPlaceholder
 
     input_defs_by_name: dict[str, InputDefinition] = OrderedDict()
-    mapping_keys: set[str] = set()
+    mapping_keys: Set[str] = set()
 
     target_input_types_by_graph_input_name: dict[str, set[DagsterType]] = defaultdict(set)
 

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -232,3 +232,7 @@ class NodeDefinition(NamedConfigurableDefinition):
     def get_op_output_handles(
         self, parent: Optional["NodeHandle"]
     ) -> AbstractSet["NodeOutputHandle"]: ...
+
+    @property
+    @abstractmethod
+    def pools(self) -> set[str]: ...

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, AbstractSet, Optional  # noqa: UP035
 
 import dagster._check as check
@@ -235,4 +235,4 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @property
     @abstractmethod
-    def pools(self) -> set[str]: ...
+    def pools(self) -> Set[str]: ...

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -80,8 +80,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         code_version (Optional[str]): (Experimental) Version of the code encapsulated by the op. If set,
             this is used as a default code version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
-        pool (Optional[str]): A string that identifies the concurrency limit group that governs
-            this op's execution.
+        pool (Optional[str]): A string that identifies the pool that governs this op's execution.
 
 
     Examples:
@@ -602,7 +601,7 @@ def _validate_pool(pool, tags):
     tag_concurrency_key = tags.get(GLOBAL_CONCURRENCY_TAG)
     if pool and tag_concurrency_key and pool != tag_concurrency_key:
         raise DagsterInvalidDefinitionError(
-            f'Concurrency group "{pool}" that conflicts with the concurrency key tag "{tag_concurrency_key}".'
+            f'Pool "{pool}" conflicts with the concurrency key tag "{tag_concurrency_key}".'
         )
 
     if pool:

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -163,7 +163,8 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
         )
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
-        self._concurrency_group = _validate_concurrency_group(concurrency_group, tags)
+        self._concurrency_group = concurrency_group
+        concurrency_group = _validate_concurrency_group(concurrency_group, tags)
 
         positional_inputs = (
             self._compute_fn.positional_inputs()
@@ -295,7 +296,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
 
     @property
     def concurrency_group(self) -> Optional[str]:
-        """Optional[str]: The concurrency key for this op."""
+        """Optional[str]: The concurrency group for this op."""
         return self._concurrency_group
 
     def is_from_decorator(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -601,7 +601,7 @@ def _validate_concurrency_key(concurrency_key, tags):
     tag_concurrency_key = tags.get(GLOBAL_CONCURRENCY_TAG)
     if concurrency_key and tag_concurrency_key and concurrency_key != tag_concurrency_key:
         raise DagsterInvalidDefinitionError(
-            f"Op '{concurrency_key}' has a concurrency key '{concurrency_key}' that conflicts with the concurrency key tag '{tag_concurrency_key}'."
+            f'Concurrency key "{concurrency_key}" that conflicts with the concurrency key tag "{tag_concurrency_key}".'
         )
 
     if concurrency_key:

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -80,6 +80,8 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         code_version (Optional[str]): (Experimental) Version of the code encapsulated by the op. If set,
             this is used as a default code version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
+        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that governs
+            this op's execution.
 
 
     Examples:
@@ -101,6 +103,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     _required_resource_keys: AbstractSet[str]
     _version: Optional[str]
     _retry_policy: Optional[RetryPolicy]
+    _concurrency_key: Optional[str]
 
     def __init__(
         self,
@@ -115,6 +118,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
         code_version: Optional[str] = None,
+        concurrency_key: Optional[str] = None,
     ):
         from dagster._core.definitions.decorators.op_decorator import (
             DecoratedOpFunction,
@@ -159,6 +163,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
         )
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
+        self._concurrency_key = _validate_concurrency_key(concurrency_key, tags)
 
         positional_inputs = (
             self._compute_fn.positional_inputs()
@@ -188,6 +193,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str],
         retry_policy: Optional[RetryPolicy],
         code_version: Optional[str],
+        concurrency_key: Optional[str],
     ) -> "OpDefinition":
         return OpDefinition(
             compute_fn=compute_fn,
@@ -201,6 +207,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             version=version,
             retry_policy=retry_policy,
             code_version=code_version,
+            concurrency_key=concurrency_key,
         )
 
     @property
@@ -285,6 +292,11 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def with_retry_policy(self, retry_policy: RetryPolicy) -> "PendingNodeInvocation":
         """Creates a copy of this op with the given retry policy."""
         return super().with_retry_policy(retry_policy)
+
+    @property
+    def concurrency_key(self) -> Optional[str]:
+        """Optional[str]: The concurrency key for this op."""
+        return self._concurrency_key
 
     def is_from_decorator(self) -> bool:
         from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
@@ -372,6 +384,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             code_version=self._version,
             retry_policy=self.retry_policy,
             version=None,  # code_version replaces version
+            concurrency_key=self.concurrency_key,
         )
 
     def copy_for_configured(
@@ -578,3 +591,23 @@ def _validate_context_type_hint(fn):
 def _is_result_object_type(ttype):
     # Is this type special result object type
     return ttype in (MaterializeResult, ObserveResult, AssetCheckResult)
+
+
+def _validate_concurrency_key(concurrency_key, tags):
+    from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
+
+    check.opt_str_param(concurrency_key, "concurrency_key")
+    tags = check.opt_mapping_param(tags, "tags")
+    tag_concurrency_key = tags.get(GLOBAL_CONCURRENCY_TAG)
+    if concurrency_key and tag_concurrency_key and concurrency_key != tag_concurrency_key:
+        raise DagsterInvalidDefinitionError(
+            f"Op '{concurrency_key}' has a concurrency key '{concurrency_key}' that conflicts with the concurrency key tag '{tag_concurrency_key}'."
+        )
+
+    if concurrency_key:
+        return concurrency_key
+
+    if tag_concurrency_key:
+        return tag_concurrency_key
+
+    return None

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -80,7 +80,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         code_version (Optional[str]): (Experimental) Version of the code encapsulated by the op. If set,
             this is used as a default code version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
-        concurrency_key (Optional[str]): A string that identifies the concurrency limit group that governs
+        concurrency_group (Optional[str]): A string that identifies the concurrency limit group that governs
             this op's execution.
 
 
@@ -103,7 +103,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     _required_resource_keys: AbstractSet[str]
     _version: Optional[str]
     _retry_policy: Optional[RetryPolicy]
-    _concurrency_key: Optional[str]
+    _concurrency_group: Optional[str]
 
     def __init__(
         self,
@@ -118,7 +118,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
         code_version: Optional[str] = None,
-        concurrency_key: Optional[str] = None,
+        concurrency_group: Optional[str] = None,
     ):
         from dagster._core.definitions.decorators.op_decorator import (
             DecoratedOpFunction,
@@ -163,7 +163,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
         )
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
-        self._concurrency_key = _validate_concurrency_key(concurrency_key, tags)
+        self._concurrency_group = _validate_concurrency_group(concurrency_group, tags)
 
         positional_inputs = (
             self._compute_fn.positional_inputs()
@@ -193,7 +193,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str],
         retry_policy: Optional[RetryPolicy],
         code_version: Optional[str],
-        concurrency_key: Optional[str],
+        concurrency_group: Optional[str],
     ) -> "OpDefinition":
         return OpDefinition(
             compute_fn=compute_fn,
@@ -207,7 +207,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             version=version,
             retry_policy=retry_policy,
             code_version=code_version,
-            concurrency_key=concurrency_key,
+            concurrency_group=concurrency_group,
         )
 
     @property
@@ -294,9 +294,9 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         return super().with_retry_policy(retry_policy)
 
     @property
-    def concurrency_key(self) -> Optional[str]:
+    def concurrency_group(self) -> Optional[str]:
         """Optional[str]: The concurrency key for this op."""
-        return self._concurrency_key
+        return self._concurrency_group
 
     def is_from_decorator(self) -> bool:
         from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
@@ -384,7 +384,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             code_version=self._version,
             retry_policy=self.retry_policy,
             version=None,  # code_version replaces version
-            concurrency_key=self.concurrency_key,
+            concurrency_group=self.concurrency_group,
         )
 
     def copy_for_configured(
@@ -593,19 +593,19 @@ def _is_result_object_type(ttype):
     return ttype in (MaterializeResult, ObserveResult, AssetCheckResult)
 
 
-def _validate_concurrency_key(concurrency_key, tags):
+def _validate_concurrency_group(concurrency_group, tags):
     from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 
-    check.opt_str_param(concurrency_key, "concurrency_key")
+    check.opt_str_param(concurrency_group, "concurrency_group")
     tags = check.opt_mapping_param(tags, "tags")
     tag_concurrency_key = tags.get(GLOBAL_CONCURRENCY_TAG)
-    if concurrency_key and tag_concurrency_key and concurrency_key != tag_concurrency_key:
+    if concurrency_group and tag_concurrency_key and concurrency_group != tag_concurrency_key:
         raise DagsterInvalidDefinitionError(
-            f'Concurrency key "{concurrency_key}" that conflicts with the concurrency key tag "{tag_concurrency_key}".'
+            f'Concurrency group "{concurrency_group}" that conflicts with the concurrency key tag "{tag_concurrency_key}".'
         )
 
-    if concurrency_key:
-        return concurrency_key
+    if concurrency_group:
+        return concurrency_group
 
     if tag_concurrency_key:
         return tag_concurrency_key

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -1,5 +1,5 @@
 import inspect
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Union, cast  # noqa: UP035
 
 from typing_extensions import TypeAlias, get_args, get_origin
@@ -301,7 +301,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         return self._pool if self._pool else self.tags.get(GLOBAL_CONCURRENCY_TAG)
 
     @property
-    def pools(self) -> set[str]:
+    def pools(self) -> Set[str]:
         """Optional[str]: The concurrency pools for this op node."""
         return {self._pool} if self._pool else set()
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -35,7 +35,7 @@ from dagster._core.errors import (
 )
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils import IHasInternalInit
-from dagster._utils.warnings import normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param, preview_warning
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_layer import AssetLayer
@@ -297,6 +297,11 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def pool(self) -> Optional[str]:
         """Optional[str]: The concurrency group for this op."""
         return self._pool
+
+    @property
+    def pools(self) -> set[str]:
+        """Optional[str]: The concurrency group for this op."""
+        return {self._pool} if self._pool else set()
 
     def is_from_decorator(self) -> bool:
         from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
@@ -605,6 +610,7 @@ def _validate_pool(pool, tags):
         )
 
     if pool:
+        preview_warning("Pools")
         return pool
 
     if tag_concurrency_key:

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -33,6 +33,7 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
+from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils import IHasInternalInit
 from dagster._utils.warnings import normalize_renamed_param, preview_warning
@@ -295,12 +296,13 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
 
     @property
     def pool(self) -> Optional[str]:
-        """Optional[str]: The concurrency group for this op."""
-        return self._pool
+        """Optional[str]: The concurrency pool for this op."""
+        # fallback to fetching from tags for backwards compatibility
+        return self._pool if self._pool else self.tags.get(GLOBAL_CONCURRENCY_TAG)
 
     @property
     def pools(self) -> set[str]:
-        """Optional[str]: The concurrency group for this op."""
+        """Optional[str]: The concurrency pools for this op node."""
         return {self._pool} if self._pool else set()
 
     def is_from_decorator(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -23,7 +23,7 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode, RetryState
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG, PRIORITY_TAG
+from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._utils.interrupts import pop_captured_interrupt
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
@@ -338,15 +338,14 @@ class ActiveExecution:
             if run_scoped_concurrency_limits_counter:
                 run_scoped_concurrency_limits_counter.update_counters_with_launched_item(step)
 
-            step_concurrency_key = step.tags.get(GLOBAL_CONCURRENCY_TAG)
-            if step_concurrency_key and self._instance_concurrency_context:
+            if step.concurrency_key and self._instance_concurrency_context:
                 try:
                     step_priority = int(step.tags.get(PRIORITY_TAG, 0))
                 except ValueError:
                     step_priority = 0
 
                 if not self._instance_concurrency_context.claim(
-                    step_concurrency_key, step.key, step_priority
+                    step.concurrency_key, step.key, step_priority
                 ):
                     continue
 
@@ -644,7 +643,7 @@ class ActiveExecution:
             ):
                 step = self.get_step_by_key(step_key)
                 step_context = plan_context.for_step(step)
-                step_concurrency_key = cast(str, step.tags.get(GLOBAL_CONCURRENCY_TAG))
+                step_concurrency_key = cast(str, step.concurrency_key)
                 self._messaged_concurrency_slots[step_key] = time.time()
                 is_initial_message = last_messaged_timestamp is None
                 yield DagsterEvent.step_concurrency_blocked(

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -23,7 +23,7 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode, RetryState
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG, PRIORITY_TAG
+from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._utils.interrupts import pop_captured_interrupt
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
@@ -339,14 +339,13 @@ class ActiveExecution:
                 run_scoped_concurrency_limits_counter.update_counters_with_launched_item(step)
 
             # fallback to fetching from tags for backwards compatibility
-            pool = step.pool if step.pool else step.tags.get(GLOBAL_CONCURRENCY_TAG)
-            if pool and self._instance_concurrency_context:
+            if step.pool and self._instance_concurrency_context:
                 try:
                     step_priority = int(step.tags.get(PRIORITY_TAG, 0))
                 except ValueError:
                     step_priority = 0
 
-                if not self._instance_concurrency_context.claim(pool, step.key, step_priority):
+                if not self._instance_concurrency_context.claim(step.pool, step.key, step_priority):
                     continue
 
             batch.append(step)
@@ -643,7 +642,7 @@ class ActiveExecution:
             ):
                 step = self.get_step_by_key(step_key)
                 step_context = plan_context.for_step(step)
-                pool = cast(str, step.pool)
+                pool = check.inst(step.pool, str)
                 self._messaged_concurrency_slots[step_key] = time.time()
                 is_initial_message = last_messaged_timestamp is None
                 yield DagsterEvent.step_concurrency_blocked(

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -338,14 +338,14 @@ class ActiveExecution:
             if run_scoped_concurrency_limits_counter:
                 run_scoped_concurrency_limits_counter.update_counters_with_launched_item(step)
 
-            if step.concurrency_key and self._instance_concurrency_context:
+            if step.concurrency_group and self._instance_concurrency_context:
                 try:
                     step_priority = int(step.tags.get(PRIORITY_TAG, 0))
                 except ValueError:
                     step_priority = 0
 
                 if not self._instance_concurrency_context.claim(
-                    step.concurrency_key, step.key, step_priority
+                    step.concurrency_group, step.key, step_priority
                 ):
                     continue
 
@@ -643,9 +643,9 @@ class ActiveExecution:
             ):
                 step = self.get_step_by_key(step_key)
                 step_context = plan_context.for_step(step)
-                step_concurrency_key = cast(str, step.concurrency_key)
+                concurrency_group = cast(str, step.concurrency_group)
                 self._messaged_concurrency_slots[step_key] = time.time()
                 is_initial_message = last_messaged_timestamp is None
                 yield DagsterEvent.step_concurrency_blocked(
-                    step_context, step_concurrency_key, initial=is_initial_message
+                    step_context, concurrency_group, initial=is_initial_message
                 )

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -302,7 +302,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_group=node.definition.concurrency_group,
+                        pool=node.definition.pool,
                     )
                 elif has_pending_input:
                     new_step = UnresolvedCollectExecutionStep(
@@ -313,7 +313,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_group=node.definition.concurrency_group,
+                        pool=node.definition.pool,
                     )
                 else:
                     new_step = ExecutionStep(
@@ -322,7 +322,7 @@ class _PlanBuilder:
                         step_inputs=cast(list[StepInput], step_inputs),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_group=node.definition.concurrency_group,
+                        pool=node.definition.pool,
                     )
 
                 self.add_step(new_step)
@@ -1017,7 +1017,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (plain StepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_group,
+                    step_snap.pool,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
@@ -1029,7 +1029,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedMappedStepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_group,
+                    step_snap.pool,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
@@ -1038,7 +1038,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedCollectStepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_group,
+                    step_snap.pool,
                 )
             else:
                 raise Exception(f"Unexpected step kind {step_snap.kind}")

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -302,7 +302,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_key=node.definition.concurrency_key,
+                        concurrency_group=node.definition.concurrency_group,
                     )
                 elif has_pending_input:
                     new_step = UnresolvedCollectExecutionStep(
@@ -313,7 +313,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_key=node.definition.concurrency_key,
+                        concurrency_group=node.definition.concurrency_group,
                     )
                 else:
                     new_step = ExecutionStep(
@@ -322,7 +322,7 @@ class _PlanBuilder:
                         step_inputs=cast(list[StepInput], step_inputs),
                         step_outputs=step_outputs,
                         tags=node.tags,
-                        concurrency_key=node.definition.concurrency_key,
+                        concurrency_group=node.definition.concurrency_group,
                     )
 
                 self.add_step(new_step)
@@ -1017,7 +1017,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (plain StepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_key,
+                    step_snap.concurrency_group,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
@@ -1029,7 +1029,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedMappedStepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_key,
+                    step_snap.concurrency_group,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
@@ -1038,7 +1038,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedCollectStepInput only)
                     step_outputs,
                     step_snap.tags,
-                    step_snap.concurrency_key,
+                    step_snap.concurrency_group,
                 )
             else:
                 raise Exception(f"Unexpected step kind {step_snap.kind}")

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -302,6 +302,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
+                        concurrency_key=node.definition.concurrency_key,
                     )
                 elif has_pending_input:
                     new_step = UnresolvedCollectExecutionStep(
@@ -312,6 +313,7 @@ class _PlanBuilder:
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
+                        concurrency_key=node.definition.concurrency_key,
                     )
                 else:
                     new_step = ExecutionStep(
@@ -320,6 +322,7 @@ class _PlanBuilder:
                         step_inputs=cast(list[StepInput], step_inputs),
                         step_outputs=step_outputs,
                         tags=node.tags,
+                        concurrency_key=node.definition.concurrency_key,
                     )
 
                 self.add_step(new_step)
@@ -1014,6 +1017,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (plain StepInput only)
                     step_outputs,
                     step_snap.tags,
+                    step_snap.concurrency_key,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
@@ -1025,6 +1029,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedMappedStepInput only)
                     step_outputs,
                     step_snap.tags,
+                    step_snap.concurrency_key,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
@@ -1033,6 +1038,7 @@ class ExecutionPlan(
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedCollectStepInput only)
                     step_outputs,
                     step_snap.tags,
+                    step_snap.concurrency_key,
                 )
             else:
                 raise Exception(f"Unexpected step kind {step_snap.kind}")

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -80,6 +80,11 @@ class IExecutionStep:
 
     @property
     @abstractmethod
+    def concurrency_key(self) -> Optional[str]:
+        pass
+
+    @property
+    @abstractmethod
     def step_inputs(
         self,
     ) -> Sequence[Union[StepInput, UnresolvedCollectStepInput, UnresolvedMappedStepInput]]:
@@ -122,6 +127,7 @@ class ExecutionStep(
             ("tags", Mapping[str, str]),
             ("logging_tags", Mapping[str, str]),
             ("key", str),
+            ("concurrency_key", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -135,6 +141,7 @@ class ExecutionStep(
         step_inputs: Sequence[StepInput],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
+        concurrency_key: Optional[str],
         logging_tags: Optional[Mapping[str, str]] = None,
         key: Optional[str] = None,
     ):
@@ -151,6 +158,7 @@ class ExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=tags or {},
+            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),
@@ -221,6 +229,7 @@ class UnresolvedMappedExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedMappedStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
+            ("concurrency_key", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -234,6 +243,7 @@ class UnresolvedMappedExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedMappedStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
+        concurrency_key: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -250,6 +260,7 @@ class UnresolvedMappedExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
+            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
         )
 
     @property
@@ -354,6 +365,7 @@ class UnresolvedMappedExecutionStep(
                     step_inputs=resolved_inputs,
                     step_outputs=self.step_outputs,
                     tags=self.tags,
+                    concurrency_key=self.concurrency_key,
                 )
             )
 
@@ -379,6 +391,7 @@ class UnresolvedCollectExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedCollectStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
+            ("concurrency_key", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -392,6 +405,7 @@ class UnresolvedCollectExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedCollectStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
+        concurrency_key: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -408,6 +422,7 @@ class UnresolvedCollectExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
+            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
         )
 
     @property
@@ -489,4 +504,5 @@ class UnresolvedCollectExecutionStep(
             step_inputs=resolved_inputs,
             step_outputs=self.step_outputs,
             tags=self.tags,
+            concurrency_key=self.concurrency_key,
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -80,7 +80,7 @@ class IExecutionStep:
 
     @property
     @abstractmethod
-    def concurrency_key(self) -> Optional[str]:
+    def concurrency_group(self) -> Optional[str]:
         pass
 
     @property
@@ -127,7 +127,7 @@ class ExecutionStep(
             ("tags", Mapping[str, str]),
             ("logging_tags", Mapping[str, str]),
             ("key", str),
-            ("concurrency_key", Optional[str]),
+            ("concurrency_group", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -141,7 +141,7 @@ class ExecutionStep(
         step_inputs: Sequence[StepInput],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_key: Optional[str],
+        concurrency_group: Optional[str],
         logging_tags: Optional[Mapping[str, str]] = None,
         key: Optional[str] = None,
     ):
@@ -158,7 +158,7 @@ class ExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=tags or {},
-            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
+            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),
@@ -229,7 +229,7 @@ class UnresolvedMappedExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedMappedStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
-            ("concurrency_key", Optional[str]),
+            ("concurrency_group", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -243,7 +243,7 @@ class UnresolvedMappedExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedMappedStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_key: Optional[str],
+        concurrency_group: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -260,7 +260,7 @@ class UnresolvedMappedExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
-            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
+            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
         )
 
     @property
@@ -365,7 +365,7 @@ class UnresolvedMappedExecutionStep(
                     step_inputs=resolved_inputs,
                     step_outputs=self.step_outputs,
                     tags=self.tags,
-                    concurrency_key=self.concurrency_key,
+                    concurrency_group=self.concurrency_group,
                 )
             )
 
@@ -391,7 +391,7 @@ class UnresolvedCollectExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedCollectStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
-            ("concurrency_key", Optional[str]),
+            ("concurrency_group", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -405,7 +405,7 @@ class UnresolvedCollectExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedCollectStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_key: Optional[str],
+        concurrency_group: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -422,7 +422,7 @@ class UnresolvedCollectExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
-            concurrency_key=check.opt_str_param(concurrency_key, "concurrency_key"),
+            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
         )
 
     @property
@@ -504,5 +504,5 @@ class UnresolvedCollectExecutionStep(
             step_inputs=resolved_inputs,
             step_outputs=self.step_outputs,
             tags=self.tags,
-            concurrency_key=self.concurrency_key,
+            concurrency_group=self.concurrency_group,
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -80,7 +80,7 @@ class IExecutionStep:
 
     @property
     @abstractmethod
-    def concurrency_group(self) -> Optional[str]:
+    def pool(self) -> Optional[str]:
         pass
 
     @property
@@ -127,7 +127,7 @@ class ExecutionStep(
             ("tags", Mapping[str, str]),
             ("logging_tags", Mapping[str, str]),
             ("key", str),
-            ("concurrency_group", Optional[str]),
+            ("pool", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -141,7 +141,7 @@ class ExecutionStep(
         step_inputs: Sequence[StepInput],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_group: Optional[str],
+        pool: Optional[str],
         logging_tags: Optional[Mapping[str, str]] = None,
         key: Optional[str] = None,
     ):
@@ -158,7 +158,7 @@ class ExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=tags or {},
-            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
+            pool=check.opt_str_param(pool, "pool"),
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),
@@ -229,7 +229,7 @@ class UnresolvedMappedExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedMappedStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
-            ("concurrency_group", Optional[str]),
+            ("pool", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -243,7 +243,7 @@ class UnresolvedMappedExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedMappedStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_group: Optional[str],
+        pool: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -260,7 +260,7 @@ class UnresolvedMappedExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
-            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
+            pool=check.opt_str_param(pool, "pool"),
         )
 
     @property
@@ -365,7 +365,7 @@ class UnresolvedMappedExecutionStep(
                     step_inputs=resolved_inputs,
                     step_outputs=self.step_outputs,
                     tags=self.tags,
-                    concurrency_group=self.concurrency_group,
+                    pool=self.pool,
                 )
             )
 
@@ -391,7 +391,7 @@ class UnresolvedCollectExecutionStep(
             ("step_input_dict", Mapping[str, Union[StepInput, UnresolvedCollectStepInput]]),
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
-            ("concurrency_group", Optional[str]),
+            ("pool", Optional[str]),
         ],
     ),
     IExecutionStep,
@@ -405,7 +405,7 @@ class UnresolvedCollectExecutionStep(
         step_inputs: Sequence[Union[StepInput, UnresolvedCollectStepInput]],
         step_outputs: Sequence[StepOutput],
         tags: Optional[Mapping[str, str]],
-        concurrency_group: Optional[str],
+        pool: Optional[str],
     ):
         return super().__new__(
             cls,
@@ -422,7 +422,7 @@ class UnresolvedCollectExecutionStep(
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
-            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
+            pool=check.opt_str_param(pool, "pool"),
         )
 
     @property
@@ -504,5 +504,5 @@ class UnresolvedCollectExecutionStep(
             step_inputs=resolved_inputs,
             step_outputs=self.step_outputs,
             tags=self.tags,
-            concurrency_group=self.concurrency_group,
+            pool=self.pool,
         )

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -11,7 +11,6 @@ from dagster._core.storage.dagster_run import (
     RunOpConcurrency,
     RunRecord,
 )
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._time import get_current_timestamp
 
 
@@ -29,11 +28,10 @@ def compute_run_op_concurrency_info_for_snapshot(
     for step in plan_snapshot.steps:
         if step.key not in root_step_keys:
             continue
-        concurrency_key = step.tags.get(GLOBAL_CONCURRENCY_TAG) if step.tags else None
-        if concurrency_key is None:
+        if step.concurrency_key is None:
             has_unconstrained_root_nodes = True
         else:
-            concurrency_key_counts[concurrency_key] += 1
+            concurrency_key_counts[step.concurrency_key] += 1
 
     if len(concurrency_key_counts) == 0:
         return None

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -23,21 +23,21 @@ def compute_run_op_concurrency_info_for_snapshot(
     root_step_keys = set(
         [step_key for step_key, deps in plan_snapshot.step_deps.items() if not deps]
     )
-    concurrency_key_counts: Mapping[str, int] = defaultdict(int)
+    pool_counts: Mapping[str, int] = defaultdict(int)
     has_unconstrained_root_nodes = False
     for step in plan_snapshot.steps:
         if step.key not in root_step_keys:
             continue
-        if step.concurrency_key is None:
+        if step.pool is None:
             has_unconstrained_root_nodes = True
         else:
-            concurrency_key_counts[step.concurrency_key] += 1
+            pool_counts[step.pool] += 1
 
-    if len(concurrency_key_counts) == 0:
+    if len(pool_counts) == 0:
         return None
 
     return RunOpConcurrency(
-        root_key_counts=dict(concurrency_key_counts),
+        root_key_counts=dict(pool_counts),
         has_unconstrained_root_nodes=has_unconstrained_root_nodes,
     )
 
@@ -50,12 +50,15 @@ class GlobalOpConcurrencyLimitsCounter:
         in_progress_run_records: Sequence[RunRecord],
         slot_count_offset: int = 0,
     ):
-        self._root_concurrency_keys_by_run = {}
-        self._concurrency_info_by_key = {}
-        self._launched_concurrency_key_counts = defaultdict(int)
-        self._in_progress_concurrency_key_counts = defaultdict(int)
+        self._root_pools_by_run = {}
+        self._concurrency_info_by_pool = {}
+        self._launched_pool_counts = defaultdict(int)
+        self._in_progress_pool_counts = defaultdict(int)
         self._slot_count_offset = slot_count_offset
-        self._started_run_concurrency_keys_allotted_seconds = int(
+        self._in_progress_run_ids: set[str] = set(
+            [record.dagster_run.run_id for record in in_progress_run_records]
+        )
+        self._started_run_pools_allotted_seconds = int(
             os.getenv("DAGSTER_OP_CONCURRENCY_KEYS_ALLOTTED_FOR_STARTED_RUN_SECONDS", "5")
         )
 
@@ -69,45 +72,45 @@ class GlobalOpConcurrencyLimitsCounter:
     def _fetch_concurrency_info(self, instance: DagsterInstance, queued_runs: Sequence[DagsterRun]):
         # fetch all the concurrency slot information for the root concurrency keys of all the queued
         # runs
-        all_run_concurrency_keys = set()
+        all_run_pools = set()
 
-        configured_concurrency_keys = instance.event_log_storage.get_concurrency_keys()
+        configured_pools = instance.event_log_storage.get_concurrency_keys()
         for run in queued_runs:
             if run.run_op_concurrency:
-                all_run_concurrency_keys.update(run.run_op_concurrency.root_key_counts.keys())
+                all_run_pools.update(run.run_op_concurrency.root_key_counts.keys())
 
-        for key in all_run_concurrency_keys:
+        for key in all_run_pools:
             if key is None:
                 continue
 
-            if key not in configured_concurrency_keys:
+            if key not in configured_pools:
                 instance.event_log_storage.initialize_concurrency_limit_to_default(key)
 
-            self._concurrency_info_by_key[key] = instance.event_log_storage.get_concurrency_info(
+            self._concurrency_info_by_pool[key] = instance.event_log_storage.get_concurrency_info(
                 key
             )
 
-    def _should_allocate_slots_for_root_concurrency_keys(self, record: RunRecord):
+    def _should_allocate_slots_for_root_pools(self, record: RunRecord):
         status = record.dagster_run.status
         if status == DagsterRunStatus.STARTING:
             return True
         if status != DagsterRunStatus.STARTED or not record.start_time:
             return False
         time_elapsed = get_current_timestamp() - record.start_time
-        if time_elapsed < self._started_run_concurrency_keys_allotted_seconds:
+        if time_elapsed < self._started_run_pools_allotted_seconds:
             return True
 
     def _process_in_progress_runs(self, in_progress_records: Sequence[RunRecord]):
         for record in in_progress_records:
             if (
-                self._should_allocate_slots_for_root_concurrency_keys(record)
+                self._should_allocate_slots_for_root_pools(record)
                 and record.dagster_run.run_op_concurrency
             ):
                 for (
-                    concurrency_key,
+                    pool,
                     count,
                 ) in record.dagster_run.run_op_concurrency.root_key_counts.items():
-                    self._in_progress_concurrency_key_counts[concurrency_key] += count
+                    self._in_progress_pool_counts[pool] += count
 
     def is_blocked(self, run: DagsterRun) -> bool:
         # if any of the ops in the run can make progress (not blocked by concurrency keys), we
@@ -116,17 +119,17 @@ class GlobalOpConcurrencyLimitsCounter:
             # if there exists a root node that is not concurrency blocked, we should dequeue.
             return False
 
-        for concurrency_key in run.run_op_concurrency.root_key_counts.keys():
-            if concurrency_key not in self._concurrency_info_by_key:
+        for pool in run.run_op_concurrency.root_key_counts.keys():
+            if pool not in self._concurrency_info_by_pool:
                 # there is no concurrency limit set for this key, we should dequeue
                 return False
 
-            key_info = self._concurrency_info_by_key[concurrency_key]
+            key_info = self._concurrency_info_by_pool[pool]
             available_count = (
                 key_info.slot_count
                 - len(key_info.pending_steps)
-                - self._launched_concurrency_key_counts[concurrency_key]
-                - self._in_progress_concurrency_key_counts[concurrency_key]
+                - self._launched_pool_counts[pool]
+                - self._in_progress_pool_counts[pool]
             )
             if available_count > -1 * self._slot_count_offset:
                 # there exists a root concurrency key that is not blocked, we should dequeue
@@ -140,25 +143,25 @@ class GlobalOpConcurrencyLimitsCounter:
             return {}
 
         log_info = {}
-        for concurrency_key in run.run_op_concurrency.root_key_counts.keys():
-            concurrency_info = self._concurrency_info_by_key.get(concurrency_key)
+        for pool in run.run_op_concurrency.root_key_counts.keys():
+            concurrency_info = self._concurrency_info_by_pool.get(pool)
             if not concurrency_info:
                 continue
 
-            log_info[concurrency_key] = {
+            log_info[pool] = {
                 "slot_count": concurrency_info.slot_count,
                 "pending_step_count": len(concurrency_info.pending_steps),
                 "pending_step_run_ids": list(
                     {step.run_id for step in concurrency_info.pending_steps}
                 ),
-                "launched_count": self._launched_concurrency_key_counts[concurrency_key],
-                "in_progress_count": self._in_progress_concurrency_key_counts[concurrency_key],
+                "launched_count": self._launched_pool_counts[pool],
+                "in_progress_count": self._in_progress_pool_counts[pool],
             }
         return log_info
 
     def update_counters_with_launched_item(self, run: DagsterRun):
         if not run.run_op_concurrency:
             return
-        for concurrency_key, count in run.run_op_concurrency.root_key_counts.items():
-            if concurrency_key:
-                self._launched_concurrency_key_counts[concurrency_key] += count
+        for pool, count in run.run_op_concurrency.root_key_counts.items():
+            if pool:
+                self._launched_pool_counts[pool] += count

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -150,7 +150,7 @@ class ExecutionStepSnap(
             ("metadata_items", Sequence["ExecutionPlanMetadataItemSnap"]),
             ("tags", Optional[Mapping[str, str]]),
             ("step_handle", Optional[StepHandleUnion]),
-            ("step_concurrency_key", Optional[str]),
+            ("concurrency_group", Optional[str]),
         ],
     )
 ):
@@ -164,7 +164,7 @@ class ExecutionStepSnap(
         metadata_items: Sequence["ExecutionPlanMetadataItemSnap"],
         tags: Optional[Mapping[str, str]] = None,
         step_handle: Optional[StepHandleUnion] = None,
-        step_concurrency_key: Optional[str] = None,
+        concurrency_group: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -178,18 +178,18 @@ class ExecutionStepSnap(
             ),
             tags=check.opt_nullable_mapping_param(tags, "tags", key_type=str, value_type=str),
             step_handle=check.opt_inst_param(step_handle, "step_handle", StepHandleTypes),
-            # stores the concurrency key arg as separate from the concurrency_key property since the
+            # stores the concurrency group arg as separate from the concurrency_key property since the
             # snapshot may have been generated before concurrency_key was added as a separate
             # argument
-            step_concurrency_key=check.opt_str_param(step_concurrency_key, "step_concurrency_key"),
+            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
         )
 
     @property
     def concurrency_key(self):
-        # Need to sthere in case the snapshot was created before concurrency_key was added as
+        # Separate property in case the snapshot was created before concurrency_group was added as
         # a separate argument from tags
-        if self.step_concurrency_key:
-            return self.step_concurrency_key
+        if self.concurrency_group:
+            return self.concurrency_group
         if not self.tags:
             return None
         return self.tags.get(GLOBAL_CONCURRENCY_TAG)
@@ -326,7 +326,7 @@ def _snapshot_from_execution_step(execution_step: IExecutionStep) -> ExecutionSt
         ),
         tags=execution_step.tags,
         step_handle=execution_step.handle,
-        step_concurrency_key=execution_step.concurrency_key,
+        concurrency_group=execution_step.concurrency_group,
     )
 
 

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -150,7 +150,7 @@ class ExecutionStepSnap(
             ("metadata_items", Sequence["ExecutionPlanMetadataItemSnap"]),
             ("tags", Optional[Mapping[str, str]]),
             ("step_handle", Optional[StepHandleUnion]),
-            ("concurrency_group", Optional[str]),
+            ("pool", Optional[str]),
         ],
     )
 ):
@@ -164,7 +164,7 @@ class ExecutionStepSnap(
         metadata_items: Sequence["ExecutionPlanMetadataItemSnap"],
         tags: Optional[Mapping[str, str]] = None,
         step_handle: Optional[StepHandleUnion] = None,
-        concurrency_group: Optional[str] = None,
+        pool: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -181,15 +181,15 @@ class ExecutionStepSnap(
             # stores the concurrency group arg as separate from the concurrency_key property since the
             # snapshot may have been generated before concurrency_key was added as a separate
             # argument
-            concurrency_group=check.opt_str_param(concurrency_group, "concurrency_group"),
+            pool=check.opt_str_param(pool, "pool"),
         )
 
     @property
     def concurrency_key(self):
-        # Separate property in case the snapshot was created before concurrency_group was added as
+        # Separate property in case the snapshot was created before pool was added as
         # a separate argument from tags
-        if self.concurrency_group:
-            return self.concurrency_group
+        if self.pool:
+            return self.pool
         if not self.tags:
             return None
         return self.tags.get(GLOBAL_CONCURRENCY_TAG)
@@ -326,7 +326,7 @@ def _snapshot_from_execution_step(execution_step: IExecutionStep) -> ExecutionSt
         ),
         tags=execution_step.tags,
         step_handle=execution_step.handle,
-        concurrency_group=execution_step.concurrency_group,
+        pool=execution_step.pool,
     )
 
 

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -178,7 +178,7 @@ class ExecutionStepSnap(
             ),
             tags=check.opt_nullable_mapping_param(tags, "tags", key_type=str, value_type=str),
             step_handle=check.opt_inst_param(step_handle, "step_handle", StepHandleTypes),
-            # stores the concurrency group arg as separate from the concurrency_key property since the
+            # stores the pool arg as separate from the concurrency_key property since the
             # snapshot may have been generated before concurrency_key was added as a separate
             # argument
             pool=check.opt_str_param(pool, "pool"),

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -21,6 +21,7 @@ from dagster._core.execution.plan.step import (
     UnresolvedCollectExecutionStep,
     UnresolvedMappedExecutionStep,
 )
+from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._serdes import create_snapshot_id, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
@@ -149,6 +150,7 @@ class ExecutionStepSnap(
             ("metadata_items", Sequence["ExecutionPlanMetadataItemSnap"]),
             ("tags", Optional[Mapping[str, str]]),
             ("step_handle", Optional[StepHandleUnion]),
+            ("step_concurrency_key", Optional[str]),
         ],
     )
 ):
@@ -162,6 +164,7 @@ class ExecutionStepSnap(
         metadata_items: Sequence["ExecutionPlanMetadataItemSnap"],
         tags: Optional[Mapping[str, str]] = None,
         step_handle: Optional[StepHandleUnion] = None,
+        step_concurrency_key: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -175,7 +178,21 @@ class ExecutionStepSnap(
             ),
             tags=check.opt_nullable_mapping_param(tags, "tags", key_type=str, value_type=str),
             step_handle=check.opt_inst_param(step_handle, "step_handle", StepHandleTypes),
+            # stores the concurrency key arg as separate from the concurrency_key property since the
+            # snapshot may have been generated before concurrency_key was added as a separate
+            # argument
+            step_concurrency_key=check.opt_str_param(step_concurrency_key, "step_concurrency_key"),
         )
+
+    @property
+    def concurrency_key(self):
+        # Need to sthere in case the snapshot was created before concurrency_key was added as
+        # a separate argument from tags
+        if self.step_concurrency_key:
+            return self.step_concurrency_key
+        if not self.tags:
+            return None
+        return self.tags.get(GLOBAL_CONCURRENCY_TAG)
 
 
 @whitelist_for_serdes
@@ -309,6 +326,7 @@ def _snapshot_from_execution_step(execution_step: IExecutionStep) -> ExecutionSt
         ),
         tags=execution_step.tags,
         step_handle=execution_step.handle,
+        step_concurrency_key=execution_step.concurrency_key,
     )
 
 

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -21,7 +21,6 @@ from dagster._core.execution.plan.step import (
     UnresolvedCollectExecutionStep,
     UnresolvedMappedExecutionStep,
 )
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._serdes import create_snapshot_id, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
@@ -183,16 +182,6 @@ class ExecutionStepSnap(
             # argument
             pool=check.opt_str_param(pool, "pool"),
         )
-
-    @property
-    def concurrency_key(self):
-        # Separate property in case the snapshot was created before pool was added as
-        # a separate argument from tags
-        if self.pool:
-            return self.pool
-        if not self.tags:
-            return None
-        return self.tags.get(GLOBAL_CONCURRENCY_TAG)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, Sequence, Set
 from functools import cached_property
 from typing import Optional, Union
 
@@ -159,7 +159,7 @@ class GraphDefSnap:
     dep_structure_snapshot: DependencyStructureSnapshot
     input_mapping_snaps: Sequence[InputMappingSnap]
     output_mapping_snaps: Sequence[OutputMappingSnap]
-    pools: set[str]
+    pools: Set[str]
 
     @cached_property
     def input_def_map(self) -> Mapping[str, InputDefSnap]:
@@ -178,7 +178,7 @@ class GraphDefSnap:
 
 @whitelist_for_serdes(storage_name="SolidDefSnap")
 @record
-class OpDefSnap(IHaveNew):
+class OpDefSnap:
     name: str
     input_def_snaps: Sequence[InputDefSnap]
     output_def_snaps: Sequence[OutputDefSnap]

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -185,6 +185,7 @@ class OpDefSnap:
     tags: Mapping[str, str]
     required_resource_keys: Sequence[str]
     config_field_snap: Optional[ConfigFieldSnap]
+    pool: Optional[str]
 
     @cached_property
     def input_def_map(self) -> Mapping[str, InputDefSnap]:
@@ -274,6 +275,7 @@ def build_op_def_snap(op_def: OpDefinition) -> OpDefSnap:
             if op_def.has_config_field
             else None
         ),
+        pool=op_def.pool,
     )
 
 

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -176,8 +176,8 @@ class GraphDefSnap:
 
 
 @whitelist_for_serdes(storage_name="SolidDefSnap")
-@record
-class OpDefSnap:
+@record_custom
+class OpDefSnap(IHaveNew):
     name: str
     input_def_snaps: Sequence[InputDefSnap]
     output_def_snaps: Sequence[OutputDefSnap]
@@ -186,6 +186,29 @@ class OpDefSnap:
     required_resource_keys: Sequence[str]
     config_field_snap: Optional[ConfigFieldSnap]
     pool: Optional[str]
+
+    def __new__(
+        cls,
+        name: str,
+        input_def_snaps: Sequence[InputDefSnap],
+        output_def_snaps: Sequence[OutputDefSnap],
+        description: Optional[str],
+        tags: Mapping[str, str],
+        required_resource_keys: Sequence[str],
+        config_field_snap: Optional[ConfigFieldSnap],
+        pool: Optional[str] = None,
+    ):
+        return super().__new__(
+            cls,
+            name=name,
+            input_def_snaps=input_def_snaps,
+            output_def_snaps=output_def_snaps,
+            description=description,
+            tags=tags,
+            required_resource_keys=required_resource_keys,
+            config_field_snap=config_field_snap,
+            pool=pool,
+        )
 
     @cached_property
     def input_def_map(self) -> Mapping[str, InputDefSnap]:

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -177,7 +177,7 @@ class GraphDefSnap:
 
 
 @whitelist_for_serdes(storage_name="SolidDefSnap")
-@record_custom
+@record
 class OpDefSnap(IHaveNew):
     name: str
     input_def_snaps: Sequence[InputDefSnap]
@@ -186,30 +186,7 @@ class OpDefSnap(IHaveNew):
     tags: Mapping[str, str]
     required_resource_keys: Sequence[str]
     config_field_snap: Optional[ConfigFieldSnap]
-    pool: Optional[str]
-
-    def __new__(
-        cls,
-        name: str,
-        input_def_snaps: Sequence[InputDefSnap],
-        output_def_snaps: Sequence[OutputDefSnap],
-        description: Optional[str],
-        tags: Mapping[str, str],
-        required_resource_keys: Sequence[str],
-        config_field_snap: Optional[ConfigFieldSnap],
-        pool: Optional[str] = None,
-    ):
-        return super().__new__(
-            cls,
-            name=name,
-            input_def_snaps=input_def_snaps,
-            output_def_snaps=output_def_snaps,
-            description=description,
-            tags=tags,
-            required_resource_keys=required_resource_keys,
-            config_field_snap=config_field_snap,
-            pool=pool,
-        )
+    pool: Optional[str] = None
 
     @cached_property
     def input_def_map(self) -> Mapping[str, InputDefSnap]:

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -159,6 +159,7 @@ class GraphDefSnap:
     dep_structure_snapshot: DependencyStructureSnapshot
     input_mapping_snaps: Sequence[InputMappingSnap]
     output_mapping_snaps: Sequence[OutputMappingSnap]
+    pools: set[str]
 
     @cached_property
     def input_def_map(self) -> Mapping[str, InputDefSnap]:
@@ -281,6 +282,7 @@ def build_graph_def_snap(graph_def: GraphDefinition) -> GraphDefSnap:
         dep_structure_snapshot=build_dep_structure_snapshot_from_graph_def(graph_def),
         input_mapping_snaps=list(map(build_input_mapping_snap, graph_def.input_mappings)),
         output_mapping_snaps=list(map(build_output_mapping_snap, graph_def.output_mappings)),
+        pools=graph_def.pools,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -168,11 +168,11 @@ def define_concurrency_job(use_tags):
         tags = None
         concurrency_kwarg = "foo"
 
-    @op(tags=tags, concurrency_key=concurrency_kwarg)
+    @op(tags=tags, concurrency_group=concurrency_kwarg)
     def foo_op():
         pass
 
-    @op(tags=tags, concurrency_key=concurrency_kwarg)
+    @op(tags=tags, concurrency_group=concurrency_kwarg)
     def bar_op():
         pass
 
@@ -273,7 +273,7 @@ def define_concurrency_retry_job(use_tags):
         tags = None
         concurrency_kwarg = "foo"
 
-    @op(tags=tags, concurrency_key=concurrency_kwarg)
+    @op(tags=tags, concurrency_group=concurrency_kwarg)
     def foo_op():
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -168,11 +168,11 @@ def define_concurrency_job(use_tags):
         tags = None
         concurrency_kwarg = "foo"
 
-    @op(tags=tags, concurrency_group=concurrency_kwarg)
+    @op(tags=tags, pool=concurrency_kwarg)
     def foo_op():
         pass
 
-    @op(tags=tags, concurrency_group=concurrency_kwarg)
+    @op(tags=tags, pool=concurrency_kwarg)
     def bar_op():
         pass
 
@@ -273,7 +273,7 @@ def define_concurrency_retry_job(use_tags):
         tags = None
         concurrency_kwarg = "foo"
 
-    @op(tags=tags, concurrency_group=concurrency_kwarg)
+    @op(tags=tags, pool=concurrency_kwarg)
     def foo_op():
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -160,12 +160,19 @@ def test_recover_in_between_steps():
             )
 
 
-def define_concurrency_job():
-    @op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+def define_concurrency_job(use_tags):
+    if use_tags:
+        tags = {GLOBAL_CONCURRENCY_TAG: "foo"}
+        concurrency_kwarg = None
+    else:
+        tags = None
+        concurrency_kwarg = "foo"
+
+    @op(tags=tags, concurrency_key=concurrency_kwarg)
     def foo_op():
         pass
 
-    @op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+    @op(tags=tags, concurrency_key=concurrency_kwarg)
     def bar_op():
         pass
 
@@ -177,8 +184,9 @@ def define_concurrency_job():
     return foo_job
 
 
-def test_active_concurrency():
-    foo_job = define_concurrency_job()
+@pytest.mark.parametrize("use_tags", [True, False])
+def test_active_concurrency(use_tags):
+    foo_job = define_concurrency_job(use_tags)
     run_id = make_new_run_id()
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -257,8 +265,15 @@ class MockInstanceConcurrencyContext(InstanceConcurrencyContext):
         pass
 
 
-def define_concurrency_retry_job():
-    @op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+def define_concurrency_retry_job(use_tags):
+    if use_tags:
+        tags = {GLOBAL_CONCURRENCY_TAG: "foo"}
+        concurrency_kwarg = None
+    else:
+        tags = None
+        concurrency_kwarg = "foo"
+
+    @op(tags=tags, concurrency_key=concurrency_kwarg)
     def foo_op():
         pass
 
@@ -274,9 +289,10 @@ def define_concurrency_retry_job():
     return foo_job
 
 
-def test_active_concurrency_sleep():
+@pytest.mark.parametrize("use_tags", [True, False])
+def test_active_concurrency_sleep(use_tags):
     instance_concurrency_context = MockInstanceConcurrencyContext(2.0)
-    foo_job = define_concurrency_retry_job()
+    foo_job = define_concurrency_retry_job(use_tags)
     with pytest.raises(DagsterExecutionInterruptedError):
         with create_execution_plan(foo_job).start(
             RetryMode.ENABLED,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -1112,6 +1112,7 @@
                 "name": "result"
               }
             ],
+            "pool": null,
             "required_resource_keys": [],
             "tags": {}
           }
@@ -2267,6 +2268,7 @@
                     "name": "result"
                   }
                 ],
+                "pool": null,
                 "required_resource_keys": [],
                 "tags": {}
               }

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -24,6 +24,7 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [],
         "key": "op_one",
         "kind": {
@@ -53,7 +54,6 @@
           }
         ],
         "solid_handle_id": "op_one",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "op_one",
@@ -67,6 +67,7 @@
       },
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -126,7 +127,6 @@
           }
         ],
         "solid_handle_id": "op_two",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "op_two",
@@ -166,6 +166,7 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [],
         "key": "noop_op",
         "kind": {
@@ -195,7 +196,6 @@
           }
         ],
         "solid_handle_id": "noop_op",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "noop_op",
@@ -235,6 +235,7 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [],
         "key": "noop_op",
         "kind": {
@@ -275,7 +276,6 @@
           }
         ],
         "solid_handle_id": "noop_op",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "noop_op",
@@ -322,6 +322,7 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -410,7 +411,6 @@
           }
         ],
         "solid_handle_id": "add",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "add",
@@ -424,6 +424,7 @@
       },
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -487,7 +488,6 @@
           }
         ],
         "solid_handle_id": "comp_1.add_one",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_1.add_one",
@@ -505,6 +505,7 @@
       },
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [],
         "key": "comp_1.return_one",
         "kind": {
@@ -538,7 +539,6 @@
           }
         ],
         "solid_handle_id": "comp_1.return_one",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_1.return_one",
@@ -556,6 +556,7 @@
       },
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -619,7 +620,6 @@
           }
         ],
         "solid_handle_id": "comp_2.add_one",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_2.add_one",
@@ -637,6 +637,7 @@
       },
       {
         "__class__": "ExecutionStepSnap",
+        "concurrency_group": null,
         "inputs": [],
         "key": "comp_2.return_one",
         "kind": {
@@ -670,7 +671,6 @@
           }
         ],
         "solid_handle_id": "comp_2.return_one",
-        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_2.return_one",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -53,6 +53,7 @@
           }
         ],
         "solid_handle_id": "op_one",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "op_one",
@@ -125,6 +126,7 @@
           }
         ],
         "solid_handle_id": "op_two",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "op_two",
@@ -193,6 +195,7 @@
           }
         ],
         "solid_handle_id": "noop_op",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "noop_op",
@@ -272,6 +275,7 @@
           }
         ],
         "solid_handle_id": "noop_op",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "noop_op",
@@ -406,6 +410,7 @@
           }
         ],
         "solid_handle_id": "add",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "add",
@@ -482,6 +487,7 @@
           }
         ],
         "solid_handle_id": "comp_1.add_one",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_1.add_one",
@@ -532,6 +538,7 @@
           }
         ],
         "solid_handle_id": "comp_1.return_one",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_1.return_one",
@@ -612,6 +619,7 @@
           }
         ],
         "solid_handle_id": "comp_2.add_one",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_2.add_one",
@@ -662,6 +670,7 @@
           }
         ],
         "solid_handle_id": "comp_2.return_one",
+        "step_concurrency_key": null,
         "step_handle": {
           "__class__": "StepHandle",
           "key": "comp_2.return_one",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -15,7 +15,7 @@
       },
       "step_output_versions": []
     },
-    "pipeline_snapshot_id": "da8c01714b1e44006e9cf334fbe3bc446dd7edcf",
+    "pipeline_snapshot_id": "9a249ea2e68f01696a6527edc4f16a3105d4ff08",
     "snapshot_version": 1,
     "step_keys_to_execute": [
       "op_one",
@@ -24,7 +24,6 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [],
         "key": "op_one",
         "kind": {
@@ -53,6 +52,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "op_one",
         "step_handle": {
           "__class__": "StepHandle",
@@ -67,7 +67,6 @@
       },
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -126,6 +125,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "op_two",
         "step_handle": {
           "__class__": "StepHandle",
@@ -158,7 +158,7 @@
       },
       "step_output_versions": []
     },
-    "pipeline_snapshot_id": "2be758e018ad9a646ff3f425bcd0100b6f7c9db5",
+    "pipeline_snapshot_id": "2e1a9c7bcca1fbd5675ae312810b00213b71f5c5",
     "snapshot_version": 1,
     "step_keys_to_execute": [
       "noop_op"
@@ -166,7 +166,6 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [],
         "key": "noop_op",
         "kind": {
@@ -195,6 +194,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "noop_op",
         "step_handle": {
           "__class__": "StepHandle",
@@ -227,7 +227,7 @@
       },
       "step_output_versions": []
     },
-    "pipeline_snapshot_id": "e27e6d43717f02d68975024eeecd407fb2c3ea9e",
+    "pipeline_snapshot_id": "fc39b83b76579bcfdee52119fbd707f12bdf7eb1",
     "snapshot_version": 1,
     "step_keys_to_execute": [
       "noop_op"
@@ -235,7 +235,6 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [],
         "key": "noop_op",
         "kind": {
@@ -275,6 +274,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "noop_op",
         "step_handle": {
           "__class__": "StepHandle",
@@ -310,7 +310,7 @@
       },
       "step_output_versions": []
     },
-    "pipeline_snapshot_id": "abd9ab67d88662d348cd56af4d70283f2c09f978",
+    "pipeline_snapshot_id": "3057df527127ce93bc08075d3dc3149b5054065a",
     "snapshot_version": 1,
     "step_keys_to_execute": [
       "comp_1.return_one",
@@ -322,7 +322,6 @@
     "steps": [
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -410,6 +409,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "add",
         "step_handle": {
           "__class__": "StepHandle",
@@ -424,7 +424,6 @@
       },
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -487,6 +486,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "comp_1.add_one",
         "step_handle": {
           "__class__": "StepHandle",
@@ -505,7 +505,6 @@
       },
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [],
         "key": "comp_1.return_one",
         "kind": {
@@ -538,6 +537,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "comp_1.return_one",
         "step_handle": {
           "__class__": "StepHandle",
@@ -556,7 +556,6 @@
       },
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [
           {
             "__class__": "ExecutionStepInputSnap",
@@ -619,6 +618,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "comp_2.add_one",
         "step_handle": {
           "__class__": "StepHandle",
@@ -637,7 +637,6 @@
       },
       {
         "__class__": "ExecutionStepSnap",
-        "concurrency_group": null,
         "inputs": [],
         "key": "comp_2.return_one",
         "kind": {
@@ -670,6 +669,7 @@
             }
           }
         ],
+        "pool": null,
         "solid_handle_id": "comp_2.return_one",
         "step_handle": {
           "__class__": "StepHandle",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -310,7 +310,7 @@
       },
       "step_output_versions": []
     },
-    "pipeline_snapshot_id": "3057df527127ce93bc08075d3dc3149b5054065a",
+    "pipeline_snapshot_id": "b57cc7e00dc45fd4927a082265100e665a21f23d",
     "snapshot_version": 1,
     "step_keys_to_execute": [
       "comp_1.return_one",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_job_snap.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_job_snap.ambr
@@ -1173,6 +1173,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -1200,6 +1201,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -1210,7 +1212,7 @@
   '''
 # ---
 # name: test_basic_dep_fan_out.1
-  '9376013e33a3e52fed33f38d78bdfa32c05fac25'
+  'e061a27410eaba2c87df3adcd2b9f0fa85d81902'
 # ---
 # name: test_basic_fan_in
   '''
@@ -2371,6 +2373,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         },
@@ -2405,6 +2408,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -2415,7 +2419,7 @@
   '''
 # ---
 # name: test_basic_fan_in.1
-  '90ef3d60327e171213dc830e6c582d1e714bd10e'
+  'ca4f5d95b481a2514dd9b1165ec6582478264b1f'
 # ---
 # name: test_deserialize_node_def_snaps_multi_type_config
   '''
@@ -3560,6 +3564,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -3570,7 +3575,7 @@
   '''
 # ---
 # name: test_empty_job_snap_props.1
-  '2be758e018ad9a646ff3f425bcd0100b6f7c9db5'
+  '2e1a9c7bcca1fbd5675ae312810b00213b71f5c5'
 # ---
 # name: test_empty_job_snap_snapshot
   '''
@@ -4679,6 +4684,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -5795,6 +5801,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -5807,7 +5814,7 @@
   '''
 # ---
 # name: test_job_snap_all_props.1
-  '5365f964888a995ab736b47025f9bcce9da3a57b'
+  '0db77de4cfb28cfe1d213e9385eab27d87f8b495'
 # ---
 # name: test_multi_type_config_array_dict_fields[Permissive]
   '''
@@ -7171,6 +7178,7 @@
               "name": "result"
             }
           ],
+          "pool": null,
           "required_resource_keys": [],
           "tags": {}
         }
@@ -7181,5 +7189,5 @@
   '''
 # ---
 # name: test_two_invocations_deps_snap.1
-  'f86a9e94c60e91934153cb384caacfeee9976853'
+  '781698a4c8d4a870837133c4d9f108b410e834f1'
 # ---

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -10,7 +10,6 @@ from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import execute_job, execute_run_iterator
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._core.workspace.context import WorkspaceRequestContext
 
@@ -19,12 +18,12 @@ from dagster_tests.execution_tests.engine_tests.test_step_delegating_executor im
 )
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+@op(concurrency_key="foo")
 def should_never_execute(_x):
     assert False  # this should never execute
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+@op(concurrency_key="foo")
 def throw_error():
     raise Exception("bad programmer")
 
@@ -34,14 +33,14 @@ def error_graph():
     should_never_execute(throw_error())
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+@op(concurrency_key="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
     return {"active": foo_info.active_slot_count, "pending": foo_info.pending_step_count}
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+@op(concurrency_key="foo")
 def second_op(context, _):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
@@ -67,7 +66,7 @@ def two_tier_graph():
     second_op(simple_op())
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"}, retry_policy=RetryPolicy(max_retries=1))
+@op(concurrency_key="foo", retry_policy=RetryPolicy(max_retries=1))
 def retry_op():
     raise Failure("I fail")
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -18,12 +18,12 @@ from dagster_tests.execution_tests.engine_tests.test_step_delegating_executor im
 )
 
 
-@op(concurrency_key="foo")
+@op(concurrency_group="foo")
 def should_never_execute(_x):
     assert False  # this should never execute
 
 
-@op(concurrency_key="foo")
+@op(concurrency_group="foo")
 def throw_error():
     raise Exception("bad programmer")
 
@@ -33,14 +33,14 @@ def error_graph():
     should_never_execute(throw_error())
 
 
-@op(concurrency_key="foo")
+@op(concurrency_group="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
     return {"active": foo_info.active_slot_count, "pending": foo_info.pending_step_count}
 
 
-@op(concurrency_key="foo")
+@op(concurrency_group="foo")
 def second_op(context, _):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
@@ -66,7 +66,7 @@ def two_tier_graph():
     second_op(simple_op())
 
 
-@op(concurrency_key="foo", retry_policy=RetryPolicy(max_retries=1))
+@op(concurrency_group="foo", retry_policy=RetryPolicy(max_retries=1))
 def retry_op():
     raise Failure("I fail")
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -18,12 +18,12 @@ from dagster_tests.execution_tests.engine_tests.test_step_delegating_executor im
 )
 
 
-@op(concurrency_group="foo")
+@op(pool="foo")
 def should_never_execute(_x):
     assert False  # this should never execute
 
 
-@op(concurrency_group="foo")
+@op(pool="foo")
 def throw_error():
     raise Exception("bad programmer")
 
@@ -33,14 +33,14 @@ def error_graph():
     should_never_execute(throw_error())
 
 
-@op(concurrency_group="foo")
+@op(pool="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
     return {"active": foo_info.active_slot_count, "pending": foo_info.pending_step_count}
 
 
-@op(concurrency_group="foo")
+@op(pool="foo")
 def second_op(context, _):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")
@@ -66,7 +66,7 @@ def two_tier_graph():
     second_op(simple_op())
 
 
-@op(concurrency_group="foo", retry_policy=RetryPolicy(max_retries=1))
+@op(pool="foo", retry_policy=RetryPolicy(max_retries=1))
 def retry_op():
     raise Failure("I fail")
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -32,7 +32,8 @@ from dagster._core.executor.step_delegating import (
     StepHandler,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
+
+# from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._utils.merger import merge_dicts
 from dagster._utils.test.definitions import lazy_definitions, scoped_definitions_load_context
@@ -496,7 +497,7 @@ def test_dynamic_failure_retry(job_fn, config_fn):
     assert_expected_failure_behavior(job_fn, config_fn)
 
 
-@op(tags={GLOBAL_CONCURRENCY_TAG: "foo"})
+@op(concurrency_key="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -32,8 +32,6 @@ from dagster._core.executor.step_delegating import (
     StepHandler,
 )
 from dagster._core.instance import DagsterInstance
-
-# from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._utils.merger import merge_dicts
 from dagster._utils.test.definitions import lazy_definitions, scoped_definitions_load_context
@@ -497,7 +495,7 @@ def test_dynamic_failure_retry(job_fn, config_fn):
     assert_expected_failure_behavior(job_fn, config_fn)
 
 
-@op(concurrency_key="foo")
+@op(concurrency_group="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -495,7 +495,7 @@ def test_dynamic_failure_retry(job_fn, config_fn):
     assert_expected_failure_behavior(job_fn, config_fn)
 
 
-@op(concurrency_group="foo")
+@op(pool="foo")
 def simple_op(context):
     time.sleep(0.1)
     foo_info = context.instance.event_log_storage.get_concurrency_info("foo")


### PR DESCRIPTION
## Summary & Motivation
Tags are a bad mechanism for specifying concurrency controls.  Adds a top-level argument `pool` to asset/op definitions to replace the use of op tags to specify concurrency conditions.

This provides more cues for what you can place concurrency limits on (e.g. op defs not graph defs, asset defs not asset specs)

## How I Tested These Changes
BK

## Changelog
Adds a top-level argument `pool` to asset/op definitions to replace the use of op tags to specify concurrency conditions.