### PR TITLE
add support for run retries with default sqlite storage

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -491,13 +491,6 @@ class DagsterInstance(DynamicPartitionsStore):
                 " run worker will be marked as failed, but will not be resumed.",
             )
 
-        if self.run_retries_enabled:
-            check.invariant(
-                self.event_log_storage.supports_event_consumer_queries(),
-                "Run retries are enabled, but the configured event log storage does not support"
-                " them. Consider switching to Postgres or Mysql.",
-            )
-
         # Used for batched event handling
         self._event_buffer: Dict[str, List[EventLogEntry]] = defaultdict(list)
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -336,9 +336,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     ) -> Sequence[EventLogRecord]:
         pass
 
-    def supports_event_consumer_queries(self) -> bool:
-        return False
-
     def get_logs_for_all_runs_by_log_id(
         self,
         after_cursor: int = -1,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1017,9 +1017,6 @@ class SqlEventLogStorage(EventLogStorage):
 
         return event_records
 
-    def supports_event_consumer_queries(self) -> bool:
-        return True
-
     def _get_event_records_result(
         self,
         event_records_filter: EventRecordsFilter,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -434,9 +434,6 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         has_more = len(records) == limit
         return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
 
-    def supports_event_consumer_queries(self) -> bool:
-        return False
-
     def wipe(self) -> None:
         # should delete all the run-sharded db files and drop the contents of the index
         for filename in (

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -416,6 +416,19 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             run_id, cursor, of_type, limit, ascending
         )
 
+    def get_logs_for_all_runs_by_log_id(
+        self,
+        after_cursor: int = -1,
+        dagster_event_type: Optional[Union["DagsterEventType", Set["DagsterEventType"]]] = None,
+        limit: Optional[int] = None,
+    ) -> Mapping[int, "EventLogEntry"]:
+        return self._storage.event_log_storage.get_logs_for_all_runs_by_log_id(
+            after_cursor=after_cursor, dagster_event_type=dagster_event_type, limit=limit
+        )
+
+    def get_maximum_record_id(self) -> Optional[int]:
+        return self._storage.event_log_storage.get_maximum_record_id()
+
     def get_stats_for_run(self, run_id: str) -> "DagsterRunStatsSnapshot":
         return self._storage.event_log_storage.get_stats_for_run(run_id)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -70,6 +70,9 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
         assert isinstance(event_log_storage, SqliteEventLogStorage)
         yield instance.event_log_storage
 
+    def supports_multiple_event_type_queries(self):
+        return False
+
     def test_filesystem_event_log_storage_run_corrupted(self, storage):
         # URL begins sqlite:///
 
@@ -185,6 +188,9 @@ class TestLegacyStorage(TestEventLogStorage):
 
     def is_sqlite(self, storage):
         return True
+
+    def supports_multiple_event_type_queries(self):
+        return False
 
     @pytest.mark.parametrize("dagster_event_type", ["dummy"])
     def test_get_latest_tags_by_partition(self, storage, instance, dagster_event_type):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4142,9 +4142,6 @@ class TestEventLogStorage:
         assert result.run_id == records[0].asset_entry.last_run_id
 
     def test_get_logs_for_all_runs_by_log_id_of_type(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         @op
         def return_one(_):
             return 1
@@ -4164,9 +4161,6 @@ class TestEventLogStorage:
         ) == [DagsterEventType.RUN_SUCCESS, DagsterEventType.RUN_SUCCESS]
 
     def test_get_logs_for_all_runs_by_log_id_by_multi_type(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         if not self.supports_multiple_event_type_queries():
             pytest.skip("storage does not support deprecated multi-event-type queries")
 
@@ -4197,9 +4191,6 @@ class TestEventLogStorage:
         ]
 
     def test_get_logs_for_all_runs_by_log_id_cursor(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         @op
         def return_one(_):
             return 1
@@ -4234,9 +4225,6 @@ class TestEventLogStorage:
         ]
 
     def test_get_logs_for_all_runs_by_log_id_cursor_multi_type(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         if not self.supports_multiple_event_type_queries():
             pytest.skip("storage does not support deprecated multi-event-type queries")
 
@@ -4281,9 +4269,6 @@ class TestEventLogStorage:
         ]
 
     def test_get_logs_for_all_runs_by_log_id_limit(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         @op
         def return_one(_):
             return 1
@@ -4314,9 +4299,6 @@ class TestEventLogStorage:
         ]
 
     def test_get_logs_for_all_runs_by_log_id_limit_multi_type(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         if not self.supports_multiple_event_type_queries():
             pytest.skip("storage does not support deprecated multi-event-type queries")
 
@@ -4347,9 +4329,6 @@ class TestEventLogStorage:
         ]
 
     def test_get_maximum_record_id(self, storage: EventLogStorage):
-        if not storage.supports_event_consumer_queries():
-            pytest.skip("storage does not support event consumer queries")
-
         storage.wipe()
 
         storage.store_event(
@@ -4360,9 +4339,8 @@ class TestEventLogStorage:
                 run_id=make_new_run_id(),
                 timestamp=time.time(),
                 dagster_event=DagsterEvent(
-                    DagsterEventType.ENGINE_EVENT.value,
-                    "nonce",
-                    event_specific_data=EngineEventData.in_process(999),
+                    DagsterEventType.RUN_SUCCESS.value,
+                    "my_job",
                 ),
             )
         )
@@ -4379,9 +4357,8 @@ class TestEventLogStorage:
                     run_id=make_new_run_id(),
                     timestamp=time.time(),
                     dagster_event=DagsterEvent(
-                        DagsterEventType.ENGINE_EVENT.value,
-                        "nonce",
-                        event_specific_data=EngineEventData.in_process(999),
+                        DagsterEventType.RUN_SUCCESS.value,
+                        "my_job",
                     ),
                 )
             )


### PR DESCRIPTION
Summary:
The underlying storage changes were already ready to go for this and it was just a matter of removing gating and tweaking some tests.

BK

Run retries can now be used while using Sqlite storage.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
