### PR TITLE
[components] Fix dagster-dg component type scaffold and tests

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -115,7 +115,7 @@ def generate_component_type_command(name: str) -> None:
         click.echo(click.style(f"A component type named `{name}` already exists.", fg="red"))
         sys.exit(1)
 
-    generate_component_type(Path(context.component_types_root_path), name)
+    generate_component_type(context, name)
 
 
 @generate_cli.command(name="component")

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import click
 
+from dagster_dg.context import CodeLocationProjectContext
 from dagster_dg.utils import (
     camelcase,
     discover_git_root,
@@ -65,7 +66,8 @@ def generate_code_location(path: Path, editable_dagster_root: Optional[str] = No
     execute_code_location_command(Path(path), ("uv", "sync"))
 
 
-def generate_component_type(root_path: Path, name: str) -> None:
+def generate_component_type(context: CodeLocationProjectContext, name: str) -> None:
+    root_path = Path(context.component_types_root_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{name}.py.")
 
     generate_subtree(
@@ -76,6 +78,9 @@ def generate_component_type(root_path: Path, name: str) -> None:
         component_type_class_name=camelcase(name),
         component_type=name,
     )
+
+    with open(root_path / "__init__.py", "a") as f:
+        f.write(f"from {context.component_types_root_module}.{name} import {camelcase(name)}\n")
 
 
 def generate_component_instance(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
@@ -100,6 +100,8 @@ def isolated_example_code_location_bar_with_component_type_baz(
     runner: CliRunner, in_deployment: bool = True
 ) -> Iterator[None]:
     with isolated_example_code_location_bar(runner, in_deployment):
+        with open("bar/lib/__init__.py", "a") as f:
+            f.write("from bar.lib.baz import Baz\n")
         with open("bar/lib/baz.py", "w") as f:
             component_type_source = textwrap.dedent(
                 inspect.getsource(_example_component_type_baz).split("\n", 1)[1]


### PR DESCRIPTION
## Summary & Motivation

Tests for this were broken by the extras support PR, since components local to a code location now to be added to `lib/__init__.py`. This fixes the component-type scaffolding and tests.

## How I Tested These Changes

Modified unit tests.