### PR TITLE
[9/n][dagster-airbyte] Implement base sync method in AirbyteCloudClient

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -994,13 +994,14 @@ class AirbyteCloudClient(DagsterModel):
 
     def start_sync_job(self, connection_id: str) -> Mapping[str, Any]:
         return self._make_request(
-                endpoint="jobs",
-                data={
-                    "connectionId": connection_id,
-                    "jobType": "sync",
-                },
-            )
-
+            method="POST",
+            endpoint="jobs",
+            base_url=self.rest_api_base_url,
+            data={
+                "connectionId": connection_id,
+                "jobType": "sync",
+            },
+        )
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -992,6 +992,16 @@ class AirbyteCloudClient(DagsterModel):
             base_url=self.rest_api_base_url,
         )
 
+    def start_sync_job(self, connection_id: str) -> Mapping[str, Any]:
+        return self._make_request(
+                endpoint="jobs",
+                data={
+                    "connectionId": connection_id,
+                    "jobType": "sync",
+                },
+            )
+
+
 
 @experimental
 class AirbyteCloudWorkspace(ConfigurableResource):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -166,6 +166,8 @@ SAMPLE_JOB_RESPONSE = {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "status": "running",
     "jobType": "sync",
+    "startTime": "2023-03-25T01:30:50Z",
+    "connectionId": TEST_CONNECTION_ID
 }
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -163,7 +163,7 @@ SAMPLE_DESTINATION_DETAILS = {
 
 
 SAMPLE_JOB_RESPONSE = {
-    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "jobId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "status": "running",
     "jobType": "sync",
     "startTime": "2023-03-25T01:30:50Z",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -162,6 +162,13 @@ SAMPLE_DESTINATION_DETAILS = {
 }
 
 
+SAMPLE_JOB_RESPONSE = {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "status": "running",
+    "jobType": "sync",
+}
+
+
 @pytest.fixture(
     name="base_api_mocks",
 )
@@ -201,3 +208,18 @@ def fetch_workspace_data_api_mocks_fixture(
         status=200,
     )
     yield base_api_mocks
+
+
+@pytest.fixture(
+    name="all_api_mocks",
+)
+def all_api_mocks_fixture(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.add(
+        method=responses.POST,
+        url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs",
+        json=SAMPLE_JOB_RESPONSE,
+        status=200,
+    )
+    yield fetch_workspace_data_api_mocks

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -144,7 +144,7 @@ SAMPLE_CONNECTION_DETAILS = {
 }
 
 
-# Taken from Airbyte API documentation
+# Taken from Airbyte REST API documentation
 # https://reference.airbyte.com/reference/getdestination
 SAMPLE_DESTINATION_DETAILS = {
     "destinationId": TEST_DESTINATION_ID,
@@ -162,6 +162,8 @@ SAMPLE_DESTINATION_DETAILS = {
 }
 
 
+# Taken from Airbyte REST API documentation
+# https://reference.airbyte.com/reference/getjob
 SAMPLE_JOB_RESPONSE = {
     "jobId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "status": "running",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -167,7 +167,7 @@ SAMPLE_JOB_RESPONSE = {
     "status": "running",
     "jobType": "sync",
     "startTime": "2023-03-25T01:30:50Z",
-    "connectionId": TEST_CONNECTION_ID
+    "connectionId": TEST_CONNECTION_ID,
 }
 
 


### PR DESCRIPTION
## Summary & Motivation

Implement endpoint to start a sync job in Airbyte Cloud. To be used in subsequent PRs in sync and poll process.

## How I Tested These Changes

Additional tests with BK

