### PR TITLE
[components] Simplify component folder creation

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -4,8 +4,7 @@ from typing import Any, Type
 
 import click
 import yaml
-from dagster._generate.generate import generate_project
-from dagster._utils import pushd
+from dagster._utils import mkdir_p, pushd
 
 from dagster_components.core.component import Component
 
@@ -25,18 +24,9 @@ def generate_component_instance(
     component_type_name: str,
     generate_params: Any,
 ) -> None:
-    click.echo(f"Creating a Dagster component instance at {root_path}/{name}.py.")
-
     component_instance_root_path = os.path.join(root_path, name)
-    generate_project(
-        path=component_instance_root_path,
-        name_placeholder="COMPONENT_INSTANCE_NAME_PLACEHOLDER",
-        templates_path=os.path.join(
-            os.path.dirname(__file__), "templates", "COMPONENT_INSTANCE_NAME_PLACEHOLDER"
-        ),
-        project_name=name,
-        component_type=component_type_name,
-    )
+    click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")
+    mkdir_p(component_instance_root_path)
     with pushd(component_instance_root_path):
         component_params = component_type.generate_files(generate_params)
         component_data = {"type": component_type_name, "params": component_params or {}}

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -85,19 +85,9 @@ def generate_component_instance(
     json_params: Optional[str],
     extra_args: Tuple[str, ...],
 ) -> None:
-    click.echo(f"Creating a Dagster component instance at {root_path}/{name}.py.")
-
     component_instance_root_path = root_path / name
-    generate_subtree(
-        path=component_instance_root_path,
-        name_placeholder="COMPONENT_INSTANCE_NAME_PLACEHOLDER",
-        templates_path=os.path.join(
-            os.path.dirname(__file__), "templates", "COMPONENT_INSTANCE_NAME_PLACEHOLDER"
-        ),
-        project_name=name,
-        component_type=component_type,
-    )
-
+    click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")
+    os.makedirs(component_instance_root_path, exist_ok=True)
     code_location_command = (
         "generate",
         "component",


### PR DESCRIPTION
## Summary & Motivation

There were very confusion calls to `generate_project` and `generate_subtree` in our scaffolding code that did nothing but generate a folder, even though they referred to nonexistent templates. 

Turns out this worked because `os.walk` silent returns an empty generator when it points to a directory that does not exist.

Just changing this to a `mkdir_p` call for clarity and simplicity.

## How I Tested These Changes

Manual test. BK
