### PR TITLE
[test-all] Add 1.7 dbt-core lower bound pin

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -18,7 +18,7 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
-  dbt17: dbt-core==1.7.*
+  dbt17: dbt-core==1.7.*,>=1.7.10 # first release protobuf upper bound pin was added
   dbt17: dbt-duckdb==1.7.*
   dbt17: dbt-snowflake==1.7.*
   dbt17: dbt-bigquery==1.7.*


### PR DESCRIPTION
Summary:
[test-all] The removal of our protobuf pin caused us to hit an issue where older dbt-core 1.7 versions were missing their own protobuf pin.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
