### PR TITLE
reduce the number of logs queried for run stats in base implementation

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/stats.py
+++ b/python_modules/dagster/dagster/_core/execution/stats.py
@@ -4,10 +4,23 @@ from typing import Any, Dict, Iterable, NamedTuple, Optional, Sequence, cast
 
 import dagster._check as check
 from dagster._core.definitions import ExpectationResult
-from dagster._core.events import MARKER_EVENTS, DagsterEventType, StepExpectationResultData
+from dagster._core.events import (
+    MARKER_EVENTS,
+    PIPELINE_EVENTS,
+    DagsterEventType,
+    StepExpectationResultData,
+)
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._serdes import whitelist_for_serdes
+
+RUN_STATS_EVENT_TYPES = {
+    *PIPELINE_EVENTS,
+    DagsterEventType.STEP_FAILURE,
+    DagsterEventType.STEP_SUCCESS,
+    DagsterEventType.ASSET_MATERIALIZATION,
+    DagsterEventType.STEP_EXPECTATION_RESULT,
+}
 
 STEP_STATS_EVENT_TYPES = {
     DagsterEventType.STEP_START,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -29,6 +29,7 @@ from dagster._core.event_api import (
 )
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.stats import (
+    RUN_STATS_EVENT_TYPES,
     STEP_STATS_EVENT_TYPES,
     RunStepKeyStatsSnapshot,
     build_run_stats_from_events,
@@ -255,7 +256,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     def get_stats_for_run(self, run_id: str) -> DagsterRunStatsSnapshot:
         """Get a summary of events that have ocurred in a run."""
-        return build_run_stats_from_events(run_id, self.get_logs_for_run(run_id))
+        return build_run_stats_from_events(
+            run_id, self.get_logs_for_run(run_id, of_type=RUN_STATS_EVENT_TYPES)
+        )
 
     def get_step_stats_for_run(
         self, run_id: str, step_keys: Optional[Sequence[str]] = None


### PR DESCRIPTION
## Summary & Motivation
This reduces the number of events fetched for the base implementation of `get_run_stats`

## How I Tested These Changes
BK

