### PR TITLE
[dagster-aws] correctly use image from task definition in ECSRunLauncher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -204,7 +204,7 @@ def get_task_definition_dict_from_current_task(
     ecs,
     family,
     current_task,
-    image,
+    image: str,
     container_name,
     environment,
     command=None,


### PR DESCRIPTION
## Summary & Motivation

Looks like #23337 introduced a regression by checking if the user has set `DAGSTER_CURRENT_IMAGE` in the code location too early.

This image is not used when a task definition is provided directly by the user (instead of generating one automatically), so this check was too early. 

I moved the check to the appropriate location, provided correct type annotations for the `image` argument to prevent similar confusion in the future, and improved the exception message to be more explicit. 

Resolve #26138

## How I Tested These Changes

## Changelog

[dagster-aws] Resolved a bug in the ECSRunLauncher that prevented it from accepting a user-provided task definition when DAGSTER_CURRENT_IMAGE was not set in the code location.