### PR TITLE
[dagster-airlift] ✨Support Python 3.7

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
@@ -235,7 +235,8 @@ class BaseDagsterAssetsOperator(BaseOperator, ABC):
     def wait_for_run_to_complete(
         self, session: requests.Session, dagster_url: str, run_id: str
     ) -> DagsterRunResult:
-        while response := self.get_dagster_run_obj(session, dagster_url, run_id):
+        while True:
+            response = self.get_dagster_run_obj(session, dagster_url, run_id)
             status = response["status"]
             if status in ["SUCCESS", "FAILURE", "CANCELED"]:
                 break

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
@@ -72,7 +72,8 @@ def matched_dag_id(asset_node: Mapping[str, Any], dag_id: str) -> bool:
         if entry["__typename"] == "JsonMetadataEntry"
     }
 
-    if mapping_entry := json_metadata_entries.get(DAG_MAPPING_METADATA_KEY):
+    mapping_entry = json_metadata_entries.get(DAG_MAPPING_METADATA_KEY)
+    if mapping_entry:
         mappings = json.loads(mapping_entry)
         return any(mapping["dag_id"] == dag_id for mapping in mappings)
     return False

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
@@ -151,7 +151,8 @@ def matched_dag_id_task_id(asset_node: Mapping[str, Any], dag_id: str, task_id: 
         if entry["__typename"] == "JsonMetadataEntry"
     }
 
-    if mapping_entry := json_metadata_entries.get(TASK_MAPPING_METADATA_KEY):
+    mapping_entry = json_metadata_entries.get(TASK_MAPPING_METADATA_KEY)
+    if mapping_entry:
         task_handle_dict_list = json.loads(mapping_entry)
         for task_handle_dict in task_handle_dict_list:
             if task_handle_dict["dag_id"] == dag_id and task_handle_dict["task_id"] == task_id:


### PR DESCRIPTION
## Summary & Motivation
This is an optional PR to keep the Python code compatible with older Python versions. 

If we want to maximize the reach of Airlift as a migration tool, it could support older Airflow deployments running on older versions of Python. 

In my use case, the target environment is Python 3.7, which does not support the walrus operator (`:=`). 

## How I Tested These Changes

## Changelog

> [dagster-airlift] Support Python 3.7
