### PR TITLE
[components] Fix copy in dg's generate help

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
@@ -29,7 +29,7 @@ def generate_cli() -> None:
 @generate_cli.command(name="deployment")
 @click.argument("path", type=str)
 def generate_deployment_command(path: str) -> None:
-    """Generate a Dagster deployment instance."""
+    """Generate a Dagster deployment project."""
     dir_abspath = os.path.abspath(path)
     if os.path.exists(dir_abspath):
         click.echo(
@@ -43,7 +43,7 @@ def generate_deployment_command(path: str) -> None:
 @generate_cli.command(name="code-location")
 @click.argument("name", type=str)
 def generate_code_location_command(name: str) -> None:
-    """Generate a Dagster code location inside a component."""
+    """Generate a Dagster code location inside a deployment."""
     if not is_inside_deployment_project(Path(".")):
         click.echo(
             click.style("This command must be run inside a Dagster deployment project.", fg="red")
@@ -62,7 +62,7 @@ def generate_code_location_command(name: str) -> None:
 @generate_cli.command(name="component-type")
 @click.argument("name", type=str)
 def generate_component_type_command(name: str) -> None:
-    """Generate a Dagster component instance."""
+    """Generate a Dagster component type in the current project's component library."""
     if not is_inside_code_location_project(Path(".")):
         click.echo(
             click.style(

--- a/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
@@ -43,7 +43,7 @@ def generate_deployment_command(path: str) -> None:
 @generate_cli.command(name="code-location")
 @click.argument("name", type=str)
 def generate_code_location_command(name: str) -> None:
-    """Generate an Dagster code location subproject embedded in a deployment project."""
+    """Generate a Dagster code location subproject embedded in a deployment project."""
     if not is_inside_deployment_project(Path(".")):
         click.echo(
             click.style("This command must be run inside a Dagster deployment project.", fg="red")

--- a/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
@@ -43,7 +43,7 @@ def generate_deployment_command(path: str) -> None:
 @generate_cli.command(name="code-location")
 @click.argument("name", type=str)
 def generate_code_location_command(name: str) -> None:
-    """Generate a Dagster code location inside a deployment."""
+    """Generate an Dagster code location subproject embedded in a deployment project."""
     if not is_inside_deployment_project(Path(".")):
         click.echo(
             click.style("This command must be run inside a Dagster deployment project.", fg="red")


### PR DESCRIPTION
## Summary & Motivation

The copy of dg's generate commands were off. This fixes them.

## How I Tested These Changes

```
(dagster-python-3.12-2024-11-22) schrockn@dagsterlabs-macair-11-2024 dagster % dg generate -h
Usage: dg generate [OPTIONS] COMMAND [ARGS]...

  Commands for generating Dagster components and related entities.

Options:
  -h, --help  Show this message and exit.

Commands:
  code-location   Generate an Dagster code location subproject embedded in a deployment project.
  component       Generate a Dagster component instance.
  component-type  Generate a Dagster component type in the current project's component library.
  deployment      Generate a Dagster deployment project..
```
