### PR TITLE
Fix direct invocation for partition ranges

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -508,6 +508,20 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         check.failed("Tried to access partition_key for a non-partitioned run")
 
     @property
+    def partition_keys(self) -> Sequence[str]:
+        key_range = self.partition_key_range
+        partitions_def = self.assets_def.partitions_def
+        if partitions_def is None:
+            raise DagsterInvariantViolationError(
+                "Cannot access partition_keys for a non-partitioned run"
+            )
+
+        return partitions_def.get_partition_keys_in_range(
+            key_range,
+            dynamic_partitions_store=self.instance,
+        )
+
+    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The range of partition keys for the current run.
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1303,8 +1303,10 @@ def test_partition_range_asset_invocation():
 
     @asset(partitions_def=partitions_def)
     def foo(context: AssetExecutionContext):
-        keys = partitions_def.get_partition_keys_in_range(context.partition_key_range)
-        return {k: True for k in keys}
+        keys1 = partitions_def.get_partition_keys_in_range(context.partition_key_range)
+        keys2 = context.partition_keys
+        assert keys1 == keys2
+        return {k: True for k in keys1}
 
     context = build_asset_context(
         partition_key_range=PartitionKeyRange("2023-01-01", "2023-01-02"),


### PR DESCRIPTION
## Summary & Motivation

We changed the partition_keys implementation on the main execution context class, which made it incompatible with DirectExecutionContext

## How I Tested These Changes

Added test failed before, passes now

## Changelog

NOCHANGELOG
