### PR TITLE
[auto-reexecution] make run_failure_reason a parameter to determine if should retry

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2487,14 +2487,16 @@ class DagsterInstance(DynamicPartitionsStore):
                 if run and event.get_dagster_event().is_run_failure and self.run_retries_enabled:
                     # Note that this tag is only applied to runs that fail. Successful runs will not
                     # have a WILL_RETRY_TAG tag.
-                    is_step_failure = (
-                        run.tags.get(RUN_FAILURE_REASON_TAG) == RunFailureReason.STEP_FAILURE.value
+                    run_failure_reason = (
+                        RunFailureReason(run.tags.get(RUN_FAILURE_REASON_TAG))
+                        if run.tags.get(RUN_FAILURE_REASON_TAG)
+                        else None
                     )
                     self.add_run_tags(
                         run_id,
                         {
                             WILL_RETRY_TAG: str(
-                                auto_reexecution_should_retry_run(self, run, is_step_failure)
+                                auto_reexecution_should_retry_run(self, run, run_failure_reason)
                             ).lower()
                         },
                     )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -77,6 +77,7 @@ from dagster._core.storage.tags import (
     PARTITION_NAME_TAG,
     RESUME_RETRY_TAG,
     ROOT_RUN_ID_TAG,
+    RUN_FAILURE_REASON_TAG,
     TAGS_TO_MAYBE_OMIT_ON_RETRY,
     WILL_RETRY_TAG,
 )
@@ -2443,6 +2444,8 @@ class DagsterInstance(DynamicPartitionsStore):
             event (EventLogEntry): The event to handle.
             batch_metadata (Optional[DagsterEventBatchMetadata]): Metadata for batch writing.
         """
+        from dagster._core.events import RunFailureReason
+
         if batch_metadata is None or not _is_batch_writing_enabled():
             events = [event]
         else:
@@ -2484,9 +2487,16 @@ class DagsterInstance(DynamicPartitionsStore):
                 if run and event.get_dagster_event().is_run_failure and self.run_retries_enabled:
                     # Note that this tag is only applied to runs that fail. Successful runs will not
                     # have a WILL_RETRY_TAG tag.
+                    is_step_failure = (
+                        run.tags.get(RUN_FAILURE_REASON_TAG) == RunFailureReason.STEP_FAILURE.value
+                    )
                     self.add_run_tags(
                         run_id,
-                        {WILL_RETRY_TAG: str(auto_reexecution_should_retry_run(self, run)).lower()},
+                        {
+                            WILL_RETRY_TAG: str(
+                                auto_reexecution_should_retry_run(self, run, is_step_failure)
+                            ).lower()
+                        },
                     )
             for sub in self._subscribers[run_id]:
                 sub(event)


### PR DESCRIPTION
## Summary & Motivation
A reorganization of the `auto_reexecution_should_retry_run` function to take the run failure reason. This removes an implicit dependency on a tag's existence that was causing some errors in the associated internal pr

associate internal pr https://github.com/dagster-io/internal/pull/13039

## How I Tested These Changes
existing tests
