### PR TITLE
[module-loaders] Use new loader code in checks loaders

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
@@ -1,4 +1,4 @@
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 from dagster._core.definitions.materialize import materialize
 from docs_snippets.guides.dagster.asset_tutorial import cereal
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
@@ -6,5 +6,5 @@ from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 
 @patch_cereal_requests
 def test_cereal():
-    assets, source_assets, _ = assets_from_modules([cereal])
+    assets, source_assets, _ = load_assets_from_modules([cereal])
     assert materialize([*assets, *source_assets])

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
@@ -1,4 +1,4 @@
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 from dagster._core.definitions.materialize import materialize
 from docs_snippets.guides.dagster.asset_tutorial import serial_asset_graph
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
@@ -6,5 +6,5 @@ from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 
 @patch_cereal_requests
 def test_serial_asset_graph():
-    assets, source_assets, _ = assets_from_modules([serial_asset_graph])
+    assets, source_assets, _ = load_assets_from_modules([serial_asset_graph])
     assert materialize([*assets, *source_assets])

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -184,13 +184,13 @@ class FileCodePointer(
 
 
 def _load_target_from_module(module: ModuleType, fn_name: str, error_suffix: str) -> object:
-    from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+    from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
     from dagster._core.workspace.autodiscovery import LOAD_ALL_ASSETS
 
     if fn_name == LOAD_ALL_ASSETS:
         # LOAD_ALL_ASSETS is a special symbol that's returned when, instead of loading a particular
         # attribute, we should load all the assets in the module.
-        module_assets, module_source_assets, _ = assets_from_modules([module])
+        module_assets, module_source_assets, _ = load_assets_from_modules([module])
         return [*module_assets, *module_source_assets]
     else:
         if not hasattr(module, fn_name):

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -5,7 +5,7 @@ from typing import Callable, NamedTuple, Optional, Sequence, Tuple, Type, Union
 from dagster import DagsterInvariantViolationError, GraphDefinition, RepositoryDefinition
 from dagster._core.code_pointer import load_python_file, load_python_module
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 
 LOAD_ALL_ASSETS = "<<LOAD_ALL_ASSETS>>"
 
@@ -114,7 +114,7 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
             )
         )
 
-    module_assets, module_source_assets, _ = assets_from_modules([module])
+    module_assets, module_source_assets, _ = load_assets_from_modules([module])
     if len(module_assets) > 0 or len(module_source_assets) > 0:
         return [LoadableTarget(LOAD_ALL_ASSETS, [*module_assets, *module_source_assets])]
 


### PR DESCRIPTION
Make use of the new asset loading internal APIs under the hood on the checks loaders. This allows us to actually delete the old `prefix_assets` method, which was still in use here. 

A lot of the added code lines here are explicit coercion to "asset checks definitions" from assetsdefinitions after they have had attributes replaced. I wonder if this is actually necessary and can't be removed in another PR which handles that case holistically.

But now at least everything is using the same stuff under the hood, and we're able to remove this tangled mess of helper methods.