### PR TITLE
[bugfix] k8s client now waits for main container to be ready

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -673,7 +673,6 @@ class DagsterKubernetesClient:
             # State checks below, see:
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstate-v1-core
             state = container_status.state
-
             if state.running is not None:
                 if wait_for_state == WaitForPodState.Ready:
                     # ready is boolean field of container status
@@ -684,6 +683,11 @@ class DagsterKubernetesClient:
                         continue
                     else:
                         ready_containers.add(container_status.name)
+                        if container_status.name in initcontainers:
+                            self.logger(
+                                f'Init container "{container_status.name}" is ready, waiting for non-init containers...'
+                            )
+                            continue
                         if initcontainers.issubset(exited_containers | ready_containers):
                             self.logger(f'Pod "{pod_name}" is ready, done waiting')
                             break


### PR DESCRIPTION
## Summary & Motivation

A more complete fix for issue #23497. The recent change in PR #24432 exits the loop if all sidecar init containers are in a ready state, and doesn't wait until the regular (non init container). If the main (dagster) container takes longer to startup, for example if it's using a large image, the code fails when it attempts to read the log.

## How I Tested These Changes
* Fixed the existing unit tests to represent the full state of the pod when we expect it to be ready. The existing tests did not ensure that the main container is ready, and instead returned when the init containers were ready (or terminated)
* Tested locally with our k8s deployment and deployed to production to fix the issue for our jobs

## Changelog

> Insert changelog entry or delete this section.
