### PR TITLE
[componenet] Enable dsl access to os.environ as var

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -8,6 +8,8 @@ from dagster._core.errors import DagsterError
 from dagster._utils import snakecase
 from typing_extensions import Self
 
+from dagster_components.core.templated_param_resolver import TemplatedParamResolver
+
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
 
@@ -72,18 +74,28 @@ def register_components_in_module(registry: ComponentRegistry, root_module: Modu
 
 
 class ComponentLoadContext:
-    def __init__(self, *, resources: Mapping[str, object], registry: ComponentRegistry):
+    def __init__(
+        self,
+        *,
+        resources: Mapping[str, object],
+        registry: ComponentRegistry,
+        param_resolver: TemplatedParamResolver,
+    ):
         self.registry = registry
         self.resources = resources
+        self.param_resolver = param_resolver
 
     @staticmethod
     def for_test(
         *,
         resources: Optional[Mapping[str, object]] = None,
         registry: Optional[ComponentRegistry] = None,
+        param_resolver: Optional[TemplatedParamResolver] = None,
     ) -> "ComponentLoadContext":
         return ComponentLoadContext(
-            resources=resources or {}, registry=registry or ComponentRegistry.empty()
+            resources=resources or {},
+            registry=registry or ComponentRegistry.empty(),
+            param_resolver=param_resolver or TemplatedParamResolver({}),
         )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -21,6 +21,7 @@ from dagster_components.core.component_decl_builder import (
     path_to_decl_node,
 )
 from dagster_components.core.deployment import CodeLocationProjectContext
+from dagster_components.core.templated_param_resolver import TemplatedParamResolver
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -94,7 +95,11 @@ def build_defs_from_component_path(
     resources: Mapping[str, object],
 ) -> "Definitions":
     """Build a definitions object from a folder within the components hierarchy."""
-    context = ComponentLoadContext(resources=resources, registry=registry)
+    context = ComponentLoadContext(
+        resources=resources,
+        registry=registry,
+        param_resolver=TemplatedParamResolver.with_os_environ_as_vars(),
+    )
 
     decl_node = path_to_decl_node(path=path)
     if not decl_node:

--- a/python_modules/libraries/dagster-components/dagster_components/core/templated_param_resolver.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/templated_param_resolver.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping, Optional
 
@@ -7,6 +8,13 @@ from jinja2 import Template
 class TemplatedParamResolver:
     def __init__(self, context_vars: Mapping[str, Any]):
         self.context_vars = context_vars
+
+    @staticmethod
+    def with_os_environ_as_vars() -> "TemplatedParamResolver":
+        def _env(name: str) -> Optional[str]:
+            return os.environ.get(name)
+
+        return TemplatedParamResolver({"env": _env})
 
     @contextmanager
     def with_context_vars(

--- a/python_modules/libraries/dagster-components/dagster_components/impls/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/impls/dbt_project.py
@@ -47,14 +47,14 @@ class DbtProjectComponentTranslator(DagsterDbtTranslator):
     def __init__(
         self,
         *,
-        translator_params: Optional[DbtNodeTranslatorParams] = None,
+        translator_params: DbtNodeTranslatorParams,
+        param_resolver: TemplatedParamResolver,
     ):
         self.translator_params = translator_params
-        # TODO thread from above
-        self.param_resolver = TemplatedParamResolver({})
+        self.param_resolver = param_resolver
 
     def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-        if not self.translator_params or not self.translator_params.key:
+        if not self.translator_params.key:
             return super().get_asset_key(dbt_resource_props)
 
         return AssetKey.from_user_string(
@@ -64,7 +64,7 @@ class DbtProjectComponentTranslator(DagsterDbtTranslator):
         )
 
     def get_group_name(self, dbt_resource_props) -> Optional[str]:
-        if not self.translator_params or not self.translator_params.group:
+        if not self.translator_params.group:
             return super().get_group_name(dbt_resource_props)
 
         return self.param_resolver.resolve_with_kwargs(
@@ -100,7 +100,8 @@ class DbtProjectComponent(Component):
             dbt_resource=loaded_params.dbt,
             op_spec=loaded_params.op,
             dbt_translator=DbtProjectComponentTranslator(
-                translator_params=loaded_params.translator
+                translator_params=loaded_params.translator or DbtNodeTranslatorParams(),
+                param_resolver=context.param_resolver,
             ),
         )
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -1,6 +1,7 @@
 from dagster import AssetKey, DagsterInstance
 from dagster_components import __component_registry__
 from dagster_components.core.component import Component, ComponentLoadContext, ComponentRegistry
+from dagster_components.core.templated_param_resolver import TemplatedParamResolver
 
 
 def registry() -> ComponentRegistry:
@@ -8,7 +9,9 @@ def registry() -> ComponentRegistry:
 
 
 def script_load_context() -> ComponentLoadContext:
-    return ComponentLoadContext(registry=registry(), resources={})
+    return ComponentLoadContext.for_test(
+        registry=registry(), param_resolver=TemplatedParamResolver.with_os_environ_as_vars()
+    )
 
 
 def get_asset_keys(component: Component) -> set[AssetKey]:


### PR DESCRIPTION
## Summary & Motivation

Make the environment variables available to the components DSL as `var`.

This means you can do things like this:

```yaml
type: dbt_project
params:
  dbt:
    project_dir: jaffle_shop
    translator:
       key: "{{ var('SOME_ENV') }}/{{ node.name }}"
```

The choice of `var` is deliberate as it provides some option value to source from things that are not environment variables in the future. Could also be something like `secret`.

## How I Tested These Changes

BK