### PR TITLE
[ui] Avoid a “0 partitions” tag when an un-partitioned asset is backfilled

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -238,7 +238,7 @@ const BackfillRequestedRange = ({
 }) => {
   const {partitionNames, numPartitions} = backfill;
 
-  if (numPartitions === null) {
+  if (numPartitions === null || numPartitions === 0) {
     return <span />;
   }
 


### PR DESCRIPTION
## Summary & Motivation

This is a tiny fix for https://linear.app/dagster-labs/issue/FE-703/backfill-table-non-partitioned-assets-show-0-partitions

## How I Tested These Changes

I verified this manually, but I don't think it's worth writing a test for it because this backfills page may be getting folded away into the runs feed soon. Also verified that the new runs feed doesn't have this issue.

