### PR TITLE
[docs] remove note that concurrency is only supported for non-sqlite databases

### DIFF
--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -391,11 +391,6 @@ height={1638}
 
 ### Limiting op/asset concurrency across runs
 
-<Note>
-  This feature is experimental and is only supported with Postgres/MySQL
-  storages.
-</Note>
-
 #### For specific ops/assets
 
 Limits can be specified on the Dagster instance using the special op tag `dagster/concurrency_key`. If this instance limit would be exceeded by launching an op/asset, then the op/asset will be queued.


### PR DESCRIPTION
## Summary & Motivation

Phil's work makes it so concurrency limits work by default, even when using the sqlite database.

This removes the note that it's experimental and only supporting certain storages.

## How I Tested These Changes

## Changelog

NOCHANGELOG
