### PR TITLE
[partition-metadata][rfc] add_asset_metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
+++ b/python_modules/dagster/dagster/_core/execution/context/metadata_logging.py
@@ -1,5 +1,6 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._record import record
 from dagster._utils.merger import merge_dicts
 
@@ -11,24 +12,73 @@ class OutputMetadataHandle:
 
 
 @record
+class AssetMetadataHandle:
+    asset_key: AssetKey
+    partition_key: Optional[str]
+
+
+@record
 class OutputMetadataAccumulator:
-    per_output_metadata: Mapping[OutputMetadataHandle, Mapping[str, Any]]
+    per_output_metadata: Mapping[
+        Union[OutputMetadataHandle, AssetMetadataHandle], Mapping[str, Any]
+    ]
 
     @staticmethod
     def empty() -> "OutputMetadataAccumulator":
         return OutputMetadataAccumulator(per_output_metadata={})
 
-    def get_metadata(self, output_name: str, mapping_key: Optional[str]) -> Mapping[str, Any]:
-        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+    def get_output_metadata(
+        self, output_name: str, mapping_key: Optional[str]
+    ) -> Mapping[str, Any]:
+        handle = OutputMetadataHandle(
+            output_name=output_name,
+            mapping_key=mapping_key,
+        )
         return self.per_output_metadata.get(handle, {})
 
-    def with_additional_metadata(
-        self, output_name: str, mapping_key: Optional[str], metadata: Mapping[str, Any]
+    def get_asset_metadata(
+        self, asset_key: AssetKey, partition_key: Optional[str]
+    ) -> Mapping[str, Any]:
+        handle = AssetMetadataHandle(
+            asset_key=asset_key,
+            partition_key=partition_key,
+        )
+        return self.per_output_metadata.get(handle, {})
+
+    def with_additional_output_metadata(
+        self,
+        output_name: str,
+        mapping_key: Optional[str],
+        metadata: Mapping[str, Any],
     ) -> "OutputMetadataAccumulator":
-        handle = OutputMetadataHandle(output_name=output_name, mapping_key=mapping_key)
+        return self._with_metadata(
+            handle=OutputMetadataHandle(
+                output_name=output_name,
+                mapping_key=mapping_key,
+            ),
+            metadata=metadata,
+        )
+
+    def _with_metadata(
+        self, handle: Union[OutputMetadataHandle, AssetMetadataHandle], metadata: Mapping[str, Any]
+    ) -> "OutputMetadataAccumulator":
         return OutputMetadataAccumulator(
             per_output_metadata=merge_dicts(
                 self.per_output_metadata,
                 {handle: merge_dicts(self.per_output_metadata.get(handle, {}), metadata)},
             )
+        )
+
+    def with_additional_asset_metadata(
+        self,
+        asset_key: AssetKey,
+        partition_key: Optional[str],
+        metadata: Mapping[str, Any],
+    ) -> "OutputMetadataAccumulator":
+        return self._with_metadata(
+            handle=AssetMetadataHandle(
+                asset_key=asset_key,
+                partition_key=partition_key,
+            ),
+            metadata=metadata,
         )


### PR DESCRIPTION
## Summary & Motivation
Introduce an `AssetExecutionContext.add_asset_metadata` method, which will add metadata to materialization events (but not output events).

Storing metadata only on asset events seems like a naturally good thing to do. It's primarily what we display in the UI / is primarily what is queryable by users, and not storing it on output events saves db write size.

For partitioned assets, you are able to specify per-partition metadata that will only be added to the relevant partitioned materialization. This solves a long-standing user request to have per-partition handling in `add_output_metadata` more naturally.

## How I Tested These Changes
Added a bunch of new tests for both non-partitioned and partitioned cases.

## Changelog
A new `AssetExecutionContext.add_asset_metadata` method, which allows you to add metadata to materialization events for a given asset or asset partition. See the API docs here: https://docs.dagster.io/_modules/dagster/_core/execution/context/asset_execution_context#AssetExecutionContext.add_asset_metadata