### PR TITLE
[ui] sort global search results

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -72,6 +72,14 @@ const initialState: State = {
 
 const DEBOUNCE_MSEC = 100;
 
+// sort by Fuse score ascending, lower is better
+const sortResultsByFuseScore = (
+  a: Fuse.FuseResult<SearchResult>,
+  b: Fuse.FuseResult<SearchResult>,
+) => {
+  return (a.score ?? 0) - (b.score ?? 0);
+};
+
 export const SearchDialog = () => {
   const history = useHistory();
   const {initialize, loading, searchPrimary, searchSecondary} = useGlobalSearch({
@@ -82,7 +90,7 @@ export const SearchDialog = () => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const {shown, queryString, primaryResults, secondaryResults, highlight} = state;
 
-  const results = [...primaryResults, ...secondaryResults];
+  const results = [...primaryResults, ...secondaryResults].sort(sortResultsByFuseScore);
   const renderedResults = results.slice(0, MAX_DISPLAYED_RESULTS);
   const numRenderedResults = renderedResults.length;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -307,6 +307,7 @@ const fuseOptions = {
   threshold: 0.3,
   useExtendedSearch: true,
   includeMatches: true,
+  includeScore: true,
 
   // Allow searching to continue to the end of the string.
   ignoreLocation: true,


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/OPER-1521/prioritize-exact-matches-in-global-search-results-for-better-usability

Sorts by fuse score on the frontend, so more relevant results will be pushed on top.

## How I Tested These Changes
Tested the original case on enigma using app-proxy, verified the best matches show up first
