### PR TITLE
[ui] Make sensor and schedule links from the run feed list clickable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {CreatedByTagCell, CreatedByTagCellWrapper} from './CreatedByTag';
+import {CreatedByTagCell} from './CreatedByTag';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
@@ -29,6 +29,7 @@ import {BackfillActionsMenu, backfillCanCancelRuns} from '../instance/backfill/B
 import {BackfillTarget} from '../instance/backfill/BackfillRow';
 import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
 import {appendCurrentQueryParams} from '../util/appendCurrentQueryParams';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 export const RunsFeedRow = ({
   entry,
@@ -59,6 +60,16 @@ export const RunsFeedRow = ({
   };
 
   const isReexecution = entry.tags.some((tag) => tag.key === DagsterTag.ParentRunId);
+  const repoAddress = React.useMemo(
+    () =>
+      entry.__typename === 'Run' && entry.repositoryOrigin
+        ? buildRepoAddress(
+            entry.repositoryOrigin.repositoryName,
+            entry.repositoryOrigin.repositoryLocationName,
+          )
+        : null,
+    [entry],
+  );
 
   const [showQueueCriteria, setShowQueueCriteria] = React.useState(false);
   const [isHovered, setIsHovered] = React.useState(false);
@@ -135,7 +146,7 @@ export const RunsFeedRow = ({
               <RunTargetLink
                 isJob={true}
                 run={{...entry, pipelineName: entry.jobName!, stepKeysToExecute: []}}
-                repoAddress={null}
+                repoAddress={repoAddress}
               />
             ) : (
               <BackfillTarget backfill={entry} repoAddress={null} />
@@ -144,7 +155,7 @@ export const RunsFeedRow = ({
         </Tag>
       </RowCell>
       <RowCell>
-        <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} />
+        <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} repoAddress={repoAddress} />
       </RowCell>
       <RowCell>
         <div>
@@ -211,10 +222,4 @@ const RowGrid = styled(Box)`
   display: grid;
   grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
-  .bp5-popover-target {
-    display: block;
-  }
-  ${CreatedByTagCellWrapper} {
-    display: block;
-  }
 `;


### PR DESCRIPTION
## Summary & Motivation

This is a small fix for https://linear.app/dagster-labs/issue/FE-707/clickable-launched-by-column-for-runs-feed

I also discussed the removal of the `display:block` with Marco, it fixes the centering of the popover menu and truncation still works with it gone. Hypothesis is that the change we made to the RowCell default styling fixed it.

![image](https://github.com/user-attachments/assets/1699eb34-8196-49eb-a4dd-d3c6ef0a6950)


## How I Tested These Changes

## Changelog

[ui] Sensors and schedules that appear in the runs feed are now clickable