### PR TITLE
Replace string reason check in k8s client with status check

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -468,7 +468,7 @@ class DagsterKubernetesClient:
             try:
                 job = self.batch_api.read_namespaced_job_status(job_name, namespace=namespace)
             except kubernetes.client.rest.ApiException as e:
-                if e.reason == "Not Found":
+                if e.status == 404:
                     return None
                 else:
                     raise
@@ -518,14 +518,14 @@ class DagsterKubernetesClient:
                 for error in errors:
                     if not (
                         isinstance(error, kubernetes.client.rest.ApiException)
-                        and error.reason == "Not Found"
+                        and error.status == 404
                     ):
                         raise error
                 raise errors[0]
 
             return True
         except kubernetes.client.rest.ApiException as e:
-            if e.reason == "Not Found":
+            if e.status == 404:
                 return False
             raise e
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -700,7 +700,7 @@ def test_check_run_health(kubeconfig_file):
             assert health.status == WorkerStatus.FAILED, health.msg
 
             mock_k8s_client_batch_api.read_namespaced_job_status.side_effect = (
-                kubernetes.client.rest.ApiException(reason="Not Found")
+                kubernetes.client.rest.ApiException(status=404, reason="Not Found")
             )
 
             finished_k8s_job_name = get_job_name_from_run_id(finished_run.run_id)


### PR DESCRIPTION
Summary:
Both work, but string matching on a reason is more error-pone.

BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
