### PR TITLE
[dagster_aws][pipes] Don't cause an error when get_log_events raises certain exceptions

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
@@ -217,12 +217,16 @@ class PipesLambdaLogsMessageReader(PipesMessageReader):
         )
 
 
-def get_log_events(client: "CloudWatchLogsClient", **log_params):
+# Number of retries to attempt getting cloudwatch logs when faced with a throttling exception.
+DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES = 10
+
+def get_log_events(client: "CloudWatchLogsClient", max_retries: Optional[int] = None, **log_params):
+    max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
     return backoff(
         fn=client.get_log_events,
         kwargs=log_params,
         retry_on=(client.exceptions.ThrottlingException,),
-        max_retries=5,
+        max_retries=max_retries,
     )
 
 
@@ -231,17 +235,19 @@ def tail_cloudwatch_events(
     log_group: str,
     log_stream: str,
     start_time: Optional[int] = None,
+    max_retries: Optional[int] = None,
 ) -> Generator[List["OutputLogEventTypeDef"], None, None]:
     """Yields events from a CloudWatch log stream."""
     params: Dict[str, Any] = {
         "logGroupName": log_group,
         "logStreamName": log_stream,
     }
+    max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
 
     if start_time is not None:
         params["startTime"] = start_time
 
-    response = get_log_events(client=client, **params)
+    response = get_log_events(client=client, max_retries=max_retries, **params)
 
     while True:
         events = response.get("events")
@@ -264,6 +270,7 @@ class PipesCloudWatchLogReader(PipesLogReader):
         target_stream: Optional[IO[str]] = None,
         start_time: Optional[int] = None,
         debug_info: Optional[str] = None,
+        max_retries: Optional[int] = None,
     ):
         self.client = client or boto3.client("logs")
         self.log_group = log_group
@@ -272,6 +279,7 @@ class PipesCloudWatchLogReader(PipesLogReader):
         self.thread = None
         self.start_time = start_time
         self._debug_info = debug_info
+        self.max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
 
     @property
     def debug_info(self) -> Optional[str]:
@@ -315,7 +323,7 @@ class PipesCloudWatchLogReader(PipesLogReader):
         start_time = cast(int, self.start_time or params.get("start_time"))
 
         for events in tail_cloudwatch_events(
-            self.client, log_group, log_stream, start_time=start_time
+            self.client, log_group, log_stream, start_time=start_time, max_retries=self.max_retries
         ):
             for event in events:
                 for line in event.get("message", "").splitlines():
@@ -342,6 +350,7 @@ class PipesCloudWatchMessageReader(PipesThreadedMessageReader):
         log_group: Optional[str] = None,
         log_stream: Optional[str] = None,
         log_readers: Optional[Sequence[PipesLogReader]] = None,
+        max_retries: Optional[int] = None,
     ):
         """Args:
         client (boto3.client): boto3 CloudWatch client.
@@ -349,6 +358,7 @@ class PipesCloudWatchMessageReader(PipesThreadedMessageReader):
         self.client: "CloudWatchLogsClient" = client or boto3.client("logs")
         self.log_group = log_group
         self.log_stream = log_stream
+        self.max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
 
         self.start_time = datetime.now()
 
@@ -397,7 +407,7 @@ class PipesCloudWatchMessageReader(PipesThreadedMessageReader):
         if cursor is not None:
             params["nextToken"] = cursor
 
-        response = get_log_events(client=self.client, **params)
+        response = get_log_events(client=self.client, max_retries=self.max_retries, **params)
 
         events = response.get("events")
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
@@ -230,7 +230,11 @@ def get_log_events_delay_generator() -> Iterator[float]:
         i += random.uniform(0, 1)
 
 
-def get_log_events(client: "CloudWatchLogsClient", max_retries: Optional[int] = None, **log_params):
+def get_log_events(
+    client: "CloudWatchLogsClient",
+    max_retries: Optional[int] = DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES,
+    **log_params,
+):
     max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
 
     return backoff(
@@ -268,7 +272,7 @@ def tail_cloudwatch_events(
 
         params["nextToken"] = response["nextForwardToken"]
 
-        response = get_log_events(client=client, **params)
+        response = get_log_events(client=client, max_retries=max_retries, **params)
 
 
 @experimental

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
@@ -220,15 +220,18 @@ class PipesLambdaLogsMessageReader(PipesMessageReader):
 # Number of retries to attempt getting cloudwatch logs when faced with a throttling exception.
 DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES = 10
 
+
+# Custom backoff delay_generator for get_log_events which adds some jitter
+def get_log_events_delay_generator() -> Iterator[float]:
+    i = 0.5
+    while True:
+        yield i
+        i *= 2
+        i += random.uniform(0, 1)
+
+
 def get_log_events(client: "CloudWatchLogsClient", max_retries: Optional[int] = None, **log_params):
     max_retries = max_retries or DEFAULT_CLOUDWATCH_LOGS_MAX_RETRIES
-
-    def get_log_events_delay_generator() -> Iterator[float]:
-        i = 0.5
-        while True:
-            yield i
-            i *= 2
-            i += random.uniform(0, 1)
 
     return backoff(
         fn=client.get_log_events,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -504,34 +504,6 @@ def test_cloudwatch_logs_reader(cloudwatch_client: "CloudWatchLogsClient", capsy
     assert capsys.readouterr().out.strip() == "1\n2\n3"
 
 
-def test_cloudwatch_logs_reader_does_not_repeat_logs(cloudwatch_client: "CloudWatchLogsClient", capsys):
-    reader = PipesCloudWatchLogReader(client=cloudwatch_client)
-
-    is_session_closed = threading.Event()
-
-    log_group = "/pipes/tests"
-    log_stream = "test-cloudwatch-logs-reader"
-
-    cloudwatch_client.create_log_group(logGroupName=log_group)
-    cloudwatch_client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
-
-    for i in range(5):
-        cloudwatch_client.put_log_events(
-            logGroupName=log_group,
-            logStreamName=log_stream,
-            logEvents=[
-                {"timestamp": int(datetime.now().timestamp() * 1000), "message": f"{i}"},
-            ],
-        )
-        time.sleep(0.1)
-
-    reader.start({"log_group": log_group, "log_stream": log_stream}, is_session_closed)
-    time.sleep(0.1)
-    reader.stop()
-
-    assert capsys.readouterr().out.strip() == "0\n1\n2\n3\n4"
-
-
 def test_cloudwatch_message_reader(cloudwatch_client: "CloudWatchLogsClient", capsys):
     log_group = "/pipes/tests/messages"
     messages_log_stream = "test-cloudwatch-messages-reader"


### PR DESCRIPTION
When triggering an ECS task it usually takes 30s plus for the container to start up, and so the log stream typically isn't available for that period.

Currently we attempt to get_log_events() before the log stream is available which causes errors to show on Dagster.

This change catches the errors so they don't show. They will still appear in stderr but not in the Events output. This also fixes the result of the run showing on the materialized asset at the end of the run, where as previously the thrown error would stop it receiving the required messages back from the ECS task.

Simlarly, sometimes ThrottlingException's are thrown if you have a few
tasks on the go querying logs. This will handle this as well so it
doesnt' pollute the event view and break the result materialization.
Again, these errors are still shown in stderr.

## Summary & Motivation

Messages weren't showing from my ECS task due to an exception being thrown about the log stream not being ready. 

| Before | After | 
|--------|------|
| ![before](https://github.com/user-attachments/assets/7277ca74-9316-4216-b1be-8e209c9bc007) | ![after](https://github.com/user-attachments/assets/34878c9e-58d8-438e-b5b7-f76b04f779aa) |


## How I Tested These Changes

I wasn't sure how to unit test this but the existing tests still pass. I did copy the changes into a local Dagster install to verify it fixed the issue I was having.

## Changelog

* ResourceNotFound and Throttling exceptions no longer break ECS messages being displayed on ECS pipes
