### PR TITLE
Move `useFullAssetGraphData` to use webworker too

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.types.ts
@@ -1,13 +1,25 @@
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {AssetGraphFetchScope, AssetGraphQueryItem} from './useAssetGraphData';
 
-export type ComputeGraphDataMessageType = {
+type BaseType = {
   id: number;
+  flagAssetSelectionSyntax?: boolean;
+};
+
+export type ComputeGraphDataMessageType = BaseType & {
   type: 'computeGraphData';
   repoFilteredNodes?: AssetNodeForGraphQueryFragment[];
   graphQueryItems?: AssetGraphQueryItem[];
   opsQuery: string;
   kinds: AssetGraphFetchScope['kinds'];
   hideEdgesToNodesOutsideQuery?: boolean;
-  flagAssetSelectionSyntax?: boolean;
 };
+
+export type BuildGraphDataMessageType = BaseType & {
+  nodes: AssetNodeForGraphQueryFragment[];
+  type: 'buildGraphData';
+};
+
+export type ComputeGraphDataWorkerMessageType =
+  | ComputeGraphDataMessageType
+  | BuildGraphDataMessageType;


### PR DESCRIPTION
Similar to https://github.com/dagster-io/dagster/pull/26315, moves `buildGraphData` for the `useFullAssetGraphData` hook into a webworker.


## Test plan

Tested using app-proxy and loading a big asset graph