### PR TITLE
[components] Move global options to subcommands

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import click
 
+from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.context import DeploymentDirectoryContext, DgContext, is_inside_deployment_directory
 from dagster_dg.generate import generate_code_location
 from dagster_dg.utils import DgClickCommand, DgClickGroup
@@ -40,9 +41,12 @@ def code_location_group():
     default=False,
     help="Do not create a virtual environment for the code location.",
 )
-@click.pass_context
+@dg_global_options
 def code_location_generate_command(
-    cli_context: click.Context, name: str, use_editable_dagster: Optional[str], skip_venv: bool
+    name: str,
+    use_editable_dagster: Optional[str],
+    skip_venv: bool,
+    **global_options: object,
 ) -> None:
     """Generate a Dagster code location file structure and a uv-managed virtual environment scoped
     to the code location.
@@ -53,6 +57,7 @@ def code_location_generate_command(
     The code location file structure defines a Python package with some pre-existing internal
     structure:
 
+    \b
     ├── <name>
     │   ├── __init__.py
     │   ├── components
@@ -66,8 +71,8 @@ def code_location_generate_command(
     The `<name>.components` directory holds components (which can be created with `dg generate
     component`).  The `<name>.lib` directory holds custom component types scoped to the code
     location (which can be created with `dg component-type generate`).
-    """
-    dg_context = DgContext.from_cli_context(cli_context)
+    """  # noqa: D301
+    dg_context = DgContext.from_cli_global_options(global_options)
     if is_inside_deployment_directory(Path.cwd()):
         context = DeploymentDirectoryContext.from_path(Path.cwd(), dg_context)
         if context.has_code_location(name):
@@ -101,10 +106,10 @@ def code_location_generate_command(
 
 
 @code_location_group.command(name="list", cls=DgClickCommand)
-@click.pass_context
-def code_location_list_command(cli_context: click.Context) -> None:
+@dg_global_options
+def code_location_list_command(**global_options: object) -> None:
     """List code locations in the current deployment."""
-    dg_context = DgContext.from_cli_context(cli_context)
+    dg_context = DgContext.from_cli_global_options(global_options)
     if not is_inside_deployment_directory(Path.cwd()):
         click.echo(
             click.style("This command must be run inside a Dagster deployment directory.", fg="red")

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -1,11 +1,18 @@
 import sys
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import click
 from click.core import ParameterSource
 
+from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentType
+from dagster_dg.config import (
+    DgConfig,
+    get_config_from_cli_context,
+    has_config_on_cli_context,
+    set_config_on_cli_context,
+)
 from dagster_dg.context import (
     CodeLocationDirectoryContext,
     DgContext,
@@ -16,6 +23,7 @@ from dagster_dg.utils import (
     DgClickCommand,
     DgClickGroup,
     json_schema_property_to_click_option,
+    not_none,
     parse_json_option,
 )
 
@@ -48,14 +56,17 @@ class ComponentGenerateGroup(DgClickGroup):
             self._define_commands(cli_context)
         return super().get_command(cli_context, cmd_name)
 
-    def list_commands(self, cli_context):
+    def list_commands(self, cli_context: click.Context) -> List[str]:
         if not self._commands_defined:
             self._define_commands(cli_context)
         return super().list_commands(cli_context)
 
     def _define_commands(self, cli_context: click.Context) -> None:
         """Dynamically define a command for each registered component type."""
-        app_context = DgContext.from_cli_context(cli_context)
+        if not has_config_on_cli_context(cli_context):
+            cli_context.invoke(not_none(self.callback), **cli_context.params)
+        config = get_config_from_cli_context(cli_context)
+        dg_context = DgContext.from_config(config)
 
         if not is_inside_code_location_directory(Path.cwd()):
             click.echo(
@@ -65,21 +76,77 @@ class ComponentGenerateGroup(DgClickGroup):
             )
             sys.exit(1)
 
-        context = CodeLocationDirectoryContext.from_path(Path.cwd(), app_context)
+        context = CodeLocationDirectoryContext.from_path(Path.cwd(), dg_context)
         for key, component_type in context.iter_component_types():
             command = _create_component_generate_subcommand(key, component_type)
             self.add_command(command)
 
 
-@component_group.group(name="generate", cls=ComponentGenerateGroup)
-def component_generate_group() -> None:
+class ComponentGenerateSubCommand(DgClickCommand):
+    def format_usage(self, context: click.Context, formatter: click.HelpFormatter) -> None:
+        if not isinstance(self, click.Command):
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
+        arg_pieces = self.collect_usage_pieces(context)
+        command_parts = context.command_path.split(" ")
+        command_parts.insert(-1, "[GLOBAL OPTIONS]")
+        return formatter.write_usage(" ".join(command_parts), " ".join(arg_pieces))
+
+    def format_options(self, context: click.Context, formatter: click.HelpFormatter) -> None:
+        # This will not produce any global options since there are none defined on component
+        # generate subcommands.
+        super().format_options(context, formatter)
+
+        # Get the global options off the parent group.
+        parent_context = not_none(context.parent)
+        parent_command = not_none(context.parent).command
+        if not isinstance(parent_command, DgClickGroup):
+            raise ValueError("Parent command must be a DgClickGroup.")
+        _, global_opts = parent_command.get_partitioned_opts(context)
+
+        with formatter.section("Global options"):
+            records = [not_none(p.get_help_record(parent_context)) for p in global_opts]
+            formatter.write_dl(records)
+
+
+# We have to override the usual Click processing of `--help` here. The issue is
+# that click will process this option before processing anything else, but because we are
+# dynamically generating subcommands based on the content of other options, the output of --help
+# actually depends on these other options. So we opt out of Click's short-circuiting
+# behavior of `--help` by setting `help_option_names=[]`, ensuring that we can process the other
+# options first and generate the correct subcommands. We then add a custom `--help` option that
+# gets invoked inside the callback.
+@component_group.group(
+    name="generate",
+    cls=ComponentGenerateGroup,
+    invoke_without_command=True,
+    context_settings={"help_option_names": []},
+)
+@click.option("-h", "--help", "help_", is_flag=True, help="Show this message and exit.")
+@dg_global_options
+@click.pass_context
+def component_generate_group(context: click.Context, help_: bool, **global_options: object) -> None:
     """Generate a scaffold of a Dagster component."""
+    # Click attempts to resolve subcommands BEFORE it invokes this callback.
+    # Therefore we need to manually invoke this callback during subcommand generation to make sure
+    # it runs first. It will be invoked again later by Click. We make it idempotent to deal with
+    # that.
+    if not has_config_on_cli_context(context):
+        set_config_on_cli_context(context, DgConfig.from_cli_global_options(global_options))
+    if help_:
+        click.echo(context.get_help())
+        context.exit(0)
 
 
 def _create_component_generate_subcommand(
     component_key: str, component_type: RemoteComponentType
 ) -> DgClickCommand:
-    @click.command(name=component_key, cls=DgClickCommand)
+    # We need to "reset" the help option names to the default ones because we inherit the parent
+    # value of context settings from the parent group, which has been customized.
+    @click.command(
+        name=component_key,
+        cls=ComponentGenerateSubCommand,
+        context_settings={"help_option_names": ["-h", "--help"]},
+    )
     @click.argument("component_name", type=str)
     @click.option(
         "--json-params",
@@ -112,7 +179,8 @@ def _create_component_generate_subcommand(
 
         It is an error to pass both --json-params and key-value pairs as options.
         """
-        dg_context = DgContext.from_cli_context(cli_context)
+        config = get_config_from_cli_context(cli_context)
+        dg_context = DgContext.from_config(config)
         if not is_inside_code_location_directory(Path.cwd()):
             click.echo(
                 click.style(
@@ -185,10 +253,10 @@ def _create_component_generate_subcommand(
 
 
 @component_group.command(name="list", cls=DgClickCommand)
-@click.pass_context
-def component_list_command(cli_context: click.Context) -> None:
+@dg_global_options
+def component_list_command(**global_options: object) -> None:
     """List Dagster component instances defined in the current code location."""
-    dg_context = DgContext.from_cli_context(cli_context)
+    dg_context = DgContext.from_cli_global_options(global_options)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping
 
 import click
 
+from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.context import (
     CodeLocationDirectoryContext,
     DgContext,
@@ -26,14 +27,14 @@ def component_type_group():
 
 @component_type_group.command(name="generate", cls=DgClickCommand)
 @click.argument("name", type=str)
-@click.pass_context
-def component_type_generate_command(cli_context: click.Context, name: str) -> None:
+@dg_global_options
+def component_type_generate_command(name: str, **global_options: object) -> None:
     """Generate a scaffold of a custom Dagster component type.
 
     This command must be run inside a Dagster code location directory. The component type scaffold
     will be generated in submodule `<code_location_name>.lib.<name>`.
     """
-    dg_context = DgContext.from_cli_context(cli_context)
+    dg_context = DgContext.from_cli_global_options(global_options)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(
@@ -60,16 +61,16 @@ def component_type_generate_command(cli_context: click.Context, name: str) -> No
 @click.option("--description", is_flag=True, default=False)
 @click.option("--generate-params-schema", is_flag=True, default=False)
 @click.option("--component-params-schema", is_flag=True, default=False)
-@click.pass_context
+@dg_global_options
 def component_type_info_command(
-    cli_context: click.Context,
     component_type: str,
     description: bool,
     generate_params_schema: bool,
     component_params_schema: bool,
+    **global_options: object,
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
-    dg_context = DgContext.from_cli_context(cli_context)
+    dg_context = DgContext.from_cli_global_options(global_options)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(
@@ -136,10 +137,10 @@ def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
 
 
 @component_type_group.command(name="list", cls=DgClickCommand)
-@click.pass_context
-def component_type_list(cli_context: click.Context) -> None:
+@dg_global_options
+def component_type_list(**global_options: object) -> None:
     """List registered Dagster components in the current code location environment."""
-    dg_context = DgContext.from_cli_context(cli_context)
+    dg_context = DgContext.from_cli_global_options(global_options)
     if not is_inside_code_location_directory(Path.cwd()):
         click.echo(
             click.style(

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/deployment.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/deployment.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import click
 
+from dagster_dg.cli.global_options import dg_global_options
+from dagster_dg.context import DgContext
 from dagster_dg.generate import generate_deployment
 from dagster_dg.utils import DgClickCommand, DgClickGroup
 
@@ -19,13 +21,15 @@ def deployment_group():
 
 
 @deployment_group.command(name="generate", cls=DgClickCommand)
+@dg_global_options
 @click.argument("path", type=Path)
-def deployment_generate_command(path: Path) -> None:
+def deployment_generate_command(path: Path, **global_options: object) -> None:
     """Generate a Dagster deployment file structure.
 
     The deployment file structure includes a directory for code locations and configuration files
     for deploying to Dagster Plus.
     """
+    dg_context = DgContext.from_cli_global_options(global_options)
     dir_abspath = os.path.abspath(path)
     if os.path.exists(dir_abspath):
         click.echo(
@@ -33,4 +37,4 @@ def deployment_generate_command(path: Path) -> None:
             + "\nPlease delete the contents of this path or choose another location."
         )
         sys.exit(1)
-    generate_deployment(path)
+    generate_deployment(path, dg_context)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence, TypeVar, Union
+
+import click
+
+from dagster_dg.config import DgConfig
+
+T_Command = TypeVar("T_Command", bound=Union[Callable[..., Any], click.Command])
+
+# Defaults are defined on the DgConfig object.
+GLOBAL_OPTIONS = {
+    option.name: option
+    for option in [
+        click.Option(
+            ["--cache-dir"],
+            type=Path,
+            default=DgConfig.cache_dir,
+            help="Specify a directory to use for the cache.",
+        ),
+        click.Option(
+            ["--disable-cache"],
+            is_flag=True,
+            default=DgConfig.disable_cache,
+            help="Disable the cache..",
+        ),
+        click.Option(
+            ["--verbose"],
+            is_flag=True,
+            default=DgConfig.verbose,
+            help="Enable verbose output for debugging.",
+        ),
+        click.Option(
+            ["--builtin-component-lib"],
+            type=str,
+            default=DgConfig.builtin_component_lib,
+            help="Specify a builitin component library to use.",
+        ),
+    ]
+}
+
+
+def dg_global_options(
+    fn: Optional[T_Command] = None, *, names: Optional[Sequence[str]] = None
+) -> Union[T_Command, Callable[[T_Command], T_Command]]:
+    if fn:
+        options = [GLOBAL_OPTIONS[name] for name in names or list(GLOBAL_OPTIONS.keys())]
+        if isinstance(fn, click.Command):
+            for option in options:
+                fn.params.append(option)
+        else:
+            # This is borrowed from click itself, it is how its decorators operate on both commands
+            # and regular functions.
+            if not hasattr(fn, "__click_params__"):
+                fn.__click_params__ = []  # type: ignore
+            for option in options:
+                fn.__click_params__.append(option)  # type: ignore
+
+        return fn
+    else:
+        return lambda fn: dg_global_options(fn, names=names)  # type: ignore
+
+
+def validate_global_opts(context: click.Context, **global_options: object) -> None:
+    for name, value in global_options.items():
+        if name not in GLOBAL_OPTIONS:
+            raise click.UsageError(f"Unknown global option: {name}")
+        GLOBAL_OPTIONS[name].process_value(context, value)

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,11 +1,14 @@
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping, Type, TypeVar
 
 import click
 from typing_extensions import Self
 
 from dagster_dg.error import DgError
+
+T = TypeVar("T")
 
 DEFAULT_BUILTIN_COMPONENT_LIB = "dagster_components"
 
@@ -40,16 +43,30 @@ class DgConfig:
     builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
 
     @classmethod
-    def from_cli_context(cls, cli_context: click.Context) -> Self:
-        if _CLI_CONTEXT_CONFIG_KEY not in cli_context.obj:
-            raise DgError(
-                "Attempted to extract DgConfig from CLI context but nothing stored under designated key `{_CLI_CONTEXT_CONFIG_KEY}`."
-            )
-        return cli_context.obj[_CLI_CONTEXT_CONFIG_KEY]
+    def from_cli_global_options(cls, global_options: Mapping[str, object]) -> Self:
+        return cls(
+            disable_cache=_validate_global_option(global_options, "disable_cache", bool),
+            cache_dir=_validate_global_option(global_options, "cache_dir", Path),
+            verbose=_validate_global_option(global_options, "verbose", bool),
+            builtin_component_lib=_validate_global_option(
+                global_options, "builtin_component_lib", str
+            ),
+        )
 
     @classmethod
     def default(cls) -> "DgConfig":
         return cls()
+
+
+# This validation will generally already be done by click, but this internal validation routine
+# provides insurance and satisfies the type checker.
+def _validate_global_option(
+    global_options: Mapping[str, object], key: str, expected_type: Type[T]
+) -> T:
+    value = global_options.get(key, getattr(DgConfig, key))
+    if not isinstance(value, expected_type):
+        raise DgError(f"Global option {key} must be of type {expected_type}.")
+    return value
 
 
 _CLI_CONTEXT_CONFIG_KEY = "config"
@@ -58,3 +75,12 @@ _CLI_CONTEXT_CONFIG_KEY = "config"
 def set_config_on_cli_context(cli_context: click.Context, config: DgConfig) -> None:
     cli_context.ensure_object(dict)
     cli_context.obj[_CLI_CONTEXT_CONFIG_KEY] = config
+
+
+def has_config_on_cli_context(cli_context: click.Context) -> bool:
+    return _CLI_CONTEXT_CONFIG_KEY in cli_context.ensure_object(dict)
+
+
+def get_config_from_cli_context(cli_context: click.Context) -> DgConfig:
+    cli_context.ensure_object(dict)
+    return cli_context.obj[_CLI_CONTEXT_CONFIG_KEY]

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -18,7 +18,7 @@ from dagster_dg.utils import camelcase, execute_code_location_command, generate_
 # ########################
 
 
-def generate_deployment(path: Path) -> None:
+def generate_deployment(path: Path, dg_context: DgContext) -> None:
     click.echo(f"Creating a Dagster deployment at {path}.")
 
     generate_subtree(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -6,57 +6,54 @@ from dagster_dg.utils import DgClickCommand, DgClickGroup, ensure_dagster_dg_tes
 
 ensure_dagster_dg_tests_import()
 
-from dagster_dg_tests.utils import assert_runner_result
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    assert_runner_result,
+    isolated_example_code_location_bar,
+)
 
 # ########################
 # ##### TEST CLI
 # ########################
 
+# The names of our global options are special-cased, so use one of them here (--disable-cache) as
+# a test case.
 
-@click.group(name="test", cls=DgClickGroup)
-@click.option("--test-opt", type=str, default="test", help="Test option.")
-def test_cli(test_opt):
-    """Test CLI group."""
+
+@click.group(name="root", cls=DgClickGroup)
+@click.option("--root-opt", type=str, default="root", help="Root option.")
+@click.option("--disable-cache", type=str, default="test", help="Disable cache.")
+def root(root_opt, disable_cache):
+    """Root group."""
     pass
 
 
-@test_cli.group(name="sub-test-1", cls=DgClickGroup)
-@click.option("--sub-test-1-opt", type=str, default="sub-test-1", help="Sub-test 1 option.")
-def sub_test_1(sub_test_1_opt):
-    """Sub-test 1 group."""
+@root.group(name="sub-group", cls=DgClickGroup)
+@click.option("--sub-group-opt", type=str, default="sub-group", help="Sub-group option.")
+@click.option("--disable-cache", type=str, default="test", help="Disable cache.")
+def sub_group(sub_group_opt, disable_cache):
+    """Sub-group."""
     pass
 
 
-@sub_test_1.command(name="alpha", cls=DgClickCommand)
-@click.option("--alpha-opt", type=str, default="alpha", help="Alpha option.")
-def alpha(alpha_opt):
-    """Alpha command."""
+@sub_group.command(name="sub-group-command", cls=DgClickCommand)
+@click.option(
+    "--sub-group-command-opt",
+    type=str,
+    default="sub_group_command",
+    help="Sub-group-command option.",
+)
+@click.option("--disable-cache", type=str, default="test", help="Disable cache.")
+def sub_group_command(sub_group_command_opt, disable_cache):
+    """Sub-group-command."""
     pass
 
 
-@test_cli.group(name="sub-test-2", cls=DgClickGroup)
-def sub_test_2():
-    """Sub-test 2 group."""
-    pass
-
-
-@click.option("--beta-opt", type=str, default="alpha", help="Beta option.")
-@sub_test_2.command(name="beta", cls=DgClickCommand)
-def beta(beta_opt):
-    """Beta command."""
-    pass
-
-
-@click.option("--delta-opt", type=str, default="delta", help="Delta option.")
-@test_cli.command(name="delta", cls=DgClickCommand)
-def delta(delta_opt):
-    """Delta command."""
-    pass
-
-
-@test_cli.command(name="gamma", cls=DgClickCommand)
-def gamma(gamma_opt):
-    """Gamma command."""
+@root.group(name="sub-command", cls=DgClickGroup)
+@click.option("--sub-command-opt", type=str, default="sub-command", help="Sub-command option.")
+@click.option("--disable-cache", type=str, default="test", help="Disable cache.")
+def sub_command(sub_command_opt, disable_cache):
+    """Sub-command."""
     pass
 
 
@@ -65,158 +62,117 @@ def gamma(gamma_opt):
 # ########################
 
 
-def test_root_group_help_message():
+def test_root_help_message():
     runner = CliRunner()
-    result = runner.invoke(test_cli, ["--help"])
+    result = runner.invoke(root, ["--help"])
     assert_runner_result(result)
     assert (
         result.output.strip()
         == textwrap.dedent("""
-        Usage: test [OPTIONS] COMMAND [ARGS]...
+        Usage: root [OPTIONS] COMMAND [ARGS]...
 
-          Test CLI group.
+          Root group.
 
         Commands:
-          delta       Delta command.
-          gamma       Gamma command.
-          sub-test-1  Sub-test 1 group.
-          sub-test-2  Sub-test 2 group.
+          sub-command  Sub-command.
+          sub-group    Sub-group.
 
         Options:
-          --test-opt TEXT  Test option.
+          --root-opt TEXT  Root option.
           --help           Show this message and exit.
+
+        Global options:
+          --disable-cache TEXT  Disable cache.
     """).strip()
     )
 
 
 def test_sub_group_with_option_help_message():
     runner = CliRunner()
-    result = runner.invoke(test_cli, ["sub-test-1", "--help"])
+    result = runner.invoke(root, ["sub-group", "--help"])
     assert_runner_result(result)
     assert (
         result.output.strip()
         == textwrap.dedent("""
-        Usage: test [OPTIONS] sub-test-1 [OPTIONS] COMMAND [ARGS]...
+        Usage: root sub-group [OPTIONS] COMMAND [ARGS]...
 
-          Sub-test 1 group.
+          Sub-group.
 
         Commands:
-          alpha  Alpha command.
+          sub-group-command  Sub-group-command.
 
         Options:
-          --sub-test-1-opt TEXT  Sub-test 1 option.
-          --help                 Show this message and exit.
+          --sub-group-opt TEXT  Sub-group option.
+          --help                Show this message and exit.
 
-        Options (test):
-          --test-opt TEXT  Test option.
+        Global options:
+          --disable-cache TEXT  Disable cache.
     """).strip()
     )
 
 
-def test_command_in_sub_group_with_option_help_message():
+def test_sub_group_command_with_option_help_message():
     runner = CliRunner()
-    result = runner.invoke(test_cli, ["sub-test-1", "alpha", "--help"])
+    result = runner.invoke(root, ["sub-group", "sub-group-command", "--help"])
     assert_runner_result(result)
     assert (
         result.output.strip()
         == textwrap.dedent("""
-        Usage: test [OPTIONS] sub-test-1 [OPTIONS] alpha [OPTIONS]
+        Usage: root sub-group sub-group-command [OPTIONS]
 
-          Alpha command.
+          Sub-group-command.
 
         Options:
-          --alpha-opt TEXT  Alpha option.
-          --help            Show this message and exit.
+          --sub-group-command-opt TEXT  Sub-group-command option.
+          --help                        Show this message and exit.
 
-        Options (test sub-test-1):
-          --sub-test-1-opt TEXT  Sub-test 1 option.
-
-        Options (test):
-          --test-opt TEXT  Test option.
+        Global options:
+          --disable-cache TEXT  Disable cache.
     """).strip()
     )
 
 
-def test_sub_group_with_no_option_help_message():
+def test_sub_command_with_option_help_message():
     runner = CliRunner()
-    result = runner.invoke(test_cli, ["sub-test-2", "--help"])
+    result = runner.invoke(root, ["sub-command", "--help"])
     assert_runner_result(result)
     assert (
         result.output.strip()
         == textwrap.dedent("""
-        Usage: test [OPTIONS] sub-test-2 [OPTIONS] COMMAND [ARGS]...
+        Usage: root sub-command [OPTIONS] COMMAND [ARGS]...
 
-          Sub-test 2 group.
-
-        Commands:
-          beta  Beta command.
+          Sub-command.
 
         Options:
-          --help  Show this message and exit.
+          --sub-command-opt TEXT  Sub-command option.
+          --help                  Show this message and exit.
 
-        Options (test):
-          --test-opt TEXT  Test option.
+        Global options:
+          --disable-cache TEXT  Disable cache.
     """).strip()
     )
 
 
-def test_command_in_sub_group_with_no_option_help_message():
-    runner = CliRunner()
-    result = runner.invoke(test_cli, ["sub-test-2", "beta", "--help"])
-    assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: test [OPTIONS] sub-test-2 beta [OPTIONS]
+def test_dynamic_subcommand_help_message():
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke(
+            "component", "generate", "dagster_components.test.simple_pipes_script_asset", "--help"
+        )
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+            Usage: dg component generate [GLOBAL OPTIONS] dagster_components.test.simple_pipes_script_asset [OPTIONS] COMPONENT_NAME
 
-          Beta command.
+            Options:
+              --json-params TEXT  JSON string of component parameters.
+              --asset-key TEXT    asset_key
+              --filename TEXT     filename
+              -h, --help          Show this message and exit.
 
-        Options:
-          --beta-opt TEXT  Beta option.
-          --help           Show this message and exit.
-
-        Options (test):
-          --test-opt TEXT  Test option.
-    """).strip()
-    )
-
-
-def test_command_with_option_in_root_group_help_message():
-    runner = CliRunner()
-    result = runner.invoke(test_cli, ["delta", "--help"])
-    assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: test [OPTIONS] delta [OPTIONS]
-
-          Delta command.
-
-        Options:
-          --delta-opt TEXT  Delta option.
-          --help            Show this message and exit.
-
-        Options (test):
-          --test-opt TEXT  Test option.
-    """).strip()
-    )
-
-
-def test_command_with_no_option_in_root_group_help_message():
-    runner = CliRunner()
-    result = runner.invoke(test_cli, ["gamma", "--help"])
-    assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: test [OPTIONS] gamma [OPTIONS]
-
-          Gamma command.
-
-        Options:
-          --help  Show this message and exit.
-
-        Options (test):
-          --test-opt TEXT  Test option.
-    """).strip()
-    )
+            Global options:
+              --builtin-component-lib TEXT  Specify a builitin component library to use.
+              --verbose                     Enable verbose output for debugging.
+              --disable-cache               Disable the cache..
+              --cache-dir PATH              Specify a directory to use for the cache.
+        """).strip()
+        )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
@@ -14,3 +14,17 @@ def test_all_commands_custom_subclass():
                 crawl(command)
 
     crawl(cli)
+
+
+# Important that all nodes of the command tree inherit from one of our customized click
+# Command/Group subclasses to ensure that the help formatting is consistent.
+def test_all_commands_have_global_options():
+    def crawl(command):
+        assert isinstance(
+            command, (DgClickGroup, DgClickCommand)
+        ), f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        if isinstance(command, DgClickGroup):
+            for command in command.commands.values():
+                crawl(command)
+
+    crawl(cli)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -2,8 +2,6 @@ import subprocess
 from functools import partial
 from pathlib import Path
 
-import pytest
-
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
@@ -69,22 +67,17 @@ def test_cache_no_invalidation_modified_pkg():
         assert "CACHE [hit]" in result.output
 
 
-@pytest.mark.parametrize("with_command", [True, False])
-def test_cache_clear(with_command: bool):
+def test_clear_cache():
     with ProxyRunner.test(verbose=True) as runner, example_code_location(runner):
         result = runner.invoke("component-type", "list")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
-        if with_command:
-            result = runner.invoke("--clear-cache", "component-type", "list")
-            assert "CACHE [clear-all]" in result.output
-        else:
-            result = runner.invoke("--clear-cache")
-            assert_runner_result(result)
-            assert "CACHE [clear-all]" in result.output
-            result = runner.invoke("component-type", "list")
+        result = runner.invoke("--clear-cache")
+        assert_runner_result(result)
+        assert "CACHE [clear-all]" in result.output
+        result = runner.invoke("component-type", "list")
 
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output


### PR DESCRIPTION
## Summary & Motivation

This changes the options scheme in `dagster-dg` so that options are no longer hierarchically processed and passed down the command tree, _except_ in the special case of `dg component generate` subcommands, where global options are defined on the containing group.

Now, all leaves of the tree (except for `dg component generate` subcommands) have the same set of "global options" appended to their options list. These are visually separated in the help message. We correspondingly simplify the Usage message to have a single `[OPTIONS]` input spot.

There are also now fewer apparent global options because two of the old ones, `--clear-cache` and `--rebuild-component-registry`, must be executed as standalone pseudo-commands (e.g. `dg --clear-cache`) rather than used as modifiers to other commands.

Before (`dg component-type info --help`):

```
Usage: dg [OPTIONS] component-type info [OPTIONS] COMPONENT_TYPE

  Get detailed information on a registered Dagster component type.

Options:
  --description
  --generate-params-schema
  --component-params-schema
  -h, --help                 Show this message and exit.

Options (dg):
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable caching of component registry data.
  --clear-cache                 Clear the cache before running the command.
  --rebuild-component-registry  Recompute and cache the set of available component types for the current environment.
                                Note that this also happens automatically whenever the cache is detected to be stale.
  --cache-dir PATH              Specify a directory to use for the cache.
```

After (`dg component-type info --help`):

```
Usage: dg component-type info [OPTIONS] COMPONENT_TYPE

  Get detailed information on a registered Dagster component type.

Options:
  --description
  --generate-params-schema
  --component-params-schema
  -h, --help                 Show this message and exit.

Global options:
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable the cache..
  --cache-dir PATH              Specify a directory to use for the cache.
```

---

Before (`dg generate component dagster_components.dbt_project --help`):

```
Usage: dg [OPTIONS] component generate dagster_components.dbt_project [OPTIONS] COMPONENT_NAME

Options:
  --json-params TEXT   JSON string of component parameters.
  --init BOOLEAN       init
  --project-path TEXT  project_path
  -h, --help           Show this message and exit.

Options (dg):
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable caching of component registry data.
  --clear-cache                 Clear the cache before running the command.
  --rebuild-component-registry  Recompute and cache the set of available component types for the current environment.
                                Note that this also happens automatically whenever the cache is detected to be stale.
  --cache-dir PATH              Specify a directory to use for the cache.
```

After (`dg generate component dagster_components.dbt_project --help`):

```
Usage: dg component generate [GLOBAL OPTIONS] dagster_components.dbt_project [OPTIONS] COMPONENT_NAME

Options:
  --json-params TEXT   JSON string of component parameters.
  --init BOOLEAN       init
  --project-path TEXT  project_path
  -h, --help           Show this message and exit.

Global options:
  --builtin-component-lib TEXT  Specify a builitin component library to use.
  --verbose                     Enable verbose output for debugging.
  --disable-cache               Disable the cache..
  --cache-dir PATH              Specify a directory to use for the cache.
```

## How I Tested These Changes

Modified unit tests, played with it on the command line.