### PR TITLE
[components] cleanup component loading

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -9,7 +9,6 @@ from dagster._utils.warnings import suppress_dagster_warnings
 
 from dagster_components.core.component import (
     Component,
-    ComponentDeclNode,
     ComponentLoadContext,
     ComponentRegistry,
     get_component_name,
@@ -39,24 +38,22 @@ def load_module_from_path(module_name, path) -> ModuleType:
     return module
 
 
-def build_components_from_decl_node(
-    context: ComponentLoadContext, decl_node: ComponentDeclNode
-) -> Sequence[Component]:
-    if isinstance(decl_node, YamlComponentDecl):
-        component_type = component_type_from_yaml_decl(context, decl_node)
-        return [component_type.from_decl_node(context, decl_node)]
-    elif isinstance(decl_node, ComponentFolder):
+def load_components_from_context(context: ComponentLoadContext) -> Sequence[Component]:
+    if isinstance(context.decl_node, YamlComponentDecl):
+        component_type = component_type_from_yaml_decl(context.registry, context.decl_node)
+        return [component_type.load(context)]
+    elif isinstance(context.decl_node, ComponentFolder):
         components = []
-        for sub_decl in decl_node.sub_decls:
-            components.extend(build_components_from_decl_node(context, sub_decl))
+        for sub_decl in context.decl_node.sub_decls:
+            components.extend(load_components_from_context(context.for_decl_node(sub_decl)))
         return components
 
-    raise NotImplementedError(f"Unknown component type {decl_node}")
+    raise NotImplementedError(f"Unknown component type {context.decl_node}")
 
 
 def component_type_from_yaml_decl(
-    context: ComponentLoadContext, decl_node: YamlComponentDecl
-) -> Type:
+    registry: ComponentRegistry, decl_node: YamlComponentDecl
+) -> Type[Component]:
     parsed_defs = decl_node.component_file_model
     if parsed_defs.type.startswith("."):
         component_registry_key = parsed_defs.type[1:]
@@ -79,16 +76,15 @@ def component_type_from_yaml_decl(
             f"Could not find component type {component_registry_key} in {decl_node.path}"
         )
 
-    return context.registry.get(parsed_defs.type)
+    return registry.get(parsed_defs.type)
 
 
 def build_components_from_component_folder(
-    context: ComponentLoadContext,
-    path: Path,
+    context: ComponentLoadContext, path: Path
 ) -> Sequence[Component]:
     component_folder = path_to_decl_node(path)
     assert isinstance(component_folder, ComponentFolder)
-    return build_components_from_decl_node(context, component_folder)
+    return load_components_from_context(context.for_decl_node(component_folder))
 
 
 def build_defs_from_component_path(
@@ -97,12 +93,12 @@ def build_defs_from_component_path(
     resources: Mapping[str, object],
 ) -> "Definitions":
     """Build a definitions object from a folder within the components hierarchy."""
-    context = ComponentLoadContext(resources=resources, registry=registry)
-
     decl_node = path_to_decl_node(path=path)
     if not decl_node:
         raise Exception(f"No component found at path {path}")
-    components = build_components_from_decl_node(context, decl_node)
+
+    context = ComponentLoadContext(resources=resources, registry=registry, decl_node=decl_node)
+    components = load_components_from_context(context)
     return defs_from_components(resources=resources, context=context, components=components)
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -44,19 +44,17 @@ def dbt_path() -> Generator[Path, None, None]:
 
 
 def test_python_params(dbt_path: Path) -> None:
-    component = DbtProjectComponent.from_decl_node(
-        context=script_load_context(),
-        decl_node=YamlComponentDecl(
-            path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="dbt_project",
-                params={
-                    "dbt": {"project_dir": "jaffle_shop"},
-                    "op": {"name": "some_op", "tags": {"tag1": "value"}},
-                },
-            ),
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="dbt_project",
+            params={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "op": {"name": "some_op", "tags": {"tag1": "value"}},
+            },
         ),
     )
+    component = DbtProjectComponent.load(context=script_load_context(decl_node))
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
     defs = component.build_defs(script_load_context())
     assert defs.get_assets_def("stg_customers").op.name == "some_op"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -66,17 +66,15 @@ def sling_path() -> Generator[Path, None, None]:
 
 
 def test_python_params(sling_path: Path) -> None:
-    context = script_load_context()
-    component = SlingReplicationComponent.from_decl_node(
-        context=context,
-        decl_node=YamlComponentDecl(
-            path=sling_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="sling_replication",
-                params={"sling": {}},
-            ),
+    decl_node = YamlComponentDecl(
+        path=sling_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="sling_replication",
+            params={"sling": {}},
         ),
     )
+    context = script_load_context(decl_node)
+    component = SlingReplicationComponent.load(context)
     assert component.op_spec is None
     assert get_asset_keys(component) == {
         AssetKey("input_csv"),
@@ -89,17 +87,15 @@ def test_python_params(sling_path: Path) -> None:
 
 
 def test_python_params_op_name(sling_path: Path) -> None:
-    context = script_load_context()
-    component = SlingReplicationComponent.from_decl_node(
-        context=context,
-        decl_node=YamlComponentDecl(
-            path=sling_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="sling_replication",
-                params={"sling": {}, "op": {"name": "my_op"}},
-            ),
+    decl_node = YamlComponentDecl(
+        path=sling_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="sling_replication",
+            params={"sling": {}, "op": {"name": "my_op"}},
         ),
     )
+    context = script_load_context(decl_node)
+    component = SlingReplicationComponent.load(context=context)
     assert component.op_spec
     assert component.op_spec.name == "my_op"
     defs = component.build_defs(context)
@@ -112,17 +108,15 @@ def test_python_params_op_name(sling_path: Path) -> None:
 
 
 def test_python_params_op_tags(sling_path: Path) -> None:
-    context = script_load_context()
-    component = SlingReplicationComponent.from_decl_node(
-        context=context,
-        decl_node=YamlComponentDecl(
-            path=sling_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="sling_replication",
-                params={"sling": {}, "op": {"tags": {"tag1": "value1"}}},
-            ),
+    decl_node = YamlComponentDecl(
+        path=sling_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="sling_replication",
+            params={"sling": {}, "op": {"tags": {"tag1": "value1"}}},
         ),
     )
+    context = script_load_context(decl_node)
+    component = SlingReplicationComponent.load(context=context)
     assert component.op_spec
     assert component.op_spec.tags == {"tag1": "value1"}
     defs = component.build_defs(context)
@@ -150,15 +144,15 @@ def test_sling_subclass() -> None:
         ) -> Iterator[Union[AssetMaterialization, MaterializeResult]]:
             return sling.replicate(context=context, debug=True)
 
-    component_inst = DebugSlingReplicationComponent.from_decl_node(
-        context=script_load_context(),
-        decl_node=YamlComponentDecl(
-            path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="debug_sling_replication",
-                params={"sling": {}},
-            ),
+    decl_node = YamlComponentDecl(
+        path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="debug_sling_replication",
+            params={"sling": {}},
         ),
+    )
+    component_inst = DebugSlingReplicationComponent.load(
+        context=script_load_context(decl_node),
     )
     assert get_asset_keys(component_inst) == {
         AssetKey("input_csv"),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -62,42 +62,40 @@ def dbt_path() -> Generator[Path, None, None]:
 
 
 def test_python_params_node_rename(dbt_path: Path) -> None:
-    component = DbtProjectComponent.from_decl_node(
-        context=script_load_context(),
-        decl_node=YamlComponentDecl(
-            path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="dbt_project",
-                params={
-                    "dbt": {"project_dir": "jaffle_shop"},
-                    "translator": {
-                        "key": "some_prefix/{{ node.name }}",
-                    },
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="dbt_project",
+            params={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "translator": {
+                    "key": "some_prefix/{{ node.name }}",
                 },
-            ),
+            },
         ),
+    )
+    component = DbtProjectComponent.load(
+        context=script_load_context(decl_node),
     )
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS_WITH_PREFIX
 
 
 def test_python_params_group(dbt_path: Path) -> None:
-    comp = DbtProjectComponent.from_decl_node(
-        context=script_load_context(),
-        decl_node=YamlComponentDecl(
-            path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
-                type="dbt_project",
-                params={
-                    "dbt": {"project_dir": "jaffle_shop"},
-                    "translator": {
-                        "group": "some_group",
-                    },
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="dbt_project",
+            params={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "translator": {
+                    "group": "some_group",
                 },
-            ),
+            },
         ),
     )
+    comp = DbtProjectComponent.load(context=script_load_context(decl_node))
     assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
-    defs: Definitions = comp.build_defs(script_load_context())
+    defs: Definitions = comp.build_defs(script_load_context(None))
     for key in get_asset_keys(comp):
         assert defs.get_assets_def(key).get_asset_spec(key).group_name == "some_group"
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -25,34 +25,32 @@ def test_python_native() -> None:
 
 
 def test_python_params() -> None:
-    component = PipesSubprocessScriptCollection.from_decl_node(
-        load_context=script_load_context(),
-        decl_node=YamlComponentDecl(
-            path=LOCATION_PATH / "components" / "scripts",
-            component_file_model=ComponentFileModel(
-                type="pipes_subprocess_script_collection",
-                params={
-                    "scripts": [
-                        {
-                            "path": "script_one.py",
-                            "assets": [
-                                {"key": "a", "automation_condition": {"type": "eager"}},
-                                {
-                                    "key": "b",
-                                    "automation_condition": {
-                                        "type": "on_cron",
-                                        "params": {"cron_schedule": "@daily"},
-                                    },
-                                    "deps": ["up1", "up2"],
+    component_decl = YamlComponentDecl(
+        path=LOCATION_PATH / "components" / "scripts",
+        component_file_model=ComponentFileModel(
+            type="pipes_subprocess_script_collection",
+            params={
+                "scripts": [
+                    {
+                        "path": "script_one.py",
+                        "assets": [
+                            {"key": "a", "automation_condition": {"type": "eager"}},
+                            {
+                                "key": "b",
+                                "automation_condition": {
+                                    "type": "on_cron",
+                                    "params": {"cron_schedule": "@daily"},
                                 },
-                            ],
-                        },
-                        {"path": "subdir/script_three.py", "assets": [{"key": "key_override"}]},
-                    ]
-                },
-            ),
+                                "deps": ["up1", "up2"],
+                            },
+                        ],
+                    },
+                    {"path": "subdir/script_three.py", "assets": [{"key": "key_override"}]},
+                ]
+            },
         ),
     )
+    component = PipesSubprocessScriptCollection.load(context=script_load_context(component_decl))
     assert get_asset_keys(component) == {
         AssetKey("a"),
         AssetKey("b"),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -2,19 +2,24 @@ import textwrap
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import AbstractSet, Iterator
+from typing import AbstractSet, Iterator, Optional
 
 from dagster import AssetKey, DagsterInstance
 from dagster._utils import pushd
-from dagster_components.core.component import Component, ComponentLoadContext, ComponentRegistry
+from dagster_components.core.component import (
+    Component,
+    ComponentDeclNode,
+    ComponentLoadContext,
+    ComponentRegistry,
+)
 
 
 def registry() -> ComponentRegistry:
     return ComponentRegistry.from_entry_point_discovery()
 
 
-def script_load_context() -> ComponentLoadContext:
-    return ComponentLoadContext(registry=registry(), resources={})
+def script_load_context(decl_node: Optional[ComponentDeclNode] = None) -> ComponentLoadContext:
+    return ComponentLoadContext(registry=registry(), resources={}, decl_node=decl_node)
 
 
 def get_asset_keys(component: Component) -> AbstractSet[AssetKey]:


### PR DESCRIPTION
## Summary & Motivation

Simplifies the load path a few ways:

1. `from_decl_node()` -> `load()`: this is just one fewer concept for the user to think about
2. just pass in `context`: same as above
3. adds a load_params() method to ComponentLoadContext: this is something we were doing in all subclasses anyway, this is just simpler to manage

## How I Tested These Changes

## Changelog

NOCHANGELOG
