### PR TITLE
fix(helm): registry missing in postgresql templating

### DIFF
--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
         {{- if $celeryK8sRunLauncherConfig.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
+          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" $ | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
         {{- if $celeryK8sRunLauncherConfig.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgresImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" $ | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
         {{- if .Values.dagsterDaemon.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgresImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
         {{- if .Values.dagsterDaemon.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalImage.name" $.Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
         {{- if .Values.flower.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgresImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
         {{- if .Values.flower.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
+          image: {{ include "dagster.externalPostgreImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -49,7 +49,7 @@ spec:
       initContainers:
         {{- if .Values.dagsterWebserver.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalPostgreImage.name" .Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgresImage.name" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -49,7 +49,7 @@ spec:
       initContainers:
         {{- if .Values.dagsterWebserver.checkDbReadyInitContainer }}
         - name: check-db-ready
-          image: {{ include "dagster.externalImage.name" .Values.postgresql.image | quote }}
+          image: {{ include "dagster.externalPostgreImage.name" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -30,7 +30,7 @@ If release name contains chart name it will be used as a full name.
 {{- .repository -}}:{{- .tag -}}
 {{- end }}
 
-{{- define "dagster.externalPostgreImage.name" }}
+{{- define "dagster.externalPostgresImage.name" }}
 {{- .registry -}}/{{- .repository -}}:{{- .tag -}}
 {{- end }}
 

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -30,6 +30,10 @@ If release name contains chart name it will be used as a full name.
 {{- .repository -}}:{{- .tag -}}
 {{- end }}
 
+{{- define "dagster.externalPostgreImage.name" }}
+{{- .registry -}}/{{- .repository -}}:{{- .tag -}}
+{{- end }}
+
 {{- define "dagster.dagsterImage.name" }}
   {{- $ := index . 0 }}
 

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -767,6 +767,7 @@ postgresql:
 
   # Used by init container to check that db is running. (Even if enabled:false)
   image:
+    registry: "docker.io"
     repository: "library/postgres"
     tag: "14.6"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary & Motivation
The postgresql chart uses the "registry" value to prefix the image name. This value was not already set in the values.yaml so I had to dig into the chart.

Additionally, the Dagster helm templates don't use this registry value to create the image name. So if you do provide a custom registry: "myprivate.acr.io", then it will be correctly used in the postgresql helm, but not in the dagster initdbcontainerReady creation, since there the registry is missing, and it will fail to pull the image.
