### PR TITLE
change backfill log message when waiting for runs to retry

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -57,6 +57,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
     BACKFILL_ID_TAG,
     PARTITION_NAME_TAG,
+    WILL_RETRY_TAG,
 )
 from dagster._core.utils import make_new_run_id, toposort
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
@@ -968,16 +969,19 @@ def backfill_is_complete(
         run.run_id
         for run in instance.get_runs(
             filters=RunsFilter(
-                tags={BACKFILL_ID_TAG: backfill_id},
+                tags={BACKFILL_ID_TAG: backfill_id, WILL_RETRY_TAG: "true"},
                 statuses=[DagsterRunStatus.FAILURE],
             )
         )
         if run.is_complete_and_waiting_to_retry
     ]
     if len(runs_waiting_to_retry) > 0:
-        formatted_runs = "\n".join(runs_waiting_to_retry)
+        num_runs_to_log = 50
+        formatted_runs = "\n".join(runs_waiting_to_retry[:num_runs_to_log])
+        if len(runs_waiting_to_retry) > num_runs_to_log:
+            formatted_runs += f"\n... {len(runs_waiting_to_retry) - num_runs_to_log} more"
         logger.info(
-            f"The following runs for the backfill will be retried, but have not been launched. Backfill is still in progress:\n{formatted_runs}"
+            f"The following runs for the backfill will be retried, but retries have not been launched. Backfill is still in progress:\n{formatted_runs}"
         )
         return False
     return True

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -964,19 +964,20 @@ def backfill_is_complete(
         logger.info("Backfill has in progress runs. Backfill is still in progress.")
         return False
     # Condition 3 - if there are runs that will be retried, but have not yet been retried, the backfill is not complete
-    if any(
-        [
-            run.is_complete_and_waiting_to_retry
-            for run in instance.get_runs(
-                filters=RunsFilter(
-                    tags={BACKFILL_ID_TAG: backfill_id},
-                    statuses=[DagsterRunStatus.FAILURE],
-                )
+    runs_waiting_to_retry = [
+        run.run_id
+        for run in instance.get_runs(
+            filters=RunsFilter(
+                tags={BACKFILL_ID_TAG: backfill_id},
+                statuses=[DagsterRunStatus.FAILURE],
             )
-        ]
-    ):
+        )
+        if run.is_complete_and_waiting_to_retry
+    ]
+    if len(runs_waiting_to_retry) > 0:
+        formatted_runs = "\n".join(runs_waiting_to_retry)
         logger.info(
-            "Some runs for the backfill will be retried, but have not been launched. Backfill is still in progress."
+            f"The following runs for the backfill will be retried, but have not been launched. Backfill is still in progress:\n{formatted_runs}"
         )
         return False
     return True

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -976,7 +976,7 @@ def backfill_is_complete(
         if run.is_complete_and_waiting_to_retry
     ]
     if len(runs_waiting_to_retry) > 0:
-        num_runs_to_log = 50
+        num_runs_to_log = 20
         formatted_runs = "\n".join(runs_waiting_to_retry[:num_runs_to_log])
         if len(runs_waiting_to_retry) > num_runs_to_log:
             formatted_runs += f"\n... {len(runs_waiting_to_retry) - num_runs_to_log} more"


### PR DESCRIPTION
## Summary & Motivation
Updates the log message when a backfill is waiting for runs to retry to log the run ids it is waiting on. 

## How I Tested These Changes
forced a backfill into a situation where these logs get printed. output
```
2024-12-09 15:40:44 -0500 - dagster.daemon.BackfillDaemon - INFO - The following runs for the backfill will be retried, but have not been launched. Backfill is still in progress:
1908f288-6c03-4620-92ec-36b8fb24888e
af189906-96ba-467d-9ea0-d74be361a880
9a98a638-2ab5-4cd0-8d27-02cf40352adc
```


