### PR TITLE
Use markdown for images in new docs

### DIFF
--- a/docs/docs-beta/CONTRIBUTING.md
+++ b/docs/docs-beta/CONTRIBUTING.md
@@ -26,14 +26,7 @@ Before:
 After:
 
 ```
-<ThemedImage
-  alt="Highlighted Redeploy option in the dropdown menu next to a code location in Dagster+"
-  style={{width:'100%', height: 'auto'}}
-  sources={{
-    light: '/images/dagster-cloud/developing-testing/code-locations/redeploy-code-location.png',
-    dark: '/images/dagster-cloud/developing-testing/code-locations/redeploy-code-location.png',
-  }}
-/>
+![Highlighted Redeploy option in the dropdown menu next to a code location in Dagster+](/images/dagster-cloud/developing-testing/code-locations/redeploy-code-location.png)
 ```
 
 ### Notes


### PR DESCRIPTION
## Summary & Motivation

Since we don't have dark theme images for old screenshots, let's just format images with Markdown for now instead of using the ThemedImage` component. Later, we'll do a big screenshot sweep to create dark theme images and switch from Markdown to the component.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
