### PR TITLE
add support for incremental step stats calculations

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -9,9 +9,13 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 import sqlalchemy
 import sqlalchemy as db
-from dagster import AssetKey, AssetMaterialization, DagsterInstance, Output, op
+from dagster import AssetKey, AssetMaterialization, DagsterInstance, Out, Output, RetryRequested, op
 from dagster._core.errors import DagsterEventLogInvalidForRun
-from dagster._core.execution.stats import build_run_stats_from_events
+from dagster._core.execution.stats import (
+    StepEventStatus,
+    build_run_stats_from_events,
+    build_run_step_stats_from_events,
+)
 from dagster._core.storage.event_log import (
     ConsolidatedSqliteEventLogStorage,
     SqlEventLogStorageMetadata,
@@ -332,3 +336,48 @@ def test_run_stats():
         )
 
     assert incremental_run_stats == run_stats
+
+
+def test_step_stats():
+    @op
+    def op_success(_):
+        return 1
+
+    @op
+    def asset_op(_):
+        yield AssetMaterialization(asset_key=AssetKey("asset_1"))
+        yield Output(1)
+
+    @op(out=Out(str))
+    def op_failure(_):
+        time.sleep(0.001)
+        raise RetryRequested(max_retries=3)
+
+    def _ops():
+        op_success()
+        asset_op()
+        op_failure()
+
+    events, result = _synthesize_events(_ops, check_success=False)
+
+    step_stats = build_run_step_stats_from_events(result.run_id, events)
+    assert len(step_stats) == 3
+    assert len([step for step in step_stats if step.status == StepEventStatus.SUCCESS]) == 2
+    assert len([step for step in step_stats if step.status == StepEventStatus.FAILURE]) == 1
+    assert all([step.run_id == result.run_id for step in step_stats])
+
+    op_failure_stats = next(
+        iter([step for step in step_stats if step.step_key == "op_failure"]), None
+    )
+    assert op_failure_stats
+    assert op_failure_stats.attempts == 4
+    assert len(op_failure_stats.attempts_list) == 4
+
+    # build up run stats through incremental events
+    incremental_step_stats = None
+    for event in events:
+        incremental_step_stats = build_run_step_stats_from_events(
+            result.run_id, [event], incremental_step_stats
+        )
+
+    assert incremental_step_stats == step_stats

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -15,6 +15,7 @@ from dagster._core.execution.stats import (
     StepEventStatus,
     build_run_stats_from_events,
     build_run_step_stats_from_events,
+    build_run_step_stats_snapshot_from_events,
 )
 from dagster._core.storage.event_log import (
     ConsolidatedSqliteEventLogStorage,
@@ -374,10 +375,11 @@ def test_step_stats():
     assert len(op_failure_stats.attempts_list) == 4
 
     # build up run stats through incremental events
-    incremental_step_stats = None
+    incremental_snapshot = None
     for event in events:
-        incremental_step_stats = build_run_step_stats_from_events(
-            result.run_id, [event], incremental_step_stats
+        incremental_snapshot = build_run_step_stats_snapshot_from_events(
+            result.run_id, [event], incremental_snapshot
         )
 
-    assert incremental_step_stats == step_stats
+    assert incremental_snapshot
+    assert incremental_snapshot.step_key_stats == step_stats


### PR DESCRIPTION
## Summary & Motivation
This is the counterpart of https://github.com/dagster-io/dagster/pull/26550, but for step stats instead of run stats.

The step stats calculations are a little more complicated because it relies on intermediate state in between dagster events to be held.  This includes the `previous_attempt_start` time for a given step.  This PR introduces a field in the snapshot to carry over this state, which should only be used in the incremental calculation.

Another change made here is that marker events (e.g. resource init/teardown) can be associated with a step, but generally occur before the step has started.  That means that previously step snapshots did not include these marker events if the step had not yet started.  This PR changes that behavior so that every step will have a snapshot if it has a marker event, even if it has not started.   The output for incremental vs completed run snapshots should match exactly.

## How I Tested These Changes
BK
