### PR TITLE
[core-api][experimental] `create_external_assets_from_specs`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Any, Dict, Iterable, Optional, Sequence, Union, cast
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     DEADLINE_CRON_PARAM_KEY,
     DEFAULT_FRESHNESS_SEVERITY,
@@ -40,7 +40,7 @@ from dagster._utils.schedules import (
 )
 
 
-@experimental
+@beta
 def build_last_update_freshness_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Iterator, Optional, Sequence, Tuple, Union, cast
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     FRESH_UNTIL_METADATA_KEY,
     ensure_no_duplicate_asset_checks,
@@ -33,7 +33,7 @@ FRESHNESS_SENSOR_DESCRIPTION = """
     """
 
 
-@experimental
+@beta
 def build_sensor_for_freshness_checks(
     *,
     freshness_checks: Sequence[AssetChecksDefinition],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Iterable, Sequence, Union
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     DEADLINE_CRON_PARAM_KEY,
     DEFAULT_FRESHNESS_SEVERITY,
@@ -37,7 +37,7 @@ from dagster._utils.schedules import (
 )
 
 
-@experimental
+@beta
 def build_time_partition_freshness_checks(
     *,
     assets: Sequence[Union[SourceAsset, CoercibleToAssetKey, AssetsDefinition]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
@@ -2,7 +2,7 @@ import re
 from typing import Optional, Sequence, Tuple, Union, cast
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     assets_to_keys,
     build_multi_asset_check,
@@ -21,7 +21,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
 
 
-@experimental
+@beta
 def build_metadata_bounds_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
@@ -2,7 +2,7 @@ from typing import Dict, Mapping, Sequence, Tuple, Union, cast
 
 from pydantic import BaseModel
 
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import build_multi_asset_check
 from dagster._core.definitions.asset_check_spec import (
     AssetCheckKey,
@@ -17,7 +17,7 @@ from dagster._core.definitions.metadata import TableColumn, TableMetadataSet, Ta
 from dagster._core.instance import DagsterInstance
 
 
-@experimental
+@beta
 def build_column_schema_change_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -1,7 +1,7 @@
 from typing import List, Sequence
 
 from dagster import _check as check
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import deprecated
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
     SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
@@ -23,7 +23,6 @@ def external_asset_from_spec(spec: AssetSpec) -> AssetsDefinition:
 
 
 @deprecated(breaking_version="1.9.0", additional_warn_text="Directly use the AssetSpecs instead.")
-@experimental
 def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinition]:
     """Create an external assets definition from a sequence of asset specs.
 

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated_param, experimental_param
+from dagster._annotations import PublicAttr, deprecated_param, superseded
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.inference import InferredInputProps
 from dagster._core.definitions.metadata import (
@@ -59,8 +59,7 @@ def _check_default_value(input_name: str, dagster_type: DagsterType, default_val
     return default_value  # type: ignore  # (pyright bug)
 
 
-@experimental_param(param="asset_key")
-@experimental_param(param="asset_partitions")
+@superseded(additional_warn_text="Use `In` instead", emit_runtime_warning=False)
 class InputDefinition:
     """Defines an argument to an op's compute function.
 


### PR DESCRIPTION
## Summary & Motivation

decision: experimental -> deprecated
reason: this was actually marked as both experimental and deprecated, which doesn't make sense
docs exist: n/a

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
