### PR TITLE
[core-api][experimental] repository_def in RunStatusSensorDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union, ca
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, experimental_param, public
+from dagster._annotations import beta_param, deprecated_param, public
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -331,7 +331,7 @@ class RunFailureSensorContext(RunStatusSensorContext):
         return [cast(DagsterEvent, record.event_log_entry.dagster_event) for record in records]
 
 
-@experimental_param(param="repository_def")
+@beta_param(param="repository_def")
 def build_run_status_sensor_context(
     sensor_name: str,
     dagster_event: DagsterEvent,


### PR DESCRIPTION
## Summary & Motivation

decision: experimental -> beta
reason: this is an unfortunate case where a fairly-new option actually ended up needing to reference the superseded repository API. we should fix that before making this GA (and this is a fairly niche option)
docs exist: n/a

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
