### PR TITLE
add nothing input def

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -246,12 +246,12 @@ def asset_check(
             named_ins_by_asset_key=named_in_by_asset_key,
             named_outs_by_asset_key={},
             internal_deps={},
-            op_name=spec.get_python_identifier(),
+            node_name=spec.get_python_identifier(),
             args=builder_args,
             fn=fn,
         )
 
-        op_def = builder.create_op_definition()
+        op_def = builder.create_node_definition()
 
         return AssetChecksDefinition.create(
             keys_by_input_name={

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -767,6 +767,7 @@ def graph_asset(
     code_version: Optional[str] = None,
     key: Optional[CoercibleToAssetKey] = None,
     kinds: Optional[AbstractSet[str]] = None,
+    specs: Optional[Sequence[AssetSpec]] = None,
     **kwargs,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Creates a software-defined asset that's computed using a graph of ops.
@@ -861,6 +862,7 @@ def graph_asset(
             code_version=code_version,
             key=key,
             kinds=kinds,
+            specs=specs,
         )
     else:
         return graph_asset_no_defaults(
@@ -885,6 +887,7 @@ def graph_asset(
             code_version=code_version,
             key=key,
             kinds=kinds,
+            specs=specs,
         )
 
 
@@ -909,9 +912,11 @@ def graph_asset_no_defaults(
     code_version: Optional[str],
     key: Optional[CoercibleToAssetKey],
     kinds: Optional[AbstractSet[str]],
+    specs: Optional[Sequence[AssetSpec]],
 ) -> AssetsDefinition:
     ins = ins or {}
     named_ins = build_named_ins(compose_fn, ins or {}, set())
+    if specs is None:
     out_asset_key, _asset_name = resolve_asset_key_and_name_for_decorator(
         key=key,
         key_prefix=key_prefix,
@@ -987,6 +992,7 @@ def graph_multi_asset(
     can_subset: bool = False,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
+    asset_specs: Optional[Sequence[AssetSpec]] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same graph of

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -250,13 +250,13 @@ class DecoratorAssetsDefinitionBuilder:
         named_ins_by_asset_key: Mapping[AssetKey, NamedIn],
         named_outs_by_asset_key: Mapping[AssetKey, NamedOut],
         internal_deps: Mapping[AssetKey, Set[AssetKey]],
-        op_name: str,
+        node_name: str,
         args: DecoratorAssetsDefinitionBuilderArgs,
         fn: Callable[..., Any],
     ) -> None:
         self.named_outs_by_asset_key = named_outs_by_asset_key
         self.internal_deps = internal_deps
-        self.op_name = op_name
+        self.node_name = node_name
         self.args = args
         self.fn = fn
 
@@ -385,7 +385,7 @@ class DecoratorAssetsDefinitionBuilder:
             named_ins_by_asset_key=named_ins_by_asset_key,
             named_outs_by_asset_key=named_outs_by_asset_key,
             internal_deps=internal_deps,
-            op_name=op_name,
+            node_name=op_name,
             args=passed_args,
             fn=fn,
         )
@@ -452,7 +452,7 @@ class DecoratorAssetsDefinitionBuilder:
             named_ins_by_asset_key=named_ins_by_asset_key,
             named_outs_by_asset_key=named_outs_by_asset_key,
             internal_deps=internal_deps,
-            op_name=op_name,
+            node_name=op_name,
             args=passed_args,
             fn=fn,
         )
@@ -530,7 +530,7 @@ class DecoratorAssetsDefinitionBuilder:
         return get_partition_mappings_from_deps(
             partition_mappings=partition_mappings,
             deps=self.args.upstream_asset_deps,
-            asset_name=self.op_name,
+            asset_name=self.node_name,
         )
 
     @cached_property
@@ -542,9 +542,9 @@ class DecoratorAssetsDefinitionBuilder:
             decorator_name=self.args.decorator_name,
         )
 
-    def create_op_definition(self) -> OpDefinition:
+    def create_node_definition(self) -> OpDefinition:
         return _Op(
-            name=self.op_name,
+            name=self.node_name,
             description=self.args.op_description,
             ins=self.ins_by_input_names,
             out=self.combined_outs_by_output_name,
@@ -562,7 +562,7 @@ class DecoratorAssetsDefinitionBuilder:
         return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=self.asset_keys_by_input_names,
             keys_by_output_name=self.asset_keys_by_output_name,
-            node_def=self.create_op_definition(),
+            node_def=self.create_node_definition(),
             partitions_def=self.args.partitions_def,
             can_subset=self.args.can_subset,
             resource_defs=self.args.assets_def_resource_defs,

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -85,6 +85,9 @@ class NodeDefinition(NamedConfigurableDefinition):
     def describe_node(self) -> str:
         return f"{self.node_type_str} '{self.name}'"
 
+    @abstractmethod
+    def add_nothing_input_def(self, name: str) -> "NodeDefinition": ...
+
     @property
     def description(self) -> Optional[str]:
         return self._description

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -44,7 +44,7 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
-from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
+from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind, Nothing
 from dagster._utils import IHasInternalInit
 from dagster._utils.warnings import normalize_renamed_param
 
@@ -221,6 +221,17 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     @property
     def is_graph_job_op_node(self) -> bool:
         return True
+    
+    def add_nothing_input_def(self, name) -> "OpDefinition":
+        if name in self._input_dict:
+            raise DagsterInvalidDefinitionError(
+                f"Input '{name}' already exists on Op '{self.name}'."
+            )
+
+        return self.with_replaced_properties(
+            name=self.name,
+            ins={**self.ins, name: In(Nothing)},
+        )
 
     @public
     @property


### PR DESCRIPTION
This PR goes through the exercise of allowing for Nothing input defs on a GraphDefinition, which would be the basis for supporting AssetSpec(..., deps=...) patterns on graph-backed assets.