### PR TITLE
[ui] Global AMP: Fix timeline pagination

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -7,7 +7,7 @@ import {
   Subtitle2,
   Table,
 } from '@dagster-io/ui-components';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
 import {AutomaterializationTickDetailDialog} from './AutomaterializationTickDetailDialog';
@@ -47,6 +47,7 @@ export const GlobalAutomaterializationContent = () => {
   const [isPaused, setIsPaused] = useState(false);
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
   const [timeRange, setTimerange] = useState<undefined | [number, number]>(undefined);
+
   const getVariables = useCallback(
     (now = Date.now()) => {
       if (timeRange || statuses) {
@@ -71,6 +72,11 @@ export const GlobalAutomaterializationContent = () => {
     async () => await fetch({variables: getVariables()}),
     [fetch, getVariables],
   );
+
+  // When the variables have changed (e.g. due to pagination), refresh.
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   useRefreshAtInterval({
     refresh,


### PR DESCRIPTION
## Summary & Motivation

In the global AMP view, the tick timeline is broken when paginating to older ticks. The (paginated) table view sets the parent's time range, but the time range isn't being used as a signal to refetch the list of ticks used by the timeline. Fix this with an effect.

## How I Tested These Changes

View AMP overview for Discord. Page backward in time, verify that the timeline updates with the correct ticks displayed.

## Changelog

[ui] Fix global auto-materialize tick timeline when paginating.
