### PR TITLE
[dagster-openai][rfc] Add models to usage metadata

### DIFF
--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 from weakref import WeakKeyDictionary
 
 from dagster import (
@@ -38,7 +38,10 @@ context_to_counters = WeakKeyDictionary()
 
 
 def _add_to_asset_metadata(
-    context: AssetExecutionContext, usage_metadata: dict, output_name: Optional[str]
+    context: AssetExecutionContext,
+    usage_metadata: Dict[str, int],
+    model_metadata: Dict[str, str],
+    output_name: Optional[str],
 ):
     if context not in context_to_counters:
         context_to_counters[context] = defaultdict(lambda: 0)
@@ -46,7 +49,7 @@ def _add_to_asset_metadata(
 
     for metadata_key, delta in usage_metadata.items():
         counters[metadata_key] += delta
-    context.add_output_metadata(dict(counters), output_name)
+    context.add_output_metadata({**dict(counters), **model_metadata}, output_name)
 
 
 @public
@@ -136,7 +139,8 @@ def with_usage_metadata(
         }
         if hasattr(usage, "completion_tokens"):
             usage_metadata["openai.completion_tokens"] = usage.completion_tokens
-        _add_to_asset_metadata(context, usage_metadata, output_name)
+        model_metadata = {"openai.model": response.model}
+        _add_to_asset_metadata(context, usage_metadata, model_metadata, output_name)
 
         return response
 

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 from weakref import WeakKeyDictionary
 
 from dagster import (
@@ -35,12 +35,15 @@ API_ENDPOINT_CLASSES_TO_ENDPOINT_METHODS_MAPPING = {
 }
 
 context_to_counters = WeakKeyDictionary()
+context_to_models = WeakKeyDictionary()
+
+OPENAI_MODELS_METADATA_KEY = "openai.models"
 
 
 def _add_to_asset_metadata(
     context: AssetExecutionContext,
-    usage_metadata: Dict[str, int],
-    model_metadata: Dict[str, str],
+    usage_metadata: dict[str, int],
+    model: str,
     output_name: Optional[str],
 ):
     if context not in context_to_counters:
@@ -49,7 +52,19 @@ def _add_to_asset_metadata(
 
     for metadata_key, delta in usage_metadata.items():
         counters[metadata_key] += delta
-    context.add_output_metadata({**dict(counters), **model_metadata}, output_name)
+
+    if context not in context_to_models:
+        context_to_models[context] = defaultdict(set)
+    models = context_to_models[context]
+    models[OPENAI_MODELS_METADATA_KEY].add(model)
+
+    context.add_output_metadata(
+        metadata={
+            **dict(counters),
+            **dict({key: sorted(list(value)) for key, value in models.items()}),
+        },
+        output_name=output_name,
+    )
 
 
 @public
@@ -139,8 +154,12 @@ def with_usage_metadata(
         }
         if hasattr(usage, "completion_tokens"):
             usage_metadata["openai.completion_tokens"] = usage.completion_tokens
-        model_metadata = {"openai.model": response.model}
-        _add_to_asset_metadata(context, usage_metadata, model_metadata, output_name)
+        _add_to_asset_metadata(
+            context=context,
+            usage_metadata=usage_metadata,
+            model=response.model,
+            output_name=output_name,
+        )
 
         return response
 

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -21,6 +21,8 @@ from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_openai import OpenAIResource, with_usage_metadata
 
+TEST_MODEL = "test_model"
+
 
 @patch("dagster_openai.resources.Client")
 def test_openai_client(mock_client) -> None:
@@ -290,6 +292,7 @@ def test_openai_wrapper_with_asset(mock_client, mock_context, mock_wrapper):
         assert openai_resource
 
         mock_completion = MagicMock()
+        mock_completion.model = TEST_MODEL
         mock_usage = MagicMock()
         mock_usage.prompt_tokens = 1
         mock_usage.total_tokens = 1
@@ -309,6 +312,7 @@ def test_openai_wrapper_with_asset(mock_client, mock_context, mock_wrapper):
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
+                    "openai.model": TEST_MODEL,
                     "openai.calls": 1,
                     "openai.total_tokens": 1,
                     "openai.prompt_tokens": 1,
@@ -344,6 +348,7 @@ def test_openai_wrapper_with_graph_backed_asset(mock_client, mock_context, mock_
         assert openai_resource
 
         mock_completion = MagicMock()
+        mock_completion.model = TEST_MODEL
         mock_usage = MagicMock()
         mock_usage.prompt_tokens = 1
         mock_usage.total_tokens = 1
@@ -361,6 +366,7 @@ def test_openai_wrapper_with_graph_backed_asset(mock_client, mock_context, mock_
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
+                    "openai.model": TEST_MODEL,
                     "openai.calls": 1,
                     "openai.total_tokens": 1,
                     "openai.prompt_tokens": 1,
@@ -394,6 +400,7 @@ def test_openai_wrapper_with_multi_asset(mock_client, mock_context, mock_wrapper
         assert openai_resource
 
         mock_completion = MagicMock()
+        mock_completion.model = TEST_MODEL
         mock_usage = MagicMock()
         mock_usage.prompt_tokens = 1
         mock_usage.total_tokens = 1
@@ -415,6 +422,7 @@ def test_openai_wrapper_with_multi_asset(mock_client, mock_context, mock_wrapper
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
+                    "openai.model": TEST_MODEL,
                     "openai.calls": 1,
                     "openai.total_tokens": 1,
                     "openai.prompt_tokens": 1,
@@ -455,6 +463,7 @@ def test_openai_wrapper_with_partitioned_asset(mock_client, mock_wrapper):
             mock_context.__class__ = AssetExecutionContext
 
             mock_completion = MagicMock()
+            mock_completion.model = TEST_MODEL
             mock_usage = MagicMock()
             mock_usage.prompt_tokens = 1
             mock_usage.total_tokens = 1
@@ -473,6 +482,7 @@ def test_openai_wrapper_with_partitioned_asset(mock_client, mock_wrapper):
                 )
                 mock_context.add_output_metadata.assert_called_with(
                     {
+                        "openai.model": TEST_MODEL,
                         "openai.calls": 1,
                         "openai.total_tokens": 1,
                         "openai.prompt_tokens": 1,

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -24,6 +24,16 @@ from dagster_openai import OpenAIResource, with_usage_metadata
 TEST_MODEL = "test_model"
 TEST_ANOTHER_MODEL = "test_another_model"
 
+TEST_MODEL_CALLS_KEY = f"openai.{TEST_MODEL}.calls"
+TEST_MODEL_TOTAL_TOKENS_KEY = f"openai.{TEST_MODEL}.total_tokens"
+TEST_MODEL_PROMPT_TOKENS_KEY = f"openai.{TEST_MODEL}.prompt_tokens"
+TEST_MODEL_COMPLETION_TOKENS_KEY = f"openai.{TEST_MODEL}.completion_tokens"
+
+TEST_ANOTHER_MODEL_CALLS_KEY = f"openai.{TEST_ANOTHER_MODEL}.calls"
+TEST_ANOTHER_MODEL_TOTAL_TOKENS_KEY = f"openai.{TEST_ANOTHER_MODEL}.total_tokens"
+TEST_ANOTHER_MODEL_PROMPT_TOKENS_KEY = f"openai.{TEST_ANOTHER_MODEL}.prompt_tokens"
+TEST_ANOTHER_MODEL_COMPLETION_TOKENS_KEY = f"openai.{TEST_ANOTHER_MODEL}.completion_tokens"
+
 
 @patch("dagster_openai.resources.Client")
 def test_openai_client(mock_client) -> None:
@@ -311,11 +321,10 @@ def test_openai_wrapper_with_asset(mock_client, mock_context, mock_wrapper):
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
-                    "openai.models": [TEST_MODEL],
-                    "openai.calls": 1,
-                    "openai.total_tokens": 1,
-                    "openai.prompt_tokens": 1,
-                    "openai.completion_tokens": 1,
+                    TEST_MODEL_CALLS_KEY: 1,
+                    TEST_MODEL_TOTAL_TOKENS_KEY: 1,
+                    TEST_MODEL_PROMPT_TOKENS_KEY: 1,
+                    TEST_MODEL_COMPLETION_TOKENS_KEY: 1,
                 },
                 output_name="openai_asset",
             )
@@ -372,11 +381,14 @@ def test_openai_wrapper_with_multiple_models_per_output(mock_client, mock_contex
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
-                    "openai.models": [TEST_ANOTHER_MODEL, TEST_MODEL],
-                    "openai.calls": 2,
-                    "openai.total_tokens": 2,
-                    "openai.prompt_tokens": 2,
-                    "openai.completion_tokens": 2,
+                    TEST_MODEL_CALLS_KEY: 1,
+                    TEST_MODEL_TOTAL_TOKENS_KEY: 1,
+                    TEST_MODEL_PROMPT_TOKENS_KEY: 1,
+                    TEST_MODEL_COMPLETION_TOKENS_KEY: 1,
+                    TEST_ANOTHER_MODEL_CALLS_KEY: 1,
+                    TEST_ANOTHER_MODEL_TOTAL_TOKENS_KEY: 1,
+                    TEST_ANOTHER_MODEL_PROMPT_TOKENS_KEY: 1,
+                    TEST_ANOTHER_MODEL_COMPLETION_TOKENS_KEY: 1,
                 },
                 output_name="openai_asset",
             )
@@ -426,11 +438,10 @@ def test_openai_wrapper_with_graph_backed_asset(mock_client, mock_context, mock_
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
-                    "openai.models": [TEST_MODEL],
-                    "openai.calls": 1,
-                    "openai.total_tokens": 1,
-                    "openai.prompt_tokens": 1,
-                    "openai.completion_tokens": 1,
+                    TEST_MODEL_CALLS_KEY: 1,
+                    TEST_MODEL_TOTAL_TOKENS_KEY: 1,
+                    TEST_MODEL_PROMPT_TOKENS_KEY: 1,
+                    TEST_MODEL_COMPLETION_TOKENS_KEY: 1,
                 },
                 output_name="openai_asset",
             )
@@ -480,11 +491,10 @@ def test_openai_wrapper_with_multi_asset(mock_client, mock_context, mock_wrapper
 
             mock_context.add_output_metadata.assert_called_with(
                 metadata={
-                    "openai.models": [TEST_MODEL],
-                    "openai.calls": 1,
-                    "openai.total_tokens": 1,
-                    "openai.prompt_tokens": 1,
-                    "openai.completion_tokens": 1,
+                    TEST_MODEL_CALLS_KEY: 1,
+                    TEST_MODEL_TOTAL_TOKENS_KEY: 1,
+                    TEST_MODEL_PROMPT_TOKENS_KEY: 1,
+                    TEST_MODEL_COMPLETION_TOKENS_KEY: 1,
                 },
                 output_name="result",
             )
@@ -538,11 +548,10 @@ def test_openai_wrapper_with_partitioned_asset(mock_client, mock_wrapper):
                 client.fine_tuning.jobs.create(model=TEST_MODEL, training_file="some_training_file")
                 mock_context.add_output_metadata.assert_called_with(
                     metadata={
-                        "openai.models": [TEST_MODEL],
-                        "openai.calls": 1,
-                        "openai.total_tokens": 1,
-                        "openai.prompt_tokens": 1,
-                        "openai.completion_tokens": 1,
+                        TEST_MODEL_CALLS_KEY: 1,
+                        TEST_MODEL_TOTAL_TOKENS_KEY: 1,
+                        TEST_MODEL_PROMPT_TOKENS_KEY: 1,
+                        TEST_MODEL_COMPLETION_TOKENS_KEY: 1,
                     },
                     output_name=None,
                 )


### PR DESCRIPTION
## Summary & Motivation

Adds OpenAI models in the output metadata. Nothing prevents users to use multiple OpenAI models per output, so a list of models is added in the metadata.

Although best practice for users would be to use only one model per output, they can use the client to create completions with different models in the same output.

The main downside to supporting a list of models is that users won't know in the insights how many completion/usage tokens were used per model.

2 alternatives if we think using a list of models is not the best:
- We could add only one model in the output metadata and log a warning if users are using another model - using more than one OpenAI model in the same output feels like an anti-pattern.
- We could log usage metadata using the model name in the metadata key, something like "openai.gpt-3.5-turbo.calls" instead of "openai.calls".

Edit May 1st, 2025:

> We could log usage metadata using the model name in the metadata key, something like "openai.gpt-3.5-turbo.calls" instead of "openai.calls".

We will use this approach, which seems the best one for observing metadata in Insights.

## How I Tested These Changes

Tested locally + new and updated tests with BK
