### PR TITLE
[dagster-dbt] Use Iterator[T] in DbtEventIterator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Optional, Union, cast
 
 from dagster import (
     AssetCheckResult,
@@ -185,7 +185,7 @@ def _fetch_row_count_metadata(
         return None
 
 
-class DbtEventIterator(Generic[T], Iterator):
+class DbtEventIterator(Iterator[T]):
     """A wrapper around an iterator of dbt events which contains additional methods for
     post-processing the events, such as fetching row counts for materialized tables.
     """


### PR DESCRIPTION
## Summary & Motivation

Following changes in #26424, we subclass DbtEventIterator with Iterator[T] and remove Generic[T] 

## How I Tested These Changes

Same tests with BK