### PR TITLE
Rename run group side bar to Re-executions instead of the job name

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
@@ -96,7 +96,7 @@ export const RunGroupPanel = ({
   });
 
   return (
-    <SidebarSection title={runs[0] ? `${runs[0].pipelineName} (${runs.length})` : ''}>
+    <SidebarSection title={runs[0] ? `Retries (${runs.length - 1})` : ''}>
       <>
         {runs.map((g, idx) =>
           g ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
@@ -96,7 +96,7 @@ export const RunGroupPanel = ({
   });
 
   return (
-    <SidebarSection title={runs[0] ? `Retries (${runs.length - 1})` : ''}>
+    <SidebarSection title={runs[0] ? `Re-executions (${runs.length - 1})` : ''}>
       <>
         {runs.map((g, idx) =>
           g ? (


### PR DESCRIPTION
## Summary & Motivation
During dogfooding of some changes to retry logic, @anuthebananu pointed out that the title for the lineage of retried runs was a bit confusing. It's currently the name of the job, which for asset jobs leaks the internal  `__ASSET_JOB` name 
<img width="630" alt="Screenshot 2024-12-09 at 3 01 30 PM" src="https://github.com/user-attachments/assets/8f5841b8-9ea7-4a14-93ec-d373dc8d56a8">

This PR renames it `Re-executions`. 
<img width="572" alt="Screenshot 2024-12-12 at 11 28 57 AM" src="https://github.com/user-attachments/assets/43feabc3-febe-4573-8b33-9299c722bf4e" />


## How I Tested These Changes

## Changelog

Renamed the run lineage sidebar on the Run details page to `Re-executions`. 
