### PR TITLE
[components] create venv when scaffolding code location

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -61,6 +61,9 @@ def generate_code_location(path: str, editable_dagster_root: Optional[str] = Non
         uv_sources=uv_sources,
     )
 
+    # Build the venv
+    execute_code_location_command(Path(path), ("uv", "sync"))
+
 
 def generate_component_type(root_path: str, name: str) -> None:
     click.echo(f"Creating a Dagster component type at {root_path}/{name}.py.")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
@@ -142,6 +142,10 @@ def test_generate_code_location_inside_deployment_success() -> None:
         assert Path("code_locations/bar/bar_tests").exists()
         assert Path("code_locations/bar/pyproject.toml").exists()
 
+        # Check venv created
+        assert Path("code_locations/bar/.venv").exists()
+        assert Path("code_locations/bar/uv.lock").exists()
+
         # Commented out because we are always adding sources right now
         # with open("code_locations/bar/pyproject.toml") as f:
         #     toml = tomli.loads(f.read())
@@ -161,6 +165,10 @@ def test_generate_code_location_outside_deployment_success() -> None:
         assert Path("bar/bar/components").exists()
         assert Path("bar/bar_tests").exists()
         assert Path("bar/pyproject.toml").exists()
+
+        # Check venv created
+        assert Path("bar/.venv").exists()
+        assert Path("bar/uv.lock").exists()
 
 
 def _find_git_root():


### PR DESCRIPTION
## Summary & Motivation

Run `uv sync` to generate the virutal environment immediately after scaffolding a code location. This is a more natural place to run it than the first time you try to e.g. list component types.

## How I Tested These Changes

Unit tests.