### PR TITLE
[components] Add cache to dagster-dg

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -1,0 +1,74 @@
+import shutil
+import sys
+from pathlib import Path
+from typing import Final, Literal, Optional, Tuple
+
+from typing_extensions import Self, TypeAlias
+
+from dagster_dg.config import DgConfig
+
+_CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
+
+CachableDataType: TypeAlias = Literal["component_registry_data"]
+
+
+def get_default_cache_dir() -> Path:
+    if sys.platform == "win32":
+        return Path.home() / "AppData" / "dg" / "cache"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "dg"
+    else:
+        return Path.home() / ".cache" / "dg"
+
+
+class DgCache:
+    @classmethod
+    def from_default(cls) -> Self:
+        return cls.from_parent_path(get_default_cache_dir())
+
+    @classmethod
+    def from_config(cls, config: DgConfig) -> Self:
+        return cls.from_parent_path(
+            parent_path=config.cache_dir,
+            logging_enabled=config.verbose,
+        )
+
+    # This is the preferred constructor to use when creating a cache. It ensures that all data is
+    # stored inside an additional container directory inside the user-specified cache directory.
+    # When we clear the cache, we only delete this container directory. This is to avoid accidents
+    # when the user mistakenly specifies a cache directory that contains other data.
+    @classmethod
+    def from_parent_path(cls, parent_path: Path, logging_enabled: bool = False) -> Self:
+        root_path = parent_path / _CACHE_CONTAINER_DIR_NAME
+        return cls(root_path, logging_enabled)
+
+    def __init__(self, root_path: Path, logging_enabled: bool):
+        self._root_path = root_path
+        self._root_path.mkdir(parents=True, exist_ok=True)
+        self._logging_enabled = logging_enabled
+
+    def clear(self) -> None:
+        shutil.rmtree(self._root_path)
+        self.log(f"CACHE [clear]: {self._root_path}")
+
+    def get(self, key: Tuple[str, ...]) -> Optional[str]:
+        path = self._get_path(key)
+        if path.exists():
+            self.log(f"CACHE [hit]: {path}")
+            return path.read_text()
+        else:
+            self.log(f"CACHE [miss]: {path}")
+            return None
+
+    def set(self, key: Tuple[str, ...], value: str) -> None:
+        path = self._get_path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+        self.log(f"CACHE [write]: {path}")
+
+    def _get_path(self, key: Tuple[str, ...]) -> Path:
+        return Path(self._root_path, *key)
+
+    def log(self, message: str) -> None:
+        if self._logging_enabled:
+            print(message)  # noqa: T201

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import click
 
+from dagster_dg.cache import DgCache
 from dagster_dg.cli.generate import generate_cli
 from dagster_dg.cli.info import info_cli
 from dagster_dg.cli.list import list_cli
@@ -14,27 +17,69 @@ def create_dg_cli():
         "list": list_cli,
     }
 
+    # Defaults are defined on the DgConfig object.
     @click.group(
         commands=commands,
         context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
+        invoke_without_command=True,
     )
-    @click.version_option(__version__, "--version", "-v")
     @click.option(
         "--builtin-component-lib",
         type=str,
         default=DgConfig.builtin_component_lib,
         help="Specify a builitin component library to use.",
     )
+    @click.option(
+        "--verbose",
+        is_flag=True,
+        default=DgConfig.verbose,
+        help="Enable verbose output for debugging.",
+    )
+    @click.option(
+        "--disable-cache",
+        is_flag=True,
+        default=DgConfig.disable_cache,
+        help="Disable caching of component registry data.",
+    )
+    @click.option(
+        "--clear-cache",
+        is_flag=True,
+        help="Clear the cache before running the command.",
+        default=False,
+    )
+    @click.option(
+        "--cache-dir",
+        type=Path,
+        default=DgConfig.cache_dir,
+        help="Specify a directory to use for the cache.",
+    )
+    @click.version_option(__version__, "--version", "-v")
     @click.pass_context
-    def group(context: click.Context, builtin_component_lib: str):
+    def group(
+        context: click.Context,
+        builtin_component_lib: str,
+        verbose: bool,
+        disable_cache: bool,
+        cache_dir: Path,
+        clear_cache: bool,
+    ):
         """CLI tools for working with Dagster components."""
         context.ensure_object(dict)
-        set_config_on_cli_context(
-            context,
-            DgConfig(
-                builtin_component_lib=builtin_component_lib,
-            ),
+        config = DgConfig(
+            builtin_component_lib=builtin_component_lib,
+            verbose=verbose,
+            disable_cache=disable_cache,
+            cache_dir=cache_dir,
         )
+        if clear_cache:
+            DgCache.from_config(config).clear()
+            if context.invoked_subcommand is None:
+                context.exit(0)
+        elif context.invoked_subcommand is None:
+            click.echo(context.get_help())
+            context.exit(0)
+
+        set_config_on_cli_context(context, config)
 
     return group
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,4 +1,6 @@
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import click
 from typing_extensions import Self
@@ -8,14 +10,33 @@ from dagster_dg.error import DgError
 DEFAULT_BUILTIN_COMPONENT_LIB = "dagster_components"
 
 
+def _get_default_cache_dir() -> Path:
+    if sys.platform == "win32":
+        return Path.home() / "AppData" / "dg" / "cache"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "dg"
+    else:
+        return Path.home() / ".cache" / "dg"
+
+
+DEFAULT_CACHE_DIR = _get_default_cache_dir()
+
+
 @dataclass
 class DgConfig:
     """Global configuration for Dg.
 
     Attributes:
+        disable_cache (bool): If True, disable caching. Defaults to False.
+        cache_dir (Optional[str]): The directory to use for caching. If None, the default cache will
+            be used.
+        verbose (bool): If True, log debug information.
         builitin_component_lib (str): The name of the builtin component library to load.
     """
 
+    disable_cache: bool = False
+    cache_dir: Path = DEFAULT_CACHE_DIR
+    verbose: bool = False
     builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
 
     @classmethod

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -12,8 +12,7 @@ from dagster_dg_tests.utils import (
 
 
 def test_info_component_type_all_metadata_success():
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke(
             "info",
             "component-type",
@@ -77,8 +76,7 @@ def test_info_component_type_all_metadata_success():
 
 
 def test_info_component_type_all_metadata_empty_success():
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke(
             "info",
             "component-type",
@@ -94,8 +92,7 @@ def test_info_component_type_all_metadata_empty_success():
 
 
 def test_info_component_type_flag_fields_success():
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke(
             "info",
             "component-type",
@@ -176,8 +173,7 @@ def test_info_component_type_flag_fields_success():
 
 
 def test_info_component_type_outside_code_location_fails() -> None:
-    runner = ProxyRunner.test()
-    with runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
             "info",
             "component-type",
@@ -189,8 +185,7 @@ def test_info_component_type_outside_code_location_fails() -> None:
 
 
 def test_info_component_type_multiple_flags_fails() -> None:
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke(
             "info",
             "component-type",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -13,8 +13,7 @@ from dagster_dg_tests.utils import (
 
 
 def test_list_code_locations_success():
-    runner = ProxyRunner.test()
-    with isolated_example_deployment_foo(runner):
+    with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
         runner.invoke("generate", "code-location", "foo")
         runner.invoke("generate", "code-location", "bar")
         result = runner.invoke("list", "code-locations")
@@ -29,16 +28,14 @@ def test_list_code_locations_success():
 
 
 def test_list_code_locations_outside_deployment_fails() -> None:
-    runner = ProxyRunner.test()
-    with runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("list", "code-locations")
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster deployment directory" in result.output
 
 
 def test_list_component_types_success():
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke("list", "component-types")
         assert_runner_result(result)
         assert (
@@ -54,16 +51,14 @@ def test_list_component_types_success():
 
 
 def test_list_component_types_outside_code_location_fails() -> None:
-    runner = ProxyRunner.test()
-    with runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("list", "component-types")
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster code location directory" in result.output
 
 
 def test_list_components_succeeds():
-    runner = ProxyRunner.test()
-    with isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke(
             "generate",
             "component",
@@ -82,8 +77,7 @@ def test_list_components_succeeds():
 
 
 def test_list_components_command_outside_code_location_fails() -> None:
-    runner = ProxyRunner.test()
-    with runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("list", "components")
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster code location directory" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -1,0 +1,93 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    assert_runner_result,
+    isolated_example_code_location_bar,
+)
+
+
+def test_load_from_cache():
+    with ProxyRunner.test(verbose=True) as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+        assert "CACHE [write]" in result.output
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [hit]" in result.output
+
+
+def test_cache_invalidation_uv_lock():
+    with ProxyRunner.test(verbose=True) as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+        assert "CACHE [write]" in result.output
+
+        subprocess.run(["uv", "add", "dagster-components[dbt]"], check=True)
+
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+
+
+def test_cache_invalidation_modified_lib():
+    with ProxyRunner.test(verbose=True) as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+        assert "CACHE [write]" in result.output
+
+        result = runner.invoke("generate", "component-type", "my_component")
+        assert_runner_result(result)
+
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+
+
+def test_cache_no_invalidation_modified_pkg():
+    with ProxyRunner.test(verbose=True) as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+        assert "CACHE [write]" in result.output
+
+        Path("bar/submodule.py").write_text("print('hello')")
+
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [hit]" in result.output
+
+
+@pytest.mark.parametrize("with_command", [True, False])
+def test_cache_clear(with_command: bool):
+    with ProxyRunner.test(verbose=True) as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+        assert "CACHE [write]" in result.output
+
+        if with_command:
+            result = runner.invoke("--clear-cache", "list", "component-types")
+        else:
+            result = runner.invoke("--clear-cache")
+            assert_runner_result(result)
+            result = runner.invoke("list", "component-types")
+
+        assert_runner_result(result)
+        assert "CACHE [miss]" in result.output
+
+
+def test_cache_disabled():
+    with (
+        ProxyRunner.test(verbose=True, disable_cache=True) as runner,
+        isolated_example_code_location_bar(runner),
+    ):
+        result = runner.invoke("list", "component-types")
+        assert_runner_result(result)
+        assert "CACHE" not in result.output


### PR DESCRIPTION
## Summary & Motivation

Initial implementation of a cache for `dagster-dg`. Currently just caches the registered components for a code location. Cache key is (code loc abs path, env hash, type of payload). The environment hash is calculated over the file metadata of `uv.lock` and the content of `pkg.lib` (i.e. where local component types can be defined).
 
## How I Tested These Changes

New unit tests + manual testing (running `dg list component-types` multiple times in the same code loc, observing speedup).