### PR TITLE
[ui] Limit the amount of asset info required for evaluation list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationList.tsx
@@ -1,15 +1,16 @@
 import {Table} from '@dagster-io/ui-components';
 
+import {AssetKey} from '../types';
 import {EvaluationListRow} from './EvaluationListRow';
 import {AssetConditionEvaluationRecordFragment} from './types/GetEvaluationsQuery.types';
-import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
 interface Props {
-  definition: AssetViewDefinitionNodeFragment;
+  assetKey: AssetKey;
+  isPartitioned: boolean;
   evaluations: AssetConditionEvaluationRecordFragment[];
 }
 
-export const EvaluationList = ({definition, evaluations}: Props) => {
+export const EvaluationList = ({assetKey, isPartitioned, evaluations}: Props) => {
   return (
     <Table>
       <thead>
@@ -25,7 +26,8 @@ export const EvaluationList = ({definition, evaluations}: Props) => {
             <EvaluationListRow
               key={evaluation.id}
               evaluation={evaluation}
-              definition={definition}
+              assetKey={assetKey}
+              isPartitioned={isPartitioned}
             />
           );
         })}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
@@ -10,20 +10,21 @@ import {
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
 
+import {AssetKey} from '../types';
 import {EvaluationDetailDialog} from './EvaluationDetailDialog';
 import {EvaluationStatusTag} from './EvaluationStatusTag';
 import {AssetConditionEvaluationRecordFragment} from './types/GetEvaluationsQuery.types';
 import {DEFAULT_TIME_FORMAT} from '../../app/time/TimestampFormat';
 import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
-import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
 interface Props {
-  definition: AssetViewDefinitionNodeFragment;
+  assetKey: AssetKey;
+  isPartitioned: boolean;
   evaluation: AssetConditionEvaluationRecordFragment;
 }
 
-export const EvaluationListRow = ({evaluation, definition}: Props) => {
+export const EvaluationListRow = ({evaluation, assetKey, isPartitioned}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -39,27 +40,32 @@ export const EvaluationListRow = ({evaluation, definition}: Props) => {
         </td>
         <td style={{verticalAlign: 'middle'}}>
           <EvaluationStatusTag
-            definition={definition}
+            assetKey={assetKey}
+            isPartitioned={isPartitioned}
             selectedEvaluation={evaluation}
             selectPartition={() => {}}
           />
         </td>
         <td style={{verticalAlign: 'middle'}}>
-          <EvaluationRunInfo evaluation={evaluation} />
+          <EvaluationRunInfo runIds={evaluation.runIds} timestamp={evaluation.timestamp} />
         </td>
       </tr>
       <EvaluationDetailDialog
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         evaluationID={evaluation.id}
-        assetKeyPath={definition.assetKey.path}
+        assetKeyPath={assetKey.path}
       />
     </>
   );
 };
 
-const EvaluationRunInfo = ({evaluation}: {evaluation: AssetConditionEvaluationRecordFragment}) => {
-  const {runIds} = evaluation;
+interface EvaluationRunInfoProps {
+  runIds: string[];
+  timestamp: number;
+}
+
+const EvaluationRunInfo = ({runIds, timestamp}: EvaluationRunInfoProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   if (runIds.length === 0) {
@@ -95,7 +101,7 @@ const EvaluationRunInfo = ({evaluation}: {evaluation: AssetConditionEvaluationRe
               <>
                 Runs at{' '}
                 <TimestampDisplay
-                  timestamp={evaluation.timestamp}
+                  timestamp={timestamp}
                   timeFormat={{...DEFAULT_TIME_FORMAT, showSeconds: true}}
                 />
               </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationStatusTag.tsx
@@ -1,17 +1,23 @@
 import {Box, Colors, Icon, Popover, Tag} from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 
+import {AssetKey} from '../types';
 import {PartitionSubsetList} from './PartitionSubsetList';
 import {AssetConditionEvaluationRecordFragment} from './types/GetEvaluationsQuery.types';
-import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
 interface Props {
-  definition: AssetViewDefinitionNodeFragment;
+  assetKey: AssetKey;
+  isPartitioned: boolean;
   selectedEvaluation: AssetConditionEvaluationRecordFragment;
   selectPartition: (partitionKey: string | null) => void;
 }
 
-export const EvaluationStatusTag = ({definition, selectedEvaluation, selectPartition}: Props) => {
+export const EvaluationStatusTag = ({
+  assetKey,
+  isPartitioned,
+  selectedEvaluation,
+  selectPartition,
+}: Props) => {
   const evaluation = selectedEvaluation?.evaluation;
   const rootEvaluationNode = useMemo(
     () => evaluation?.evaluationNodes.find((node) => node.uniqueId === evaluation.rootUniqueId),
@@ -19,8 +25,7 @@ export const EvaluationStatusTag = ({definition, selectedEvaluation, selectParti
   );
   const rootUniqueId = evaluation?.rootUniqueId;
 
-  const partitionDefinition = definition?.partitionDefinition;
-  const assetKeyPath = definition?.assetKey.path || [];
+  const assetKeyPath = assetKey.path || [];
   const numRequested = selectedEvaluation?.numRequested;
 
   const numTrue =
@@ -29,7 +34,7 @@ export const EvaluationStatusTag = ({definition, selectedEvaluation, selectParti
       : null;
 
   if (numRequested) {
-    if (partitionDefinition && rootUniqueId && numTrue) {
+    if (isPartitioned && rootUniqueId && numTrue) {
       return (
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           <Popover

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/EvaluationList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/EvaluationList.stories.tsx
@@ -23,7 +23,11 @@ export const Default = () => {
 
   return (
     <MockedProvider>
-      <EvaluationList definition={definition} evaluations={evaluations} />
+      <EvaluationList
+        assetKey={definition.assetKey}
+        isPartitioned={false}
+        evaluations={evaluations}
+      />
     </MockedProvider>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

We don't need so much fragment data for the evaluation list, so let's require less so that consumers don't need to overquery.

## How I Tested These Changes

TS, lint, storybook.