### PR TITLE
[rfc] Asset tags accessible via io manager

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -306,6 +306,17 @@ class InputContext:
 
         return self._step_context
 
+    @property
+    def asset_tags(self) -> Mapping[str, str]:
+        """Tags from the inputted asset."""
+        return (
+            check.not_none(
+                self._step_context, "asset_tags is not currently supported via this context."
+            )
+            .job_def.asset_layer.asset_graph.assets_def_for_key(self.asset_key)
+            .tags_by_key[self.asset_key]
+        )
+
     @public
     @property
     def has_partition_key(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -481,6 +481,17 @@ class OutputContext:
 
         return self.step_context.asset_partition_key_range_for_output(self.name)
 
+    @property
+    def asset_tags(self) -> Mapping[str, str]:
+        """Tags from the output asset."""
+        return (
+            check.not_none(
+                self._step_context, "asset_tags is not currently supported via this context."
+            )
+            .job_def.asset_layer.asset_graph.assets_def_for_key(self.asset_key)
+            .tags_by_key[self.asset_key]
+        )
+
     @public
     @property
     def asset_partition_keys(self) -> Sequence[str]:


### PR DESCRIPTION
## Summary & Motivation
This PR makes asset tags easily accessible via the IO manager. The use case is being able to easily configure IO management behavior on a per-asset basis.
Can add direct invocation support in a followup.

## How I Tested These Changes
New test for the property

## Changelog
A new property `asset_tags` on `OutputContext` and `InputContext`, which allows you to access the tags of the asset being loaded / stored via an IO manager.