### PR TITLE
Regenerate pyright pins with a more reasonable fastapi pin

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -1,8 +1,8 @@
 agate==1.9.1
-aiobotocore==2.15.2
+aiobotocore==2.16.0
 aiofile==3.9.0
 aiohappyeyeballs==2.4.4
-aiohttp==3.11.10
+aiohttp==3.11.11
 aioitertools==0.12.0
 aiosignal==1.3.2
 alembic==1.14.0
@@ -24,10 +24,10 @@ backoff==2.2.1
 backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
 bleach==6.2.0
-boto3==1.35.36
+boto3==1.35.81
 boto3-stubs-lite==1.35.70
-botocore==1.35.36
-botocore-stubs==1.35.82
+botocore==1.35.81
+botocore-stubs==1.35.84
 buildkite-test-collector==0.1.9
 cachetools==5.5.0
 caio==0.9.17
@@ -66,12 +66,12 @@ daff==1.3.46
 -e python_modules/libraries/dagster-spark
 -e python_modules/dagster-webserver
 db-dtypes==1.3.1
-dbt-adapters==1.10.4
+dbt-adapters==1.12.0
 dbt-common==1.14.0
-dbt-core==1.8.9
+dbt-core==1.9.1
 dbt-duckdb==1.9.1
 dbt-extractor==0.5.1
-dbt-semantic-interfaces==0.5.1
+dbt-semantic-interfaces==0.7.4
 dbt-snowflake==1.9.0
 debugpy==1.8.11
 decopatch==1.4.10
@@ -95,7 +95,7 @@ frozenlist==1.5.0
 fsspec==2024.3.0
 gcsfs==0.8.0
 google-api-core==2.24.0
-google-api-python-client==2.155.0
+google-api-python-client==2.156.0
 google-auth==2.37.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.1
@@ -145,13 +145,12 @@ jupyter-events==0.11.0
 jupyter-lsp==2.2.5
 jupyter-server==2.14.2
 jupyter-server-terminals==0.5.3
-jupyterlab==4.3.3
+jupyterlab==4.3.4
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
 keyring==25.5.0
 kiwisolver==1.4.7
 leather==0.4.0
-logbook==1.5.3
 makefun==1.15.6
 mako==1.3.8
 markdown-it-py==3.0.0
@@ -161,7 +160,6 @@ matplotlib==3.10.0
 matplotlib-inline==0.1.7
 mccabe==0.7.0
 mdurl==0.1.2
-minimal-snowplow-tracker==0.0.2
 mistune==3.0.2
 more-itertools==10.5.0
 morefs==0.2.2
@@ -169,7 +167,7 @@ msgpack==1.1.0
 multidict==6.1.0
 multimethod==1.12
 mypy==1.13.0
-mypy-boto3-ecs==1.35.77
+mypy-boto3-ecs==1.35.83
 mypy-boto3-emr==1.35.68
 mypy-boto3-emr-serverless==1.35.79
 mypy-boto3-glue==1.35.80
@@ -210,7 +208,7 @@ prometheus-client==0.21.1
 prompt-toolkit==3.0.48
 propcache==0.2.1
 proto-plus==1.25.0
-protobuf==5.29.1
+protobuf==5.29.2
 psutil==6.1.0
 psycopg2-binary==2.9.10
 ptyprocess==0.7.0
@@ -220,8 +218,8 @@ pyarrow==18.1.0
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
 pycparser==2.22
-pydantic==2.10.3
-pydantic-core==2.27.1
+pydantic==2.10.4
+pydantic-core==2.27.2
 pygments==2.18.0
 pyjwt==2.10.1
 pylint==3.3.2
@@ -244,7 +242,7 @@ pytimeparse==1.1.8
 pytz==2024.2
 pyyaml==6.0.2
 pyzmq==26.2.0
-rapidfuzz==3.10.1
+rapidfuzz==3.11.0
 referencing==0.35.1
 requests==2.32.3
 requests-oauthlib==2.0.0
@@ -264,14 +262,15 @@ send2trash==1.8.3
 setuptools==75.6.0
 shellingham==1.5.4
 six==1.17.0
-slack-sdk==3.33.5
+slack-sdk==3.34.0
 sniffio==1.3.1
 snowflake-connector-python==3.12.4
 snowflake-sqlalchemy==1.5.1
+snowplow-tracker==1.0.4
 sortedcontainers==2.4.0
 soupsieve==2.6
 sqlalchemy==1.4.54
-sqlglot==26.0.0
+sqlglot==26.0.1
 sqlglotrs==0.3.0
 sqlparse==0.5.3
 stack-data==0.6.3
@@ -292,7 +291,7 @@ tqdm==4.67.1
 traitlets==5.14.3
 typeguard==4.4.1
 typer==0.15.1
-types-awscrt==0.23.5
+types-awscrt==0.23.6
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-cffi==1.16.0.20240331

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -1,4 +1,4 @@
-acryl-datahub==0.14.1.12
+acryl-datahub==0.15.0
 agate==1.9.1
 aiofile==3.9.0
 aiohappyeyeballs==2.4.4
@@ -58,10 +58,10 @@ billiard==4.2.1
 bleach==6.2.0
 blinker==1.9.0
 bokeh==3.6.2
-boto3==1.35.82
+boto3==1.35.84
 boto3-stubs-lite==1.35.70
-botocore==1.35.82
-botocore-stubs==1.35.82
+botocore==1.35.84
+botocore-stubs==1.35.84
 buildkite-test-collector==0.1.9
 cachecontrol==0.14.1
 cached-property==2.0.1
@@ -89,7 +89,7 @@ coloredlogs==14.0
 colorlog==4.8.0
 comm==0.2.2
 configupdater==3.2
-confluent-kafka==2.6.1
+confluent-kafka==2.6.2
 connexion==2.14.2
 contourpy==1.3.1
 coverage==7.6.9
@@ -173,8 +173,8 @@ dagster-contrib-modal==0.0.2
 -e python_modules/libraries/dagster-wandb
 -e python_modules/dagster-webserver
 -e python_modules/libraries/dagstermill
-dask==2024.12.0
-dask-expr==1.1.20
+dask==2024.12.1
+dask-expr==1.1.21
 dask-jobqueue==0.9.0
 dask-kubernetes==2022.9.0
 dask-yarn==0.9
@@ -184,13 +184,13 @@ dataclasses-json==0.6.7
 datadog==0.50.2
 dataproperty==1.0.1
 db-dtypes==1.3.1
-dbt-adapters==1.10.2
+dbt-adapters==1.12.0
 dbt-common==1.14.0
-dbt-core==1.8.9
+dbt-core==1.9.1
 dbt-duckdb==1.9.1
 -e examples/starlift-demo
 dbt-extractor==0.5.1
-dbt-semantic-interfaces==0.5.1
+dbt-semantic-interfaces==0.7.4
 debugpy==1.8.11
 decopatch==1.4.10
 decorator==5.1.1
@@ -202,10 +202,10 @@ deprecated==1.2.15
 dict2css==0.3.0.post1
 dill==0.3.9
 distlib==0.3.9
-distributed==2024.12.0
+distributed==2024.12.1
 distro==1.9.0
 -e examples/experimental/dagster-dlift/kitchen-sink
-dlt==1.4.1
+dlt==1.5.0
 dnspython==2.7.0
 docker==7.1.0
 docker-image-py==0.1.13
@@ -223,7 +223,7 @@ execnet==2.1.1
 executing==2.1.0
 expandvars==0.12.0
 faiss-cpu==1.8.0
-fastapi==0.1.17
+fastapi==0.115.6
 fastavro==1.9.7
 fastjsonschema==2.21.1
 -e examples/feature_graph_backed_assets
@@ -252,7 +252,7 @@ gitdb==4.0.11
 gitpython==3.1.43
 giturlparse==0.12.0
 google-api-core==2.24.0
-google-api-python-client==2.155.0
+google-api-python-client==2.156.0
 google-auth==2.37.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.1
@@ -327,7 +327,7 @@ jupyter-events==0.11.0
 jupyter-lsp==2.2.5
 jupyter-server==2.14.2
 jupyter-server-terminals==0.5.3
-jupyterlab==4.3.3
+jupyterlab==4.3.4
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
 jupyterlab-widgets==3.0.13
@@ -337,12 +337,12 @@ kiwisolver==1.4.7
 kombu==5.4.2
 kopf==1.37.4
 kubernetes==31.0.0
-kubernetes-asyncio==31.1.1
+kubernetes-asyncio==32.0.0
 langchain==0.3.7
 langchain-community==0.3.5
-langchain-core==0.3.25
+langchain-core==0.3.27
 langchain-openai==0.2.5
-langchain-text-splitters==0.3.3
+langchain-text-splitters==0.3.4
 langsmith==0.1.147
 lazy-object-proxy==1.10.0
 leather==0.4.0
@@ -352,7 +352,6 @@ linkify-it-py==2.0.3
 lkml==1.3.6
 locket==1.0.0
 lockfile==0.12.2
-logbook==1.5.3
 looker-sdk==24.16.2
 lxml==5.3.0
 makefun==1.15.6
@@ -363,17 +362,16 @@ markupsafe==3.0.2
 marshmallow==3.23.1
 marshmallow-oneofschema==3.1.1
 marshmallow-sqlalchemy==0.26.1
-mashumaro==3.15
+mashumaro==3.14
 matplotlib==3.10.0
 matplotlib-inline==0.1.3
 mbstrdecoder==1.1.3
 mdit-py-plugins==0.4.2
 mdurl==0.1.2
-minimal-snowplow-tracker==0.0.2
 mistune==3.0.2
 mixpanel==4.10.1
 mlflow==1.27.0
-modal==0.68.26
+modal==0.68.41
 more-itertools==10.5.0
 morefs==0.2.2
 moto==4.2.14
@@ -383,7 +381,7 @@ msal-extensions==1.2.0
 msgpack==1.1.0
 multidict==6.1.0
 multimethod==1.12
-mypy-boto3-ecs==1.35.77
+mypy-boto3-ecs==1.35.83
 mypy-boto3-emr==1.35.68
 mypy-boto3-emr-serverless==1.35.79
 mypy-boto3-glue==1.35.80
@@ -409,7 +407,7 @@ objgraph==3.6.2
 onnx==1.17.0
 onnxconverter-common==1.13.0
 onnxruntime==1.20.1
-openai==1.57.4
+openai==1.58.1
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
 opentelemetry-api==1.29.0
@@ -461,7 +459,7 @@ prometheus-flask-exporter==0.23.1
 prompt-toolkit==3.0.48
 propcache==0.2.1
 proto-plus==1.25.0
-protobuf==5.29.1
+protobuf==5.29.2
 psutil==6.1.0
 psycopg2-binary==2.9.10
 ptyprocess==0.7.0
@@ -473,8 +471,8 @@ pyarrow-hotfix==0.6
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
 pycparser==2.22
-pydantic==2.10.3
-pydantic-core==2.27.1
+pydantic==2.10.4
+pydantic-core==2.27.2
 pydantic-settings==2.7.0
 pydata-google-auth==1.9.0
 pyflakes==3.2.0
@@ -513,7 +511,7 @@ pytzdata==2020.1
 pyyaml==6.0.2
 pyzmq==26.2.0
 querystring-parser==1.2.4
-rapidfuzz==3.10.1
+rapidfuzz==3.11.0
 readme-renderer==44.0
 referencing==0.35.1
 regex==2024.11.6
@@ -552,15 +550,16 @@ sigtools==4.0.1
 simplejson==3.19.3
 six==1.17.0
 skein==0.8.2
-skl2onnx==1.17.0
-slack-sdk==3.33.5
+skl2onnx==1.18.0
+slack-sdk==3.34.0
 sling==1.3.3
 sling-mac-arm64==1.3.3
 smmap==5.0.1
 sniffio==1.3.1
 snowballstemmer==2.2.0
 snowflake-connector-python==3.12.4
-snowflake-sqlalchemy==1.7.1
+snowflake-sqlalchemy==1.7.2
+snowplow-tracker==1.0.4
 sortedcontainers==2.4.0
 soupsieve==2.6
 sphinx==8.1.3
@@ -578,16 +577,16 @@ sphinxcontrib-serializinghtml==2.0.0
 sqlalchemy==1.4.54
 sqlalchemy-jsonfield==1.0.2
 sqlalchemy-utils==0.41.2
-sqlglot==26.0.0
+sqlglot==26.0.1
 sqlglotrs==0.3.0
 sqlparse==0.5.3
 sshpubkeys==3.3.1
 sshtunnel==0.4.0
 stack-data==0.6.3
-starlette==0.42.0
+starlette==0.41.3
 structlog==24.4.0
 sympy==1.13.1
-synchronicity==0.9.6
+synchronicity==0.9.7
 syrupy==4.8.0
 tableauserverclient==0.34
 tabledata==1.3.3
@@ -620,7 +619,7 @@ twine==6.0.1
 typeguard==4.4.1
 typepy==1.3.2
 typer==0.15.1
-types-awscrt==0.23.5
+types-awscrt==0.23.6
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-cffi==1.16.0.20240331

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -107,7 +107,7 @@ wordcloud  # (quickstart-*)
 apache-airflow>2.7
 pendulum<3
 types-sqlalchemy==1.4.53.34
-
+fastapi>=0.115.6 # producing a bizarrely early version of fastapi without this
 
 ### EXAMPLES
 


### PR DESCRIPTION
Summary:
For whatever reason the current constraints are producing a fastapi version from 2019 that is getting flagged by dependabot. Give it a hint to produce a version that is more modern.

Test Plan: BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
