### PR TITLE
Fix asset loader for sourceassets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
@@ -349,11 +349,7 @@ class DagsterObjectsList:
                     else new_asset
                 )
             elif isinstance(dagster_def, SourceAsset):
-                return_list.append(
-                    dagster_def.with_attributes(
-                        group_name=group_name if group_name else dagster_def.group_name
-                    )
-                )
+                return_list.append(dagster_def.with_attributes(group_name=group_name))
             elif isinstance(dagster_def, AssetSpec):
                 return_list.append(
                     _spec_mapper_disallow_group_override(group_name, automation_condition)(

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -460,9 +460,13 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
     def with_attributes(
         self, group_name: Optional[str] = None, key: Optional[AssetKey] = None
     ) -> "SourceAsset":
-        if group_name is not None and self.group_name != DEFAULT_GROUP_NAME:
+        if (
+            group_name is not None
+            and self.group_name != DEFAULT_GROUP_NAME
+            and self.group_name != group_name
+        ):
             raise DagsterInvalidDefinitionError(
-                "A group name has already been provided to source asset"
+                f"Attempted to override group name to {group_name} for SourceAsset {self.key.to_user_string()}, which already has group name {self.group_name}."
                 f" {self.key.to_user_string()}"
             )
 


### PR DESCRIPTION
## Summary & Motivation
Fix some goofiness regarding source asset group_name remapping;
- If you try to remap the group name to have the same group name, then allow that.
- In the error message, tell us what the original group_name is and what we're trying to change it to.
- We were hitting an error in DOP because we were trying to set group_name back to itself, which is not currently allowed. So fix that as well (although that is now allowed).
## How I Tested These Changes
Existing tests
