### PR TITLE
Remove unnecessary "Code of Conduct" link in bug report template's `Message from the maintainers` block

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_bug.yml
@@ -89,8 +89,4 @@ body:
     attributes:
       label: Message from the maintainers
       description: This form field should be ignored. This is to include a footer message on the generated issue.
-      value: >
-        Impacted by this issue? Give it a 👍! We factor engagement into prioritization.
-        
-        By submitting this issue, you agree to follow Dagster's
-        [Code of Conduct](https://github.com/dagster-io/dagster/blob/master/.github/CODE_OF_CONDUCT.md).
+      value: Impacted by this issue? Give it a 👍! We factor engagement into prioritization.


### PR DESCRIPTION
## Summary & Motivation
Remove unnecessary "Code of Conduct" link in `Message from the maintainers` so it matches the [feature request issue template](https://github.com/dagster-io/dagster/edit/master/.github/ISSUE_TEMPLATE/request_a_feature.yml)

## How I Tested These Changes
👀