### PR TITLE
[dagster-embedded-elt] Expose dlt and sling extras

### DIFF
--- a/docs/docs-beta/docs/integrations/libraries/dlt.md
+++ b/docs/docs-beta/docs/integrations/libraries/dlt.md
@@ -24,7 +24,7 @@ This integration allows you to use [dlt](https://dlthub.com/) to easily ingest a
 ### Installation
 
 ```bash
-pip install dagster-embedded-elt
+pip install dagster-embedded-elt[dlt]
 ```
 
 ### Example

--- a/docs/docs-beta/docs/integrations/libraries/sling.md
+++ b/docs/docs-beta/docs/integrations/libraries/sling.md
@@ -24,7 +24,7 @@ This integration allows you to use [Sling](https://slingdata.io/) to extract and
 ### Installation
 
 ```bash
-pip install dagster-embedded-elt
+pip install dagster-embedded-elt[sling]
 ```
 
 ### Example

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -29,7 +29,7 @@ deps =
   -e ../../python_modules/libraries/dagster-deltalake-polars
   -e ../../python_modules/libraries/dagster-duckdb
   -e ../../python_modules/libraries/dagster-duckdb-pandas
-  -e ../../python_modules/libraries/dagster-embedded-elt
+  -e ../../python_modules/libraries/dagster-embedded-elt[dlt,sling]
   -e ../../python_modules/libraries/dagster-fivetran
   -e ../../python_modules/libraries/dagster-gcp
   -e ../../python_modules/libraries/dagster-k8s

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -49,7 +49,7 @@ setup(
         ],
     },
     extras_require={
-        "sling": ["dagster-embedded-elt"],
+        "sling": ["dagster-embedded-elt[sling]"],
         "dbt": ["dagster-dbt"],
         "test": ["dbt-duckdb"],
     },

--- a/python_modules/libraries/dagster-components/tox.ini
+++ b/python_modules/libraries/dagster-components/tox.ini
@@ -12,7 +12,7 @@ deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
-  -e ../../../python_modules/libraries/dagster-embedded-elt
+  -e ../../../python_modules/libraries/dagster-embedded-elt[sling]
   -e ../../../python_modules/libraries/dagster-dbt
   -e .[test]
 allowlist_externals =

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -34,11 +34,15 @@ setup(
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
-    install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4"],
+    install_requires=[f"dagster{pin}"],
     zip_safe=False,
     extras_require={
+        "dlt": ["dlt>=0.4"],
+        "sling": ["sling>=1.1.5"],
         "test": [
+            "dlt>=0.4",
             "duckdb",
-        ]
+            "sling>=1.1.5",
+        ],
     },
 )


### PR DESCRIPTION
## Summary & Motivation

As a user, I don't unnecessarily want to install Sling if I'm only using dlt and vice versa.

## How I Tested These Changes

## Changelog

> dlt and Sling are now extra requirements of the `dagster-embedded-elt` package; to include them, install `dagster-embedded-elt[dlt]` or `dagster-embedded-elt[sling]`, respectively.
