### PR TITLE
[docs] add note of defer_table_reflect to dlt docs

### DIFF
--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -183,6 +183,16 @@ The <PyObject object="dlt_assets" module="dagster_embedded_elt.dlt" decorator />
 
 In the same file containing your Dagster assets, you can create an instance of your <PyObject object="dlt_assets" module="dagster_embedded_elt.dlt" decorator /> by doing something like the following:
 
+<Note>
+  If you are using the{" "}
+  <a href="https://dlthub.com/docs/api_reference/sources/sql_database/__init__#sql_database">
+    sql_database
+  </a>{" "}
+  source, consider setting <code>defer_table_reflect=True</code> to reduce
+  database reads. By default, the Dagster daemon will refresh definitions
+  roughly every minute, which will query the database for resource definitions.
+</Note>
+
 ```python
 from dagster import AssetExecutionContext, Definitions
 from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets


### PR DESCRIPTION
## Summary & Motivation

- A community member pointed out that by setting this you can reduce the reads on your database when the Dagster daemon polls to refresh definitions

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/c230b6cb-1586-4436-99c1-7dfd30cb36be" />

Closes https://github.com/dagster-io/dagster/issues/26627

## How I Tested These Changes

## Changelog

NOCHANGELOG
