### PR TITLE
[module-loaders] Make asset check coercion explicit in with_attributes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -116,3 +116,6 @@ class AssetCheckSpec(
     @property
     def key(self) -> AssetCheckKey:
         return AssetCheckKey(self.asset_key, self.name)
+
+    def replace_key(self, key: AssetCheckKey) -> "AssetCheckSpec":
+        return self._replace(asset_key=key.asset_key, name=key.name)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -204,7 +204,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         # AssetKey not subject to any further manipulation.
         resolved_deps = ResolvedAssetDependencies(assets_defs, [])
 
-        input_asset_key_replacements = [
+        asset_key_replacements = [
             {
                 raw_key: normalized_key
                 for input_name, raw_key in ad.keys_by_input_name.items()
@@ -218,8 +218,8 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
 
         # Only update the assets defs if we're actually replacing input asset keys
         assets_defs = [
-            ad.with_attributes(input_asset_key_replacements=reps) if reps else ad
-            for ad, reps in zip(assets_defs, input_asset_key_replacements)
+            ad.with_attributes(asset_key_replacements=reps) if reps else ad
+            for ad, reps in zip(assets_defs, asset_key_replacements)
         ]
 
         # Create unexecutable external assets definitions for any referenced keys for which no

--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -256,6 +256,12 @@ class AssetCheckKey(NamedTuple):
     def to_db_string(self) -> str:
         return seven.json.dumps({"asset_key": self.asset_key.to_string(), "check_name": self.name})
 
+    def with_asset_key_prefix(self, prefix: CoercibleToAssetKeyPrefix) -> "AssetCheckKey":
+        return AssetCheckKey(self.asset_key.with_prefix(prefix), self.name)
+
+    def replace_asset_key(self, asset_key: AssetKey) -> "AssetCheckKey":
+        return AssetCheckKey(asset_key, self.name)
+
 
 EntityKey = Union[AssetKey, AssetCheckKey]
 T_EntityKey = TypeVar("T_EntityKey", AssetKey, AssetCheckKey, EntityKey)

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -153,8 +153,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
 
     def with_attributes(
         self,
-        output_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
-        input_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
+        asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
         freshness_policy: Optional[
             Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
@@ -162,8 +161,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
     ) -> "CacheableAssetsDefinition":
         return PrefixOrGroupWrappedCacheableAssetsDefinition(
             self,
-            output_asset_key_replacements=output_asset_key_replacements,
-            input_asset_key_replacements=input_asset_key_replacements,
+            asset_key_replacements=asset_key_replacements,
             group_names_by_key=group_names_by_key,
             freshness_policy=freshness_policy,
         )
@@ -247,8 +245,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
     def __init__(
         self,
         wrapped: CacheableAssetsDefinition,
-        output_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
-        input_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
+        asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
         group_name_for_all_assets: Optional[str] = None,
         prefix_for_all_assets: Optional[List[str]] = None,
@@ -260,8 +257,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         ] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
     ):
-        self._output_asset_key_replacements = output_asset_key_replacements or {}
-        self._input_asset_key_replacements = input_asset_key_replacements or {}
+        self._asset_key_replacements = asset_key_replacements or {}
         self._group_names_by_key = group_names_by_key or {}
         self._group_name_for_all_assets = group_name_for_all_assets
         self._prefix_for_all_assets = prefix_for_all_assets
@@ -274,12 +270,8 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
             "Cannot set both group_name_for_all_assets and group_names_by_key",
         )
         check.invariant(
-            not (
-                prefix_for_all_assets
-                and (output_asset_key_replacements or input_asset_key_replacements)
-            ),
-            "Cannot set both prefix_for_all_assets and output_asset_key_replacements or"
-            " input_asset_key_replacements",
+            not (prefix_for_all_assets and (asset_key_replacements)),
+            "Cannot set both prefix_for_all_assets and asset_key_replacements",
         )
 
         super().__init__(
@@ -290,22 +282,10 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
     def _get_hash(self) -> str:
         """Generate a stable hash of the various prefix/group mappings."""
         contents = hashlib.sha1()
-        if self._output_asset_key_replacements:
+        if self._asset_key_replacements:
             contents.update(
                 _map_to_hashable(
-                    {
-                        tuple(k.path): tuple(v.path)
-                        for k, v in self._output_asset_key_replacements.items()
-                    }
-                )
-            )
-        if self._input_asset_key_replacements:
-            contents.update(
-                _map_to_hashable(
-                    {
-                        tuple(k.path): tuple(v.path)
-                        for k, v in self._input_asset_key_replacements.items()
-                    }
+                    {tuple(k.path): tuple(v.path) for k, v in self._asset_key_replacements.items()}
                 )
             )
         if self._group_names_by_key:
@@ -330,33 +310,13 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
             if self._group_name_for_all_assets
             else self._group_names_by_key
         )
-        output_asset_key_replacements = (
+        asset_key_replacements = (
             {
-                k: AssetKey(
-                    path=(
-                        self._prefix_for_all_assets + list(k.path)
-                        if self._prefix_for_all_assets
-                        else k.path
-                    )
-                )
-                for k in assets_def.keys
+                k: k.with_prefix(self._prefix_for_all_assets) if self._prefix_for_all_assets else k
+                for k in assets_def.keys | set(assets_def.dependency_keys)
             }
             if self._prefix_for_all_assets
-            else self._output_asset_key_replacements
-        )
-        input_asset_key_replacements = (
-            {
-                k: AssetKey(
-                    path=(
-                        self._prefix_for_all_assets + list(k.path)
-                        if self._prefix_for_all_assets
-                        else k.path
-                    )
-                )
-                for k in assets_def.dependency_keys
-            }
-            if self._prefix_for_all_assets
-            else self._input_asset_key_replacements
+            else self._asset_key_replacements
         )
         if isinstance(self._auto_materialize_policy, dict):
             automation_condition = {
@@ -367,8 +327,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         else:
             automation_condition = None
         return assets_def.with_attributes(
-            output_asset_key_replacements=output_asset_key_replacements,
-            input_asset_key_replacements=input_asset_key_replacements,
+            asset_key_replacements=asset_key_replacements,
             group_names_by_key=group_names_by_key,
             freshness_policy=self._freshness_policy,
             automation_condition=automation_condition,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -355,11 +355,9 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
     for prefix in reversed(prefixes or []):
         prefixed_assets = [
             assets_def.with_attributes(
-                input_asset_key_replacements={
-                    key: key.with_prefix(prefix) for key in assets_def.keys_by_input_name.values()
-                },
-                output_asset_key_replacements={
-                    key: key.with_prefix(prefix) for key in assets_def.keys
+                asset_key_replacements={
+                    key: key.with_prefix(prefix)
+                    for key in set(assets_def.keys_by_input_name.values()) | set(assets_def.keys)
                 },
             )
             for assets_def in prefixed_assets

--- a/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import List, Sequence, Union, cast
 
 import dagster._check as check
 import pytest
@@ -151,7 +151,9 @@ def test_resolve_wrong_data():
         recon_repo.get_definition()
 
 
-def define_uncacheable_and_resource_dependent_cacheable_assets():
+def define_uncacheable_and_resource_dependent_cacheable_assets() -> (
+    Sequence[Union[CacheableAssetsDefinition, AssetsDefinition]]
+):
     class ResourceDependentCacheableAsset(CacheableAssetsDefinition):
         def __init__(self):
             super().__init__("res_midstream")
@@ -295,7 +297,7 @@ def test_group_cached_assets():
     )
 
 
-def test_multiple_wrapped_cached_assets():
+def test_multiple_wrapped_cached_assets() -> None:
     """Test that multiple wrappers (with_attributes, with_resources) work properly on cacheable assets."""
 
     @resource
@@ -304,9 +306,7 @@ def test_multiple_wrapped_cached_assets():
 
     my_cacheable_assets_with_group_and_asset = [
         x.with_attributes(
-            output_asset_key_replacements={
-                AssetKey("res_downstream"): AssetKey("res_downstream_too")
-            }
+            asset_key_replacements={AssetKey("res_downstream"): AssetKey("res_downstream_too")}
         )
         for x in with_resources(
             [
@@ -333,13 +333,19 @@ def test_multiple_wrapped_cached_assets():
         assert isinstance(repo.get_job("all_asset_job"), JobDefinition)
 
         my_cool_group_sel = AssetSelection.groups("my_cool_group")
+        cacheable_resource_asset = cast(
+            CacheableAssetsDefinition, my_cacheable_assets_with_group_and_asset[0]
+        )
+        resolved_defs = list(
+            cacheable_resource_asset.build_definitions(
+                cacheable_resource_asset.compute_cacheable_data()
+            )
+        )
         assert (
             len(
                 my_cool_group_sel.resolve(
-                    my_cacheable_assets_with_group_and_asset[0].build_definitions(
-                        my_cacheable_assets_with_group_and_asset[0].compute_cacheable_data()
-                    )
-                    + my_cacheable_assets_with_group_and_asset[1:]
+                    resolved_defs
+                    + cast(List[AssetsDefinition], my_cacheable_assets_with_group_and_asset[1:])
                 )
             )
             == 1


### PR DESCRIPTION
## Summary & Motivation
This was one of the most confusing parts of the original code path; that asset check key changing was happening _implicitly_ within with_attributes when you changed output_asset_keys.

Instead, provide a top-level, explicit way to remap asset check keys. I think the old behavior was highly mysterious. I found myself questioning what the heck was happening. This is much more; "what it says on the tin."

## How I Tested These Changes
Existing tests.

