### PR TITLE
[components] Add dagster-components to DagsterLibraryRegistry

### DIFF
--- a/python_modules/automation/automation_tests/telemetry/test_resource_telemetry.py
+++ b/python_modules/automation/automation_tests/telemetry/test_resource_telemetry.py
@@ -37,6 +37,8 @@ def test_resource_telemetry():
     libraries.remove("dagster_airflow")
     # new library, not added yet
     libraries.remove("dagster_embedded_elt")
+    # temporary library that will be merged into dagster
+    libraries.remove("dagster_components")
 
     resources_without_telemetry = []
 

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -18,3 +18,9 @@ __component_registry__ = {
     "sling_replication": SlingReplicationComponent,
     "dbt_project": DbtProjectComponent,
 }
+
+from dagster._core.libraries import DagsterLibraryRegistry
+
+from dagster_components.version import __version__ as __version__
+
+DagsterLibraryRegistry.register("dagster-components", __version__)


### PR DESCRIPTION
## Summary & Motivation

Fix automation tests by adding `dagster-components` to the library registry.

## How I Tested These Changes

Existing test suite.