### PR TITLE
[dagster-fivetran] Remove OpExecutionContext support in FivetranWorkspace.sync_and_poll

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -16,7 +16,6 @@ from dagster import (
     InitResourceContext,
     MaterializeResult,
     MetadataValue,
-    OpExecutionContext,
     __version__,
     _check as check,
     get_dagster_logger,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1014,14 +1014,14 @@ class FivetranWorkspace(ConfigurableResource):
                 )
 
     def sync_and_poll(
-        self, context: Union[OpExecutionContext, AssetExecutionContext]
+        self, context: AssetExecutionContext
     ) -> FivetranEventIterator[Union[AssetMaterialization, MaterializeResult]]:
         """Executes a sync and poll process to materialize Fivetran assets.
+            This method can only be used in the context of an asset execution.
 
         Args:
-            context (Union[OpExecutionContext, AssetExecutionContext]): The execution context
-                from within `@fivetran_assets`. If an AssetExecutionContext is passed,
-                its underlying OpExecutionContext will be used.
+            context (AssetExecutionContext): The execution context
+                from within `@fivetran_assets`.
 
         Returns:
             Iterator[Union[AssetMaterialization, MaterializeResult]]: An iterator of MaterializeResult
@@ -1031,7 +1031,7 @@ class FivetranWorkspace(ConfigurableResource):
             events=self._sync_and_poll(context=context), fivetran_workspace=self, context=context
         )
 
-    def _sync_and_poll(self, context: Union[OpExecutionContext, AssetExecutionContext]):
+    def _sync_and_poll(self, context: AssetExecutionContext):
         assets_def = context.assets_def
         dagster_fivetran_translator = get_translator_from_fivetran_assets(assets_def)
         connector_id = next(


### PR DESCRIPTION
## Summary & Motivation

Following [this discussion](https://github.com/dagster-io/dagster/pull/26432#discussion_r1890538958) for Airbyte Cloud - `FivetranWorkspace.sync_and_poll` should only accept context of type `AssetExecutionContext`.

## How I Tested These Changes

Same tests with BK

