### PR TITLE
time_window_partitions: add get_partition_key helper method that converts date/datetime to str partition key

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1018,6 +1018,17 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
             and self.end_offset == other.end_offset
         )
 
+    def get_partition_key(self, key: Union[str, date, datetime]) -> str:
+        if isinstance(key, date) or isinstance(key, datetime):
+            key = key.strftime(self.fmt)
+
+        # now should have str
+        check.str_param(key, "key")
+        if not self.has_partition_key(key):
+            raise ValueError(f"Got invalid partition key {key!r}")
+
+        return key
+
     @property
     def is_basic_daily(self) -> bool:
         return is_basic_daily(self.cron_schedule)


### PR DESCRIPTION
## Summary & Motivation

Create a helper method `get_partition_key` on `TimeWindowPartitionsDefinition` that allows to get a string representation of a partition key using a string, datetime or date. This can be convenient for hourly/daily/weekly/monthly partitioned assets, as the method will automatically use the relevant partition definition format.

The current implementation will error if it gets a date/datetime that is not a valid partition key for the given partition definition.

## How I Tested These Changes

Added tests in `test_partitioned_assets.py`. Also, tested in a local Dagster.

## Changelog

> Add get_partition_key helper method that can be used on hourly/daily/weekly/montly partitioned assets to get partition key using date or datetime.