### PR TITLE
use context manager for sqlite table connection

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -113,7 +113,9 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def has_table(self, table_name: str) -> bool:
         engine = create_engine(self._conn_string, poolclass=NullPool)
-        return bool(engine.dialect.has_table(engine.connect(), table_name))
+        with engine.connect() as conn:
+            has_table = bool(engine.dialect.has_table(conn, table_name))
+        return has_table
 
     def get_db_path(self):
         return os.path.join(self._base_dir, f"{SQLITE_EVENT_LOG_FILENAME}.db")


### PR DESCRIPTION
## Summary & Motivation
Consolidated SQLite storage is probably not used outside of tests, but we're probably hanging connections / locking db files because we're not using the context manager for connections in these table checks.

## How I Tested These Changes
BK

## Changelog
- Fixed database locking bug for the `ConsolidatedSqliteEventLogStorage`, which is mostly used for tests.