### PR TITLE
[components] Create unique name for dynamically load module

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -7,13 +7,16 @@ import sys
 import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 from types import ModuleType
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Dict,
     Iterable,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -25,13 +28,17 @@ from typing import (
 import click
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.utils import is_valid_name
 from dagster._core.errors import DagsterError
-from dagster._record import record
+from dagster._record import IHaveNew, record, record_custom
 from dagster._utils import pushd, snakecase
 from pydantic import TypeAdapter
 from typing_extensions import Self
 
 from dagster_components.core.component_rendering import TemplatedValueResolver, preprocess_value
+
+if TYPE_CHECKING:
+    from dagster_components.core.component_decl_builder import YamlComponentDecl
 
 
 class ComponentDeclNode: ...
@@ -206,12 +213,40 @@ def get_registered_components_in_module(module: ModuleType) -> Iterable[Type[Com
 T = TypeVar("T")
 
 
+@record_custom
+class ComponentKey(IHaveNew):
+    """Uniquely identifies a component instance within a component hierarchy. Parts
+    typically correspond to the folder structure of the component hierarchy.
+    """
+
+    def __new__(cls, parts: Iterable[str]):
+        for part in parts:
+            if not is_valid_name(part):
+                check.param_invariant(False, "parts", f"Invalid key part {part}")
+
+        return super().__new__(cls, parts=parts)
+
+    parts: List[str]
+
+    @staticmethod
+    def root() -> "ComponentKey":
+        return ComponentKey(parts=[])
+
+    def child(self, part: str) -> "ComponentKey":
+        return ComponentKey(parts=self.parts + [part])
+
+    @property
+    def dot_path(self) -> str:
+        return ".".join(self.parts)
+
+
 @dataclass
 class ComponentLoadContext:
     resources: Mapping[str, object]
     registry: ComponentRegistry
     decl_node: Optional[ComponentDeclNode]
     templated_value_resolver: TemplatedValueResolver
+    code_location_name: str
 
     @staticmethod
     def for_test(
@@ -219,22 +254,35 @@ class ComponentLoadContext:
         resources: Optional[Mapping[str, object]] = None,
         registry: Optional[ComponentRegistry] = None,
         decl_node: Optional[ComponentDeclNode] = None,
+        code_location_name: Optional[str] = None,
     ) -> "ComponentLoadContext":
         return ComponentLoadContext(
             resources=resources or {},
             registry=registry or ComponentRegistry.empty(),
             decl_node=decl_node,
             templated_value_resolver=TemplatedValueResolver.default(),
+            code_location_name=code_location_name or "test",
         )
 
-    @property
-    def path(self) -> Path:
+    @cached_property
+    def yaml_decl_node(self) -> "YamlComponentDecl":
         from dagster_components.core.component_decl_builder import YamlComponentDecl
 
         if not isinstance(self.decl_node, YamlComponentDecl):
             check.failed(f"Unsupported decl_node type {type(self.decl_node)}")
+        return self.decl_node
 
-        return self.decl_node.path
+    @property
+    def path(self) -> Path:
+        return self.yaml_decl_node.path
+
+    @property
+    def component_instance_key(self) -> ComponentKey:
+        return self.yaml_decl_node.key
+
+    @property
+    def component_type(self) -> str:
+        return self.yaml_decl_node.component_file_model.type
 
     def with_rendering_scope(self, rendering_scope: Mapping[str, Any]) -> "ComponentLoadContext":
         return dataclasses.replace(
@@ -258,6 +306,17 @@ class ComponentLoadContext:
                 self.templated_value_resolver, self._raw_params(), params_schema
             )
             return TypeAdapter(params_schema).validate_python(preprocessed_params)
+
+
+def get_python_module_name(context: ComponentLoadContext, subkey: str) -> str:
+    """Utility function to generate a unique name for a Python module that is being dynamically
+    loaded for a particular component instance.
+    """
+    return (
+        f"__dagster_code_location__.{context.code_location_name}."
+        f"__component_instance__.{context.component_instance_key.dot_path}."
+        f"__{context.component_type}__.{subkey}"
+    )
 
 
 COMPONENT_REGISTRY_KEY_ATTR = "__dagster_component_registry_key"

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -9,6 +9,7 @@ from dagster._utils.warnings import suppress_dagster_warnings
 
 from dagster_components.core.component import (
     Component,
+    ComponentKey,
     ComponentLoadContext,
     ComponentRegistry,
     TemplatedValueResolver,
@@ -84,18 +85,19 @@ def component_type_from_yaml_decl(
 def build_components_from_component_folder(
     context: ComponentLoadContext, path: Path
 ) -> Sequence[Component]:
-    component_folder = path_to_decl_node(path)
+    component_folder = path_to_decl_node(path, ComponentKey.root())
     assert isinstance(component_folder, ComponentFolder)
     return load_components_from_context(context.for_decl_node(component_folder))
 
 
 def build_defs_from_component_path(
+    code_location_name: str,
     path: Path,
     registry: ComponentRegistry,
     resources: Mapping[str, object],
 ) -> "Definitions":
     """Build a definitions object from a folder within the components hierarchy."""
-    decl_node = path_to_decl_node(path=path)
+    decl_node = path_to_decl_node(path=path, current_key=ComponentKey.root())
     if not decl_node:
         raise Exception(f"No component found at path {path}")
 
@@ -104,6 +106,7 @@ def build_defs_from_component_path(
         registry=registry,
         decl_node=decl_node,
         templated_value_resolver=TemplatedValueResolver.default(),
+        code_location_name=code_location_name,
     )
     components = load_components_from_context(context)
     return defs_from_components(resources=resources, context=context, components=components)
@@ -149,6 +152,7 @@ def build_component_defs(
     for component in context.component_instances:
         component_path = Path(context.get_component_instance_path(component))
         defs = build_defs_from_component_path(
+            code_location_name=context.name,
             path=component_path,
             registry=context.component_registry,
             resources=resources or {},

--- a/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
@@ -75,17 +75,17 @@ class CodeLocationProjectContext:
         components_folder: Path,
     ):
         self._root_path = root_path
-        self._name = name
+        self.name = name
         self._component_registry = component_registry
         self._components_folder = components_folder
 
     @property
     def component_types_root_path(self) -> str:
-        return os.path.join(self._root_path, self._name, _CODE_LOCATION_CUSTOM_COMPONENTS_DIR)
+        return os.path.join(self._root_path, self.name, _CODE_LOCATION_CUSTOM_COMPONENTS_DIR)
 
     @property
     def component_types_root_module(self) -> str:
-        return f"{self._name}.{_CODE_LOCATION_CUSTOM_COMPONENTS_DIR}"
+        return f"{self.name}.{_CODE_LOCATION_CUSTOM_COMPONENTS_DIR}"
 
     @property
     def component_registry(self) -> "ComponentRegistry":

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -13,6 +13,7 @@ from dagster_components.core.deployment import CodeLocationProjectContext
 def load_test_component_defs(name: str) -> Definitions:
     context = load_test_component_project_context()
     return build_defs_from_component_path(
+        code_location_name=context.name,
         path=Path(__file__).parent / "components" / name,
         registry=context.component_registry,
         resources={},

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -6,7 +6,7 @@ from typing import Generator
 
 import pytest
 from dagster import AssetKey
-from dagster_components.core.component_decl_builder import ComponentFileModel
+from dagster_components.core.component_decl_builder import ComponentFileModel, ComponentKey
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
     build_components_from_component_folder,
@@ -53,6 +53,7 @@ def test_python_params(dbt_path: Path) -> None:
                 "op": {"name": "some_op", "tags": {"tag1": "value"}},
             },
         ),
+        key=ComponentKey(parts=["dbt_project"]),
     )
     component = DbtProjectComponent.load(context=script_load_context(decl_node))
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
@@ -11,3 +11,13 @@ def test_definitions_component_with_default_file() -> None:
 def test_definitions_component_with_explicit_file() -> None:
     defs = load_test_component_defs("definitions/explicit_file")
     assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("asset_in_some_file")}
+
+
+def test_definitions_component_with_include_file_absolute() -> None:
+    defs = load_test_component_defs("definitions/include_file_absolute_import")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("an_asset")}
+
+
+def test_definitions_component_with_include_file_relative() -> None:
+    defs = load_test_component_defs("definitions/include_file_relative_import")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("an_asset")}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.env import environ
+from dagster_components.core.component import ComponentKey
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -23,6 +24,7 @@ from dagster_components_tests.utils import assert_assets, get_asset_keys, script
 
 STUB_LOCATION_PATH = Path(__file__).parent.parent / "stub_code_locations" / "sling_location"
 COMPONENT_RELPATH = "components/ingest"
+COMPONENT_INSTANCE_KEY = ComponentKey(parts=["ingest"])
 
 
 def _update_yaml(path: Path, fn) -> None:
@@ -72,6 +74,7 @@ def test_python_params(sling_path: Path) -> None:
             type="sling_replication",
             params={"sling": {}},
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     context = script_load_context(decl_node)
     component = SlingReplicationComponent.load(context)
@@ -93,6 +96,7 @@ def test_python_params_op_name(sling_path: Path) -> None:
             type="sling_replication",
             params={"sling": {}, "op": {"name": "my_op"}},
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     context = script_load_context(decl_node)
     component = SlingReplicationComponent.load(context=context)
@@ -114,6 +118,7 @@ def test_python_params_op_tags(sling_path: Path) -> None:
             type="sling_replication",
             params={"sling": {}, "op": {"tags": {"tag1": "value1"}}},
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     context = script_load_context(decl_node)
     component = SlingReplicationComponent.load(context=context)
@@ -150,6 +155,7 @@ def test_sling_subclass() -> None:
             type="debug_sling_replication",
             params={"sling": {}},
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     component_inst = DebugSlingReplicationComponent.load(
         context=script_load_context(decl_node),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Generator
 import pytest
 from dagster import AssetKey
 from dagster._utils.env import environ
-from dagster_components.core.component_decl_builder import ComponentFileModel
+from dagster_components.core.component_decl_builder import ComponentFileModel, ComponentKey
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
     build_components_from_component_folder,
@@ -27,6 +27,7 @@ STUB_LOCATION_PATH = (
     / "templated_custom_keys_dbt_project_location"
 )
 COMPONENT_RELPATH = "components/jaffle_shop_dbt"
+COMPONENT_INSTANCE_KEY = ComponentKey(parts=["jaffle_shop_dbt"])
 
 JAFFLE_SHOP_KEYS = {
     AssetKey("customers"),
@@ -74,6 +75,7 @@ def test_python_params_node_rename(dbt_path: Path) -> None:
                 },
             },
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     component = DbtProjectComponent.load(
         context=script_load_context(decl_node),
@@ -93,6 +95,7 @@ def test_python_params_group(dbt_path: Path) -> None:
                 },
             },
         ),
+        key=COMPONENT_INSTANCE_KEY,
     )
     comp = DbtProjectComponent.load(context=script_load_context(decl_node))
     assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
@@ -132,6 +135,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
                     },
                 },
             ),
+            key=COMPONENT_INSTANCE_KEY,
         )
         comp = DbtProjectComponent.load(context=script_load_context(decl_node))
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
@@ -153,6 +157,7 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
                     },
                 },
             ),
+            key=COMPONENT_INSTANCE_KEY,
         )
         comp = DbtProjectComponent.load(context=script_load_context(decl_node))
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS_WITH_PREFIX

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_custom_scope.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_custom_scope.py
@@ -11,6 +11,7 @@ def test_custom_scope() -> None:
         path=Path(__file__).parent / "custom_scope_component",
         registry=registry(),
         resources={},
+        code_location_name="custom_scope",
     )
 
     assets = list(defs.assets or [])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_dynamic_python_modules.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_dynamic_python_modules.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component_decl_builder import (
+    ComponentFileModel,
+    ComponentKey,
+    YamlComponentDecl,
+)
+from dagster_components.lib.definitions_component import get_python_module_name
+
+
+def test_get_python_module_name() -> None:
+    assert (
+        get_python_module_name(
+            context=ComponentLoadContext.for_test(
+                code_location_name="test",
+                decl_node=YamlComponentDecl(
+                    key=ComponentKey(parts=["a", "b"]),
+                    path=Path("a/b"),
+                    component_file_model=ComponentFileModel(
+                        type="some_type",
+                        params={},
+                    ),
+                ),
+            ),
+            subkey="defs",
+        )
+        == "__dagster_code_location__.test.__component_instance__.a.b.__some_type__.defs"
+    )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from dagster import AssetKey
+from dagster_components.core.component import ComponentKey
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -49,6 +50,7 @@ def test_python_params() -> None:
                 ]
             },
         ),
+        key=ComponentKey(["scripts"]),
     )
     component = PipesSubprocessScriptCollection.load(context=script_load_context(component_decl))
     assert get_asset_keys(component) == {
@@ -94,7 +96,10 @@ def test_load_from_path() -> None:
 
 def test_load_from_location_path() -> None:
     defs = build_defs_from_component_path(
-        LOCATION_PATH / "components" / "scripts", script_load_context().registry, {}
+        path=LOCATION_PATH / "components" / "scripts",
+        registry=script_load_context().registry,
+        resources={},
+        code_location_name="test",
     )
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),


### PR DESCRIPTION
## Summary & Motivation

This changes the `DefinitionsComponent` to use a unique module name for python code it dynamically loads.

This also introduces some terminology.

Notably it introduces `ComponentInstanceKey` which uniquely identifies a component within a given code location. This concept will probably live forever and become user-facing (even in UI) so it is worth bikeshedding it.

This also makes `code_location_name` available on `ComponentLoadContext`. We could go further here and just provide the full code location context object.

## How I Tested These Changes

BK
