### PR TITLE
[ui] Fix endless log loading

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, NonIdealState, Row} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, Row, SpinnerWithText} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useEffect, useRef} from 'react';
 import styled from 'styled-components';
@@ -81,12 +81,10 @@ export const LogsScrollingTable = (props: Props) => {
   }, [totalHeight, virtualizer]);
 
   const content = () => {
-    if (logs.loading) {
+    if (logs.allNodeChunks.length === 0 && logs.loading) {
       return (
-        <Box margin={{top: 32}}>
-          <ListEmptyState>
-            <NonIdealState icon="spinner" title="Fetching logs..." />
-          </ListEmptyState>
+        <Box margin={{top: 32}} flex={{direction: 'column', alignItems: 'center'}}>
+          <SpinnerWithText label="Loading run logs…" />
         </Box>
       );
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {LogsProviderLogs} from './LogsProvider';
 import {RunContext} from './RunContext';
 import {gql} from '../apollo-client';
+import {flattenOneLevel} from '../util/flattenOneLevel';
 import {RunFragment} from './types/RunFragments.types';
 import {RunMetadataProviderMessageFragment} from './types/RunMetadataProvider.types';
 import {StepEventStatus} from '../graphql/types';
@@ -371,7 +372,8 @@ export const RunMetadataProvider = ({logs, children}: IRunMetadataProviderProps)
   const run = React.useContext(RunContext);
   const runMetadata = React.useMemo(() => extractMetadataFromRun(run), [run]);
   const metadata = React.useMemo(
-    () => (logs.loading ? runMetadata : extractMetadataFromLogs(logs.allNodes)),
+    () =>
+      logs.loading ? runMetadata : extractMetadataFromLogs(flattenOneLevel(logs.allNodeChunks)),
     [logs, runMetadata],
   );
   return <>{children(metadata)}</>;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
@@ -8,7 +8,7 @@ import {
   Mono,
   Spinner,
 } from '@dagster-io/ui-components';
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -22,6 +22,7 @@ import {IRunMetadataDict, RunMetadataProvider} from './RunMetadataProvider';
 import {titleForRun} from './RunUtils';
 import {useComputeLogFileKeyForSelection} from './useComputeLogFileKeyForSelection';
 import {DagsterEventType} from '../graphql/types';
+import {flattenOneLevel} from '../util/flattenOneLevel';
 
 export function useStepLogs({runId, stepKeys}: {runId?: string; stepKeys?: string[]}) {
   const [showingLogs, setShowingLogs] = React.useState<{runId: string; stepKeys: string[]} | null>(
@@ -113,9 +114,12 @@ export const StepLogsModalContent = ({
   const [logType, setComputeLogType] = useState<LogType>(LogType.structured);
   const [computeLogUrl, setComputeLogUrl] = React.useState<string | null>(null);
 
-  const firstLogForStep = logs.allNodes.find(
+  const flatLogs = useMemo(() => flattenOneLevel(logs.allNodeChunks), [logs]);
+
+  const firstLogForStep = flatLogs.find(
     (l) => l.eventType === DagsterEventType.STEP_START && l.stepKey && stepKeys.includes(l.stepKey),
   );
+
   const firstLogForStepTime = firstLogForStep ? Number(firstLogForStep.timestamp) : 0;
 
   const [filter, setFilter] = useState<LogFilter>({

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
@@ -3,9 +3,10 @@ import {eventTypeToDisplayType} from './getRunFilterProviders';
 import {logNodeLevel} from './logNodeLevel';
 import {LogNode} from './types';
 import {weakmapMemoize} from '../app/Util';
+import {flattenOneLevel} from '../util/flattenOneLevel';
 
 export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
-  const filteredNodes = logs.allNodes.filter((node) => {
+  const filteredNodes = flattenOneLevel(logs.allNodeChunks).filter((node) => {
     // These events are used to determine which assets a run will materialize and are not intended
     // to be displayed in the Dagster UI. Pagination is offset based, so we remove these logs client-side.
     if (

--- a/js_modules/dagster-ui/packages/ui-core/src/util/flattenOneLevel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/flattenOneLevel.tsx
@@ -1,0 +1,10 @@
+/**
+ * Flattens a two-dimensional array into a one-dimensional array.
+ *
+ * @param nodeChunks - The two-dimensional array to flatten.
+ * @returns The flattened one-dimensional array.
+ */
+// https://jsbench.me/o8kqzo8olz/1
+export function flattenOneLevel<T>(arrays: T[][]) {
+  return ([] as T[]).concat(...arrays);
+}


### PR DESCRIPTION
## Summary & Motivation

We received a bug report from an org with some very, very long log output on some of their runs. Specifically, hundreds of thousands of large logs for individual runs. I noticed two issues during testing:

- When a chunk of logs loads and indicates that there are more older logs left to stream, we consider that a "loading" state and simply don't show any logs in the logs table at all.
  - This is unnecessary, since we're streaming logs in. Instead, just show the loading state if there are no logs available yet at all.
- First, we're using the spread-to-concat antipattern in the subscription handler reducer, which means iterating over the entire existing list of nodes before adding the newly received logs.
  - To resolve this, I'm changing the state array to track *chunks* of logs instead of flattened logs. This means we can more efficiently push chunks into state without mutating state or taking the time to copy entire chunks, then flatten them as needed for filtering/rendering.
  - I used `[].concat(...chunks)` as the flattening approach, based on benchmarking. it seems to be faster than `flat()`.

## How I Tested These Changes

View run with neverending log loading. Verify that logs appear and stream in.

Use Chrome profiler to determine that the chunking and flattening behavior appears to be performant at scale. The `filterLogs` function remains expensive, but I think in this case it's because the logs themselves are enormous and require a ton of JSON stringification to support text searching.

## Changelog

[ui] Fix run log streaming for runs with a large volume of logs.
