### PR TITLE
Allow croniter 5.0.1, but not 4.0.0

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -83,7 +83,7 @@ setup(
         # core (not explicitly expressed atm)
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0",
-        "croniter>=0.3.34,<4",
+        "croniter>=0.3.34,!=4.0.0,<6",
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",


### PR DESCRIPTION
## Summary & Motivation

This allows installing Meltano alongside Dagster.

See https://github.com/kiorky/croniter/blob/5.0.1/CHANGELOG.rst

## How I Tested These Changes

I ran `make dev_install`. I believe this is valid syntax.

## Changelog

> Allow croniter >= 5.0.1, but not 4.0.0, to reallow DayOfWeek as 7.
