### PR TITLE
[ui] add pipelineName in consideration with launching all runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -29,7 +29,9 @@ export function useLaunchMultipleRunsWithTelemetry() {
         const executionParamsList = Array.isArray(variables.executionParamsList)
           ? variables.executionParamsList
           : [variables.executionParamsList];
-        const jobNames = executionParamsList.map((params) => params.selector?.jobName);
+        const jobNames = executionParamsList.map(
+          (params) => params.selector.jobName || params.selector.pipelineName,
+        );
 
         if (
           jobNames.length !== executionParamsList.length ||


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/AD-728/sensor-triggered-asset-materialization-error

Since useLaunchMultipleWithTelemetry is based off of useLaunchWithTelemetry, here is the relevant code in useLaunchWithTelemetry: https://github.com/dagster-io/dagster/blob/279d44aa2f325f2d2a883807da6f29bf3a2b10e1/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchWithTelemetry.oss.ts#L29-L31

## How I Tested These Changes
Tested locally