### PR TITLE
dagster-snowflake: encode private_key str before passing it to serialization.load_pem_private_key()

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -384,8 +384,10 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             # read the file from the path.
             with open(config.get("private_key_path"), "rb") as key:
                 private_key = key.read()
+        elif config.get("private_key", None) is not None:
+            private_key = config["private_key"].encode()
         else:
-            private_key = config.get("private_key", None)
+            private_key = None
 
         kwargs = {}
         if config.get("private_key_password", None) is not None:


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/26276

`private_key` is `Optional[str]`, and when it's `str`, we pass it directly to `serialization.load_pem_private_key()`, which will fail because according to its [doc](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.load_pem_private_key) it expects a bytes-like argument. We should convert `private_key` to `bytes`, similar to what we are already doing to `private_key_password`.

This is not a breaking change as it would have never worked if someone passed in a private key without base64-encoding it. If their `private_key` is already base64-encoded, then this line will still fail (as expected) and the below try block will still succeed.

## How I Tested These Changes

I ran the code in "how to reproduce" in the issue, and it succeeded.

