### PR TITLE
[module-loaders] [rfc] Include specs in asset module loaders

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
@@ -1,4 +1,4 @@
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 from dagster._core.definitions.materialize import materialize
 from docs_snippets.guides.dagster.asset_tutorial import cereal
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
@@ -6,5 +6,5 @@ from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 
 @patch_cereal_requests
 def test_cereal():
-    assets, source_assets, _ = assets_from_modules([cereal])
+    assets, source_assets, _ = load_assets_from_modules([cereal])
     assert materialize([*assets, *source_assets])

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
@@ -1,4 +1,4 @@
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 from dagster._core.definitions.materialize import materialize
 from docs_snippets.guides.dagster.asset_tutorial import serial_asset_graph
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
@@ -6,5 +6,5 @@ from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 
 @patch_cereal_requests
 def test_serial_asset_graph():
-    assets, source_assets, _ = assets_from_modules([serial_asset_graph])
+    assets, source_assets, _ = load_assets_from_modules([serial_asset_graph])
     assert materialize([*assets, *source_assets])

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -184,13 +184,13 @@ class FileCodePointer(
 
 
 def _load_target_from_module(module: ModuleType, fn_name: str, error_suffix: str) -> object:
-    from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+    from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
     from dagster._core.workspace.autodiscovery import LOAD_ALL_ASSETS
 
     if fn_name == LOAD_ALL_ASSETS:
         # LOAD_ALL_ASSETS is a special symbol that's returned when, instead of loading a particular
         # attribute, we should load all the assets in the module.
-        module_assets, module_source_assets, _ = assets_from_modules([module])
+        module_assets, module_source_assets, _ = load_assets_from_modules([module])
         return [*module_assets, *module_source_assets]
     else:
         if not hasattr(module, fn_name):

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -313,6 +313,7 @@ class AssetSpec(
         tags: Optional[Mapping[str, str]] = ...,
         kinds: Optional[Set[str]] = ...,
         partitions_def: Optional[PartitionsDefinition] = ...,
+        freshness_policy: Optional[FreshnessPolicy] = ...,
     ) -> "AssetSpec":
         """Returns a new AssetSpec with the specified attributes replaced."""
         current_tags_without_kinds = {

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -48,7 +48,7 @@ def find_subclasses_in_module(
 
 
 def assets_from_modules(
-    modules: Iterable[ModuleType], extra_source_assets: Optional[Sequence[SourceAsset]] = None
+    modules: Iterable[ModuleType],
 ) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
     """Constructs three lists, a list of assets, a list of source assets, and a list of cacheable
     assets from the given modules.
@@ -65,9 +65,7 @@ def assets_from_modules(
     """
     asset_ids: Set[int] = set()
     asset_keys: Dict[AssetKey, ModuleType] = dict()
-    source_assets: List[SourceAsset] = list(
-        check.opt_sequence_param(extra_source_assets, "extra_source_assets", of_type=SourceAsset)
-    )
+    source_assets: List[SourceAsset] = []
     cacheable_assets: List[CacheableAssetsDefinition] = []
     assets: Dict[AssetKey, AssetsDefinition] = {}
     for module in modules:
@@ -220,7 +218,6 @@ def load_assets_from_current_module(
 
 def assets_from_package_module(
     package_module: ModuleType,
-    extra_source_assets: Optional[Sequence[SourceAsset]] = None,
 ) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
     """Constructs three lists, a list of assets, a list of source assets, and a list of cacheable assets
     from the given package module.
@@ -235,9 +232,7 @@ def assets_from_package_module(
             A tuple containing a list of assets, a list of source assets, and a list of cacheable assets
             defined in the given modules.
     """
-    return assets_from_modules(
-        find_modules_in_package(package_module), extra_source_assets=extra_source_assets
-    )
+    return assets_from_modules(find_modules_in_package(package_module))
 
 
 def load_assets_from_package_module(

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -4,7 +4,19 @@ from collections import defaultdict
 from functools import cached_property
 from importlib import import_module
 from types import ModuleType
-from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import (
@@ -12,6 +24,7 @@ from dagster._core.definitions.asset_key import (
     CoercibleToAssetKeyPrefix,
     check_opt_coercible_to_asset_key_prefix_param,
 )
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
@@ -21,7 +34,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.definitions.utils import resolve_automation_condition
+from dagster._core.definitions.utils import DEFAULT_GROUP_NAME, resolve_automation_condition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 
@@ -89,6 +102,14 @@ class LoadedAssetsList:
         return list(self.objects_by_id.values())
 
     @cached_property
+    def assets_defs(self) -> Sequence[AssetsDefinition]:
+        return [asset for asset in self.deduped_objects if isinstance(asset, AssetsDefinition)]
+
+    @cached_property
+    def source_assets(self) -> Sequence[SourceAsset]:
+        return [asset for asset in self.deduped_objects if isinstance(asset, SourceAsset)]
+
+    @cached_property
     def module_name_by_id(self) -> Dict[int, str]:
         return {
             id(asset_object): module_name
@@ -106,24 +127,6 @@ class LoadedAssetsList:
                 objects_by_key[key].append(asset_object)
         return objects_by_key
 
-    @cached_property
-    def sources(self) -> Sequence[SourceAsset]:
-        return [asset for asset in self.deduped_objects if isinstance(asset, SourceAsset)]
-
-    @cached_property
-    def assets_defs(self) -> Sequence[AssetsDefinition]:
-        return [
-            asset
-            for asset in self.deduped_objects
-            if isinstance(asset, AssetsDefinition) and asset.keys
-        ]
-
-    @cached_property
-    def cacheable_assets_defs(self) -> Sequence[CacheableAssetsDefinition]:
-        return [
-            asset for asset in self.deduped_objects if isinstance(asset, CacheableAssetsDefinition)
-        ]
-
     def _do_collision_detection(self) -> None:
         for key, asset_objects in self.objects_by_key.items():
             # If there is more than one asset_object in the list for a given key, and the objects do not refer to the same asset_object in memory, we have a collision.
@@ -131,36 +134,58 @@ class LoadedAssetsList:
                 set(id(asset_object) for asset_object in asset_objects)
             )
             if len(asset_objects) > 1 and num_distinct_objects_for_key > 1:
-                asset_objects_str = ", ".join(
-                    set(self.module_name_by_id[id(asset_object)] for asset_object in asset_objects)
+                affected_modules = set(
+                    self.module_name_by_id[id(asset_object)] for asset_object in asset_objects
+                )
+                asset_objects_str = ", ".join(affected_modules)
+                modules_str = (
+                    f"Definitions found in modules: {asset_objects_str}."
+                    if len(affected_modules) > 1
+                    else ""
                 )
                 raise DagsterInvalidDefinitionError(
-                    f"Asset key {key.to_user_string()} is defined multiple times. Definitions found in modules: {asset_objects_str}."
+                    f"Asset key {key.to_user_string()} is defined multiple times. {modules_str}".strip()
                 )
 
-
-def assets_from_modules(
-    modules: Iterable[ModuleType],
-) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
-    """Constructs three lists, a list of assets, a list of source assets, and a list of cacheable
-    assets from the given modules.
-
-    Args:
-        modules (Iterable[ModuleType]): The Python modules to look for assets inside.
-        extra_source_assets (Optional[Sequence[SourceAsset]]): Source assets to include in the
-            group in addition to the source assets found in the modules.
-
-    Returns:
-        Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]]:
-            A tuple containing a list of assets, a list of source assets, and a list of
-            cacheable assets defined in the given modules.
-    """
-    assets_list = LoadedAssetsList.from_modules(modules)
-    return assets_list.assets_defs, assets_list.sources, assets_list.cacheable_assets_defs
+    def to_post_load(self) -> "ResolvedAssetObjectList":
+        return ResolvedAssetObjectList(self.deduped_objects)
 
 
-def key_iterator(asset: Union[AssetsDefinition, SourceAsset]) -> Iterator[AssetKey]:
-    return iter(asset.keys) if isinstance(asset, AssetsDefinition) else iter([asset.key])
+def _spec_mapper_disallow_group_override(
+    group_name: Optional[str],
+    automation_condition: Optional[AutomationCondition],
+) -> Callable[[AssetSpec], AssetSpec]:
+    def _inner(spec: AssetSpec) -> AssetSpec:
+        if (
+            group_name is not None
+            and spec.group_name is not None
+            and group_name != spec.group_name
+            and spec.group_name != DEFAULT_GROUP_NAME
+        ):
+            raise DagsterInvalidDefinitionError(
+                f"Asset spec {spec.key.to_user_string()} has group name {spec.group_name}, which conflicts with the group name {group_name} provided in load_assets_from_modules."
+            )
+        return spec.replace_attributes(
+            group_name=group_name if group_name else ...,
+            automation_condition=automation_condition if automation_condition else ...,
+        )
+
+    return _inner
+
+
+def key_iterator(
+    asset: Union[AssetsDefinition, SourceAsset], included_targeted_keys: bool = False
+) -> Iterator[AssetKey]:
+    return (
+        iter(
+            *[asset.keys],
+            *[check_key.asset_key for check_key in asset.check_keys]
+            if included_targeted_keys
+            else [],
+        )
+        if isinstance(asset, AssetsDefinition)
+        else iter([asset.key])
+    )
 
 
 def load_assets_from_modules(
@@ -196,29 +221,26 @@ def load_assets_from_modules(
         Sequence[Union[AssetsDefinition, SourceAsset]]:
             A list containing assets and source assets defined in the given modules.
     """
-    group_name = check.opt_str_param(group_name, "group_name")
-    key_prefix = check_opt_coercible_to_asset_key_prefix_param(key_prefix, "key_prefix")
-    freshness_policy = check.opt_inst_param(freshness_policy, "freshness_policy", FreshnessPolicy)
-    backfill_policy = check.opt_inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
-
-    (
-        assets,
-        source_assets,
-        cacheable_assets,
-    ) = assets_from_modules(modules)
-
-    return assets_with_attributes(
-        assets,
-        source_assets,
-        cacheable_assets,
-        key_prefix=key_prefix,
-        group_name=group_name,
-        freshness_policy=freshness_policy,
-        automation_condition=resolve_automation_condition(
-            automation_condition, auto_materialize_policy
-        ),
-        backfill_policy=backfill_policy,
-        source_key_prefix=source_key_prefix,
+    return (
+        LoadedAssetsList.from_modules(modules)
+        .to_post_load()
+        .with_attributes(
+            key_prefix=check_opt_coercible_to_asset_key_prefix_param(key_prefix, "key_prefix"),
+            source_key_prefix=check_opt_coercible_to_asset_key_prefix_param(
+                source_key_prefix, "source_key_prefix"
+            ),
+            group_name=check.opt_str_param(group_name, "group_name"),
+            freshness_policy=check.opt_inst_param(
+                freshness_policy, "freshness_policy", FreshnessPolicy
+            ),
+            automation_condition=resolve_automation_condition(
+                automation_condition, auto_materialize_policy
+            ),
+            backfill_policy=check.opt_inst_param(
+                backfill_policy, "backfill_policy", BackfillPolicy
+            ),
+        )
+        .loaded_objects
     )
 
 
@@ -272,25 +294,6 @@ def load_assets_from_current_module(
     )
 
 
-def assets_from_package_module(
-    package_module: ModuleType,
-) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
-    """Constructs three lists, a list of assets, a list of source assets, and a list of cacheable assets
-    from the given package module.
-
-    Args:
-        package_module (ModuleType): The package module to looks for assets inside.
-        extra_source_assets (Optional[Sequence[SourceAsset]]): Source assets to include in the
-            group in addition to the source assets found in the modules.
-
-    Returns:
-        Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
-            A tuple containing a list of assets, a list of source assets, and a list of cacheable assets
-            defined in the given modules.
-    """
-    return assets_from_modules(find_modules_in_package(package_module))
-
-
 def load_assets_from_package_module(
     package_module: ModuleType,
     group_name: Optional[str] = None,
@@ -301,7 +304,7 @@ def load_assets_from_package_module(
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> Sequence[LoadableAssetTypes]:
     """Constructs a list of assets and source assets that includes all asset
     definitions, source assets, and cacheable assets in all sub-modules of the given package module.
 
@@ -327,26 +330,13 @@ def load_assets_from_package_module(
         Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
-    group_name = check.opt_str_param(group_name, "group_name")
-    key_prefix = check_opt_coercible_to_asset_key_prefix_param(key_prefix, "key_prefix")
-    freshness_policy = check.opt_inst_param(freshness_policy, "freshness_policy", FreshnessPolicy)
-    backfill_policy = check.opt_inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
-
-    (
-        assets,
-        source_assets,
-        cacheable_assets,
-    ) = assets_from_package_module(package_module)
-    return assets_with_attributes(
-        assets,
-        source_assets,
-        cacheable_assets,
-        key_prefix=key_prefix,
-        group_name=group_name,
+    return load_assets_from_modules(
+        [*find_modules_in_package(package_module)],
+        group_name,
+        key_prefix,
         freshness_policy=freshness_policy,
-        automation_condition=resolve_automation_condition(
-            automation_condition, auto_materialize_policy
-        ),
+        auto_materialize_policy=auto_materialize_policy,
+        automation_condition=automation_condition,
         backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
     )
@@ -414,6 +404,126 @@ def find_modules_in_package(package_module: ModuleType) -> Iterable[ModuleType]:
         )
 
 
+def replace_keys_in_asset(
+    asset: Union[AssetsDefinition, SourceAsset],
+    key_replacements: Mapping[AssetKey, AssetKey],
+) -> Union[AssetsDefinition, SourceAsset]:
+    return (
+        asset.with_attributes(
+            output_asset_key_replacements={
+                key: key_replacements.get(key, key) for key in asset.keys
+            },
+            input_asset_key_replacements={
+                key: key_replacements.get(key, key) for key in asset.keys_by_input_name.values()
+            },
+        )
+        if isinstance(asset, AssetsDefinition)
+        else asset.with_attributes(key=key_replacements.get(asset.key, asset.key))
+    )
+
+
+class ResolvedAssetObjectList:
+    def __init__(
+        self,
+        loaded_objects: Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]],
+    ):
+        self.loaded_objects = loaded_objects
+
+    @cached_property
+    def assets_defs(self) -> Sequence[AssetsDefinition]:
+        return [
+            dagster_object
+            for dagster_object in self.loaded_objects
+            if isinstance(dagster_object, AssetsDefinition) and dagster_object.keys
+        ]
+
+    @cached_property
+    def source_assets(self) -> Sequence[SourceAsset]:
+        return [asset for asset in self.loaded_objects if isinstance(asset, SourceAsset)]
+
+    def assets_with_loadable_prefix(
+        self, key_prefix: CoercibleToAssetKeyPrefix
+    ) -> "ResolvedAssetObjectList":
+        # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
+        # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
+        # at prefix-time it is not known that its dependency is one of the cacheable assets.
+        # https://github.com/dagster-io/dagster/pull/10389#pullrequestreview-1170913271
+        result_list = []
+        all_asset_keys = {
+            key
+            for asset_object in self.assets_defs
+            for key in key_iterator(asset_object, included_targeted_keys=True)
+        }
+        key_replacements = {key: key.with_prefix(key_prefix) for key in all_asset_keys}
+        for asset_object in self.loaded_objects:
+            if isinstance(asset_object, CacheableAssetsDefinition):
+                result_list.append(asset_object.with_prefix_for_all(key_prefix))
+            elif isinstance(asset_object, AssetsDefinition):
+                result_list.append(replace_keys_in_asset(asset_object, key_replacements))
+            else:
+                # We don't replace the key for SourceAssets.
+                result_list.append(asset_object)
+        return ResolvedAssetObjectList(result_list)
+
+    def assets_with_source_prefix(
+        self, key_prefix: CoercibleToAssetKeyPrefix
+    ) -> "ResolvedAssetObjectList":
+        result_list = []
+        key_replacements = {
+            source_asset.key: source_asset.key.with_prefix(key_prefix)
+            for source_asset in self.source_assets
+        }
+        for asset_object in self.loaded_objects:
+            if isinstance(asset_object, KeyScopedAssetObjects):
+                result_list.append(replace_keys_in_asset(asset_object, key_replacements))
+            else:
+                result_list.append(asset_object)
+        return ResolvedAssetObjectList(result_list)
+
+    def with_attributes(
+        self,
+        key_prefix: Optional[CoercibleToAssetKeyPrefix],
+        source_key_prefix: Optional[CoercibleToAssetKeyPrefix],
+        group_name: Optional[str],
+        freshness_policy: Optional[FreshnessPolicy],
+        automation_condition: Optional[AutomationCondition],
+        backfill_policy: Optional[BackfillPolicy],
+    ) -> "ResolvedAssetObjectList":
+        assets_list = self.assets_with_loadable_prefix(key_prefix) if key_prefix else self
+        assets_list = (
+            assets_list.assets_with_source_prefix(source_key_prefix)
+            if source_key_prefix
+            else assets_list
+        )
+        return_list = []
+        for asset in assets_list.loaded_objects:
+            if isinstance(asset, AssetsDefinition):
+                return_list.append(
+                    asset.map_asset_specs(
+                        _spec_mapper_disallow_group_override(group_name, automation_condition)
+                    ).with_attributes(
+                        backfill_policy=backfill_policy, freshness_policy=freshness_policy
+                    )
+                )
+            elif isinstance(asset, SourceAsset):
+                return_list.append(
+                    asset.with_attributes(group_name=group_name if group_name else asset.group_name)
+                )
+            else:
+                return_list.append(
+                    asset.with_attributes_for_all(
+                        group_name,
+                        freshness_policy=freshness_policy,
+                        auto_materialize_policy=automation_condition.as_auto_materialize_policy()
+                        if automation_condition
+                        else None,
+                        backfill_policy=backfill_policy,
+                    )
+                )
+        return ResolvedAssetObjectList(return_list)
+
+
+# No longer used in load_assets_from_modules, next PR will fix for load_asset_checks_from_modules
 def prefix_assets(
     assets_defs: Sequence[AssetsDefinition],
     key_prefix: CoercibleToAssetKeyPrefix,
@@ -503,60 +613,3 @@ def prefix_assets(
         result_source_assets = source_assets
 
     return result_assets, result_source_assets
-
-
-def assets_with_attributes(
-    assets_defs: Sequence[AssetsDefinition],
-    source_assets: Sequence[SourceAsset],
-    cacheable_assets: Sequence[CacheableAssetsDefinition],
-    key_prefix: Optional[Sequence[str]],
-    group_name: Optional[str],
-    freshness_policy: Optional[FreshnessPolicy],
-    automation_condition: Optional[AutomationCondition],
-    backfill_policy: Optional[BackfillPolicy],
-    source_key_prefix: Optional[Sequence[str]],
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
-    # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
-    # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
-    # at prefix-time it is not known that its dependency is one of the cacheable assets.
-    # https://github.com/dagster-io/dagster/pull/10389#pullrequestreview-1170913271
-    if key_prefix:
-        assets_defs, source_assets = prefix_assets(
-            assets_defs, key_prefix, source_assets, source_key_prefix
-        )
-        cacheable_assets = [
-            cached_asset.with_prefix_for_all(key_prefix) for cached_asset in cacheable_assets
-        ]
-
-    if group_name or freshness_policy or automation_condition or backfill_policy:
-        assets_defs = [
-            asset.with_attributes(
-                group_names_by_key=(
-                    {asset_key: group_name for asset_key in asset.keys}
-                    if group_name is not None
-                    else {}
-                ),
-                freshness_policy=freshness_policy,
-                automation_condition=automation_condition,
-                backfill_policy=backfill_policy,
-            )
-            for asset in assets_defs
-        ]
-        if group_name:
-            source_assets = [
-                source_asset.with_attributes(group_name=group_name)
-                for source_asset in source_assets
-            ]
-        cacheable_assets = [
-            cached_asset.with_attributes_for_all(
-                group_name,
-                freshness_policy=freshness_policy,
-                auto_materialize_policy=automation_condition.as_auto_materialize_policy()
-                if automation_condition
-                else None,
-                backfill_policy=backfill_policy,
-            )
-            for cached_asset in cacheable_assets
-        ]
-
-    return [*assets_defs, *source_assets, *cacheable_assets]

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -63,8 +63,8 @@ def find_subclasses_in_module(
             yield value
 
 
-LoadableAssetTypes = Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]
-KeyScopedAssetObjects = (AssetsDefinition, SourceAsset)
+LoadableAssetTypes = Union[AssetsDefinition, AssetSpec, SourceAsset, CacheableAssetsDefinition]
+KeyScopedAssetObjects = (AssetsDefinition, AssetSpec, SourceAsset)
 
 
 class LoadedAssetsList:
@@ -81,7 +81,8 @@ class LoadedAssetsList:
             {
                 module.__name__: list(
                     find_objects_in_module_of_types(
-                        module, (AssetsDefinition, SourceAsset, CacheableAssetsDefinition)
+                        module,
+                        (AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec),
                     )
                 )
                 for module in modules
@@ -175,7 +176,7 @@ def _spec_mapper_disallow_group_override(
 
 
 def key_iterator(
-    asset: Union[AssetsDefinition, SourceAsset], included_targeted_keys: bool = False
+    asset: Union[AssetsDefinition, SourceAsset, AssetSpec], included_targeted_keys: bool = False
 ) -> Iterator[AssetKey]:
     return (
         iter(
@@ -203,7 +204,8 @@ def load_assets_from_modules(
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+    include_specs: bool = False,
+) -> Sequence[Union[AssetsDefinition, AssetSpec, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets from the given modules.
 
     Args:
@@ -226,6 +228,14 @@ def load_assets_from_modules(
         Sequence[Union[AssetsDefinition, SourceAsset]]:
             A list containing assets and source assets defined in the given modules.
     """
+
+    def _asset_filter(asset: LoadableAssetTypes) -> bool:
+        if isinstance(asset, AssetsDefinition) and not has_only_asset_checks(asset):
+            return True
+        if isinstance(asset, AssetSpec):
+            return include_specs
+        return True
+
     return (
         LoadedAssetsList.from_modules(modules)
         .to_post_load()
@@ -245,7 +255,7 @@ def load_assets_from_modules(
                 backfill_policy, "backfill_policy", BackfillPolicy
             ),
         )
-        .assets_only
+        .get_objects(_asset_filter)
     )
 
 
@@ -258,7 +268,8 @@ def load_assets_from_current_module(
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+    include_specs: bool = False,
+) -> Sequence[Union[AssetsDefinition, AssetSpec, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets from the module where
     this function is called.
 
@@ -296,6 +307,7 @@ def load_assets_from_current_module(
         ),
         backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
+        include_specs=include_specs,
     )
 
 
@@ -309,6 +321,7 @@ def load_assets_from_package_module(
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    include_specs: bool = False,
 ) -> Sequence[LoadableAssetTypes]:
     """Constructs a list of assets and source assets that includes all asset
     definitions, source assets, and cacheable assets in all sub-modules of the given package module.
@@ -344,6 +357,7 @@ def load_assets_from_package_module(
         automation_condition=automation_condition,
         backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
+        include_specs=include_specs,
     )
 
 
@@ -356,7 +370,8 @@ def load_assets_from_package_name(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+    include_specs: bool = False,
+) -> Sequence[Union[AssetsDefinition, AssetSpec, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets that includes all asset
     definitions and source assets in all sub-modules of the given package.
 
@@ -389,6 +404,7 @@ def load_assets_from_package_name(
         auto_materialize_policy=auto_materialize_policy,
         backfill_policy=backfill_policy,
         source_key_prefix=source_key_prefix,
+        include_specs=include_specs,
     )
 
 
@@ -410,11 +426,17 @@ def find_modules_in_package(package_module: ModuleType) -> Iterable[ModuleType]:
 
 
 def replace_keys_in_asset(
-    asset: Union[AssetsDefinition, SourceAsset],
+    asset: Union[AssetsDefinition, AssetSpec, SourceAsset],
     key_replacements: Mapping[AssetKey, AssetKey],
-) -> Union[AssetsDefinition, SourceAsset]:
-    updated_object = (
-        asset.with_attributes(
+) -> Union[AssetsDefinition, AssetSpec, SourceAsset]:
+    if isinstance(asset, SourceAsset):
+        return asset.with_attributes(key=key_replacements.get(asset.key, asset.key))
+    if isinstance(asset, AssetSpec):
+        return asset.replace_attributes(
+            key=key_replacements.get(asset.key, asset.key),
+        )
+    else:
+        updated_object = asset.with_attributes(
             output_asset_key_replacements={
                 key: key_replacements.get(key, key)
                 for key in key_iterator(asset, included_targeted_keys=True)
@@ -423,34 +445,31 @@ def replace_keys_in_asset(
                 key: key_replacements.get(key, key) for key in asset.keys_by_input_name.values()
             },
         )
-        if isinstance(asset, AssetsDefinition)
-        else asset.with_attributes(key=key_replacements.get(asset.key, asset.key))
-    )
-    if isinstance(asset, AssetChecksDefinition):
-        updated_object = cast(AssetsDefinition, updated_object)
-        updated_object = AssetChecksDefinition.create(
-            keys_by_input_name=updated_object.keys_by_input_name,
-            node_def=updated_object.op,
-            check_specs_by_output_name=updated_object.check_specs_by_output_name,
-            resource_defs=updated_object.resource_defs,
-            can_subset=updated_object.can_subset,
-        )
-    return updated_object
+        if isinstance(asset, AssetsDefinition) and has_only_asset_checks(asset):
+            updated_object = AssetChecksDefinition.create(
+                keys_by_input_name=updated_object.keys_by_input_name,
+                node_def=updated_object.op,
+                check_specs_by_output_name=updated_object.check_specs_by_output_name,
+                resource_defs=updated_object.resource_defs,
+                can_subset=updated_object.can_subset,
+            )
+        return updated_object
 
 
 class ResolvedAssetObjectList:
     def __init__(
         self,
-        loaded_objects: Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]],
+        loaded_objects: Sequence[LoadableAssetTypes],
     ):
         self.loaded_objects = loaded_objects
 
     @cached_property
-    def assets_defs(self) -> Sequence[AssetsDefinition]:
+    def assets_defs_and_specs(self) -> Sequence[Union[AssetsDefinition, AssetSpec]]:
         return [
             dagster_object
             for dagster_object in self.loaded_objects
-            if isinstance(dagster_object, AssetsDefinition) and dagster_object.keys
+            if (isinstance(dagster_object, AssetsDefinition) and dagster_object.keys)
+            or isinstance(dagster_object, AssetSpec)
         ]
 
     @cached_property
@@ -462,8 +481,10 @@ class ResolvedAssetObjectList:
         ]
 
     @cached_property
-    def assets_and_checks_defs(self) -> Sequence[Union[AssetsDefinition, AssetChecksDefinition]]:
-        return [*self.assets_defs, *self.checks_defs]
+    def assets_defs_specs_and_checks_defs(
+        self,
+    ) -> Sequence[Union[AssetsDefinition, AssetSpec, AssetChecksDefinition]]:
+        return [*self.assets_defs_and_specs, *self.checks_defs]
 
     @cached_property
     def source_assets(self) -> Sequence[SourceAsset]:
@@ -475,9 +496,10 @@ class ResolvedAssetObjectList:
             asset for asset in self.loaded_objects if isinstance(asset, CacheableAssetsDefinition)
         ]
 
-    @cached_property
-    def assets_only(self) -> Sequence[LoadableAssetTypes]:
-        return [*self.source_assets, *self.assets_defs, *self.cacheable_assets]
+    def get_objects(
+        self, filter_fn: Callable[[LoadableAssetTypes], bool]
+    ) -> Sequence[LoadableAssetTypes]:
+        return [asset for asset in self.loaded_objects if filter_fn(asset)]
 
     def assets_with_loadable_prefix(
         self, key_prefix: CoercibleToAssetKeyPrefix
@@ -489,7 +511,7 @@ class ResolvedAssetObjectList:
         result_list = []
         all_asset_keys = {
             key
-            for asset_object in self.assets_and_checks_defs
+            for asset_object in self.assets_defs_specs_and_checks_defs
             for key in key_iterator(asset_object, included_targeted_keys=True)
         }
         key_replacements = {key: key.with_prefix(key_prefix) for key in all_asset_keys}
@@ -553,6 +575,10 @@ class ResolvedAssetObjectList:
             elif isinstance(asset, SourceAsset):
                 return_list.append(
                     asset.with_attributes(group_name=group_name if group_name else asset.group_name)
+                )
+            elif isinstance(asset, AssetSpec):
+                return_list.append(
+                    _spec_mapper_disallow_group_override(group_name, automation_condition)(asset)
                 )
             else:
                 return_list.append(

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -5,7 +5,7 @@ from typing import Callable, NamedTuple, Optional, Sequence, Tuple, Type, Union
 from dagster import DagsterInvariantViolationError, GraphDefinition, RepositoryDefinition
 from dagster._core.code_pointer import load_python_file, load_python_module
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.load_assets_from_modules import assets_from_modules
+from dagster._core.definitions.load_assets_from_modules import load_assets_from_modules
 
 LOAD_ALL_ASSETS = "<<LOAD_ALL_ASSETS>>"
 
@@ -114,7 +114,7 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
             )
         )
 
-    module_assets, module_source_assets, _ = assets_from_modules([module])
+    module_assets, module_source_assets, _ = load_assets_from_modules([module])
     if len(module_assets) > 0 or len(module_source_assets) > 0:
         return [LoadableTarget(LOAD_ALL_ASSETS, [*module_assets, *module_source_assets])]
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/__init__.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/__init__.py
@@ -1,4 +1,5 @@
 from dagster import AssetKey, SourceAsset, asset
+from dagster._core.definitions.asset_spec import AssetSpec
 
 
 @asset
@@ -27,6 +28,9 @@ def make_list_of_source_assets():
     jerry_lee_lewis = SourceAsset(key=AssetKey("jerry_lee_lewis"))
 
     return [buddy_holly, jerry_lee_lewis]
+
+
+top_level_spec = AssetSpec("top_level_spec")
 
 
 list_of_assets_and_source_assets = [*make_list_of_assets(), *make_list_of_source_assets()]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
@@ -1,4 +1,5 @@
 from dagster import AssetKey, SourceAsset, asset, graph_asset, op
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata import (
     CodeReferencesMetadataSet,
     CodeReferencesMetadataValue,
@@ -41,3 +42,6 @@ def multiply_by_two(input_num):
 @graph_asset
 def graph_backed_asset():
     return multiply_by_two(one())
+
+
+my_spec = AssetSpec("my_asset_spec")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -142,7 +142,7 @@ def test_load_assets_from_modules(monkeypatch):
         with pytest.raises(
             DagsterInvalidDefinitionError,
             match=re.escape(
-                "Asset key AssetKey(['little_richard']) is defined multiple times. "
+                "Asset key little_richard is defined multiple times. "
                 "Definitions found in modules: dagster_tests.asset_defs_tests.asset_package."
             ),
         ):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -141,10 +141,7 @@ def test_load_assets_from_modules(monkeypatch):
         m.setattr(asset_package, "little_richard_dup", little_richard, raising=False)
         with pytest.raises(
             DagsterInvalidDefinitionError,
-            match=re.escape(
-                "Asset key little_richard is defined multiple times. "
-                "Definitions found in modules: dagster_tests.asset_defs_tests.asset_package."
-            ),
+            match=re.escape("Asset key little_richard is defined multiple times."),
         ):
             load_assets_from_modules([asset_package, module_with_assets])
 
@@ -270,7 +267,9 @@ def test_source_key_prefix(load_fn):
     assert get_assets_def_with_key(
         assets_with_prefix_sources, AssetKey(["foo", "my_cool_prefix", "chuck_berry"])
     ).dependency_keys == {
+        # source prefix
         AssetKey(["bar", "cooler_prefix", "elvis_presley"]),
+        # loadable prefix
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
 


### PR DESCRIPTION
## Summary & Motivation
This PR is the tablestakes approach for adding spec support to our asset module loaders. It enables asset spec loading in the code path, and gates it behind a bool so as to not change behavior for any existing users.

One intricacy here is that the loading the following module will error:
```python
import dagster as dg

spec = dg.AssetSpec("my_asset")

@dg.multi_asset(specs=[spec])
def uses_spec():
    ...
```

At this point in time, I think this is fine. It will just basically push users towards a pattern like this:

```python
import dagster as dg

def specs():
 return [dg.AssetSpec("my_asset")]

@dg.multi_asset(specs=specs())
def uses_spec():
    ...
```

### How I tested this
Added additional testing for spec loading case, ensured existing test behavior did not change.

### Changelog
Our asset loading functions can now load `AssetSpec` objects when called with the `include_specs` parameter.  This includes `load_assets_from_package_name`, `load_assets_from_modules`, `load_assets_from_modules`, and `load_assets_from_current_module`.
