### PR TITLE
[components] Add dagster-dg global config and AppContext

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -3,7 +3,7 @@ import click
 from dagster_dg.cli.generate import generate_cli
 from dagster_dg.cli.info import info_cli
 from dagster_dg.cli.list import list_cli
-from dagster_dg.utils import CLI_BUILTIN_COMPONENT_LIB_KEY, DEFAULT_BUILTIN_COMPONENT_LIB
+from dagster_dg.config import DgConfig, set_config_on_cli_context
 from dagster_dg.version import __version__
 
 
@@ -22,14 +22,19 @@ def create_dg_cli():
     @click.option(
         "--builtin-component-lib",
         type=str,
-        default=DEFAULT_BUILTIN_COMPONENT_LIB,
+        default=DgConfig.builtin_component_lib,
         help="Specify a builitin component library to use.",
     )
     @click.pass_context
-    def group(context: click.Context, builtin_component_lib: bool):
+    def group(context: click.Context, builtin_component_lib: str):
         """CLI tools for working with Dagster components."""
         context.ensure_object(dict)
-        context.obj[CLI_BUILTIN_COMPONENT_LIB_KEY] = builtin_component_lib
+        set_config_on_cli_context(
+            context,
+            DgConfig(
+                builtin_component_lib=builtin_component_lib,
+            ),
+        )
 
     return group
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -8,6 +8,7 @@ import click
 from dagster_dg.context import (
     CodeLocationDirectoryContext,
     DeploymentDirectoryContext,
+    DgContext,
     is_inside_code_location_directory,
     is_inside_deployment_directory,
 )
@@ -17,7 +18,6 @@ from dagster_dg.generate import (
     generate_component_type,
     generate_deployment,
 )
-from dagster_dg.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
 
 
 @click.group(name="generate")
@@ -57,7 +57,10 @@ def generate_deployment_command(path: Path) -> None:
         " the location of the local Dagster clone will be read from the `DAGSTER_GIT_REPO_DIR` environment variable."
     ),
 )
-def generate_code_location_command(name: str, use_editable_dagster: Optional[str]) -> None:
+@click.pass_context
+def generate_code_location_command(
+    cli_context: click.Context, name: str, use_editable_dagster: Optional[str]
+) -> None:
     """Generate a Dagster code location file structure and a uv-managed virtual environment scoped
     to the code location.
 
@@ -81,8 +84,9 @@ def generate_code_location_command(name: str, use_editable_dagster: Optional[str
     component`).  The `<name>.lib` directory holds custom component types scoped to the code
     location (which can be created with `dg generate component-type`).
     """
+    dg_context = DgContext.from_cli_context(cli_context)
     if is_inside_deployment_directory(Path.cwd()):
-        context = DeploymentDirectoryContext.from_path(Path.cwd())
+        context = DeploymentDirectoryContext.from_path(Path.cwd(), dg_context)
         if context.has_code_location(name):
             click.echo(click.style(f"A code location named {name} already exists.", fg="red"))
             sys.exit(1)
@@ -110,12 +114,14 @@ def generate_code_location_command(name: str, use_editable_dagster: Optional[str
 
 @generate_cli.command(name="component-type")
 @click.argument("name", type=str)
-def generate_component_type_command(name: str) -> None:
+@click.pass_context
+def generate_component_type_command(cli_context: click.Context, name: str) -> None:
     """Generate a scaffold of a custom Dagster component type.
 
     This command must be run inside a Dagster code location directory. The component type scaffold
     will be generated in submodule `<code_location_name>.lib.<name>`.
     """
+    dg_context = DgContext.from_cli_context(cli_context)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(
@@ -123,7 +129,7 @@ def generate_component_type_command(name: str) -> None:
             )
         )
         sys.exit(1)
-    context = CodeLocationDirectoryContext.from_path(Path.cwd())
+    context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
     full_component_name = f"{context.name}.{name}"
     if context.has_component_type(full_component_name):
         click.echo(click.style(f"A component type named `{name}` already exists.", fg="red"))
@@ -142,7 +148,7 @@ def generate_component_type_command(name: str) -> None:
 @click.argument("extra_args", nargs=-1, type=str)
 @click.pass_context
 def generate_component_command(
-    context: click.Context,
+    cli_context: click.Context,
     component_type: str,
     component_name: str,
     json_params: Optional[str],
@@ -172,7 +178,7 @@ def generate_component_command(
 
     It is an error to pass both --json-params and EXTRA_ARGS.
     """
-    builtin_component_lib = context.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
+    dg_context = DgContext.from_cli_context(cli_context)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(
@@ -181,13 +187,13 @@ def generate_component_command(
         )
         sys.exit(1)
 
-    dg_context = CodeLocationDirectoryContext.from_path(Path.cwd(), builtin_component_lib)
-    if not dg_context.has_component_type(component_type):
+    context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
+    if not context.has_component_type(component_type):
         click.echo(
             click.style(f"No component type `{component_type}` could be resolved.", fg="red")
         )
         sys.exit(1)
-    elif dg_context.has_component_instance(component_name):
+    elif context.has_component_instance(component_name):
         click.echo(
             click.style(f"A component instance named `{component_name}` already exists.", fg="red")
         )
@@ -204,10 +210,10 @@ def generate_component_command(
         sys.exit(1)
 
     generate_component_instance(
-        Path(dg_context.component_instances_root_path),
+        Path(context.component_instances_root_path),
         component_name,
         component_type,
         json_params,
         extra_args,
-        builtin_component_lib=builtin_component_lib,
+        dg_context,
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
@@ -5,8 +5,11 @@ from typing import Any, Mapping
 
 import click
 
-from dagster_dg.context import CodeLocationDirectoryContext, is_inside_code_location_directory
-from dagster_dg.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
+from dagster_dg.context import (
+    CodeLocationDirectoryContext,
+    DgContext,
+    is_inside_code_location_directory,
+)
 
 
 @click.group(name="info")
@@ -25,14 +28,14 @@ def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
 @click.option("--component-params-schema", is_flag=True, default=False)
 @click.pass_context
 def info_component_type_command(
-    context: click.Context,
+    cli_context: click.Context,
     component_type: str,
     description: bool,
     generate_params_schema: bool,
     component_params_schema: bool,
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
-    builtin_component_lib = context.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
+    dg_context = DgContext.from_cli_context(cli_context)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(
@@ -41,10 +44,8 @@ def info_component_type_command(
         )
         sys.exit(1)
 
-    dg_context = CodeLocationDirectoryContext.from_path(
-        Path.cwd(), builtin_component_lib=builtin_component_lib
-    )
-    if not dg_context.has_component_type(component_type):
+    context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
+    if not context.has_component_type(component_type):
         click.echo(
             click.style(f"No component type `{component_type}` could be resolved.", fg="red")
         )
@@ -59,7 +60,7 @@ def info_component_type_command(
         )
         sys.exit(1)
 
-    component_type_metadata = dg_context.get_component_type(component_type)
+    component_type_metadata = context.get_component_type(component_type)
 
     if description:
         if component_type_metadata.description:

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+import click
+from typing_extensions import Self
+
+from dagster_dg.error import DgError
+
+DEFAULT_BUILTIN_COMPONENT_LIB = "dagster_components"
+
+
+@dataclass
+class DgConfig:
+    """Global configuration for Dg.
+
+    Attributes:
+        builitin_component_lib (str): The name of the builtin component library to load.
+    """
+
+    builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
+
+    @classmethod
+    def from_cli_context(cls, cli_context: click.Context) -> Self:
+        if _CLI_CONTEXT_CONFIG_KEY not in cli_context.obj:
+            raise DgError(
+                "Attempted to extract DgConfig from CLI context but nothing stored under designated key `{_CLI_CONTEXT_CONFIG_KEY}`."
+            )
+        return cli_context.obj[_CLI_CONTEXT_CONFIG_KEY]
+
+    @classmethod
+    def default(cls) -> "DgConfig":
+        return cls()
+
+
+_CLI_CONTEXT_CONFIG_KEY = "config"
+
+
+def set_config_on_cli_context(cli_context: click.Context, config: DgConfig) -> None:
+    cli_context.ensure_object(dict)
+    cli_context.obj[_CLI_CONTEXT_CONFIG_KEY] = config

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -6,9 +6,8 @@ from typing import Optional, Tuple
 
 import click
 
-from dagster_dg.context import CodeLocationDirectoryContext
+from dagster_dg.context import CodeLocationDirectoryContext, DgContext
 from dagster_dg.utils import (
-    DEFAULT_BUILTIN_COMPONENT_LIB,
     camelcase,
     execute_code_location_command,
     generate_subtree,
@@ -151,7 +150,7 @@ def generate_component_instance(
     component_type: str,
     json_params: Optional[str],
     extra_args: Tuple[str, ...],
-    builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB,
+    dg_context: "DgContext",
 ) -> None:
     component_instance_root_path = root_path / name
     click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")
@@ -167,5 +166,5 @@ def generate_component_instance(
     execute_code_location_command(
         Path(component_instance_root_path),
         code_location_command,
-        builtin_component_lib=builtin_component_lib,
+        dg_context,
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -5,26 +5,30 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Final, Iterator, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Final, Iterator, List, Mapping, Optional, Sequence, Union
 
 import click
 import jinja2
 
 from dagster_dg.version import __version__ as dagster_version
 
-CLI_BUILTIN_COMPONENT_LIB_KEY = "builtin_component_lib"
-DEFAULT_BUILTIN_COMPONENT_LIB: Final = "dagster_components"
+if TYPE_CHECKING:
+    from dagster_dg.context import DgContext
+
+CLI_CONFIG_KEY = "config"
 
 
 _CODE_LOCATION_COMMAND_PREFIX: Final = ["uv", "run", "dagster-components"]
 
 
-def execute_code_location_command(
-    path: Path, cmd: Sequence[str], builtin_component_lib: Optional[str] = None
-) -> str:
+def execute_code_location_command(path: Path, cmd: Sequence[str], dg_context: "DgContext") -> str:
     full_cmd = [
         *_CODE_LOCATION_COMMAND_PREFIX,
-        *(["--builtin-component-lib", builtin_component_lib] if builtin_component_lib else []),
+        *(
+            ["--builtin-component-lib", dg_context.config.builtin_component_lib]
+            if dg_context.config.builtin_component_lib
+            else []
+        ),
         *cmd,
     ]
     with pushd(path):

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_generate_commands.py
@@ -7,7 +7,7 @@ import pytest
 import tomli
 from click.testing import CliRunner
 from dagster_dg.cli import cli as dg_cli
-from dagster_dg.context import CodeLocationDirectoryContext
+from dagster_dg.context import CodeLocationDirectoryContext, DgContext
 from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import
 
 ensure_dagster_dg_tests_import()
@@ -142,7 +142,7 @@ def test_generate_component_type_success(in_deployment: bool) -> None:
         result = runner.invoke("generate", "component-type", "baz")
         assert_runner_result(result)
         assert Path("bar/lib/baz.py").exists()
-        context = CodeLocationDirectoryContext.from_path(Path.cwd())
+        context = CodeLocationDirectoryContext.from_path(Path.cwd(), DgContext.default())
         assert context.has_component_type("bar.baz")
 
 


### PR DESCRIPTION
## Summary & Motivation

Add a global `AppContext` and `DgConfig` object in `dagster-dg`. The purpose of these abstractions is to capture global configuration and pass it throughout the system. Global configuration is supported via top-level options passed to `dg` on the command line.

`AppContext` may appear premature in this PR, since it just wraps `DgConfig`. Upstack we add the cache to it.

## How I Tested These Changes

Unit tests.