### PR TITLE
Basic SlingReplicationComponent

### DIFF
--- a/examples/experimental/dagster-components/dagster_components/impls/sling_replication.py
+++ b/examples/experimental/dagster-components/dagster_components/impls/sling_replication.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+import yaml
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_embedded_elt.sling import SlingResource, sling_assets
+from dagster_embedded_elt.sling.resources import AssetExecutionContext
+from pydantic import TypeAdapter
+from typing_extensions import Self
+
+from dagster_components import Component, ComponentLoadContext
+from dagster_components.core.component_decl_builder import ComponentDeclNode, YamlComponentDecl
+
+
+class SlingReplicationComponent(Component):
+    params_schema = SlingResource
+
+    def __init__(self, dirpath: Path, resource: SlingResource):
+        self.dirpath = dirpath
+        self.resource = resource
+
+    @classmethod
+    def from_decl_node(cls, context: ComponentLoadContext, decl_node: ComponentDeclNode) -> Self:
+        assert isinstance(decl_node, YamlComponentDecl)
+        loaded_params = TypeAdapter(cls.params_schema).validate_python(
+            decl_node.defs_file_model.component_params
+        )
+        return cls(dirpath=decl_node.path, resource=loaded_params)
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        @sling_assets(replication_config=self.dirpath / "replication.yaml")
+        def _fn(context: AssetExecutionContext, sling: SlingResource):
+            yield from sling.replicate(context=context)
+
+        return Definitions(assets=[_fn], resources={"sling": self.resource})
+
+    @classmethod
+    def generate_files(cls) -> None:
+        replication_path = Path(os.getcwd()) / "replication.yaml"
+        with open(replication_path, "w") as f:
+            yaml.dump(
+                {"source": None, "target": None, "streams": None},
+                f,
+            )

--- a/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/components/ingest/defs.yml
+++ b/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/components/ingest/defs.yml
@@ -1,0 +1,7 @@
+component_type: sling_replication
+
+component_params:
+  connections:
+    - name: DUCKDB
+      type: duckdb
+      instance: <PLACEHOLDER>

--- a/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/components/ingest/replication.yaml
+++ b/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/components/ingest/replication.yaml
@@ -1,0 +1,14 @@
+source: LOCAL
+target: DUCKDB
+
+defaults:
+  mode: full-refresh
+  object: "{stream_table}"
+
+streams:
+  <PLACEHOLDER>:
+    object: "main.tbl"
+    meta:
+      dagster:
+        asset_key: input_duckdb
+        deps: [input_csv]

--- a/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/input.csv
+++ b/examples/experimental/dagster-components/dagster_components_tests/stub_code_locations/sling_location/input.csv
@@ -1,0 +1,4 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+abcdef,scrubjay,1
+defghi,bluejay,2
+jklnop,blackbird,2

--- a/examples/experimental/dagster-components/dagster_components_tests/test_pipes_subprocess_script_collection.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/test_pipes_subprocess_script_collection.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
 from dagster import AssetKey
-from dagster._core.instance import DagsterInstance
-from dagster_components.core.component import Component, ComponentLoadContext, ComponentRegistry
 from dagster_components.core.component_decl_builder import DefsFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -13,42 +11,16 @@ from dagster_components.impls.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollection,
 )
 
+from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
+
 LOCATION_PATH = Path(__file__).parent / "code_locations" / "python_script_location"
-
-
-def registry() -> ComponentRegistry:
-    return ComponentRegistry(
-        {"pipes_subprocess_script_collection": PipesSubprocessScriptCollection}
-    )
-
-
-def script_load_context() -> ComponentLoadContext:
-    return ComponentLoadContext(registry=registry(), resources={})
-
-
-def _asset_keys(component: Component) -> set[AssetKey]:
-    return {
-        key
-        for key in component.build_defs(ComponentLoadContext.for_test())
-        .get_asset_graph()
-        .get_all_asset_keys()
-    }
-
-
-def _assert_assets(component: Component, expected_assets: int) -> None:
-    defs = component.build_defs(ComponentLoadContext.for_test())
-    assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
-    result = defs.get_implicit_global_asset_job_def().execute_in_process(
-        instance=DagsterInstance.ephemeral()
-    )
-    assert result.success
 
 
 def test_python_native() -> None:
     component = PipesSubprocessScriptCollection.introspect_from_path(
         LOCATION_PATH / "components" / "scripts"
     )
-    _assert_assets(component, 3)
+    assert_assets(component, 3)
 
 
 def test_python_params() -> None:
@@ -70,7 +42,7 @@ def test_python_params() -> None:
             ),
         ),
     )
-    assert _asset_keys(component) == {
+    assert get_asset_keys(component) == {
         AssetKey("a"),
         AssetKey("b"),
         AssetKey("up1"),
@@ -84,7 +56,7 @@ def test_load_from_path() -> None:
         script_load_context(), LOCATION_PATH / "components"
     )
     assert len(components) == 1
-    assert _asset_keys(components[0]) == {
+    assert get_asset_keys(components[0]) == {
         AssetKey("a"),
         AssetKey("b"),
         AssetKey("c"),
@@ -93,7 +65,7 @@ def test_load_from_path() -> None:
         AssetKey("override_key"),
     }
 
-    _assert_assets(components[0], 6)
+    assert_assets(components[0], 6)
 
     defs = defs_from_components(
         context=script_load_context(),

--- a/examples/experimental/dagster-components/dagster_components_tests/test_sling_replication.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/test_sling_replication.py
@@ -1,0 +1,89 @@
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Generator, Mapping
+
+import pytest
+import yaml
+from dagster import AssetKey
+from dagster_components.core.component_decl_builder import DefsFileModel
+from dagster_components.core.component_defs_builder import (
+    YamlComponentDecl,
+    build_components_from_component_folder,
+)
+from dagster_components.impls.sling_replication import SlingReplicationComponent
+
+from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
+
+STUB_LOCATION_PATH = Path(__file__).parent / "stub_code_locations" / "sling_location"
+COMPONENT_RELPATH = "components/ingest"
+
+
+def _update_yaml(path: Path, fn) -> None:
+    # applies some arbitrary fn to an existing yaml dictionary
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+    with open(path, "w") as f:
+        yaml.dump(fn(data), f)
+
+
+@contextmanager
+@pytest.fixture(scope="module")
+def sling_path() -> Generator[Path, None, None]:
+    """Sets up a temporary directory with a replication.yaml and defs.yml file that reference
+    the proper temp path.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        shutil.copytree(STUB_LOCATION_PATH, temp_dir, dirs_exist_ok=True)
+
+        # update the replication yaml to reference a CSV file in the tempdir
+        replication_path = Path(temp_dir) / COMPONENT_RELPATH / "replication.yaml"
+
+        def _update_replication(data: Dict[str, Any]) -> Mapping[str, Any]:
+            placeholder_data = data["streams"].pop("<PLACEHOLDER>")
+            data["streams"][f"file://{temp_dir}/input.csv"] = placeholder_data
+            return data
+
+        _update_yaml(replication_path, _update_replication)
+
+        # update the defs yaml to add a duckdb instance
+        defs_path = Path(temp_dir) / COMPONENT_RELPATH / "defs.yml"
+
+        def _update_defs(data: Dict[str, Any]) -> Mapping[str, Any]:
+            data["component_params"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
+            return data
+
+        _update_yaml(defs_path, _update_defs)
+
+        yield Path(temp_dir)
+
+
+def test_python_params(sling_path: Path) -> None:
+    component = SlingReplicationComponent.from_decl_node(
+        context=script_load_context(),
+        decl_node=YamlComponentDecl(
+            path=sling_path / COMPONENT_RELPATH,
+            defs_file_model=DefsFileModel(
+                component_type="sling_replication",
+                component_params={},
+            ),
+        ),
+    )
+    assert get_asset_keys(component) == {
+        AssetKey("input_csv"),
+        AssetKey("input_duckdb"),
+    }
+
+
+def test_load_from_path(sling_path: Path) -> None:
+    components = build_components_from_component_folder(
+        script_load_context(), sling_path / "components"
+    )
+    assert len(components) == 1
+    assert get_asset_keys(components[0]) == {
+        AssetKey("input_csv"),
+        AssetKey("input_duckdb"),
+    }
+
+    assert_assets(components[0], 2)

--- a/examples/experimental/dagster-components/dagster_components_tests/utils.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/utils.py
@@ -1,0 +1,37 @@
+from dagster import AssetKey, DagsterInstance
+from dagster_components.core.component import Component, ComponentLoadContext, ComponentRegistry
+from dagster_components.impls.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollection,
+)
+from dagster_components.impls.sling_replication import SlingReplicationComponent
+
+
+def registry() -> ComponentRegistry:
+    return ComponentRegistry(
+        {
+            "sling_replication": SlingReplicationComponent,
+            "pipes_subprocess_script_collection": PipesSubprocessScriptCollection,
+        }
+    )
+
+
+def script_load_context() -> ComponentLoadContext:
+    return ComponentLoadContext(registry=registry(), resources={})
+
+
+def get_asset_keys(component: Component) -> set[AssetKey]:
+    return {
+        key
+        for key in component.build_defs(ComponentLoadContext.for_test())
+        .get_asset_graph()
+        .get_all_asset_keys()
+    }
+
+
+def assert_assets(component: Component, expected_assets: int) -> None:
+    defs = component.build_defs(ComponentLoadContext.for_test())
+    assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
+    result = defs.get_implicit_global_asset_job_def().execute_in_process(
+        instance=DagsterInstance.ephemeral()
+    )
+    assert result.success

--- a/examples/experimental/dagster-components/setup.py
+++ b/examples/experimental/dagster-components/setup.py
@@ -44,4 +44,8 @@ setup(
             "dg = dagster_components.cli:main",
         ]
     },
+    extras_require={
+        "sling": ["dagster-embedded-elt"],
+        "test": ["dagster-embedded-elt"],
+    },
 )

--- a/examples/experimental/dagster-components/tox.ini
+++ b/examples/experimental/dagster-components/tox.ini
@@ -12,7 +12,7 @@ deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
-  -e .
+  -e .[test]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary & Motivation

This implements a basic SlingReplicationComponent, which does a few things:

1. On generation, creates a mostly-empty `replication.yaml` file
2. Uses the existing sling_assets decorator to build an AssetsDefinition based on this replication.yaml file
3. Configures connection info based off of information stored in the `defs.yaml` file

This final bit is the first toe in the water of resource configuration handling. In this case, I just embed the resource directly into the config schema, which works out quite nicely in practice.

## How I Tested These Changes

It's a bit tricky to set up tests for this, as we need to create a temporary directory so that there's an absolute path that we can reference in the stream config. Set up a fixture for this purpose

## Changelog

NOCHANGELOG
