### PR TITLE
[dagster-dbt] Subclass typing.Iterator in DbtEventIterator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -1,4 +1,3 @@
-from collections import abc
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator, Optional, Union, cast
 
@@ -186,7 +185,7 @@ def _fetch_row_count_metadata(
         return None
 
 
-class DbtEventIterator(Generic[T], abc.Iterator):
+class DbtEventIterator(Generic[T], Iterator):
     """A wrapper around an iterator of dbt events which contains additional methods for
     post-processing the events, such as fetching row counts for materialized tables.
     """


### PR DESCRIPTION
## Summary & Motivation

Subclass `typing.Iterator` instead of `abc.Iterator` in `DbtEventIterator`. This is motivated by [this discussion](https://github.com/dagster-io/dagster/pull/26396#discussion_r1881167290).

## How I Tested These Changes

Same tests with BK

