### PR TITLE
[components] [rfc] `UvRunComponent` and `NativeStepComponent`

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
@@ -86,9 +86,11 @@ class RenderedModel(BaseModel):
 
         # validate that the rendered properties match the output type
         for k, v in rendered_properties.items():
-            annotation = self.model_fields[k].annotation
-            if annotation is None:
-                raise Exception(f"Annotation missing for field {k}")
+            annotation = self.__annotations__[k]
+            # TODO this was my first attempt to handle inheritance
+            # annotation = self.model_fields[k].annotation
+            # if annotation is None:
+            #     raise Exception(f"Annotation missing for field {k}")
             expected_type = _get_expected_type(annotation)
             if expected_type is not None:
                 # hook into pydantic's type validation to handle complicated stuff like Optional[Mapping[str, int]]

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
@@ -86,7 +86,9 @@ class RenderedModel(BaseModel):
 
         # validate that the rendered properties match the output type
         for k, v in rendered_properties.items():
-            annotation = self.__annotations__[k]
+            annotation = self.model_fields[k].annotation
+            if annotation is None:
+                raise Exception(f"Annotation missing for field {k}")
             expected_type = _get_expected_type(annotation)
             if expected_type is not None:
                 # hook into pydantic's type validation to handle complicated stuff like Optional[Mapping[str, int]]

--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -24,8 +24,7 @@ class OpSpecBaseModel(BaseModel):
     tags: Optional[Dict[str, str]] = None
 
 
-class AssetAttributesModel(RenderedModel):
-    key: Optional[str] = None
+class AssetModelBase(RenderedModel):
     deps: Sequence[str] = []
     description: Optional[str] = None
     metadata: Annotated[
@@ -41,6 +40,18 @@ class AssetAttributesModel(RenderedModel):
     automation_condition: Annotated[
         Optional[str], RenderingMetadata(output_type=Optional[AutomationCondition])
     ] = None
+
+
+class AssetAttributesModel(AssetModelBase):
+    key: Optional[str] = None
+
+
+class AssetSpecModel(AssetModelBase):
+    key: str
+
+    def render_spec(self, value_resolver: TemplatedValueResolver) -> AssetSpec:
+        attributes = self.render_properties(value_resolver)
+        return AssetSpec(**attributes)
 
 
 class AssetSpecProcessor(ABC, BaseModel):

--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -24,7 +24,27 @@ class OpSpecBaseModel(BaseModel):
     tags: Optional[Dict[str, str]] = None
 
 
-class AssetModelBase(RenderedModel):
+# class AssetModelBase(RenderedModel):
+#     deps: Sequence[str] = []
+#     description: Optional[str] = None
+#     metadata: Annotated[
+#         Union[str, Mapping[str, Any]], RenderingMetadata(output_type=Mapping[str, Any])
+#     ] = {}
+#     group_name: Optional[str] = None
+#     skippable: bool = False
+#     code_version: Optional[str] = None
+#     owners: Sequence[str] = []
+#     tags: Annotated[
+#         Union[str, Mapping[str, str]], RenderingMetadata(output_type=Mapping[str, str])
+#     ] = {}
+#     automation_condition: Annotated[
+#         Optional[str], RenderingMetadata(output_type=Optional[AutomationCondition])
+#     ] = None
+
+
+# TODO share common base class with AssetSpecModel
+class AssetAttributesModel(RenderedModel):
+    key: Optional[str] = None
     deps: Sequence[str] = []
     description: Optional[str] = None
     metadata: Annotated[
@@ -42,12 +62,23 @@ class AssetModelBase(RenderedModel):
     ] = None
 
 
-class AssetAttributesModel(AssetModelBase):
-    key: Optional[str] = None
-
-
-class AssetSpecModel(AssetModelBase):
+class AssetSpecModel(RenderedModel):
     key: str
+    deps: Sequence[str] = []
+    description: Optional[str] = None
+    metadata: Annotated[
+        Union[str, Mapping[str, Any]], RenderingMetadata(output_type=Mapping[str, Any])
+    ] = {}
+    group_name: Optional[str] = None
+    skippable: bool = False
+    code_version: Optional[str] = None
+    owners: Sequence[str] = []
+    tags: Annotated[
+        Union[str, Mapping[str, str]], RenderingMetadata(output_type=Mapping[str, str])
+    ] = {}
+    automation_condition: Annotated[
+        Optional[str], RenderingMetadata(output_type=Optional[AutomationCondition])
+    ] = None
 
     def render_spec(self, value_resolver: TemplatedValueResolver) -> AssetSpec:
         attributes = self.render_properties(value_resolver)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
@@ -17,3 +17,4 @@ from dagster_components.lib.definitions_component import (
 from dagster_components.lib.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollection as PipesSubprocessScriptCollection,
 )
+from dagster_components.lib.uv_run_component import UvRunComponent as UvRunComponent

--- a/python_modules/libraries/dagster-components/dagster_components/lib/native_step_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/native_step_component.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Sequence
 
 from dagster import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_embedded_elt.sling.resources import AssetExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from pydantic import BaseModel
 from typing_extensions import Self
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/native_step_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/native_step_component.py
@@ -1,0 +1,63 @@
+from abc import abstractmethod
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from dagster import multi_asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_embedded_elt.sling.resources import AssetExecutionContext
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from dagster_components import Component, ComponentLoadContext
+from dagster_components.core.component import ComponentGenerateRequest
+from dagster_components.core.dsl_schema import AssetSpecModel, OpSpecBaseModel
+
+
+class NativeStepComponentSchema(BaseModel):
+    op: OpSpecBaseModel
+    assets: Optional[Sequence[AssetSpecModel]] = None
+
+
+# Possibilities
+# * op
+# * step
+# * task
+# * computation
+
+
+class NativeStepComponent(Component):
+    params_schema = NativeStepComponentSchema
+
+    def __init__(
+        self, op: OpSpecBaseModel, assets: Optional[Sequence[AssetSpecModel]], script_path: Path
+    ):
+        self.op = op
+        self.assets = assets or []
+        self.script_path = script_path
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        @multi_asset(
+            name=self.op.name,
+            op_tags=self.op.tags,
+            specs=[asset.render_spec(context.templated_value_resolver) for asset in self.assets],
+        )
+        def _the_step(context: AssetExecutionContext):
+            return self.execute(context)
+
+        return Definitions([_the_step])
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> Self:
+        # all paths should be resolved relative to the directory we're in
+        loaded_params = context.load_params(cls.params_schema)
+
+        return cls(
+            op=loaded_params.op, assets=loaded_params.assets, script_path=context.path / "step.py"
+        )
+
+    @classmethod
+    def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None:
+        super().generate_files(request, params)
+
+    @abstractmethod
+    def execute(self, context: AssetExecutionContext): ...

--- a/python_modules/libraries/dagster-components/dagster_components/lib/uv_run_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/uv_run_component.py
@@ -1,0 +1,13 @@
+from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster_embedded_elt.sling.resources import AssetExecutionContext
+
+from dagster_components.core.component import component_type
+from dagster_components.lib.native_step_component import NativeStepComponent
+
+
+@component_type(name="uv_run")
+class UvRunComponent(NativeStepComponent):
+    def execute(self, context: AssetExecutionContext):
+        client = PipesSubprocessClient()
+        invocation = client.run(context=context, command=["uv", "run", str(self.script_path)])
+        return invocation.get_results()

--- a/python_modules/libraries/dagster-components/dagster_components/lib/uv_run_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/uv_run_component.py
@@ -1,5 +1,5 @@
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
-from dagster_embedded_elt.sling.resources import AssetExecutionContext
 
 from dagster_components.core.component import component_type
 from dagster_components.lib.native_step_component import NativeStepComponent

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/native_steps/uv_run_hello_world/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/native_steps/uv_run_hello_world/component.yaml
@@ -1,0 +1,12 @@
+type: dagster_components.uv_run
+
+params:
+  op:
+    name: the_step
+    tags:
+      tag1: value1
+      tag2: value2
+
+  assets:
+    - key: an_asset
+      description: "A description"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/native_steps/uv_run_hello_world/step.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/native_steps/uv_run_hello_world/step.py
@@ -1,0 +1,20 @@
+# /// script
+# dependencies = [
+#   "dagster-pipes",
+#   "cowsay",
+# ]
+# ///
+
+import cowsay  # type: ignore
+from dagster_pipes import PipesContext, open_dagster_pipes
+
+
+def execute(context: PipesContext) -> None:
+    context.report_asset_materialization(
+        metadata={"foo": "bar", "cowsay": cowsay.get_output_string("cow", "hello world")}
+    )
+
+
+if __name__ == "__main__":
+    with open_dagster_pipes() as pipes:
+        execute(pipes)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_uv_run_step.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_uv_run_step.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
+from dagster._core.events import StepMaterializationData
+from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
+from dagster._utils import pushd
+
+from dagster_components_tests.integration_tests.component_loader import load_test_component_defs
+
+
+def get_materialization(
+    result: ExecuteInProcessResult, key: CoercibleToAssetKey
+) -> AssetMaterialization:
+    asset_key = AssetKey.from_coercible(key)
+    for event in result.get_asset_materialization_events():
+        assert isinstance(event.event_specific_data, StepMaterializationData)
+        if event.event_specific_data.materialization.asset_key == asset_key:
+            return event.event_specific_data.materialization
+
+    raise Exception(f"Materialization for asset key {asset_key} not found in result")
+
+
+def text_metadata(materialization: AssetMaterialization, key: str) -> str:
+    assert key in materialization.metadata
+    metadata_value = materialization.metadata[key]
+    assert isinstance(metadata_value, TextMetadataValue)
+    assert metadata_value.value is not None
+    return metadata_value.value
+
+
+def test_uv_run_hello_world() -> None:
+    defs = load_test_component_defs("native_steps/uv_run_hello_world")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("an_asset")}
+
+    asset_spec = {spec.key: spec for spec in defs.get_all_asset_specs()}[AssetKey("an_asset")]
+    assert asset_spec.description == "A description"
+
+    assets_def = defs.get_asset_graph().assets_def_for_key(AssetKey("an_asset"))
+    assert assets_def.op.name == "the_step"
+    assert assets_def.op.tags == {"tag1": "value1", "tag2": "value2"}
+
+    with pushd(str(Path(__file__).parent)):
+        result = defs.get_implicit_global_asset_job_def().execute_in_process()
+    assert result.success
+    mat_events = result.get_asset_materialization_events()
+    assert len(mat_events) == 1
+    materialization = get_materialization(result, "an_asset")
+    assert text_metadata(materialization, "foo") == "bar"
+    cowsay_text = text_metadata(materialization, "cowsay")
+    assert "hello world" in cowsay_text
+    assert r"(oo)\_______" in cowsay_text


### PR DESCRIPTION
## Summary & Motivation

This is mostly an RFC for now but I would like to land some variant of this for next week as I think it will be useful for demos.

This PR demonstrates a few things:

* A useful standalone component that invokes `uv run` on a pipes script, allowing for completely isolated virtual environments on a per step basis, leveraging uv support for per-script dependencies ([docs](https://docs.astral.sh/uv/guides/scripts/))

This allows you to write steps like the following:

```python
# /// script
# dependencies = [
#   "dagster-pipes",
#   "cowsay",
# ]
# ///
import cowsay  # type: ignore
from dagster_pipes import PipesContext, open_dagster_pipes
def execute(context: PipesContext) -> None:
    context.report_asset_materialization(
        metadata={"foo": "bar", "cowsay": cowsay.get_output_string("cow", "hello world")}
    )

if __name__ == "__main__":
    with open_dagster_pipes() as pipes:
        execute(pipes)
```



* A generic `NativeStepComponent` that is a generic components to allow users single step assets easily. This is in effect a wholesale replacement for simple asset factories.

* A new `AssetSpecModel` that largely overlaps with `AssetAttributesModel` except for that `AssetSpecModel` _requires_ an asset key.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
