### PR TITLE
[module-loaders] Consolidate with_attributes methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -330,7 +330,9 @@ class AssetSpec(
                 skippable=skippable if skippable is not ... else self.skippable,
                 group_name=group_name if group_name is not ... else self.group_name,
                 code_version=code_version if code_version is not ... else self.code_version,
-                freshness_policy=self.freshness_policy,
+                freshness_policy=freshness_policy
+                if freshness_policy is not ...
+                else self.freshness_policy,
                 automation_condition=automation_condition
                 if automation_condition is not ...
                 else self.automation_condition,
@@ -339,6 +341,17 @@ class AssetSpec(
                 kinds=kinds if kinds is not ... else self.kinds,
                 partitions_def=partitions_def if partitions_def is not ... else self.partitions_def,
             )
+
+    def with_attributes(
+        self,
+        group_name: Optional[str] = ...,
+        automation_condition: Optional[AutomationCondition] = ...,
+        **kwargs,
+    ) -> "AssetSpec":
+        """Returns a new AssetSpec with the specified attributes replaced."""
+        return self.replace_attributes(
+            group_name=group_name, automation_condition=automation_condition
+        )
 
     @public
     def merge_attributes(

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1218,7 +1218,14 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             Union[AutomationCondition, Mapping[AssetKey, AutomationCondition]]
         ] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
+        group_name: Optional[str] = None,
     ) -> "AssetsDefinition":
+        check.invariant(
+            not (group_name and group_names_by_key),
+            "Cannot use both group_name, which specifies the group for every contained asset, and group_names_by_key, which specifies group on a per-asset basis.",
+        )
+        if group_name:
+            group_names_by_key = {key: group_name for key in self.keys}
         conflicts_by_attr_name: Dict[str, Set[AssetKey]] = defaultdict(set)
         replaced_specs = []
 

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -458,7 +458,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
             )
 
     def with_attributes(
-        self, group_name: Optional[str] = None, key: Optional[AssetKey] = None
+        self, group_name: Optional[str] = None, key: Optional[AssetKey] = None, **_kwargs
     ) -> "SourceAsset":
         if group_name is not None and self.group_name != DEFAULT_GROUP_NAME:
             raise DagsterInvalidDefinitionError(


### PR DESCRIPTION
## Summary & Motivation
Each with_attributes method on the different asset types has a different set of attributes that it supports. This means that all callsites handling all these different asset types, has to individually special case the with_attributes call.

Instead, just add **kwargs so that we can pick and choose which parameters to handle internally. This contains the complexity of adding support for new attributes to the class itself.

I think there's a downside in that; a person adding a new callsite might think an attribute is supported when it isn't; this is what tests are for.

## How I Tested These Changes
Existing tests
