### PR TITLE
[components] Make op name and tags configurable on DbtProjectComponent

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -1,0 +1,8 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+
+class OpSpecBaseModel(BaseModel):
+    name: Optional[str] = None
+    tags: Optional[Dict[str, str]] = None

--- a/python_modules/libraries/dagster-components/dagster_components/impls/sling_replication.py
+++ b/python_modules/libraries/dagster-components/dagster_components/impls/sling_replication.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Union
+from typing import Iterator, Optional, Union
 
 import yaml
 from dagster._core.definitions.definitions_class import Definitions
@@ -14,11 +14,7 @@ from typing_extensions import Self
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import component
 from dagster_components.core.component_decl_builder import ComponentDeclNode, YamlComponentDecl
-
-
-class OpSpecBaseModel(BaseModel):
-    name: Optional[str] = None
-    tags: Optional[Dict[str, str]] = None
+from dagster_components.core.dsl_schema import OpSpecBaseModel
 
 
 class SlingReplicationParams(BaseModel):
@@ -30,9 +26,7 @@ class SlingReplicationParams(BaseModel):
 class SlingReplicationComponent(Component):
     params_schema = SlingReplicationParams
 
-    def __init__(
-        self, dirpath: Path, resource: SlingResource, op_spec: Optional[OpSpecBaseModel] = None
-    ):
+    def __init__(self, dirpath: Path, resource: SlingResource, op_spec: Optional[OpSpecBaseModel]):
         self.dirpath = dirpath
         self.resource = resource
         self.op_spec = op_spec

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -50,11 +50,17 @@ def test_python_params(dbt_path: Path) -> None:
             path=dbt_path / COMPONENT_RELPATH,
             defs_file_model=DefsFileModel(
                 component_type="dbt_project",
-                component_params={"dbt": {"project_dir": "jaffle_shop"}},
+                component_params={
+                    "dbt": {"project_dir": "jaffle_shop"},
+                    "op": {"name": "some_op", "tags": {"tag1": "value"}},
+                },
             ),
         ),
     )
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
+    defs = component.build_defs(script_load_context())
+    assert defs.get_assets_def("stg_customers").op.name == "some_op"
+    assert defs.get_assets_def("stg_customers").op.tags["tag1"] == "value"
 
 
 def test_load_from_path(dbt_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -199,6 +199,7 @@ class DbtProject(IHaveNew):
 
     """
 
+    name: str
     project_dir: Path
     target_path: Path
     target: Optional[str]
@@ -250,6 +251,7 @@ class DbtProject(IHaveNew):
 
         return super().__new__(
             cls,
+            name=dbt_project_yml["name"],
             project_dir=project_dir,
             target_path=target_path,
             target=target,


### PR DESCRIPTION
## Summary & Motivation

See title. This also moves `OpSpecBaseModel` to core/dsl_schema for reuse.

## How I Tested These Changes

BK
