### PR TITLE
Make PyPI existence check use /json suffix when scaffolding

### DIFF
--- a/python_modules/dagster/dagster/_cli/project.py
+++ b/python_modules/dagster/dagster/_cli/project.py
@@ -63,7 +63,7 @@ def check_if_pypi_package_conflict_exists(project_name: str) -> PackageConflictC
     """
     if any(keyword in project_name for keyword in FLAGGED_PACKAGE_KEYWORDS):
         try:
-            res = requests.get(f"https://pypi.org/pypi/{project_name}")
+            res = requests.get(f"https://pypi.org/pypi/{project_name}/json")
             if res.status_code == 200:
                 return PackageConflictCheckResult(request_error_msg=None, conflict_exists=True)
         except Exception as e:


### PR DESCRIPTION
## Summary & Motivation

Fix breaking scaffolding tests. PyPI changed it's behavior so that hitting https://pypi.org/pypi/<package_name> ALWAYS returns a 200-- we were hitting this URL and ensuring the response was not 200 for the scaffolded package name to ensure no conflict with an already published package. That no longer works. However, the old semantics old if you just hit https://pypi.org/pypi/<package_name>/json instead.

## How I Tested These Changes

Existing test suite.