### PR TITLE
[components] DltPipelineCollection component impl

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/dlt_pipeline_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dlt_pipeline_collection.py
@@ -1,0 +1,105 @@
+import importlib
+from typing import Any, Iterator, Mapping, Optional, Sequence
+
+import dlt
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._record import record
+from dagster_embedded_elt.dlt.asset_decorator import dlt_assets
+from dagster_embedded_elt.dlt.resource import DagsterDltResource
+from dlt.extract import DltSource
+from dlt.pipeline import Pipeline
+from pydantic import BaseModel, TypeAdapter
+
+from dagster_components.core.component import (
+    Component,
+    ComponentDeclNode,
+    ComponentLoadContext,
+    component,
+)
+from dagster_components.core.component_decl_builder import YamlComponentDecl
+
+
+@record
+class DltPipelineRun:
+    pipeline: Pipeline
+    source: DltSource
+
+
+class DltPipelineBaseModel(BaseModel):
+    """Passed into `dlt.pipeline()` to create a pipeline."""
+
+    pipeline_name: str
+    dataset_name: str
+    destination: str
+
+
+class DltSourceBaseModel(BaseModel):
+    """Pointer to a dlt source factory and the params to pass to it."""
+
+    source_reference: str
+    params: Optional[Mapping[str, Any]] = None
+
+
+class DltPipelineRunSpecBaseModel(BaseModel):
+    """Holds configuration for a dlt pipeline run."""
+
+    pipeline: DltPipelineBaseModel
+    source: DltSourceBaseModel
+
+
+class DltPipelineCollectionParamsSchema(BaseModel):
+    pipeline_runs: Sequence[DltPipelineRunSpecBaseModel]
+
+
+def _get_source(source_reference: str, params: Mapping[str, Any]) -> DltSource:
+    source_module, source_factory = source_reference.rsplit(".", 1)
+    source_module = importlib.import_module(source_module)
+    source_factory = getattr(source_module, source_factory)
+    return source_factory(**(params or {}))
+
+
+@component(name="dlt_pipeline_collection")
+class DltPipelineCollection(Component):
+    params_schema = DltPipelineCollectionParamsSchema
+
+    def __init__(self, pipeline_runs: Sequence[DltPipelineRun]):
+        self.pipeline_runs = pipeline_runs
+
+    @classmethod
+    def from_decl_node(
+        cls, context: ComponentLoadContext, decl_node: ComponentDeclNode
+    ) -> "DltPipelineCollection":
+        assert isinstance(decl_node, YamlComponentDecl)
+        loaded_params = TypeAdapter(cls.params_schema).validate_python(
+            decl_node.component_file_model.params
+        )
+
+        pipeline_runs = []
+        for pipeline_run_spec in loaded_params.pipeline_runs:
+            pipeline = dlt.pipeline(**pipeline_run_spec.pipeline.model_dump())
+            source = _get_source(
+                pipeline_run_spec.source.source_reference, pipeline_run_spec.source.params or {}
+            )
+            pipeline_runs.append(DltPipelineRun(pipeline=pipeline, source=source))
+
+        return cls(pipeline_runs=pipeline_runs)
+
+    def build_defs(self, load_context: "ComponentLoadContext") -> "Definitions":
+        return Definitions(
+            assets=[self._create_asset_def(pipeline_run) for pipeline_run in self.pipeline_runs]
+        )
+
+    def _create_asset_def(self, pipeline_run: DltPipelineRun) -> AssetsDefinition:
+        source = pipeline_run.source
+        pipeline = pipeline_run.pipeline
+
+        @dlt_assets(dlt_source=source, dlt_pipeline=pipeline)
+        def _asset(context: AssetExecutionContext):
+            yield from self.execute(context, dlt=DagsterDltResource())
+
+        return _asset
+
+    def execute(self, context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
+        yield from dlt.run(context)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -70,21 +70,21 @@ class PipesSubprocessScriptCollection(Component):
 
     @classmethod
     def from_decl_node(
-        cls, load_context: ComponentLoadContext, component_decl: ComponentDeclNode
+        cls, context: ComponentLoadContext, decl_node: ComponentDeclNode
     ) -> "PipesSubprocessScriptCollection":
-        assert isinstance(component_decl, YamlComponentDecl)
+        assert isinstance(decl_node, YamlComponentDecl)
         loaded_params = TypeAdapter(cls.params_schema).validate_python(
-            component_decl.component_file_model.params
+            decl_node.component_file_model.params
         )
 
         path_specs = {}
         for script in loaded_params.scripts:
-            script_path = component_decl.path / script.path
+            script_path = decl_node.path / script.path
             if not script_path.exists():
                 raise FileNotFoundError(f"Script {script_path} does not exist")
             path_specs[script_path] = [spec.to_asset_spec() for spec in script.assets]
 
-        return cls(dirpath=component_decl.path, path_specs=path_specs)
+        return cls(dirpath=decl_node.path, path_specs=path_specs)
 
     def build_defs(self, load_context: "ComponentLoadContext") -> "Definitions":
         from dagster._core.definitions.definitions_class import Definitions

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dlt_location/components/my_dlt_project/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dlt_location/components/my_dlt_project/component.yaml
@@ -1,0 +1,12 @@
+type: dagster_components.dlt_pipeline_collection
+
+params:
+  pipeline_runs:
+    - pipeline:
+        pipeline_name: csv_to_duckdb
+        dataset_name: csv
+        destination: duckdb
+      source:
+        source_reference: dagster_components_tests.dlt_sources.filesystem.csv_source
+        params:
+          bucket_url: file://../../../input.csv

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dlt_location/input.csv
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dlt_location/input.csv
@@ -1,0 +1,4 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+abcdef,scrubjay,1
+defghi,bluejay,2
+jklnop,blackbird,2

--- a/python_modules/libraries/dagster-components/dagster_components_tests/dlt_sources/filesystem/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/dlt_sources/filesystem/__init__.py
@@ -1,0 +1,50 @@
+from typing import Any, Iterator, List, Tuple
+
+import dlt
+from dlt.sources import DltResource, TDataItems
+from dlt.sources.filesystem import FileItem, FileItemDict, fsspec_filesystem, glob_files
+
+
+def _read_csv(
+    items: Iterator[FileItemDict], chunksize: int = 10000, **pandas_kwargs: Any
+) -> Iterator[TDataItems]:
+    import pandas as pd
+
+    kwargs = {**{"header": "infer", "chunksize": chunksize}, **pandas_kwargs}
+    for file_obj in items:
+        with file_obj.open() as file:
+            for df in pd.read_csv(file, **kwargs):
+                yield df.to_dict(orient="records")
+
+
+@dlt.resource(primary_key="file_url", standalone=True)
+def filesystem(
+    bucket_url: str = dlt.secrets.value,
+    file_glob: str = "*",
+    files_per_page: int = 100,
+    extract_content: bool = False,
+) -> Iterator[List[FileItem]]:
+    fs_client = fsspec_filesystem(bucket_url)[0]
+
+    files_chunk: List[FileItem] = []
+    for file_model in glob_files(fs_client, bucket_url, file_glob):
+        file_dict = FileItemDict(file_model)
+        if extract_content:
+            file_dict["file_content"] = file_dict.read_bytes()
+        files_chunk.append(file_dict)  # type: ignore
+
+        # wait for the chunk to be full
+        if len(files_chunk) >= files_per_page:
+            yield files_chunk
+            files_chunk = []
+    if files_chunk:
+        yield files_chunk
+
+
+@dlt.source()
+def csv_source(
+    bucket_url: str = dlt.secrets.value, file_glob: str = "*"
+) -> Tuple[DltResource, ...]:
+    return (
+        filesystem(bucket_url, file_glob=file_glob) | dlt.transformer(name="read_csv")(_read_csv),
+    )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dlt_pipeline_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dlt_pipeline_collection.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from dagster import AssetKey
+from dagster_components.core.component_decl_builder import ComponentFileModel
+from dagster_components.core.component_defs_builder import (
+    YamlComponentDecl,
+    build_components_from_component_folder,
+)
+from dagster_components.lib.dlt_pipeline_collection import DltPipelineCollection
+
+from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
+
+DLT_LOCATION_PATH = Path(__file__).parent.parent / "code_locations" / "dlt_location"
+COMPONENT_RELPATH = "components/my_dlt_project"
+
+
+def test_python_params() -> None:
+    context = script_load_context()
+    component = DltPipelineCollection.from_decl_node(
+        context=context,
+        decl_node=YamlComponentDecl(
+            path=DLT_LOCATION_PATH / COMPONENT_RELPATH,
+            component_file_model=ComponentFileModel(
+                type="dagster_components.dlt_pipeline_collection",
+                params={
+                    "pipeline_runs": [
+                        {
+                            "pipeline": {
+                                "pipeline_name": "csv_to_duckdb",
+                                "dataset_name": "csv",
+                                "destination": "duckdb",
+                            },
+                            "source": {
+                                "source_reference": "dagster_components_tests.dlt_sources.filesystem.csv_source",
+                                "params": {"bucket_url": f"file://{DLT_LOCATION_PATH}/input.csv"},
+                            },
+                            "runtime_params": {},
+                        }
+                    ]
+                },
+            ),
+        ),
+    )
+    assert get_asset_keys(component) == {
+        AssetKey("csv_source_filesystem"),
+        AssetKey("dlt_csv_source_read_csv"),
+    }
+
+
+def test_load_from_path() -> None:
+    components = build_components_from_component_folder(
+        script_load_context(), DLT_LOCATION_PATH / "components"
+    )
+    assert len(components) == 1
+    assert get_asset_keys(components[0]) == {
+        AssetKey("csv_source_filesystem"),
+        AssetKey("dlt_csv_source_read_csv"),
+    }
+
+    assert_assets(components[0], 2)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -26,8 +26,8 @@ def test_python_native() -> None:
 
 def test_python_params() -> None:
     component = PipesSubprocessScriptCollection.from_decl_node(
-        load_context=script_load_context(),
-        component_decl=YamlComponentDecl(
+        context=script_load_context(),
+        decl_node=YamlComponentDecl(
             path=LOCATION_PATH / "components" / "scripts",
             component_file_model=ComponentFileModel(
                 type="pipes_subprocess_script_collection",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -1,9 +1,21 @@
 from dagster import AssetKey, DagsterInstance
-from dagster_components.core.component import Component, ComponentLoadContext, ComponentRegistry
+from dagster_components import lib
+from dagster_components.core.component import (
+    Component,
+    ComponentLoadContext,
+    ComponentRegistry,
+    get_component_name,
+    get_registered_components_in_module,
+)
 
 
 def registry() -> ComponentRegistry:
-    return ComponentRegistry.from_entry_point_discovery()
+    return ComponentRegistry(
+        {
+            f"dagster_components.{get_component_name(component)}": component
+            for component in get_registered_components_in_module(lib)
+        }
+    )
 
 
 def script_load_context() -> ComponentLoadContext:


### PR DESCRIPTION
## Summary & Motivation

This is a starting point for a dagster-dlt components integration.

The core thing that the user defines in dlt-land is a source. Then, they configure "pipeline runs" by creating pipelines with the standard dlt pipeline parameters, and associating those with a source.

This source provides an importable source reference location, as well as any necessary params.

## How I Tested These Changes

## Changelog

NOCHANGELOG
