### PR TITLE
[components] Fix component type name in generated component.yaml

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
@@ -61,5 +61,9 @@ def generate_component_command(
         generate_params = None
 
     generate_component_instance(
-        context.component_instances_root_path, component_name, component_type_cls, generate_params
+        context.component_instances_root_path,
+        component_name,
+        component_type_cls,
+        component_type,
+        generate_params,
     )

--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -7,7 +7,7 @@ import yaml
 from dagster._generate.generate import generate_project
 from dagster._utils import pushd
 
-from dagster_components.core.component import Component, get_component_name
+from dagster_components.core.component import Component
 
 
 class ComponentDumper(yaml.Dumper):
@@ -19,12 +19,15 @@ class ComponentDumper(yaml.Dumper):
 
 
 def generate_component_instance(
-    root_path: str, name: str, component_type: Type[Component], generate_params: Any
+    root_path: str,
+    name: str,
+    component_type: Type[Component],
+    component_type_name: str,
+    generate_params: Any,
 ) -> None:
     click.echo(f"Creating a Dagster component instance at {root_path}/{name}.py.")
 
     component_instance_root_path = os.path.join(root_path, name)
-    component_registry_key = get_component_name(component_type)
     generate_project(
         path=component_instance_root_path,
         name_placeholder="COMPONENT_INSTANCE_NAME_PLACEHOLDER",
@@ -32,11 +35,11 @@ def generate_component_instance(
             os.path.dirname(__file__), "templates", "COMPONENT_INSTANCE_NAME_PLACEHOLDER"
         ),
         project_name=name,
-        component_type=component_registry_key,
+        component_type=component_type_name,
     )
     with pushd(component_instance_root_path):
         component_params = component_type.generate_files(generate_params)
-        component_data = {"type": component_registry_key, "params": component_params or {}}
+        component_data = {"type": component_type_name, "params": component_params or {}}
     with open(Path(component_instance_root_path) / "component.yaml", "w") as f:
         yaml.dump(
             component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False

--- a/python_modules/libraries/dg-cli/dg_cli_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dg-cli/dg_cli_tests/cli_tests/test_generate_commands.py
@@ -249,6 +249,9 @@ def test_generate_component_success(in_deployment: bool) -> None:
         assert result.exit_code == 0
         assert Path("bar/components/qux").exists()
         assert Path("bar/components/qux/sample.py").exists()
+        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert component_yaml_path.exists()
+        assert "type: bar.baz" in component_yaml_path.read_text()
 
 
 def test_generate_component_outside_code_location_fails() -> None:
@@ -279,9 +282,9 @@ def test_generate_sling_replication_instance() -> None:
         assert result.exit_code == 0
         assert Path("bar/components/file_ingest").exists()
 
-        defs_path = Path("bar/components/file_ingest/component.yaml")
-        assert defs_path.exists()
-        assert "type: sling_replication" in defs_path.read_text()
+        component_yaml_path = Path("bar/components/file_ingest/component.yaml")
+        assert component_yaml_path.exists()
+        assert "type: dagster_components.sling_replication" in component_yaml_path.read_text()
 
         replication_path = Path("bar/components/file_ingest/replication.yaml")
         assert replication_path.exists()
@@ -307,10 +310,10 @@ def test_generate_dbt_project_instance(params) -> None:
         assert result.exit_code == 0
         assert Path("bar/components/my_project").exists()
 
-        defs_path = Path("bar/components/my_project/component.yaml")
-        assert defs_path.exists()
-        assert "type: dbt_project" in defs_path.read_text()
+        component_yaml_path = Path("bar/components/my_project/component.yaml")
+        assert component_yaml_path.exists()
+        assert "type: dagster_components.dbt_project" in component_yaml_path.read_text()
         assert (
             "stub_code_locations/dbt_project_location/components/jaffle_shop"
-            in defs_path.read_text()
+            in component_yaml_path.read_text()
         )


### PR DESCRIPTION
## Summary & Motivation

Fix bug with the component_type name inserted into the `component.yaml` of generated components-- now is the fully qualified name rather than last component.

## How I Tested These Changes

Unit tests.