### PR TITLE
[docs] sensors docs: clarify run_key behavior in a single sensor evaluation

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -127,6 +127,8 @@ In the example, a <PyObject object="RunRequest"/> is requested for each file dur
 
 Run keys allow you to write sensor evaluation functions that declaratively describe what runs should exist, and helps you avoid the need for more complex logic that manages state. However, when dealing with high-volume external events, some state-tracking optimizations might be necessary.
 
+NOTE: when a sensor evaluation yields multiple <PyObject object="RunRequest"/> objects with the same `run_key`, Dagster will execute all of them. The `run_key` will not be used to deduplicate or skip <PyObject object="RunRequest"/> objects within the same sensor evaluation.
+
 ### Sensor optimizations using cursors
 
 When writing a sensor that deals with high-volume events, it might not be feasible to yield a <PyObject object="RunRequest"/> during every sensor evaluation. For example, you may have an `s3` storage bucket that contains thousands of files.


### PR DESCRIPTION
## Summary & Motivation

I was caught off-guard in a production environment when a sensor that yields multiple RunRequests with the same run_key didn't de-duplicate them. Based on the current phrasing of the documentation, I would've thought that it would possibly take the first RunRequest and only launch that one but that doesn't seem to be the case.

I think it's better for the documentation to explicitly state what is the expected behavior in this scenario (assuming the current behavior is intentional).

## How I Tested These Changes

Straightforward documentation change. Ran `cd docs; cd next; yarn dev` to spin up the docs locally and checked that it looks fine.

## Changelog

> Specified run_key behavior when emitting multiple RunRequests with the same run_key within a single sensor evaluation
