### PR TITLE
[ui] add tracking to launch all button

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
@@ -34,6 +34,7 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {assertUnreachable} from '../app/Util';
+import {useTrackEvent} from '../app/analytics';
 import {TimeContext} from '../app/time/TimeContext';
 import {timestampToString} from '../app/time/timestampToString';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
@@ -77,6 +78,8 @@ export const EvaluateScheduleDialog = (props: Props) => {
 };
 
 const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
+  const trackEvent = useTrackEvent();
+
   const [selectedTimestamp, setSelectedTimestamp] = useState<{ts: number; label: string}>();
   const scheduleSelector: ScheduleSelector = useMemo(
     () => ({
@@ -181,6 +184,8 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
     if (!canLaunchAll) {
       return;
     }
+
+    trackEvent('launch-all-schedule');
     setLaunching(true);
 
     try {
@@ -193,7 +198,7 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
 
     setLaunching(false);
     onClose();
-  }, [canLaunchAll, executionParamsList, launchMultipleRunsWithTelemetry, onClose]);
+  }, [canLaunchAll, executionParamsList, launchMultipleRunsWithTelemetry, onClose, trackEvent]);
 
   const content = useMemo(() => {
     // launching all runs state

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -32,6 +32,7 @@ import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {assertUnreachable} from '../app/Util';
+import {useTrackEvent} from '../app/analytics';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {SensorSelector} from '../graphql/types';
 import {useLaunchMultipleRunsWithTelemetry} from '../launchpad/useLaunchMultipleRunsWithTelemetry';
@@ -74,6 +75,8 @@ export const SensorDryRunDialog = (props: Props) => {
 };
 
 const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Props) => {
+  const trackEvent = useTrackEvent();
+
   const [sensorDryRun] = useMutation<SensorDryRunMutation, SensorDryRunMutationVariables>(
     EVALUATE_SENSOR_MUTATION,
   );
@@ -187,6 +190,8 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
     if (!canLaunchAll) {
       return;
     }
+
+    trackEvent('launch-all-sensor');
     setLaunching(true);
 
     try {
@@ -206,6 +211,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
     launchMultipleRunsWithTelemetry,
     onClose,
     onCommitTickResult,
+    trackEvent,
   ]);
 
   const leftButtons = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -29,9 +29,7 @@ jest.mock('react-router-dom', () => ({
 
 // Mocking useTrackEvent
 jest.mock('../../app/analytics', () => ({
-  useTrackEvent: jest.fn(() => {
-    jest.fn();
-  }),
+  useTrackEvent: jest.fn(() => jest.fn()),
 }));
 
 const onCloseMock = jest.fn();

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter, useHistory} from 'react-router-dom';
 
 import {Resolvers} from '../../apollo-client';
+import {useTrackEvent} from '../../app/analytics';
 import {EvaluateScheduleDialog} from '../EvaluateScheduleDialog';
 import {
   GetScheduleQueryMock,
@@ -24,6 +25,13 @@ jest.mock('../DryRunRequestTable', () => {
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: jest.fn(),
+}));
+
+// Mocking useTrackEvent
+jest.mock('../../app/analytics', () => ({
+  useTrackEvent: jest.fn(() => {
+    jest.fn();
+  }),
 }));
 
 const onCloseMock = jest.fn();
@@ -118,6 +126,8 @@ describe('EvaluateScheduleTest', () => {
       push: pushSpy,
       createHref: createHrefSpy,
     });
+
+    (useTrackEvent as jest.Mock).mockReturnValue(jest.fn());
 
     render(
       <MemoryRouter initialEntries={['/automation']}>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -23,9 +23,7 @@ jest.mock('react-router-dom', () => ({
 
 // Mocking useTrackEvent
 jest.mock('../../app/analytics', () => ({
-  useTrackEvent: jest.fn(() => {
-    jest.fn();
-  }),
+  useTrackEvent: jest.fn(() => jest.fn()),
 }));
 
 const onCloseMock = jest.fn();

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter, useHistory} from 'react-router-dom';
 
 import {Resolvers} from '../../apollo-client';
+import {useTrackEvent} from '../../app/analytics';
 import {SensorDryRunDialog} from '../SensorDryRunDialog';
 import * as Mocks from '../__fixtures__/SensorDryRunDialog.fixtures';
 
@@ -18,6 +19,13 @@ jest.mock('../DryRunRequestTable', () => {
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: jest.fn(),
+}));
+
+// Mocking useTrackEvent
+jest.mock('../../app/analytics', () => ({
+  useTrackEvent: jest.fn(() => {
+    jest.fn();
+  }),
 }));
 
 const onCloseMock = jest.fn();
@@ -97,6 +105,8 @@ describe('SensorDryRunTest', () => {
       push: pushSpy,
       createHref: createHrefSpy,
     });
+
+    (useTrackEvent as jest.Mock).mockReturnValue(jest.fn());
 
     render(
       <MemoryRouter initialEntries={['/automation']}>


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-719/add-tracking-to-the-launch-all-button

Adds tracking to the launch all button in the preview tick result modal

## How I Tested These Changes
Tested locally