### PR TITLE
[dagster-dbt][refactor] Clean up multi-asset creation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -101,7 +101,7 @@ class AssetKey(IHaveNew):
         if suffix is not None:
             path.append(suffix)
 
-        return "__".join(path).replace("-", "_")
+        return "__".join(path).replace("-", "_").replace(".", "_")
 
     @staticmethod
     def from_user_string(asset_key_string: str) -> "AssetKey":

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -14,7 +14,7 @@ from dagster._utils.warnings import suppress_dagster_warnings
 from dagster_dbt.asset_utils import (
     DAGSTER_DBT_EXCLUDE_METADATA_KEY,
     DAGSTER_DBT_SELECT_METADATA_KEY,
-    build_dbt_multi_asset_args,
+    build_dbt_specs,
 )
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
@@ -302,14 +302,9 @@ def dbt_assets(
     dagster_dbt_translator = validate_translator(dagster_dbt_translator or DagsterDbtTranslator())
     manifest = validate_manifest(manifest)
 
-    (
-        deps,
-        outs,
-        internal_asset_deps,
-        check_specs,
-    ) = build_dbt_multi_asset_args(
+    specs, check_specs = build_dbt_specs(
+        translator=dagster_dbt_translator,
         manifest=manifest,
-        dagster_dbt_translator=dagster_dbt_translator,
         select=select,
         exclude=exclude or "",
         io_manager_key=io_manager_key,
@@ -342,15 +337,13 @@ def dbt_assets(
         backfill_policy = BackfillPolicy.single_run()
 
     return multi_asset(
-        outs=outs,
         name=name,
-        internal_asset_deps=internal_asset_deps,
-        deps=deps,
+        specs=specs,
+        check_specs=check_specs,
+        can_subset=True,
         required_resource_keys=required_resource_keys,
         partitions_def=partitions_def,
-        can_subset=True,
         op_tags=resolved_op_tags,
-        check_specs=check_specs,
         backfill_policy=backfill_policy,
         retry_policy=retry_policy,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -1,13 +1,13 @@
 import hashlib
 import os
 import textwrap
+from collections import defaultdict
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
     Dict,
-    FrozenSet,
     List,
     Mapping,
     Optional,
@@ -22,7 +22,6 @@ from dagster import (
     AssetCheckSpec,
     AssetDep,
     AssetKey,
-    AssetOut,
     AssetsDefinition,
     AssetSelection,
     AssetSpec,
@@ -51,7 +50,6 @@ from dagster._core.definitions.metadata.source_code import (
     CodeReferencesMetadataValue,
     LocalFileCodeReference,
 )
-from dagster._core.definitions.tags import build_kind_tag
 from dagster._utils.merger import merge_dicts
 
 from dagster_dbt.metadata_set import DbtMetadataSet
@@ -70,6 +68,7 @@ DAGSTER_DBT_MANIFEST_METADATA_KEY = "dagster_dbt/manifest"
 DAGSTER_DBT_TRANSLATOR_METADATA_KEY = "dagster_dbt/dagster_dbt_translator"
 DAGSTER_DBT_SELECT_METADATA_KEY = "dagster_dbt/select"
 DAGSTER_DBT_EXCLUDE_METADATA_KEY = "dagster_dbt/exclude"
+DAGSTER_DBT_UNIQUE_ID_METADATA_KEY = "dagster_dbt/unique_id"
 
 DUPLICATE_ASSET_KEY_ERROR_MESSAGE = (
     "The following dbt resources are configured with identical Dagster asset keys."
@@ -611,6 +610,7 @@ def default_asset_check_fn(
         asset=asset_key,
         description=test_resource_props.get("meta", {}).get("description"),
         additional_deps=additional_deps,
+        metadata={DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: test_unique_id},
     )
 
 
@@ -680,254 +680,217 @@ def is_non_asset_node(dbt_resource_props: Mapping[str, Any]):
     )
 
 
-def get_deps(
-    dbt_nodes: Mapping[str, Any],
-    selected_unique_ids: AbstractSet[str],
-    asset_resource_types: List[str],
-) -> Mapping[str, FrozenSet[str]]:
-    def _valid_parent_node(dbt_resource_props):
-        # sources are valid parents, but not assets
-        return dbt_resource_props["resource_type"] in asset_resource_types + ["source"]
-
-    asset_deps: Dict[str, Set[str]] = {}
-    for unique_id in selected_unique_ids:
-        dbt_resource_props = dbt_nodes[unique_id]
-        node_resource_type = dbt_resource_props["resource_type"]
-
-        # skip non-assets, such as semantic models, metrics, tests, and ephemeral models
-        if is_non_asset_node(dbt_resource_props) or node_resource_type not in asset_resource_types:
-            continue
-
-        asset_deps[unique_id] = set()
-        for parent_unique_id in dbt_resource_props.get("depends_on", {}).get("nodes", []):
-            parent_node_info = dbt_nodes[parent_unique_id]
-            # for metrics or ephemeral dbt models, BFS to find valid parents
-            if is_non_asset_node(parent_node_info):
-                visited = set()
-                replaced_parent_ids = set()
-                # make a copy to avoid mutating the actual dictionary
-                queue = list(parent_node_info.get("depends_on", {}).get("nodes", []))
-                while queue:
-                    candidate_parent_id = queue.pop()
-                    if candidate_parent_id in visited:
-                        continue
-                    visited.add(candidate_parent_id)
-
-                    candidate_parent_info = dbt_nodes[candidate_parent_id]
-                    if is_non_asset_node(candidate_parent_info):
-                        queue.extend(candidate_parent_info.get("depends_on", {}).get("nodes", []))
-                    elif _valid_parent_node(candidate_parent_info):
-                        replaced_parent_ids.add(candidate_parent_id)
-
-                asset_deps[unique_id] |= replaced_parent_ids
-            # ignore nodes which are not assets / sources
-            elif _valid_parent_node(parent_node_info):
-                asset_deps[unique_id].add(parent_unique_id)
-
-    frozen_asset_deps = {
-        unique_id: frozenset(asset_deps[unique_id])
-        for unique_id in sorted(asset_deps)  # sort to stabilize job snapshots
-    }
-
-    return frozen_asset_deps
+def is_valid_upstream_node(dbt_resource_props: Mapping[str, Any]) -> bool:
+    # sources are valid parents, but not assets
+    return dbt_resource_props["resource_type"] in ASSET_RESOURCE_TYPES + ["source"]
 
 
-def build_dbt_multi_asset_args(
-    *,
+def get_upstream_unique_ids(
+    dbt_nodes: Mapping[str, Any], dbt_resource_props: Mapping[str, Any]
+) -> AbstractSet[str]:
+    upstreams = set()
+    for parent_unique_id in dbt_resource_props.get("depends_on", {}).get("nodes", []):
+        parent_node_info = dbt_nodes[parent_unique_id]
+        # for metrics or ephemeral dbt models, BFS to find valid parents
+        if is_non_asset_node(parent_node_info):
+            visited = set()
+            replaced_parent_ids = set()
+            # make a copy to avoid mutating the actual dictionary
+            queue = list(parent_node_info.get("depends_on", {}).get("nodes", []))
+            while queue:
+                candidate_parent_id = queue.pop()
+                if candidate_parent_id in visited:
+                    continue
+                visited.add(candidate_parent_id)
+
+                candidate_parent_info = dbt_nodes[candidate_parent_id]
+                if is_non_asset_node(candidate_parent_info):
+                    queue.extend(candidate_parent_info.get("depends_on", {}).get("nodes", []))
+                elif is_valid_upstream_node(candidate_parent_info):
+                    replaced_parent_ids.add(candidate_parent_id)
+
+            upstreams |= replaced_parent_ids
+        # ignore nodes which are not assets / sources
+        elif is_valid_upstream_node(parent_node_info):
+            upstreams.add(parent_unique_id)
+
+    return upstreams
+
+
+def get_asset_spec(
+    translator: "DagsterDbtTranslator",
     manifest: Mapping[str, Any],
-    dagster_dbt_translator: "DagsterDbtTranslator",
+    dbt_nodes: Mapping[str, Any],
+    group_props: Mapping[str, Any],
+    project: Optional["DbtProject"],
+    resource_props: Mapping[str, Any],
+) -> AssetSpec:
+    """Returns an AssetSpec representing a specific dbt resource. In the future, this will be a method directly on
+    the DagsterDbtTranslator.
+    """
+    from dagster_dbt.dagster_dbt_translator import DbtManifestWrapper
+
+    # calculate the dependencies for the asset
+    upstream_ids = get_upstream_unique_ids(dbt_nodes, resource_props)
+    deps = [
+        AssetDep(
+            asset=translator.get_asset_key(dbt_nodes[upstream_id]),
+            partition_mapping=translator.get_partition_mapping(
+                resource_props, dbt_nodes[upstream_id]
+            ),
+        )
+        for upstream_id in upstream_ids
+    ]
+    self_partition_mapping = translator.get_partition_mapping(resource_props, resource_props)
+    if self_partition_mapping and has_self_dependency(resource_props):
+        deps.append(
+            AssetDep(
+                asset=translator.get_asset_key(resource_props),
+                partition_mapping=self_partition_mapping,
+            )
+        )
+
+    resource_group_props = group_props.get(resource_props.get("group") or "")
+    spec = AssetSpec(
+        key=translator.get_asset_key(resource_props),
+        deps=deps,
+        description=translator.get_description(resource_props),
+        metadata=translator.get_metadata(resource_props),
+        skippable=True,
+        group_name=translator.get_group_name(resource_props),
+        code_version=translator.get_code_version(resource_props),
+        automation_condition=translator.get_automation_condition(resource_props),
+        freshness_policy=translator.get_freshness_policy(resource_props),
+        owners=translator.get_owners(
+            {
+                **resource_props,
+                # this overrides the group key in resource_props, which is bad as
+                # this key is not always empty and this dictionary generally differs
+                # in structure from other inputs, but this is necessary for backcompat
+                **({"group": resource_group_props} if resource_group_props else {}),
+            }
+        ),
+        tags=translator.get_tags(resource_props),
+        kinds={"dbt", manifest.get("metadata", {}).get("adapter_type", "dbt")},
+        partitions_def=translator.get_partitions_def(resource_props),
+    )
+
+    # add integration-specific metadata to the spec
+    spec = spec.merge_attributes(
+        metadata={
+            DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
+            DAGSTER_DBT_TRANSLATOR_METADATA_KEY: translator,
+            DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: resource_props["unique_id"],
+        }
+    )
+    if translator.settings.enable_code_references:
+        if not project:
+            raise DagsterInvalidDefinitionError(
+                "enable_code_references requires a DbtProject to be supplied"
+                " to the @dbt_assets decorator."
+            )
+
+        spec = spec.replace_attributes(
+            metadata=_attach_sql_model_code_reference(
+                existing_metadata=spec.metadata,
+                dbt_resource_props=resource_props,
+                project=project,
+            )
+        )
+    return spec
+
+
+def build_dbt_specs(
+    *,
+    translator: "DagsterDbtTranslator",
+    manifest: Mapping[str, Any],
     select: str,
     exclude: str,
     io_manager_key: Optional[str],
     project: Optional["DbtProject"],
-) -> Tuple[
-    Sequence[AssetDep],
-    Dict[str, AssetOut],
-    Dict[str, Set[AssetKey]],
-    Sequence[AssetCheckSpec],
-]:
-    from dagster_dbt.dagster_dbt_translator import DbtManifestWrapper
+) -> Tuple[Sequence[AssetSpec], Sequence[AssetCheckSpec]]:
+    dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(manifest)
+    group_props = {group["name"]: group for group in manifest.get("groups", {}).values()}
 
-    unique_ids = select_unique_ids_from_manifest(
-        select=select, exclude=exclude or "", manifest_json=manifest
-    )
-    dbt_resource_props_by_dbt_unique_id = get_dbt_resource_props_by_dbt_unique_id_from_manifest(
-        manifest
-    )
-    dbt_unique_id_deps = get_deps(
-        dbt_nodes=dbt_resource_props_by_dbt_unique_id,
-        selected_unique_ids=unique_ids,
-        asset_resource_types=ASSET_RESOURCE_TYPES,
+    selected_unique_ids = select_unique_ids_from_manifest(
+        select=select, exclude=exclude, manifest_json=manifest
     )
 
-    deps: Dict[AssetKey, AssetDep] = {}
-    outs: Dict[str, AssetOut] = {}
-    internal_asset_deps: Dict[str, Set[AssetKey]] = {}
-    check_specs_by_key: Dict[AssetCheckKey, AssetCheckSpec] = {}
+    specs: List[AssetSpec] = []
+    check_specs: List[AssetCheckSpec] = []
+    key_by_unique_id: Dict[str, AssetKey] = {}
+    for unique_id in selected_unique_ids:
+        resource_props = dbt_nodes[unique_id]
+        resource_type = resource_props["resource_type"]
 
-    dbt_unique_id_and_resource_types_by_asset_key: Dict[AssetKey, Tuple[Set[str], Set[str]]] = {}
-    dbt_group_resource_props_by_group_name: Dict[str, Dict[str, Any]] = {
-        dbt_group_resource_props["name"]: dbt_group_resource_props
-        for dbt_group_resource_props in manifest["groups"].values()
-    }
+        # skip non-assets, such as semantic models, metrics, tests, and ephemeral models
+        if is_non_asset_node(resource_props) or resource_type not in ASSET_RESOURCE_TYPES:
+            continue
 
-    dbt_adapter_type = manifest.get("metadata", {}).get("adapter_type")
+        # get the spec for the given node
+        spec = get_asset_spec(translator, manifest, dbt_nodes, group_props, project, resource_props)
+        key_by_unique_id[unique_id] = spec.key
 
-    for unique_id, parent_unique_ids in dbt_unique_id_deps.items():
-        dbt_resource_props = dbt_resource_props_by_dbt_unique_id[unique_id]
+        # add the io manager key
+        if io_manager_key is not None:
+            spec = spec.with_io_manager_key(io_manager_key)
 
-        dbt_group_name = dbt_resource_props.get("group")
-        dbt_group_resource_props = (
-            dbt_group_resource_props_by_group_name.get(dbt_group_name) if dbt_group_name else None
-        )
+        specs.append(spec)
 
-        output_name = dagster_name_fn(dbt_resource_props)
-        asset_key = dagster_dbt_translator.get_asset_key(dbt_resource_props)
+        # add check specs associated with the asset
+        for child_unique_id in manifest["child_map"][unique_id]:
+            if not child_unique_id.startswith("test"):
+                continue
 
-        unique_ids_for_asset_key, resource_types_for_asset_key = (
-            dbt_unique_id_and_resource_types_by_asset_key.setdefault(asset_key, (set(), set()))
-        )
-        unique_ids_for_asset_key.add(unique_id)
-        resource_types_for_asset_key.add(dbt_resource_props["resource_type"])
-
-        metadata = {
-            **dagster_dbt_translator.get_metadata(dbt_resource_props),
-            DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
-            DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,
-        }
-        if dagster_dbt_translator.settings.enable_code_references:
-            if not project:
-                raise DagsterInvalidDefinitionError(
-                    "enable_code_references requires a DbtProject to be supplied"
-                    " to the @dbt_assets decorator."
-                )
-
-            metadata = _attach_sql_model_code_reference(
-                existing_metadata=metadata,
-                dbt_resource_props=dbt_resource_props,
-                project=project,
-            )
-
-        spec = AssetSpec(
-            key=asset_key,
-            description=dagster_dbt_translator.get_description(dbt_resource_props),
-            metadata=metadata,
-            owners=dagster_dbt_translator.get_owners(
-                {
-                    **dbt_resource_props,
-                    **({"group": dbt_group_resource_props} if dbt_group_resource_props else {}),
-                }
-            ),
-            tags={
-                **build_kind_tag("dbt"),
-                **(build_kind_tag(dbt_adapter_type) if dbt_adapter_type else {}),
-                **dagster_dbt_translator.get_tags(dbt_resource_props),
-            },
-            group_name=dagster_dbt_translator.get_group_name(dbt_resource_props),
-            code_version=dagster_dbt_translator.get_code_version(dbt_resource_props),
-            freshness_policy=dagster_dbt_translator.get_freshness_policy(dbt_resource_props),
-            automation_condition=dagster_dbt_translator.get_automation_condition(
-                dbt_resource_props
-            ),
-            partitions_def=dagster_dbt_translator.get_partitions_def(dbt_resource_props),
-        )
-
-        outs[output_name] = AssetOut.from_spec(
-            spec=spec,
-            dagster_type=Nothing,
-            is_required=False,
-            io_manager_key=io_manager_key,
-        )
-
-        test_unique_ids = [
-            child_unique_id
-            for child_unique_id in manifest["child_map"][unique_id]
-            if child_unique_id.startswith("test")
-        ]
-        for test_unique_id in test_unique_ids:
             check_spec = default_asset_check_fn(
-                manifest,
-                dbt_resource_props_by_dbt_unique_id,
-                dagster_dbt_translator,
-                asset_key,
-                test_unique_id,
+                manifest, dbt_nodes, translator, spec.key, child_unique_id
             )
             if check_spec:
-                check_specs_by_key[check_spec.key] = check_spec
+                check_specs.append(check_spec)
 
-        # Translate parent unique ids to dependencies
-        output_internal_deps = internal_asset_deps.setdefault(output_name, set())
-        for parent_unique_id in parent_unique_ids:
-            dbt_parent_resource_props = dbt_resource_props_by_dbt_unique_id[parent_unique_id]
-            parent_asset_key = dagster_dbt_translator.get_asset_key(dbt_parent_resource_props)
-            parent_partition_mapping = dagster_dbt_translator.get_partition_mapping(
-                dbt_resource_props,
-                dbt_parent_resource_props=dbt_parent_resource_props,
+        # update the keys_by_unqiue_id dictionary to include keys created for upstream
+        # assets. note that this step may need to change once the translator is updated
+        # to no longer rely on `get_asset_key` as a standalone method
+        for upstream_id in get_upstream_unique_ids(dbt_nodes, resource_props):
+            key_by_unique_id[upstream_id] = translator.get_asset_key(dbt_nodes[upstream_id])
+
+    _validate_asset_keys(translator, dbt_nodes, key_by_unique_id)
+    return specs, check_specs
+
+
+def _validate_asset_keys(
+    translator: "DagsterDbtTranslator",
+    dbt_nodes: Mapping[str, Any],
+    key_by_unique_id: Mapping[str, AssetKey],
+) -> None:
+    unique_ids_by_key = defaultdict(set)
+    for unique_id, key in key_by_unique_id.items():
+        unique_ids_by_key[key].add(unique_id)
+
+    error_messages = []
+    for key, unique_ids in unique_ids_by_key.items():
+        if len(unique_ids) == 1:
+            continue
+        if translator.settings.enable_duplicate_source_asset_keys:
+            resource_types = {dbt_nodes[unique_id]["resource_type"] for unique_id in unique_ids}
+            if resource_types == {"source"}:
+                continue
+        formatted_ids = [
+            f"  - `{id}` ({dbt_nodes[id]['original_file_path']})" for id in sorted(unique_ids)
+        ]
+        error_messages.append(
+            "\n".join(
+                [
+                    f"The following dbt resources have the asset key `{key.path}`:",
+                    *formatted_ids,
+                ]
             )
-
-            parent_unique_ids_for_asset_key, parent_resource_types_for_asset_key = (
-                dbt_unique_id_and_resource_types_by_asset_key.setdefault(
-                    parent_asset_key, (set(), set())
-                )
-            )
-            parent_unique_ids_for_asset_key.add(parent_unique_id)
-            parent_resource_types_for_asset_key.add(dbt_parent_resource_props["resource_type"])
-
-            # Add this parent as an internal dependency
-            output_internal_deps.add(parent_asset_key)
-
-            # Mark this parent as an input if it has no dependencies
-            if parent_unique_id not in dbt_unique_id_deps:
-                deps[parent_asset_key] = AssetDep(
-                    asset=parent_asset_key,
-                    partition_mapping=parent_partition_mapping,
-                )
-
-        self_partition_mapping = dagster_dbt_translator.get_partition_mapping(
-            dbt_resource_props,
-            dbt_parent_resource_props=dbt_resource_props,
         )
-        if self_partition_mapping and has_self_dependency(dbt_resource_props):
-            deps[asset_key] = AssetDep(
-                asset=asset_key,
-                partition_mapping=self_partition_mapping,
-            )
-            output_internal_deps.add(asset_key)
 
-    dbt_unique_ids_by_duplicate_asset_key = {
-        asset_key: sorted(unique_ids)
-        for asset_key, (
-            unique_ids,
-            resource_types,
-        ) in dbt_unique_id_and_resource_types_by_asset_key.items()
-        if len(unique_ids) != 1
-        and not (
-            resource_types == set(["source"])
-            and dagster_dbt_translator.settings.enable_duplicate_source_asset_keys
-        )
-    }
-    if dbt_unique_ids_by_duplicate_asset_key:
-        error_messages = []
-        for asset_key, unique_ids in dbt_unique_ids_by_duplicate_asset_key.items():
-            formatted_ids = []
-            for id in unique_ids:
-                unique_id_file_path = dbt_resource_props_by_dbt_unique_id[id]["original_file_path"]
-                formatted_ids.append(f"  - `{id}` ({unique_id_file_path})")
-
-            error_messages.append(
-                "\n".join(
-                    [
-                        f"The following dbt resources have the asset key `{asset_key.path}`:",
-                        *formatted_ids,
-                    ]
-                )
-            )
-
+    if error_messages:
         raise DagsterInvalidDefinitionError(
             "\n\n".join([DUPLICATE_ASSET_KEY_ERROR_MESSAGE, *error_messages])
         )
-
-    return list(deps.values()), outs, internal_asset_deps, list(check_specs_by_key.values())
 
 
 def get_asset_deps(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -40,7 +40,6 @@ from sqlglot.lineage import lineage
 from sqlglot.optimizer import optimize
 
 from dagster_dbt.asset_utils import (
-    dagster_name_fn,
     default_metadata_from_dbt_resource_props,
     get_asset_check_key_for_test,
 )
@@ -395,19 +394,18 @@ class DbtCliEventMessage:
                     exc_info=True,
                 )
 
-            if has_asset_def:
+            dbt_resource_props = manifest["nodes"][unique_id]
+            asset_key = dagster_dbt_translator.get_asset_key(dbt_resource_props)
+            if context and has_asset_def:
                 yield Output(
                     value=None,
-                    output_name=dagster_name_fn(event_node_info),
+                    output_name=asset_key.to_python_identifier(),
                     metadata={
                         **default_metadata,
                         **lineage_metadata,
                     },
                 )
             else:
-                dbt_resource_props = manifest["nodes"][unique_id]
-                asset_key = dagster_dbt_translator.get_asset_key(dbt_resource_props)
-
                 yield AssetMaterialization(
                     asset_key=asset_key,
                     metadata={

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -16,7 +16,7 @@ from dagster import (
     materialize,
 )
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.core.resource import DbtCliResource
+from dagster_dbt.core.resource import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY, DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
 from dagster_dbt_tests.dbt_projects import test_asset_checks_path, test_dbt_alias_path
@@ -76,7 +76,13 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: Dict[str, A
     )
     assert my_dbt_assets.check_specs_by_output_name
 
-    assert my_dbt_assets.check_specs_by_output_name == {
+    # too annoying to manually input all of the individual metadata fields
+    stripped_specs_by_output_name = {}
+    for output_name, spec in my_dbt_assets.check_specs_by_output_name.items():
+        assert spec.metadata and spec.metadata[DAGSTER_DBT_UNIQUE_ID_METADATA_KEY]
+        stripped_specs_by_output_name[output_name] = spec._replace(metadata={})
+
+    assert stripped_specs_by_output_name == {
         "customers_not_null_customers_customer_id": AssetCheckSpec(
             name="not_null_customers_customer_id",
             asset=AssetKey(["customers"]),


### PR DESCRIPTION
## Summary & Motivation

This was mostly a passion project, but it preempts some work that needed to get done in this area in the near future anyway.

We have a bunch of complex logic going on here, purely because we are not taking advantage of the features around passing specs into @multi_asset (because this code predates asset specs!)

Crucially, before this change, we were manually creating internal_asset_deps, AssetIns, and AssetOuts independently, alongside juggling a bunch of different dictionaries to keep track of it all.

Now, I've created a single `get_asset_spec` method. Once we're ready, this can essentially be copy-pasted into the DagsterDbtTranslator class once we're ready, but for now this is purely-internal construct.

The only change in the constructed object is that we no longer have control over the generated output names for each key, and instead they are automatically generated using AssetKey.to_python_identifier. This is the cause of the updated tests.

I judge this is totally fine -- the output names are not actually user-facing in this context, it's just framework code that needs to handle this mapping (and this framework code actually gets a bit nicer as well)

## How I Tested These Changes

## Changelog

NOCHANGELOG
