### PR TITLE
Draft: [dagster-k8s] 🐛 respect container context image when constructing k8s job

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -554,9 +554,22 @@ class K8sContainerContext(
             ),
         )
 
-    def get_k8s_job_config(self, job_image, run_launcher) -> DagsterK8sJobConfig:
+    def get_k8s_job_config(
+        self, job_image: Optional[str], run_launcher: "K8sRunLauncher"
+    ) -> DagsterK8sJobConfig:
+        """Job Images resolved in the following order of priority:
+        - container_context run config image
+        - :param: job_image
+        - :param: run_launcher job_image.
+        """
+        image = run_launcher.job_image
+        if job_image:
+            image = job_image
+        container_image = self.run_k8s_config.container_config.get("image")
+        if container_image:
+            image = container_image
         return DagsterK8sJobConfig(
-            job_image=job_image if job_image else run_launcher.job_image,
+            job_image=image,
             dagster_home=run_launcher.dagster_home,
             instance_config_map=run_launcher.instance_config_map,
             postgres_password_secret=run_launcher.postgres_password_secret,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -270,7 +270,7 @@ class K8sStepHandler(StepHandler):
         container_context = self._get_container_context(step_handler_context)
 
         job_config = container_context.get_k8s_job_config(
-            self._executor_image, step_handler_context.instance.run_launcher
+            self._executor_image, cast(K8sRunLauncher, step_handler_context.instance.run_launcher)
         )
 
         args = step_handler_context.execute_step_args.get_command_args(


### PR DESCRIPTION
## Summary & Motivation

While constructing a k8s job from a `K8sContainerContext`, runtime k8s configs aren't respected. This rears it's head as a bug in the following case.

```yml
execution:
  config:
    per_step_k8s_config:
      foo:
        container_config:
          image: 'image:foo_step'
```

Given a job:
```python
@job
def simple_job():
    @op
    def foo(): ...
    foo()
```

## How I Tested These Changes

I modified the existing test to propagate a `per_k8s_config` image config. Then I ensured this is propagated both in the k8s container context and the launched job is configured to properly use said image.

cc @Kuhlwein 


resolves #26536 
