### PR TITLE
[azure-docs] refine deployment with ACR docs

### DIFF
--- a/docs/content/dagster-plus/deployment/azure/acr-user-code.mdx
+++ b/docs/content/dagster-plus/deployment/azure/acr-user-code.mdx
@@ -89,18 +89,26 @@ First, we'll need to generate a service principal for GitHub Actions to use to a
 az ad sp create-for-rbac --name "github-actions-acr" --role contributor --scopes /subscriptions/<your_azure_subscription_id>/resourceGroups/<your_resource_group>/providers/Microsoft.ContainerRegistry/registries/<your_acr_name>
 ```
 
-This command will output a JSON object with the service principal details. Make sure to save the `appId`, `password`, and `tenant` values - we'll use them in the next step.
+This command will output a JSON object with the service principal details. Make sure to save the `appId` and `password` values - we'll use them in the next step.
 
 ### Add secrets to your repository
 
 We'll add the service principal details as secrets in our repository. Go to your repository in GitHub, and navigate to `Settings` -> `Secrets`. Add the following secrets:
 
+- `DAGSTER_CLOUD_API_TOKEN`: An agent token. For more details see [Managing agent tokens](/dagster-plus/account/managing-user-agent-tokens#managing-agent-tokens).
 - `AZURE_CLIENT_ID`: The `appId` from the service principal JSON object.
 - `AZURE_CLIENT_SECRET`: The `password` from the service principal JSON object.
 
-### Update the workflow
+### Update the GitHub Actions workflow
 
-Finally, we'll update the workflow to use the service principal details. Open `.github/workflows/dagster-cloud-deploy.yml` in your repository, and uncomment the section on Azure Container Registry. It should look like this:
+For this step, open `.github/workflows/dagster-cloud-deploy.yml` in your repository with your preferred text editor to perform the changes below.
+
+In the `env` section of the workflow, update the following variables:
+
+- `DAGSTER_CLOUD_ORGANIZATION`: The name of your Dagster Cloud organization.
+- `IMAGE_REGISTRY`: The URL of your Azure Container Registry: `<your-acr-name>.azurecr.io`.
+
+We'll update the workflow to use the Azure Container Registry by uncommenting its section and providing the principal details. It should look like this:
 
 ```yaml
 # Azure Container Registry (ACR)
@@ -112,6 +120,34 @@ Finally, we'll update the workflow to use the service principal details. Open `.
     registry: ${{ env.IMAGE_REGISTRY }}
     username: ${{ secrets.AZURE_CLIENT_ID }}
     password: ${{ secrets.AZURE_CLIENT_SECRET }}
+```
+
+Finally, update the tags in the "Build and upload Docker image" step to match the full URL of your image in ACR:
+
+```yaml
+- name: Build and upload Docker image for "quickstart_etl"
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/build-push-action@v4
+  with:
+    context: .
+    push: true
+    tags: ${{ env.IMAGE_REGISTRY }}/<image-name>:${{ env.IMAGE_TAG }}
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+### Update the `dagster_cloud.yaml` build configuration to use the Azure Container Registry
+
+Edit the `dagster_cloud.yaml` file in the root of your repository. Update the `build` section to use the Azure Container Registry, and provide an image name specific to the code location. This must match the registry and image name used in the previous step.
+
+```yaml
+locations:
+  - location_name: quickstart_etl
+    code_source:
+      package_name: quickstart_etl.definitions
+    build:
+      directory: ./
+      registry: <your-acr-name>.azurecr.io/<image-name>
 ```
 
 ### Push and run the workflow


### PR DESCRIPTION
## Summary & Motivation
Updates the Azure Container Registry (ACR) user code documentation with missing instructions for configuring GitHub Actions and Dagster Cloud. Adds detailed steps for setting up environment variables, updating other step of the CI/CD workflow, and configuring the `dagster_cloud.yaml` file to work with ACR.

## How I Tested These Changes
- All changes are resulting from reproducing and fixing omissions in the previous version.

## Changelog
- NOCHANGELOG