### PR TITLE
[components] Make the components folder parameterizable

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -53,7 +53,10 @@ class Component(ABC):
         return {}
 
     @classmethod
-    def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None: ...
+    def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None:
+        from dagster_components.generate import generate_component_yaml
+
+        generate_component_yaml(request, {})
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -129,6 +129,7 @@ def build_component_defs(
     code_location_root: Path,
     resources: Optional[Mapping[str, object]] = None,
     registry: Optional["ComponentRegistry"] = None,
+    components_folder: Optional[Path] = None,
 ) -> "Definitions":
     """Build a Definitions object for all the component instances in a given code location.
 
@@ -139,7 +140,9 @@ def build_component_defs(
     from dagster._core.definitions.definitions_class import Definitions
 
     context = CodeLocationProjectContext.from_code_location_path(
-        code_location_root, registry or ComponentRegistry.from_entry_point_discovery()
+        code_location_root,
+        registry or ComponentRegistry.from_entry_point_discovery(),
+        components_folder=components_folder,
     )
 
     all_defs: List[Definitions] = []

--- a/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
@@ -64,7 +64,7 @@ class CodeLocationProjectContext:
             name=name,
             component_registry=component_registry,
             components_folder=components_folder
-            or path / name / _CODE_LOCATION_CUSTOM_COMPONENTS_DIR,
+            or path / name / _CODE_LOCATION_COMPONENT_INSTANCES_DIR,
         )
 
     def __init__(


### PR DESCRIPTION
## Summary & Motivation

This increases the flexibility of code layout in components-enabled code location by allowing `build_components_defs` to load any arbitrary folder as the components folder. This will be useful for codebases where users have their own folder layout conventions, as well as for testing (we could have many componet folders for a single code location directory for example).

## How I Tested These Changes

Manual
