### PR TITLE
[components] Rendering engine

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
@@ -1,0 +1,97 @@
+import json
+from typing import AbstractSet, Any, Mapping, Optional, Sequence, Type, TypeVar, Union
+
+import dagster._check as check
+from dagster._record import record
+from jinja2 import Template
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+T = TypeVar("T")
+
+REF_BASE = "#/$defs/"
+REF_TEMPLATE = f"{REF_BASE}{{model}}"
+
+CONTEXT_KEY = "required_rendering_context"
+
+
+def add_required_rendering_context(field: FieldInfo, context: AbstractSet[str]) -> Any:
+    return FieldInfo.merge_field_infos(
+        field, FieldInfo(json_schema_extra={CONTEXT_KEY: json.dumps(list(context))})
+    )
+
+
+def get_required_rendering_context(subschema: Mapping[str, Any]) -> Optional[AbstractSet[str]]:
+    raw = check.opt_inst(subschema.get(CONTEXT_KEY), str)
+    return set(json.loads(raw)) if raw else None
+
+
+@record
+class TemplatedValueResolver:
+    context: Mapping[str, Any]
+
+    def resolve(self, val: str) -> str:
+        return Template(val).render(**self.context)
+
+
+def _should_render(
+    valpath: Sequence[Union[str, int]], json_schema: Mapping[str, Any], subschema: Mapping[str, Any]
+) -> bool:
+    # List[ComplexType] (e.g.) will contain a reference to the complex type schema in the
+    # top-level $defs, so we dereference it here.
+    if "$ref" in subschema:
+        subschema = json_schema["$defs"].get(subschema["$ref"][len(REF_BASE) :])
+
+    if get_required_rendering_context(subschema) is not None:
+        return False
+    elif len(valpath) == 0:
+        return True
+
+    # Optional[ComplexType] (e.g.) will contain multiple schemas in the "anyOf" field
+    if "anyOf" in subschema:
+        return any(_should_render(valpath, json_schema, inner) for inner in subschema["anyOf"])
+
+    el = valpath[0]
+    if isinstance(el, str):
+        # valpath: ['field']
+        # field: X
+        inner = subschema.get("properties", {}).get(el)
+    elif isinstance(el, int):
+        # valpath: ['field', 0]
+        # field: List[X]
+        inner = subschema.get("items")
+    else:
+        check.failed(f"Unexpected valpath element: {el}")
+
+    # the path wasn't valid
+    if not inner:
+        return False
+
+    _, *rest = valpath
+    return _should_render(rest, json_schema, inner)
+
+
+def _render_values(
+    value_resolver: TemplatedValueResolver,
+    val: Any,
+    valpath: Sequence[Union[str, int]],
+    json_schema: Optional[Mapping[str, Any]],
+) -> Any:
+    if json_schema and not _should_render(valpath, json_schema, json_schema):
+        return val
+    elif isinstance(val, dict):
+        return {
+            k: _render_values(value_resolver, v, [*valpath, k], json_schema) for k, v in val.items()
+        }
+    elif isinstance(val, list):
+        return [
+            _render_values(value_resolver, v, [*valpath, i], json_schema) for i, v in enumerate(val)
+        ]
+    else:
+        return value_resolver.resolve(val)
+
+
+def preprocess_value(renderer: TemplatedValueResolver, val: T, target_type: Type) -> T:
+    """Given a raw value, preprocesses it by rendering any templated values that are not marked as deferred in the target_type's json schema."""
+    json_schema = target_type.model_json_schema() if issubclass(target_type, BaseModel) else None
+    return _render_values(renderer, val, [], json_schema)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_rendering.py
@@ -1,0 +1,81 @@
+from typing import Optional, Sequence
+
+import pytest
+from dagster_components.core.component_rendering import (
+    TemplatedValueResolver,
+    _should_render,
+    add_required_rendering_context,
+    preprocess_value,
+)
+from pydantic import BaseModel, Field, TypeAdapter
+
+
+class Inner(BaseModel):
+    a: Optional[str] = None
+    deferred: Optional[str] = add_required_rendering_context(
+        Field(default=None), {"foo", "bar", "baz"}
+    )
+
+
+class Outer(BaseModel):
+    a: str
+    deferred: str = add_required_rendering_context(Field(), {"a"})
+    inner: Sequence[Inner]
+    inner_deferred: Sequence[Inner] = add_required_rendering_context(Field(), {"b"})
+
+    inner_optional: Optional[Sequence[Inner]] = None
+    inner_deferred_optional: Optional[Sequence[Inner]] = add_required_rendering_context(
+        Field(default=None), {"b"}
+    )
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (["a"], True),
+        (["deferred"], False),
+        (["inner", 0, "a"], True),
+        (["inner", 0, "deferred"], False),
+        (["inner_deferred", 0, "a"], False),
+        (["inner_deferred", 0, "deferred"], False),
+        (["inner_optional"], True),
+        (["inner_optional", 0, "a"], True),
+        (["inner_optional", 0, "deferred"], False),
+        (["inner_deferred_optional", 0], False),
+        (["inner_deferred_optional", 0, "a"], False),
+        (["NONEXIST", 0, "deferred"], False),
+    ],
+)
+def test_should_render(path, expected: bool) -> None:
+    assert _should_render(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
+
+
+def test_render() -> None:
+    data = {
+        "a": "{{ foo_val }}",
+        "deferred": "{{ deferred }}",
+        "inner": [
+            {"a": "{{ bar_val }}", "deferred": "{{ deferred }}"},
+            {"a": "zzz", "deferred": "zzz"},
+        ],
+        "inner_deferred": [
+            {"a": "{{ deferred }}", "deferred": "zzz"},
+        ],
+    }
+
+    renderer = TemplatedValueResolver(context={"foo_val": "foo", "bar_val": "bar"})
+    rendered_data = preprocess_value(renderer, data, Outer)
+
+    assert rendered_data == {
+        "a": "foo",
+        "deferred": "{{ deferred }}",
+        "inner": [
+            {"a": "bar", "deferred": "{{ deferred }}"},
+            {"a": "zzz", "deferred": "zzz"},
+        ],
+        "inner_deferred": [
+            {"a": "{{ deferred }}", "deferred": "zzz"},
+        ],
+    }
+
+    TypeAdapter(Outer).validate_python(rendered_data)


### PR DESCRIPTION
## Summary & Motivation

This is the initial layer for a jinja-based rendering engine for the contents of `components.yaml`. To keep this diff simpler, I didn't hook this up to anythin quite yet.

The key bit here is that in some cases, we want to defer the templating logic until a point in time where we will have more context available. For example, the asset translation logic for the dbt_project component needs to apply its template to each individual node, which won't be available until runtime.

Other fields need to be substituted in before the initial load, such as those being passed into resources used during the component init process.

This allows us to distinguish between these two cases by setting metadata in the generated json schema, which is then used to determine if rendering should be deferred or not.

Note that rendering is done at a per-value level, which caps the amount of craziness someone can do in these (i.e. you can't dynamically generate a nested dictionary of fields). This is generally intentional, I think once you get to that level of complexity you should really be doing that in python land, and attempting to support that sort of thing would make the mental model a lot more complicated.

## How I Tested These Changes

## Changelog

NOCHANGELOG
