### PR TITLE
[components] Allow for the parameterization of op tags

### DIFF
--- a/examples/experimental/dagster-components/dagster_components/impls/sling_replication.py
+++ b/examples/experimental/dagster-components/dagster_components/impls/sling_replication.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import yaml
 from dagster._core.definitions.definitions_class import Definitions
@@ -15,6 +15,7 @@ from dagster_components.core.component_decl_builder import ComponentDeclNode, Ya
 
 class OpSpecBaseModel(BaseModel):
     name: Optional[str] = None
+    tags: Optional[Dict[str, str]] = None
 
 
 class SlingReplicationParams(BaseModel):
@@ -47,6 +48,7 @@ class SlingReplicationComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         @sling_assets(
             name=self.op_spec.name if self.op_spec else self.dirpath.stem,
+            op_tags=self.op_spec.tags if self.op_spec else {},
             replication_config=self.dirpath / "replication.yaml",
         )
         def _fn(context: AssetExecutionContext, sling: SlingResource):

--- a/examples/experimental/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/examples/experimental/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -109,6 +109,24 @@ def test_python_params_op_name(sling_path: Path) -> None:
     assert defs.get_assets_def("input_duckdb").op.name == "my_op"
 
 
+def test_python_params_op_tags(sling_path: Path) -> None:
+    context = script_load_context()
+    component = SlingReplicationComponent.from_decl_node(
+        context=context,
+        decl_node=YamlComponentDecl(
+            path=sling_path / COMPONENT_RELPATH,
+            defs_file_model=DefsFileModel(
+                component_type="sling_replication",
+                component_params={"sling": {}, "op": {"tags": {"tag1": "value1"}}},
+            ),
+        ),
+    )
+    assert component.op_spec
+    assert component.op_spec.tags == {"tag1": "value1"}
+    defs = component.build_defs(context)
+    assert defs.get_assets_def("input_duckdb").op.tags == {"tag1": "value1"}
+
+
 def test_load_from_path(sling_path: Path) -> None:
     components = build_components_from_component_folder(
         script_load_context(), sling_path / "components"


### PR DESCRIPTION
## Summary & Motivation

Similar to #26319 but for tags.

Note how this passes through to `op_tags` whereas the #26319 passed through to `name`. Nesting under `op:` makes it much more clear what is going on

## How I Tested These Changes

BK
