### PR TITLE
Add sql syntax highlighting to dbt asset descriptions

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -573,7 +573,7 @@ def default_description_fn(dbt_resource_props: Mapping[str, Any], display_raw_sq
         or f"dbt {dbt_resource_props['resource_type']} {dbt_resource_props['name']}",
     ]
     if display_raw_sql:
-        description_sections.append(f"#### Raw SQL:\n```\n{code_block}\n```")
+        description_sections.append(f"#### Raw SQL:\n```sql\n{code_block}\n```")
     return "\n\n".join(filter(None, description_sections))
 
 


### PR DESCRIPTION
## Summary & Motivation
Adds SQL syntax highlighting to raw sql code in dbt asset descriptions. Only for dbt assets, when the dbt asset exposes the raw sql.

## How I Tested These Changes
Spun up the sample dbt project and navigated to a dbt asset. The sql code in the description has syntax highlighting.

Light mode:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/41f3e6c6-0400-475d-9a2d-f8b7c7200531">

Dark mode:
<img width="502" alt="image" src="https://github.com/user-attachments/assets/52b581d7-84cc-4a3b-9bad-e58a66f2ab92">

> @salazarm we had discussed using custom CSS to make the blue text stand out more in dark mode, but it appears to be fairly readable in my browser. Let me know if you feel we still need custom CSS here.
## Changelog

> Not sure if this needs a changelog? I can add one if necessary.
