### PR TITLE
[dagster-azure] explicitly support access key and sas token in compute log manager

### DIFF
--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/dagster-yamls/access-key-credential.yaml
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/dagster-yamls/access-key-credential.yaml
@@ -1,0 +1,14 @@
+compute_logs:
+  module: dagster_azure.blob.compute_log_manager
+  class: AzureBlobComputeLogManager
+  config:
+    storage_account:
+      env: TEST_AZURE_STORAGE_ACCOUNT_ID
+    container: 
+      env: TEST_AZURE_CONTAINER_ID 
+    access_key_or_sas_token:
+      env: TEST_AZURE_ACCESS_KEY 
+    prefix: 
+      env: TEST_AZURE_LOG_PREFIX
+    local_dir: "/tmp/cool"
+    upload_interval: 30    

--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
@@ -33,7 +33,9 @@ def container_client(credentials: ClientSecretCredential) -> Generator[Container
 
 
 @pytest.mark.parametrize(
-    "dagster_yaml", ["secret-credential.yaml", "default-credential.yaml"], indirect=True
+    "dagster_yaml",
+    ["secret-credential.yaml", "default-credential.yaml", "access-key-credential.yaml"],
+    indirect=True,
 )
 def test_compute_log_manager(
     dagster_dev: subprocess.Popen,


### PR DESCRIPTION
## Summary & Motivation
Adds back support of asset keys and sas tokens to the azure compute log manager under a new configurable parameter;
`access_key_or_sas_token`. I'm torn on whether these should be two separate variables, but since they're handled identically it seems reasonable to have them live in the same field. Downside is ugly name.

We should also add back support for credential under the old name and issue a deprecation warning.
## How I Tested These Changes
Added a new parametrization of the compute log manager integration test suite. Currently failing in bk because credentials need to be rotated, but passes local for me with a real access key.

## Changelog
[dagster-azure] A new `access_key_or_sas_token` parameter to the `AzureBlobComputeLogManager`, which allows you to authenticate via either access key or sas token.
