### PR TITLE
[asset backfill] fix self dependency with backfill policy issues

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1605,6 +1605,8 @@ def can_run_with_parent(
         candidate.asset_key, parent_asset_key=parent.asset_key
     )
 
+    is_self_dependency = parent.asset_key == candidate.asset_key
+
     parent_node = asset_graph.get(parent.asset_key)
     candidate_node = asset_graph.get(candidate.asset_key)
     # checks if there is a simple partition mapping between the parent and the child
@@ -1666,8 +1668,11 @@ def can_run_with_parent(
                 or parent_node.backfill_policy.max_partitions_per_run
                 > len(asset_partitions_to_request_map[parent.asset_key])
             )
-            # all targeted parents are being requested this tick
-            and len(asset_partitions_to_request_map[parent.asset_key]) == parent_target_subset.size
+            # all targeted parents are being requested this tick, or its a self dependency
+            and (
+                len(asset_partitions_to_request_map[parent.asset_key]) == parent_target_subset.size
+                or is_self_dependency
+            )
         )
     ):
         return True, ""


### PR DESCRIPTION
Currently the evaluation for determining what can be run together in an asset backfill looks at the previous results that have been resolved so far during breadth first search over the topo-sorted graph. For self dependencies, the `len(asset_partitions_to_request_map[parent.asset_key]) == parent_target_subset.size` would fail since `parent` is the `candidate` and we in the middle of filling `asset_partitions_to_request_map` with `parent_target_subset`. This failure would cause the backfill to issue the partitions of the self dependency iteratively. This additionally created a mismatch in expectations between the backfill and how the runs would end up getting split up, causing dependencies to not be respected. 

Both of these issues are fixed by disregarding that check if we are evaluating a self dependency. 


## How I Tested These Changes

added test

## Changelog 

Assets with self dependencies and `BackfillPolicy` are now evaluated correctly during backfills. Self dependent assets no longer result in serial partition submissions or disregarded upstream dependencies.

