### PR TITLE
[freshness-checks][rfc] Retrieve latest completed check execution in summary records.

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -29,6 +29,12 @@ class AssetCheckExecutionRecordStatus(enum.Enum):
     FAILED = "FAILED"  # explicit fail result
 
 
+COMPLETED_ASSET_CHECK_EXECUTION_RECORD_STATUSES = {
+    AssetCheckExecutionRecordStatus.SUCCEEDED,
+    AssetCheckExecutionRecordStatus.FAILED,
+}
+
+
 class AssetCheckExecutionResolvedStatus(enum.Enum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,4 +1,14 @@
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
@@ -9,7 +19,10 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionRecord,
+    AssetCheckExecutionRecordStatus,
+)
 from dagster._core.storage.base_storage import DagsterStorage
 from dagster._core.storage.event_log.base import (
     AssetCheckSummaryRecord,
@@ -687,11 +700,13 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         check_key: "AssetCheckKey",
         limit: int,
         cursor: Optional[int] = None,
+        status: Optional[AbstractSet[AssetCheckExecutionRecordStatus]] = None,
     ) -> Sequence[AssetCheckExecutionRecord]:
         return self._storage.event_log_storage.get_asset_check_execution_history(
             check_key=check_key,
             limit=limit,
             cursor=cursor,
+            status=status,
         )
 
     def get_latest_asset_check_execution_by_key(


### PR DESCRIPTION
## Summary & Motivation
This is in preparation to make some fixes to the freshness check sensor, which needs to understand both when a check is in flight, and the last completed execution of the check.

Previously, on an AssetCheckExecutionSummaryRecord, we were only storing the latest record regardless of status. For freshness checks, we additionally need to know the latest _completed_ execution of a check. This PR adds that behavior by making it possible to query check execution history based on status; a cloud PR companion will follow up if we think this is reasonable.

Here's my intuition regarding perf:
- In most cases, this will retrieve the latest 2 check executions at most.
- In some degenerate cases, we could potentially have to scan many check execution records if there are many in flight checks at once for the same check key. But it's hard to imagine this happening reasonably often.

## How I Tested These Changes
Added new assertions to event log storage tests, a new assertion in instance tests to show what the status behavior is for runless events.