### PR TITLE
Make 'Ask AI' button font consistent with page

### DIFF
--- a/docs/next/pages/_document.js
+++ b/docs/next/pages/_document.js
@@ -38,7 +38,7 @@ export default class MyDocument extends Document {
             <co-pilot copilot_id="dagster">
               <div
                 slot="fab"
-                className="bg-lavender text-gray-700 px-24 py-2 rounded-full flex flex-row items-center prose gap-2"
+                className="bg-lavender text-gray-700 px-24 py-2 rounded-full flex flex-row items-center font-sans gap-2"
               >
                 <div className="pt-1">
                   <svg
@@ -54,7 +54,7 @@ export default class MyDocument extends Document {
                     />
                   </svg>
                 </div>
-                <p class="mt-0">Ask AI</div>
+                <div>Ask AI</div>
               </div>
             </co-pilot>
           </div>

--- a/docs/next/pages/_document.js
+++ b/docs/next/pages/_document.js
@@ -38,9 +38,9 @@ export default class MyDocument extends Document {
             <co-pilot copilot_id="dagster">
               <div
                 slot="fab"
-                className="bg-lavender text-gray-700 px-24 py-2 rounded-full flex flex-row items-center"
+                className="bg-lavender text-gray-700 px-24 py-2 rounded-full flex flex-row items-center prose gap-2"
               >
-                <div className="pt-1 pr-1">
+                <div className="pt-1">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="24"
@@ -54,7 +54,7 @@ export default class MyDocument extends Document {
                     />
                   </svg>
                 </div>
-                <div>Ask AI</div>
+                <p class="mt-0">Ask AI</div>
               </div>
             </co-pilot>
           </div>


### PR DESCRIPTION
## Summary & Motivation
When browsing Dagster's docs, I noticed that the "Ask AI" button's font seems to have a different font from the rest of the page. It seemed to use the default sans-serif font rather than the one in the theme. This is what it looked like on Chrome (v 131.0.6778.204 on Linux):
![Before - Chrome](https://github.com/user-attachments/assets/aa90441b-8773-42b4-93f5-58cfc6de6218)
And on Firefox (v133.0.3, also on Linux):
![Before - Firefox](https://github.com/user-attachments/assets/23e459c7-1fbc-4690-b14e-e743711bbcfc)

It's a really minor thing, but I looked into the source code, saw TailwindCSS, and thought I might as well make a PR :)

## How I Tested These Changes
I made changes in the browser inspector and verified that these changes look alright. I also ran the documentation website locally. Here's a screenshot of the result:
![image](https://github.com/user-attachments/assets/327ef4b8-0bf1-48a9-8f6e-f1ea810525b4)
