### PR TITLE
[components] Access more detailed component information from `dg` CLI

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import click
 
-from dagster_components.core.component import ComponentRegistry
+from dagster_components.core.component import ComponentMetadata, ComponentRegistry
 from dagster_components.core.deployment import (
     CodeLocationProjectContext,
     is_inside_code_location_project,
@@ -32,9 +32,11 @@ def list_component_types_command() -> None:
         Path.cwd(), ComponentRegistry.from_entry_point_discovery()
     )
     output: Dict[str, Any] = {}
-    for component_type in context.list_component_types():
-        # package, name = component_type.rsplit(".", 1)
-        output[component_type] = {
-            "name": component_type,
-        }
+    for key, component_type in context.list_component_types():
+        package, name = key.rsplit(".", 1)
+        output[key] = ComponentMetadata(
+            name=name,
+            package=package,
+            **component_type.get_metadata(),
+        )
     click.echo(json.dumps(output))

--- a/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Final, Iterable, Type
+from typing import Final, Iterable, Tuple, Type
 
 import tomli
 from dagster._core.errors import DagsterError
@@ -78,8 +78,9 @@ class CodeLocationProjectContext:
             raise DagsterError(f"No component type named {name}")
         return self._component_registry.get(name)
 
-    def list_component_types(self) -> Iterable[str]:
-        return sorted(self._component_registry.keys())
+    def list_component_types(self) -> Iterable[Tuple[str, Type[Component]]]:
+        for key in sorted(self._component_registry.keys()):
+            yield key, self._component_registry.get(key)
 
     def get_component_instance_path(self, name: str) -> str:
         if name not in self.component_instances:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -55,6 +55,8 @@ class PipesSubprocessScriptCollectionParams(BaseModel):
 
 @component(name="pipes_subprocess_script_collection")
 class PipesSubprocessScriptCollection(Component):
+    """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
+
     params_schema = PipesSubprocessScriptCollectionParams
 
     def __init__(self, dirpath: Path, path_specs: Mapping[Path, Sequence[AssetSpec]]):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from dagster_dg.cli.generate import generate_cli
+from dagster_dg.cli.info import info_cli
 from dagster_dg.cli.list import list_cli
 from dagster_dg.version import __version__
 
@@ -8,6 +9,7 @@ from dagster_dg.version import __version__
 def create_dg_cli():
     commands = {
         "generate": generate_cli,
+        "info": info_cli,
         "list": list_cli,
     }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
@@ -1,0 +1,85 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+import click
+
+from dagster_dg.context import CodeLocationDirectoryContext, is_inside_code_location_directory
+
+
+@click.group(name="info")
+def info_cli():
+    """Commands for listing Dagster components and related entities."""
+
+
+def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
+    return json.dumps(schema, indent=4)
+
+
+@info_cli.command(name="component-type")
+@click.argument("component_type", type=str)
+@click.option("--description", is_flag=True, default=False)
+@click.option("--generate-params-schema", is_flag=True, default=False)
+@click.option("--component-params-schema", is_flag=True, default=False)
+def info_component_type_command(
+    component_type: str,
+    description: bool,
+    generate_params_schema: bool,
+    component_params_schema: bool,
+) -> None:
+    """Get detailed information on a registered Dagster component type."""
+    if not is_inside_code_location_directory(Path.cwd()):
+        click.echo(
+            click.style(
+                "This command must be run inside a Dagster code location directory.", fg="red"
+            )
+        )
+        sys.exit(1)
+
+    context = CodeLocationDirectoryContext.from_path(Path.cwd())
+    if not context.has_component_type(component_type):
+        click.echo(
+            click.style(f"No component type `{component_type}` could be resolved.", fg="red")
+        )
+        sys.exit(1)
+
+    if sum([description, generate_params_schema, component_params_schema]) > 1:
+        click.echo(
+            click.style(
+                "Only one of --description, --generate-params-schema, and --component-params-schema can be specified.",
+                fg="red",
+            )
+        )
+        sys.exit(1)
+
+    context = CodeLocationDirectoryContext.from_path(Path.cwd())
+    component_type_metadata = context.get_component_type(component_type)
+
+    if description:
+        if component_type_metadata.description:
+            click.echo(component_type_metadata.description)
+        else:
+            click.echo("No description available.")
+    elif generate_params_schema:
+        if component_type_metadata.generate_params_schema:
+            click.echo(component_type_metadata.generate_params_schema)
+        else:
+            click.echo("No generate params schema defined.")
+    elif component_params_schema:
+        if component_type_metadata.component_params_schema:
+            click.echo(component_type_metadata.component_params_schema)
+        else:
+            click.echo("No component params schema defined.")
+    # print all available metadata
+    else:
+        click.echo(component_type)
+        if component_type_metadata.description:
+            click.echo("\nDescription:\n")
+            click.echo(component_type_metadata.description)
+        if component_type_metadata.generate_params_schema:
+            click.echo("\nGenerate params schema:\n")
+            click.echo(_serialize_json_schema(component_type_metadata.generate_params_schema))
+        if component_type_metadata.component_params_schema:
+            click.echo("\nComponent params schema:\n")
+            click.echo(_serialize_json_schema(component_type_metadata.component_params_schema))

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -42,8 +42,10 @@ def list_component_types_command() -> None:
         sys.exit(1)
 
     context = CodeLocationDirectoryContext.from_path(Path.cwd())
-    for component_type in context.get_component_type_names():
-        click.echo(component_type)
+    for key, component_type in context.iter_component_types():
+        click.echo(key)
+        if component_type.summary:
+            click.echo(f"    {component_type.summary}")
 
 
 @list_cli.command(name="components")

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -1,11 +1,16 @@
 import copy
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Mapping
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 
 @dataclass
 class RemoteComponentType:
     name: str
+    package: str
+    summary: Optional[str]
+    description: Optional[str]
+    generate_params_schema: Optional[Mapping[str, Any]]  # json schema
+    component_params_schema: Optional[Mapping[str, Any]]  # json schema
 
     @property
     def key(self) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Final, Iterable, Mapping, Optional
+from typing import Final, Iterable, Mapping, Optional, Tuple
 
 import tomli
 from typing_extensions import Self
@@ -140,8 +140,9 @@ class CodeLocationDirectoryContext:
     def local_component_types_root_module_name(self) -> str:
         return f"{self._name}.{_CODE_LOCATION_CUSTOM_COMPONENTS_DIR}"
 
-    def get_component_type_names(self) -> Iterable[str]:
-        return sorted(self._component_registry.keys())
+    def iter_component_types(self) -> Iterable[Tuple[str, RemoteComponentType]]:
+        for key in sorted(self._component_registry.keys()):
+            yield key, self._component_registry.get(key)
 
     def has_component_type(self, name: str) -> bool:
         return self._component_registry.has(name)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Final, Iterator, List, Mapping, Optional, Sequence, Union
 
@@ -163,3 +164,13 @@ def _should_skip_file(path: str, excludes: List[str] = _DEFAULT_EXCLUDES):
             return True
 
     return False
+
+
+def ensure_dagster_dg_tests_import() -> None:
+    from dagster_dg import __file__ as dagster_dg_init_py
+
+    dagster_dg_package_root = (Path(dagster_dg_init_py) / ".." / "..").resolve()
+    assert (
+        dagster_dg_package_root / "dagster_dg_tests"
+    ).exists(), "Could not find dagster_dg_tests where expected"
+    sys.path.append(dagster_dg_package_root.as_posix())

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -1,0 +1,92 @@
+import textwrap
+
+from click.testing import CliRunner
+from dagster_dg.cli.info import info_component_type_command
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
+from dagster_dg_tests.cli_tests.test_generate_commands import isolated_example_code_location_bar
+
+
+def test_info_component_type_all_metadata_success():
+    runner = CliRunner()
+    with isolated_example_code_location_bar(runner):
+        result = runner.invoke(
+            info_component_type_command, ["dagster_components.pipes_subprocess_script_collection"]
+        )
+        assert result.exit_code == 0
+        assert result.output.startswith(
+            textwrap.dedent("""
+                dagster_components.pipes_subprocess_script_collection
+
+                Description:
+
+                Assets that wrap Python scripts
+        """).strip()
+        )
+
+
+def test_info_component_type_flag_fields_success():
+    runner = CliRunner()
+    with isolated_example_code_location_bar(runner):
+        result = runner.invoke(
+            info_component_type_command,
+            ["dagster_components.pipes_subprocess_script_collection", "--description"],
+        )
+        assert result.exit_code == 0
+        assert result.output.startswith(
+            textwrap.dedent("""
+                Assets that wrap Python scripts
+        """).strip()
+        )
+
+        result = runner.invoke(
+            info_component_type_command,
+            ["dagster_components.pipes_subprocess_script_collection", "--generate-params-schema"],
+        )
+        assert result.exit_code == 0
+        assert result.output.startswith(
+            textwrap.dedent("""
+                No generate params schema defined.
+        """).strip()
+        )
+
+        result = runner.invoke(
+            info_component_type_command,
+            ["dagster_components.pipes_subprocess_script_collection", "--component-params-schema"],
+        )
+        assert result.exit_code == 0
+        assert result.output.startswith(
+            textwrap.dedent("""
+                No component params schema defined.
+        """).strip()
+        )
+
+
+def test_info_component_type_outside_code_location_fails() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            info_component_type_command, ["dagster_components.pipes_subprocess_script_collection"]
+        )
+        assert result.exit_code != 0
+        assert "must be run inside a Dagster code location directory" in result.output
+
+
+def test_info_component_type_multiple_flags_fails() -> None:
+    runner = CliRunner()
+    with isolated_example_code_location_bar(runner):
+        result = runner.invoke(
+            info_component_type_command,
+            [
+                "dagster_components.pipes_subprocess_script_collection",
+                "--description",
+                "--generate-params-schema",
+            ],
+        )
+        assert result.exit_code != 0
+        assert (
+            "Only one of --description, --generate-params-schema, and --component-params-schema can be specified."
+            in result.output
+        )


### PR DESCRIPTION
## Summary & Motivation

Adds summary output to `dg list component-types` and a new `dg info component-type` command.

`dg info component-type` takes any of `--description`, `--generate-params-schema`, or `--component-params-schema` to print a single field. If none of these are passed than all fields are printed. 

## How I Tested These Changes

Unit tests, manually.

Example output from manual test in env with all `dagster-components` extras installed:

```
$ dg list component-types

dagster_components.dbt_project
dagster_components.pipes_subprocess_script_collection
    Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient.
dagster_components.sling_replication
```

```
$ dg info component-type dagster_components.dbt_project

dagster_components.dbt_project

Generate params schema:

{
    "properties": {
        "init": {
            "default": false,
            "title": "Init",
            "type": "boolean"
        },
        "project_path": {
            "anyOf": [
                {
                    "type": "string"
                },
                {
                    "type": "null"
                }
            ],
            "default": null,
            "title": "Project Path"
        }
    },
    "title": "DbtGenerateParams",
    "type": "object"
}
```
