### PR TITLE
Fix asset catalog loading state showing "No assets found" while asset selection filtering is loading.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -80,7 +80,7 @@ export const AssetTable = ({
   }, [checkedDisplayKeys, displayKeys, groupedByDisplayKey]);
 
   const content = () => {
-    if (!assets.length) {
+    if (!assets.length && !isLoading) {
       if (assetSelection) {
         return (
           <Box padding={{top: 64}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -251,8 +251,6 @@ export const AssetsCatalogTable = ({
     );
   }
 
-  console.log({assets, filtered, displayed, fetchResult, filteredAssetsLoading});
-
   return (
     <AssetTable
       view={view}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -251,11 +251,13 @@ export const AssetsCatalogTable = ({
     );
   }
 
+  console.log({assets, filtered, displayed, fetchResult, filteredAssetsLoading});
+
   return (
     <AssetTable
       view={view}
       assets={displayed}
-      isLoading={filteredAssetsLoading}
+      isLoading={filteredAssetsLoading || fetchResult.loading}
       isFiltered={isFiltered}
       actionBarComponents={
         <div


### PR DESCRIPTION
## Summary & Motivation

We added asset selection based filtering to the catalog page but need to make sure the page properly waits for that filtering to occurring

## How I Tested These Changes

app-proxy