### PR TITLE
[components] Standardize generator param passing

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -35,11 +35,7 @@ def generate_component_instance(
         component_type=component_registry_key,
     )
     with pushd(component_instance_root_path):
-        component_params = (
-            component_type.generate_files(generate_params)
-            if generate_params
-            else component_type.generate_files()  # type: ignore
-        )
+        component_params = component_type.generate_files(generate_params)
         component_data = {"type": component_registry_key, "params": component_params or {}}
     with open(Path(component_instance_root_path) / "component.yaml", "w") as f:
         yaml.dump(

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 
 import yaml
 from dagster._core.definitions.definitions_class import Definitions
@@ -55,7 +55,7 @@ class SlingReplicationComponent(Component):
         return Definitions(assets=[_fn], resources={"sling": self.resource})
 
     @classmethod
-    def generate_files(cls) -> None:
+    def generate_files(cls, params: Any) -> None:
         replication_path = Path(os.getcwd()) / "replication.yaml"
         with open(replication_path, "w") as f:
             yaml.dump(

--- a/python_modules/libraries/dg-cli/dg_cli_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dg-cli/dg_cli_tests/cli_tests/test_generate_commands.py
@@ -33,6 +33,8 @@ def _assert_module_imports(module_name: str):
 
 # This is a holder for code that is intended to be written to a file
 def _example_component_type_baz():
+    from typing import Any
+
     from dagster import AssetExecutionContext, Definitions, PipesSubprocessClient, asset
     from dagster_components import Component, ComponentLoadContext, component
 
@@ -46,7 +48,7 @@ def _example_component_type_baz():
     @component(name="baz")
     class Baz(Component):
         @classmethod
-        def generate_files(cls):
+        def generate_files(cls, params: Any):
             with open("sample.py", "w") as f:
                 f.write(_SAMPLE_PIPES_SCRIPT)
 


### PR DESCRIPTION
## Summary & Motivation

Status quo: `Component.generate_files()` could be defined with or without a `params` argument. Then it would get called with or without params depending on whether params were passed, rather than function sig.

Change: `Component.generate_files()` always takes `params`. `None` will be passed if you didn't pass any on the command line.

This fixed errors I was encountering in manual testing.

## How I Tested These Changes

Unit tests + manually.
