### PR TITLE
[components] Fix component.yaml generation to have a trailing newline

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -25,6 +25,7 @@ def generate_component_yaml(
         yaml.dump(
             component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
         )
+        f.writelines([""])
 
 
 def generate_component_instance(


### PR DESCRIPTION
## Summary & Motivation

Without this the `component.yaml` files trigger prettier errors.

## How I Tested These Changes

Manual.
