### PR TITLE
[docs-beta] migrate - rate limits doc

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/management/rate-limits.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/management/rate-limits.md
@@ -1,6 +1,12 @@
 ---
 title: Dagster+ rate limits
-unlisted: true
 ---
 
-{/* TODO move from https://docs.dagster.io/dagster-plus/references/limits */}
+Dagster+ enforces several rate limits to smoothly distribute the load. Deployments are limited to:
+
+- 40,000 user log events (e.g, `context.log.info`) per minute. This limit only applies to custom logs; system events like the ones that drive orchestration or materialize assets are not subject to this limit.
+- 35MB of events per minute. This limit applies to both custom events and system events.
+
+Rate-limited requests return a "429 - Too Many Requests" response. Dagster+ agents automatically retry these requests.
+
+Switching from [Structured event logs](/concepts/logging#structured-event-logs) to [Raw compute logs](/concepts/logging#raw-compute-logs) or reducing your custom log volume can help you stay within these limits.

--- a/docs/docs-beta/docs/dagster-plus/deployment/management/rate-limits.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/management/rate-limits.md
@@ -9,4 +9,5 @@ Dagster+ enforces several rate limits to smoothly distribute the load. Deploymen
 
 Rate-limited requests return a "429 - Too Many Requests" response. Dagster+ agents automatically retry these requests.
 
-Switching from [Structured event logs](/concepts/logging#structured-event-logs) to [Raw compute logs](/concepts/logging#raw-compute-logs) or reducing your custom log volume can help you stay within these limits.
+{/* Switching from [Structured event logs](/concepts/logging#structured-event-logs) to [Raw compute logs](/concepts/logging#raw-compute-logs) or reducing your custom log volume can help you stay within these limits. */}
+Switching from [Structured event logs](/todo) to [Raw compute logs](/todo) or reducing your custom log volume can help you stay within these limits.


### PR DESCRIPTION
## Summary & Motivation

Broken links converted to `/todo`:

```
  - Broken link on source page path = /dagster-plus/deployment/management/rate-limits:
     -> linking to /concepts/logging#structured-event-logs
     -> linking to /concepts/logging#raw-compute-logs
```

## How I Tested These Changes

## Changelog

NOCHANGELOG
