### PR TITLE
[components] Move dagster-components test component lib to dagster_components.lib.test

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
@@ -3,7 +3,7 @@ from dagster.version import __version__
 
 from dagster_components.cli.generate import generate_cli
 from dagster_components.cli.list import list_cli
-from dagster_components.core.component import BUILTIN_PUBLISHED_COMPONENT_ENTRY_POINT
+from dagster_components.core.component import BUILTIN_MAIN_COMPONENT_ENTRY_POINT
 from dagster_components.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
 
 
@@ -20,7 +20,7 @@ def create_dagster_components_cli():
     @click.option(
         "--builtin-component-lib",
         type=str,
-        default=BUILTIN_PUBLISHED_COMPONENT_ENTRY_POINT,
+        default=BUILTIN_MAIN_COMPONENT_ENTRY_POINT,
         help="Specify the builitin component library to load.",
     )
     @click.version_option(__version__, "--version", "-v")

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -32,7 +32,6 @@ from pydantic import TypeAdapter
 from typing_extensions import Self
 
 from dagster_components.core.component_rendering import TemplatedValueResolver, preprocess_value
-from dagster_components.utils import ensure_dagster_components_tests_import
 
 
 class ComponentDeclNode: ...
@@ -123,14 +122,14 @@ def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.m
 
 COMPONENTS_ENTRY_POINT_GROUP = "dagster.components"
 BUILTIN_COMPONENTS_ENTRY_POINT_BASE = "dagster_components"
-BUILTIN_PUBLISHED_COMPONENT_ENTRY_POINT = BUILTIN_COMPONENTS_ENTRY_POINT_BASE
+BUILTIN_MAIN_COMPONENT_ENTRY_POINT = BUILTIN_COMPONENTS_ENTRY_POINT_BASE
 BUILTIN_TEST_COMPONENT_ENTRY_POINT = ".".join([BUILTIN_COMPONENTS_ENTRY_POINT_BASE, "test"])
 
 
 class ComponentRegistry:
     @classmethod
     def from_entry_point_discovery(
-        cls, builtin_component_lib: str = BUILTIN_PUBLISHED_COMPONENT_ENTRY_POINT
+        cls, builtin_component_lib: str = BUILTIN_MAIN_COMPONENT_ENTRY_POINT
     ) -> "ComponentRegistry":
         """Discover components registered in the Python environment via the `dagster_components` entry point group.
 
@@ -153,11 +152,6 @@ class ComponentRegistry:
                 and not entry_point.name == builtin_component_lib
             ):
                 continue
-            elif entry_point.name == BUILTIN_TEST_COMPONENT_ENTRY_POINT:
-                if builtin_component_lib:
-                    ensure_dagster_components_tests_import()
-                else:
-                    continue
 
             root_module = entry_point.load()
             if not isinstance(root_module, ModuleType):

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/__init__.py
@@ -1,0 +1,7 @@
+from dagster_components.lib.test.all_metadata_empty_asset import (
+    AllMetadataEmptyAsset as AllMetadataEmptyAsset,
+)
+from dagster_components.lib.test.simple_asset import SimpleAsset as SimpleAsset
+from dagster_components.lib.test.simple_pipes_script_asset import (
+    SimplePipesScriptAsset as SimplePipesScriptAsset,
+)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
@@ -3,11 +3,12 @@ from typing import TYPE_CHECKING, Any
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from typing_extensions import Self
+
 from dagster_components import Component, ComponentLoadContext, component
 from dagster_components.core.component import ComponentGenerateRequest
 from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.generate import generate_component_yaml
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from dagster_components.core.component import ComponentDeclNode

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
@@ -4,12 +4,13 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from pydantic import BaseModel, TypeAdapter
+from typing_extensions import Self
+
 from dagster_components import Component, ComponentLoadContext, component
 from dagster_components.core.component import ComponentGenerateRequest
 from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.generate import generate_component_yaml
-from pydantic import BaseModel, TypeAdapter
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from dagster_components.core.component import ComponentDeclNode

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_pipes_script_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_pipes_script_asset.py
@@ -8,12 +8,13 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
+from pydantic import BaseModel, TypeAdapter
+from typing_extensions import Self
+
 from dagster_components import Component, ComponentLoadContext, component
 from dagster_components.core.component import ComponentGenerateRequest
 from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.generate import generate_component_yaml
-from pydantic import BaseModel, TypeAdapter
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from dagster_components.core.component import ComponentDeclNode

--- a/python_modules/libraries/dagster-components/dagster_components_tests/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/lib/__init__.py
@@ -1,7 +1,0 @@
-from dagster_components_tests.lib.all_metadata_empty_asset import (
-    AllMetadataEmptyAsset as AllMetadataEmptyAsset,
-)
-from dagster_components_tests.lib.simple_asset import SimpleAsset as SimpleAsset
-from dagster_components_tests.lib.simple_pipes_script_asset import (
-    SimplePipesScriptAsset as SimplePipesScriptAsset,
-)

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -46,7 +46,7 @@ setup(
         ],
         "dagster.components": [
             "dagster_components = dagster_components.lib",
-            "dagster_components.test = dagster_components_tests.lib",
+            "dagster_components.test = dagster_components.lib.test",
         ],
     },
     extras_require={

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -33,7 +33,7 @@ def test_cache_invalidation_uv_lock():
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
-        subprocess.run(["uv", "add", "dagster-components[dbt]"], check=True)
+        subprocess.run(["uv", "add", "dagster-components[dbt]", "dagster-dbt"], check=True)
 
         result = runner.invoke("list", "component-types")
         assert_runner_result(result)


### PR DESCRIPTION
## Summary & Motivation

Move the `dagster-components` test component library from `dagster_components_tests.lib` to `dagster_components.lib.test`. This lets us simplify entry point loading code (eliminate call to `ensure_dagster_components_tests_import`) and also ensures these components are accessible whether from a published `dagster-components` or local (we don't include our test packages in published distributions as a rule)

## How I Tested These Changes

Existing test suite.