### PR TITLE
[ui] Reject throttleLatest promise with a string instead of an Error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/throttleLatest.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/throttleLatest.test.tsx
@@ -25,7 +25,7 @@ describe('throttleLatest', () => {
     const promise1 = throttledFunction(1);
     const promise2 = throttledFunction(2);
 
-    await expect(promise1).rejects.toThrow('Throttled: A new call has been made.');
+    await expect(promise1).rejects.toEqual('Throttled: A new call has been made.');
 
     expect(mockFunction).toHaveBeenCalledTimes(1);
 
@@ -41,7 +41,7 @@ describe('throttleLatest', () => {
 
     const promise2 = throttledFunction(2);
 
-    await expect(promise1).rejects.toThrow('Throttled: A new call has been made.');
+    await expect(promise1).rejects.toEqual('Throttled: A new call has been made.');
 
     jest.advanceTimersByTime(1000);
 
@@ -89,7 +89,7 @@ describe('throttleLatest', () => {
     const promise2 = throttledFunction(2);
 
     // The first promise should be rejected
-    await expect(promise1).rejects.toThrow('Throttled: A new call has been made.');
+    await expect(promise1).rejects.toEqual('Throttled: A new call has been made.');
 
     // The second promise is scheduled to execute after the remaining time (2000 - 100 = 1900ms)
     jest.advanceTimersByTime(1900);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/throttleLatest.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/throttleLatest.ts
@@ -16,7 +16,7 @@ export function throttleLatest<T extends (...args: any[]) => Promise<any>>(
     return new Promise((resolve, reject) => {
       // If a call is already active, reject its promise
       if (activeReject) {
-        activeReject(new Error('Throttled: A new call has been made.'));
+        activeReject('Throttled: A new call has been made.');
         activeReject = null;
       }
 


### PR DESCRIPTION
## Summary & Motivation

When `throttleLatest` rejects the Promise for an active call, use a string instead of an `Error` to avoid surfacing unnecessary errors in our error tracking. Since the Promise rejection represents the function behaving as intended, the `Error` doesn't need to be tracked or raise any alarms.

## How I Tested These Changes

Repro the Promise rejection case by viewing a Job dag that has surfaced it. Verify that an error appears in the console. Verify that with this change, no error is surfaced.
