### PR TITLE
[components] Refactor definition buider code to operate on nodes rather than folders

### DIFF
--- a/examples/experimental/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/examples/experimental/dagster-components/dagster_components/core/component_decl_builder.py
@@ -25,7 +25,7 @@ class ComponentFolder(ComponentDeclNode):
     sub_decls: Sequence[Union[YamlComponentDecl, "ComponentFolder"]]
 
 
-def find_component_decl(path: Path) -> Optional[ComponentDeclNode]:
+def path_to_decl_node(path: Path) -> Optional[ComponentDeclNode]:
     # right now, we only support two types of components, both of which are folders
     # if the folder contains a defs.yml file, it's a component instance
     # otherwise, it's a folder containing sub-components
@@ -43,7 +43,7 @@ def find_component_decl(path: Path) -> Optional[ComponentDeclNode]:
 
     subs = []
     for subpath in path.iterdir():
-        component = find_component_decl(subpath)
+        component = path_to_decl_node(subpath)
         if component:
             subs.append(component)
 

--- a/examples/experimental/dagster-components/dagster_components_tests/test_pipes_subprocess_script_collection.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/test_pipes_subprocess_script_collection.py
@@ -5,6 +5,7 @@ from dagster_components.core.component_decl_builder import DefsFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
     build_components_from_component_folder,
+    build_defs_from_component_path,
     defs_from_components,
 )
 from dagster_components.impls.pipes_subprocess_script_collection import (
@@ -73,6 +74,20 @@ def test_load_from_path() -> None:
         resources={},
     )
 
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey("a"),
+        AssetKey("b"),
+        AssetKey("c"),
+        AssetKey("up1"),
+        AssetKey("up2"),
+        AssetKey("override_key"),
+    }
+
+
+def test_load_from_location_path() -> None:
+    defs = build_defs_from_component_path(
+        LOCATION_PATH / "components" / "scripts", script_load_context().registry, {}
+    )
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),
         AssetKey("b"),


### PR DESCRIPTION
## Summary & Motivation

This refactoring makes these functions more generic, so you can create `Definitions` and load components at arbitrary spots in the component hiearchy

## How I Tested These Changes

BK
