### PR TITLE
[dagster-fivetran] Update custom translator example in docstrings for Fivetran asset decorator and factory

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -76,7 +76,7 @@ def fivetran_assets(
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
                     default_spec = super().get_asset_spec(props)
                     return default_spec.replace_attributes(
-                        key=asset_spec.key.with_prefix("my_prefix"),
+                        key=default_spec.key.with_prefix("my_prefix"),
                     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -74,9 +74,8 @@ def fivetran_assets(
 
             class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
-                    asset_spec = super().get_asset_spec(props)
-                    return replace_attributes(
-                        asset_spec,
+                    default_spec = super().get_asset_spec(props)
+                    return default_spec.replace_attributes(
                         key=asset_spec.key.with_prefix("my_prefix"),
                     )
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -793,7 +793,7 @@ def build_fivetran_assets_definitions(
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
                     default_spec = super().get_asset_spec(props)
                     return default_spec.replace_attributes(
-                        key=asset_spec.key.with_prefix("my_prefix"),
+                        key=default_spec.key.with_prefix("my_prefix"),
                     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -791,9 +791,8 @@ def build_fivetran_assets_definitions(
 
             class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
-                    asset_spec = super().get_asset_spec(props)
-                    return replace_attributes(
-                        asset_spec,
+                    default_spec = super().get_asset_spec(props)
+                    return default_spec.replace_attributes(
                         key=asset_spec.key.with_prefix("my_prefix"),
                     )
 


### PR DESCRIPTION
## Summary & Motivation

As title. The example should be using the new `AssetSpec.replace_attributes(...)` pattern.

## How I Tested These Changes

Docs preview
