### PR TITLE
[docs-beta] rm comment in dockerfile as is invalid syntax

### DIFF
--- a/docs/docs-beta/docs/guides/deploy/deployment-options/docker.md
+++ b/docs/docs-beta/docs/guides/deploy/deployment-options/docker.md
@@ -27,8 +27,8 @@ RUN pip install \
     dagster \
     dagster-graphql \
     dagster-webserver \
-    dagster-postgres \   # Database for Dagster storage
-    dagster-docker       # Enables the Docker run launcher
+    dagster-postgres \
+    dagster-docker
 
 # Set $DAGSTER_HOME and copy dagster.yaml and workspace.yaml there
 ENV DAGSTER_HOME=/opt/dagster/dagster_home/


### PR DESCRIPTION
## Summary & Motivation

It is invalid syntax to have a comment after a `\` in your Dockerfile.

## How I Tested These Changes

Ran locally.

## Changelog

> Insert changelog entry or delete this section.
