### PR TITLE
[dagster-airlift] airflow-side retries test behavior

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -13,7 +13,7 @@ from dagster._time import get_current_datetime
 
 from dagster_airlift.core.serialization.serialized_data import DagInfo, TaskInfo
 
-TERMINAL_STATES = {"success", "failed", "skipped", "up_for_retry", "up_for_reschedule"}
+TERMINAL_STATES = {"success", "failed", "canceled"}
 # This limits the number of task ids that we attempt to query from airflow's task instance rest API at a given time.
 # Airflow's batch task instance retrieval rest API doesn't have a limit parameter, but we query a single run at a time, meaning we should be getting
 # a single task instance per task id.

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Generator, List, Optional
 
+import psutil
 import pytest
 import requests
 from dagster._core.test_utils import environ
 from dagster._time import get_current_timestamp
+from dagster._utils import process_is_alive
 
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
@@ -100,8 +102,9 @@ def stand_up_airflow(
         assert airflow_ready, "Airflow did not start within 30 seconds..."
         yield process
     finally:
-        # Kill process group, since process.kill and process.terminate do not work.
-        os.killpg(process.pid, signal.SIGKILL)
+        if process_is_alive(process.pid):
+            # Kill process group, since process.kill and process.terminate do not work.
+            os.killpg(process.pid, signal.SIGKILL)
 
 
 @pytest.fixture(name="airflow_instance")
@@ -179,7 +182,9 @@ def stand_up_dagster(
         assert dagster_ready, "Dagster did not start within 30 seconds..."
         yield process
     finally:
-        os.killpg(process.pid, signal.SIGKILL)
+        if psutil.Process(pid=process.pid).is_running():
+            # Kill process group, since process.kill and process.terminate do not work.
+            os.killpg(process.pid, signal.SIGKILL)
 
 
 ####################################################################################################

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/has_retries.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/has_retries.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+def succeeds_on_retry(**context) -> None:
+    if context["task_instance"].try_number == 1:
+        raise Exception("Failing on first try")
+    else:
+        print("Succeeding on retry")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 2,
+}
+
+
+with DAG(
+    "unmapped__dag_with_retries",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as dag:
+    PythonOperator(
+        task_id="print_task", python_callable=succeeds_on_retry, retry_delay=timedelta(seconds=1)
+    )


### PR DESCRIPTION
## Summary & Motivation
Airflow only has task-level, not dag-level, retries, but let's make sure we handle them gracefully with a test.

This test uses dagster-airlift[core] dag-triggering utilities to trigger a dag whose sole task only succeeds on retry. Ensure that the polling mechanism successfully waits for all retries of this task to complete.