### PR TITLE
[components] Add support for extras (conditional imports version)

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -88,16 +88,12 @@ class ComponentRegistry:
         return f"<ComponentRegistry {list(self._components.keys())}>"
 
 
-def get_registered_components_in_module(root_module: ModuleType) -> Iterable[Type[Component]]:
-    from dagster._core.definitions.load_assets_from_modules import (
-        find_modules_in_package,
-        find_subclasses_in_module,
-    )
+def get_registered_components_in_module(module: ModuleType) -> Iterable[Type[Component]]:
+    from dagster._core.definitions.load_assets_from_modules import find_subclasses_in_module
 
-    for module in find_modules_in_package(root_module):
-        for component in find_subclasses_in_module(module, (Component,)):
-            if is_registered_component(component):
-                yield component
+    for component in find_subclasses_in_module(module, (Component,)):
+        if is_registered_component(component):
+            yield component
 
 
 class ComponentLoadContext:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
@@ -1,0 +1,16 @@
+import importlib.util
+
+_has_dagster_dbt = importlib.util.find_spec("dagster_dbt") is not None
+_has_dagster_embedded_elt = importlib.util.find_spec("dagster_embedded_elt") is not None
+
+if _has_dagster_dbt:
+    from dagster_components.lib.dbt_project import DbtProjectComponent as DbtProjectComponent
+
+if _has_dagster_embedded_elt:
+    from dagster_components.lib.sling_replication import (
+        SlingReplicationComponent as SlingReplicationComponent,
+    )
+
+from dagster_components.lib.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollection as PipesSubprocessScriptCollection,
+)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
@@ -6,9 +6,9 @@ import click
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils import pushd
 from dagster_dbt import DagsterDbtTranslator, DbtCliResource, DbtProject, dbt_assets
-from dagster_embedded_elt.sling.resources import AssetExecutionContext
 from dbt.cli.main import dbtRunner
 from jinja2 import Template
 from pydantic import BaseModel, Field, TypeAdapter


### PR DESCRIPTION
## Summary & Motivation

Add support for extras in component discovery in `dagster-components`. Alternative to #26417 (conditional entry point loading) that instead uses conditional import statements:

- Discovery mechanism has changed so that submodules of the target module of an entry point are no longer traversed. Instead we look only at the specified module for declared components.
- Because we load everything coming from the entry point target, and we unconditionally load every declared entry point, we place the burden on component library authors to examine the environment and skip loading any components corresponding to uninstalled extras.
- Implementation of this approach in `dagster_components.lib`, where we condition imports of components for the `dbt` and `sling` extras on the presence of `dagster-dbt` and `dagster-embedded-elt` packages in the environment. Basically we are just hardcoding in `dagster_components/lib/__init__.py` a repeat of the dependencies associated with each extra rather than reading them from package metadata (approach in #26417).

## How I Tested These Changes

Unit tests confirming only the correct components are registered when each extra is installed.