### PR TITLE
[easy] fix graph test  + error message

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -446,8 +446,8 @@ def resolve_checked_op_fn_inputs(
         )
         raise DagsterInvalidDefinitionError(
             f"{decorator_name} '{fn_name}' decorated function does not have argument(s)"
-            f" '{undeclared_inputs_printed}'. {decorator_name}-decorated functions should have a"
-            f" keyword argument for each of their Ins{nothing_exemption}. Alternatively, they can"
+            f" '{undeclared_inputs_printed}'. {decorator_name}-decorated functions should have an"
+            f" argument for each of their Ins{nothing_exemption}. Alternatively, they can"
             " accept **kwargs."
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -1507,6 +1507,8 @@ def test_graph_inputs_error():
         def _(): ...
 
     except DagsterInvalidDefinitionError as err:
+        assert "'_' decorated function does not have argument(s) 'start'" in str(err)
+        # Ensure that dagster type code path doesn't throw since we're using Nothing type.
         assert "except for Ins that have the Nothing dagster_type" not in str(err)
 
     try:
@@ -1515,4 +1517,6 @@ def test_graph_inputs_error():
         def _(): ...
 
     except DagsterInvalidDefinitionError as err:
+        assert "'_' decorated function does not have argument(s) 'start'" in str(err)
+        # Ensure that dagster type code path doesn't throw since we're using Nothing type.
         assert "except for Ins that have the Nothing dagster_type" not in str(err)


### PR DESCRIPTION
I think this test was previously weird; we should be asserting on the expected error message, not the _lack_ of an error message. 

Also, fix the error message itself, the argument doesn't need to be a "keyword" argument. Just an argument.