### PR TITLE
[module-loaders] Simplify module asset loader code path

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -142,7 +142,7 @@ def test_load_assets_from_modules(monkeypatch):
         with pytest.raises(
             DagsterInvalidDefinitionError,
             match=re.escape(
-                "Asset key AssetKey(['little_richard']) is defined multiple times. "
+                "Asset key little_richard is defined multiple times. "
                 "Definitions found in modules: dagster_tests.asset_defs_tests.asset_package."
             ),
         ):


### PR DESCRIPTION
## Summary & Motivation
This code path was highly crufty - code smell here is "iterating through big list and doing a ton of things at once". Solution is to create a lookup table of cacheable properties and imperatively call properties as you need them (stole this pattern from @schrockn when we were working on airlift stuff) I think the code is a lot clearer now.

I also got rid of an error message we were devoting a lot of lines to that felt very outdated; nobody is using with_resources, and repository_def is misleading.

I think we also end up catching a few hidden error states; for example, we weren't checking assetsdefs against sourceassets with the same key, sourceasset collision checking felt more like a side effect.

## How I Tested These Changes
Existing tests
