### PR TITLE
[dagster-airlift] ✨ Support Airflow 1 imports

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
@@ -6,8 +6,15 @@ from datetime import datetime
 from typing import Any, Dict, Iterable, Mapping, Sequence, Tuple
 
 import requests
-from airflow.models.operator import BaseOperator
-from airflow.utils.context import Context
+from airflow.models import BaseOperator
+
+try:
+    # Attempt to import the Context type from Airflow 2
+    from airflow.utils.context import Context
+except ImportError:
+    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
+    Context = Dict[str, Any]  # Define Context as a dictionary
+
 from requests import Response
 
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY, TASK_ID_TAG_KEY

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
@@ -7,14 +7,6 @@ from typing import Any, Dict, Iterable, Mapping, Sequence, Tuple
 
 import requests
 from airflow.models import BaseOperator
-
-try:
-    # Attempt to import the Context type from Airflow 2
-    from airflow.utils.context import Context
-except ImportError:
-    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
-    Context = Dict[str, Any]  # Define Context as a dictionary
-
 from requests import Response
 
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY, TASK_ID_TAG_KEY
@@ -34,6 +26,11 @@ logger = logging.getLogger(__name__)
 
 # A job in dagster is uniquely defined by (location_name, repository_name, job_name).
 DagsterJobIdentifier = Tuple[str, str, str]
+
+# Airflow context type. Instead of using a strongly typed `Context` from Airflow 2.x,
+# it is defined as a generic mapping for compatibility with Airflow 1.x
+Context = Mapping[str, Any]
+
 IMPLICIT_ASSET_JOB_PREFIX = "__ASSET_JOB"
 
 DEFAULT_DAGSTER_RUN_STATUS_POLL_INTERVAL = 1

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
@@ -6,17 +6,8 @@ from typing import Any, Iterable, Mapping, Sequence
 import requests
 from airflow import DAG
 
-try:
-    # Attempt to import the Context type from Airflow 2
-    from airflow.utils.context import Context
-except ImportError:
-    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
-    from typing import Dict
-
-    Context = Dict[str, Any]  # Define Context as a dictionary
-
 from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
-from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator
+from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator, Context
 
 
 class BaseProxyDAGToDagsterOperator(BaseDagsterAssetsOperator):

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
@@ -5,7 +5,15 @@ from typing import Any, Iterable, Mapping, Sequence
 
 import requests
 from airflow import DAG
-from airflow.utils.context import Context
+
+try:
+    # Attempt to import the Context type from Airflow 2
+    from airflow.utils.context import Context
+except ImportError:
+    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
+    from typing import Dict
+
+    Context = Dict[str, Any]  # Define Context as a dictionary
 
 from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
 from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/materialize_assets_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/materialize_assets_operator.py
@@ -1,7 +1,14 @@
 import re
 from typing import Any, Iterable, Mapping, Sequence, Union
 
-from airflow.utils.context import Context
+try:
+    # Attempt to import the Context type from Airflow 2
+    from airflow.utils.context import Context
+except ImportError:
+    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
+    from typing import Dict
+
+    Context = Dict[str, Any]  # Define Context as a dictionary
 
 from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/materialize_assets_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/materialize_assets_operator.py
@@ -1,16 +1,7 @@
 import re
 from typing import Any, Iterable, Mapping, Sequence, Union
 
-try:
-    # Attempt to import the Context type from Airflow 2
-    from airflow.utils.context import Context
-except ImportError:
-    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
-    from typing import Dict
-
-    Context = Dict[str, Any]  # Define Context as a dictionary
-
-from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator
+from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator, Context
 
 UNESCAPED_SLASH_RE = re.compile(r"(?<!\\)/")
 ESCAPED_SLASH = "\\/"

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
@@ -4,8 +4,14 @@ import os
 from typing import Any, Callable, Dict, Iterable, Mapping, Sequence, Set, Tuple, Type
 
 import requests
-from airflow.models.operator import BaseOperator
-from airflow.utils.context import Context
+from airflow.models import BaseOperator
+
+try:
+    # Attempt to import the Context type from Airflow 2
+    from airflow.utils.context import Context
+except ImportError:
+    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
+    Context = Dict[str, Any]  # Define Context as a dictionary
 
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
@@ -6,15 +6,8 @@ from typing import Any, Callable, Dict, Iterable, Mapping, Sequence, Set, Tuple,
 import requests
 from airflow.models import BaseOperator
 
-try:
-    # Attempt to import the Context type from Airflow 2
-    from airflow.utils.context import Context
-except ImportError:
-    # Fallback for Airflow 1: Use a generic dictionary type as a substitute
-    Context = Dict[str, Any]  # Define Context as a dictionary
-
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
-from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator
+from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator, Context
 
 
 class BaseProxyTaskToDagsterOperator(BaseDagsterAssetsOperator):


### PR DESCRIPTION
## Summary & Motivation
- Airlift assumes an Airflow 2 installation, particularly for connecting with Airflow's REST API stabilized in `airflow=2` for the Peering phase. That said, we are figuring out ways to extend the usage of Airlift for older Airflow instances (sans peering). 

One issues ran with using Airlift on Airflow 1.x is the imports. Below's my attempt at making the imports compatible with Airflow 1. 

## How I Tested These Changes
- Inspecting import paths in Airflow v1.10
- Ran `make ruff`
- `make pyright` failed for me (when installing `pendulum`) so I wasn't able to run type checks

## Changelog

> [dagster-airlift] Make Airflow imports compatible with Airflow 1
