### PR TITLE
[dagster-aws] Terraform samples for ECS deployment

### DIFF
--- a/examples/deploy_ecs/terraform/README.md
+++ b/examples/deploy_ecs/terraform/README.md
@@ -1,0 +1,32 @@
+# Dagster AWS ECS Deployment Example - Terraform
+
+This example demonstrates how to deploy Dagster on AWS ECS using Terraform.
+
+Two Terraform modules are provided:
+
+- [dagster-deployment](./dagster-deployment): responsible for deploying the Dagster Daemon and Dagster Webserver as ECS services.
+- [dagster-code-location](./dagster-code-location): responsible for deploying code locations as ECS services.
+
+The example expects the following resources to be used in the deployment:
+
+- a VPC with public and private subnets
+- a configured ECS cluster
+- a Postgres database for storing the Dagster event log
+
+During the deployment, the following resources are created:
+
+- IAM roles and policies for ECS tasks (optional, can be provided instead)
+- CloudWatch log group for the ECS tasks (optional, can be provided instead)
+- ECS services for the Dagster Daemon and Dagster Webserver
+- ECS services for code locations
+- AWS Application Load Balancer for the Dagster Webserver (optional, can be provided instead)
+
+By default, the `dagster-deployment` automatically creates basic IAM roles and policies for the ECS tasks, and deploys an AWS Application Load Balancer for the Dagster Webserver. **This will make the Dagster Webserver accessible from the public internet**, which is useful for a quickstart, testing or development purposes. Make sure to use public subnets for `webserver_subnet_ids` if you want to access the webserver from the internet.
+
+However, it is recommended to create IAM roles and policies separately and pass them to the module as `task_role_arn` and `execution_role_arn`. Also, if you want to restrict access to the webserver, you can set `create_lb` to `false` and configure the ALB manually.
+
+Both modules take a `dagster_home` argument, which is the path to the directory with `dagster.yaml` and `workspace.yaml` files. `workspace.yaml` only has to be present in the daemon and webserver containers.
+
+---
+
+This example should be considered as a starting point for deploying Dagster on AWS ECS. It is recommended to review the Terraform modules and adjust them to fit your specific requirements.

--- a/examples/deploy_ecs/terraform/dagster-code-location/main.tf
+++ b/examples/deploy_ecs/terraform/dagster-code-location/main.tf
@@ -1,0 +1,120 @@
+data "aws_vpc" "dagster_vpc" {
+  # get from var.vpc_id
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "code_location" {
+  name_prefix = "code-location-sg-"
+  vpc_id      = var.vpc_id
+
+  # Allow traffic on port 4000 (from dagster services or internal network)
+  ingress {
+    from_port   = 4000
+    to_port     = 4000
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.dagster_vpc.cidr_block]
+  }
+
+  # Egress allows all outbound traffic (common default)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "code_location" {
+  family                   = var.service_name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  task_role_arn            = var.task_role_arn
+  execution_role_arn       = var.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.service_name
+      image     = var.image
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = var.log_group
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = var.service_name
+        }
+      }
+      command = ["dagster", "api", "grpc", "--module-name", var.module_name, "--host", "0.0.0.0", "--port", "4000"]
+      portMappings = [
+        {
+          containerPort = 4000
+          hostPort      = 4000
+          protocol      = "tcp"
+          name          = "grpc"
+        }
+      ]
+      environment = concat(
+        [
+          { name = "DAGSTER_HOME", value = var.dagster_home },
+          { name = "DAGSTER_POSTGRES_HOST", value = var.postgres_host },
+          { name = "DAGSTER_POSTGRES_PASSWORD", value = var.postgres_password },
+          { name = "DAGSTER_CURRENT_IMAGE", value = var.image },
+        ],
+        var.environment
+      )
+      secrets = var.secrets
+    }
+  ])
+}
+
+
+# Create a service discovery service
+resource "aws_service_discovery_service" "dagster-code-location" {
+  name = var.service_name
+
+  dns_config {
+    namespace_id = var.namespace_id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_service" "code_location" {
+  name            = var.service_name
+  cluster         = var.ecs_cluster_id
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.code_location.arn
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  # this ensures the code location is scaled down to 0 before rolling out a new version
+  # which prevents possible inconsistencies
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.code_location.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.dagster-code-location.arn
+  }
+
+  force_new_deployment = true
+}

--- a/examples/deploy_ecs/terraform/dagster-code-location/outputs.tf
+++ b/examples/deploy_ecs/terraform/dagster-code-location/outputs.tf
@@ -1,0 +1,9 @@
+output "security_group_id" {
+  description = "Security Group ID for the Code Location"
+  value       = aws_security_group.code_location.id
+}
+
+output "task_definition_arn" {
+  description = "Task Definition ARN for the Code Location"
+  value       = aws_ecs_task_definition.code_location.arn
+}

--- a/examples/deploy_ecs/terraform/dagster-code-location/variables.tf
+++ b/examples/deploy_ecs/terraform/dagster-code-location/variables.tf
@@ -1,0 +1,99 @@
+variable "region" {
+  description = "The AWS region."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet ids for the ECS task."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Whether to assign a public IP to the ECS tasks. Warning: this might will expose the tasks to the internet."
+  type        = bool
+  default     = true
+}
+
+variable "ecs_cluster_id" {
+  description = "ECS Cluster ID."
+  type        = string
+}
+
+variable "task_role_arn" {
+  description = "The ARN of the task role."
+  type        = string
+}
+
+variable "execution_role_arn" {
+  description = "The ARN of the execution role."
+  type        = string
+}
+
+variable "namespace_id" {
+  description = "The namespace ID for the service."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the code location service."
+  type        = string
+}
+
+variable "dagster_home" {
+  description = "Directory with dagster.yaml"
+  type        = string
+}
+
+variable "environment" {
+  description = "List of environment variables for ECS tasks."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "secrets" {
+  description = "List of secrets to pass to the ECS task as environment variables."
+  type = list(object({
+    name       = string
+    value_from = string
+  }))
+  default = []
+}
+
+variable "module_name" {
+  description = "The module name for the gRPC server."
+  type        = string
+}
+
+variable "image" {
+  description = "Docker image for the gRPC service."
+  type        = string
+}
+
+variable "postgres_host" {
+  description = "PostgreSQL host for Dagster."
+  type        = string
+}
+
+variable "postgres_user" {
+  description = "PostgreSQL user for Dagster."
+  type        = string
+}
+
+variable "postgres_password" {
+  description = "PostgreSQL password for Dagster."
+  type        = string
+  sensitive = true
+}
+
+variable "log_group" {
+  description = "The CloudWatch log group for the service."
+  type        = string
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/alb.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/alb.tf
@@ -1,0 +1,43 @@
+locals {
+  dagster_webserver_lb_dns_name = var.create_lb ? aws_lb.dagster_webserver[0].dns_name : null
+  lb_target_group_arn = var.create_lb ? aws_lb_target_group.dagster_webserver[0].arn : var.lb_target_group_arn
+}
+
+resource "aws_lb" "dagster_webserver" {
+  count = var.create_lb ? 1 : 0
+  # no longer than 6 characters
+  name_prefix        = "dgweb-"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.dagster.id]
+  subnets            = var.webserver_subnet_ids
+}
+
+resource "aws_lb_target_group" "dagster_webserver" {
+  count       = var.create_lb ? 1 : 0
+  # no longer than 6 characters
+  name_prefix = "dgweb-"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    matcher             = "200-399"
+  }
+}
+
+resource "aws_lb_listener" "dagster_webserver" {
+  count             = var.create_lb ? 1 : 0
+  load_balancer_arn = aws_lb.dagster_webserver[0].arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = local.lb_target_group_arn
+  }
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/cloudwatch.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/cloudwatch.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "ecs_task_log_group" {
+  count = var.create_log_group ? 1 : 0
+  name_prefix = "/ecs/dagster-"
+  retention_in_days = 7
+}
+
+locals {
+  log_group = var.create_log_group ? aws_cloudwatch_log_group.ecs_task_log_group[0].name : var.log_group
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/iam.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/iam.tf
@@ -1,0 +1,128 @@
+resource "aws_iam_role" "task" {
+  count       = var.create_iam_roles ? 1 : 0
+  name_prefix = "dagster-ecs-task-"
+  description = "Role for Dagster ECS tasks"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "task" {
+  count       = var.create_iam_roles ? 1 : 0
+  name_prefix = "dagster-ecs-task-"
+  description = "Policy for Dagster ECS tasks"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      # full access to specific s3 bucket
+      {
+        Effect = "Allow",
+        Action = "s3:*",
+        Resource = "*"
+      },
+      # actions for the ECS Run Launcher and ECS Executor
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:PassRole",
+          "ecs:RunTask",
+          "ecs:DescribeTasks",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
+          "ecs:ListTasks",
+          "ecs:StopTask",
+          "ecs:TagResource",
+          "ec2:DescribeNetworkInterfaces",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecrets",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+        ],
+        Resource = "*"
+      }
+    ],
+  })
+}
+
+
+resource "aws_iam_role_policy_attachment" "task" {
+  count      = var.create_iam_roles ? 1 : 0
+  role       = aws_iam_role.task[0].name
+  policy_arn = aws_iam_policy.task[0].arn
+}
+
+resource "aws_iam_policy_attachment" "task-AmazonECSTaskExecutionRolePolicy" {
+  count      = var.create_iam_roles ? 1 : 0
+  name       = "${aws_iam_role.task[0].name}-AmazonECSTaskExecutionRolePolicy"
+  roles      = [aws_iam_role.task[0].name]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "execution" {
+  count       = var.create_iam_roles ? 1 : 0
+  name_prefix = "dagster-ecs-execution-"
+  description = "Role for ECS task execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution-AmazonECSTaskExecutionRolePolicy" {
+  count      = var.create_iam_roles ? 1 : 0
+  role       = aws_iam_role.execution[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_policy" "execution" {
+  count       = var.create_iam_roles ? 1 : 0
+  name_prefix = "dagster-ecs-execution-"
+  description = "Policy for ECS execution role with ECR permissions"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "dagster-ecs-execution-role-policy-attachment" {
+  count      = var.create_iam_roles ? 1 : 0
+  role       = aws_iam_role.execution[0].name
+  policy_arn = aws_iam_policy.execution[0].arn
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/main.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/main.tf
@@ -1,0 +1,165 @@
+data "aws_vpc" "dagster_vpc" {
+  # get from var.vpc_id
+  id = var.vpc_id
+}
+
+locals {
+  task_role_arn      = var.create_iam_roles ? aws_iam_role.task[0].arn : var.task_role_arn
+  execution_role_arn = var.create_iam_roles ? aws_iam_role.execution[0].arn : var.execution_role_arn
+}
+
+resource "aws_security_group" "dagster" {
+  name_prefix = "dagster-sg-"
+  vpc_id      = var.vpc_id
+
+  # Allow traffic for webserver (HTTP)
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow traffic for gRPC services (from other containers)
+  ingress {
+    from_port   = 4000
+    to_port     = 4000
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.dagster_vpc.cidr_block]
+  }
+
+  # Egress allows all outbound traffic (common default)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "dagster_daemon" {
+  family                   = "dagster-daemon"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  task_role_arn            = local.task_role_arn
+  execution_role_arn       = local.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "dagster-daemon"
+      image     = var.dagster_image
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = local.log_group
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "dagster-daemon"
+        }
+      }
+      command = ["dagster-daemon", "run", "-w", "${var.dagster_home}/workspace.yaml"]
+      environment = concat(
+        [
+          { name = "DAGSTER_HOME", value = var.dagster_home },
+          { name = "DAGSTER_POSTGRES_HOST", value = var.postgres_host },
+          { name = "DAGSTER_POSTGRES_PASSWORD", value = var.postgres_password }
+        ],
+        var.environment
+      )
+      secrets = var.secrets
+    }
+  ])
+}
+
+resource "aws_ecs_service" "dagster_daemon" {
+  name            = "dagster-daemon"
+  cluster         = var.ecs_cluster_id
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.dagster_daemon.arn
+
+  network_configuration {
+    subnets          = var.daemon_subnet_ids
+    security_groups  = [aws_security_group.dagster.id]
+    # when running in public subnet, consider setting assign_public_ip = true
+    # however, this is not recommended for production as it exposes the container to the internet
+    assign_public_ip = var.create_lb ? true : var.assign_public_ip
+  }
+
+  force_new_deployment = true
+}
+
+
+resource "aws_ecs_task_definition" "dagster_webserver" {
+  family                   = "dagster-webserver"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  task_role_arn            = local.task_role_arn
+  execution_role_arn       = local.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "dagster-webserver"
+      image     = var.dagster_image
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = local.log_group
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "dagster-webserver"
+        }
+      }
+      portMappings = [
+        {
+          containerPort = 80
+          hostPort      = 80
+          protocol      = "tcp"
+          name          = "http"
+        }
+      ]
+      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "80", "-w", "${var.dagster_home}/workspace.yaml"]
+      environment = concat(
+        [
+          { name = "DAGSTER_HOME", value = var.dagster_home },
+          { name = "DAGSTER_POSTGRES_HOST", value = var.postgres_host },
+          { name = "DAGSTER_POSTGRES_PASSWORD", value = var.postgres_password }
+        ],
+        var.environment
+      )
+      secrets = var.secrets
+    }
+  ])
+}
+
+
+resource "aws_ecs_service" "dagster-webserver" {
+  name            = "dagster-webserver"
+  cluster         = var.ecs_cluster_id
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.dagster_webserver.arn
+
+  network_configuration {
+    subnets          = var.webserver_subnet_ids
+    security_groups  = [aws_security_group.dagster.id]
+    # when running in public subnet, consider setting assign_public_ip = true
+    # however, this is not recommended for production as it exposes the container to the internet
+    assign_public_ip = var.create_lb ? true : var.assign_public_ip
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.create_lb ? [1] : []
+    content {
+      target_group_arn = local.lb_target_group_arn
+      container_name   = "dagster-webserver"
+      container_port   = 80
+    }
+  }
+
+  force_new_deployment = true
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/outputs.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/outputs.tf
@@ -1,0 +1,19 @@
+output "security_group_id" {
+  description = "Security Group ID for Dagster"
+  value       = aws_security_group.dagster.id
+}
+
+output "task_role_arn" {
+  description = "Task Role ARN for Dagster"
+  value       = local.task_role_arn
+}
+
+output "execution_role_arn" {
+  description = "Execution ARN Name for Dagster"
+  value       = local.execution_role_arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name for Dagster"
+  value       = local.log_group
+}

--- a/examples/deploy_ecs/terraform/dagster-deployment/variables.tf
+++ b/examples/deploy_ecs/terraform/dagster-deployment/variables.tf
@@ -1,0 +1,110 @@
+variable "region" {
+  description = "The AWS region."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC."
+  type        = string
+}
+
+variable "daemon_subnet_ids" {
+  description = "List of subnet ids for the Dagster Daemon ECS task."
+  type        = list(string)
+}
+
+variable "webserver_subnet_ids" {
+  description = "List of subnet ids for the Dagster Webserver ECS task."
+  type        = list(string)
+}
+
+variable "ecs_cluster_id" {
+  description = "ECS Cluster ID."
+  type        = string
+}
+
+variable "create_iam_roles" {
+  description = "Whether to create IAM roles and policies."
+  type        = bool
+  default     = true
+}
+
+variable "execution_role_arn" {
+  description = "The ARN of the execution role. Provide this if create_iam_roles is false."
+  type        = string
+  default     = null
+}
+
+variable "task_role_arn" {
+  description = "The ARN of the task role. Provide this if create_iam_roles is false."
+  type        = string
+  default     = null
+}
+
+variable "create_lb" {
+  description = "Whether to create a load balancer."
+  type        = bool
+  default     = true
+}
+
+variable "lb_target_group_arn" {
+  description = "The ARN of the target group for the load balancer. Provide this if create_lb is false."
+  type        = string
+  default     = null
+}
+
+variable "assign_public_ip" {
+  description = "Whether to assign a public IP to the ECS tasks. Warning: this might will expose the tasks to the internet."
+  type        = bool
+  default     = true
+}
+
+variable "create_log_group" {
+  description = "Whether to create a CloudWatch log group."
+  type        = bool
+  default     = true
+}
+
+variable "log_group" {
+  description = "The CloudWatch log group for the tasks. Provide this if create_log_group is false."
+  type        = string
+}
+
+variable "dagster_image" {
+  description = "Docker image for Dagster services."
+  type        = string
+}
+
+variable "postgres_host" {
+  description = "PostgreSQL host for Dagster."
+  type        = string
+}
+
+variable "postgres_password" {
+  description = "PostgreSQL password for Dagster."
+  type        = string
+  sensitive   = true
+}
+
+variable "dagster_home" {
+  description = "Directory with dagster.yaml"
+  type        = string
+}
+
+variable "environment" {
+  description = "List of environment variables for ECS tasks."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "secrets" {
+  description = "List of secrets to pass to the ECS task as environment variables."
+  type = list(object({
+    name       = string
+    value_from = string
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary & Motivation

Adding Terraform code with minimal configuration for Dagster deployment on AWS ECS.

There are 2 modules added: `dagster-deployment` and `dagster-code-location`. 
The first one can be configured to automatically create resources for IAM, CloudWatch logs, and a load balancer. 

## How I Tested These Changes

I have been using this code to deploy Dagster in my personal AWS account. 

## Changelog

[dagster-aws] added sample Terraform modules for Dagster deployment on AWS ECS 
