### PR TITLE
[components] Error on passing both --json-params and EXTRA_ARGS to `dg generate component`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -153,6 +153,8 @@ def generate_component_command(
 
     When key-value pairs are used, the value type will be inferred from the
     underlying component generation schema.
+
+    It is an error to pass both --json-params and EXTRA_ARGS.
     """
     if not is_inside_code_location_project(Path.cwd()):
         click.echo(
@@ -171,6 +173,16 @@ def generate_component_command(
     elif context.has_component_instance(component_name):
         click.echo(
             click.style(f"A component instance named `{component_name}` already exists.", fg="red")
+        )
+        sys.exit(1)
+
+    if json_params is not None and extra_args:
+        click.echo(
+            click.style(
+                "Detected both --json-params and EXTRA_ARGS. These are mutually exclusive means of passing"
+                " component generation parameters. Use only one.",
+                fg="red",
+            )
         )
         sys.exit(1)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -103,7 +103,7 @@ def generate_component_instance(
         "component",
         component_type,
         name,
-        *([f"--json-params={json_params}"] if json_params else []),
+        *(["--json-params", json_params] if json_params else []),
         *(["--", *extra_args] if extra_args else []),
     )
     execute_code_location_command(Path(component_instance_root_path), code_location_command)

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -46,6 +46,6 @@ setup(
         ]
     },
     extras_require={
-        "test": ["pytest"],
+        "test": ["click", "pydantic", "pytest"],
     },
 )


### PR DESCRIPTION
## Summary & Motivation

Have `dagster-dg` throw an error when both `--json-params` and `EXTRA_ARGS` are passed to `dg generate component`. These are mutually exclusive ways of specifying parameters.

## How I Tested These Changes

New unit tests.