### PR TITLE
[components] Add extra dagster-* editable dependencies to generated pyproject.toml

### DIFF
--- a/python_modules/libraries/dg-cli/dg_cli/generate.py
+++ b/python_modules/libraries/dg-cli/dg_cli/generate.py
@@ -39,9 +39,10 @@ def generate_code_location(path: str, editable_dagster_root: Optional[str] = Non
     editable_dagster_uv_sources = textwrap.dedent(f"""
     [tool.uv.sources]
     dagster = {{ path = "{editable_dagster_root}/python_modules/dagster", editable = true }}
-    dagster-components = {{ path = "{editable_dagster_root}/python_modules/libraries/dagster-components", editable = true }}
+    dagster-graphql = {{ path = "{editable_dagster_root}/python_modules/dagster-graphql", editable = true }}
     dagster-pipes = {{ path = "{editable_dagster_root}/python_modules/dagster-pipes", editable = true }}
     dagster-webserver = {{ path = "{editable_dagster_root}/python_modules/dagster-webserver", editable = true }}
+    dagster-components = {{ path = "{editable_dagster_root}/python_modules/libraries/dagster-components", editable = true }}
     dagster-embedded-elt = {{ path = "{editable_dagster_root}/python_modules/libraries/dagster-embedded-elt", editable = true }}
     dagster-dbt = {{ path = "{editable_dagster_root}/python_modules/libraries/dagster-dbt", editable = true }}
     """)

--- a/python_modules/libraries/dg-cli/dg_cli/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dg-cli/dg_cli/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -4,6 +4,9 @@ requires-python = ">=3.9,<3.13"
 version = "0.1.0"
 dependencies = [
     "dagster",
+    "dagster-graphql",
+    "dagster-pipes",
+    "dagster-webserver",
     "dagster-components[sling,dbt]",
     "dagster-embedded-elt",
     "dagster-dbt",


### PR DESCRIPTION
## Summary & Motivation

`uv` package sources only work for direct dependencies of a package. This makes sure all dagster packages needed by a scaffolded code location are direct dependencies and have a listed uv source (fixes bug in tutorial).

## How I Tested These Changes

Manual testing.