### PR TITLE
[components] Allow generate_files to be paramterized

### DIFF
--- a/examples/experimental/dagster-components/dagster_components/core/component.py
+++ b/examples/experimental/dagster-components/dagster_components/core/component.py
@@ -1,7 +1,7 @@
 import copy
 from abc import ABC, abstractmethod
 from types import ModuleType
-from typing import TYPE_CHECKING, ClassVar, Dict, Iterable, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Mapping, Optional, Type
 
 from dagster._core.errors import DagsterError
 from dagster._utils import snakecase
@@ -16,14 +16,15 @@ class ComponentDeclNode: ...
 
 class Component(ABC):
     name: ClassVar[Optional[str]] = None
+    defs_params_schema: ClassVar[Type] = Type[None]
+    generate_params_schema: ClassVar[Type] = Type[None]
 
     @classmethod
     def registered_name(cls) -> str:
         return cls.name or snakecase(cls.__name__)
 
     @classmethod
-    def generate_files(cls) -> None:
-        raise NotImplementedError()
+    def generate_files(cls, params: Any) -> Optional[Mapping[str, Any]]: ...
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> "Definitions": ...

--- a/examples/experimental/dagster-components/dagster_components/templates/COMPONENT_INSTANCE_NAME_PLACEHOLDER/defs.yml.jinja
+++ b/examples/experimental/dagster-components/dagster_components/templates/COMPONENT_INSTANCE_NAME_PLACEHOLDER/defs.yml.jinja
@@ -1,1 +1,0 @@
-component_type: {{ component_type }}

--- a/examples/experimental/dagster-components/setup.py
+++ b/examples/experimental/dagster-components/setup.py
@@ -47,5 +47,6 @@ setup(
     extras_require={
         "sling": ["dagster-embedded-elt"],
         "dbt": ["dagster-dbt"],
+        "test": ["dbt-duckdb"],
     },
 )

--- a/examples/experimental/dagster-components/tox.ini
+++ b/examples/experimental/dagster-components/tox.ini
@@ -14,7 +14,7 @@ deps =
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-embedded-elt
   -e ../../../python_modules/libraries/dagster-dbt
-  -e .
+  -e .[test]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary & Motivation

Reworks https://github.com/dagster-io/dagster/pull/26283/files to be less fancy.

Just a generic json blob that gets passed through params. Future PR will add an alternative entrypoint with fancier behavior so you don't have to pass in raw json.

## How I Tested These Changes

```
dg generate component dbt_project my_project --params "{\"project_path\": \"../../../dagster/\"}"

```

## Changelog

NOCHANGELOG
