### PR TITLE
[ui] add more detail in launch multiple runs' error text

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -36,7 +36,9 @@ export function useLaunchMultipleRunsWithTelemetry() {
           jobNames.includes(undefined) ||
           jobNames.includes(null)
         ) {
-          throw new Error('Invalid job names');
+          throw new Error(
+            'Error: Invalid job names. Each RunRequest must specify a job name to launch all runs',
+          );
         }
 
         const metadata: {[key: string]: string | string[] | null | undefined} = {


### PR DESCRIPTION
## Summary & Motivation
Previous error message was not clear to users when their "Launch all runs" operation fails due to ill-defined RunRequests. The feature requires RunRequests having job_name defined which is optional:
https://github.com/dagster-io/dagster/blob/54b39a2595408ae723e77830919fc3219f268c70/python_modules/dagster/dagster/_core/definitions/run_request.py#L81

## How I Tested These Changes
Tested locally