### PR TITLE
[partition-metadata] add_output_metadata refactor

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
+++ b/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
@@ -1,0 +1,34 @@
+from typing import Any, Mapping, Optional
+
+from dagster._record import record
+from dagster._utils.merger import merge_dicts
+
+
+@record
+class OutputMetadataHandle:
+    output_name: str
+    mapping_key: Optional[str]
+
+
+@record
+class OutputMetadataAccumulator:
+    per_output_metadata: Mapping[OutputMetadataHandle, Mapping[str, Any]]
+
+    @staticmethod
+    def empty() -> "OutputMetadataAccumulator":
+        return OutputMetadataAccumulator(per_output_metadata={})
+
+    def get_metadata(self, output_name: str, mapping_key: Optional[str]) -> Mapping[str, Any]:
+        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+        return self.per_output_metadata.get(handle, {})
+
+    def with_additional_metadata(
+        self, output_name: str, mapping_key: Optional[str], metadata: Mapping[str, Any]
+    ) -> "OutputMetadataAccumulator":
+        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+        return OutputMetadataAccumulator(
+            per_output_metadata=merge_dicts(
+                self.per_output_metadata,
+                {handle: merge_dicts(self.per_output_metadata.get(handle, {}), metadata)},
+            )
+        )

--- a/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
+++ b/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
@@ -1,5 +1,6 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._record import record
 from dagster._utils.merger import merge_dicts
 
@@ -11,24 +12,73 @@ class OutputMetadataHandle:
 
 
 @record
+class AssetMetadataHandle:
+    asset_key: AssetKey
+    partition_key: Optional[str]
+
+
+@record
 class OutputMetadataAccumulator:
-    per_output_metadata: Mapping[OutputMetadataHandle, Mapping[str, Any]]
+    per_output_metadata: Mapping[
+        Union[OutputMetadataHandle, AssetMetadataHandle], Mapping[str, Any]
+    ]
 
     @staticmethod
     def empty() -> "OutputMetadataAccumulator":
         return OutputMetadataAccumulator(per_output_metadata={})
 
-    def get_metadata(self, output_name: str, mapping_key: Optional[str]) -> Mapping[str, Any]:
-        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+    def get_output_metadata(
+        self, output_name: str, mapping_key: Optional[str]
+    ) -> Mapping[str, Any]:
+        handle = OutputMetadataHandle(
+            output_name=output_name,
+            mapping_key=mapping_key,
+        )
         return self.per_output_metadata.get(handle, {})
 
-    def with_additional_metadata(
-        self, output_name: str, mapping_key: Optional[str], metadata: Mapping[str, Any]
+    def get_asset_metadata(
+        self, asset_key: AssetKey, partition_key: Optional[str]
+    ) -> Mapping[str, Any]:
+        handle = AssetMetadataHandle(
+            asset_key=asset_key,
+            partition_key=partition_key,
+        )
+        return self.per_output_metadata.get(handle, {})
+
+    def with_additional_output_metadata(
+        self,
+        output_name: str,
+        mapping_key: Optional[str],
+        metadata: Mapping[str, Any],
     ) -> "OutputMetadataAccumulator":
-        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+        return self._with_metadata(
+            handle=OutputMetadataHandle(
+                output_name=output_name,
+                mapping_key=mapping_key,
+            ),
+            metadata=metadata,
+        )
+
+    def _with_metadata(
+        self, handle: Union[OutputMetadataHandle, AssetMetadataHandle], metadata: Mapping[str, Any]
+    ) -> "OutputMetadataAccumulator":
         return OutputMetadataAccumulator(
             per_output_metadata=merge_dicts(
                 self.per_output_metadata,
                 {handle: merge_dicts(self.per_output_metadata.get(handle, {}), metadata)},
             )
+        )
+
+    def with_additional_asset_metadata(
+        self,
+        asset_key: AssetKey,
+        partition_key: Optional[str],
+        metadata: Mapping[str, Any],
+    ) -> "OutputMetadataAccumulator":
+        return self._with_metadata(
+            handle=AssetMetadataHandle(
+                asset_key=asset_key,
+                partition_key=partition_key,
+            ),
+            metadata=metadata,
         )


### PR DESCRIPTION
## Summary & Motivation
I was finding that complex series of ternaries really hard to parse. Most of the complexity is the result of using the same dictionary to represent metadata per output name, and metadata per output name and mapping key. 

Instead, have a top-level accumulator class and add an "OutputMetadataHandle", so that every metadata dictionary has the same scope level. We keep the same checks in place as before, but the logic is much simpler now.

## How I Tested These Changes
Existing tests
