### PR TITLE
[components] Nicer parameter handling

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -17,8 +17,8 @@ class ComponentDeclNode: ...
 
 class Component(ABC):
     name: ClassVar[Optional[str]] = None
-    defs_params_schema: ClassVar[Type] = Type[None]
-    generate_params_schema: ClassVar[Type] = Type[None]
+    defs_params_schema: ClassVar = None
+    generate_params_schema: ClassVar = None
 
     @classmethod
     def generate_files(cls, params: Any) -> Optional[Mapping[str, Any]]: ...

--- a/python_modules/libraries/dagster-components/dagster_components/impls/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/impls/dbt_project.py
@@ -2,13 +2,14 @@ import os
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+import click
 import dagster._check as check
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
 from dagster_embedded_elt.sling.resources import AssetExecutionContext
 from dbt.cli.main import dbtRunner
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
@@ -21,8 +22,15 @@ class DbtProjectParams(BaseModel):
 
 
 class DbtGenerateParams(BaseModel):
-    init: bool = False
+    init: bool = Field(default=False)
     project_path: Optional[str] = None
+
+    @staticmethod
+    @click.command
+    @click.option("--project-path", "-p", type=click.Path(resolve_path=True), default=None)
+    @click.option("--init", "-i", is_flag=True, default=False)
+    def cli(project_path: Optional[str], init: bool) -> "DbtGenerateParams":
+        return DbtGenerateParams(project_path=project_path, init=init)
 
 
 @component(name="dbt_project")

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -17,7 +17,7 @@ from dagster_dbt import DbtProject
 
 from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
 
-STUB_LOCATION_PATH = Path(__file__).parent / "stub_code_locations" / "dbt_project_location"
+STUB_LOCATION_PATH = Path(__file__).parent.parent / "stub_code_locations" / "dbt_project_location"
 COMPONENT_RELPATH = "components/jaffle_shop_dbt"
 
 JAFFLE_SHOP_KEYS = {


### PR DESCRIPTION
## Summary & Motivation

Allows you to pass arguments to an underlying cli invocation, rather than via a raw json blob

For now, we don't do any auto-generation of the parameter schema for the cli invocation. There are existing libraries that do this sort of thing (convert pydantic models to click commands), which we could potentially consider hooking into.


## How I Tested These Changes

```
dg generate component dbt_project my_project -- --project-path abc

dg generate component dbt_project my_project -- --init
```

## Changelog

NOCHANGELOG
