### PR TITLE
[RFC][dagster-powerbi] Implement copy_with_context in DagsterPowerBITranslator

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -437,7 +437,7 @@ class PowerBIWorkspaceDefsLoader(StateBackedDefinitionsLoader[PowerBIWorkspaceDa
             )
 
     def defs_from_state(self, state: PowerBIWorkspaceData) -> Definitions:
-        translator = self.translator_cls(context=state)
+        translator = self.translator_cls().copy_with_context(context=state)
 
         all_external_data = [
             *state.dashboards_by_id.values(),

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -158,9 +158,7 @@ class DagsterPowerBITranslator:
     """
 
     def __init__(self, context: Optional[PowerBIWorkspaceData] = None):
-        if type(self).__init__ is not DagsterPowerBITranslator.__init__ and "context" not in set(
-            inspect.getfullargspec(type(self).__init__).args
-        ):
+        if self._has_custom_init_function and not self._has_context_param_in_init_function:
             raise DagsterInvariantViolationError(
                 f"Invalid custom `__init__` function in custom translator class {type(self)}. "
                 f"The custom `__init__` function must include "
@@ -196,6 +194,16 @@ class DagsterPowerBITranslator:
             )
         kwargs["context"] = context
         return self.__class__(**kwargs)
+
+    @property
+    def _has_custom_init_function(self) -> bool:
+        return type(self).__init__ is not DagsterPowerBITranslator.__init__
+
+    @property
+    def _has_context_param_in_init_function(self) -> bool:
+        return "context" in set(
+            inspect.getfullargspec(type(self).__init__).args
+        )
 
     @property
     def workspace_data(self) -> PowerBIWorkspaceData:

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -166,7 +166,7 @@ class DagsterPowerBITranslator:
             )
         self._context = context
 
-    def get_init_kwargs_from_instance(self):
+    def _get_init_kwargs_from_instance(self):
         _vars = vars(self)
         _params = set(inspect.getfullargspec(self.__init__).args)
 
@@ -186,7 +186,7 @@ class DagsterPowerBITranslator:
         return kwargs
 
     def copy_with_context(self, context: PowerBIWorkspaceData):
-        kwargs = self.get_init_kwargs_from_instance()
+        kwargs = self._get_init_kwargs_from_instance()
         if kwargs["context"]:
             raise DagsterInvariantViolationError(
                 f"The context already exist on this translator instance {self}. "

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -207,7 +207,7 @@ class DagsterPowerBITranslator:
 
     @property
     def workspace_data(self) -> PowerBIWorkspaceData:
-        return self._context
+        return check.not_none(self._context)
 
     def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
         if data.content_type == PowerBIContentType.DASHBOARD:

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -201,9 +201,7 @@ class DagsterPowerBITranslator:
 
     @property
     def _has_context_param_in_init_function(self) -> bool:
-        return "context" in set(
-            inspect.getfullargspec(type(self).__init__).args
-        )
+        return "context" in set(inspect.getfullargspec(type(self).__init__).args)
 
     @property
     def workspace_data(self) -> PowerBIWorkspaceData:

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -189,7 +189,7 @@ class DagsterPowerBITranslator:
 
     def copy_with_context(self, context: PowerBIWorkspaceData):
         kwargs = self.get_init_kwargs_from_instance()
-        if kwargs.get("context"):
+        if kwargs["context"]:
             raise DagsterInvariantViolationError(
                 f"The context already exist on this translator instance {self}. "
                 "Cannot create a new translator instance with new context."

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -180,9 +180,9 @@ class DagsterPowerBITranslator:
             private_param = f"_{param}"
             if param not in _vars and private_param not in _vars:
                 raise KeyError(
-                    f"Could not find __init__ param {param} or it's private counterpart {private_param} "
+                    f"Could not find `__init__` param {param} or it's private counterpart {private_param} "
                     f"in the attributes {_vars} of translator {self}. "
-                    f"Make sure that your __init__ parameters matches the attributes of your translator."
+                    f"Make sure that your `__init__` parameters matches the attributes of your translator."
                 )
             kwargs[param] = _vars.get(param) or _vars.get(private_param)
         return kwargs

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -199,7 +199,7 @@ class MyCustomTranslatorWithInvalidAttribute(DagsterPowerBITranslator):
 def test_custom_translator_with_invalid_attribute(workspace_data: PowerBIWorkspaceData) -> None:
     with pytest.raises(
         KeyError,
-        match="Could not find `__init__ param",
+        match="Could not find `__init__` param",
     ):
         MyCustomTranslatorWithInvalidAttribute(my_param="test").copy_with_context(
             context=workspace_data

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -199,7 +199,7 @@ class MyCustomTranslatorWithInvalidAttribute(DagsterPowerBITranslator):
 def test_custom_translator_with_invalid_attribute(workspace_data: PowerBIWorkspaceData) -> None:
     with pytest.raises(
         KeyError,
-        match="Could not find `__init__` param",
+        match="Could not find `__init__ param",
     ):
         MyCustomTranslatorWithInvalidAttribute(my_param="test").copy_with_context(
             context=workspace_data

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -199,7 +199,7 @@ class MyCustomTranslatorWithInvalidAttribute(DagsterPowerBITranslator):
 def test_custom_translator_with_invalid_attribute(workspace_data: PowerBIWorkspaceData) -> None:
     with pytest.raises(
         KeyError,
-        match="Could not find __init__ param",
+        match="Could not find `__init__` param",
     ):
         MyCustomTranslatorWithInvalidAttribute(my_param="test").copy_with_context(
             context=workspace_data


### PR DESCRIPTION
## Summary & Motivation

This PR is motivated by this [discussion](https://github.com/dagster-io/dagster/pull/25944#issuecomment-2495112807) 

Context: 

Translators for BI integrations required the contextual data from the workspace to create the asset specs. To pass this data to the translator, we ask users to pass the type of the translator to the spec loader, and we initialize the translator with its context in the state-back defs. 

This approach works well, but is not flexible for users that want to customize their translators - users often customize the `__init__` method,  but passing this approach prevent them to initialize the translator with the correct arguments.

We want to update BI integrations so that users can pass an instance of the translator to spec loaders, which is more flexible, instead of the type.

Challenges:

- the translator object should to be immutable
- users can customize `__init__` method and add new parameters to its signature, which are unknown to us
- once a context is set in a translator instance, it should not change
- keep this as simple as possible for users

Solution:

Use the `copy_with_context` method to rebuild a translator with its context.

To make this possible we need to:
- infer the `__init__` kwargs from the attributes and the `__init__` signature, using `_get_init_kwargs_from_instance`
- have matching attributes and params in the translator
- have the context as a parameter in the `__init__` method of a custom translator

So, to make this possible, we require a few things from users:
- the signature of the custom `__init__` method must include the `context` parameter
- Every attribute or private attribute must match their `__init__` param, eg. the attribute for `my_param` can be `my_param` or `_my_param`


```python

class MyCustomTranslator(DagsterPowerBITranslator):
    def __init__(self, my_param: str, context: Optional[PowerBIWorkspaceData] = None):
        self.my_param = my_param
        super().__init__(context=context)

    def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
        default_spec = super().get_asset_spec(data)
        return default_spec.merge_attributes(
            metadata={"custom": self.my_param},
        )
 
# user code
translator = MyCustomTranslator(my_param=test_param)

# internal code
translator.copy_with_context(
    context=context
)
asset_spec = translator.get_asset_spec(...)

```

Proposals that were not retained:

1. Pass a callable factory to construct a translator, see [here](https://dagsterlabs.slack.com/archives/C0433R043T3/p1732657754083949?thread_ts=1732561781.201499&cid=C0433R043T3) - this complexifies the user code
2. Pass the context to get_asset_spec, see [here](https://dagsterlabs.slack.com/archives/C0433R043T3/p1732658412175729?thread_ts=1732561781.201499&cid=C0433R043T3) - this is breaking change that we would like to avoid.
3. Set the context on a translator after it’s initialization, see [here](https://dagsterlabs.slack.com/archives/C0433R043T3/p1732659288332329?thread_ts=1732561781.201499&cid=C0433R043T3) - that makes the object mutable

## How I Tested These Changes

New tests with BK

## Changelog

> Insert changelog entry or delete this section.
