### PR TITLE
[components] Move test_dbt_project.py into integration+_tests

### DIFF
--- a/examples/experimental/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -17,7 +17,7 @@ from dagster_dbt import DbtProject
 
 from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
 
-STUB_LOCATION_PATH = Path(__file__).parent / "stub_code_locations" / "dbt_project_location"
+STUB_LOCATION_PATH = Path(__file__).parent.parent / "stub_code_locations" / "dbt_project_location"
 COMPONENT_RELPATH = "components/jaffle_shop_dbt"
 
 JAFFLE_SHOP_KEYS = {


### PR DESCRIPTION
## Summary & Motivation

Moving slow-running `test_dbt_project.py` to the `integration_tests` folder.

## How I Tested These Changes

BK
