### PR TITLE
[components] Expose generation CLI params in dagster-dg

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -22,6 +22,7 @@ from typing import (
     TypeVar,
 )
 
+import click
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterError
@@ -85,6 +86,16 @@ def _clean_docstring(docstring: str) -> str:
     else:
         rest = textwrap.dedent("\n".join(lines[1:]))
         return f"{first_line}\n{rest}"
+
+
+def _get_click_cli_help(command: click.Command) -> str:
+    with click.Context(command) as ctx:
+        formatter = click.formatting.HelpFormatter()
+        param_records = [
+            p.get_help_record(ctx) for p in command.get_params(ctx) if p.name != "help"
+        ]
+        formatter.write_dl([pr for pr in param_records if pr])
+        return formatter.getvalue()
 
 
 class ComponentInternalMetadata(TypedDict):

--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -32,7 +32,7 @@ def generate_component_instance(
     name: str,
     component_type: Type[Component],
     component_type_name: str,
-    generate_params: Any,
+    generate_params: Mapping[str, Any],
 ) -> None:
     component_instance_root_path = Path(os.path.join(root_path, name))
     click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Optional, Sequence
 
-import click
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
@@ -41,13 +40,6 @@ class DbtProjectParams(BaseModel):
 class DbtGenerateParams(BaseModel):
     init: bool = Field(default=False)
     project_path: Optional[str] = None
-
-    @staticmethod
-    @click.command
-    @click.option("--project-path", "-p", type=click.Path(resolve_path=True), default=None)
-    @click.option("--init", "-i", is_flag=True, default=False)
-    def cli(project_path: Optional[str], init: bool) -> "DbtGenerateParams":
-        return DbtGenerateParams(project_path=project_path, init=init)
 
 
 class DbtProjectComponentTranslator(DagsterDbtTranslator):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -1,10 +1,12 @@
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional
 
 import click
+from click.core import ParameterSource
 
+from dagster_dg.component import RemoteComponentType
 from dagster_dg.context import (
     CodeLocationDirectoryContext,
     DeploymentDirectoryContext,
@@ -18,7 +20,12 @@ from dagster_dg.generate import (
     generate_component_type,
     generate_deployment,
 )
-from dagster_dg.utils import DgClickCommand, DgClickGroup
+from dagster_dg.utils import (
+    DgClickCommand,
+    DgClickGroup,
+    json_schema_property_to_click_option,
+    parse_json_option,
+)
 
 
 @click.group(name="generate", cls=DgClickGroup)
@@ -139,82 +146,150 @@ def generate_component_type_command(cli_context: click.Context, name: str) -> No
     generate_component_type(context, name)
 
 
-@generate_cli.command(name="component", cls=DgClickCommand)
-@click.argument(
-    "component_type",
-    type=str,
-)
-@click.argument("component_name", type=str)
-@click.option("--json-params", type=str, default=None, help="JSON string of component parameters.")
-@click.argument("extra_args", nargs=-1, type=str)
-@click.pass_context
-def generate_component_command(
-    cli_context: click.Context,
-    component_type: str,
-    component_name: str,
-    json_params: Optional[str],
-    extra_args: Tuple[str, ...],
-) -> None:
-    """Generate a scaffold of a Dagster component.
+# The `dg generate component` command is special because its subcommands are dynamically generated
+# from the registered component types in the code location. Because the registered component types
+# depend on the built-in component library we are using, we cannot resolve them until we have the
+# built-in component library, which can be set via a global option, e.g.:
+#
+#     dg --builtin-component-lib dagster_components.test ...
+#
+# To handle this, we define a custom click.Group subclass that loads the commands on demand.
+class GenerateComponentGroup(DgClickGroup):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._commands_defined = False
 
-    This command must be run inside a Dagster code location directory. The component scaffold will be
-    generated in submodule `<code_location_name>.components.<name>`.
+    def get_command(self, cli_context: click.Context, cmd_name: str) -> Optional[click.Command]:
+        if not self._commands_defined:
+            self._define_commands(cli_context)
+        return super().get_command(cli_context, cmd_name)
 
-    The COMPONENT_TYPE must be a registered component type in the code location environment.
-    You can view all registered component types with `dg list component-types`. The COMPONENT_NAME
-    will be used to name the submodule created under <code_location_name>.components.
+    def list_commands(self, cli_context):
+        if not self._commands_defined:
+            self._define_commands(cli_context)
+        return super().list_commands(cli_context)
 
-    Components can optionally be passed generate parameters. There are two ways to do this:
+    def _define_commands(self, cli_context: click.Context) -> None:
+        """Dynamically define a command for each registered component type."""
+        app_context = DgContext.from_cli_context(cli_context)
 
-    - Passing --json-params with a JSON string of parameters. For example:
-
-        dg generate component foo.bar my_component --json-params '{"param1": "value", "param2": "value"}'`.
-
-    - Passing key-value pairs as space-separated EXTRA_ARGS after `--`. For example:
-
-        dg generate component foo.bar my_component -- param1=value param2=value
-
-    When key-value pairs are used, the value type will be inferred from the
-    underlying component generation schema.
-
-    It is an error to pass both --json-params and EXTRA_ARGS.
-    """
-    dg_context = DgContext.from_cli_context(cli_context)
-    if not is_inside_code_location_directory(Path.cwd()):
-        click.echo(
-            click.style(
-                "This command must be run inside a Dagster code location directory.", fg="red"
+        if not is_inside_code_location_directory(Path.cwd()):
+            click.echo(
+                click.style(
+                    "This command must be run inside a Dagster code location directory.", fg="red"
+                )
             )
-        )
-        sys.exit(1)
+            sys.exit(1)
 
-    context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
-    if not context.has_component_type(component_type):
-        click.echo(
-            click.style(f"No component type `{component_type}` could be resolved.", fg="red")
-        )
-        sys.exit(1)
-    elif context.has_component_instance(component_name):
-        click.echo(
-            click.style(f"A component instance named `{component_name}` already exists.", fg="red")
-        )
-        sys.exit(1)
+        context = CodeLocationDirectoryContext.from_path(Path.cwd(), app_context)
+        for key, component_type in context.iter_component_types():
+            command = _create_generate_component_subcommand(key, component_type)
+            self.add_command(command)
 
-    if json_params is not None and extra_args:
-        click.echo(
-            click.style(
-                "Detected both --json-params and EXTRA_ARGS. These are mutually exclusive means of passing"
-                " component generation parameters. Use only one.",
-                fg="red",
-            )
-        )
-        sys.exit(1)
 
-    generate_component_instance(
-        Path(context.component_instances_root_path),
-        component_name,
-        component_type,
-        json_params,
-        extra_args,
-        dg_context,
+@generate_cli.group(name="component", cls=GenerateComponentGroup)
+def generate_component_group() -> None:
+    """Generate a scaffold of a Dagster component."""
+
+
+def _create_generate_component_subcommand(
+    component_key: str, component_type: RemoteComponentType
+) -> DgClickCommand:
+    @click.command(name=component_key, cls=DgClickCommand)
+    @click.argument("component_name", type=str)
+    @click.option(
+        "--json-params",
+        type=str,
+        default=None,
+        help="JSON string of component parameters.",
+        callback=parse_json_option,
     )
+    @click.pass_context
+    def generate_component_command(
+        cli_context: click.Context,
+        component_name: str,
+        json_params: Mapping[str, Any],
+        **key_value_params: Any,
+    ) -> None:
+        f"""Generate a scaffold of a {component_type.name} component.
+
+        This command must be run inside a Dagster code location directory. The component scaffold will be
+        generated in submodule `<code_location_name>.components.<COMPONENT_NAME>`.
+
+        Components can optionally be passed generate parameters. There are two ways to do this:
+
+        (1) Passing a single --json-params option with a JSON string of parameters. For example:
+
+            dg generate component foo.bar my_component --json-params '{{"param1": "value", "param2": "value"}}'`.
+
+        (2) Passing each parameter as an option. For example:
+
+            dg generate component foo.bar my_component --param1 value1 --param2 value2`
+
+        It is an error to pass both --json-params and key-value pairs as options.
+        """
+        dg_context = DgContext.from_cli_context(cli_context)
+        if not is_inside_code_location_directory(Path.cwd()):
+            click.echo(
+                click.style(
+                    "This command must be run inside a Dagster code location directory.", fg="red"
+                )
+            )
+            sys.exit(1)
+
+        context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
+        if not context.has_component_type(component_key):
+            click.echo(
+                click.style(f"No component type `{component_key}` could be resolved.", fg="red")
+            )
+            sys.exit(1)
+        elif context.has_component_instance(component_name):
+            click.echo(
+                click.style(
+                    f"A component instance named `{component_name}` already exists.", fg="red"
+                )
+            )
+            sys.exit(1)
+
+        # Specified key-value params will be passed to this function with their default value of
+        # `None` even if the user did not set them. Filter down to just the ones that were set by
+        # the user.
+        user_provided_key_value_params = {
+            k: v
+            for k, v in key_value_params.items()
+            if cli_context.get_parameter_source(k) == ParameterSource.COMMANDLINE
+        }
+        if json_params is not None and user_provided_key_value_params:
+            click.echo(
+                click.style(
+                    "Detected params passed as both --json-params and individual options. These are mutually exclusive means of passing"
+                    " component generation parameters. Use only one.",
+                    fg="red",
+                )
+            )
+            sys.exit(1)
+        elif json_params:
+            generate_params = json_params
+        elif user_provided_key_value_params:
+            generate_params = user_provided_key_value_params
+        else:
+            generate_params = None
+
+        generate_component_instance(
+            Path(context.component_instances_root_path),
+            component_name,
+            component_key,
+            generate_params,
+            dg_context,
+        )
+
+    # If there are defined generate params, add them to the command
+    schema = component_type.generate_params_schema
+    if schema:
+        for key, field_info in schema["properties"].items():
+            # All fields are currently optional because they can also be passed under
+            # `--json-params`
+            option = json_schema_property_to_click_option(key, field_info, required=False)
+            generate_component_command.params.append(option)
+
+    return generate_component_command

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -1,8 +1,9 @@
+import json
 import os
 import subprocess
 import textwrap
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional
 
 import click
 
@@ -148,8 +149,7 @@ def generate_component_instance(
     root_path: Path,
     name: str,
     component_type: str,
-    json_params: Optional[str],
-    extra_args: Tuple[str, ...],
+    generate_params: Optional[Mapping[str, Any]],
     dg_context: "DgContext",
 ) -> None:
     component_instance_root_path = root_path / name
@@ -160,8 +160,7 @@ def generate_component_instance(
         "component",
         component_type,
         name,
-        *(["--json-params", json_params] if json_params else []),
-        *(["--", *extra_args] if extra_args else []),
+        *(["--json-params", json.dumps(generate_params)] if generate_params else []),
     )
     execute_code_location_command(
         Path(component_instance_root_path),


### PR DESCRIPTION
## Summary & Motivation

Exposes CLI params (if defined) for component types in `dagster-dg`.

- `dg generate component` used to take the component type as an argument, but now dynamically generates a subcommand for each component type.
- We no longer define `cli` as a static method on components. Instead we just send the schema over the wire to `dagster-dg`, where it is automatically converted into click options (fields with an object type take a JSON param).
- Because component types are subcommands, we no longer use the special `-- --key1=val1 --key2=val2 ...` CLI syntax to set params. Instead they are passed as normal params to the subcommand.
- All component subcommands can still take `--json-params` instead of individual options. It is an error to pass `--json-params` _and_ individual options.
- User-defined parameters populate an isolated namespace under the component-generated subcommand. The only parameters we define in here are `--json-params` and `--help`. If we need to define other common component generation params in the future, we can define them under the `dg generate component` command namespace, where they will not clash with user-defined params. For example:

```
dg generate component --some-option dagster_components.dbt_project ...
```

- You can see the available params with `dg generate component COMPONENT_TYPE --help`. For example:

```
$ dg generate component dagster_components.dbt_project --help

Usage: dg [OPTIONS] generate component dagster_components.dbt_project [OPTIONS] COMPONENT_NAME

Options:
  --json-params TEXT   JSON string of component parameters.
  --init BOOLEAN       init
  --project-path TEXT  project_path
  -h, --help           Show this message and exit.

Options (dg):
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable caching of component registry data.
  --clear-cache                 Clear the cache before running the command.
  --cache-dir PATH              Specify a directory to use for the cache.
```

Issues for followup:

- Ensure our published components ship descriptions for the properties in their JSON schema
- More thorough testing of different parameter situations

## How I Tested These Changes

New unit tests