### PR TITLE
[dagster-databricks] Fix Cluster Drive Log Root Error when no extras provided for pipe

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -474,7 +474,9 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
     # job has finished.
     def _get_log_path(self, params: PipesParams) -> Optional[str]:
         if self.log_path is None:
-            cluster_driver_log_root = params["extras"].get("cluster_driver_log_root") if "extras" in params else None
+            cluster_driver_log_root = (
+                params["extras"].get("cluster_driver_log_root") if "extras" in params else None
+            )
             if cluster_driver_log_root is None:
                 return None
             try:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -474,7 +474,7 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
     # job has finished.
     def _get_log_path(self, params: PipesParams) -> Optional[str]:
         if self.log_path is None:
-            cluster_driver_log_root = params["extras"].get("cluster_driver_log_root")
+            cluster_driver_log_root = params["extras"].get("cluster_driver_log_root") if "extras" in params else None
             if cluster_driver_log_root is None:
                 return None
             try:


### PR DESCRIPTION
## Summary & Motivation
Addresses bug #26434 where an error is thrown for any Databricks Pipes where extras have not been provided for the pipe. 

Update checks if extras is available in params first to prevent the bug from being thrown

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
