### PR TITLE
Add base class for custom component types

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -43,6 +43,9 @@ def path_to_decl_node(path: Path) -> Optional[ComponentDeclNode]:
 
     subs = []
     for subpath in path.iterdir():
+        if subpath.name.startswith("."):
+            continue
+
         component = path_to_decl_node(subpath)
         if component:
             subs.append(component)

--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -20,8 +20,18 @@ class ComponentDumper(yaml.Dumper):
 def generate_component_yaml(
     request: ComponentGenerateRequest, component_params: Optional[Mapping[str, Any]]
 ) -> None:
-    with open(request.component_instance_root_path / "component.yaml", "w") as f:
-        component_data = {"type": request.component_type_name, "params": component_params or {}}
+    generate_custom_component_yaml(
+        request.component_instance_root_path, request.component_type_name, component_params
+    )
+
+
+def generate_custom_component_yaml(
+    component_instance_root_path: Path,
+    component_type_name: str,
+    component_params: Optional[Mapping[str, Any]],
+) -> None:
+    with open(component_instance_root_path / "component.yaml", "w") as f:
+        component_data = {"type": component_type_name, "params": component_params or {}}
         yaml.dump(
             component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
         )

--- a/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
@@ -11,6 +11,7 @@ if _has_dagster_embedded_elt:
         SlingReplicationComponent as SlingReplicationComponent,
     )
 
+from dagster_components.lib.custom_component import CustomComponent as CustomComponent
 from dagster_components.lib.definitions_component import (
     DefinitionsComponent as DefinitionsComponent,
 )

--- a/python_modules/libraries/dagster-components/dagster_components/lib/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/custom_component.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 
-import click
 from dagster._utils import snakecase
 from pydantic import BaseModel
 
@@ -13,7 +12,7 @@ from dagster_components.core.component import (
     Component,
     ComponentGenerateRequest,
     ComponentLoadContext,
-    component,
+    component_type,
 )
 from dagster_components.generate import generate_custom_component_yaml
 
@@ -25,12 +24,12 @@ def custom_component_template():
     from dagster import Definitions
     from pydantic import BaseModel
 
-    from dagster_components import ComponentLoadContext, component
+    from dagster_components import ComponentLoadContext, component_type
     from dagster_components.lib.custom_component import CustomComponent
 
     class ClassNamePlaceholderComponentSchema(BaseModel): ...
 
-    @component(name="component_type_name_placeholder")
+    @component_type(name="component_type_name_placeholder")
     class ClassNamePlaceholderComponent(CustomComponent):
         params_schema = ClassNamePlaceholderComponentSchema
 
@@ -51,14 +50,8 @@ COMPONENT_TYPE_NAME_PLACEHOLDER = "component_type_name_placeholder"
 class GenerateCustomComponentParams(BaseModel):
     class_name: str
 
-    @staticmethod
-    @click.command
-    @click.option("--class-name", "- ", type=click.STRING)
-    def cli(class_name: str) -> "GenerateCustomComponentParams":
-        return GenerateCustomComponentParams(class_name=class_name)
 
-
-@component(name="custom")
+@component_type(name="custom")
 class CustomComponent(Component):
     """Component base class for generating a custom component local to the component instance."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/custom_component.py
@@ -1,0 +1,89 @@
+import inspect
+import os
+import textwrap
+from abc import abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping, Optional
+
+import click
+from dagster._utils import snakecase
+from pydantic import BaseModel
+
+from dagster_components.core.component import (
+    Component,
+    ComponentGenerateRequest,
+    ComponentLoadContext,
+    component,
+)
+from dagster_components.generate import generate_custom_component_yaml
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.definitions_class import Definitions
+
+
+def custom_component_template():
+    from dagster import Definitions
+    from pydantic import BaseModel
+
+    from dagster_components import ComponentLoadContext, component
+    from dagster_components.lib.custom_component import CustomComponent
+
+    class ClassNamePlaceholderComponentSchema(BaseModel): ...
+
+    @component(name="component_type_name_placeholder")
+    class ClassNamePlaceholderComponent(CustomComponent):
+        params_schema = ClassNamePlaceholderComponentSchema
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
+
+        @classmethod
+        def load(cls, context: ComponentLoadContext) -> "ClassNamePlaceholderComponent":
+            loaded_params = context.load_params(cls.params_schema)
+            assert loaded_params  # silence linter complaints
+            return cls()
+
+
+CLASSNAME_PLACEHODLER = "ClassNamePlaceholder"
+COMPONENT_TYPE_NAME_PLACEHOLDER = "component_type_name_placeholder"
+
+
+class GenerateCustomComponentParams(BaseModel):
+    class_name: str
+
+    @staticmethod
+    @click.command
+    @click.option("--class-name", "- ", type=click.STRING)
+    def cli(class_name: str) -> "GenerateCustomComponentParams":
+        return GenerateCustomComponentParams(class_name=class_name)
+
+
+@component(name="custom")
+class CustomComponent(Component):
+    """Component base class for generating a custom component local to the component instance."""
+
+    generate_params_schema = GenerateCustomComponentParams
+
+    @classmethod
+    def generate_files(
+        cls, request: ComponentGenerateRequest, params: GenerateCustomComponentParams
+    ) -> Optional[Mapping[str, Any]]:
+        component_type_name = snakecase(params.class_name)
+        generate_custom_component_yaml(
+            request.component_instance_root_path, "." + component_type_name, {}
+        )
+        replication_path = Path(os.getcwd()) / "component.py"
+        with open(replication_path, "w") as f:
+            f.write(get_custom_component_template(params.class_name, component_type_name))
+
+    @abstractmethod
+    def build_defs(self, context: "ComponentLoadContext") -> "Definitions": ...
+
+
+def get_custom_component_template(class_name: str, component_type_name: str) -> str:
+    raw_source = inspect.getsource(custom_component_template)
+    without_decl = raw_source.split("\n", 1)[1]
+    dedented = textwrap.dedent(without_decl)
+    return dedented.replace(CLASSNAME_PLACEHODLER, class_name).replace(
+        COMPONENT_TYPE_NAME_PLACEHOLDER, component_type_name
+    )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_custom_component.py
@@ -1,0 +1,7 @@
+from dagster_components.lib.custom_component import get_custom_component_template
+
+
+def test_custom_component_template() -> None:
+    source_from_fn = get_custom_component_template("Foo", "foo")
+
+    assert "class FooComponent" in source_from_fn


### PR DESCRIPTION
## Summary & Motivation

This adds a "custom component" component type to `dagster_components`. This makes it very easy to build a non-resuable component type local to a component instance.

## How I Tested These Changes

`dg generate component dagster_components.custom_component a_custom_component -- --class-name ACustomComponent`