### PR TITLE
[components] Refactor generate files to call explicit function to build component.yaml

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -1,5 +1,6 @@
 from dagster_components.core.component import (
     Component as Component,
+    ComponentGenerateRequest as ComponentGenerateRequest,
     ComponentLoadContext as ComponentLoadContext,
     ComponentRegistry as ComponentRegistry,
     component as component,

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import inspect
 import sys
 from abc import ABC, abstractmethod
+from pathlib import Path
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -20,6 +21,7 @@ from typing import (
 
 from dagster import _check as check
 from dagster._core.errors import DagsterError
+from dagster._record import record
 from dagster._utils import snakecase
 from typing_extensions import Self
 
@@ -30,13 +32,19 @@ if TYPE_CHECKING:
 class ComponentDeclNode: ...
 
 
+@record
+class ComponentGenerateRequest:
+    component_type_name: str
+    component_instance_root_path: Path
+
+
 class Component(ABC):
     name: ClassVar[Optional[str]] = None
     component_params_schema: ClassVar = None
     generate_params_schema: ClassVar = None
 
     @classmethod
-    def generate_files(cls, params: Any) -> Optional[Mapping[str, Any]]: ...
+    def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None: ...
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> "Definitions": ...

--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
-from typing import Any, Type
+from typing import Any, Mapping, Optional, Type
 
 import click
 import yaml
-from dagster._utils import mkdir_p, pushd
+from dagster._utils import mkdir_p
 
-from dagster_components.core.component import Component
+from dagster_components.core.component import Component, ComponentGenerateRequest
 
 
 class ComponentDumper(yaml.Dumper):
@@ -17,6 +17,16 @@ class ComponentDumper(yaml.Dumper):
         super().write_line_break()
 
 
+def generate_component_yaml(
+    request: ComponentGenerateRequest, component_params: Optional[Mapping[str, Any]]
+) -> None:
+    with open(request.component_instance_root_path / "component.yaml", "w") as f:
+        component_data = {"type": request.component_type_name, "params": component_params or {}}
+        yaml.dump(
+            component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
+        )
+
+
 def generate_component_instance(
     root_path: str,
     name: str,
@@ -24,13 +34,20 @@ def generate_component_instance(
     component_type_name: str,
     generate_params: Any,
 ) -> None:
-    component_instance_root_path = os.path.join(root_path, name)
+    component_instance_root_path = Path(os.path.join(root_path, name))
     click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")
-    mkdir_p(component_instance_root_path)
-    with pushd(component_instance_root_path):
-        component_params = component_type.generate_files(generate_params)
-        component_data = {"type": component_type_name, "params": component_params or {}}
-    with open(Path(component_instance_root_path) / "component.yaml", "w") as f:
-        yaml.dump(
-            component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
+    mkdir_p(str(component_instance_root_path))
+    component_type.generate_files(
+        ComponentGenerateRequest(
+            component_type_name=component_type_name,
+            component_instance_root_path=component_instance_root_path,
+        ),
+        generate_params,
+    )
+
+    component_yaml_path = component_instance_root_path / "component.yaml"
+
+    if not component_yaml_path.exists():
+        raise Exception(
+            f"Currently all components require a component.yaml file. Please ensure your implementation of generate_files writes this file at {component_yaml_path}."
         )

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
@@ -15,9 +15,10 @@ from pydantic import BaseModel, Field, TypeAdapter
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component import component
+from dagster_components.core.component import ComponentGenerateRequest, component
 from dagster_components.core.component_decl_builder import ComponentDeclNode, YamlComponentDecl
 from dagster_components.core.dsl_schema import AssetSpecProcessorModel, OpSpecBaseModel
+from dagster_components.generate import generate_component_yaml
 
 
 class DbtNodeTranslatorParams(BaseModel):
@@ -122,7 +123,7 @@ class DbtProjectComponent(Component):
         return defs
 
     @classmethod
-    def generate_files(cls, params: DbtGenerateParams) -> Mapping[str, Any]:
+    def generate_files(cls, request: ComponentGenerateRequest, params: DbtGenerateParams) -> None:
         cwd = os.getcwd()
         if params.project_path:
             # NOTE: CWD is not set "correctly" above so we prepend "../../.." as a temporary hack to
@@ -141,7 +142,7 @@ class DbtProjectComponent(Component):
         else:
             relative_path = None
 
-        return {"dbt": {"project_dir": relative_path}}
+        generate_component_yaml(request, {"dbt": {"project_dir": relative_path}})
 
     def execute(self, context: AssetExecutionContext, dbt: DbtCliResource) -> Iterator:
         yield from dbt.cli(["build"], context=context).stream()

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
@@ -12,9 +12,10 @@ from pydantic import BaseModel, TypeAdapter
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component import component
+from dagster_components.core.component import ComponentGenerateRequest, component
 from dagster_components.core.component_decl_builder import ComponentDeclNode, YamlComponentDecl
 from dagster_components.core.dsl_schema import AssetSpecProcessorModel, OpSpecBaseModel
+from dagster_components.generate import generate_component_yaml
 
 
 class SlingReplicationParams(BaseModel):
@@ -67,7 +68,8 @@ class SlingReplicationComponent(Component):
         return defs
 
     @classmethod
-    def generate_files(cls, params: Any) -> None:
+    def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None:
+        generate_component_yaml(request, params)
         replication_path = Path(os.getcwd()) / "replication.yaml"
         with open(replication_path, "w") as f:
             yaml.dump(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
@@ -25,7 +25,13 @@ from dagster_dg.utils import discover_git_root, pushd
 def _example_component_type_baz():
     import click
     from dagster import AssetExecutionContext, Definitions, PipesSubprocessClient, asset
-    from dagster_components import Component, ComponentLoadContext, component
+    from dagster_components import (
+        Component,
+        ComponentGenerateRequest,
+        ComponentLoadContext,
+        component,
+    )
+    from dagster_components.generate import generate_component_yaml
     from pydantic import BaseModel
 
     _SAMPLE_PIPES_SCRIPT = """
@@ -49,7 +55,8 @@ def _example_component_type_baz():
         generate_params_schema = BazGenerateParams
 
         @classmethod
-        def generate_files(cls, params: BazGenerateParams):
+        def generate_files(cls, request: ComponentGenerateRequest, params: BazGenerateParams):
+            generate_component_yaml(request, {})
             with open(params.filename, "w") as f:
                 f.write(_SAMPLE_PIPES_SCRIPT)
 


### PR DESCRIPTION
## Summary & Motivation

I'm in the process of creating scaffolding for generic custom components and want to customize the scaffolding process more. This means giving more explicit control to users to define their own scaffolding to some degree.

Hence I'm making it so that the user explicitly invokes the creation of a component.yaml file rather than having our framework do it. This lets the user customize the behavior. I also think this is more obvious and understandable, at the cost of an extra import.

In order to ensure that a custom component author doesn't screw this up, we add a check after `generate_files` to ensure that `component.yaml` exists. 

## How I Tested These Changes

BK and manual
