### PR TITLE
DOC-588 Add note about required storage backend to run retries page

### DIFF
--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -5,6 +5,10 @@ description: Automatically retry Dagster runs
 
 # Run Retries
 
+<notebook>
+  This feature requires a PostgreSQL or MySQL storage backend.
+</Note>
+
 If you configure run retries, a new run will be kicked off whenever a run fails for any reason. Compared to [op retries](/concepts/ops-jobs-graphs/op-retries), the maximum retry limit for run retries applies to the whole run instead of each individual op. Run retries also handle the case where the run process crashes or is unexpectedly terminated.
 
 ## Configuration

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -5,9 +5,7 @@ description: Automatically retry Dagster runs
 
 # Run Retries
 
-<Note>
-  This feature requires a PostgreSQL or MySQL storage backend.
-</Note>
+<Note>This feature requires a PostgreSQL or MySQL storage backend.</Note>
 
 If you configure run retries, a new run will be kicked off whenever a run fails for any reason. Compared to [op retries](/concepts/ops-jobs-graphs/op-retries), the maximum retry limit for run retries applies to the whole run instead of each individual op. Run retries also handle the case where the run process crashes or is unexpectedly terminated.
 

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -5,7 +5,7 @@ description: Automatically retry Dagster runs
 
 # Run Retries
 
-<notebook>
+<Note>
   This feature requires a PostgreSQL or MySQL storage backend.
 </Note>
 


### PR DESCRIPTION
## Summary & Motivation

Addresses https://linear.app/dagster-labs/issue/DOC-588/add-warning-admonition-to-run-retries-page-only-works-wpostgresmysql

## How I Tested These Changes

Staging deployment.

## Changelog

> Insert changelog entry or delete this section.
