### PR TITLE
[12/n][dagster-airbyte] Implement sync_and_poll method in AirbyteCloudClient

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -23,12 +23,15 @@ from dagster_airbyte.resources import (
     AirbyteCloudResource as AirbyteCloudResource,
     AirbyteCloudWorkspace as AirbyteCloudWorkspace,
     AirbyteResource as AirbyteResource,
-    AirbyteState as AirbyteState,
     airbyte_cloud_resource as airbyte_cloud_resource,
     airbyte_resource as airbyte_resource,
     load_airbyte_cloud_asset_specs as load_airbyte_cloud_asset_specs,
 )
-from dagster_airbyte.translator import DagsterAirbyteTranslator as DagsterAirbyteTranslator
+from dagster_airbyte.translator import (
+    AirbyteJobStatusType as AirbyteJobStatusType,
+    AirbyteState as AirbyteState,
+    DagsterAirbyteTranslator as DagsterAirbyteTranslator,
+)
 from dagster_airbyte.types import AirbyteOutput as AirbyteOutput
 from dagster_airbyte.version import __version__ as __version__
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -33,6 +33,8 @@ from requests.exceptions import RequestException
 from dagster_airbyte.translator import (
     AirbyteConnection,
     AirbyteDestination,
+    AirbyteJob,
+    AirbyteJobStatusType,
     AirbyteWorkspaceData,
     DagsterAirbyteTranslator,
 )
@@ -51,16 +53,6 @@ DEFAULT_POLL_INTERVAL_SECONDS = 10
 AIRBYTE_CLOUD_REFRESH_TIMEDELTA_SECONDS = 150
 
 AIRBYTE_RECONSTRUCTION_METADATA_KEY_PREFIX = "dagster-airbyte/reconstruction_metadata"
-
-
-class AirbyteState:
-    RUNNING = "running"
-    SUCCEEDED = "succeeded"
-    CANCELLED = "cancelled"
-    PENDING = "pending"
-    FAILED = "failed"
-    ERROR = "error"
-    INCOMPLETE = "incomplete"
 
 
 class AirbyteResourceState:
@@ -252,13 +244,17 @@ class BaseAirbyteResource(ConfigurableResource):
                 job_info = cast(Dict[str, object], job_details.get("job", {}))
                 state = job_info.get("status")
 
-                if state in (AirbyteState.RUNNING, AirbyteState.PENDING, AirbyteState.INCOMPLETE):
+                if state in (
+                    AirbyteJobStatusType.RUNNING,
+                    AirbyteJobStatusType.PENDING,
+                    AirbyteJobStatusType.INCOMPLETE,
+                ):
                     continue
-                elif state == AirbyteState.SUCCEEDED:
+                elif state == AirbyteJobStatusType.SUCCEEDED:
                     break
-                elif state == AirbyteState.ERROR:
+                elif state == AirbyteJobStatusType.ERROR:
                     raise Failure(f"Job failed: {job_id}")
-                elif state == AirbyteState.CANCELLED:
+                elif state == AirbyteJobStatusType.CANCELLED:
                     raise Failure(f"Job was cancelled: {job_id}")
                 else:
                     raise Failure(f"Encountered unexpected state `{state}` for job_id {job_id}")
@@ -266,7 +262,12 @@ class BaseAirbyteResource(ConfigurableResource):
             # if Airbyte sync has not completed, make sure to cancel it so that it doesn't outlive
             # the python process
             if (
-                state not in (AirbyteState.SUCCEEDED, AirbyteState.ERROR, AirbyteState.CANCELLED)
+                state
+                not in (
+                    AirbyteJobStatusType.SUCCEEDED,
+                    AirbyteJobStatusType.ERROR,
+                    AirbyteJobStatusType.CANCELLED,
+                )
                 and self.cancel_sync_on_run_termination
             ):
                 self.cancel_job(job_id)
@@ -742,13 +743,17 @@ class AirbyteResource(BaseAirbyteResource):
                 job_info = cast(Dict[str, object], job_details.get("job", {}))
                 state = job_info.get("status")
 
-                if state in (AirbyteState.RUNNING, AirbyteState.PENDING, AirbyteState.INCOMPLETE):
+                if state in (
+                    AirbyteJobStatusType.RUNNING,
+                    AirbyteJobStatusType.PENDING,
+                    AirbyteJobStatusType.INCOMPLETE,
+                ):
                     continue
-                elif state == AirbyteState.SUCCEEDED:
+                elif state == AirbyteJobStatusType.SUCCEEDED:
                     break
-                elif state == AirbyteState.ERROR:
+                elif state == AirbyteJobStatusType.ERROR:
                     raise Failure(f"Job failed: {job_id}")
-                elif state == AirbyteState.CANCELLED:
+                elif state == AirbyteJobStatusType.CANCELLED:
                     raise Failure(f"Job was cancelled: {job_id}")
                 else:
                     raise Failure(f"Encountered unexpected state `{state}` for job_id {job_id}")
@@ -756,7 +761,12 @@ class AirbyteResource(BaseAirbyteResource):
             # if Airbyte sync has not completed, make sure to cancel it so that it doesn't outlive
             # the python process
             if (
-                state not in (AirbyteState.SUCCEEDED, AirbyteState.ERROR, AirbyteState.CANCELLED)
+                state
+                not in (
+                    AirbyteJobStatusType.SUCCEEDED,
+                    AirbyteJobStatusType.ERROR,
+                    AirbyteJobStatusType.CANCELLED,
+                )
                 and self.cancel_sync_on_run_termination
             ):
                 self.cancel_job(job_id)
@@ -1018,6 +1028,7 @@ class AirbyteCloudClient(DagsterModel):
         connection_id: str,
         poll_interval: Optional[float] = None,
         poll_timeout: Optional[float] = None,
+        cancel_on_termination: bool = True,
     ) -> AirbyteOutput:
         """Initializes a sync operation for the given connection, and polls until it completes.
 
@@ -1027,69 +1038,58 @@ class AirbyteCloudClient(DagsterModel):
             poll_interval (float): The time (in seconds) that will be waited between successive polls.
             poll_timeout (float): The maximum time that will wait before this operation is timed
                 out. By default, this will never time out.
+            cancel_on_termination (bool): Whether to cancel a sync in Airbyte if the Dagster runner is terminated.
+                This may be useful to disable if using Airbyte sources that cannot be cancelled and
+                resumed easily, or if your Dagster deployment may experience runner interruptions
+                that do not impact your Airbyte deployment.
 
         Returns:
             :py:class:`~AirbyteOutput`:
                 Details of the sync job.
         """
         connection_details = self.get_connection_details(connection_id)
-        job_details = self.start_sync(connection_id)
-        # TODO: Use AirbyteJob class
-        job_id = job_details["id"]
+        start_job_details = self.start_sync(connection_id)
+        job = AirbyteJob.from_job_details(job_details=start_job_details)
 
-        self._log.info(f"Job {job_id} initialized for connection_id={connection_id}.")
+        self._log.info(f"Job {job.id} initialized for connection_id={connection_id}.")
         start = time.monotonic()
-        logged_attempts = 0
-        logged_lines = 0
-        state = None
-
         try:
             while True:
                 if poll_timeout and start + poll_timeout < time.monotonic():
                     raise Failure(
-                        f"Timeout: Airbyte job {job_id} is not ready after the timeout"
+                        f"Timeout: Airbyte job {job.id} is not ready after the timeout"
                         f" {poll_timeout} seconds"
                     )
                 time.sleep(poll_interval or self.poll_interval)
-                job_details = self.get_job_status(connection_id, job_id)
-                attempts = cast(List, job_details.get("attempts", []))
-                cur_attempt = len(attempts)
-                # spit out the available Airbyte log info
-                if cur_attempt:
-                    if self._should_forward_logs:
-                        log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
-
-                        for line in log_lines[logged_lines:]:
-                            sys.stdout.write(line + "\n")
-                            sys.stdout.flush()
-                        logged_lines = len(log_lines)
-
-                    # if there's a next attempt, this one will have no more log messages
-                    if logged_attempts < cur_attempt - 1:
-                        logged_lines = 0
-                        logged_attempts += 1
-
-                state = job_details["status"]
-                if state in (AirbyteState.RUNNING, AirbyteState.PENDING, AirbyteState.INCOMPLETE):
+                poll_job_details = self.get_job_status(connection_id, job.id)
+                job = AirbyteJob.from_job_details(job_details=poll_job_details)
+                if job.status in (
+                    AirbyteJobStatusType.RUNNING,
+                    AirbyteJobStatusType.PENDING,
+                    AirbyteJobStatusType.INCOMPLETE,
+                ):
                     continue
-                elif state == AirbyteState.SUCCEEDED:
+                elif job.status == AirbyteJobStatusType.SUCCEEDED:
                     break
-                elif state == AirbyteState.ERROR:
-                    raise Failure(f"Job failed: {job_id}")
-                elif state == AirbyteState.CANCELLED:
-                    raise Failure(f"Job was cancelled: {job_id}")
+                elif job.status == AirbyteJobStatusType.ERROR:
+                    raise Failure(f"Job failed: {job.id}")
+                elif job.status == AirbyteJobStatusType.CANCELLED:
+                    raise Failure(f"Job was cancelled: {job.id}")
                 else:
-                    raise Failure(f"Encountered unexpected state `{state}` for job_id {job_id}")
+                    raise Failure(
+                        f"Encountered unexpected state `{job.status}` for job_id {job.id}"
+                    )
         finally:
             # if Airbyte sync has not completed, make sure to cancel it so that it doesn't outlive
             # the python process
-            if (
-                state not in (AirbyteState.SUCCEEDED, AirbyteState.ERROR, AirbyteState.CANCELLED)
-                and self.cancel_sync_on_run_termination
+            if cancel_on_termination and job.status not in (
+                AirbyteJobStatusType.SUCCEEDED,
+                AirbyteJobStatusType.ERROR,
+                AirbyteJobStatusType.CANCELLED,
             ):
-                self.cancel_job(job_id)
+                self.cancel_job(job.id)
 
-        return AirbyteOutput(job_details=job_details, connection_details=connection_details)
+        return AirbyteOutput(job_details=poll_job_details, connection_details=connection_details)
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1065,6 +1065,7 @@ class AirbyteCloudClient(DagsterModel):
                     )
 
                 time.sleep(poll_interval)
+                # We return these job details in the AirbyteOutput when the job succeeds
                 poll_job_details = self.get_job_details(job.id)
                 job = AirbyteJob.from_job_details(job_details=poll_job_details)
                 if job.status in (

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
@@ -135,16 +135,16 @@ class AirbyteStream:
 class AirbyteJob:
     """Represents an Airbyte job, based on data as returned from the API."""
 
-    id: str
+    id: int
     status: str
 
     @classmethod
     def from_job_details(
         cls,
         job_details: Mapping[str, Any],
-    ) -> "AirbyteStream":
+    ) -> "AirbyteJob":
         return cls(
-            id=job_details["id"],
+            id=job_details["jobId"],
             status=job_details["status"],
         )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from typing import Optional
 from unittest import mock
 
+import pytest
 import responses
+from dagster import Failure
 from dagster_airbyte import AirbyteCloudWorkspace
 from dagster_airbyte.resources import (
     AIRBYTE_CONFIGURATION_API_BASE,
@@ -11,15 +13,20 @@ from dagster_airbyte.resources import (
     AIRBYTE_REST_API_BASE,
     AIRBYTE_REST_API_VERSION,
 )
+from dagster_airbyte.translator import AirbyteJobStatusType
+from dagster_airbyte.types import AirbyteOutput
 
 from dagster_airbyte_tests.experimental.conftest import (
+    SAMPLE_CONNECTION_DETAILS,
     TEST_ACCESS_TOKEN,
     TEST_CLIENT_ID,
     TEST_CLIENT_SECRET,
     TEST_CONNECTION_ID,
     TEST_DESTINATION_ID,
     TEST_JOB_ID,
+    TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE,
     TEST_WORKSPACE_ID,
+    get_job_details_sample,
 )
 
 
@@ -36,11 +43,18 @@ def assert_token_call_and_split_calls(calls: responses.CallList):
     return calls[1:]
 
 
-def assert_rest_api_call(call: responses.Call, endpoint: str, object_id: Optional[str] = None):
+def assert_rest_api_call(
+    call: responses.Call,
+    endpoint: str,
+    object_id: Optional[str] = None,
+    method: Optional[str] = None,
+):
     rest_api_url = call.request.url.split("?")[0]
     assert rest_api_url == f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/{endpoint}"
     if object_id:
         assert object_id in call.request.body.decode()
+    if method:
+        assert method == call.request.method
     assert call.request.headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
 
 
@@ -144,3 +158,215 @@ def test_basic_resource_request(
     assert_rest_api_call(call=api_calls[3], endpoint="jobs", object_id=TEST_CONNECTION_ID)
     assert_rest_api_call(call=api_calls[4], endpoint=f"jobs/{TEST_JOB_ID}")
     assert_rest_api_call(call=api_calls[5], endpoint=f"jobs/{TEST_JOB_ID}")
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        AirbyteJobStatusType.SUCCEEDED,
+        AirbyteJobStatusType.CANCELLED,
+        AirbyteJobStatusType.ERROR,
+        AirbyteJobStatusType.FAILED,
+        TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE,
+    ],
+)
+def test_airbyte_sync_and_poll_client_job_status(
+    status: str, base_api_mocks: responses.RequestsMock
+) -> None:
+    resource = AirbyteCloudWorkspace(
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    client = resource.get_client()
+
+    test_job_endpoint = f"jobs/{TEST_JOB_ID}"
+    test_job_api_url = f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/{test_job_endpoint}"
+
+    # Create mock responses to mock full sync and poll behavior to test statuses, used only in this test
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs",
+        json=get_job_details_sample(status=AirbyteJobStatusType.PENDING),
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=test_job_api_url,
+        json=get_job_details_sample(status=status),
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/connections/get",
+        json=SAMPLE_CONNECTION_DETAILS,
+        status=200,
+    )
+
+    if status == TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE:
+        base_api_mocks.add(
+            method=responses.DELETE,
+            url=test_job_api_url,
+            status=200,
+            json=get_job_details_sample(status=AirbyteJobStatusType.CANCELLED),
+        )
+
+    if status in [AirbyteJobStatusType.ERROR, AirbyteJobStatusType.FAILED]:
+        with pytest.raises(Failure, match="Job failed"):
+            client.sync_and_poll(connection_id=TEST_CONNECTION_ID, poll_interval=0)
+
+    elif status == AirbyteJobStatusType.CANCELLED:
+        with pytest.raises(Failure, match="Job was cancelled"):
+            client.sync_and_poll(connection_id=TEST_CONNECTION_ID, poll_interval=0)
+
+    elif status == TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE:
+        with pytest.raises(Failure, match="unexpected state"):
+            client.sync_and_poll(connection_id=TEST_CONNECTION_ID, poll_interval=0)
+        assert_rest_api_call(
+            call=base_api_mocks.calls[-1], endpoint=test_job_endpoint, method=responses.DELETE
+        )
+
+    else:
+        result = client.sync_and_poll(connection_id=TEST_CONNECTION_ID, poll_interval=0)
+        assert result == AirbyteOutput(
+            job_details=get_job_details_sample(AirbyteJobStatusType.SUCCEEDED),
+            connection_details=SAMPLE_CONNECTION_DETAILS,
+        )
+
+
+@pytest.mark.parametrize(
+    "n_polls, succeed_at_end",
+    [
+        (0, True),
+        (0, False),
+        (4, True),
+        (4, False),
+        (30, True),
+    ],
+    ids=[
+        "sync_short_success",
+        "sync_short_failure",
+        "sync_medium_success",
+        "sync_medium_failure",
+        "sync_long_success",
+    ],
+)
+def test_airbyte_sync_and_poll_client_poll_process(
+    n_polls, succeed_at_end, base_api_mocks: responses.RequestsMock
+):
+    resource = AirbyteCloudWorkspace(
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    client = resource.get_client()
+
+    # Create mock responses to mock full sync and poll behavior, used only in this test
+    def _mock_interaction():
+        # initial state
+        base_api_mocks.add(
+            method=responses.POST,
+            url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs",
+            json=get_job_details_sample(status=AirbyteJobStatusType.PENDING),
+            status=200,
+        )
+        base_api_mocks.add(
+            method=responses.POST,
+            url=f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/connections/get",
+            json=SAMPLE_CONNECTION_DETAILS,
+            status=200,
+        )
+        # n polls before updating
+        for _ in range(n_polls):
+            base_api_mocks.add(
+                method=responses.GET,
+                url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs/{TEST_JOB_ID}",
+                json=get_job_details_sample(status=AirbyteJobStatusType.RUNNING),
+                status=200,
+            )
+        # final state will be updated
+        base_api_mocks.add(
+            method=responses.GET,
+            url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs/{TEST_JOB_ID}",
+            json=get_job_details_sample(
+                status=AirbyteJobStatusType.SUCCEEDED
+                if succeed_at_end
+                else AirbyteJobStatusType.FAILED
+            ),
+            status=200,
+        )
+        return client.sync_and_poll(connection_id=TEST_CONNECTION_ID, poll_interval=0.1)
+
+    if succeed_at_end:
+        assert _mock_interaction() == AirbyteOutput(
+            job_details=get_job_details_sample(AirbyteJobStatusType.SUCCEEDED),
+            connection_details=SAMPLE_CONNECTION_DETAILS,
+        )
+    else:
+        with pytest.raises(Failure, match="Job failed"):
+            _mock_interaction()
+
+
+@pytest.mark.parametrize(
+    "cancel_on_termination",
+    [
+        True,
+        False,
+    ],
+)
+def test_airbyte_sync_and_poll_client_cancel_on_termination(
+    cancel_on_termination: bool, base_api_mocks: responses.RequestsMock
+) -> None:
+    resource = AirbyteCloudWorkspace(
+        workspace_id=TEST_WORKSPACE_ID,
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+    )
+    client = resource.get_client()
+
+    test_job_endpoint = f"jobs/{TEST_JOB_ID}"
+    test_job_api_url = f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/{test_job_endpoint}"
+
+    # Create mock responses to mock full sync and poll behavior to test statuses, used only in this test
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{AIRBYTE_REST_API_BASE}/{AIRBYTE_REST_API_VERSION}/jobs",
+        json=get_job_details_sample(status=AirbyteJobStatusType.PENDING),
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=test_job_api_url,
+        json=get_job_details_sample(status=TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE),
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{AIRBYTE_CONFIGURATION_API_BASE}/{AIRBYTE_CONFIGURATION_API_VERSION}/connections/get",
+        json=SAMPLE_CONNECTION_DETAILS,
+        status=200,
+    )
+
+    if cancel_on_termination:
+        base_api_mocks.add(
+            method=responses.DELETE,
+            url=test_job_api_url,
+            status=200,
+            json=get_job_details_sample(status=AirbyteJobStatusType.CANCELLED),
+        )
+
+    with pytest.raises(Failure, match="unexpected state"):
+        client.sync_and_poll(
+            connection_id=TEST_CONNECTION_ID,
+            poll_interval=0,
+            cancel_on_termination=cancel_on_termination,
+        )
+    if cancel_on_termination:
+        assert_rest_api_call(
+            call=base_api_mocks.calls[-1], endpoint=test_job_endpoint, method=responses.DELETE
+        )
+    else:
+        # If we don't cancel on termination, the last call will be a call to fetch the job details
+        assert_rest_api_call(
+            call=base_api_mocks.calls[-1], endpoint=test_job_endpoint, method=responses.GET
+        )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/test_resources.py
@@ -169,6 +169,13 @@ def test_basic_resource_request(
         AirbyteJobStatusType.FAILED,
         TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE,
     ],
+    ids=[
+        "job_status_succeeded",
+        "job_status_cancelled",
+        "job_status_error",
+        "job_status_failed",
+        "job_status_unrecognized",
+    ],
 )
 def test_airbyte_sync_and_poll_client_job_status(
     status: str, base_api_mocks: responses.RequestsMock
@@ -312,6 +319,10 @@ def test_airbyte_sync_and_poll_client_poll_process(
     [
         True,
         False,
+    ],
+    ids=[
+        "cancel_on_termination_true",
+        "cancel_on_termination_false",
     ],
 )
 def test_airbyte_sync_and_poll_client_cancel_on_termination(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/experimental/utils.py
@@ -1,0 +1,18 @@
+from contextlib import contextmanager
+from typing import Optional, Type
+
+import pytest
+
+
+@contextmanager
+def optional_pytest_raise(
+    error_expected: bool, exception_cls: Type[Exception], exception_message: Optional[str] = None
+):
+    if error_expected:
+        kwargs = {}
+        if exception_message:
+            kwargs["match"] = exception_message
+        with pytest.raises(exception_cls, **kwargs):
+            yield
+    else:
+        yield

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 import responses
 from dagster import Failure
-from dagster_airbyte import AirbyteCloudResource, AirbyteOutput, AirbyteState
+from dagster_airbyte import AirbyteCloudResource, AirbyteJobStatusType, AirbyteOutput
 
 
 @responses.activate
@@ -50,7 +50,12 @@ def test_trigger_connection_fail() -> None:
 @responses.activate
 @pytest.mark.parametrize(
     "state",
-    [AirbyteState.SUCCEEDED, AirbyteState.CANCELLED, AirbyteState.ERROR, "unrecognized"],
+    [
+        AirbyteJobStatusType.SUCCEEDED,
+        AirbyteJobStatusType.CANCELLED,
+        AirbyteJobStatusType.ERROR,
+        "unrecognized",
+    ],
 )
 def test_sync_and_poll(state) -> None:
     ab_resource = AirbyteCloudResource(
@@ -83,11 +88,11 @@ def test_sync_and_poll(state) -> None:
             json={"jobId": 1, "status": "cancelled", "jobType": "sync"},
         )
 
-    if state == AirbyteState.ERROR:
+    if state == AirbyteJobStatusType.ERROR:
         with pytest.raises(Failure, match="Job failed"):
             ab_resource.sync_and_poll("some_connection", 0)
 
-    elif state == AirbyteState.CANCELLED:
+    elif state == AirbyteJobStatusType.CANCELLED:
         with pytest.raises(Failure, match="Job was cancelled"):
             ab_resource.sync_and_poll("some_connection", 0)
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -1,5 +1,5 @@
 from dagster._utils.merger import deep_merge_dicts
-from dagster_airbyte import AirbyteState
+from dagster_airbyte import AirbyteJobStatusType
 
 
 def get_sample_connection_json(stream_prefix="", **kwargs):
@@ -59,7 +59,7 @@ def get_sample_connection_json(stream_prefix="", **kwargs):
 
 def get_sample_job_json(schema_prefix=""):
     return {
-        "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+        "job": {"id": 1, "status": AirbyteJobStatusType.SUCCEEDED},
         "attempts": [
             {
                 "attempt": {
@@ -89,7 +89,7 @@ def get_sample_job_list_json(schema_prefix=""):
     return {
         "jobs": [
             {
-                "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+                "job": {"id": 1, "status": AirbyteJobStatusType.SUCCEEDED},
                 "attempts": [
                     {
                         "streamStats": [
@@ -371,7 +371,7 @@ def get_project_connection_json(**kwargs):
 
 def get_project_job_json():
     return {
-        "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+        "job": {"id": 1, "status": AirbyteJobStatusType.SUCCEEDED},
         "attempts": [
             {
                 "attempt": {


### PR DESCRIPTION
## Summary & Motivation

Implement full sync and poll process in `AirbyteCloudClient`. This will be used in a subsequent PR in `AirbyteCloudWorkspace.sync_and_poll` to materialize Airbyte assets.

## How I Tested These Changes

Additional tests with BK

