### PR TITLE
[freshness-checks][rfc] fix tickets

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -29,6 +29,12 @@ class AssetCheckExecutionRecordStatus(enum.Enum):
     FAILED = "FAILED"  # explicit fail result
 
 
+COMPLETED_ASSET_CHECK_EXECUTION_RECORD_STATUSES = {
+    AssetCheckExecutionRecordStatus.SUCCEEDED,
+    AssetCheckExecutionRecordStatus.FAILED,
+}
+
+
 class AssetCheckExecutionResolvedStatus(enum.Enum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,4 +1,14 @@
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
@@ -9,7 +19,10 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionRecord,
+    AssetCheckExecutionRecordStatus,
+)
 from dagster._core.storage.base_storage import DagsterStorage
 from dagster._core.storage.event_log.base import (
     AssetCheckSummaryRecord,
@@ -687,11 +700,13 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         check_key: "AssetCheckKey",
         limit: int,
         cursor: Optional[int] = None,
+        status: Optional[AbstractSet[AssetCheckExecutionRecordStatus]] = None,
     ) -> Sequence[AssetCheckExecutionRecord]:
         return self._storage.event_log_storage.get_asset_check_execution_history(
             check_key=check_key,
             limit=limit,
             cursor=cursor,
+            status=status,
         )
 
     def get_latest_asset_check_execution_by_key(

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
@@ -21,12 +21,14 @@ from dagster._core.definitions.asset_check_factories.utils import FRESH_UNTIL_ME
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.metadata import FloatMetadataValue
 from dagster._core.definitions.run_request import RunRequest, SkipReason
 from dagster._core.definitions.sensor_definition import build_sensor_context
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
-from dagster._core.test_utils import freeze_time
+from dagster._core.storage.tags import SENSOR_NAME_TAG
+from dagster._core.test_utils import create_run_for_test, freeze_time
 from dagster._core.utils import make_new_run_id
 from dagster._time import get_current_datetime
 
@@ -132,7 +134,7 @@ def test_sensor_multi_asset_different_states(instance: DagsterInstance) -> None:
 
 
 def test_sensor_evaluation_planned(instance: DagsterInstance) -> None:
-    """Test the case where the asset check is currently planned to evaluate. We shouldn't attempt to re-evalaute the check in this case."""
+    """Test the case where the asset check is currently planned to evaluate, and has never previously evaluated. We shouldn't be kicking off a new run of the check."""
 
     @asset
     def my_asset():
@@ -142,6 +144,7 @@ def test_sensor_evaluation_planned(instance: DagsterInstance) -> None:
         assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
     )
 
+    # Check has never completed evaluation but is in flight. We should skip the check.
     frozen_time = get_current_datetime()
     with freeze_time(frozen_time):
         instance.event_log_storage.store_event(
@@ -166,6 +169,238 @@ def test_sensor_evaluation_planned(instance: DagsterInstance) -> None:
 
         # Upon evaluation, we shouldn't get a run request for any asset checks.
         assert isinstance(sensor(context), SkipReason)
+        # Cursor should be None, since we made it through all assets.
+        assert context.cursor is None
+
+
+def test_sensor_eval_planned_prev_success(instance: DagsterInstance) -> None:
+    """Test the case where the asset check is currently planned to evaluate, and has previously evaluated successfully. We should be kicking off a run of the check once the freshness interval has passed."""
+
+    @asset
+    def my_asset():
+        pass
+
+    freshness_checks = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+
+    # Check has never completed evaluation but is in flight. We should skip the check.
+    frozen_time = get_current_datetime()
+    with freeze_time(frozen_time - datetime.timedelta(minutes=5)):
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=my_asset.key,
+                check_name="freshness_check",
+                passed=True,
+                metadata={
+                    FRESH_UNTIL_METADATA_KEY: FloatMetadataValue(frozen_time.timestamp() + 5)
+                },
+            )
+        )
+    with freeze_time(frozen_time):
+        instance.event_log_storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id=make_new_run_id(),
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluationPlanned(
+                        asset_key=my_asset.key, check_name="freshness_check"
+                    ),
+                ),
+            )
+        )
+        sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
+        defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
+        context = build_sensor_context(instance=instance, definitions=defs)
+
+        # Upon evaluation, we do not yet expect a run request, since the freshness interval has not yet passed.
+        result = sensor(context)
+        assert isinstance(result, SkipReason)
+        # Cursor should be None, since we made it through all assets.
+        assert context.cursor is None
+
+        # Move time forward to when the check should be evaluated.
+        with freeze_time(frozen_time + datetime.timedelta(minutes=6)):
+            # Upon evaluation, we should get a run request for the asset check.
+            run_request = sensor(context)
+            assert isinstance(run_request, RunRequest)
+            assert run_request.asset_check_keys == [AssetCheckKey(my_asset.key, "freshness_check")]
+            # Cursor should be None, since we made it through all assets.
+            assert context.cursor is None
+
+
+def test_sensor_eval_planned_prev_failed(instance: DagsterInstance) -> None:
+    """Test the case where the asset check is currently planned to evaluate, and has previously evaluated unsuccessfully. We should not be kicking off a run of the check."""
+
+    @asset
+    def my_asset():
+        pass
+
+    freshness_checks = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+
+    # Check has never completed evaluation but is in flight. We should skip the check.
+    frozen_time = get_current_datetime()
+    with freeze_time(frozen_time - datetime.timedelta(minutes=5)):
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=my_asset.key,
+                check_name="freshness_check",
+                passed=False,
+                metadata={},
+            )
+        )
+    with freeze_time(frozen_time):
+        instance.event_log_storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id=make_new_run_id(),
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluationPlanned(
+                        asset_key=my_asset.key, check_name="freshness_check"
+                    ),
+                ),
+            )
+        )
+        sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
+        defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
+        context = build_sensor_context(instance=instance, definitions=defs)
+
+        # Upon evaluation, we should not get a run request for the asset check.
+        result = sensor(context)
+        assert isinstance(result, SkipReason)
+        # Cursor should be None, since we made it through all assets.
+        assert context.cursor is None
+
+
+def test_sensor_eval_failed_and_outdated(instance: DagsterInstance) -> None:
+    """Test the case where the asset check has previously failed, but the result is now out of date. We should kick off a new check evaluation."""
+
+    @asset
+    def my_asset():
+        pass
+
+    freshness_checks = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+
+    frozen_time = get_current_datetime()
+    with freeze_time(frozen_time - datetime.timedelta(minutes=5)):
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=my_asset.key,
+                check_name="freshness_check",
+                passed=False,
+                metadata={},
+            )
+        )
+    # Freshness check has previously failed, but we've since received a materialization for the asset making it out of date.
+    with freeze_time(frozen_time):
+        instance.report_runless_asset_event(AssetMaterialization(asset_key=my_asset.key))
+        sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
+        defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
+        context = build_sensor_context(instance=instance, definitions=defs)
+
+        # Upon evaluation, we should get a run request for the asset check.
+        run_request = sensor(context)
+        assert isinstance(run_request, RunRequest)
+        assert run_request.asset_check_keys == [AssetCheckKey(my_asset.key, "freshness_check")]
+        # Cursor should be None, since we made it through all assets.
+        assert context.cursor is None
+
+
+def test_sensor_eval_planned_and_launched_by_sensor(instance: DagsterInstance) -> None:
+    """Test the case where the asset check is currently planned to evaluate, but the sensor is what launched the in-flight evaluation. We should not kick off a new evaluation."""
+
+    @asset
+    def my_asset():
+        pass
+
+    freshness_checks = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+    sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks, name="my_sensor")
+    defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
+
+    frozen_time = get_current_datetime()
+    with freeze_time(frozen_time - datetime.timedelta(minutes=5)):
+        run_id = make_new_run_id()
+        # Create a run, simulate started by this sensor
+        create_run_for_test(
+            instance=instance,
+            run_id=run_id,
+            job_name="my_sensor",
+            tags={SENSOR_NAME_TAG: "my_sensor"},
+        )
+        instance.event_log_storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id=run_id,
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluationPlanned(
+                        asset_key=my_asset.key, check_name="freshness_check"
+                    ),
+                ),
+            )
+        )
+
+    with freeze_time(frozen_time):
+        context = build_sensor_context(instance=instance, definitions=defs)
+        skip_reason = sensor(context)
+        assert isinstance(skip_reason, SkipReason)
+
+
+def test_sensor_eval_success_and_outdated(instance: DagsterInstance) -> None:
+    """Test the case where the asset check has previously succeeded, but the result is now out of date. We should not kick off an evaluation unless FRESH_UNTIL_TIMESTAMP has passed."""
+
+    @asset
+    def my_asset():
+        pass
+
+    freshness_checks = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+
+    frozen_time = get_current_datetime()
+    with freeze_time(frozen_time - datetime.timedelta(minutes=5)):
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=my_asset.key,
+                check_name="freshness_check",
+                passed=True,
+                metadata={
+                    FRESH_UNTIL_METADATA_KEY: FloatMetadataValue(
+                        (frozen_time + datetime.timedelta(minutes=5)).timestamp()
+                    )
+                },
+            )
+        )
+    # Freshness check has previously succeeded, but we've since received a materialization for the asset making it out of date.
+    with freeze_time(frozen_time):
+        instance.report_runless_asset_event(AssetMaterialization(asset_key=my_asset.key))
+        sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
+        defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
+        context = build_sensor_context(instance=instance, definitions=defs)
+
+        # Upon evaluation, we should not get a run request for the asset check.
+        skip_reason = sensor(context)
+        assert isinstance(skip_reason, SkipReason)
         # Cursor should be None, since we made it through all assets.
         assert context.cursor is None
 


### PR DESCRIPTION
## Summary & Motivation
Attempts to fix tickets for freshness checks: https://linear.app/dagster-labs/issue/BUILD-527/%5Bfreshness-sensor%5D-check-for-newer-materialization-when-last-check and https://linear.app/dagster-labs/issue/BUILD-528/%5Bfreshness-sensor%5D-catch-long-runtime-issues-even-when-checks-are#comment-8cfd22cb.

The exact cases in question:
- When the asset becomes overdue because the evaluation is taking too long, and there is a planned freshness check evaluation as part of the run, we should still kick off a run of the check so that users can get alerted.
- When there's a materialization more recent than the latest check result, kick off another evaluation of the check.

## How I Tested These Changes
I added new tests for the previously failing cases.

## Changelog
[bugfixes]
- Previously, the freshness check sensor would not re-evaluate freshness checks if an in-flight run was planning on evaluating that check. Now, the freshness check sensor will kick off an independent run of the check, even if there's already an in flight run, as long as the freshness check can potentially fail.
- Previously, if the freshness check was in a failing state, the sensor would wait for a run of some sort to update the freshness check before re-evaluating. Now, if there's a materialization later than the last evaluation of the freshness check and no planned evaluation, we will re-evaluate the freshness check automatically.
