### PR TITLE
[ui] make reload button on RepositoryLocationErrorDialog optional

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationErrorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationErrorDialog.tsx
@@ -9,7 +9,7 @@ interface Props {
   error: PythonErrorFragment | {message: string} | null;
   reloading: boolean;
   onDismiss: () => void;
-  onTryReload: () => void;
+  onTryReload?: () => void;
 }
 
 export const RepositoryLocationErrorDialog = (props: Props) => {
@@ -27,9 +27,11 @@ export const RepositoryLocationErrorDialog = (props: Props) => {
         <ErrorContents location={location} error={error} />
       </DialogBody>
       <DialogFooter>
-        <Button onClick={onTryReload} loading={reloading} intent="primary">
-          Reload again
-        </Button>
+        {onTryReload && (
+          <Button onClick={onTryReload} loading={reloading} intent="primary">
+            Reload again
+          </Button>
+        )}
         <Button onClick={onDismiss}>Dismiss</Button>
       </DialogFooter>
     </Dialog>
@@ -50,9 +52,11 @@ export const RepositoryLocationNonBlockingErrorDialog = (props: Props) => {
         <ErrorContents location={location} error={error} />
       </DialogBody>
       <DialogFooter>
-        <Button onClick={onTryReload} loading={reloading} intent="primary">
-          Reload
-        </Button>
+        {onTryReload && (
+          <Button onClick={onTryReload} loading={reloading} intent="primary">
+            Reload
+          </Button>
+        )}
         <Button onClick={onDismiss}>Close</Button>
       </DialogFooter>
     </Dialog>


### PR DESCRIPTION
## Summary

Used in https://github.com/dagster-io/internal/pull/12903 for cases where we're showing a historical error, not a current error (which might prompt a reload)

