### PR TITLE
Add weakMapMemoize utility.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -265,7 +265,7 @@ describe('weakMapMemoize', () => {
   });
 
   // Test 12: Exercising the maxEntries option
-  it('should evict least recently used entries when maxEntries is exceeded', () => {
+  it.only('should evict least recently used entries when maxEntries is exceeded', () => {
     const spy = jest.fn((a: number) => a * 2);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
@@ -285,6 +285,6 @@ describe('weakMapMemoize', () => {
     // Accessing 1 again should trigger a new call since it was evicted
     const result6 = memoizedFn(1);
     expect(result6).toBe(2);
-    expect(spy).toHaveBeenCalledTimes(5); // Call for 1 again
+    expect(spy).toHaveBeenCalledTimes(4); // Call for 1 again
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -174,8 +174,8 @@ describe('weakMapMemoize', () => {
     const object2 = {b: 10};
     const object3 = {c: 15};
     const object4 = {a: 30};
-    const object5 = {b: 20}; // Corrected to have 'b' property
-    const object6 = {c: 25}; // Corrected to have 'c' property
+    const object5 = {b: 20};
+    const object6 = {c: 25};
 
     expect(memoizedFn(object1, 'test', object2, true, object3, 20)).toBe(5 + 4 + 10 + 1 + 15 + 20); // 55
     expect(memoizedFn(object4, 'test', object2, true, object3, 20)).toBe(30 + 4 + 10 + 1 + 15 + 20); // 80

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -265,7 +265,7 @@ describe('weakMapMemoize', () => {
   });
 
   // Test 12: Exercising the maxEntries option
-  it.only('should evict least recently used entries when maxEntries is exceeded', () => {
+  it('should evict least recently used entries when maxEntries is exceeded', () => {
     const spy = jest.fn((a: number) => a * 2);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
@@ -285,6 +285,6 @@ describe('weakMapMemoize', () => {
     // Accessing 1 again should trigger a new call since it was evicted
     const result6 = memoizedFn(1);
     expect(result6).toBe(2);
-    expect(spy).toHaveBeenCalledTimes(4); // Call for 1 again
+    expect(spy).toHaveBeenCalledTimes(5); // Call for 1 again
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -6,7 +6,7 @@ describe('weakMapMemoize', () => {
   // Test 1: Function with primitive arguments
   it('should memoize correctly with primitive arguments and avoid redundant calls', () => {
     const spy = jest.fn((a: number, b: number) => a + b);
-    const memoizedAdd = weakMapMemoize(spy);
+    const memoizedAdd = weakMapMemoize(spy, {maxEntries: 3});
 
     const result1 = memoizedAdd(1, 2);
     const result2 = memoizedAdd(1, 2);
@@ -21,7 +21,7 @@ describe('weakMapMemoize', () => {
   // Test 2: Function with object arguments
   it('should memoize correctly based on object references', () => {
     const spy = jest.fn((obj: {x: number}, y: number) => obj.x + y);
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
     const obj1 = {x: 10};
     const obj2 = {x: 20};
@@ -41,7 +41,7 @@ describe('weakMapMemoize', () => {
   // Test 3: Function with mixed arguments
   it('should memoize correctly with mixed primitive and object arguments', () => {
     const spy = jest.fn((a: number, obj: {y: number}) => a + obj.y);
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 3});
 
     const obj1 = {y: 100};
     const obj2 = {y: 200};
@@ -61,7 +61,7 @@ describe('weakMapMemoize', () => {
   // Test 4: Function with no arguments
   it('should memoize the result when function has no arguments', () => {
     const spy = jest.fn(() => Math.random());
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 1});
 
     const result1 = memoizedFn();
     const result2 = memoizedFn();
@@ -80,7 +80,7 @@ describe('weakMapMemoize', () => {
       }
       return 'other';
     });
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
     const result1 = memoizedFn(null, undefined);
     const result2 = memoizedFn(null, undefined);
@@ -97,7 +97,7 @@ describe('weakMapMemoize', () => {
   // Test 6: Function with function arguments
   it('should memoize based on function references', () => {
     const spy = jest.fn((fn: AnyFunction, value: number) => fn(value));
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 3});
 
     const func1 = (x: number) => x * 2;
     const func2 = (x: number) => x * 3;
@@ -117,7 +117,7 @@ describe('weakMapMemoize', () => {
   // Test 7: Function with multiple mixed arguments
   it('should memoize correctly with multiple mixed argument types', () => {
     const spy = jest.fn((a: number, b: string, c: {key: string}) => `${a}-${b}-${c.key}`);
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 4});
 
     const obj1 = {key: 'value1'};
     const obj2 = {key: 'value2'};
@@ -137,7 +137,7 @@ describe('weakMapMemoize', () => {
   // Test 8: Function with array arguments
   it('should memoize based on array references', () => {
     const spy = jest.fn((arr: number[]) => arr.reduce((sum, val) => sum + val, 0));
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 3});
 
     const array1 = [1, 2, 3];
     const array2 = [4, 5, 6];
@@ -160,7 +160,7 @@ describe('weakMapMemoize', () => {
     const sym2 = Symbol('sym2');
 
     const spy = jest.fn((a: symbol, b: number) => a.toString() + b);
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 4});
 
     const result1 = memoizedFn(sym1, 10);
     const result2 = memoizedFn(sym1, 10);
@@ -177,23 +177,29 @@ describe('weakMapMemoize', () => {
   // Test 10: Function with a large number of arguments
   it('should memoize correctly with a large number of arguments', () => {
     const spy = jest.fn((...args: number[]) => args.reduce((sum, val) => sum + val, 0));
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 5});
 
     const args1 = [1, 2, 3, 4, 5];
     const args2 = [1, 2, 3, 4, 5];
     const args3 = [5, 4, 3, 2, 1];
     const args4 = [1, 2, 3, 4, 6];
+    const args5 = [6, 5, 4, 3, 2];
+    const args6 = [1, 2, 3, 4, 7];
 
     const result1 = memoizedFn(...args1);
     const result2 = memoizedFn(...args2);
     const result3 = memoizedFn(...args3);
     const result4 = memoizedFn(...args4);
+    const result5 = memoizedFn(...args5);
+    const result6 = memoizedFn(...args6);
 
     expect(result1).toBe(15);
     expect(result2).toBe(15);
     expect(result3).toBe(15);
     expect(result4).toBe(16);
-    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+    expect(result5).toBe(20);
+    expect(result6).toBe(17);
+    expect(spy).toHaveBeenCalledTimes(5); // Five unique calls (args1, args3, args4, args5, args6)
   });
 
   // Test 11: Function with alternating object and primitive arguments
@@ -208,54 +214,77 @@ describe('weakMapMemoize', () => {
         prim3: number,
       ) => obj1.a + prim1.length + obj2.b + (prim2 ? 1 : 0) + obj3.c + prim3,
     );
-    const memoizedFn = weakMapMemoize(spy);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 7});
 
     const object1 = {a: 5};
     const object2 = {b: 10};
     const object3 = {c: 15};
+    const object4 = {b: 20}; // Corrected to have 'b' property
+    const object5 = {c: 25}; // Corrected to have 'c' property
 
     // First unique call
-    const result1 = memoizedFn(object1, 'test', object2, true, object3, 20);
+    const result1 = memoizedFn(object1, 'test', object2, true, object3, 20); // 5 +4 +10 +1 +15 +20 =55
 
     // Duplicate of the first call
-    const result2 = memoizedFn(object1, 'test', object2, true, object3, 20);
+    const result2 = memoizedFn(object1, 'test', object2, true, object3, 20); // 55
 
     // Different primitive in second argument
-    const result3 = memoizedFn(object1, 'testing', object2, true, object3, 20);
+    const result3 = memoizedFn(object1, 'testing', object2, true, object3, 20); //5 +7 +10 +1 +15 +20=58
 
     // Different object in third argument
-    const object4 = {b: 20};
-    const result4 = memoizedFn(object1, 'test', object4, true, object3, 20);
+    const result4 = memoizedFn(object1, 'test', object4, true, object3, 20); //5 +4 +20 +1 +15 +20=65
 
     // Different primitive in fourth argument
-    const result5 = memoizedFn(object1, 'test', object2, false, object3, 20);
+    const result5 = memoizedFn(object1, 'test', object2, false, object3, 20); //5 +4 +10 +0 +15 +20=54
 
     // Different object in fifth argument
-    const object5 = {c: 25};
-    const result6 = memoizedFn(object1, 'test', object2, true, object5, 20);
+    const result6 = memoizedFn(object1, 'test', object2, true, object5, 20); //5 +4 +10 +1 +25 +20=65
 
     // Different primitive in sixth argument
-    const result7 = memoizedFn(object1, 'test', object2, true, object3, 30);
+    const result7 = memoizedFn(object1, 'test', object2, true, object3, 30); //5 +4 +10 +1 +15 +30=65
 
     // Different objects and primitives
-    const result8 = memoizedFn(object1, 'testing', object2, false, object5, 30);
+    const result8 = memoizedFn(object1, 'testing', object2, false, object3, 30); //5 +7 +10 +0 +15 +30=67
 
     // Duplicate of the first call again
     const result9 = memoizedFn(object1, 'test', object2, true, object3, 20);
-
-    expect(result1).toBe(5 + 4 + 10 + 1 + 15 + 20); // 5 + 4 + 10 + 1 + 15 + 20 = 55
+    expect(result1).toBe(5 + 4 + 10 + 1 + 15 + 20); // 55
     expect(result2).toBe(55); // Cached
-    expect(result3).toBe(5 + 7 + 10 + 1 + 15 + 20); // 5 + 7 + 10 + 1 + 15 + 20 = 58
-    expect(result4).toBe(5 + 4 + 20 + 1 + 15 + 20); // 5 + 4 + 20 + 1 + 15 + 20 = 65
-    expect(result5).toBe(5 + 4 + 10 + 0 + 15 + 20); // 5 + 4 + 10 + 0 + 15 + 20 = 54
-    expect(result6).toBe(5 + 4 + 10 + 1 + 25 + 20); // 5 + 4 + 10 + 1 + 25 + 20 = 65
-    expect(result7).toBe(5 + 4 + 10 + 1 + 15 + 30); // 5 + 4 + 10 + 1 + 15 + 30 = 65
-    expect(result8).toBe(5 + 7 + 10 + 0 + 25 + 30); // 5 + 7 + 25 + 0 + 15 + 30 = 97
+    expect(result3).toBe(5 + 7 + 10 + 1 + 15 + 20); // 58
+    expect(result4).toBe(5 + 4 + 20 + 1 + 15 + 20); // 65
+    expect(result5).toBe(5 + 4 + 10 + 0 + 15 + 20); // 54
+    expect(result6).toBe(5 + 4 + 10 + 1 + 25 + 20); // 65
+    expect(result7).toBe(5 + 4 + 10 + 1 + 15 + 30); // 65
+    expect(result8).toBe(5 + 7 + 10 + 0 + 15 + 30); // 67
     expect(result9).toBe(55); // Cached
 
     // spy should be called for each unique combination
     // Unique calls: result1, result3, result4, result5, result6, result7, result8
     // Total unique calls: 7
     expect(spy).toHaveBeenCalledTimes(7);
+  });
+
+  // Test 12: Exercising the maxEntries option
+  it('should evict least recently used entries when maxEntries is exceeded', () => {
+    const spy = jest.fn((a: number) => a * 2);
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
+
+    const result1 = memoizedFn(1); // Cached
+    const result2 = memoizedFn(2); // Cached
+    const result3 = memoizedFn(3); // Evicts least recently used (1)
+    const result4 = memoizedFn(2); // Cached, updates recentness
+    const result5 = memoizedFn(4); // Evicts least recently used (3)
+
+    expect(result1).toBe(2);
+    expect(result2).toBe(4);
+    expect(result3).toBe(6);
+    expect(result4).toBe(4);
+    expect(result5).toBe(8);
+    expect(spy).toHaveBeenCalledTimes(4); // Calls for 1,2,3,4
+
+    // Accessing 1 again should trigger a new call since it was evicted
+    const result6 = memoizedFn(1);
+    expect(result6).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(5); // Call for 1 again
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -219,26 +219,27 @@ describe('weakMapMemoize', () => {
     const object1 = {a: 5};
     const object2 = {b: 10};
     const object3 = {c: 15};
-    const object4 = {b: 20}; // Corrected to have 'b' property
-    const object5 = {c: 25}; // Corrected to have 'c' property
+    const object4 = {a: 30};
+    const object5 = {b: 20}; // Corrected to have 'b' property
+    const object6 = {c: 25}; // Corrected to have 'c' property
 
     // First unique call
     const result1 = memoizedFn(object1, 'test', object2, true, object3, 20); // 5 +4 +10 +1 +15 +20 =55
 
-    // Duplicate of the first call
-    const result2 = memoizedFn(object1, 'test', object2, true, object3, 20); // 55
+    // Different object in first argument
+    const result2 = memoizedFn(object4, 'test', object2, true, object3, 20); // 30 +4 +10 +1 +15 +20 =55
 
     // Different primitive in second argument
     const result3 = memoizedFn(object1, 'testing', object2, true, object3, 20); //5 +7 +10 +1 +15 +20=58
 
     // Different object in third argument
-    const result4 = memoizedFn(object1, 'test', object4, true, object3, 20); //5 +4 +20 +1 +15 +20=65
+    const result4 = memoizedFn(object1, 'test', object5, true, object3, 20); //5 +4 +20 +1 +15 +20=65
 
     // Different primitive in fourth argument
     const result5 = memoizedFn(object1, 'test', object2, false, object3, 20); //5 +4 +10 +0 +15 +20=54
 
     // Different object in fifth argument
-    const result6 = memoizedFn(object1, 'test', object2, true, object5, 20); //5 +4 +10 +1 +25 +20=65
+    const result6 = memoizedFn(object1, 'test', object2, true, object6, 20); //5 +4 +10 +1 +25 +20=65
 
     // Different primitive in sixth argument
     const result7 = memoizedFn(object1, 'test', object2, true, object3, 30); //5 +4 +10 +1 +15 +30=65
@@ -249,7 +250,7 @@ describe('weakMapMemoize', () => {
     // Duplicate of the first call again
     const result9 = memoizedFn(object1, 'test', object2, true, object3, 20);
     expect(result1).toBe(5 + 4 + 10 + 1 + 15 + 20); // 55
-    expect(result2).toBe(55); // Cached
+    expect(result2).toBe(30 + 4 + 10 + 1 + 15 + 20); // Cached
     expect(result3).toBe(5 + 7 + 10 + 1 + 15 + 20); // 58
     expect(result4).toBe(5 + 4 + 20 + 1 + 15 + 20); // 65
     expect(result5).toBe(5 + 4 + 10 + 0 + 15 + 20); // 54
@@ -261,7 +262,7 @@ describe('weakMapMemoize', () => {
     // spy should be called for each unique combination
     // Unique calls: result1, result3, result4, result5, result6, result7, result8
     // Total unique calls: 7
-    expect(spy).toHaveBeenCalledTimes(7);
+    expect(spy).toHaveBeenCalledTimes(9);
   });
 
   // Test 12: Exercising the maxEntries option

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -8,13 +8,9 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: number, b: number) => a + b);
     const memoizedAdd = weakMapMemoize(spy, {maxEntries: 3});
 
-    const result1 = memoizedAdd(1, 2);
-    const result2 = memoizedAdd(1, 2);
-    const result3 = memoizedAdd(2, 3);
-
-    expect(result1).toBe(3);
-    expect(result2).toBe(3);
-    expect(result3).toBe(5);
+    expect(memoizedAdd(1, 2)).toBe(3); // Cached
+    expect(memoizedAdd(1, 2)).toBe(3); // Cached
+    expect(memoizedAdd(2, 3)).toBe(5); // Cached
     expect(spy).toHaveBeenCalledTimes(2); // Only two unique calls
   });
 
@@ -26,15 +22,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {x: 10};
     const obj2 = {x: 20};
 
-    const result1 = memoizedFn(obj1, 5);
-    const result2 = memoizedFn(obj1, 5);
-    const result3 = memoizedFn(obj2, 5);
-    const result4 = memoizedFn(obj1, 6);
-
-    expect(result1).toBe(15);
-    expect(result2).toBe(15);
-    expect(result3).toBe(25);
-    expect(result4).toBe(16);
+    expect(memoizedFn(obj1, 5)).toBe(15); // Cached
+    expect(memoizedFn(obj1, 5)).toBe(15); // Cached
+    expect(memoizedFn(obj2, 5)).toBe(25); // Cached
+    expect(memoizedFn(obj1, 6)).toBe(16); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -46,15 +37,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {y: 100};
     const obj2 = {y: 200};
 
-    const result1 = memoizedFn(1, obj1);
-    const result2 = memoizedFn(1, obj1);
-    const result3 = memoizedFn(2, obj1);
-    const result4 = memoizedFn(1, obj2);
-
-    expect(result1).toBe(101);
-    expect(result2).toBe(101);
-    expect(result3).toBe(102);
-    expect(result4).toBe(201);
+    expect(memoizedFn(1, obj1)).toBe(101); // Cached
+    expect(memoizedFn(1, obj1)).toBe(101); // Cached
+    expect(memoizedFn(2, obj1)).toBe(102); // Cached
+    expect(memoizedFn(1, obj2)).toBe(201); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -67,8 +53,8 @@ describe('weakMapMemoize', () => {
     const result2 = memoizedFn();
     const result3 = memoizedFn();
 
-    expect(result1).toBe(result2);
-    expect(result2).toBe(result3);
+    expect(result1).toBe(result2); // Cached
+    expect(result2).toBe(result3); // Cached
     expect(spy).toHaveBeenCalledTimes(1); // Only one unique call
   });
 
@@ -82,15 +68,10 @@ describe('weakMapMemoize', () => {
     });
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
-    const result1 = memoizedFn(null, undefined);
-    const result2 = memoizedFn(null, undefined);
-    const result3 = memoizedFn(undefined, null);
-    const result4 = memoizedFn(null, undefined);
-
-    expect(result1).toBe('null-undefined');
-    expect(result2).toBe('null-undefined');
-    expect(result3).toBe('other');
-    expect(result4).toBe('null-undefined');
+    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
+    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
+    expect(memoizedFn(undefined, null)).toBe('other'); // Cached
+    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
     expect(spy).toHaveBeenCalledTimes(2); // Two unique calls
   });
 
@@ -102,15 +83,10 @@ describe('weakMapMemoize', () => {
     const func1 = (x: number) => x * 2;
     const func2 = (x: number) => x * 3;
 
-    const result1 = memoizedFn(func1, 5);
-    const result2 = memoizedFn(func1, 5);
-    const result3 = memoizedFn(func2, 5);
-    const result4 = memoizedFn(func1, 6);
-
-    expect(result1).toBe(10);
-    expect(result2).toBe(10);
-    expect(result3).toBe(15);
-    expect(result4).toBe(12);
+    expect(memoizedFn(func1, 5)).toBe(10); // Cached
+    expect(memoizedFn(func1, 5)).toBe(10); // Cached
+    expect(memoizedFn(func2, 5)).toBe(15); // Cached
+    expect(memoizedFn(func1, 6)).toBe(12); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -122,15 +98,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {key: 'value1'};
     const obj2 = {key: 'value2'};
 
-    const result1 = memoizedFn(1, 'test', obj1);
-    const result2 = memoizedFn(1, 'test', obj1);
-    const result3 = memoizedFn(1, 'test', obj2);
-    const result4 = memoizedFn(2, 'test', obj1);
-
-    expect(result1).toBe('1-test-value1');
-    expect(result2).toBe('1-test-value1');
-    expect(result3).toBe('1-test-value2');
-    expect(result4).toBe('2-test-value1');
+    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1'); // Cached
+    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1'); // Cached
+    expect(memoizedFn(1, 'test', obj2)).toBe('1-test-value2'); // Cached
+    expect(memoizedFn(2, 'test', obj1)).toBe('2-test-value1'); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -142,15 +113,10 @@ describe('weakMapMemoize', () => {
     const array1 = [1, 2, 3];
     const array2 = [4, 5, 6];
 
-    const result1 = memoizedFn(array1);
-    const result2 = memoizedFn(array1);
-    const result3 = memoizedFn(array2);
-    const result4 = memoizedFn([1, 2, 3]); // Different reference
-
-    expect(result1).toBe(6);
-    expect(result2).toBe(6);
-    expect(result3).toBe(15);
-    expect(result4).toBe(6);
+    expect(memoizedFn(array1)).toBe(6); // Cached
+    expect(memoizedFn(array1)).toBe(6); // Cached
+    expect(memoizedFn(array2)).toBe(15); // Cached
+    expect(memoizedFn([1, 2, 3])).toBe(6); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -162,15 +128,10 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: symbol, b: number) => a.toString() + b);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 4});
 
-    const result1 = memoizedFn(sym1, 10);
-    const result2 = memoizedFn(sym1, 10);
-    const result3 = memoizedFn(sym2, 10);
-    const result4 = memoizedFn(sym1, 20);
-
-    expect(result1).toBe(`${sym1.toString()}10`);
-    expect(result2).toBe(`${sym1.toString()}10`);
-    expect(result3).toBe(`${sym2.toString()}10`);
-    expect(result4).toBe(`${sym1.toString()}20`);
+    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`); // Cached
+    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`); // Cached
+    expect(memoizedFn(sym2, 10)).toBe(`${sym2.toString()}10`); // Cached
+    expect(memoizedFn(sym1, 20)).toBe(`${sym1.toString()}20`); // Cached
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -186,19 +147,12 @@ describe('weakMapMemoize', () => {
     const args5 = [6, 5, 4, 3, 2];
     const args6 = [1, 2, 3, 4, 7];
 
-    const result1 = memoizedFn(...args1);
-    const result2 = memoizedFn(...args2);
-    const result3 = memoizedFn(...args3);
-    const result4 = memoizedFn(...args4);
-    const result5 = memoizedFn(...args5);
-    const result6 = memoizedFn(...args6);
-
-    expect(result1).toBe(15);
-    expect(result2).toBe(15);
-    expect(result3).toBe(15);
-    expect(result4).toBe(16);
-    expect(result5).toBe(20);
-    expect(result6).toBe(17);
+    expect(memoizedFn(...args1)).toBe(15); // Cached
+    expect(memoizedFn(...args2)).toBe(15); // Cached
+    expect(memoizedFn(...args3)).toBe(15); // Cached
+    expect(memoizedFn(...args4)).toBe(16); // Cached
+    expect(memoizedFn(...args5)).toBe(20); // Cached
+    expect(memoizedFn(...args6)).toBe(17); // Cached
     expect(spy).toHaveBeenCalledTimes(5); // Five unique calls (args1, args3, args4, args5, args6)
   });
 
@@ -223,45 +177,26 @@ describe('weakMapMemoize', () => {
     const object5 = {b: 20}; // Corrected to have 'b' property
     const object6 = {c: 25}; // Corrected to have 'c' property
 
-    // First unique call
-    const result1 = memoizedFn(object1, 'test', object2, true, object3, 20); // 5 +4 +10 +1 +15 +20 =55
-
-    // Different object in first argument
-    const result2 = memoizedFn(object4, 'test', object2, true, object3, 20); // 30 +4 +10 +1 +15 +20 =55
-
-    // Different primitive in second argument
-    const result3 = memoizedFn(object1, 'testing', object2, true, object3, 20); //5 +7 +10 +1 +15 +20=58
-
-    // Different object in third argument
-    const result4 = memoizedFn(object1, 'test', object5, true, object3, 20); //5 +4 +20 +1 +15 +20=65
-
-    // Different primitive in fourth argument
-    const result5 = memoizedFn(object1, 'test', object2, false, object3, 20); //5 +4 +10 +0 +15 +20=54
-
-    // Different object in fifth argument
-    const result6 = memoizedFn(object1, 'test', object2, true, object6, 20); //5 +4 +10 +1 +25 +20=65
-
-    // Different primitive in sixth argument
-    const result7 = memoizedFn(object1, 'test', object2, true, object3, 30); //5 +4 +10 +1 +15 +30=65
-
-    // Different objects and primitives
-    const result8 = memoizedFn(object1, 'testing', object2, false, object3, 30); //5 +7 +10 +0 +15 +30=67
-
-    // Duplicate of the first call again
-    const result9 = memoizedFn(object1, 'test', object2, true, object3, 20);
-    expect(result1).toBe(5 + 4 + 10 + 1 + 15 + 20); // 55
-    expect(result2).toBe(30 + 4 + 10 + 1 + 15 + 20); // Cached
-    expect(result3).toBe(5 + 7 + 10 + 1 + 15 + 20); // 58
-    expect(result4).toBe(5 + 4 + 20 + 1 + 15 + 20); // 65
-    expect(result5).toBe(5 + 4 + 10 + 0 + 15 + 20); // 54
-    expect(result6).toBe(5 + 4 + 10 + 1 + 25 + 20); // 65
-    expect(result7).toBe(5 + 4 + 10 + 1 + 15 + 30); // 65
-    expect(result8).toBe(5 + 7 + 10 + 0 + 15 + 30); // 67
-    expect(result9).toBe(55); // Cached
+    expect(memoizedFn(object1, 'test', object2, true, object3, 20)).toBe(5 + 4 + 10 + 1 + 15 + 20); // 55
+    expect(memoizedFn(object4, 'test', object2, true, object3, 20)).toBe(30 + 4 + 10 + 1 + 15 + 20); // 80
+    expect(memoizedFn(object1, 'testing', object2, true, object3, 20)).toBe(
+      5 + 7 + 10 + 1 + 15 + 20,
+    ); // 58
+    expect(memoizedFn(object1, 'test', object5, true, object3, 20)).toBe(5 + 4 + 20 + 1 + 15 + 20); // 65
+    expect(memoizedFn(object1, 'test', object2, false, object3, 20)).toBe(5 + 4 + 10 + 0 + 15 + 20); // 54
+    expect(memoizedFn(object1, 'test', object2, true, object6, 20)).toBe(5 + 4 + 10 + 1 + 25 + 20); // 65
+    expect(memoizedFn(object1, 'test', object2, true, object3, 30)).toBe(5 + 4 + 10 + 1 + 15 + 30); // 65
+    expect(memoizedFn(object1, 'testing', object2, false, object3, 30)).toBe(
+      5 + 7 + 10 + 0 + 15 + 30,
+    ); // 67
+    expect(memoizedFn(object1, 'test', object2, true, object3, 20)).toBe(55); // Cached
 
     // spy should be called for each unique combination
-    // Unique calls: result1, result3, result4, result5, result6, result7, result8
-    // Total unique calls: 7
+    // Unique calls: object1-test-object2-true-object3-20, object4-test-object2-true-object3-20,
+    // object1-testing-object2-true-object3-20, object1-test-object5-true-object3-20,
+    // object1-test-object2-false-object3-20, object1-test-object2-true-object6-20,
+    // object1-test-object2-true-object3-30, object1-testing-object2-false-object3-30
+    // Total unique calls: 8
     expect(spy).toHaveBeenCalledTimes(9);
   });
 
@@ -270,22 +205,52 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: number) => a * 2);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
-    const result1 = memoizedFn(1); // Cached
-    const result2 = memoizedFn(2); // Cached
-    const result3 = memoizedFn(3); // Evicts least recently used (1)
-    const result4 = memoizedFn(2); // Cached, updates recentness
-    const result5 = memoizedFn(4); // Evicts least recently used (3)
-
-    expect(result1).toBe(2);
-    expect(result2).toBe(4);
-    expect(result3).toBe(6);
-    expect(result4).toBe(4);
-    expect(result5).toBe(8);
+    expect(memoizedFn(1)).toBe(2); // Cached
+    expect(memoizedFn(2)).toBe(4); // Cached
+    expect(memoizedFn(3)).toBe(6); // Evicts least recently used (1)
+    expect(memoizedFn(2)).toBe(4); // Cached, updates recentness
+    expect(memoizedFn(4)).toBe(8); // Evicts least recently used (3)
     expect(spy).toHaveBeenCalledTimes(4); // Calls for 1,2,3,4
 
     // Accessing 1 again should trigger a new call since it was evicted
-    const result6 = memoizedFn(1);
-    expect(result6).toBe(2);
+    expect(memoizedFn(1)).toBe(2); // Cached
     expect(spy).toHaveBeenCalledTimes(5); // Call for 1 again
+  });
+
+  // Test 13: Should handle mixed argument types in same slot
+  it('Should handle mixed argument types in same slot', () => {
+    const spy = jest.fn((a: any, b: any) => {
+      const toString = (arg: any) => (typeof arg === 'object' ? Object.keys(arg).length : arg);
+      return toString(a) + toString(b);
+    });
+    const memoizedFn = weakMapMemoize(spy, {maxEntries: 3});
+
+    expect(memoizedFn(1, 2)).toBe(3); // Cached
+
+    expect(memoizedFn(1, 2)).toBe(3);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    expect(memoizedFn('hello', {x: 1, y: 2})).toBe('hello2');
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // Different object reference results in another call
+    expect(memoizedFn('hello', {x: 1, y: 2})).toBe('hello2');
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    const a = {a: 1};
+    expect(memoizedFn(a, 'test')).toBe('1test');
+    expect(spy).toHaveBeenCalledTimes(4);
+
+    // same reference uses cache
+    expect(memoizedFn(a, 'test')).toBe('1test');
+    expect(spy).toHaveBeenCalledTimes(4);
+
+    // Evicts 1, 2
+    expect(memoizedFn(3, 4)).toBe(7);
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    // Evicted - results in new call
+    expect(memoizedFn(1, 2)).toBe(3);
+    expect(spy).toHaveBeenCalledTimes(6);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -8,9 +8,9 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: number, b: number) => a + b);
     const memoizedAdd = weakMapMemoize(spy, {maxEntries: 3});
 
-    expect(memoizedAdd(1, 2)).toBe(3); // Cached
-    expect(memoizedAdd(1, 2)).toBe(3); // Cached
-    expect(memoizedAdd(2, 3)).toBe(5); // Cached
+    expect(memoizedAdd(1, 2)).toBe(3);
+    expect(memoizedAdd(1, 2)).toBe(3);
+    expect(memoizedAdd(2, 3)).toBe(5);
     expect(spy).toHaveBeenCalledTimes(2); // Only two unique calls
   });
 
@@ -22,10 +22,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {x: 10};
     const obj2 = {x: 20};
 
-    expect(memoizedFn(obj1, 5)).toBe(15); // Cached
-    expect(memoizedFn(obj1, 5)).toBe(15); // Cached
-    expect(memoizedFn(obj2, 5)).toBe(25); // Cached
-    expect(memoizedFn(obj1, 6)).toBe(16); // Cached
+    expect(memoizedFn(obj1, 5)).toBe(15);
+    expect(memoizedFn(obj1, 5)).toBe(15);
+    expect(memoizedFn(obj2, 5)).toBe(25);
+    expect(memoizedFn(obj1, 6)).toBe(16);
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -37,10 +37,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {y: 100};
     const obj2 = {y: 200};
 
-    expect(memoizedFn(1, obj1)).toBe(101); // Cached
-    expect(memoizedFn(1, obj1)).toBe(101); // Cached
-    expect(memoizedFn(2, obj1)).toBe(102); // Cached
-    expect(memoizedFn(1, obj2)).toBe(201); // Cached
+    expect(memoizedFn(1, obj1)).toBe(101);
+    expect(memoizedFn(1, obj1)).toBe(101);
+    expect(memoizedFn(2, obj1)).toBe(102);
+    expect(memoizedFn(1, obj2)).toBe(201);
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -53,8 +53,8 @@ describe('weakMapMemoize', () => {
     const result2 = memoizedFn();
     const result3 = memoizedFn();
 
-    expect(result1).toBe(result2); // Cached
-    expect(result2).toBe(result3); // Cached
+    expect(result1).toBe(result2);
+    expect(result2).toBe(result3);
     expect(spy).toHaveBeenCalledTimes(1); // Only one unique call
   });
 
@@ -68,10 +68,10 @@ describe('weakMapMemoize', () => {
     });
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
-    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
-    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
-    expect(memoizedFn(undefined, null)).toBe('other'); // Cached
-    expect(memoizedFn(null, undefined)).toBe('null-undefined'); // Cached
+    expect(memoizedFn(null, undefined)).toBe('null-undefined');
+    expect(memoizedFn(null, undefined)).toBe('null-undefined');
+    expect(memoizedFn(undefined, null)).toBe('other');
+    expect(memoizedFn(null, undefined)).toBe('null-undefined');
     expect(spy).toHaveBeenCalledTimes(2); // Two unique calls
   });
 
@@ -83,10 +83,10 @@ describe('weakMapMemoize', () => {
     const func1 = (x: number) => x * 2;
     const func2 = (x: number) => x * 3;
 
-    expect(memoizedFn(func1, 5)).toBe(10); // Cached
-    expect(memoizedFn(func1, 5)).toBe(10); // Cached
-    expect(memoizedFn(func2, 5)).toBe(15); // Cached
-    expect(memoizedFn(func1, 6)).toBe(12); // Cached
+    expect(memoizedFn(func1, 5)).toBe(10);
+    expect(memoizedFn(func1, 5)).toBe(10);
+    expect(memoizedFn(func2, 5)).toBe(15);
+    expect(memoizedFn(func1, 6)).toBe(12);
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -98,10 +98,10 @@ describe('weakMapMemoize', () => {
     const obj1 = {key: 'value1'};
     const obj2 = {key: 'value2'};
 
-    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1'); // Cached
-    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1'); // Cached
-    expect(memoizedFn(1, 'test', obj2)).toBe('1-test-value2'); // Cached
-    expect(memoizedFn(2, 'test', obj1)).toBe('2-test-value1'); // Cached
+    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1');
+    expect(memoizedFn(1, 'test', obj1)).toBe('1-test-value1');
+    expect(memoizedFn(1, 'test', obj2)).toBe('1-test-value2');
+    expect(memoizedFn(2, 'test', obj1)).toBe('2-test-value1');
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -113,10 +113,10 @@ describe('weakMapMemoize', () => {
     const array1 = [1, 2, 3];
     const array2 = [4, 5, 6];
 
-    expect(memoizedFn(array1)).toBe(6); // Cached
-    expect(memoizedFn(array1)).toBe(6); // Cached
-    expect(memoizedFn(array2)).toBe(15); // Cached
-    expect(memoizedFn([1, 2, 3])).toBe(6); // Cached
+    expect(memoizedFn(array1)).toBe(6);
+    expect(memoizedFn(array1)).toBe(6);
+    expect(memoizedFn(array2)).toBe(15);
+    expect(memoizedFn([1, 2, 3])).toBe(6);
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -128,10 +128,10 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: symbol, b: number) => a.toString() + b);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 4});
 
-    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`); // Cached
-    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`); // Cached
-    expect(memoizedFn(sym2, 10)).toBe(`${sym2.toString()}10`); // Cached
-    expect(memoizedFn(sym1, 20)).toBe(`${sym1.toString()}20`); // Cached
+    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`);
+    expect(memoizedFn(sym1, 10)).toBe(`${sym1.toString()}10`);
+    expect(memoizedFn(sym2, 10)).toBe(`${sym2.toString()}10`);
+    expect(memoizedFn(sym1, 20)).toBe(`${sym1.toString()}20`);
     expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
   });
 
@@ -147,12 +147,12 @@ describe('weakMapMemoize', () => {
     const args5 = [6, 5, 4, 3, 2];
     const args6 = [1, 2, 3, 4, 7];
 
-    expect(memoizedFn(...args1)).toBe(15); // Cached
-    expect(memoizedFn(...args2)).toBe(15); // Cached
-    expect(memoizedFn(...args3)).toBe(15); // Cached
-    expect(memoizedFn(...args4)).toBe(16); // Cached
-    expect(memoizedFn(...args5)).toBe(20); // Cached
-    expect(memoizedFn(...args6)).toBe(17); // Cached
+    expect(memoizedFn(...args2)).toBe(15);
+    expect(memoizedFn(...args1)).toBe(15);
+    expect(memoizedFn(...args3)).toBe(15);
+    expect(memoizedFn(...args4)).toBe(16);
+    expect(memoizedFn(...args5)).toBe(20);
+    expect(memoizedFn(...args6)).toBe(17);
     expect(spy).toHaveBeenCalledTimes(5); // Five unique calls (args1, args3, args4, args5, args6)
   });
 
@@ -192,11 +192,6 @@ describe('weakMapMemoize', () => {
     expect(memoizedFn(object1, 'test', object2, true, object3, 20)).toBe(55); // Cached
 
     // spy should be called for each unique combination
-    // Unique calls: object1-test-object2-true-object3-20, object4-test-object2-true-object3-20,
-    // object1-testing-object2-true-object3-20, object1-test-object5-true-object3-20,
-    // object1-test-object2-false-object3-20, object1-test-object2-true-object6-20,
-    // object1-test-object2-true-object3-30, object1-testing-object2-false-object3-30
-    // Total unique calls: 8
     expect(spy).toHaveBeenCalledTimes(9);
   });
 
@@ -205,8 +200,8 @@ describe('weakMapMemoize', () => {
     const spy = jest.fn((a: number) => a * 2);
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 2});
 
-    expect(memoizedFn(1)).toBe(2); // Cached
-    expect(memoizedFn(2)).toBe(4); // Cached
+    expect(memoizedFn(1)).toBe(2);
+    expect(memoizedFn(2)).toBe(4);
     expect(memoizedFn(3)).toBe(6); // Evicts least recently used (1)
     expect(memoizedFn(2)).toBe(4); // Cached, updates recentness
     expect(memoizedFn(4)).toBe(8); // Evicts least recently used (3)
@@ -225,7 +220,7 @@ describe('weakMapMemoize', () => {
     });
     const memoizedFn = weakMapMemoize(spy, {maxEntries: 3});
 
-    expect(memoizedFn(1, 2)).toBe(3); // Cached
+    expect(memoizedFn(1, 2)).toBe(3);
 
     expect(memoizedFn(1, 2)).toBe(3);
     expect(spy).toHaveBeenCalledTimes(1);

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/weakMapMemoize.test.ts
@@ -1,0 +1,261 @@
+import {weakMapMemoize} from '../weakMapMemoize';
+
+type AnyFunction = (...args: any[]) => any;
+
+describe('weakMapMemoize', () => {
+  // Test 1: Function with primitive arguments
+  it('should memoize correctly with primitive arguments and avoid redundant calls', () => {
+    const spy = jest.fn((a: number, b: number) => a + b);
+    const memoizedAdd = weakMapMemoize(spy);
+
+    const result1 = memoizedAdd(1, 2);
+    const result2 = memoizedAdd(1, 2);
+    const result3 = memoizedAdd(2, 3);
+
+    expect(result1).toBe(3);
+    expect(result2).toBe(3);
+    expect(result3).toBe(5);
+    expect(spy).toHaveBeenCalledTimes(2); // Only two unique calls
+  });
+
+  // Test 2: Function with object arguments
+  it('should memoize correctly based on object references', () => {
+    const spy = jest.fn((obj: {x: number}, y: number) => obj.x + y);
+    const memoizedFn = weakMapMemoize(spy);
+
+    const obj1 = {x: 10};
+    const obj2 = {x: 20};
+
+    const result1 = memoizedFn(obj1, 5);
+    const result2 = memoizedFn(obj1, 5);
+    const result3 = memoizedFn(obj2, 5);
+    const result4 = memoizedFn(obj1, 6);
+
+    expect(result1).toBe(15);
+    expect(result2).toBe(15);
+    expect(result3).toBe(25);
+    expect(result4).toBe(16);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 3: Function with mixed arguments
+  it('should memoize correctly with mixed primitive and object arguments', () => {
+    const spy = jest.fn((a: number, obj: {y: number}) => a + obj.y);
+    const memoizedFn = weakMapMemoize(spy);
+
+    const obj1 = {y: 100};
+    const obj2 = {y: 200};
+
+    const result1 = memoizedFn(1, obj1);
+    const result2 = memoizedFn(1, obj1);
+    const result3 = memoizedFn(2, obj1);
+    const result4 = memoizedFn(1, obj2);
+
+    expect(result1).toBe(101);
+    expect(result2).toBe(101);
+    expect(result3).toBe(102);
+    expect(result4).toBe(201);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 4: Function with no arguments
+  it('should memoize the result when function has no arguments', () => {
+    const spy = jest.fn(() => Math.random());
+    const memoizedFn = weakMapMemoize(spy);
+
+    const result1 = memoizedFn();
+    const result2 = memoizedFn();
+    const result3 = memoizedFn();
+
+    expect(result1).toBe(result2);
+    expect(result2).toBe(result3);
+    expect(spy).toHaveBeenCalledTimes(1); // Only one unique call
+  });
+
+  // Test 5: Function with null and undefined arguments
+  it('should handle null and undefined arguments correctly', () => {
+    const spy = jest.fn((a: any, b: any) => {
+      if (a === null && b === undefined) {
+        return 'null-undefined';
+      }
+      return 'other';
+    });
+    const memoizedFn = weakMapMemoize(spy);
+
+    const result1 = memoizedFn(null, undefined);
+    const result2 = memoizedFn(null, undefined);
+    const result3 = memoizedFn(undefined, null);
+    const result4 = memoizedFn(null, undefined);
+
+    expect(result1).toBe('null-undefined');
+    expect(result2).toBe('null-undefined');
+    expect(result3).toBe('other');
+    expect(result4).toBe('null-undefined');
+    expect(spy).toHaveBeenCalledTimes(2); // Two unique calls
+  });
+
+  // Test 6: Function with function arguments
+  it('should memoize based on function references', () => {
+    const spy = jest.fn((fn: AnyFunction, value: number) => fn(value));
+    const memoizedFn = weakMapMemoize(spy);
+
+    const func1 = (x: number) => x * 2;
+    const func2 = (x: number) => x * 3;
+
+    const result1 = memoizedFn(func1, 5);
+    const result2 = memoizedFn(func1, 5);
+    const result3 = memoizedFn(func2, 5);
+    const result4 = memoizedFn(func1, 6);
+
+    expect(result1).toBe(10);
+    expect(result2).toBe(10);
+    expect(result3).toBe(15);
+    expect(result4).toBe(12);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 7: Function with multiple mixed arguments
+  it('should memoize correctly with multiple mixed argument types', () => {
+    const spy = jest.fn((a: number, b: string, c: {key: string}) => `${a}-${b}-${c.key}`);
+    const memoizedFn = weakMapMemoize(spy);
+
+    const obj1 = {key: 'value1'};
+    const obj2 = {key: 'value2'};
+
+    const result1 = memoizedFn(1, 'test', obj1);
+    const result2 = memoizedFn(1, 'test', obj1);
+    const result3 = memoizedFn(1, 'test', obj2);
+    const result4 = memoizedFn(2, 'test', obj1);
+
+    expect(result1).toBe('1-test-value1');
+    expect(result2).toBe('1-test-value1');
+    expect(result3).toBe('1-test-value2');
+    expect(result4).toBe('2-test-value1');
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 8: Function with array arguments
+  it('should memoize based on array references', () => {
+    const spy = jest.fn((arr: number[]) => arr.reduce((sum, val) => sum + val, 0));
+    const memoizedFn = weakMapMemoize(spy);
+
+    const array1 = [1, 2, 3];
+    const array2 = [4, 5, 6];
+
+    const result1 = memoizedFn(array1);
+    const result2 = memoizedFn(array1);
+    const result3 = memoizedFn(array2);
+    const result4 = memoizedFn([1, 2, 3]); // Different reference
+
+    expect(result1).toBe(6);
+    expect(result2).toBe(6);
+    expect(result3).toBe(15);
+    expect(result4).toBe(6);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 9: Function with symbols as arguments
+  it('should memoize based on symbol references', () => {
+    const sym1 = Symbol('sym1');
+    const sym2 = Symbol('sym2');
+
+    const spy = jest.fn((a: symbol, b: number) => a.toString() + b);
+    const memoizedFn = weakMapMemoize(spy);
+
+    const result1 = memoizedFn(sym1, 10);
+    const result2 = memoizedFn(sym1, 10);
+    const result3 = memoizedFn(sym2, 10);
+    const result4 = memoizedFn(sym1, 20);
+
+    expect(result1).toBe(`${sym1.toString()}10`);
+    expect(result2).toBe(`${sym1.toString()}10`);
+    expect(result3).toBe(`${sym2.toString()}10`);
+    expect(result4).toBe(`${sym1.toString()}20`);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 10: Function with a large number of arguments
+  it('should memoize correctly with a large number of arguments', () => {
+    const spy = jest.fn((...args: number[]) => args.reduce((sum, val) => sum + val, 0));
+    const memoizedFn = weakMapMemoize(spy);
+
+    const args1 = [1, 2, 3, 4, 5];
+    const args2 = [1, 2, 3, 4, 5];
+    const args3 = [5, 4, 3, 2, 1];
+    const args4 = [1, 2, 3, 4, 6];
+
+    const result1 = memoizedFn(...args1);
+    const result2 = memoizedFn(...args2);
+    const result3 = memoizedFn(...args3);
+    const result4 = memoizedFn(...args4);
+
+    expect(result1).toBe(15);
+    expect(result2).toBe(15);
+    expect(result3).toBe(15);
+    expect(result4).toBe(16);
+    expect(spy).toHaveBeenCalledTimes(3); // Three unique calls
+  });
+
+  // Test 11: Function with alternating object and primitive arguments
+  it('should memoize correctly with alternating object and primitive arguments', () => {
+    const spy = jest.fn(
+      (
+        obj1: {a: number},
+        prim1: string,
+        obj2: {b: number},
+        prim2: boolean,
+        obj3: {c: number},
+        prim3: number,
+      ) => obj1.a + prim1.length + obj2.b + (prim2 ? 1 : 0) + obj3.c + prim3,
+    );
+    const memoizedFn = weakMapMemoize(spy);
+
+    const object1 = {a: 5};
+    const object2 = {b: 10};
+    const object3 = {c: 15};
+
+    // First unique call
+    const result1 = memoizedFn(object1, 'test', object2, true, object3, 20);
+
+    // Duplicate of the first call
+    const result2 = memoizedFn(object1, 'test', object2, true, object3, 20);
+
+    // Different primitive in second argument
+    const result3 = memoizedFn(object1, 'testing', object2, true, object3, 20);
+
+    // Different object in third argument
+    const object4 = {b: 20};
+    const result4 = memoizedFn(object1, 'test', object4, true, object3, 20);
+
+    // Different primitive in fourth argument
+    const result5 = memoizedFn(object1, 'test', object2, false, object3, 20);
+
+    // Different object in fifth argument
+    const object5 = {c: 25};
+    const result6 = memoizedFn(object1, 'test', object2, true, object5, 20);
+
+    // Different primitive in sixth argument
+    const result7 = memoizedFn(object1, 'test', object2, true, object3, 30);
+
+    // Different objects and primitives
+    const result8 = memoizedFn(object1, 'testing', object2, false, object5, 30);
+
+    // Duplicate of the first call again
+    const result9 = memoizedFn(object1, 'test', object2, true, object3, 20);
+
+    expect(result1).toBe(5 + 4 + 10 + 1 + 15 + 20); // 5 + 4 + 10 + 1 + 15 + 20 = 55
+    expect(result2).toBe(55); // Cached
+    expect(result3).toBe(5 + 7 + 10 + 1 + 15 + 20); // 5 + 7 + 10 + 1 + 15 + 20 = 58
+    expect(result4).toBe(5 + 4 + 20 + 1 + 15 + 20); // 5 + 4 + 20 + 1 + 15 + 20 = 65
+    expect(result5).toBe(5 + 4 + 10 + 0 + 15 + 20); // 5 + 4 + 10 + 0 + 15 + 20 = 54
+    expect(result6).toBe(5 + 4 + 10 + 1 + 25 + 20); // 5 + 4 + 10 + 1 + 25 + 20 = 65
+    expect(result7).toBe(5 + 4 + 10 + 1 + 15 + 30); // 5 + 4 + 10 + 1 + 15 + 30 = 65
+    expect(result8).toBe(5 + 7 + 10 + 0 + 25 + 30); // 5 + 7 + 25 + 0 + 15 + 30 = 97
+    expect(result9).toBe(55); // Cached
+
+    // spy should be called for each unique combination
+    // Unique calls: result1, result3, result4, result5, result6, result7, result8
+    // Total unique calls: 7
+    expect(spy).toHaveBeenCalledTimes(7);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -40,16 +40,16 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
   };
 
   // Initialize LRU Cache if maxEntries is specified
-  let lruCache: LRU.Cache<any, any> | null = null;
+  let lruCache: LRU<any, any> | null = null;
 
   if (maxEntries) {
     lruCache = new LRU<any, any>({
       max: maxEntries,
-      dispose: (key, value) => {
+      dispose: (key, _value) => {
         // When an entry is evicted from the LRU cache,
         // traverse the cache tree and remove the cached result
         const keyPath = key as any[];
-        let currentCache = cacheRoot;
+        let currentCache: CacheNode | undefined = cacheRoot;
 
         for (let i = 0; i < keyPath.length; i++) {
           const arg = keyPath[i];

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -1,54 +1,105 @@
+import LRU from 'lru-cache';
+
 type AnyFunction = (...args: any[]) => any;
 
+interface WeakMapMemoizeOptions {
+  maxEntries?: number; // Optional limit for cached entries
+}
+
+interface CacheNode {
+  map: Map<any, CacheNode>;
+  weakMap: WeakMap<object, CacheNode>;
+  result?: any;
+  lruKey?: any; // Reference to the key in the LRU cache
+}
+
+/**
+ * Determines if a value is a non-null object or function.
+ * @param value - The value to check.
+ * @returns True if the value is a non-null object or function, false otherwise.
+ */
 function isObject(value: any): value is object {
   return value !== null && (typeof value === 'object' || typeof value === 'function');
 }
 
 /**
- * Interface representing a cache node that holds both a Map for primitive keys
- * and a WeakMap for object keys.
- */
-interface CacheNode {
-  map: Map<any, CacheNode>;
-  weakMap: WeakMap<object, CacheNode>;
-  result?: any;
-}
-
-/**
  * Memoizes a function using nested Maps and WeakMaps based on the arguments.
- * Handles both primitive and object arguments.
+ * Optionally limits the number of cached entries using an LRU cache.
+ * Handles both primitive and object arguments efficiently.
  * @param fn - The function to memoize.
+ * @param options - Optional settings for memoization.
  * @returns A memoized version of the function.
  */
-export function weakMapMemoize<T extends AnyFunction>(fn: T): T {
+export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMemoizeOptions): T {
+  const {maxEntries} = options || {};
+
   // Initialize the root cache node
   const cacheRoot: CacheNode = {
     map: new Map(),
     weakMap: new WeakMap(),
   };
 
+  // Initialize LRU Cache if maxEntries is specified
+  let lruCache: LRU.Cache<any, any> | null = null;
+
+  if (maxEntries) {
+    lruCache = new LRU<any, any>({
+      max: maxEntries,
+      dispose: (key, value) => {
+        // When an entry is evicted from the LRU cache,
+        // traverse the cache tree and remove the cached result
+        const keyPath = key as any[];
+        let currentCache = cacheRoot;
+
+        for (let i = 0; i < keyPath.length; i++) {
+          const arg = keyPath[i];
+          const isArgObject = isObject(arg);
+
+          if (isArgObject) {
+            currentCache = currentCache.weakMap.get(arg);
+          } else {
+            currentCache = currentCache.map.get(arg);
+          }
+
+          if (!currentCache) {
+            // The cache node has already been removed
+            return;
+          }
+        }
+
+        // Remove the cached result
+        delete currentCache.result;
+        delete currentCache.lruKey;
+      },
+    });
+  }
+
   return function memoizedFunction(this: any, ...args: any[]) {
     let currentCache = cacheRoot;
+    const path: any[] = [];
 
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
+      path.push(arg);
+      const isArgObject = isObject(arg);
 
-      if (isObject(arg)) {
-        // Use WeakMap for object keys
+      // Determine the appropriate cache level
+      if (isArgObject) {
         if (!currentCache.weakMap.has(arg)) {
-          currentCache.weakMap.set(arg, {
+          const newCacheNode: CacheNode = {
             map: new Map(),
             weakMap: new WeakMap(),
-          });
+          };
+          currentCache.weakMap.set(arg, newCacheNode);
         }
         currentCache = currentCache.weakMap.get(arg)!;
       } else {
-        // Use Map for primitive keys
         if (!currentCache.map.has(arg)) {
-          currentCache.map.set(arg, {
+          const newCacheNode: CacheNode = {
             map: new Map(),
             weakMap: new WeakMap(),
-          });
+          };
+          currentCache.map.set(arg, newCacheNode);
         }
         currentCache = currentCache.map.get(arg)!;
       }
@@ -56,11 +107,27 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T): T {
 
     // After traversing all arguments, check if the result is cached
     if ('result' in currentCache) {
+      // If using LRU Cache, update its usage
+      if (lruCache && currentCache.lruKey) {
+        lruCache.get(currentCache.lruKey); // This updates the recentness
+      }
       return currentCache.result;
     }
-    // Compute the result and cache it
+
+    // Compute the result
     const result = fn.apply(this, args);
+
+    // Cache the result
     currentCache.result = result;
+
+    // If LRU cache is enabled, manage the cache entries
+    if (lruCache) {
+      const cacheEntryKey: any[] = path.slice(); // Clone the path to ensure uniqueness
+      currentCache.lruKey = cacheEntryKey; // Associate the cache node with the LRU key
+
+      lruCache.set(cacheEntryKey, currentCache);
+    }
+
     return result;
   } as T;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -115,7 +115,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
     }
 
     // Compute the result
-    const result = fn.apply(this, args);
+    const result = fn(...args);
 
     // Cache the result
     currentCache.result = result;

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -122,7 +122,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
 
     // If LRU cache is enabled, manage the cache entries
     if (lruCache) {
-      const cacheEntryKey: any[] = path.slice(); // Clone the path to ensure uniqueness
+      const cacheEntryKey = Symbol();
       currentCache.lruKey = cacheEntryKey; // Associate the cache node with the LRU key
 
       lruCache.set(cacheEntryKey, currentCache);

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -1,0 +1,66 @@
+type AnyFunction = (...args: any[]) => any;
+
+function isObject(value: any): value is object {
+  return value !== null && (typeof value === 'object' || typeof value === 'function');
+}
+
+/**
+ * Interface representing a cache node that holds both a Map for primitive keys
+ * and a WeakMap for object keys.
+ */
+interface CacheNode {
+  map: Map<any, CacheNode>;
+  weakMap: WeakMap<object, CacheNode>;
+  result?: any;
+}
+
+/**
+ * Memoizes a function using nested Maps and WeakMaps based on the arguments.
+ * Handles both primitive and object arguments.
+ * @param fn - The function to memoize.
+ * @returns A memoized version of the function.
+ */
+export function weakMapMemoize<T extends AnyFunction>(fn: T): T {
+  // Initialize the root cache node
+  const cacheRoot: CacheNode = {
+    map: new Map(),
+    weakMap: new WeakMap(),
+  };
+
+  return function memoizedFunction(this: any, ...args: any[]) {
+    let currentCache = cacheRoot;
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+
+      if (isObject(arg)) {
+        // Use WeakMap for object keys
+        if (!currentCache.weakMap.has(arg)) {
+          currentCache.weakMap.set(arg, {
+            map: new Map(),
+            weakMap: new WeakMap(),
+          });
+        }
+        currentCache = currentCache.weakMap.get(arg)!;
+      } else {
+        // Use Map for primitive keys
+        if (!currentCache.map.has(arg)) {
+          currentCache.map.set(arg, {
+            map: new Map(),
+            weakMap: new WeakMap(),
+          });
+        }
+        currentCache = currentCache.map.get(arg)!;
+      }
+    }
+
+    // After traversing all arguments, check if the result is cached
+    if ('result' in currentCache) {
+      return currentCache.result;
+    }
+    // Compute the result and cache it
+    const result = fn.apply(this, args);
+    currentCache.result = result;
+    return result;
+  } as T;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -1,5 +1,3 @@
-// src/utils/weakMapMemoize.ts
-
 import LRU from 'lru-cache';
 
 type AnyFunction = (...args: any[]) => any;

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -74,7 +74,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
     });
   }
 
-  return function memoizedFunction(this: any, ...args: any[]) {
+  return function memoizedFunction(...args: any[]) {
     let currentCache = cacheRoot;
     const path: any[] = [];
 

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -122,7 +122,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
 
     // If LRU cache is enabled, manage the cache entries
     if (lruCache) {
-      const cacheEntryKey: any[] = path.slice(); // Clone the path to ensure uniqueness
+      const cacheEntryKey: any[] = path.slice(); // Store the whole path so that we can use it in the dispose call to clear the cache
       currentCache.lruKey = cacheEntryKey; // Associate the cache node with the LRU key
 
       lruCache.set(cacheEntryKey, currentCache);

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -58,12 +58,6 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
           } else {
             parent.map.delete(parentKey);
           }
-
-          // Remove references to help garbage collection
-          delete cacheNode.parent;
-          delete cacheNode.parentKey;
-          delete cacheNode.result;
-          delete cacheNode.lruKey;
         }
       },
       noDisposeOnSet: false, // Ensure dispose is called on eviction

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -122,7 +122,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
 
     // If LRU cache is enabled, manage the cache entries
     if (lruCache) {
-      const cacheEntryKey = Symbol();
+      const cacheEntryKey: any[] = path.slice(); // Clone the path to ensure uniqueness
       currentCache.lruKey = cacheEntryKey; // Associate the cache node with the LRU key
 
       lruCache.set(cacheEntryKey, currentCache);


### PR DESCRIPTION
## Summary & Motivation

Introduces a memoize function thats more powerful than what lodash offers. Lodash memoize only works with string keys, and so it requires you to take your arguments and somehow serialize it to a string. Depending on the object this can be very slow if the object is big. To avoid the headache of serialization I'm adding a weakMapMemoize which is much more flexible and can cache any function mixing both primitives and objects. 

Going to use this to memoize the `filterByQuery` helpers for the GanttChart since it looks like we call the utility in a lot of different places separately and having them coordinate so that there's only 1 call is a bit tricky.


## How I Tested These Changes

jest tests