### PR TITLE
speed up computing a graphql id for a GraphenePipelineSnapshot

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -687,9 +687,6 @@ class GrapheneIPipelineSnapshotMixin:
     def resolve_pipeline_snapshot_id(self, _graphene_info: ResolveInfo):
         return self.get_represented_job().identifying_job_snapshot_id
 
-    def resolve_id(self, _graphene_info: ResolveInfo):
-        return self.get_represented_job().identifying_job_snapshot_id
-
     def resolve_name(self, _graphene_info: ResolveInfo):
         return self.get_represented_job().name
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/snapshot.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/snapshot.py
@@ -13,6 +13,7 @@ from dagster_graphql.schema.pipelines.pipeline import (
 )
 from dagster_graphql.schema.pipelines.pipeline_ref import GraphenePipelineReference
 from dagster_graphql.schema.solids import GrapheneSolidContainer
+from dagster_graphql.schema.util import ResolveInfo
 
 
 class GraphenePipelineSnapshot(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
@@ -20,11 +21,15 @@ class GraphenePipelineSnapshot(GrapheneIPipelineSnapshotMixin, graphene.ObjectTy
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot, GraphenePipelineReference)
         name = "PipelineSnapshot"
 
-    def __init__(self, represented_job: RepresentedJob):
+    def __init__(self, id: str, represented_job: RepresentedJob):
         super().__init__()
+        self._id = id
         self._represented_job = check.inst_param(
             represented_job, "represented_pipeline", RepresentedJob
         )
+
+    def resolve_id(self, _graphene_info: ResolveInfo):
+        return self._id
 
     def get_represented_job(self) -> RepresentedJob:
         return self._represented_job


### PR DESCRIPTION
Summary:
Right now the graphql ID is the same as the snapshot ID, but the snapshot ID can be slow to compute for large jobs. Use a faster ID instead when you don't already know the snapshot ID, and pass in the snapshot ID instead when you do. Audited existing callsites of GraphenePipelineSelector to ensure that they don't expect the id to match the selector ID.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
