### PR TITLE
Add value flag to disable check-db-ready initContainers in Helm chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -94,6 +94,7 @@ class Daemon(BaseModel, extra="forbid"):
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
+    checkDbReadyInitContainer: Optional[bool] = None
     livenessProbe: kubernetes.LivenessProbe
     readinessProbe: kubernetes.ReadinessProbe
     startupProbe: kubernetes.StartupProbe

--- a/helm/dagster/schema/schema/charts/dagster/subschema/flower.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/flower.py
@@ -13,6 +13,7 @@ class Flower(BaseModel):
     tolerations: kubernetes.Tolerations
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
+    checkDbReadyInitContainer: Optional[bool] = None
     resources: kubernetes.Resources
     livenessProbe: kubernetes.LivenessProbe
     startupProbe: kubernetes.StartupProbe

--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -40,6 +40,7 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
+    checkDbReadyInitContainer: Optional[bool] = None
     livenessProbe: kubernetes.LivenessProbe
     volumeMounts: List[kubernetes.VolumeMount]
     volumes: List[kubernetes.Volume]

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -34,6 +34,7 @@ class Webserver(BaseModel, extra="forbid"):
     tolerations: kubernetes.Tolerations
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
+    checkDbReadyInitContainer: bool
     resources: kubernetes.Resources
     readinessProbe: kubernetes.ReadinessProbe
     livenessProbe: kubernetes.LivenessProbe

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -34,7 +34,7 @@ class Webserver(BaseModel, extra="forbid"):
     tolerations: kubernetes.Tolerations
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
-    checkDbReadyInitContainer: bool
+    checkDbReadyInitContainer: Optional[bool] = None
     resources: kubernetes.Resources
     readinessProbe: kubernetes.ReadinessProbe
     livenessProbe: kubernetes.LivenessProbe

--- a/helm/dagster/schema/schema_tests/test_celery_queues.py
+++ b/helm/dagster/schema/schema_tests/test_celery_queues.py
@@ -310,6 +310,7 @@ def test_scheduler_name(deployment_template: HelmTemplate):
 
 
 def test_check_db_container_toggle(deployment_template: HelmTemplate):
+    # Off test
     helm_values = DagsterHelmValues.construct(
         runLauncher=RunLauncher(
             type=RunLauncherType.CELERY,
@@ -325,6 +326,7 @@ def test_check_db_container_toggle(deployment_template: HelmTemplate):
         container.name for container in daemon_deployment.spec.template.spec.init_containers
     ]
 
+    # On test
     helm_values = DagsterHelmValues.construct(
         runLauncher=RunLauncher(
             type=RunLauncherType.CELERY,
@@ -332,6 +334,20 @@ def test_check_db_container_toggle(deployment_template: HelmTemplate):
                 celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct(
                     checkDbReadyInitContainer=True
                 )
+            ),
+        )
+    )
+    [daemon_deployment] = deployment_template.render(helm_values)
+    assert "check-db-ready" in [
+        container.name for container in daemon_deployment.spec.template.spec.init_containers
+    ]
+
+    # Default test
+    helm_values = DagsterHelmValues.construct(
+        runLauncher=RunLauncher(
+            type=RunLauncherType.CELERY,
+            config=RunLauncherConfig(
+                celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct()
             ),
         )
     )

--- a/helm/dagster/schema/schema_tests/test_celery_queues.py
+++ b/helm/dagster/schema/schema_tests/test_celery_queues.py
@@ -346,9 +346,7 @@ def test_check_db_container_toggle(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(
         runLauncher=RunLauncher(
             type=RunLauncherType.CELERY,
-            config=RunLauncherConfig(
-                celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct()
-            ),
+            config=RunLauncherConfig(celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct()),
         )
     )
     [daemon_deployment] = deployment_template.render(helm_values)

--- a/helm/dagster/schema/schema_tests/test_celery_queues.py
+++ b/helm/dagster/schema/schema_tests/test_celery_queues.py
@@ -307,3 +307,35 @@ def test_scheduler_name(deployment_template: HelmTemplate):
 
     deployment = celery_queue_deployments[0]
     assert deployment.spec.template.spec.scheduler_name == "custom"
+
+
+def test_check_db_container_toggle(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        runLauncher=RunLauncher(
+            type=RunLauncherType.CELERY,
+            config=RunLauncherConfig(
+                celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct(
+                    checkDbReadyInitContainer=False
+                )
+            ),
+        )
+    )
+    [daemon_deployment] = deployment_template.render(helm_values)
+    assert daemon_deployment.spec.template.spec.init_containers is None or "check-db-ready" not in [
+        container.name for container in daemon_deployment.spec.template.spec.init_containers
+    ]
+
+    helm_values = DagsterHelmValues.construct(
+        runLauncher=RunLauncher(
+            type=RunLauncherType.CELERY,
+            config=RunLauncherConfig(
+                celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct(
+                    checkDbReadyInitContainer=True
+                )
+            ),
+        )
+    )
+    [daemon_deployment] = deployment_template.render(helm_values)
+    assert "check-db-ready" in [
+        container.name for container in daemon_deployment.spec.template.spec.init_containers
+    ]

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -622,9 +622,7 @@ def test_check_db_container_toggle(deployment_template: HelmTemplate):
     ]
 
     # Default test
-    helm_values = DagsterHelmValues.construct(
-        dagsterWebserver=Webserver.construct()
-    )
+    helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())
     [webserver_deployment] = deployment_template.render(helm_values)
     assert "check-db-ready" in [
         container.name for container in webserver_deployment.spec.template.spec.init_containers

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -596,3 +596,25 @@ def test_env_configmap(configmap_template):
     assert len(cm.data) == 6
     assert cm.data["DAGSTER_HOME"] == "/opt/dagster/dagster_home"
     assert cm.data["TEST_ENV"] == "test_value"
+
+
+def test_check_db_container_toggle(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(checkDbReadyInitContainer=False)
+    )
+    [webserver_deployment] = deployment_template.render(helm_values)
+    assert (
+        webserver_deployment.spec.template.spec.init_containers is None
+        or "check-db-ready"
+        not in [
+            container.name for container in webserver_deployment.spec.template.spec.init_containers
+        ]
+    )
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(checkDbReadyInitContainer=True)
+    )
+    [webserver_deployment] = deployment_template.render(helm_values)
+    assert "check-db-ready" in [
+        container.name for container in webserver_deployment.spec.template.spec.init_containers
+    ]

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -599,6 +599,7 @@ def test_env_configmap(configmap_template):
 
 
 def test_check_db_container_toggle(deployment_template: HelmTemplate):
+    # Off test
     helm_values = DagsterHelmValues.construct(
         dagsterWebserver=Webserver.construct(checkDbReadyInitContainer=False)
     )
@@ -611,8 +612,18 @@ def test_check_db_container_toggle(deployment_template: HelmTemplate):
         ]
     )
 
+    # On test
     helm_values = DagsterHelmValues.construct(
         dagsterWebserver=Webserver.construct(checkDbReadyInitContainer=True)
+    )
+    [webserver_deployment] = deployment_template.render(helm_values)
+    assert "check-db-ready" in [
+        container.name for container in webserver_deployment.spec.template.spec.init_containers
+    ]
+
+    # Default test
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct()
     )
     [webserver_deployment] = deployment_template.render(helm_values)
     assert "check-db-ready" in [

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -682,6 +682,7 @@ def test_env_configmap(env_configmap_template):
 
 
 def test_check_db_container_toggle(template: HelmTemplate):
+    # Off test
     helm_values = DagsterHelmValues.construct(
         dagsterDaemon=Daemon.construct(checkDbReadyInitContainer=False)
     )
@@ -690,8 +691,18 @@ def test_check_db_container_toggle(template: HelmTemplate):
         container.name for container in daemon_deployment.spec.template.spec.init_containers
     ]
 
+    # On test
     helm_values = DagsterHelmValues.construct(
         dagsterDaemon=Daemon.construct(checkDbReadyInitContainer=True)
+    )
+    [daemon_deployment] = template.render(helm_values)
+    assert "check-db-ready" in [
+        container.name for container in daemon_deployment.spec.template.spec.init_containers
+    ]
+
+    # Default test
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct()
     )
     [daemon_deployment] = template.render(helm_values)
     assert "check-db-ready" in [

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -701,9 +701,7 @@ def test_check_db_container_toggle(template: HelmTemplate):
     ]
 
     # Default test
-    helm_values = DagsterHelmValues.construct(
-        dagsterDaemon=Daemon.construct()
-    )
+    helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())
     [daemon_deployment] = template.render(helm_values)
     assert "check-db-ready" in [
         container.name for container in daemon_deployment.spec.template.spec.init_containers

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -40,12 +40,14 @@ spec:
       securityContext:
         {{- toYaml $celeryK8sRunLauncherConfig.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if $celeryK8sRunLauncherConfig.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" $ | squote }}]
           securityContext:
             {{- toYaml $celeryK8sRunLauncherConfig.securityContext | nindent 12 }}
+        {{- end }}
         {{- if $.Values.rabbitmq.enabled }}
         - name: check-rabbitmq-ready
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -49,6 +49,7 @@ spec:
       securityContext:
         {{- toYaml .Values.dagsterDaemon.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if .Values.dagsterDaemon.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: {{ include "dagster.externalImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
@@ -57,6 +58,7 @@ spec:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.dagsterDaemon.initContainerResources | nindent 12 }}
+        {{- end }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -36,12 +36,14 @@ spec:
       securityContext:
       {{- toYaml .Values.flower.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if .Values.flower.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml .Values.flower.securityContext | nindent 12 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -47,6 +47,7 @@ spec:
       securityContext:
         {{- toYaml $_.Values.dagsterWebserver.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if .Values.dagsterWebserver.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: {{ include "dagster.externalImage.name" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
@@ -57,6 +58,7 @@ spec:
           resources:
             {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -216,6 +216,18 @@
                 "resources": {
                     "$ref": "#/$defs/Resources"
                 },
+                "checkDbReadyInitContainer": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Checkdbreadyinitcontainer"
+                },
                 "livenessProbe": {
                     "$ref": "#/$defs/LivenessProbe"
                 },
@@ -647,6 +659,18 @@
                 "resources": {
                     "$ref": "#/$defs/Resources"
                 },
+                "checkDbReadyInitContainer": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Checkdbreadyinitcontainer"
+                },
                 "livenessProbe": {
                     "$ref": "#/$defs/LivenessProbe"
                 },
@@ -836,6 +860,18 @@
                 },
                 "securityContext": {
                     "$ref": "#/$defs/SecurityContext"
+                },
+                "checkDbReadyInitContainer": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Checkdbreadyinitcontainer"
                 },
                 "resources": {
                     "$ref": "#/$defs/Resources"
@@ -3136,6 +3172,18 @@
                 },
                 "securityContext": {
                     "$ref": "#/$defs/SecurityContext"
+                },
+                "checkDbReadyInitContainer": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Checkdbreadyinitcontainer"
                 },
                 "resources": {
                     "$ref": "#/$defs/Resources"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -165,6 +165,10 @@ dagsterWebserver:
 
   # Configure initContainer resources separately from main container
   initContainerResources: {}
+
+  # Enable the check-db-ready initContainer
+  checkDbReadyInitContainer: true
+
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -689,6 +693,8 @@ runLauncher:
       #     memory: 128Mi
       resources: {}
 
+      # Enable the check-db-ready initContainer
+      checkDbReadyInitContainer: true
       # Override the default K8s scheduler
       # schedulerName: ~
 
@@ -885,6 +891,8 @@ flower:
   podSecurityContext: {}
   securityContext: {}
 
+  # Enable the check-db-ready initContainer
+  checkDbReadyInitContainer: true
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -1219,6 +1227,8 @@ dagsterDaemon:
 
   # Configure initContainer resources separately from main container
   initContainerResources: {}
+  # Enable the check-db-ready initContainer
+  checkDbReadyInitContainer: true
   # Override the default K8s scheduler
   # schedulerName: ~
 


### PR DESCRIPTION
## Summary & Motivation

Address #26311 (partially) and #26284 (duplicate issues)

tl;dr: the `check-db-ready` container can be part of a race condition with other initContainers that are responsible for enabling the DB connection. Externally managed DBs (i.e. not the postgres container optionally included in this chart) can be validated before Helm installation so this step is not strictly required.

## How I Tested These Changes

1. Wrote some tests
2. Installed the chart to minikube with
```
helm install dagster . --set dagsterWebserver.image.tag=latest --set dagsterDaemon.image.tag=latest --set pipelineRun.image.tag=latest --set dagsterWebserver.checkDbReadyInitContainer=true
```
And observed the initContainers present. Then ran it again with `false`
```
helm install dagster . --set dagsterWebserver.image.tag=latest --set dagsterDaemon.image.tag=latest --set pipelineRun.image.tag=latest --set dagsterWebserver.checkDbReadyInitContainer=false
```
And observed the initContainers absent.

## Changelog

- Added flag `checkDbReadyInitContainer` to optionally disable db check initContainer.
