### PR TITLE
[compute logs] shift interface to avoid over-reading

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -204,21 +204,23 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """
 
     @abstractmethod
-    def get_log_data(
+    def get_log_data_for_type(
         self,
         log_key: Sequence[str],
-        cursor: Optional[str] = None,
-        max_bytes: Optional[int] = None,
-    ) -> CapturedLogData:
-        """Returns a chunk of the captured stdout logs for a given log key.
+        io_type: ComputeIOType,
+        offset: int,
+        max_bytes: Optional[int],
+    ) -> Tuple[Optional[bytes], int]:
+        """Returns a chunk of the captured io_type logs for a given log key.
 
         Args:
             log_key (List[String]): The log key identifying the captured logs
-            cursor (Optional[str]): A cursor representing the position of the log chunk to fetch
+            io_type (ComputeIOType): stderr or stdout
+            offset (Optional[int]): An offset in to the log to start from
             max_bytes (Optional[int]): A limit on the size of the log chunk to fetch
 
         Returns:
-            CapturedLogData
+            Tuple[Optional[bytes], int]: The content read and offset in to the file
         """
 
     @abstractmethod
@@ -235,7 +237,9 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def delete_logs(
-        self, log_key: Optional[Sequence[str]] = None, prefix: Optional[Sequence[str]] = None
+        self,
+        log_key: Optional[Sequence[str]] = None,
+        prefix: Optional[Sequence[str]] = None,
     ) -> None:
         """Deletes the captured logs for a given log key.
 
@@ -269,6 +273,47 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def dispose(self):
         pass
 
+    def parse_cursor(self, cursor: Optional[str] = None) -> Tuple[int, int]:
+        # Translates a string cursor into a set of byte offsets for stdout, stderr
+        if not cursor:
+            return 0, 0
+
+        parts = cursor.split(":")
+        if not parts or len(parts) != 2:
+            return 0, 0
+
+        stdout, stderr = [int(_) for _ in parts]
+        return stdout, stderr
+
+    def build_cursor(self, stdout_offset: int, stderr_offset: int) -> str:
+        return f"{stdout_offset}:{stderr_offset}"
+
+    def get_log_data(
+        self,
+        log_key: Sequence[str],
+        cursor: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+    ) -> CapturedLogData:
+        stdout_offset, stderr_offset = self.parse_cursor(cursor)
+        stdout, new_stdout_offset = self.get_log_data_for_type(
+            log_key,
+            ComputeIOType.STDOUT,
+            stdout_offset,
+            max_bytes,
+        )
+        stderr, new_stderr_offset = self.get_log_data_for_type(
+            log_key,
+            ComputeIOType.STDERR,
+            stderr_offset,
+            max_bytes,
+        )
+        return CapturedLogData(
+            log_key=log_key,
+            stdout=stdout,
+            stderr=stderr,
+            cursor=self.build_cursor(new_stdout_offset, new_stderr_offset),
+        )
+
     def build_log_key_for_run(self, run_id: str, step_key: str) -> Sequence[str]:
         """Legacy adapter to translate run_id/key to captured log manager-based log_key."""
         return [run_id, "compute_logs", step_key]
@@ -282,20 +327,27 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError("Must implement get_log_keys_for_log_key_prefix")
 
     def _get_log_lines_for_log_key(
-        self, log_key: Sequence[str], io_type: ComputeIOType
+        self,
+        log_key: Sequence[str],
+        io_type: ComputeIOType,
     ) -> Sequence[str]:
         """For a log key, gets the corresponding file, and splits the file into lines."""
-        log_data = self.get_log_data(log_key)
-        if io_type == ComputeIOType.STDOUT:
-            raw_logs = log_data.stdout.decode("utf-8") if log_data.stdout else ""
-        else:
-            raw_logs = log_data.stderr.decode("utf-8") if log_data.stderr else ""
+        log_data, _ = self.get_log_data_for_type(
+            log_key,
+            io_type,
+            offset=0,
+            max_bytes=None,
+        )
+        raw_logs = log_data.decode("utf-8") if log_data else ""
         log_lines = raw_logs.split("\n")
 
         return log_lines
 
     def read_log_lines_for_log_key_prefix(
-        self, log_key_prefix: Sequence[str], cursor: Optional[str], io_type: ComputeIOType
+        self,
+        log_key_prefix: Sequence[str],
+        cursor: Optional[str],
+        io_type: ComputeIOType,
     ) -> Tuple[Sequence[str], Optional[LogLineCursor]]:
         """For a given directory defined by log_key_prefix that contains files, read the logs from the files
         as if they are a single continuous file. Reads env var DAGSTER_CAPTURED_LOG_CHUNK_SIZE lines at a time.
@@ -360,6 +412,8 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
                     )
 
         new_cursor = LogLineCursor(
-            log_key=log_keys[log_key_to_fetch_idx], line=line_cursor, has_more_now=has_more
+            log_key=log_keys[log_key_to_fetch_idx],
+            line=line_cursor,
+            has_more_now=has_more,
         )
         return records, new_cursor

--- a/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
@@ -1,12 +1,11 @@
 from contextlib import contextmanager
-from typing import IO, Any, Generator, Mapping, Optional, Sequence
+from typing import IO, Any, Generator, Mapping, Optional, Sequence, Tuple
 
 from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.storage.compute_log_manager import (
     CapturedLogContext,
-    CapturedLogData,
     CapturedLogMetadata,
     CapturedLogSubscription,
     ComputeIOType,
@@ -48,13 +47,14 @@ class NoOpComputeLogManager(ComputeLogManager, ConfigurableClass):
     ) -> Generator[Optional[IO], None, None]:
         yield None
 
-    def get_log_data(
+    def get_log_data_for_type(
         self,
         log_key: Sequence[str],
-        cursor: Optional[str] = None,
-        max_bytes: Optional[int] = None,
-    ) -> CapturedLogData:
-        return CapturedLogData(log_key=log_key)
+        io_type: ComputeIOType,
+        offset: int,
+        max_bytes: Optional[int],
+    ) -> Tuple[Optional[bytes], int]:
+        return None, 0
 
     def get_log_metadata(self, log_key: Sequence[str]) -> CapturedLogMetadata:
         return CapturedLogMetadata()

--- a/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
@@ -1,6 +1,6 @@
 import tempfile
 from contextlib import contextmanager
-from typing import IO, Generator, Optional, Sequence
+from typing import IO, Generator, Optional, Sequence, Tuple
 
 import dagster._check as check
 from dagster import job, op
@@ -9,7 +9,6 @@ from dagster._core.launcher import DefaultRunLauncher
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.storage.compute_log_manager import (
     CapturedLogContext,
-    CapturedLogData,
     CapturedLogMetadata,
     CapturedLogSubscription,
     ComputeIOType,
@@ -45,13 +44,14 @@ class BrokenComputeLogManager(ComputeLogManager):
     def is_capture_complete(self, log_key: Sequence[str]) -> bool:
         return True
 
-    def get_log_data(
+    def get_log_data_for_type(
         self,
         log_key: Sequence[str],
-        cursor: Optional[str] = None,
-        max_bytes: Optional[int] = None,
-    ) -> CapturedLogData:
-        return CapturedLogData(log_key=log_key)
+        io_type: ComputeIOType,
+        offset: int,
+        max_bytes: Optional[int],
+    ) -> Tuple[Optional[bytes], int]:
+        return None, 0
 
     def get_log_metadata(self, log_key: Sequence[str]) -> CapturedLogMetadata:
         return CapturedLogMetadata()

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -329,7 +329,7 @@ def test_storage_download_url_fallback(gcs_bucket):
                 write_stream.write("hello hello")
 
             # can read bytes
-            log_data, _ = manager.log_data_for_type(log_key, ComputeIOType.STDERR, 0, None)
+            log_data, _ = manager.get_log_data_for_type(log_key, ComputeIOType.STDERR, 0, None)
             assert log_data.decode("utf-8") == "hello hello"
 
             url = manager.download_url_for_type(log_key, ComputeIOType.STDERR)


### PR DESCRIPTION
While working with backfill logs locally i observed that we were doing a very large number of existtance checks for `stdout` files that we didnt even want.

To avoid this I moved around some effectively duplicate code to the base class and made it so that we can fetch the data for only the stream we care about.

## How I Tested These Changes

existing coverage 