### PR TITLE
publicly export union of valid sensor return types

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -402,6 +402,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus as DefaultSensorStatus,
     SensorDefinition as SensorDefinition,
     SensorEvaluationContext as SensorEvaluationContext,
+    SensorReturnTypesUnion as SensorReturnTypesUnion,
     build_sensor_context as build_sensor_context,
 )
 from dagster._core.definitions.source_asset import SourceAsset as SourceAsset

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -9,8 +9,8 @@ from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.run_request import RunRequest, SkipReason
 from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
-    RawSensorEvaluationFunctionReturn,
     SensorDefinition,
+    SensorReturnTypesUnion,
     SensorType,
     validate_and_get_resource_dict,
 )
@@ -80,7 +80,7 @@ class AssetSensorDefinition(SensorDefinition):
         job_name: Optional[str],
         asset_materialization_fn: Callable[
             ...,
-            RawSensorEvaluationFunctionReturn,
+            SensorReturnTypesUnion,
         ],
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -31,11 +31,11 @@ from dagster._core.definitions.scoped_resources_builder import Resources, Scoped
 from dagster._core.definitions.sensor_definition import (
     DagsterRunReaction,
     DefaultSensorStatus,
-    RawSensorEvaluationFunctionReturn,
     RunRequest,
     SensorDefinition,
     SensorEvaluationContext,
     SensorResult,
+    SensorReturnTypesUnion,
     SensorType,
     SkipReason,
     get_context_param_name,
@@ -71,12 +71,12 @@ if TYPE_CHECKING:
     )
 
 RunStatusSensorEvaluationFunction: TypeAlias = Union[
-    Callable[..., RawSensorEvaluationFunctionReturn],
-    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., SensorReturnTypesUnion],
+    Callable[..., SensorReturnTypesUnion],
 ]
 RunFailureSensorEvaluationFn: TypeAlias = Union[
-    Callable[..., RawSensorEvaluationFunctionReturn],
-    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., SensorReturnTypesUnion],
+    Callable[..., SensorReturnTypesUnion],
 ]
 
 
@@ -980,7 +980,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             metadata=metadata,
         )
 
-    def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
+    def __call__(self, *args, **kwargs) -> SensorReturnTypesUnion:
         context_param_name = get_context_param_name(self._run_status_sensor_fn)
         context = get_or_create_sensor_context(
             self._run_status_sensor_fn,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -463,7 +463,7 @@ class SensorEvaluationContext:
         return self._log_key
 
 
-RawSensorEvaluationFunctionReturn = Union[
+SensorReturnTypesUnion: TypeAlias = Union[
     Iterator[Union[SkipReason, RunRequest, DagsterRunReaction, SensorResult]],
     Sequence[RunRequest],
     SkipReason,
@@ -472,7 +472,7 @@ RawSensorEvaluationFunctionReturn = Union[
     SensorResult,
     None,
 ]
-RawSensorEvaluationFunction: TypeAlias = Callable[..., RawSensorEvaluationFunctionReturn]
+RawSensorEvaluationFunction: TypeAlias = Callable[..., SensorReturnTypesUnion]
 
 SensorEvaluationFunction: TypeAlias = Callable[
     ..., Sequence[Union[None, SensorResult, SkipReason, RunRequest]]
@@ -787,7 +787,7 @@ class SensorDefinition(IHasInternalInit):
             target=target,
         )
 
-    def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
+    def __call__(self, *args, **kwargs) -> SensorReturnTypesUnion:
         context_param_name_if_present = get_context_param_name(self._raw_fn)
         context = get_or_create_sensor_context(self._raw_fn, *args, **kwargs)
 


### PR DESCRIPTION
Publicly export the union that defines valid `@sensor` function output.

## How I Tested These Changes

bk

## Changelog [new]

`SensorReturnTypesUnion` is now exported for typing the output of sensor functions
