### PR TITLE
[io-managers-deps] Allow deps and ins to coexist at decorator layer

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -40,7 +40,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
     DecoratorAssetsDefinitionBuilder,
     DecoratorAssetsDefinitionBuilderArgs,
-    build_named_ins,
+    build_and_validate_named_ins,
     build_named_outs,
     create_check_specs_by_output_name,
     validate_and_assign_output_names_to_check_specs,
@@ -911,7 +911,7 @@ def graph_asset_no_defaults(
     kinds: Optional[AbstractSet[str]],
 ) -> AssetsDefinition:
     ins = ins or {}
-    named_ins = build_named_ins(compose_fn, ins or {}, set())
+    named_ins = build_and_validate_named_ins(compose_fn, ins or {}, set())
     out_asset_key, _asset_name = resolve_asset_key_and_name_for_decorator(
         key=key,
         key_prefix=key_prefix,
@@ -1030,7 +1030,7 @@ def graph_multi_asset(
             if asset_in.partition_mapping
         }
 
-        named_ins = build_named_ins(fn, ins or {}, set())
+        named_ins = build_and_validate_named_ins(fn, ins or {}, set())
         keys_by_input_name = {
             input_name: asset_key for asset_key, (input_name, _) in named_ins.items()
         }

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
@@ -98,18 +98,18 @@ def test_additional_ins_overlap():
 
 
 def test_additional_ins_and_deps_overlap():
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=re.escape("deps value AssetKey(['asset2']) also declared as input/AssetIn"),
-    ):
+    @asset_check(
+        asset=asset1,
+        additional_ins={"asset_2": AssetIn("asset2")},
+        additional_deps=[asset2],
+    )
+    def check1(asset_2) -> AssetCheckResult:
+        return AssetCheckResult(passed=asset_2 == 5)
 
-        @asset_check(  # pyright: ignore[reportArgumentType]
-            asset=asset1,
-            additional_ins={"asset_2": AssetIn("asset2")},
-            additional_deps=[asset2],
-        )
-        def check1(asset_2):
-            pass
+    result = execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
+    assert result.success
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert all(e.passed for e in result.get_asset_check_evaluations())
 
 
 def test_additional_ins_must_correspond_to_params():


### PR DESCRIPTION
## Summary & Motivation
Previously, we would hard error if both deps and ins existed within a particular utility function `build_named_ins` in the asset decorator code paths. This would lead to us doing all sorts of gymnastics in various decorator pathways contorting the code to fit that path, while still allowing that invariant to be true (multi_asset is the most egregious example here, where we literally call the function twice with two different parameterizations).

However, downstream code paths are actually pretty good at handling this gracefully. We have ways of synthesizing and deduping asset specs from a list of asset ins and deps, so I don't think we need to be so strict here.

What we _do_ need to be strict about is the contents of the provided AssetIn. We should be hard erroring if the user tries to specify arguments on both the AssetIn and provide deps at the same time - if deps are specified, ins should be purely for input name remapping purposes.

I think this actually allows us to simplify a few code paths, and doesn't really change any test behavior.

## How I Tested These Changes
Added a bunch of new test behavior to test_asset_deps.py which shows how these arguments now coexist.
