### PR TITLE
[dagster-fivetran] Implement FivetranEventIterator

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
@@ -1,0 +1,32 @@
+from collections import abc
+from typing import TYPE_CHECKING, Generic, Iterator, Union
+
+from dagster import AssetMaterialization, MaterializeResult
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from dagster_fivetran.resources import FivetranWorkspace
+
+
+FivetranEventType = Union[AssetMaterialization, MaterializeResult]
+T = TypeVar("T", bound=FivetranEventType)
+
+
+class FivetranEventIterator(Generic[T], abc.Iterator):
+    """A wrapper around an iterator of Fivetran events which contains additional methods for
+    post-processing the events, such as fetching column metadata.
+    """
+
+    def __init__(
+        self,
+        events: Iterator[T],
+        fivetran_workspace: "FivetranWorkspace",
+    ) -> None:
+        self._inner_iterator = events
+        self._fivetran_workspace = fivetran_workspace
+
+    def __next__(self) -> T:
+        return next(self._inner_iterator)
+
+    def __iter__(self) -> "FivetranEventIterator[T]":
+        return self

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Generic, Iterator, Union
+from typing import TYPE_CHECKING, Iterator, Union
 
 from dagster import AssetMaterialization, MaterializeResult
 from typing_extensions import TypeVar
@@ -11,7 +11,7 @@ FivetranEventType = Union[AssetMaterialization, MaterializeResult]
 T = TypeVar("T", bound=FivetranEventType)
 
 
-class FivetranEventIterator(Generic[T], Iterator):
+class FivetranEventIterator(Iterator[T]):
     """A wrapper around an iterator of Fivetran events which contains additional methods for
     post-processing the events, such as fetching column metadata.
     """

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
@@ -1,4 +1,3 @@
-from collections import abc
 from typing import TYPE_CHECKING, Generic, Iterator, Union
 
 from dagster import AssetMaterialization, MaterializeResult
@@ -12,7 +11,7 @@ FivetranEventType = Union[AssetMaterialization, MaterializeResult]
 T = TypeVar("T", bound=FivetranEventType)
 
 
-class FivetranEventIterator(Generic[T], abc.Iterator):
+class FivetranEventIterator(Generic[T], Iterator):
     """A wrapper around an iterator of Fivetran events which contains additional methods for
     post-processing the events, such as fetching column metadata.
     """


### PR DESCRIPTION
## Summary & Motivation

This PR adds at basic `FivetranEventIterator` that wraps materializations yielded by `FivetranWorkspace.sync_and_poll`. This `FivetranEventIterator` will be used to implement fetch_column_metadata in the next stacked PR.

## How I Tested These Changes

Existing tests with BK
