### PR TITLE
[components] Templating for asset_attributes

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -31,7 +31,7 @@ from dagster._utils import pushd, snakecase
 from pydantic import TypeAdapter
 from typing_extensions import Self
 
-from dagster_components.core.component_rendering import TemplatedValueResolver, preprocess_value
+from dagster_components.core.component_rendering import TemplatedValueResolver
 
 
 class ComponentDeclNode: ...
@@ -255,8 +255,8 @@ class ComponentLoadContext:
 
     def load_params(self, params_schema: Type[T]) -> T:
         with pushd(str(self.path)):
-            preprocessed_params = preprocess_value(
-                self.templated_value_resolver, self._raw_params(), params_schema
+            preprocessed_params = self.templated_value_resolver.render_params(
+                self._raw_params(), params_schema
             )
             return TypeAdapter(params_schema).validate_python(preprocessed_params)
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -1,6 +1,7 @@
-from abc import ABC, abstractmethod
-from typing import Annotated, Any, Dict, Literal, Mapping, Optional, Sequence, Union
+from abc import ABC
+from typing import AbstractSet, Annotated, Any, Dict, Literal, Mapping, Optional, Sequence, Union
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.asset_spec import AssetSpec, map_asset_specs
 from dagster._core.definitions.assets import AssetsDefinition
@@ -10,6 +11,8 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
 from pydantic import BaseModel, Field
+
+from dagster_components.core.component_rendering import RenderingScope, TemplatedValueResolver
 
 
 class OpSpecBaseModel(BaseModel):
@@ -33,26 +36,31 @@ class AssetSpecProcessor(ABC, BaseModel):
     tags: Optional[Mapping[str, str]] = None
     automation_condition: Optional[AutomationConditionModel] = None
 
-    def _attributes(self) -> Mapping[str, Any]:
-        return {
-            **self.model_dump(exclude={"target", "operation"}, exclude_unset=True),
-            **{
-                "automation_condition": self.automation_condition.to_automation_condition()
-                if self.automation_condition
-                else None
-            },
-        }
+    def _apply_to_spec(self, spec: AssetSpec, attributes: Mapping[str, Any]) -> AssetSpec: ...
 
-    @abstractmethod
-    def _apply_to_spec(self, spec: AssetSpec) -> AssetSpec: ...
+    def apply_to_spec(
+        self,
+        spec: AssetSpec,
+        value_resolver: TemplatedValueResolver,
+        target_keys: AbstractSet[AssetKey],
+    ) -> AssetSpec:
+        if spec.key not in target_keys:
+            return spec
 
-    def apply(self, defs: Definitions) -> Definitions:
+        # add the original spec to the context and resolve values
+        attributes = value_resolver.with_context(asset=spec).render_obj(
+            self.model_dump(exclude={"target", "operation"}, exclude_unset=True)
+        )
+        return self._apply_to_spec(spec, attributes)
+
+    def apply(self, defs: Definitions, value_resolver: TemplatedValueResolver) -> Definitions:
         target_selection = AssetSelection.from_string(self.target, include_sources=True)
         target_keys = target_selection.resolve(defs.get_asset_graph())
 
         mappable = [d for d in defs.assets or [] if isinstance(d, (AssetsDefinition, AssetSpec))]
         mapped_assets = map_asset_specs(
-            lambda spec: self._apply_to_spec(spec) if spec.key in target_keys else spec, mappable
+            lambda spec: self.apply_to_spec(spec, value_resolver, target_keys),
+            mappable,
         )
 
         assets = [
@@ -66,8 +74,7 @@ class MergeAttributes(AssetSpecProcessor):
     # default operation is "merge"
     operation: Literal["merge"] = "merge"
 
-    def _apply_to_spec(self, spec: AssetSpec) -> AssetSpec:
-        attributes = self._attributes()
+    def _apply_to_spec(self, spec: AssetSpec, attributes: Mapping[str, Any]) -> AssetSpec:
         mergeable_attributes = {"metadata", "tags"}
         merge_attributes = {k: v for k, v in attributes.items() if k in mergeable_attributes}
         replace_attributes = {k: v for k, v in attributes.items() if k not in mergeable_attributes}
@@ -78,13 +85,13 @@ class ReplaceAttributes(AssetSpecProcessor):
     # operation must be set explicitly
     operation: Literal["replace"]
 
-    def _apply_to_spec(self, spec: AssetSpec) -> AssetSpec:
-        return spec.replace_attributes(**self._attributes())
+    def _apply_to_spec(self, spec: AssetSpec, attributes: Mapping[str, Any]) -> AssetSpec:
+        return spec.replace_attributes(**attributes)
 
 
 AssetAttributes = Sequence[
     Annotated[
         Union[MergeAttributes, ReplaceAttributes],
-        Field(union_mode="left_to_right"),
+        RenderingScope(Field(union_mode="left_to_right"), required_scope={"asset"}),
     ]
 ]

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
@@ -56,7 +56,7 @@ class DbtProjectComponentTranslator(DagsterDbtTranslator):
             return super().get_asset_key(dbt_resource_props)
 
         return AssetKey.from_user_string(
-            self.value_resolver.with_context(node=dbt_resource_props).resolve(
+            self.value_resolver.with_context(node=dbt_resource_props).render_obj(
                 self.translator_params.key
             )
         )
@@ -65,7 +65,7 @@ class DbtProjectComponentTranslator(DagsterDbtTranslator):
         if not self.translator_params or not self.translator_params.group:
             return super().get_group_name(dbt_resource_props)
 
-        return self.value_resolver.with_context(node=dbt_resource_props).resolve(
+        return self.value_resolver.with_context(node=dbt_resource_props).render_obj(
             self.translator_params.group
         )
 
@@ -117,7 +117,7 @@ class DbtProjectComponent(Component):
 
         defs = Definitions(assets=[_fn])
         for transform in self.asset_processors:
-            defs = transform.apply(defs)
+            defs = transform.apply(defs, context.templated_value_resolver)
         return defs
 
     @classmethod

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication.py
@@ -60,7 +60,7 @@ class SlingReplicationComponent(Component):
 
         defs = Definitions(assets=[_fn], resources={"sling": self.resource})
         for transform in self.asset_processors:
-            defs = transform.apply(defs)
+            defs = transform.apply(defs, context.templated_value_resolver)
         return defs
 
     @classmethod

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
@@ -4,8 +4,7 @@ import pytest
 from dagster_components.core.component_rendering import (
     RenderingScope,
     TemplatedValueResolver,
-    _should_render,
-    preprocess_value,
+    has_rendering_scope,
 )
 from pydantic import BaseModel, Field, TypeAdapter
 
@@ -44,7 +43,9 @@ class Outer(BaseModel):
     ],
 )
 def test_should_render(path, expected: bool) -> None:
-    assert _should_render(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
+    assert (
+        has_rendering_scope(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
+    )
 
 
 def test_render() -> None:
@@ -61,7 +62,7 @@ def test_render() -> None:
     }
 
     renderer = TemplatedValueResolver(context={"foo_val": "foo", "bar_val": "bar"})
-    rendered_data = preprocess_value(renderer, data, Outer)
+    rendered_data = renderer.render_params(data, Outer)
 
     assert rendered_data == {
         "a": "foo",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
@@ -1,6 +1,11 @@
 import pytest
 from dagster import AssetKey, AssetSpec, Definitions
-from dagster_components.core.dsl_schema import AssetAttributes, MergeAttributes, ReplaceAttributes
+from dagster_components.core.dsl_schema import (
+    AssetAttributes,
+    MergeAttributes,
+    ReplaceAttributes,
+    TemplatedValueResolver,
+)
 from pydantic import BaseModel, TypeAdapter
 
 
@@ -20,7 +25,7 @@ defs = Definitions(
 def test_replace_attributes() -> None:
     op = ReplaceAttributes(operation="replace", target="group:g2", tags={"newtag": "newval"})
 
-    newdefs = op.apply(defs)
+    newdefs = op.apply(defs, TemplatedValueResolver.default())
     asset_graph = newdefs.get_asset_graph()
     assert asset_graph.get(AssetKey("a")).tags == {}
     assert asset_graph.get(AssetKey("b")).tags == {"newtag": "newval"}
@@ -30,11 +35,33 @@ def test_replace_attributes() -> None:
 def test_merge_attributes() -> None:
     op = MergeAttributes(operation="merge", target="group:g2", tags={"newtag": "newval"})
 
-    newdefs = op.apply(defs)
+    newdefs = op.apply(defs, TemplatedValueResolver.default())
     asset_graph = newdefs.get_asset_graph()
     assert asset_graph.get(AssetKey("a")).tags == {}
     assert asset_graph.get(AssetKey("b")).tags == {"newtag": "newval"}
     assert asset_graph.get(AssetKey("c")).tags == {"tag": "val", "newtag": "newval"}
+
+
+def test_render_attributes_asset_context() -> None:
+    op = MergeAttributes(tags={"group_name_tag": "group__{{ asset.group_name }}"})
+
+    newdefs = op.apply(defs, TemplatedValueResolver.default().with_context(foo="theval"))
+    asset_graph = newdefs.get_asset_graph()
+    assert asset_graph.get(AssetKey("a")).tags == {"group_name_tag": "group__g1"}
+    assert asset_graph.get(AssetKey("b")).tags == {"group_name_tag": "group__g2"}
+    assert asset_graph.get(AssetKey("c")).tags == {"tag": "val", "group_name_tag": "group__g2"}
+
+
+def test_render_attributes_custom_context() -> None:
+    op = ReplaceAttributes(
+        operation="replace", target="group:g2", tags={"a": "{{ foo }}", "b": "prefix_{{ foo }}"}
+    )
+
+    newdefs = op.apply(defs, TemplatedValueResolver.default().with_context(foo="theval"))
+    asset_graph = newdefs.get_asset_graph()
+    assert asset_graph.get(AssetKey("a")).tags == {}
+    assert asset_graph.get(AssetKey("b")).tags == {"a": "theval", "b": "prefix_theval"}
+    assert asset_graph.get(AssetKey("c")).tags == {"a": "theval", "b": "prefix_theval"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

This adds a rendering scope to AssetAttributes, allowing its values to depend on the spec that's currently being evaluated. This is useful for setting properties of a spec based off of other properties (e.g. based off of a tag, set an automation condition)

Refactors component_rendering.py to be more class-based

## How I Tested These Changes

## Changelog

NOCHANGELOG
