### PR TITLE
[8/n][dagster-airbyte] Implement load_airbyte_cloud_asset_specs

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -26,6 +26,7 @@ from dagster_airbyte.resources import (
     AirbyteState as AirbyteState,
     airbyte_cloud_resource as airbyte_cloud_resource,
     airbyte_resource as airbyte_resource,
+    load_airbyte_cloud_asset_specs as load_airbyte_cloud_asset_specs,
 )
 from dagster_airbyte.translator import DagsterAirbyteTranslator as DagsterAirbyteTranslator
 from dagster_airbyte.types import AirbyteOutput as AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1100,7 +1100,7 @@ def load_airbyte_cloud_asset_specs(
 
 
             airbyte_cloud_specs = load_airbyte_cloud_asset_specs(airbyte_cloud_workspace)
-            defs = dg.Definitions(assets=airbyte_cloud_specs, resources={"airbyte": airbyte_cloud_workspace}
+            defs = dg.Definitions(assets=airbyte_cloud_specs)
     """
     with workspace.process_config_and_initialize_cm() as initialized_workspace:
         return check.is_list(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
@@ -105,6 +105,7 @@ class AirbyteStream:
         )
 
 
+@whitelist_for_serdes
 @record
 class AirbyteWorkspaceData:
     """A record representing all content in an Airbyte workspace.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
@@ -39,10 +39,10 @@ def test_translator_spec(
         all_assets = load_airbyte_cloud_asset_specs(resource)
         all_assets_keys = [asset.key for asset in all_assets]
 
-        # 4 tables for the connector
+        # 1 table for the connection
         assert len(all_assets) == 1
         assert len(all_assets_keys) == 1
 
-        # Sanity check outputs, translator tests cover details here
-        first_asset_key = next(key for key in all_assets_keys)
-        assert first_asset_key.path == ["test_prefix_test_stream"]
+        # Test the asset key for the connection table
+        the_asset_key = next(iter(all_assets_keys))
+        assert the_asset_key.path == ["test_prefix_test_stream"]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_asset_specs.py
@@ -1,5 +1,7 @@
 import responses
-from dagster_airbyte import AirbyteCloudWorkspace
+from dagster._config.field_utils import EnvVar
+from dagster._core.test_utils import environ
+from dagster_airbyte import AirbyteCloudWorkspace, load_airbyte_cloud_asset_specs
 
 from dagster_airbyte_tests.experimental.conftest import (
     TEST_CLIENT_ID,
@@ -20,3 +22,27 @@ def test_fetch_airbyte_workspace_data(
     actual_workspace_data = resource.fetch_airbyte_workspace_data()
     assert len(actual_workspace_data.connections_by_id) == 1
     assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+def test_translator_spec(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ(
+        {"AIRBYTE_CLIENT_ID": TEST_CLIENT_ID, "AIRBYTE_CLIENT_SECRET": TEST_CLIENT_SECRET}
+    ):
+        resource = AirbyteCloudWorkspace(
+            workspace_id=TEST_WORKSPACE_ID,
+            client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+            client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
+        )
+
+        all_assets = load_airbyte_cloud_asset_specs(resource)
+        all_assets_keys = [asset.key for asset in all_assets]
+
+        # 4 tables for the connector
+        assert len(all_assets) == 1
+        assert len(all_assets_keys) == 1
+
+        # Sanity check outputs, translator tests cover details here
+        first_asset_key = next(key for key in all_assets_keys)
+        assert first_asset_key.path == ["test_prefix_test_stream"]


### PR DESCRIPTION
## Summary & Motivation

This PR implements the `load_airbyte_cloud_asset_specs` function:

```python
from dagster_airbyte import AirbyteCloudWorkspace, load_airbyte_cloud_asset_specs

import dagster as dg

airbyte_cloud_workspace = AirbyteCloudWorkspace(
    workspace_id=dg.EnvVar("AIRBYTE_CLOUD_WORKSPACE_ID"),
    client_id=dg.EnvVar("AIRBYTE_CLOUD_CLIENT_ID"),
    client_secret=dg.EnvVar("AIRBYTE_CLOUD_CLIENT_SECRET"),
)

airbyte_cloud_specs = load_airbyte_cloud_asset_specs(airbyte_cloud_workspace)
defs = dg.Definitions(assets=airbyte_cloud_specs, resources={"airbyte": airbyte_cloud_workspace}
```

## How I Tested These Changes

Additional unit test

## Changelog

[dagster-airbyte] The `load_airbyte_cloud_asset_specs` function is added. It can be used with the `AirbyteCloudWorkspace` resource and `DagsterAirbyteTranslator` translator to load your Airbyte Cloud connection streams as external assets in Dagster.
