### PR TITLE
[dagster-powerbi] Move contextual data from DagsterPowerBITranslator to PowerBITranslatorData

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
@@ -23,7 +23,7 @@ power_bi_workspace = PowerBIWorkspace(
 class MyCustomPowerBITranslator(DagsterPowerBITranslator):
     def get_asset_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
         # We create the default asset spec using super()
-        default_spec = super().get_asset_spec(data)
+        default_spec = super().get_asset_spec(data)  # type: ignore
         # We customize the team owner tag for all assets,
         # and we customize the asset key prefix only for dashboards.
         return default_spec.replace_attributes(

--- a/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
+++ b/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
@@ -21,7 +21,7 @@ class CustomDagsterPowerBITranslator(DagsterPowerBITranslator):
     def get_report_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
         return (
             super()
-            .get_report_spec(data)
+            .get_report_spec(data)  # type: ignore
             .replace_attributes(
                 group_name="reporting",
             )
@@ -33,7 +33,7 @@ class CustomDagsterPowerBITranslator(DagsterPowerBITranslator):
         ]
         return (
             super()
-            .get_semantic_model_spec(data)
+            .get_semantic_model_spec(data)  # type: ignore
             .replace_attributes(
                 group_name="reporting",
                 deps=upsteam_table_deps,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -28,6 +28,7 @@ from dagster_powerbi.translator import (
     PowerBIContentData,
     PowerBIContentType,
     PowerBITagSet,
+    PowerBITranslatorData,
     PowerBIWorkspaceData,
 )
 
@@ -437,7 +438,7 @@ class PowerBIWorkspaceDefsLoader(StateBackedDefinitionsLoader[PowerBIWorkspaceDa
             )
 
     def defs_from_state(self, state: PowerBIWorkspaceData) -> Definitions:
-        translator = self.translator_cls(context=state)
+        translator = self.translator_cls()
 
         all_external_data = [
             *state.dashboards_by_id.values(),
@@ -445,7 +446,14 @@ class PowerBIWorkspaceDefsLoader(StateBackedDefinitionsLoader[PowerBIWorkspaceDa
             *state.semantic_models_by_id.values(),
         ]
         all_external_asset_specs = [
-            translator.get_asset_spec(content) for content in all_external_data
+            translator.get_asset_spec(
+                PowerBITranslatorData(
+                    content_type=content.content_type,
+                    properties=content.properties,
+                    workspace_data=state,
+                )
+            )
+            for content in all_external_data
         ]
 
         return Definitions(assets=[*all_external_asset_specs])

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -448,8 +448,7 @@ class PowerBIWorkspaceDefsLoader(StateBackedDefinitionsLoader[PowerBIWorkspaceDa
         all_external_asset_specs = [
             translator.get_asset_spec(
                 PowerBITranslatorData(
-                    content_type=content.content_type,
-                    properties=content.properties,
+                    content_data=content,
                     workspace_data=state,
                 )
             )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,7 +1,7 @@
 import re
 import urllib.parse
 from enum import Enum
-from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
+from typing import Any, Dict, List, Literal, Optional, Sequence
 
 from dagster import (
     UrlMetadataValue,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -78,7 +78,8 @@ class PowerBIContentData:
     properties: Dict[str, Any]
 
 
-class PowerBITranslatorData(NamedTuple):
+@record
+class PowerBITranslatorData:
     """A record representing a piece of content in PowerBI and the PowerBI workspace data.
     Includes the content's type and data as returned from the API.
     """

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,7 +1,7 @@
 import re
 import urllib.parse
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
 from dagster import (
     UrlMetadataValue,
@@ -78,14 +78,21 @@ class PowerBIContentData:
     properties: Dict[str, Any]
 
 
-@whitelist_for_serdes
-@record
-class PowerBITranslatorData(PowerBIContentData):
+class PowerBITranslatorData(NamedTuple):
     """A record representing a piece of content in PowerBI and the PowerBI workspace data.
     Includes the content's type and data as returned from the API.
     """
 
+    content_data: "PowerBIContentData"
     workspace_data: "PowerBIWorkspaceData"
+
+    @property
+    def content_type(self) -> PowerBIContentType:
+        return self.content_data.content_type
+
+    @property
+    def properties(self) -> Dict[str, Any]:
+        return self.content_data.properties
 
 
 @whitelist_for_serdes
@@ -165,7 +172,7 @@ class DagsterPowerBITranslator:
     Subclass this class to implement custom logic for each type of PowerBI content.
     """
 
-    def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
+    def get_asset_spec(self, data: PowerBITranslatorData) -> AssetSpec:
         data = check.inst(data, PowerBITranslatorData)
         if data.content_type == PowerBIContentType.DASHBOARD:
             return self.get_dashboard_spec(data)
@@ -182,11 +189,11 @@ class DagsterPowerBITranslator:
         breaking_version="1.10",
         additional_warn_text="Use `DagsterPowerBITranslator.get_asset_spec(...).key` instead",
     )
-    def get_dashboard_asset_key(self, data: PowerBIContentData) -> AssetKey:
+    def get_dashboard_asset_key(self, data: PowerBITranslatorData) -> AssetKey:
         data = check.inst(data, PowerBITranslatorData)
         return self.get_dashboard_spec(data).key
 
-    def get_dashboard_spec(self, data: PowerBIContentData) -> AssetSpec:
+    def get_dashboard_spec(self, data: PowerBITranslatorData) -> AssetSpec:
         data = check.inst(data, PowerBITranslatorData)
         dashboard_id = data.properties["id"]
         tile_report_ids = [
@@ -195,8 +202,7 @@ class DagsterPowerBITranslator:
         report_keys = [
             self.get_report_spec(
                 PowerBITranslatorData(
-                    content_type=data.workspace_data.reports_by_id[report_id].content_type,
-                    properties=data.workspace_data.reports_by_id[report_id].properties,
+                    content_data=data.workspace_data.reports_by_id[report_id],
                     workspace_data=data.workspace_data,
                 )
             ).key
@@ -224,11 +230,11 @@ class DagsterPowerBITranslator:
         breaking_version="1.10",
         additional_warn_text="Use `DagsterPowerBITranslator.get_asset_spec(...).key` instead",
     )
-    def get_report_asset_key(self, data: PowerBIContentData) -> AssetKey:
+    def get_report_asset_key(self, data: PowerBITranslatorData) -> AssetKey:
         data = check.inst(data, PowerBITranslatorData)
         return self.get_report_spec(data).key
 
-    def get_report_spec(self, data: PowerBIContentData) -> AssetSpec:
+    def get_report_spec(self, data: PowerBITranslatorData) -> AssetSpec:
         data = check.inst(data, PowerBITranslatorData)
         report_id = data.properties["id"]
         dataset_id = data.properties.get("datasetId")
@@ -238,8 +244,7 @@ class DagsterPowerBITranslator:
         dataset_key = (
             self.get_semantic_model_spec(
                 PowerBITranslatorData(
-                    content_type=dataset_data.content_type,
-                    properties=dataset_data.properties,
+                    content_data=dataset_data,
                     workspace_data=data.workspace_data,
                 )
             ).key
@@ -266,19 +271,18 @@ class DagsterPowerBITranslator:
         breaking_version="1.10",
         additional_warn_text="Use `DagsterPowerBITranslator.get_asset_spec(...).key` instead",
     )
-    def get_semantic_model_asset_key(self, data: PowerBIContentData) -> AssetKey:
+    def get_semantic_model_asset_key(self, data: PowerBITranslatorData) -> AssetKey:
         data = check.inst(data, PowerBITranslatorData)
         return self.get_semantic_model_spec(data).key
 
-    def get_semantic_model_spec(self, data: PowerBIContentData) -> AssetSpec:
+    def get_semantic_model_spec(self, data: PowerBITranslatorData) -> AssetSpec:
         data = check.inst(data, PowerBITranslatorData)
         dataset_id = data.properties["id"]
         source_ids = data.properties.get("sources", [])
         source_keys = [
             self.get_data_source_spec(
                 PowerBITranslatorData(
-                    content_type=data.workspace_data.data_sources_by_id[source_id].content_type,
-                    properties=data.workspace_data.data_sources_by_id[source_id].properties,
+                    content_data=data.workspace_data.data_sources_by_id[source_id],
                     workspace_data=data.workspace_data,
                 )
             ).key
@@ -328,11 +332,11 @@ class DagsterPowerBITranslator:
         breaking_version="1.10",
         additional_warn_text="Use `DagsterPowerBITranslator.get_asset_spec(...).key` instead",
     )
-    def get_data_source_asset_key(self, data: PowerBIContentData) -> AssetKey:
+    def get_data_source_asset_key(self, data: PowerBITranslatorData) -> AssetKey:
         data = check.inst(data, PowerBITranslatorData)
         return self.get_data_source_spec(data).key
 
-    def get_data_source_spec(self, data: PowerBIContentData) -> AssetSpec:
+    def get_data_source_spec(self, data: PowerBITranslatorData) -> AssetSpec:
         data = check.inst(data, PowerBITranslatorData)
         connection_name = (
             data.properties["connectionDetails"].get("path")

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -25,7 +25,7 @@ from dagster._utils.test.definitions import lazy_definitions
 from dagster_powerbi import PowerBIWorkspace
 from dagster_powerbi.assets import build_semantic_model_refresh_asset_definition
 from dagster_powerbi.resource import BASE_API_URL, PowerBIToken, load_powerbi_asset_specs
-from dagster_powerbi.translator import DagsterPowerBITranslator, PowerBIContentData
+from dagster_powerbi.translator import DagsterPowerBITranslator, PowerBITranslatorData
 
 from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 
@@ -85,8 +85,8 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
 
 
 class MyCustomTranslator(DagsterPowerBITranslator):
-    def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
-        default_spec = super().get_asset_spec(data)  # type: ignore
+    def get_asset_spec(self, data: PowerBITranslatorData) -> AssetSpec:
+        default_spec = super().get_asset_spec(data)
         return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
         ).merge_attributes(metadata={"custom": "metadata"})

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -4,14 +4,25 @@ from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.definitions.tags import build_kind_tag
 from dagster_powerbi import DagsterPowerBITranslator
-from dagster_powerbi.translator import PowerBIContentData, PowerBIContentType, PowerBIWorkspaceData
+from dagster_powerbi.translator import (
+    PowerBIContentData,
+    PowerBIContentType,
+    PowerBITranslatorData,
+    PowerBIWorkspaceData,
+)
 
 
 def test_translator_dashboard_spec(workspace_data: PowerBIWorkspaceData) -> None:
     dashboard = next(iter(workspace_data.dashboards_by_id.values()))
 
-    translator = DagsterPowerBITranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(dashboard)
+    translator = DagsterPowerBITranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=dashboard.content_type,
+            properties=dashboard.properties,
+            workspace_data=workspace_data,
+        )
+    )
 
     assert asset_spec.key.path == ["dashboard", "Sales_Returns_Sample_v201912"]
     deps = list(asset_spec.deps)
@@ -32,8 +43,14 @@ def test_translator_dashboard_spec(workspace_data: PowerBIWorkspaceData) -> None
 def test_translator_report_spec(workspace_data: PowerBIWorkspaceData) -> None:
     report = next(iter(workspace_data.reports_by_id.values()))
 
-    translator = DagsterPowerBITranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(report)
+    translator = DagsterPowerBITranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=report.content_type,
+            properties=report.properties,
+            workspace_data=workspace_data,
+        )
+    )
 
     assert asset_spec.key.path == ["report", "Sales_Returns_Sample_v201912"]
     deps = list(asset_spec.deps)
@@ -55,8 +72,14 @@ def test_translator_report_spec(workspace_data: PowerBIWorkspaceData) -> None:
 def test_translator_semantic_model(workspace_data: PowerBIWorkspaceData) -> None:
     semantic_model = next(iter(workspace_data.semantic_models_by_id.values()))
 
-    translator = DagsterPowerBITranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(semantic_model)
+    translator = DagsterPowerBITranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=semantic_model.content_type,
+            properties=semantic_model.properties,
+            workspace_data=workspace_data,
+        )
+    )
 
     assert asset_spec.key.path == ["semantic_model", "Sales_Returns_Sample_v201912"]
     deps = list(asset_spec.deps)
@@ -90,8 +113,14 @@ def test_translator_semantic_model(workspace_data: PowerBIWorkspaceData) -> None
 def test_translator_semantic_model_many_tables(second_workspace_data: PowerBIWorkspaceData) -> None:
     semantic_model = next(iter(second_workspace_data.semantic_models_by_id.values()))
 
-    translator = DagsterPowerBITranslator(second_workspace_data)
-    asset_spec = translator.get_asset_spec(semantic_model)
+    translator = DagsterPowerBITranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=semantic_model.content_type,
+            properties=semantic_model.properties,
+            workspace_data=second_workspace_data,
+        )
+    )
     assert asset_spec.metadata == {
         "dagster-powerbi/web_url": MetadataValue.url(
             "https://app.powerbi.com/groups/a2122b8f-d7e1-42e8-be2b-a5e636ca3221/datasets/8e9c85a1-7b33-4223-9590-76bde70f9a20"
@@ -128,8 +157,14 @@ class MyCustomTranslator(DagsterPowerBITranslator):
 def test_translator_custom_metadata(workspace_data: PowerBIWorkspaceData) -> None:
     dashboard = next(iter(workspace_data.dashboards_by_id.values()))
 
-    translator = MyCustomTranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(dashboard)
+    translator = MyCustomTranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=dashboard.content_type,
+            properties=dashboard.properties,
+            workspace_data=workspace_data,
+        )
+    )
 
     assert "custom" in asset_spec.metadata
     assert asset_spec.metadata["custom"] == "metadata"
@@ -153,8 +188,14 @@ def test_translator_report_spec_no_dataset(workspace_data: PowerBIWorkspaceData)
         },
     )
 
-    translator = DagsterPowerBITranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(report_no_dataset)
+    translator = DagsterPowerBITranslator()
+    asset_spec = translator.get_asset_spec(
+        PowerBITranslatorData(
+            content_type=report_no_dataset.content_type,
+            properties=report_no_dataset.properties,
+            workspace_data=workspace_data,
+        )
+    )
 
     assert asset_spec.key.path == ["report", "Sales_Returns_Sample_v201912"]
     deps = list(asset_spec.deps)

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -154,7 +154,7 @@ def test_translator_custom_metadata(workspace_data: PowerBIWorkspaceData) -> Non
 
     translator = MyCustomTranslator()
     asset_spec = translator.get_asset_spec(
-        PowerBITranslatorData(  # type: ignore
+        PowerBITranslatorData(
             content_data=dashboard,
             workspace_data=workspace_data,
         )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -18,8 +18,7 @@ def test_translator_dashboard_spec(workspace_data: PowerBIWorkspaceData) -> None
     translator = DagsterPowerBITranslator()
     asset_spec = translator.get_asset_spec(
         PowerBITranslatorData(
-            content_type=dashboard.content_type,
-            properties=dashboard.properties,
+            content_data=dashboard,
             workspace_data=workspace_data,
         )
     )
@@ -46,8 +45,7 @@ def test_translator_report_spec(workspace_data: PowerBIWorkspaceData) -> None:
     translator = DagsterPowerBITranslator()
     asset_spec = translator.get_asset_spec(
         PowerBITranslatorData(
-            content_type=report.content_type,
-            properties=report.properties,
+            content_data=report,
             workspace_data=workspace_data,
         )
     )
@@ -75,8 +73,7 @@ def test_translator_semantic_model(workspace_data: PowerBIWorkspaceData) -> None
     translator = DagsterPowerBITranslator()
     asset_spec = translator.get_asset_spec(
         PowerBITranslatorData(
-            content_type=semantic_model.content_type,
-            properties=semantic_model.properties,
+            content_data=semantic_model,
             workspace_data=workspace_data,
         )
     )
@@ -116,8 +113,7 @@ def test_translator_semantic_model_many_tables(second_workspace_data: PowerBIWor
     translator = DagsterPowerBITranslator()
     asset_spec = translator.get_asset_spec(
         PowerBITranslatorData(
-            content_type=semantic_model.content_type,
-            properties=semantic_model.properties,
+            content_data=semantic_model,
             workspace_data=second_workspace_data,
         )
     )
@@ -147,11 +143,10 @@ def test_translator_semantic_model_many_tables(second_workspace_data: PowerBIWor
 
 class MyCustomTranslator(DagsterPowerBITranslator):
     def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
-        default_spec = super().get_asset_spec(data)
+        default_spec = super().get_asset_spec(data)  # type: ignore
         return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
-            metadata={**default_spec.metadata, "custom": "metadata"},
-        )
+        ).merge_attributes(metadata={"custom": "metadata"})
 
 
 def test_translator_custom_metadata(workspace_data: PowerBIWorkspaceData) -> None:
@@ -159,9 +154,8 @@ def test_translator_custom_metadata(workspace_data: PowerBIWorkspaceData) -> Non
 
     translator = MyCustomTranslator()
     asset_spec = translator.get_asset_spec(
-        PowerBITranslatorData(
-            content_type=dashboard.content_type,
-            properties=dashboard.properties,
+        PowerBITranslatorData(  # type: ignore
+            content_data=dashboard,
             workspace_data=workspace_data,
         )
     )
@@ -191,8 +185,7 @@ def test_translator_report_spec_no_dataset(workspace_data: PowerBIWorkspaceData)
     translator = DagsterPowerBITranslator()
     asset_spec = translator.get_asset_spec(
         PowerBITranslatorData(
-            content_type=report_no_dataset.content_type,
-            properties=report_no_dataset.properties,
+            content_data=report_no_dataset,
             workspace_data=workspace_data,
         )
     )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -142,8 +142,8 @@ def test_translator_semantic_model_many_tables(second_workspace_data: PowerBIWor
 
 
 class MyCustomTranslator(DagsterPowerBITranslator):
-    def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
-        default_spec = super().get_asset_spec(data)  # type: ignore
+    def get_asset_spec(self, data: PowerBITranslatorData) -> AssetSpec:
+        default_spec = super().get_asset_spec(data)
         return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
         ).merge_attributes(metadata={"custom": "metadata"})


### PR DESCRIPTION
## Summary & Motivation

This PR implements `PowerBITranslatorData`, a container class containing a `PowerBIContentData` object (props) and a `PowerBIWorkspaceData` object (context), to pass contextual data to the translator without breaking the `get_asset_spec` signature or requiring context to be passed to the `__init__` method of the `DagsterPowerBITranslator`.

This is PR is an alternative to the proposals mentioned in https://github.com/dagster-io/dagster/pull/26617.

## How I Tested These Changes

Updated tests with BK

## Changelog

[dagster-powerbi] Type hints in the signature of `DagsterPowerBITranslator.get_asset_spec` have been updated - the parameter `data` is now of type `PowerBITranslatorData` instead of `PowerBIContentData`. Custom Power BI translators should be updated.
