### PR TITLE
[ui] Bump ui-components version to 1.2.0

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/CHANGES.md
+++ b/js_modules/dagster-ui/packages/ui-components/CHANGES.md
@@ -1,3 +1,10 @@
+# 1.2.0 (December 5, 2024)
+
+- Migrate styled-components to v6
+- Fix overaggressive middle truncation in Dialog body
+- Fix scrollbar styles in dark mode
+- Stop patching global lint in CodeMirror
+
 # 1.1.4 (October 11, 2024)
 
 - Add onBlur prop to TokenizingField

--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/ui-components",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Dagster UI Component Library",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary & Motivation

Bump ui-components lib to 1.2.0 following the styled-components upgrade.

## How I Tested These Changes

`yarn build` to verify correct build output locally.
