### PR TITLE
add extract_serialized_job_snap_from_serialized_job_data_snap

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -6,6 +6,7 @@ for that.
 
 import inspect
 import json
+import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
@@ -102,7 +103,11 @@ from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from dagster._core.utils import is_valid_email
 from dagster._record import IHaveNew, record, record_custom
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.serdes import FieldSerializer, is_whitelisted_for_serdes_object
+from dagster._serdes.serdes import (
+    FieldSerializer,
+    get_prefix_for_a_serialized,
+    is_whitelisted_for_serdes_object,
+)
 from dagster._time import datetime_from_timestamp
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.warnings import suppress_dagster_warnings
@@ -388,10 +393,13 @@ class PresetSnap(IHaveNew):
         )
 
 
+_JOB_SNAP_STORAGE_FIELD = "pipeline_snapshot"
+
+
 @whitelist_for_serdes(
     storage_name="ExternalPipelineData",
     storage_field_names={
-        "job": "pipeline_snapshot",
+        "job": _JOB_SNAP_STORAGE_FIELD,
         "parent_job": "parent_pipeline_snapshot",
     },
     # There was a period during which `JobDefinition` was a newer subclass of the legacy
@@ -1859,3 +1867,44 @@ def resolve_automation_condition_args(
     else:
         # for non-serializable conditions, only include the snapshot
         return None, automation_condition.get_snapshot()
+
+
+def _extract_fast(serialized_job_data: str):
+    target_key = f'"{_JOB_SNAP_STORAGE_FIELD}": '
+    target_substr = target_key + get_prefix_for_a_serialized(JobSnap)
+    # look for key: type
+    idx = serialized_job_data.find(target_substr)
+    check.invariant(idx > 0)
+    # slice starting after key:
+    start_idx = idx + len(target_key)
+
+    # trim outer object }
+    # assumption that pipeline_snapshot is last field under test in test_job_data_snap_layout
+    serialized_job_snap = serialized_job_data[start_idx:-1]
+    check.invariant(serialized_job_snap[0] == "{" and serialized_job_snap[-1] == "}")
+
+    return serialized_job_snap
+
+
+def _extract_safe(serialized_job_data: str):
+    # Intentionally use json directly instead of serdes to avoid losing information if the current process
+    # is older than the source process.
+    return json.dumps(json.loads(serialized_job_data)[_JOB_SNAP_STORAGE_FIELD])
+
+
+DISABLE_FAST_EXTRACT_ENV_VAR = "DAGSTER_DISABLE_JOB_SNAP_FAST_EXTRACT"
+
+
+def extract_serialized_job_snap_from_serialized_job_data_snap(serialized_job_data_snap: str):
+    # utility used by DagsterCloudAgent to extract JobSnap out of JobDataSnap
+    # efficiently and safely
+    if not serialized_job_data_snap.startswith(get_prefix_for_a_serialized(JobDataSnap)):
+        raise Exception("Passed in string does not meet expectations for a serialized JobDataSnap")
+
+    if not os.getenv(DISABLE_FAST_EXTRACT_ENV_VAR):
+        try:
+            return _extract_fast(serialized_job_data_snap)
+        except Exception:
+            pass
+
+    return _extract_safe(serialized_job_data_snap)

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -17,6 +17,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.errors import DagsterError
@@ -192,6 +193,12 @@ def sensor_raises_dagster_error(_):
     raise DagsterError("Dagster error")
 
 
+@job(metadata={"pipeline_snapshot": MetadataValue.json({"pipeline_snapshot": "pipeline_snapshot"})})
+def pipeline_snapshot():
+    do_something()
+    do_fail()
+
+
 @repository(metadata={"string": "foo", "integer": 123})
 def bar_repo():
     return {
@@ -201,9 +208,10 @@ def bar_repo():
             "dynamic_job": define_asset_job(
                 "dynamic_job", [dynamic_asset], partitions_def=dynamic_partitions_def
             ).resolve(asset_graph=AssetGraph.from_assets([dynamic_asset])),
-            "fail": fail_job,
+            "fail_job": fail_job,
             "foo": foo_job,
             "forever": forever_job,
+            "pipeline_snapshot": pipeline_snapshot.get_subset(op_selection=["do_something"]),
         },
         "schedules": define_bar_schedules(),
         "sensors": {

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -15,12 +15,19 @@ from dagster._core.remote_representation import (
     RepositorySnap,
 )
 from dagster._core.remote_representation.external import RemoteRepository
-from dagster._core.remote_representation.external_data import JobDataSnap
+from dagster._core.remote_representation.external_data import (
+    DISABLE_FAST_EXTRACT_ENV_VAR,
+    JobDataSnap,
+    JobRefSnap,
+    extract_serialized_job_snap_from_serialized_job_data_snap,
+)
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes.serdes import deserialize_value
+from dagster._serdes.serdes import deserialize_value, get_storage_fields
+from dagster._serdes.utils import hash_str
+from dagster._utils.env import environ
 
 from dagster_tests.api_tests.utils import get_bar_repo_code_location
 
@@ -121,8 +128,9 @@ def test_giant_external_repository_streaming_grpc():
             assert repository_snap.name == "giant_repo"
 
 
-def test_defer_snapshots(instance: DagsterInstance):
-    with get_bar_repo_code_location(instance) as code_location:
+@pytest.mark.parametrize("env", [{}, {DISABLE_FAST_EXTRACT_ENV_VAR: "true"}])
+def test_defer_snapshots(instance: DagsterInstance, env):
+    with get_bar_repo_code_location(instance) as code_location, environ(env):
         repo_origin = RemoteRepositoryOrigin(
             code_location.origin,
             "bar_repo",
@@ -135,16 +143,27 @@ def test_defer_snapshots(instance: DagsterInstance):
 
         _state = {}
 
-        def _ref_to_data(ref):
+        def _ref_to_data(ref: JobRefSnap):
             _state["cnt"] = _state.get("cnt", 0) + 1
             reply = code_location.client.external_job(
                 repo_origin,
                 ref.name,
             )
-            return deserialize_value(reply.serialized_job_data, JobDataSnap)
+            assert reply.serialized_job_data, reply.serialized_error
+            assert (
+                hash_str(
+                    extract_serialized_job_snap_from_serialized_job_data_snap(
+                        reply.serialized_job_data
+                    )
+                )
+                == ref.snapshot_id
+            ), ref.name
+
+            job_data_snap = deserialize_value(reply.serialized_job_data, JobDataSnap)
+            return job_data_snap
 
         repository_snap = deserialize_value(ser_repo_data, RepositorySnap)
-        assert repository_snap.job_refs and len(repository_snap.job_refs) == 6
+        assert repository_snap.job_refs and len(repository_snap.job_refs) == 7
         assert repository_snap.job_datas is None
 
         repo = RemoteRepository(
@@ -154,7 +173,7 @@ def test_defer_snapshots(instance: DagsterInstance):
             ref_to_data_fn=_ref_to_data,
         )
         jobs = repo.get_all_jobs()
-        assert len(jobs) == 6
+        assert len(jobs) == 7
         assert _state.get("cnt", 0) == 0
 
         job = jobs[0]
@@ -177,6 +196,15 @@ def test_defer_snapshots(instance: DagsterInstance):
         assert _state.get("cnt", 0) == 1
 
         # refetching job should share fetched data
-        job = repo.get_all_jobs()[0]
-        _ = job.job_snapshot
-        assert _state.get("cnt", 0) == 1
+        expected = 1  # from job[0] access
+        for job in repo.get_all_jobs():
+            _ = job.job_snapshot
+            assert _state.get("cnt", 0) == expected
+            expected += 1
+
+
+def test_job_data_snap_layout():
+    # defend against assumptions made in
+
+    # must remain last position
+    assert get_storage_fields(JobDataSnap)[-1] == "pipeline_snapshot"

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -179,7 +179,7 @@ def test_execute_run_fail_job():
         }
     ) as instance:
         with get_bar_repo_handle(instance) as repo_handle:
-            job_handle = JobHandle("fail", repo_handle)
+            job_handle = JobHandle("fail_job", repo_handle)
             runner = CliRunner()
 
             run = create_run_for_test(

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -22,6 +22,7 @@ from dagster._serdes.serdes import (
     WhitelistMap,
     _whitelist_for_serdes,
     deserialize_value,
+    get_prefix_for_a_serialized,
     get_storage_name,
     pack_value,
     serialize_value,
@@ -445,6 +446,7 @@ def test_named_tuple() -> None:
 
     val = Foo("red")
     serialized = serialize_value(val, whitelist_map=test_map)
+    assert serialized.startswith(get_prefix_for_a_serialized(Foo, whitelist_map=test_map))
     deserialized = deserialize_value(serialized, whitelist_map=test_map)
     assert deserialized == val
 
@@ -465,12 +467,14 @@ def test_named_tuple_storage_name() -> None:
     val = Foo("red")
     serialized = serialize_value(val, whitelist_map=test_env)
     assert serialized == '{"__class__": "Bar", "color": "red"}'
+    assert serialized.startswith(get_prefix_for_a_serialized(Foo, whitelist_map=test_env))
     deserialized = deserialize_value(serialized, whitelist_map=test_env)
     assert deserialized == val
 
     val = Bar("square")
     serialized = serialize_value(val, whitelist_map=test_env)
     assert serialized == '{"__class__": "Foo", "shape": "square"}'
+    assert serialized.startswith(get_prefix_for_a_serialized(Bar, whitelist_map=test_env))
     deserialized = deserialize_value(serialized, whitelist_map=test_env)
     assert deserialized == val
 


### PR DESCRIPTION
We are working towards a change in how the dagster cloud agent uploads definition snapshots to the server. An issue we currently face in that work is that the grpc server returns `JobDataSnap` but we want to upload and persist only its inner `JobSnap`.

To facilitate this as efficiently and safely as possible this PR adds a method to do the extraction quickly falling back to safely and a series of tests to defend it. 

## How I Tested These Changes

added tests
