### PR TITLE
[dagster-fivetran] Move DagsterFivetranTranslator metadata to Fivetran specs loader

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -5,7 +5,6 @@ from dagster._annotations import experimental
 
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
-from dagster_fivetran.utils import DAGSTER_FIVETRAN_TRANSLATOR_METADATA_KEY
 
 
 @experimental
@@ -109,9 +108,7 @@ def fivetran_assets(
         group_name=group_name,
         can_subset=True,
         specs=[
-            spec.merge_attributes(
-                metadata={DAGSTER_FIVETRAN_TRANSLATOR_METADATA_KEY: dagster_fivetran_translator}
-            )
+            spec
             for spec in workspace.load_asset_specs(
                 dagster_fivetran_translator=dagster_fivetran_translator
             )


### PR DESCRIPTION
## Summary & Motivation

Following [this discussion](https://github.com/dagster-io/dagster/pull/26559#discussion_r1889463330) for Airbyte Cloud, we add the translator as metadata as the spec loader level

## How I Tested These Changes

Same tests with BK

