### PR TITLE
[11/n][dagster-airbyte] Implement cancel_job method in AirbyteCloudClient

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1008,6 +1008,9 @@ class AirbyteCloudClient(DagsterModel):
             method="GET", endpoint=f"jobs/{job_id}", base_url=self.rest_api_base_url
         )
 
+    def cancel_job(self, job_id: int) -> Mapping[str, Any]:
+        return self.make_request(method="DELETE", endpoint=f"jobs/{job_id}")
+
 
 @experimental
 class AirbyteCloudWorkspace(ConfigurableResource):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1009,7 +1009,9 @@ class AirbyteCloudClient(DagsterModel):
         )
 
     def cancel_job(self, job_id: int) -> Mapping[str, Any]:
-        return self.make_request(method="DELETE", endpoint=f"jobs/{job_id}")
+        return self._make_request(
+            method="DELETE", endpoint=f"jobs/{job_id}", base_url=self.rest_api_base_url
+        )
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/conftest.py
@@ -233,4 +233,10 @@ def all_api_mocks_fixture(
         json=SAMPLE_JOB_RESPONSE,
         status=200,
     )
+    fetch_workspace_data_api_mocks.add(
+        method=responses.DELETE,
+        url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs/{TEST_JOB_ID}",
+        json=SAMPLE_JOB_RESPONSE,
+        status=200,
+    )
     yield fetch_workspace_data_api_mocks

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -130,8 +130,9 @@ def test_basic_resource_request(
     client.get_destination_details(destination_id=TEST_DESTINATION_ID)
     client.start_sync_job(connection_id=TEST_CONNECTION_ID)
     client.get_job_details(job_id=TEST_JOB_ID)
+    client.cancel_job(job_id=TEST_JOB_ID)
 
-    assert len(all_api_mocks.calls) == 6
+    assert len(all_api_mocks.calls) == 7
     # The first call is to create the access token
     api_calls = assert_token_call_and_split_calls(calls=all_api_mocks.calls)
     # The next calls are actual API calls
@@ -142,3 +143,4 @@ def test_basic_resource_request(
     assert_rest_api_call(call=api_calls[2], endpoint=f"destinations/{TEST_DESTINATION_ID}")
     assert_rest_api_call(call=api_calls[3], endpoint="jobs", object_id=TEST_CONNECTION_ID)
     assert_rest_api_call(call=api_calls[4], endpoint=f"jobs/{TEST_JOB_ID}")
+    assert_rest_api_call(call=api_calls[5], endpoint=f"jobs/{TEST_JOB_ID}")


### PR DESCRIPTION
## Summary & Motivation

Implement endpoint to cancel a job in Airbyte Cloud. To be used in subsequent PRs in sync and poll process.

## How I Tested These Changes

Additional tests with BK
