### PR TITLE
[components] Make dagster-dg help messages include parent options

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -7,6 +7,7 @@ from dagster_dg.cli.generate import generate_cli
 from dagster_dg.cli.info import info_cli
 from dagster_dg.cli.list import list_cli
 from dagster_dg.config import DgConfig, set_config_on_cli_context
+from dagster_dg.utils import DgClickGroup
 from dagster_dg.version import __version__
 
 
@@ -22,6 +23,7 @@ def create_dg_cli():
         commands=commands,
         context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
         invoke_without_command=True,
+        cls=DgClickGroup,
     )
     @click.option(
         "--builtin-component-lib",

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -18,14 +18,15 @@ from dagster_dg.generate import (
     generate_component_type,
     generate_deployment,
 )
+from dagster_dg.utils import DgClickCommand, DgClickGroup
 
 
-@click.group(name="generate")
+@click.group(name="generate", cls=DgClickGroup)
 def generate_cli() -> None:
     """Commands for generating Dagster components and related entities."""
 
 
-@generate_cli.command(name="deployment")
+@generate_cli.command(name="deployment", cls=DgClickCommand)
 @click.argument("path", type=Path)
 def generate_deployment_command(path: Path) -> None:
     """Generate a Dagster deployment file structure.
@@ -43,7 +44,7 @@ def generate_deployment_command(path: Path) -> None:
     generate_deployment(path)
 
 
-@generate_cli.command(name="code-location")
+@generate_cli.command(name="code-location", cls=DgClickCommand)
 @click.argument("name", type=str)
 @click.option(
     "--use-editable-dagster",
@@ -112,7 +113,7 @@ def generate_code_location_command(
     generate_code_location(code_location_path, editable_dagster_root)
 
 
-@generate_cli.command(name="component-type")
+@generate_cli.command(name="component-type", cls=DgClickCommand)
 @click.argument("name", type=str)
 @click.pass_context
 def generate_component_type_command(cli_context: click.Context, name: str) -> None:
@@ -138,7 +139,7 @@ def generate_component_type_command(cli_context: click.Context, name: str) -> No
     generate_component_type(context, name)
 
 
-@generate_cli.command(name="component")
+@generate_cli.command(name="component", cls=DgClickCommand)
 @click.argument(
     "component_type",
     type=str,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/info.py
@@ -10,9 +10,10 @@ from dagster_dg.context import (
     DgContext,
     is_inside_code_location_directory,
 )
+from dagster_dg.utils import DgClickCommand, DgClickGroup
 
 
-@click.group(name="info")
+@click.group(name="info", cls=DgClickGroup)
 def info_cli():
     """Commands for listing Dagster components and related entities."""
 
@@ -21,7 +22,7 @@ def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
     return json.dumps(schema, indent=4)
 
 
-@info_cli.command(name="component-type")
+@info_cli.command(name="component-type", cls=DgClickCommand)
 @click.argument("component_type", type=str)
 @click.option("--description", is_flag=True, default=False)
 @click.option("--generate-params-schema", is_flag=True, default=False)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -10,14 +10,15 @@ from dagster_dg.context import (
     is_inside_code_location_directory,
     is_inside_deployment_directory,
 )
+from dagster_dg.utils import DgClickCommand, DgClickGroup
 
 
-@click.group(name="list")
+@click.group(name="list", cls=DgClickGroup)
 def list_cli():
     """Commands for listing Dagster components and related entities."""
 
 
-@list_cli.command(name="code-locations")
+@list_cli.command(name="code-locations", cls=DgClickCommand)
 @click.pass_context
 def list_code_locations_command(cli_context: click.Context) -> None:
     """List code locations in the current deployment."""
@@ -33,7 +34,7 @@ def list_code_locations_command(cli_context: click.Context) -> None:
         click.echo(code_location)
 
 
-@list_cli.command(name="component-types")
+@list_cli.command(name="component-types", cls=DgClickCommand)
 @click.pass_context
 def list_component_types_command(cli_context: click.Context) -> None:
     """List registered Dagster components in the current code location environment."""
@@ -53,7 +54,7 @@ def list_component_types_command(cli_context: click.Context) -> None:
             click.echo(f"    {component_type.summary}")
 
 
-@list_cli.command(name="components")
+@list_cli.command(name="components", cls=DgClickCommand)
 @click.pass_context
 def list_components_command(cli_context: click.Context) -> None:
     """List Dagster component instances defined in the current code location."""

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -6,12 +6,26 @@ import subprocess
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Iterator, List, Mapping, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import click
 import jinja2
+from click.formatting import HelpFormatter
 from typing_extensions import TypeAlias
 
+from dagster_dg.error import DgError
 from dagster_dg.version import __version__ as dagster_version
 
 # There is some weirdness concerning the availabilty of hashlib.HASH between different Python
@@ -211,3 +225,107 @@ def hash_file_metadata(hasher: Hash, path: Union[str, Path]) -> None:
     hasher.update(str(path).encode())
     hasher.update(str(stat.st_mtime).encode())  # Last modified time
     hasher.update(str(stat.st_size).encode())  # File size
+
+
+T = TypeVar("T")
+
+
+def not_none(value: Optional[T]) -> T:
+    if value is None:
+        raise DgError("Expected non-none value.")
+    return value
+
+
+# ########################
+# ##### CUSTOM CLICK SUBCLASSES
+# ########################
+
+# Here we subclass click.Command and click.Group to customize the help output. We do this in order
+# to show the options for each parent group in the help output of a subcommand. The form of the
+# output can be seen in dagster_dg_tests.test_custom_help_format.
+
+# When rendering options for parent groups, exclude these options since they are not used when
+# executing a subcommand.
+_EXCLUDE_PARENT_OPTIONS = ["help", "version"]
+
+
+class DgClickHelpMixin:
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._commands: List[str] = []
+
+    def format_help(self, context: click.Context, formatter: click.HelpFormatter):
+        """Customizes the help to include hierarchical usage."""
+        if not isinstance(self, click.Command):
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
+        self.format_usage(context, formatter)
+        self.format_help_text(context, formatter)
+        if isinstance(self, click.MultiCommand):
+            self.format_commands(context, formatter)
+        self.format_options(context, formatter)
+
+        # Add section for each parent option group
+        for ctx, cmd in self._walk_parents(context):
+            cmd.format_options(ctx, formatter, as_parent=True)
+
+    def format_options(
+        self, ctx: click.Context, formatter: HelpFormatter, as_parent: bool = False
+    ) -> None:
+        """Writes all the options into the formatter if they exist.
+
+        If `as_parent` is True, the header will include the command path and the `--help` option
+        will be excluded.
+        """
+        if not isinstance(self, click.Command):
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
+
+        params = [
+            p
+            for p in self.get_params(ctx)
+            if p.name and not (as_parent and p.name in _EXCLUDE_PARENT_OPTIONS)
+        ]
+        opts = [rv for p in params if (rv := p.get_help_record(ctx)) is not None]
+        if as_parent:
+            opts = [opt for opt in opts if not opt[0].startswith("--help")]
+        if opts:
+            header = f"Options ({ctx.command_path})" if as_parent else "Options"
+            with formatter.section(header):
+                formatter.write_dl(opts)
+
+    def format_usage(self, context: click.Context, formatter: HelpFormatter) -> None:
+        if not isinstance(self, click.Command):
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
+        arg_pieces = self.collect_usage_pieces(context)
+
+        path_parts: List[str] = [not_none(context.info_name)]
+        for ctx, cmd in self._walk_parents(context):
+            if cmd.has_visible_options_as_parent(ctx):
+                path_parts.append("[OPTIONS]")
+            path_parts.append(not_none(ctx.info_name))
+        path_parts.reverse()
+        return formatter.write_usage(" ".join(path_parts), " ".join(arg_pieces))
+
+    def has_visible_options_as_parent(self, ctx: click.Context) -> bool:
+        """Returns True if the command has options that are not help-related."""
+        if not isinstance(self, click.Command):
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
+        return any(
+            p for p in self.get_params(ctx) if (p.name and p.name not in _EXCLUDE_PARENT_OPTIONS)
+        )
+
+    def _walk_parents(
+        self, ctx: click.Context
+    ) -> Iterator[Tuple[click.Context, "DgClickHelpMixin"]]:
+        while ctx.parent:
+            if not isinstance(ctx.parent.command, DgClickHelpMixin):
+                raise DgError("Parent command must be an instance of DgClickHelpMixin.")
+            yield ctx.parent, ctx.parent.command
+            ctx = ctx.parent
+
+
+class DgClickCommand(DgClickHelpMixin, click.Command):
+    pass
+
+
+class DgClickGroup(DgClickHelpMixin, click.Group):
+    pass

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -1,0 +1,222 @@
+import textwrap
+
+import click
+from click.testing import CliRunner
+from dagster_dg.utils import DgClickCommand, DgClickGroup, ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
+from dagster_dg_tests.utils import assert_runner_result
+
+# ########################
+# ##### TEST CLI
+# ########################
+
+
+@click.group(name="test", cls=DgClickGroup)
+@click.option("--test-opt", type=str, default="test", help="Test option.")
+def test_cli(test_opt):
+    """Test CLI group."""
+    pass
+
+
+@test_cli.group(name="sub-test-1", cls=DgClickGroup)
+@click.option("--sub-test-1-opt", type=str, default="sub-test-1", help="Sub-test 1 option.")
+def sub_test_1(sub_test_1_opt):
+    """Sub-test 1 group."""
+    pass
+
+
+@sub_test_1.command(name="alpha", cls=DgClickCommand)
+@click.option("--alpha-opt", type=str, default="alpha", help="Alpha option.")
+def alpha(alpha_opt):
+    """Alpha command."""
+    pass
+
+
+@test_cli.group(name="sub-test-2", cls=DgClickGroup)
+def sub_test_2():
+    """Sub-test 2 group."""
+    pass
+
+
+@click.option("--beta-opt", type=str, default="alpha", help="Beta option.")
+@sub_test_2.command(name="beta", cls=DgClickCommand)
+def beta(beta_opt):
+    """Beta command."""
+    pass
+
+
+@click.option("--delta-opt", type=str, default="delta", help="Delta option.")
+@test_cli.command(name="delta", cls=DgClickCommand)
+def delta(delta_opt):
+    """Delta command."""
+    pass
+
+
+@test_cli.command(name="gamma", cls=DgClickCommand)
+def gamma(gamma_opt):
+    """Gamma command."""
+    pass
+
+
+# ########################
+# ##### TESTS
+# ########################
+
+
+def test_root_group_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] COMMAND [ARGS]...
+
+          Test CLI group.
+
+        Commands:
+          delta       Delta command.
+          gamma       Gamma command.
+          sub-test-1  Sub-test 1 group.
+          sub-test-2  Sub-test 2 group.
+
+        Options:
+          --test-opt TEXT  Test option.
+          --help           Show this message and exit.
+    """).strip()
+    )
+
+
+def test_sub_group_with_option_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["sub-test-1", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] sub-test-1 [OPTIONS] COMMAND [ARGS]...
+
+          Sub-test 1 group.
+
+        Commands:
+          alpha  Alpha command.
+
+        Options:
+          --sub-test-1-opt TEXT  Sub-test 1 option.
+          --help                 Show this message and exit.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )
+
+
+def test_command_in_sub_group_with_option_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["sub-test-1", "alpha", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] sub-test-1 [OPTIONS] alpha [OPTIONS]
+
+          Alpha command.
+
+        Options:
+          --alpha-opt TEXT  Alpha option.
+          --help            Show this message and exit.
+
+        Options (test sub-test-1):
+          --sub-test-1-opt TEXT  Sub-test 1 option.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )
+
+
+def test_sub_group_with_no_option_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["sub-test-2", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] sub-test-2 [OPTIONS] COMMAND [ARGS]...
+
+          Sub-test 2 group.
+
+        Commands:
+          beta  Beta command.
+
+        Options:
+          --help  Show this message and exit.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )
+
+
+def test_command_in_sub_group_with_no_option_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["sub-test-2", "beta", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] sub-test-2 beta [OPTIONS]
+
+          Beta command.
+
+        Options:
+          --beta-opt TEXT  Beta option.
+          --help           Show this message and exit.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )
+
+
+def test_command_with_option_in_root_group_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["delta", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] delta [OPTIONS]
+
+          Delta command.
+
+        Options:
+          --delta-opt TEXT  Delta option.
+          --help            Show this message and exit.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )
+
+
+def test_command_with_no_option_in_root_group_help_message():
+    runner = CliRunner()
+    result = runner.invoke(test_cli, ["gamma", "--help"])
+    assert_runner_result(result)
+    assert (
+        result.output.strip()
+        == textwrap.dedent("""
+        Usage: test [OPTIONS] gamma [OPTIONS]
+
+          Gamma command.
+
+        Options:
+          --help  Show this message and exit.
+
+        Options (test):
+          --test-opt TEXT  Test option.
+    """).strip()
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
@@ -1,0 +1,16 @@
+from dagster_dg.cli import cli
+from dagster_dg.utils import DgClickCommand, DgClickGroup
+
+
+# Important that all nodes of the command tree inherit from one of our customized click
+# Command/Group subclasses to ensure that the help formatting is consistent.
+def test_all_commands_custom_subclass():
+    def crawl(command):
+        assert isinstance(
+            command, (DgClickGroup, DgClickCommand)
+        ), f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        if isinstance(command, DgClickGroup):
+            for command in command.commands.values():
+                crawl(command)
+
+    crawl(cli)


### PR DESCRIPTION
## Summary & Motivation

This customizes `click` commands and groups so that help messages now include non-help parent options.

Before:

```
$ dg generate component --help

Usage: dg generate component [OPTIONS] COMPONENT_TYPE COMPONENT_NAME [EXTRA_ARGS]...

  Generate a scaffold of a Dagster component.

  ... description ...

Options:
  --json-params TEXT  JSON string of component parameters.
  -h, --help          Show this message and exit.
```

After:

```
$ dg generate component --help

Usage: dg [OPTIONS] generate component [OPTIONS] COMPONENT_TYPE COMPONENT_NAME [EXTRA_ARGS]...

  Generate a scaffold of a Dagster component.

  ... description ...

Options:
  --json-params TEXT  JSON string of component parameters.
  -h, --help          Show this message and exit.

Options (dg):
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable caching of component registry data.
  --clear-cache                 Clear the cache before running the command.
  --cache-dir PATH              Specify a directory to use for the cache.
```

## How I Tested These Changes

New unit tests.