### PR TITLE
[dagster-airlift] remove dagster dep

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/__init__.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/__init__.py
@@ -1,5 +1,11 @@
-from dagster._core.libraries import DagsterLibraryRegistry
+from importlib import util as iutil
 
 from dagster_airlift.version import __version__
 
-DagsterLibraryRegistry.register("dagster-azure", __version__)
+is_dagster_installed = iutil.find_spec("dagster") is not None
+# In the case of running CI/CD, where we have Dagster installed in the environment, we want to be able to register the library in our library registry. But we want
+# to avoid taking an actual dependency on Dagster, so we need to gate this behind a check for the presence of the Dagster package in the environment.
+if is_dagster_installed:
+    from dagster._core.libraries import DagsterLibraryRegistry
+
+    DagsterLibraryRegistry.register("dagster-airlift", __version__)


### PR DESCRIPTION
When moving this into the python_modules/libraries directory, accidentally introduced a dagster dependency on `dagster-airlift`. 

Instead, gate the dagster import on access to the dagster package in the environment.

## Changelog
- The `dagster-airlift` package erroneously introduced a dependency on `dagster`. This has been rectified - `dagster` is only required for the `dagster-airlift[core]` submodule.
