### PR TITLE
 feat: allow passing config for dagster asset materialize cli [#26069 continued]

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -146,7 +146,11 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
         tags = {}
 
     result = execute_job(
-        job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags, run_config=config
+        job=reconstructable_job,
+        asset_selection=list(asset_keys),
+        instance=instance,
+        tags=tags,
+        run_config=config,
     )
     if not result.success:
         raise click.ClickException("Materialization failed.")

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -3,9 +3,11 @@ from typing import Mapping
 import click
 
 import dagster._check as check
+from dagster._cli.job import get_config_from_args
 from dagster._cli.utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace.cli_target import (
     get_repository_python_origin_from_kwargs,
+    python_job_config_argument,
     python_origin_target_argument,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
@@ -38,6 +40,12 @@ def asset_cli():
     help="Asset partition range to target i.e. <start>...<end>",
     required=False,
 )
+@python_job_config_argument("materialize")
+@click.option(
+    "--config-json",
+    type=click.STRING,
+    help="JSON string of run config to use for this job run. Cannot be used with -c / --config.",
+)
 def asset_materialize_command(**kwargs):
     with capture_interrupts():
         with get_possibly_temporary_instance_for_cli(
@@ -48,6 +56,7 @@ def asset_materialize_command(**kwargs):
 
 @telemetry_wrapper
 def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, str]) -> None:
+    config = get_config_from_args(kwargs)
     repository_origin = get_repository_python_origin_from_kwargs(kwargs)
 
     recon_repo = recon_repository_from_origin(repository_origin)
@@ -137,7 +146,7 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
         tags = {}
 
     result = execute_job(
-        job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags
+        job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags, run_config=config
     )
     if not result.success:
         raise click.ClickException("Materialization failed.")

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -47,7 +47,10 @@ from dagster._core.workspace.load_target import (
     WorkspaceLoadTarget,
 )
 from dagster._grpc.utils import get_loadable_targets
+from dagster._seven import JSONDecodeError, json
+from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_repository_from_origin
+from dagster._utils.yaml_utils import load_yaml_from_glob_list
 
 if TYPE_CHECKING:
     from dagster._core.workspace.context import WorkspaceProcessContext
@@ -800,3 +803,35 @@ def get_remote_job_from_kwargs(instance: DagsterInstance, version: str, kwargs: 
 
 def _sorted_quoted(strings: Iterable[str]) -> str:
     return "[" + ", ".join([f"'{s}'" for s in sorted(list(strings))]) + "]"
+
+
+def get_run_config_from_file_list(file_list: Optional[Sequence[str]]) -> Mapping[str, object]:
+    check.opt_sequence_param(file_list, "file_list", of_type=str)
+    return cast(Mapping[str, object], load_yaml_from_glob_list(file_list) if file_list else {})
+
+
+def get_config_from_args(kwargs: Mapping[str, str]) -> Mapping[str, object]:
+    config = cast(Tuple[str, ...], kwargs.get("config"))  # files
+    config_json = kwargs.get("config_json")
+
+    if not config and not config_json:
+        return {}
+
+    elif config and config_json:
+        raise click.UsageError("Cannot specify both -c / --config and --config-json")
+
+    elif config:
+        config_file_list = list(check.opt_tuple_param(config, "config", of_type=str))
+        return get_run_config_from_file_list(config_file_list)
+
+    elif config_json:
+        config_json = cast(str, config_json)
+        try:
+            return json.loads(config_json)
+
+        except JSONDecodeError:
+            raise click.UsageError(
+                f"Invalid JSON-string given for `--config-json`: {config_json}\n\n{serializable_error_info_from_exc_info(sys.exc_info()).to_string()}"
+            )
+    else:
+        check.failed("Unhandled case getting config from kwargs")

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
@@ -40,8 +40,15 @@ def multi_run_partitioned_asset() -> None: ...
 class MyConfig(Config):
     some_prop: str
 
+
 @asset
 def asset_with_config(context: AssetExecutionContext, config: MyConfig):
+    context.log.info(f"some_prop:{config.some_prop}")
+
+
+@asset
+def asset_assert_with_config(context: AssetExecutionContext, config: MyConfig):
+    assert config.some_prop == "foo"
     context.log.info(f"some_prop:{config.some_prop}")
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
@@ -1,4 +1,4 @@
-from dagster import StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, Config, StaticPartitionsDefinition, asset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 
@@ -35,6 +35,14 @@ def single_run_partitioned_asset() -> None: ...
     backfill_policy=BackfillPolicy.multi_run(),
 )
 def multi_run_partitioned_asset() -> None: ...
+
+
+class MyConfig(Config):
+    some_prop: str
+
+@asset
+def asset_with_config(context: AssetExecutionContext, config: MyConfig):
+    context.log.info(f"some_prop:{config.some_prop}")
 
 
 @asset

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
@@ -28,6 +28,8 @@ def test_no_selection():
         == "\n".join(
             [
                 "asset1",
+                "asset_assert_with_config",
+                "asset_with_config",
                 "differently_partitioned_asset",
                 "downstream_asset",
                 "fail_asset",

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -177,3 +177,14 @@ def test_partition_range_multi_run_backfill_policy():
 def test_failure():
     result = invoke_materialize("fail_asset")
     assert result.exit_code == 1
+
+
+def test_run__cli_config_json():
+    with instance_for_test() as instance:
+        runner = CliRunner()
+
+        result = runner.invoke(asset_materialize_command, ["--select", "asset_with_config", "--cli-config-json", "{\"some_prop\": \"foo\"}"])
+
+        assert "some_prop:foo" in result.output
+        assert instance.get_latest_materialization_event(AssetKey("asset_with_config")) is not None
+        assert result.exit_code == 0

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -182,9 +182,11 @@ def test_failure():
 def test_run__cli_config_json():
     with instance_for_test() as instance:
         runner = CliRunner()
+        options = ["-f", file_relative_path(__file__, "assets.py"), "--select", "asset_with_config", "--config-json", "{\"some_prop\": \"foo\"}"]
 
-        result = runner.invoke(asset_materialize_command, ["--select", "asset_with_config", "--cli-config-json", "{\"some_prop\": \"foo\"}"])
+        result = runner.invoke(asset_materialize_command, options)
 
-        assert "some_prop:foo" in result.output
-        assert instance.get_latest_materialization_event(AssetKey("asset_with_config")) is not None
+        
+        #assert "some_prop:foo" in result.output
+        #assert instance.get_latest_materialization_event(AssetKey("asset_with_config")) is not None
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary & Motivation

Continuation of #26069:

> I was browsing the repo for good first issues as a new contributor, and found #16802 interesting. It looks like @sam-goodwin's PR #20979 is nearly complete, except for a change needed for one of the imports. I used that PR's solution, but also resolved the import issue.

Which is a continuation of #20979:

> > This change adds support for -c, --config and --config-json in the dagster asset materialize CLI command.
> > Our motivation is to simply materialize a whole graph as part of CI/CD and use run_config to specify parameters that scope down that materialization for the sake of CI/CD. A single partition of our asset graph can take a long time to run and for CI/CD we don't need the whole thing.

## How I Tested These Changes

## Changelog

- [dagster-cli] Adds support for `--config-json` to the `dagster asset materialize` command
