### PR TITLE
[core-api][experimental] include_sources -> include_external_assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
@@ -27,8 +27,8 @@ def parse_traversal_depth(optional_digits):
 
 
 class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
-    def __init__(self, include_sources: bool):
-        self.include_sources = include_sources
+    def __init__(self, include_external_assets: bool):
+        self.include_external_assets = include_external_assets
 
     def visitStart(self, ctx: AssetSelectionParser.StartContext):
         return self.visit(ctx.expr())
@@ -68,7 +68,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitNotExpression(self, ctx: AssetSelectionParser.NotExpressionContext):
         selection: AssetSelection = self.visit(ctx.expr())
-        return AssetSelection.all(include_sources=self.include_sources) - selection
+        return AssetSelection.all(include_external_assets=self.include_external_assets) - selection
 
     def visitAndExpression(self, ctx: AssetSelectionParser.AndExpressionContext):
         left: AssetSelection = self.visit(ctx.expr(0))
@@ -81,7 +81,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
         return left | right
 
     def visitAllExpression(self, ctx: AssetSelectionParser.AllExpressionContext):
-        return AssetSelection.all(include_sources=self.include_sources)
+        return AssetSelection.all(include_external_assets=self.include_external_assets)
 
     def visitAttributeExpression(self, ctx: AssetSelectionParser.AttributeExpressionContext):
         return self.visit(ctx.attributeExpr())
@@ -116,7 +116,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
     def visitTagAttributeExpr(self, ctx: AssetSelectionParser.TagAttributeExprContext):
         key = self.visit(ctx.value(0))
         value = self.visit(ctx.value(1)) if ctx.EQUAL() else ""
-        return AssetSelection.tag(key, value, include_sources=self.include_sources)
+        return AssetSelection.tag(key, value, include_external_assets=self.include_external_assets)
 
     def visitOwnerAttributeExpr(self, ctx: AssetSelectionParser.OwnerAttributeExprContext):
         owner = self.visit(ctx.value())
@@ -124,11 +124,13 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitGroupAttributeExpr(self, ctx: AssetSelectionParser.GroupAttributeExprContext):
         group = self.visit(ctx.value())
-        return AssetSelection.groups(group, include_sources=self.include_sources)
+        return AssetSelection.groups(group, include_external_assets=self.include_external_assets)
 
     def visitKindAttributeExpr(self, ctx: AssetSelectionParser.KindAttributeExprContext):
         kind = self.visit(ctx.value())
-        return AssetSelection.tag(f"{KIND_PREFIX}{kind}", "", include_sources=self.include_sources)
+        return AssetSelection.tag(
+            f"{KIND_PREFIX}{kind}", "", include_external_assets=self.include_external_assets
+        )
 
     def visitCodeLocationAttributeExpr(
         self, ctx: AssetSelectionParser.CodeLocationAttributeExprContext
@@ -144,7 +146,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
 
 class AntlrAssetSelectionParser:
-    def __init__(self, selection_str: str, include_sources: bool = False):
+    def __init__(self, selection_str: str, include_external_assets: bool = False):
         lexer = AssetSelectionLexer(InputStream(selection_str))
         lexer.removeErrorListeners()  # Remove the default listener that just writes to the console
         lexer.addErrorListener(AntlrInputErrorListener())
@@ -157,7 +159,9 @@ class AntlrAssetSelectionParser:
 
         self._tree = parser.start()
         self._tree_str = self._tree.toStringTree(recog=parser)
-        self._asset_selection = AntlrAssetSelectionVisitor(include_sources).visit(self._tree)
+        self._asset_selection = AntlrAssetSelectionVisitor(include_external_assets).visit(
+            self._tree
+        )
 
     @property
     def tree_str(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -8,7 +8,7 @@ from typing import AbstractSet, Optional, Union, cast  # noqa: UP035
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental_param, public
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_key import (
@@ -93,15 +93,14 @@ class AssetSelection(ABC):
     """
 
     @public
-    @experimental_param(param="include_sources")
     @staticmethod
-    def all(include_sources: bool = False) -> "AllSelection":
+    def all(include_external_assets: bool = False) -> "AllSelection":
         """Returns a selection that includes all assets and their asset checks.
 
         Args:
-            include_sources (bool): If True, then include all source assets.
+            include_external_assets (bool): If True, then include all external assets.
         """
-        return AllSelection(include_sources=include_sources)
+        return AllSelection(include_external_assets=include_external_assets)
 
     @public
     @staticmethod
@@ -178,12 +177,12 @@ class AssetSelection(ABC):
     @public
     @staticmethod
     def key_prefixes(
-        *key_prefixes: CoercibleToAssetKeyPrefix, include_sources: bool = False
+        *key_prefixes: CoercibleToAssetKeyPrefix, include_external_assets: bool = False
     ) -> "KeyPrefixesAssetSelection":
         """Returns a selection that includes assets that match any of the provided key prefixes and all the asset checks that target them.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the key prefix(es)
+            include_external_assets (bool): If True, then include external assets matching the key prefix(es)
                 in the selection.
 
         Examples:
@@ -198,17 +197,18 @@ class AssetSelection(ABC):
         """
         _asset_key_prefixes = [key_prefix_from_coercible(key_prefix) for key_prefix in key_prefixes]
         return KeyPrefixesAssetSelection(
-            selected_key_prefixes=_asset_key_prefixes, include_sources=include_sources
+            selected_key_prefixes=_asset_key_prefixes,
+            include_external_assets=include_external_assets,
         )
 
     @staticmethod
     def key_substring(
-        key_substring: str, include_sources: bool = False
+        key_substring: str, include_external_assets: bool = False
     ) -> "KeySubstringAssetSelection":
         """Returns a selection that includes assets whose string representation contains the provided substring and all the asset checks that target it.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the substring
+            include_external_assets (bool): If True, then include external assets matching the substring
                 in the selection.
 
         Examples:
@@ -223,52 +223,59 @@ class AssetSelection(ABC):
               AssetSelection.key_substring("b/c")
         """
         return KeySubstringAssetSelection(
-            selected_key_substring=key_substring, include_sources=include_sources
+            selected_key_substring=key_substring, include_external_assets=include_external_assets
         )
 
     @public
     @staticmethod
-    def groups(*group_strs, include_sources: bool = False) -> "GroupsAssetSelection":
+    def groups(*group_strs, include_external_assets: bool = False) -> "GroupsAssetSelection":
         """Returns a selection that includes materializable assets that belong to any of the
         provided groups and all the asset checks that target them.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
         check.tuple_param(group_strs, "group_strs", of_type=str)
-        return GroupsAssetSelection(selected_groups=group_strs, include_sources=include_sources)
+        return GroupsAssetSelection(
+            selected_groups=group_strs, include_external_assets=include_external_assets
+        )
 
     @public
     @staticmethod
-    @experimental_param(param="include_sources")
-    def tag(key: str, value: str, include_sources: bool = False) -> "AssetSelection":
+    def tag(key: str, value: str, include_external_assets: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
-        return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+        return TagAssetSelection(
+            key=key, value=value, include_external_assets=include_external_assets
+        )
 
     @staticmethod
-    def tag_string(string: str, include_sources: bool = False) -> "AssetSelection":
+    def tag_string(string: str, include_external_assets: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
         split_by_equals_segments = string.split("=")
         if len(split_by_equals_segments) == 1:
-            return TagAssetSelection(key=string, value="", include_sources=include_sources)
+            return TagAssetSelection(
+                key=string, value="", include_external_assets=include_external_assets
+            )
         elif len(split_by_equals_segments) == 2:
             key, value = split_by_equals_segments
-            return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+            return TagAssetSelection(
+                key=key, value=value, include_external_assets=include_external_assets
+            )
         else:
             check.failed(f"Invalid tag selection string: {string}. Must have no more than one '='.")
 
@@ -340,8 +347,8 @@ class AssetSelection(ABC):
         the asset checks targeting the returned assets. Iterates through each asset in this
         selection and returns the union of all upstream assets.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as upstream of regular assets.
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as upstream of regular assets.
 
         Args:
             depth (Optional[int]): If provided, then only include assets to the given depth. A depth
@@ -381,8 +388,8 @@ class AssetSelection(ABC):
         A root asset is an asset that has no upstream dependencies within the asset selection.
         The root asset can have downstream dependencies outside of the asset selection.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as roots. To select source assets,
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as roots. To select external assets,
         use the `upstream_source_assets` method.
         """
         return RootsAssetSelection(child=self)
@@ -403,15 +410,15 @@ class AssetSelection(ABC):
         A root asset is a materializable asset that has no upstream dependencies within the asset
         selection. The root asset can have downstream dependencies outside of the asset selection.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as roots. To select source assets,
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as roots. To select external assets,
         use the `upstream_source_assets` method.
         """
         return self.roots()
 
     @public
     def upstream_source_assets(self) -> "ParentSourcesAssetSelection":
-        """Given an asset selection, returns a new asset selection that contains all of the source
+        """Given an asset selection, returns a new asset selection that contains all of the external
         assets that are parents of assets in the original selection. Includes the asset checks
         targeting the returned assets.
         """
@@ -495,13 +502,13 @@ class AssetSelection(ABC):
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in asset_keys}
 
     @classmethod
-    def from_string(cls, string: str, include_sources=False) -> "AssetSelection":
+    def from_string(cls, string: str, include_external_assets=False) -> "AssetSelection":
         from dagster._core.definitions.antlr_asset_selection.antlr_asset_selection import (
             AntlrAssetSelectionParser,
         )
 
         try:
-            return AntlrAssetSelectionParser(string, include_sources).asset_selection
+            return AntlrAssetSelectionParser(string, include_external_assets).asset_selection
         except:
             pass
         if string == "*":
@@ -600,14 +607,14 @@ class AssetSelection(ABC):
 @whitelist_for_serdes
 @record
 class AllSelection(AssetSelection):
-    include_sources: Optional[bool] = None
+    include_external_assets: Optional[bool] = None
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         return (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
 
@@ -913,14 +920,14 @@ class DownstreamAssetSelection(ChainedAssetSelection):
 @record
 class GroupsAssetSelection(AssetSelection):
     selected_groups: Sequence[str]
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -948,14 +955,14 @@ class GroupsAssetSelection(AssetSelection):
 class TagAssetSelection(AssetSelection):
     key: str
     value: str
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
 
@@ -1056,14 +1063,14 @@ class KeysAssetSelection(AssetSelection):
 @record
 class KeyPrefixesAssetSelection(AssetSelection):
     selected_key_prefixes: Sequence[Sequence[str]]
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -1080,14 +1087,14 @@ class KeyPrefixesAssetSelection(AssetSelection):
 @record
 class KeySubstringAssetSelection(AssetSelection):
     selected_key_substring: str
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {key for key in base_set if self.selected_key_substring in key.to_user_string()}

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -115,7 +115,7 @@ def evaluate_automation_conditions(
 
     if asset_selection is None:
         asset_selection = (
-            AssetSelection.all(include_sources=True) | AssetSelection.all_asset_checks()
+            AssetSelection.all(include_external_assets=True) | AssetSelection.all_asset_checks()
         )
 
     asset_graph = defs.get_asset_graph()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import AbstractSet, Any, Callable, Optional, Union, overload  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import experimental, hidden_param
+from dagster._annotations import beta, hidden_param
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -64,7 +64,7 @@ def observable_source_asset(
     breaking_version="1.10.0",
     additional_warn_text="use freshness checks instead.",
 )
-@experimental
+@beta
 def observable_source_asset(
     observe_fn: Optional[SourceAssetObserveFunction] = None,
     *,
@@ -225,7 +225,7 @@ class _ObservableSourceAsset:
             )
 
 
-@experimental
+@beta
 def multi_observable_source_asset(
     *,
     specs: Sequence[AssetSpec],

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, TypeVar
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.metadata.table import (
     TableColumn as TableColumn,
@@ -402,7 +402,6 @@ class MetadataValue(ABC, Generic[T_Packable]):
 
     @public
     @staticmethod
-    @experimental
     def table(
         records: Sequence[TableRecord], schema: Optional[TableSchema] = None
     ) -> "TableMetadataValue":
@@ -883,7 +882,6 @@ class DagsterAssetMetadataValue(
 
 
 # This should be deprecated or fixed so that `value` does not return itself.
-@experimental
 @whitelist_for_serdes(storage_name="TableMetadataEntryData")
 class TableMetadataValue(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import NamedTuple, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
@@ -11,7 +11,6 @@ from dagster._serdes.serdes import whitelist_for_serdes
 # ########################
 
 
-@experimental
 @whitelist_for_serdes
 class TableRecord(
     NamedTuple(
@@ -268,7 +267,6 @@ class TableSchema(
 # ###########################
 
 
-@experimental(emit_runtime_warning=False)
 @whitelist_for_serdes
 class TableColumnDep(
     NamedTuple(
@@ -293,7 +291,6 @@ class TableColumnDep(
         )
 
 
-@experimental
 @whitelist_for_serdes
 class TableColumnLineage(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -50,7 +50,7 @@ def observe(
 
     with disable_dagster_warnings():
         observation_job = define_asset_job(
-            "in_process_observation_job", selection=AssetSelection.all(include_sources=True)
+            "in_process_observation_job", selection=AssetSelection.all(include_external_assets=True)
         )
         defs = Definitions(
             assets=assets,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import NamedTuple, Optional, cast
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param
+from dagster._annotations import PublicAttr, beta_param
 from dagster._core.definitions.partition import (
     AllPartitionsSubset,
     PartitionsDefinition,
@@ -22,7 +22,7 @@ from dagster._time import add_absolute_time
 
 
 @whitelist_for_serdes
-@experimental_param(param="allow_nonexistent_upstream_partitions")
+@beta_param(param="allow_nonexistent_upstream_partitions")
 class TimeWindowPartitionMapping(
     PartitionMapping,
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -374,7 +374,9 @@ def get_default_automation_condition_sensor_selection(
         # Use AssetSelection.all if the default sensor is the only sensor - otherwise
         # enumerate the assets that are not already included in some other
         # non-default sensor
-        default_sensor_asset_selection = AssetSelection.all(include_sources=has_auto_observe_keys)
+        default_sensor_asset_selection = AssetSelection.all(
+            include_external_assets=has_auto_observe_keys
+        )
 
         # if there are any asset checks, include checks in the selection
         if any(isinstance(k, AssetCheckKey) for k in default_sensor_keys):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
@@ -74,7 +74,7 @@ from dagster._core.storage.tags import KIND_PREFIX
     ],
 )
 def test_antlr_tree(selection_str, expected_tree_str) -> None:
-    asset_selection = AntlrAssetSelectionParser(selection_str, include_sources=True)
+    asset_selection = AntlrAssetSelectionParser(selection_str, include_external_assets=True)
     assert asset_selection.tree_str == expected_tree_str
 
     generated_selection = asset_selection.asset_selection
@@ -82,7 +82,7 @@ def test_antlr_tree(selection_str, expected_tree_str) -> None:
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_sources=True,
+        include_external_assets=True,
     ).asset_selection
     assert regenerated_selection == generated_selection
 
@@ -115,7 +115,10 @@ def test_antlr_tree_invalid(selection_str):
         ('key:"*/a+"', AssetSelection.assets("*/a+")),
         ("key_substring:a", AssetSelection.key_substring("a")),
         ('key_substring:"*/a+"', AssetSelection.key_substring("*/a+")),
-        ("not key:a", AssetSelection.all(include_sources=True) - AssetSelection.assets("a")),
+        (
+            "not key:a",
+            AssetSelection.all(include_external_assets=True) - AssetSelection.assets("a"),
+        ),
         ("key:a and key:b", AssetSelection.assets("a") & AssetSelection.assets("b")),
         ("key:a or key:b", AssetSelection.assets("a") | AssetSelection.assets("b")),
         ("1+key:a", AssetSelection.assets("a").upstream(1)),
@@ -144,11 +147,14 @@ def test_antlr_tree_invalid(selection_str):
         ),
         ("sinks(key:a)", AssetSelection.assets("a").sinks()),
         ("roots(key:c)", AssetSelection.assets("c").roots()),
-        ("tag:foo", AssetSelection.tag("foo", "", include_sources=True)),
-        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_sources=True)),
+        ("tag:foo", AssetSelection.tag("foo", "", include_external_assets=True)),
+        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_external_assets=True)),
         ('owner:"owner@owner.com"', AssetSelection.owner("owner@owner.com")),
-        ("group:my_group", AssetSelection.groups("my_group", include_sources=True)),
-        ("kind:my_kind", AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_sources=True)),
+        ("group:my_group", AssetSelection.groups("my_group", include_external_assets=True)),
+        (
+            "kind:my_kind",
+            AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_external_assets=True),
+        ),
         (
             "code_location:my_location",
             CodeLocationAssetSelection(selected_code_location="my_location"),
@@ -170,14 +176,14 @@ def test_antlr_visit_basic(selection_str, expected_assets) -> None:
     def c(): ...
 
     generated_selection = AntlrAssetSelectionParser(
-        selection_str, include_sources=True
+        selection_str, include_external_assets=True
     ).asset_selection
     assert generated_selection == expected_assets
 
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_sources=True,
+        include_external_assets=True,
     ).asset_selection
     assert regenerated_selection == expected_assets
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -140,8 +140,8 @@ def test_asset_selection_all(all_assets: _AssetList):
     sel = AssetSelection.all()
     assert sel.resolve(all_assets) == _asset_keys_of(all_assets) - {earth.key}
 
-    sel_include_sources = AssetSelection.all(include_sources=True)
-    assert sel_include_sources.resolve(all_assets) == _asset_keys_of(all_assets)
+    sel_include_external_assets = AssetSelection.all(include_external_assets=True)
+    assert sel_include_external_assets.resolve(all_assets) == _asset_keys_of(all_assets)
 
 
 def test_asset_selection_and(all_assets: _AssetList):
@@ -165,7 +165,7 @@ def test_asset_selection_groups(all_assets: _AssetList):
     assert sel.resolve(all_assets) == _asset_keys_of({alice, candace, fiona})
 
     # includes source assets if flag set
-    sel = AssetSelection.groups("planets", include_sources=True)
+    sel = AssetSelection.groups("planets", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -196,7 +196,7 @@ def test_asset_selection_key_prefixes(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_prefixes("celestial", include_sources=True)
+    sel = AssetSelection.key_prefixes("celestial", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -212,7 +212,7 @@ def test_asset_selection_key_substring(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_substring("celestial/e", include_sources=True)
+    sel = AssetSelection.key_substring("celestial/e", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -554,7 +554,9 @@ def test_asset_selection_type_checking():
     test = DownstreamAssetSelection(child=valid_asset_selection, depth=0, include_self=False)
     assert isinstance(test, DownstreamAssetSelection)
 
-    test = GroupsAssetSelection(selected_groups=valid_string_sequence, include_sources=False)
+    test = GroupsAssetSelection(
+        selected_groups=valid_string_sequence, include_external_assets=False
+    )
     assert isinstance(test, GroupsAssetSelection)
 
     with pytest.raises(CheckError):
@@ -563,13 +565,15 @@ def test_asset_selection_type_checking():
     assert isinstance(test, KeysAssetSelection)
 
     with pytest.raises(CheckError):
-        GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
+        GroupsAssetSelection(selected_groups=invalid_argument, include_external_assets=False)
 
     with pytest.raises(CheckError):
-        KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
+        KeyPrefixesAssetSelection(
+            selected_key_prefixes=invalid_argument, include_external_assets=False
+        )
 
     test = KeyPrefixesAssetSelection(
-        selected_key_prefixes=valid_string_sequence_sequence, include_sources=False
+        selected_key_prefixes=valid_string_sequence_sequence, include_external_assets=False
     )
     assert isinstance(test, KeyPrefixesAssetSelection)
 
@@ -771,11 +775,11 @@ def test_empty_namedtuple_truthy():
 def test_deserialize_old_all_asset_selection():
     old_serialized_value = '{"__class__": "AllSelection"}'
     new_unserialized_value = deserialize_value(old_serialized_value, AllSelection)
-    assert not new_unserialized_value.include_sources
+    assert not new_unserialized_value.include_external_assets
 
 
 def test_from_string():
-    assert AssetSelection.from_string("*") == AssetSelection.all(include_sources=False)
+    assert AssetSelection.from_string("*") == AssetSelection.all(include_external_assets=False)
     assert AssetSelection.from_string("my_asset") == AssetSelection.assets("my_asset")
     assert AssetSelection.from_string("*my_asset") == AssetSelection.assets("my_asset").upstream(
         depth=MAX_NUM, include_self=True

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -117,7 +117,9 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
+        include_external_assets=True
+    )
 
 
 def test_default_auto_materialize_sensors_without_observable(
@@ -147,7 +149,9 @@ def test_default_auto_materialize_sensors_without_observable(
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
+        include_external_assets=False
+    )
 
 
 def test_opt_out_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):


### PR DESCRIPTION
## Summary & Motivation

decision: experimental -> GA (after parameter change)
reason: if we're going to make this change, we should acompany it with marking this API as stable (i.e. we should only make the name change once). "source assets" as a concept no longer really exist, and external assets is the more general term (and more accurate to what these parameters were actually filtering for.
docs exist: yes (api only, which is ok)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
