### PR TITLE
[components] Add --rebuild-component-registry option, `--skip-venv` option, build cache on code loc construction

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -47,9 +47,15 @@ class DgCache:
         self._root_path.mkdir(parents=True, exist_ok=True)
         self._logging_enabled = logging_enabled
 
-    def clear(self) -> None:
+    def clear_key(self, key: Tuple[str, ...]) -> None:
+        path = self._get_path(key)
+        if path.exists():
+            path.unlink()
+            self.log(f"CACHE [clear-key]: {path}")
+
+    def clear_all(self) -> None:
         shutil.rmtree(self._root_path)
-        self.log(f"CACHE [clear]: {self._root_path}")
+        self.log(f"CACHE [clear-all]: {self._root_path}")
 
     def get(self, key: Tuple[str, ...]) -> Optional[str]:
         path = self._get_path(key)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/generate.py
@@ -65,9 +65,15 @@ def generate_deployment_command(path: Path) -> None:
         " the location of the local Dagster clone will be read from the `DAGSTER_GIT_REPO_DIR` environment variable."
     ),
 )
+@click.option(
+    "--skip-venv",
+    is_flag=True,
+    default=False,
+    help="Do not create a virtual environment for the code location.",
+)
 @click.pass_context
 def generate_code_location_command(
-    cli_context: click.Context, name: str, use_editable_dagster: Optional[str]
+    cli_context: click.Context, name: str, use_editable_dagster: Optional[str], skip_venv: bool
 ) -> None:
     """Generate a Dagster code location file structure and a uv-managed virtual environment scoped
     to the code location.
@@ -117,7 +123,7 @@ def generate_code_location_command(
     else:
         editable_dagster_root = None
 
-    generate_code_location(code_location_path, editable_dagster_root)
+    generate_code_location(code_location_path, dg_context, editable_dagster_root, skip_venv)
 
 
 @generate_cli.command(name="component-type", cls=DgClickCommand)

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Iterable, Optional, Tuple
@@ -15,8 +16,10 @@ from dagster_dg.config import DgConfig
 from dagster_dg.error import DgError
 from dagster_dg.utils import (
     execute_code_location_command,
+    get_uv_command_env,
     hash_directory_metadata,
     hash_file_metadata,
+    pushd,
 )
 
 
@@ -43,13 +46,13 @@ def _is_deployment_root_directory(path: Path) -> bool:
 
 def is_inside_code_location_directory(path: Path) -> bool:
     try:
-        _resolve_code_location_root_directory(path)
+        resolve_code_location_root_directory(path)
         return True
     except DgError:
         return False
 
 
-def _resolve_code_location_root_directory(path: Path) -> Path:
+def resolve_code_location_root_directory(path: Path) -> Path:
     current_path = path.absolute()
     while not _is_code_location_root_directory(current_path):
         current_path = current_path.parent
@@ -134,6 +137,31 @@ def make_cache_key(code_location_path: Path, data_type: CachableDataType) -> Tup
     return ("_".join(path_parts), env_hash, data_type)
 
 
+def ensure_uv_lock(root_path: Path) -> None:
+    with pushd(root_path):
+        if not (root_path / "uv.lock").exists():
+            subprocess.run(["uv", "sync"], check=True, env=get_uv_command_env())
+
+
+def fetch_component_registry(path: Path, dg_context: DgContext) -> RemoteComponentRegistry:
+    root_path = resolve_code_location_root_directory(path)
+
+    cache = dg_context.cache
+    if cache:
+        cache_key = make_cache_key(root_path, "component_registry_data")
+
+    raw_registry_data = cache.get(cache_key) if cache else None
+    if not raw_registry_data:
+        raw_registry_data = execute_code_location_command(
+            root_path, ["list", "component-types"], dg_context
+        )
+        if cache:
+            cache.set(cache_key, raw_registry_data)
+
+    registry_data = json.loads(raw_registry_data)
+    return RemoteComponentRegistry.from_dict(registry_data)
+
+
 @dataclass
 class CodeLocationDirectoryContext:
     """Class encapsulating contextual information about a components code location directory.
@@ -155,23 +183,9 @@ class CodeLocationDirectoryContext:
 
     @classmethod
     def from_path(cls, path: Path, dg_context: DgContext) -> Self:
-        root_path = _resolve_code_location_root_directory(path)
-
-        cache = dg_context.cache
-        if cache:
-            cache_key = make_cache_key(root_path, "component_registry_data")
-
-        raw_registry_data = cache.get(cache_key) if cache else None
-        if not raw_registry_data:
-            raw_registry_data = execute_code_location_command(
-                root_path, ["list", "component-types"], dg_context
-            )
-            if cache:
-                cache.set(cache_key, raw_registry_data)
-
-        registry_data = json.loads(raw_registry_data)
-        component_registry = RemoteComponentRegistry.from_dict(registry_data)
-
+        root_path = resolve_code_location_root_directory(path)
+        ensure_uv_lock(root_path)
+        component_registry = fetch_component_registry(path, dg_context)
         return cls(
             root_path=root_path,
             name=path.name,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -23,7 +23,7 @@ def isolated_example_deployment_foo(runner: Union[CliRunner, "ProxyRunner"]) -> 
 
 @contextmanager
 def isolated_example_code_location_bar(
-    runner: Union[CliRunner, "ProxyRunner"], in_deployment: bool = True
+    runner: Union[CliRunner, "ProxyRunner"], in_deployment: bool = True, skip_venv: bool = False
 ) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
@@ -34,6 +34,7 @@ def isolated_example_code_location_bar(
                 "code-location",
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
+                *(["--skip-venv"] if skip_venv else []),
                 "bar",
             )
             with pushd("code_locations/bar"):
@@ -45,6 +46,7 @@ def isolated_example_code_location_bar(
                 "code-location",
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
+                *(["--skip-venv"] if skip_venv else []),
                 "bar",
             )
             with pushd("bar"):


### PR DESCRIPTION
## Summary & Motivation

Add a top-level `--rebuild-component-registry` option that clears the cache and refetches the component registry for the current environment. The reason this is called `--rebuild-component-registry` instead of `--rebuild-cache` is:

- It is scoped to just the current environment, whereas the cache encompasses multiple environments
- We may cache other info later

Also add `--skip-venv` option to `dg generate code-location` to avoid automatic venv setup and cache population on construction. Mostly useful for testing.

We also invoke this immediately after `uv sync` when constructing a new code location, so that the cache is loaded.

## How I Tested These Changes

New unit tests + manual test of code location generation.