### PR TITLE
add grpcio 1.57.0 pin to provided helm chart images

### DIFF
--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/Dockerfile
@@ -13,4 +13,5 @@ RUN python -m uv pip install \
     -e dagster-k8s \
     -e dagster-celery[flower,redis,kubernetes] \
     -e dagster-celery-k8s \
-    -e dagster-webserver
+    -e dagster-webserver \
+    grpcio==1.57.0 # https://github.com/grpc/grpc/issues/38327

--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
@@ -16,4 +16,5 @@ RUN python -m uv pip install \
     dagster-celery-k8s \
     dagster-gcp \
     dagster-graphql \
-    dagster-webserver
+    dagster-webserver \
+    grpcio==1.57.0 # https://github.com/grpc/grpc/issues/38327

--- a/python_modules/automation/automation/docker/images/dagster-k8s-editable/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-k8s-editable/Dockerfile
@@ -12,4 +12,5 @@ RUN python -m uv pip install \
     -e dagster-postgres \
     -e dagster-k8s \
     -e dagster-aws \
-    -e dagster-webserver
+    -e dagster-webserver \
+    grpcio==1.57.0 # https://github.com/grpc/grpc/issues/38327

--- a/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
@@ -14,4 +14,5 @@ RUN python -m uv pip install \
     dagster-aws \
     dagster-gcp \
     dagster-graphql \
-    dagster-webserver
+    dagster-webserver \
+    grpcio==1.57.0 # https://github.com/grpc/grpc/issues/38327


### PR DESCRIPTION
Summary:
Attempt to resolve reported memory leak versions with . Apparently the underlying issue is also resolved in python 3.13, so once we officially support that in dagster, we could potentially move these images to 3.13 and remove this.

Test Plan:
Deploy the helm chart locally with these built images

Changelog:
Added a pin to the grpcio version  used by the Dagster Helm chart daemon and webserver images, to a version that has been reported to avoid memory leaks.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
