### PR TITLE
[ui] add sorting order to show more assets and asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -52,18 +52,11 @@ function useShowMoreDialog<T>(
   dialogTitle: string,
   items: T[] | null,
   renderItem: (item: T) => React.ReactNode,
-  sortFn?: (a: T, b: T) => number,
 ) {
   const [showMore, setShowMore] = React.useState(false);
 
-  let itemsToRender = items;
-
-  if (sortFn && items) {
-    itemsToRender = [...items].sort(sortFn);
-  }
-
   const dialog =
-    !!itemsToRender && itemsToRender.length > 1 ? (
+    !!items && items.length > 1 ? (
       <Dialog
         title={dialogTitle}
         onClose={() => setShowMore(false)}
@@ -71,7 +64,7 @@ function useShowMoreDialog<T>(
         isOpen={showMore}
       >
         <div style={{height: '500px', overflow: 'hidden'}}>
-          <VirtualizedItemListForDialog items={itemsToRender} renderItem={renderItem} />
+          <VirtualizedItemListForDialog items={items} renderItem={renderItem} />
         </div>
         <DialogFooter topBorder>
           <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
@@ -164,14 +157,15 @@ export function useAdjustChildVisibilityToFill(moreLabelFn: (count: number) => s
 
 export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionProps) => {
   const {assetKeys, useTags, maxRows, dialogTitle = 'Assets in run'} = props;
-  const {setShowMore, dialog} = useShowMoreDialog(
-    dialogTitle,
-    assetKeys,
-    renderItemAssetKey,
-    sortItemAssetKey,
+
+  const sortedAssetKeys = React.useMemo(
+    () => assetKeys?.slice().sort(sortItemAssetKey) ?? null,
+    [assetKeys],
   );
 
-  const count = assetKeys?.length ?? 0;
+  const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, sortedAssetKeys, renderItemAssetKey);
+
+  const count = sortedAssetKeys?.length ?? 0;
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
   const moreLabelFn = React.useCallback(
     (displayed: number) =>
@@ -185,7 +179,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!assetKeys || !assetKeys.length) {
+  if (!sortedAssetKeys || !sortedAssetKeys.length) {
     return null;
   }
 
@@ -200,7 +194,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
         overflow: 'hidden',
       }}
     >
-      {assetKeys.slice(0, rendered).map((assetKey) => (
+      {sortedAssetKeys.slice(0, rendered).map((assetKey) => (
         // Outer span ensures the popover target is in the right place if the
         // parent is a flexbox.
         <TagActionsPopover
@@ -246,7 +240,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
               },
               {
                 label: 'View lineage',
-                to: globalAssetGraphPathForAssetsAndDescendants(assetKeys),
+                to: globalAssetGraphPathForAssetsAndDescendants(sortedAssetKeys),
               },
             ]}
           >
@@ -283,14 +277,19 @@ interface AssetCheckTagCollectionProps {
 
 export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectionProps) => {
   const {assetChecks, maxRows, useTags, dialogTitle = 'Asset checks in run'} = props;
-  const {setShowMore, dialog} = useShowMoreDialog(
-    dialogTitle,
-    assetChecks,
-    renderItemAssetCheck,
-    sortItemAssetCheck,
+
+  const sortedAssetChecks = React.useMemo(
+    () => assetChecks?.slice().sort(sortItemAssetCheck) ?? null,
+    [assetChecks],
   );
 
-  const count = assetChecks?.length ?? 0;
+  const {setShowMore, dialog} = useShowMoreDialog(
+    dialogTitle,
+    sortedAssetChecks,
+    renderItemAssetCheck,
+  );
+
+  const count = sortedAssetChecks?.length ?? 0;
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
   const moreLabelFn = React.useCallback(
     (displayed: number) =>
@@ -304,7 +303,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!assetChecks || !assetChecks.length) {
+  if (!sortedAssetChecks || !sortedAssetChecks.length) {
     return null;
   }
 
@@ -319,7 +318,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
         overflow: 'hidden',
       }}
     >
-      {assetChecks.slice(0, rendered).map((check) => (
+      {sortedAssetChecks.slice(0, rendered).map((check) => (
         <TagActionsPopover
           key={`${check.name}-${tokenForAssetKey(check.assetKey)}`}
           data={{key: '', value: ''}}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -158,15 +158,19 @@ export function useAdjustChildVisibilityToFill(moreLabelFn: (count: number) => s
 export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionProps) => {
   const {assetKeys, useTags, maxRows, dialogTitle = 'Assets in run'} = props;
 
-  const sortedAssetKeys = React.useMemo(
-    () => assetKeys?.slice().sort(sortItemAssetKey) ?? null,
-    [assetKeys],
-  );
+  const count = assetKeys?.length ?? 0;
+  const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
+
+  const {sortedAssetKeys, slicedSortedAssetKeys} = React.useMemo(() => {
+    const sortedAssetKeys = assetKeys?.slice().sort(sortItemAssetKey) ?? null;
+    return {
+      sortedAssetKeys,
+      slicedSortedAssetKeys: sortedAssetKeys?.slice(0, rendered) ?? [],
+    };
+  }, [assetKeys, rendered]);
 
   const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, sortedAssetKeys, renderItemAssetKey);
 
-  const count = sortedAssetKeys?.length ?? 0;
-  const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
   const moreLabelFn = React.useCallback(
     (displayed: number) =>
       displayed === 0
@@ -194,7 +198,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
         overflow: 'hidden',
       }}
     >
-      {sortedAssetKeys.slice(0, rendered).map((assetKey) => (
+      {slicedSortedAssetKeys.map((assetKey) => (
         // Outer span ensures the popover target is in the right place if the
         // parent is a flexbox.
         <TagActionsPopover
@@ -278,10 +282,16 @@ interface AssetCheckTagCollectionProps {
 export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectionProps) => {
   const {assetChecks, maxRows, useTags, dialogTitle = 'Asset checks in run'} = props;
 
-  const sortedAssetChecks = React.useMemo(
-    () => assetChecks?.slice().sort(sortItemAssetCheck) ?? null,
-    [assetChecks],
-  );
+  const count = assetChecks?.length ?? 0;
+  const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
+
+  const {sortedAssetChecks, slicedSortedAssetChecks} = React.useMemo(() => {
+    const sortedAssetChecks = assetChecks?.slice().sort(sortItemAssetCheck) ?? null;
+    return {
+      sortedAssetChecks,
+      slicedSortedAssetChecks: sortedAssetChecks?.slice(0, rendered) ?? [],
+    };
+  }, [assetChecks, rendered]);
 
   const {setShowMore, dialog} = useShowMoreDialog(
     dialogTitle,
@@ -289,8 +299,6 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
     renderItemAssetCheck,
   );
 
-  const count = sortedAssetChecks?.length ?? 0;
-  const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
   const moreLabelFn = React.useCallback(
     (displayed: number) =>
       displayed === 0
@@ -318,7 +326,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
         overflow: 'hidden',
       }}
     >
-      {sortedAssetChecks.slice(0, rendered).map((check) => (
+      {slicedSortedAssetChecks.map((check) => (
         <TagActionsPopover
           key={`${check.name}-${tokenForAssetKey(check.assetKey)}`}
           data={{key: '', value: ''}}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -162,7 +162,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
 
   const {sortedAssetKeys, slicedSortedAssetKeys} = React.useMemo(() => {
-    const sortedAssetKeys = assetKeys?.slice().sort(sortItemAssetKey) ?? null;
+    const sortedAssetKeys = assetKeys?.slice().sort(sortItemAssetKey) ?? [];
     return {
       sortedAssetKeys,
       slicedSortedAssetKeys: sortedAssetKeys?.slice(0, rendered) ?? [],
@@ -183,7 +183,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!assetKeys || !count) {
+  if (!count) {
     return null;
   }
 
@@ -286,7 +286,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
 
   const {sortedAssetChecks, slicedSortedAssetChecks} = React.useMemo(() => {
-    const sortedAssetChecks = assetChecks?.slice().sort(sortItemAssetCheck) ?? null;
+    const sortedAssetChecks = assetChecks?.slice().sort(sortItemAssetCheck) ?? [];
     return {
       sortedAssetChecks,
       slicedSortedAssetChecks: sortedAssetChecks?.slice(0, rendered) ?? [],
@@ -311,7 +311,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!assetChecks || !count) {
+  if (!count) {
     return null;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -183,7 +183,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!sortedAssetKeys || !sortedAssetKeys.length) {
+  if (!assetKeys || !count) {
     return null;
   }
 
@@ -311,7 +311,7 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
 
   const {containerRef, moreLabelRef} = useAdjustChildVisibilityToFill(moreLabelFn);
 
-  if (!sortedAssetChecks || !sortedAssetChecks.length) {
+  if (!assetChecks || !count) {
     return null;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -24,6 +24,14 @@ import {TagActionsPopover} from '../ui/TagActions';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 import {numberFormatter} from '../ui/formatters';
 
+const sortItemAssetKey = (a: AssetKey, b: AssetKey) => {
+  return displayNameForAssetKey(a).localeCompare(displayNameForAssetKey(b));
+};
+
+const sortItemAssetCheck = (a: Check, b: Check) => {
+  return labelForAssetCheck(a).localeCompare(labelForAssetCheck(b));
+};
+
 const renderItemAssetKey = (assetKey: AssetKey) => (
   <Link to={assetDetailsPathForKey(assetKey)} style={{display: 'block', width: '100%'}}>
     <MiddleTruncate text={displayNameForAssetKey(assetKey)} />
@@ -44,11 +52,18 @@ function useShowMoreDialog<T>(
   dialogTitle: string,
   items: T[] | null,
   renderItem: (item: T) => React.ReactNode,
+  sortFn?: (a: T, b: T) => number,
 ) {
   const [showMore, setShowMore] = React.useState(false);
 
+  let itemsToRender = items;
+
+  if (sortFn && items) {
+    itemsToRender = [...items].sort(sortFn);
+  }
+
   const dialog =
-    !!items && items.length > 1 ? (
+    !!itemsToRender && itemsToRender.length > 1 ? (
       <Dialog
         title={dialogTitle}
         onClose={() => setShowMore(false)}
@@ -56,7 +71,7 @@ function useShowMoreDialog<T>(
         isOpen={showMore}
       >
         <div style={{height: '500px', overflow: 'hidden'}}>
-          <VirtualizedItemListForDialog items={items} renderItem={renderItem} />
+          <VirtualizedItemListForDialog items={itemsToRender} renderItem={renderItem} />
         </div>
         <DialogFooter topBorder>
           <Button intent="primary" autoFocus onClick={() => setShowMore(false)}>
@@ -149,7 +164,12 @@ export function useAdjustChildVisibilityToFill(moreLabelFn: (count: number) => s
 
 export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionProps) => {
   const {assetKeys, useTags, maxRows, dialogTitle = 'Assets in run'} = props;
-  const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, assetKeys, renderItemAssetKey);
+  const {setShowMore, dialog} = useShowMoreDialog(
+    dialogTitle,
+    assetKeys,
+    renderItemAssetKey,
+    sortItemAssetKey,
+  );
 
   const count = assetKeys?.length ?? 0;
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;
@@ -263,7 +283,12 @@ interface AssetCheckTagCollectionProps {
 
 export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectionProps) => {
   const {assetChecks, maxRows, useTags, dialogTitle = 'Asset checks in run'} = props;
-  const {setShowMore, dialog} = useShowMoreDialog(dialogTitle, assetChecks, renderItemAssetCheck);
+  const {setShowMore, dialog} = useShowMoreDialog(
+    dialogTitle,
+    assetChecks,
+    renderItemAssetCheck,
+    sortItemAssetCheck,
+  );
 
   const count = assetChecks?.length ?? 0;
   const rendered = maxRows ? 10 : count === 1 ? 1 : 0;


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-692/implement-ordering-for-asset-checks-in-run-view

## How I Tested These Changes
Tested locally