### PR TITLE
[core-api][deprecated] Confirm all simple deprecations

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1151,4 +1151,9 @@ def only_allow_hidden_params_in_kwargs(annotatable: Annotatable, kwargs: Mapping
         )
 
 
-beta_param = experimental_param  # PLACEHOLDER
+# placeholder
+beta_param = experimental_param
+
+# placeholder
+confirmed_deprecated = deprecated
+confirmed_deprecated_param = deprecated_param

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -878,6 +878,7 @@ def experimental(
 ) -> Callable[[T_Annotatable], T_Annotatable]: ...
 
 
+# TODO: delete this
 def experimental(
     __obj: Optional[T_Annotatable] = None,
     *,

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1149,3 +1149,6 @@ def only_allow_hidden_params_in_kwargs(annotatable: Annotatable, kwargs: Mapping
             deprecated_params[param].hidden,
             f"Unexpected non-hidden deprecated parameter '{param}' in kwargs. Should never get here.",
         )
+
+
+beta_param = experimental_param  # PLACEHOLDER

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -13,7 +13,7 @@ import click
 import yaml
 
 from dagster import _check as check
-from dagster._annotations import deprecated
+from dagster._annotations import confirmed_deprecated
 from dagster._cli.utils import ClickArgValue, get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace.cli_target import get_workspace_load_target, workspace_options
 from dagster._core.instance import DagsterInstance
@@ -89,7 +89,7 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     required=False,
     default=False,
 )
-@deprecated(
+@confirmed_deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
 )
 def dev_command(

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -19,7 +19,7 @@ from typing_extensions import TypeAlias, TypeGuard, get_args, get_origin
 
 import dagster._check as check
 from dagster import Field as DagsterField
-from dagster._annotations import deprecated
+from dagster._annotations import confirmed_deprecated
 from dagster._config.field_utils import config_dictionary_from_values
 from dagster._config.pythonic_config.attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
@@ -376,7 +376,7 @@ class ConfigurableResourceFactory(
             to_update = {**resources_to_update, **partial_resources_to_update}
             yield self._with_updated_values(to_update)
 
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="2.0", additional_warn_text="Use `with_replaced_resource_context` instead"
     )
     def with_resource_context(

--- a/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
@@ -27,8 +27,8 @@ def parse_traversal_depth(optional_digits):
 
 
 class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
-    def __init__(self, include_sources: bool):
-        self.include_sources = include_sources
+    def __init__(self, include_external_assets: bool):
+        self.include_external_assets = include_external_assets
 
     def visitStart(self, ctx: AssetSelectionParser.StartContext):
         return self.visit(ctx.expr())
@@ -68,7 +68,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitNotExpression(self, ctx: AssetSelectionParser.NotExpressionContext):
         selection: AssetSelection = self.visit(ctx.expr())
-        return AssetSelection.all(include_sources=self.include_sources) - selection
+        return AssetSelection.all(include_external_assets=self.include_external_assets) - selection
 
     def visitAndExpression(self, ctx: AssetSelectionParser.AndExpressionContext):
         left: AssetSelection = self.visit(ctx.expr(0))
@@ -81,7 +81,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
         return left | right
 
     def visitAllExpression(self, ctx: AssetSelectionParser.AllExpressionContext):
-        return AssetSelection.all(include_sources=self.include_sources)
+        return AssetSelection.all(include_external_assets=self.include_external_assets)
 
     def visitAttributeExpression(self, ctx: AssetSelectionParser.AttributeExpressionContext):
         return self.visit(ctx.attributeExpr())
@@ -116,7 +116,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
     def visitTagAttributeExpr(self, ctx: AssetSelectionParser.TagAttributeExprContext):
         key = self.visit(ctx.value(0))
         value = self.visit(ctx.value(1)) if ctx.EQUAL() else ""
-        return AssetSelection.tag(key, value, include_sources=self.include_sources)
+        return AssetSelection.tag(key, value, include_external_assets=self.include_external_assets)
 
     def visitOwnerAttributeExpr(self, ctx: AssetSelectionParser.OwnerAttributeExprContext):
         owner = self.visit(ctx.value())
@@ -124,11 +124,13 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitGroupAttributeExpr(self, ctx: AssetSelectionParser.GroupAttributeExprContext):
         group = self.visit(ctx.value())
-        return AssetSelection.groups(group, include_sources=self.include_sources)
+        return AssetSelection.groups(group, include_external_assets=self.include_external_assets)
 
     def visitKindAttributeExpr(self, ctx: AssetSelectionParser.KindAttributeExprContext):
         kind = self.visit(ctx.value())
-        return AssetSelection.tag(f"{KIND_PREFIX}{kind}", "", include_sources=self.include_sources)
+        return AssetSelection.tag(
+            f"{KIND_PREFIX}{kind}", "", include_external_assets=self.include_external_assets
+        )
 
     def visitCodeLocationAttributeExpr(
         self, ctx: AssetSelectionParser.CodeLocationAttributeExprContext
@@ -144,7 +146,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
 
 class AntlrAssetSelectionParser:
-    def __init__(self, selection_str: str, include_sources: bool = False):
+    def __init__(self, selection_str: str, include_external_assets: bool = False):
         lexer = AssetSelectionLexer(InputStream(selection_str))
         lexer.removeErrorListeners()  # Remove the default listener that just writes to the console
         lexer.addErrorListener(AntlrInputErrorListener())
@@ -157,7 +159,9 @@ class AntlrAssetSelectionParser:
 
         self._tree = parser.start()
         self._tree_str = self._tree.toStringTree(recog=parser)
-        self._asset_selection = AntlrAssetSelectionVisitor(include_sources).visit(self._tree)
+        self._asset_selection = AntlrAssetSelectionVisitor(include_external_assets).visit(
+            self._tree
+        )
 
     @property
     def tree_str(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any, Optional, Union, cast
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     DEADLINE_CRON_PARAM_KEY,
     DEFAULT_FRESHNESS_SEVERITY,
@@ -41,7 +41,7 @@ from dagster._utils.schedules import (
 )
 
 
-@experimental
+@beta
 def build_last_update_freshness_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Sequence
 from typing import Optional, Union, cast
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     FRESH_UNTIL_METADATA_KEY,
     ensure_no_duplicate_asset_checks,
@@ -34,7 +34,7 @@ FRESHNESS_SENSOR_DESCRIPTION = """
     """
 
 
-@experimental
+@beta
 def build_sensor_for_freshness_checks(
     *,
     freshness_checks: Sequence[AssetChecksDefinition],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any, Union
 
 from dagster import _check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     DEADLINE_CRON_PARAM_KEY,
     DEFAULT_FRESHNESS_SEVERITY,
@@ -38,7 +38,7 @@ from dagster._utils.schedules import (
 )
 
 
-@experimental
+@beta
 def build_time_partition_freshness_checks(
     *,
     assets: Sequence[Union[SourceAsset, CoercibleToAssetKey, AssetsDefinition]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Optional, Union, cast
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import (
     assets_to_keys,
     build_multi_asset_check,
@@ -22,7 +22,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
 
 
-@experimental
+@beta
 def build_metadata_bounds_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
@@ -3,7 +3,7 @@ from typing import Union, cast
 
 from pydantic import BaseModel
 
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.utils import build_multi_asset_check
 from dagster._core.definitions.asset_check_spec import (
     AssetCheckKey,
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata import TableColumn, TableMetadataSet, Ta
 from dagster._core.instance import DagsterInstance
 
 
-@experimental
+@beta
 def build_column_schema_change_checks(
     *,
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -2,12 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import (
-    experimental_param,
-    hidden_param,
-    only_allow_hidden_params_in_kwargs,
-    public,
-)
+from dagster._annotations import hidden_param, only_allow_hidden_params_in_kwargs, public
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -36,8 +31,6 @@ from dagster._utils.warnings import disable_dagster_warnings
 EMPTY_ASSET_KEY_SENTINEL = AssetKey([])
 
 
-@experimental_param(param="owners")
-@experimental_param(param="tags")
 @hidden_param(
     param="freshness_policy",
     breaking_version="1.10.0",

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -8,7 +8,7 @@ from typing import AbstractSet, Optional, Union, cast  # noqa: UP035
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, experimental_param, public
+from dagster._annotations import deprecated, experimental_param, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_key import (
@@ -241,7 +241,7 @@ class AssetSelection(ABC):
 
     @public
     @staticmethod
-    @experimental
+    @experimental_param(param="include_sources")
     def tag(key: str, value: str, include_sources: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -8,7 +8,7 @@ from typing import AbstractSet, Optional, Union, cast  # noqa: UP035
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental_param, public
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_key import (
@@ -93,15 +93,14 @@ class AssetSelection(ABC):
     """
 
     @public
-    @experimental_param(param="include_sources")
     @staticmethod
-    def all(include_sources: bool = False) -> "AllSelection":
+    def all(include_external_assets: bool = False) -> "AllSelection":
         """Returns a selection that includes all assets and their asset checks.
 
         Args:
-            include_sources (bool): If True, then include all source assets.
+            include_external_assets (bool): If True, then include all external assets.
         """
-        return AllSelection(include_sources=include_sources)
+        return AllSelection(include_external_assets=include_external_assets)
 
     @public
     @staticmethod
@@ -178,12 +177,12 @@ class AssetSelection(ABC):
     @public
     @staticmethod
     def key_prefixes(
-        *key_prefixes: CoercibleToAssetKeyPrefix, include_sources: bool = False
+        *key_prefixes: CoercibleToAssetKeyPrefix, include_external_assets: bool = False
     ) -> "KeyPrefixesAssetSelection":
         """Returns a selection that includes assets that match any of the provided key prefixes and all the asset checks that target them.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the key prefix(es)
+            include_external_assets (bool): If True, then include external assets matching the key prefix(es)
                 in the selection.
 
         Examples:
@@ -198,17 +197,18 @@ class AssetSelection(ABC):
         """
         _asset_key_prefixes = [key_prefix_from_coercible(key_prefix) for key_prefix in key_prefixes]
         return KeyPrefixesAssetSelection(
-            selected_key_prefixes=_asset_key_prefixes, include_sources=include_sources
+            selected_key_prefixes=_asset_key_prefixes,
+            include_external_assets=include_external_assets,
         )
 
     @staticmethod
     def key_substring(
-        key_substring: str, include_sources: bool = False
+        key_substring: str, include_external_assets: bool = False
     ) -> "KeySubstringAssetSelection":
         """Returns a selection that includes assets whose string representation contains the provided substring and all the asset checks that target it.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the substring
+            include_external_assets (bool): If True, then include external assets matching the substring
                 in the selection.
 
         Examples:
@@ -223,52 +223,59 @@ class AssetSelection(ABC):
               AssetSelection.key_substring("b/c")
         """
         return KeySubstringAssetSelection(
-            selected_key_substring=key_substring, include_sources=include_sources
+            selected_key_substring=key_substring, include_external_assets=include_external_assets
         )
 
     @public
     @staticmethod
-    def groups(*group_strs, include_sources: bool = False) -> "GroupsAssetSelection":
+    def groups(*group_strs, include_external_assets: bool = False) -> "GroupsAssetSelection":
         """Returns a selection that includes materializable assets that belong to any of the
         provided groups and all the asset checks that target them.
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
         check.tuple_param(group_strs, "group_strs", of_type=str)
-        return GroupsAssetSelection(selected_groups=group_strs, include_sources=include_sources)
+        return GroupsAssetSelection(
+            selected_groups=group_strs, include_external_assets=include_external_assets
+        )
 
     @public
     @staticmethod
-    @experimental_param(param="include_sources")
-    def tag(key: str, value: str, include_sources: bool = False) -> "AssetSelection":
+    def tag(key: str, value: str, include_external_assets: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
-        return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+        return TagAssetSelection(
+            key=key, value=value, include_external_assets=include_external_assets
+        )
 
     @staticmethod
-    def tag_string(string: str, include_sources: bool = False) -> "AssetSelection":
+    def tag_string(string: str, include_external_assets: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_sources (bool): If True, then include source assets matching the group in the
+            include_external_assets (bool): If True, then include external assets matching the group in the
                 selection.
         """
         split_by_equals_segments = string.split("=")
         if len(split_by_equals_segments) == 1:
-            return TagAssetSelection(key=string, value="", include_sources=include_sources)
+            return TagAssetSelection(
+                key=string, value="", include_external_assets=include_external_assets
+            )
         elif len(split_by_equals_segments) == 2:
             key, value = split_by_equals_segments
-            return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+            return TagAssetSelection(
+                key=key, value=value, include_external_assets=include_external_assets
+            )
         else:
             check.failed(f"Invalid tag selection string: {string}. Must have no more than one '='.")
 
@@ -340,8 +347,8 @@ class AssetSelection(ABC):
         the asset checks targeting the returned assets. Iterates through each asset in this
         selection and returns the union of all upstream assets.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as upstream of regular assets.
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as upstream of regular assets.
 
         Args:
             depth (Optional[int]): If provided, then only include assets to the given depth. A depth
@@ -381,8 +388,8 @@ class AssetSelection(ABC):
         A root asset is an asset that has no upstream dependencies within the asset selection.
         The root asset can have downstream dependencies outside of the asset selection.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as roots. To select source assets,
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as roots. To select external assets,
         use the `upstream_source_assets` method.
         """
         return RootsAssetSelection(child=self)
@@ -403,15 +410,15 @@ class AssetSelection(ABC):
         A root asset is a materializable asset that has no upstream dependencies within the asset
         selection. The root asset can have downstream dependencies outside of the asset selection.
 
-        Because mixed selections of source and materializable assets are currently not supported,
-        keys corresponding to `SourceAssets` will not be included as roots. To select source assets,
+        Because mixed selections of external and materializable assets are currently not supported,
+        keys corresponding to external assets will not be included as roots. To select external assets,
         use the `upstream_source_assets` method.
         """
         return self.roots()
 
     @public
     def upstream_source_assets(self) -> "ParentSourcesAssetSelection":
-        """Given an asset selection, returns a new asset selection that contains all of the source
+        """Given an asset selection, returns a new asset selection that contains all of the external
         assets that are parents of assets in the original selection. Includes the asset checks
         targeting the returned assets.
         """
@@ -495,13 +502,13 @@ class AssetSelection(ABC):
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in asset_keys}
 
     @classmethod
-    def from_string(cls, string: str, include_sources=False) -> "AssetSelection":
+    def from_string(cls, string: str, include_external_assets=False) -> "AssetSelection":
         from dagster._core.definitions.antlr_asset_selection.antlr_asset_selection import (
             AntlrAssetSelectionParser,
         )
 
         try:
-            return AntlrAssetSelectionParser(string, include_sources).asset_selection
+            return AntlrAssetSelectionParser(string, include_external_assets).asset_selection
         except:
             pass
         if string == "*":
@@ -600,14 +607,14 @@ class AssetSelection(ABC):
 @whitelist_for_serdes
 @record
 class AllSelection(AssetSelection):
-    include_sources: Optional[bool] = None
+    include_external_assets: Optional[bool] = None
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         return (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
 
@@ -913,14 +920,14 @@ class DownstreamAssetSelection(ChainedAssetSelection):
 @record
 class GroupsAssetSelection(AssetSelection):
     selected_groups: Sequence[str]
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -948,14 +955,14 @@ class GroupsAssetSelection(AssetSelection):
 class TagAssetSelection(AssetSelection):
     key: str
     value: str
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
 
@@ -1056,14 +1063,14 @@ class KeysAssetSelection(AssetSelection):
 @record
 class KeyPrefixesAssetSelection(AssetSelection):
     selected_key_prefixes: Sequence[Sequence[str]]
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -1080,14 +1087,14 @@ class KeyPrefixesAssetSelection(AssetSelection):
 @record
 class KeySubstringAssetSelection(AssetSelection):
     selected_key_substring: str
-    include_sources: bool
+    include_external_assets: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_sources
+            if self.include_external_assets
             else asset_graph.materializable_asset_keys
         )
         return {key for key in base_set if self.selected_key_substring in key.to_user_string()}

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -8,7 +8,7 @@ from typing import AbstractSet, Optional, Union, cast  # noqa: UP035
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
+from dagster._annotations import confirmed_deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_key import (
@@ -144,7 +144,7 @@ class AssetSelection(ABC):
 
     @public
     @staticmethod
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="2.0",
         additional_warn_text="Use AssetSelection.assets instead.",
     )
@@ -152,7 +152,7 @@ class AssetSelection(ABC):
         """Returns a selection that includes assets with any of the provided keys and all asset
         checks that target them.
 
-        Deprecated: use AssetSelection.assets instead.
+        deprecated_confirmed: use AssetSelection.assets instead.
 
         Examples:
             .. code-block:: python
@@ -402,7 +402,9 @@ class AssetSelection(ABC):
         return MaterializableAssetSelection(child=self)
 
     @public
-    @deprecated(breaking_version="2.0", additional_warn_text="Use AssetSelection.roots instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use AssetSelection.roots instead."
+    )
     def sources(self) -> "RootsAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the root
         assets within the original asset selection. Includes the asset checks targeting the returned assets.

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -15,7 +15,6 @@ from typing import (  # noqa: UP035
 import dagster._check as check
 from dagster._annotations import (
     PublicAttr,
-    experimental_param,
     hidden_param,
     only_allow_hidden_params_in_kwargs,
     public,
@@ -98,7 +97,6 @@ def validate_kind_tags(kinds: Optional[AbstractSet[str]]) -> None:
         raise DagsterInvalidDefinitionError("Assets can have at most three kinds currently.")
 
 
-@experimental_param(param="owners")
 @hidden_param(
     param="freshness_policy",
     breaking_version="1.10.0",

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -112,7 +112,6 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     _specs_by_key: Mapping[AssetKey, AssetSpec]
     _computation: Optional[AssetGraphComputation]
 
-    @experimental_param(param="specs")
     @experimental_param(param="execution_type")
     def __init__(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -16,7 +16,7 @@ from typing import (  # noqa: UP035
 )
 
 import dagster._check as check
-from dagster._annotations import experimental_param, public
+from dagster._annotations import beta_param, experimental_param, public
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_graph_computation import AssetGraphComputation
@@ -112,7 +112,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     _specs_by_key: Mapping[AssetKey, AssetSpec]
     _computation: Optional[AssetGraphComputation]
 
-    @experimental_param(param="execution_type")
+    @beta_param(param="execution_type")
     def __init__(
         self,
         *,
@@ -399,7 +399,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         return direct_invocation_result(self, *args, **kwargs)
 
     @public
-    @experimental_param(param="resource_defs")
+    @beta_param(param="resource_defs")
     @staticmethod
     def from_graph(
         graph_def: "GraphDefinition",

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import deprecated, public
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -55,11 +55,11 @@ class AutoMaterializePolicyType(Enum):
     LAZY = "LAZY"
 
 
-@experimental
 @whitelist_for_serdes(
     old_fields={"time_window_partition_scope_minutes": 1e-6},
     serializer=AutoMaterializePolicySerializer,
 )
+@deprecated(breaking_version="1.10.0")
 class AutoMaterializePolicy(
     NamedTuple(
         "_AutoMaterializePolicy",

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
+from dagster._annotations import confirmed_deprecated, public
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -59,7 +59,7 @@ class AutoMaterializePolicyType(Enum):
     old_fields={"time_window_partition_scope_minutes": 1e-6},
     serializer=AutoMaterializePolicySerializer,
 )
-@deprecated(breaking_version="1.10.0")
+@confirmed_deprecated(breaking_version="1.10.0")
 class AutoMaterializePolicy(
     NamedTuple(
         "_AutoMaterializePolicy",
@@ -196,7 +196,7 @@ class AutoMaterializePolicy(
 
     @public
     @staticmethod
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="1.10.0",
         additional_warn_text="Use `AutomationCondition.eager()` instead.",
     )
@@ -228,12 +228,12 @@ class AutoMaterializePolicy(
 
     @public
     @staticmethod
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="1.10.0",
         additional_warn_text="Use `AutomationCondition.any_downstream_conditions()` instead.",
     )
     def lazy(max_materializations_per_minute: Optional[int] = 1) -> "AutoMaterializePolicy":
-        """(Deprecated) Constructs a lazy AutoMaterializePolicy.
+        """(deprecated_confirmed) Constructs a lazy AutoMaterializePolicy.
 
         Args:
             max_materializations_per_minute (Optional[int]): The maximum number of

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional  # noqa: UP035
 
-from dagster._annotations import experimental
+from dagster._annotations import deprecated
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
@@ -211,7 +211,7 @@ class MaterializeOnCronRule(
 
 
 @whitelist_for_serdes
-@experimental
+@deprecated(breaking_version="1.10.0")
 class AutoMaterializeAssetPartitionsFilter(
     NamedTuple(
         "_AutoMaterializeAssetPartitionsFilter",

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional  # noqa: UP035
 
-from dagster._annotations import deprecated
+from dagster._annotations import confirmed_deprecated
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
@@ -211,7 +211,7 @@ class MaterializeOnCronRule(
 
 
 @whitelist_for_serdes
-@deprecated(breaking_version="1.10.0")
+@confirmed_deprecated(breaking_version="1.10.0")
 class AutoMaterializeAssetPartitionsFilter(
     NamedTuple(
         "_AutoMaterializeAssetPartitionsFilter",

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Any, Optional, cast
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import alpha_param, beta_param
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -75,7 +75,8 @@ def not_supported(context) -> None:
     )
 
 
-@experimental
+@beta_param(param="use_user_code_server")
+@alpha_param(param="default_condition")
 class AutomationConditionSensorDefinition(SensorDefinition):
     """Targets a set of assets and repeatedly evaluates all the AutomationConditions on all of
     those assets to determine which to request runs for.

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Any, Optional, cast
 
 import dagster._check as check
-from dagster._annotations import alpha_param, beta_param
+from dagster._annotations import beta_param
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -76,7 +76,7 @@ def not_supported(context) -> None:
 
 
 @beta_param(param="use_user_code_server")
-@alpha_param(param="default_condition")
+@beta_param(param="default_condition")
 class AutomationConditionSensorDefinition(SensorDefinition):
     """Targets a set of assets and repeatedly evaluates all the AutomationConditions on all of
     those assets to determine which to request runs for.

--- a/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import NamedTuple, Optional
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -13,7 +13,7 @@ class BackfillPolicyType(Enum):
     MULTI_RUN = "MULTI_RUN"
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class BackfillPolicy(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -5,7 +5,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Callable, Final, NamedTuple, Optional, Union
 
 from dagster import _check as check
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import beta, deprecated
 from dagster._core.loader import LoadingContext
 from dagster._utils.cached_method import cached_method
 
@@ -52,7 +52,7 @@ class DataVersion(
         )
 
 
-@experimental
+@beta
 class DataVersionsByPartition(
     NamedTuple(
         "_DataVersionsByPartition", [("data_versions_by_partition", Mapping[str, DataVersion])]

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -5,7 +5,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Callable, Final, NamedTuple, Optional, Union
 
 from dagster import _check as check
-from dagster._annotations import beta, deprecated
+from dagster._annotations import beta, confirmed_deprecated
 from dagster._core.loader import LoadingContext
 from dagster._utils.cached_method import cached_method
 
@@ -159,7 +159,9 @@ class DataProvenance(
         )
 
     @property
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `input_data_versions` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `input_data_versions` instead."
+    )
     def input_logical_versions(self) -> Mapping["AssetKey", DataVersion]:
         return self.input_data_versions
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Generic, Optional, Union
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_key import (
@@ -660,7 +660,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         ).with_label("on_missing")
 
     @public
-    @experimental
+    @beta
     @staticmethod
     def any_downstream_conditions() -> "BuiltinAutomationCondition":
         """Returns an AutomationCondition which represents the union of all distinct downstream conditions."""

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -115,7 +115,7 @@ def evaluate_automation_conditions(
 
     if asset_selection is None:
         asset_selection = (
-            AssetSelection.all(include_sources=True) | AssetSelection.all_asset_checks()
+            AssetSelection.all(include_external_assets=True) | AssetSelection.all_asset_checks()
         )
 
     asset_graph = defs.get_asset_graph()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -2,11 +2,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import AbstractSet, Any, Callable, NamedTuple, Optional, Union, overload  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import (
-    experimental_param,
-    hidden_param,
-    only_allow_hidden_params_in_kwargs,
-)
+from dagster._annotations import beta_param, hidden_param, only_allow_hidden_params_in_kwargs
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_dep import (
@@ -119,9 +115,9 @@ def _validate_hidden_non_argument_dep_param(
     return non_argument_deps
 
 
-@experimental_param(param="resource_defs")
-@experimental_param(param="io_manager_def")
-@experimental_param(param="backfill_policy")
+@beta_param(param="resource_defs")
+@beta_param(param="io_manager_def")
+@beta_param(param="backfill_policy")
 @hidden_param(
     param="non_argument_deps",
     breaking_version="2.0.0",
@@ -539,7 +535,7 @@ def create_assets_def_from_fn_and_decorator_args(
     return builder.create_assets_definition()
 
 
-@experimental_param(param="resource_defs")
+@beta_param(param="resource_defs")
 @hidden_param(
     param="non_argument_deps",
     breaking_version="2.0.0",

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -122,7 +122,6 @@ def _validate_hidden_non_argument_dep_param(
 @experimental_param(param="resource_defs")
 @experimental_param(param="io_manager_def")
 @experimental_param(param="backfill_policy")
-@experimental_param(param="owners")
 @hidden_param(
     param="non_argument_deps",
     breaking_version="2.0.0",
@@ -751,7 +750,6 @@ def graph_asset(
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
 
-@experimental_param(param="owners")
 @hidden_param(
     param="freshness_policy",
     breaking_version="1.10.0",

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -14,7 +14,7 @@ from typing import (  # noqa: UP035
 )
 
 import dagster._check as check
-from dagster._annotations import deprecated_param
+from dagster._annotations import confirmed_deprecated_param
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import (
     format_docstring_for_description,
@@ -159,7 +159,7 @@ def op(
 ) -> _Op: ...
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="version", breaking_version="2.0", additional_warn_text="Use `code_version` instead"
 )
 def op(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import AbstractSet, Any, Callable, Optional, Union, overload  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import experimental, hidden_param
+from dagster._annotations import beta, hidden_param
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -64,7 +64,7 @@ def observable_source_asset(
     breaking_version="1.10.0",
     additional_warn_text="use freshness checks instead.",
 )
-@experimental
+@beta
 def observable_source_asset(
     observe_fn: Optional[SourceAssetObserveFunction] = None,
     *,
@@ -225,7 +225,7 @@ class _ObservableSourceAsset:
             )
 
 
-@experimental
+@beta
 def multi_observable_source_asset(
     *,
     specs: Sequence[AssetSpec],

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import deprecated, preview, public
+from dagster._annotations import confirmed_deprecated, preview, public
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
@@ -309,10 +309,10 @@ def _canonicalize_specs_to_assets_defs(
     return result
 
 
-@deprecated(
+@confirmed_deprecated(
     breaking_version="2.0",
     additional_warn_text=(
-        "Instantiations can be removed. Since it's behavior is now the default, this class is now a"
+        "Instantiations can be removed. Since its behavior is now the default, this class is now a"
         " no-op."
     ),
 )

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import deprecated, preview, public
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 
 
 @public
-@experimental
 def create_repository_using_definitions_args(
     name: str,
     assets: Optional[
@@ -602,7 +601,6 @@ class Definitions(IHaveNew):
         defs.get_repository_def().load_all_definitions()
 
     @public
-    @experimental
     @staticmethod
     def merge(*def_sets: "Definitions") -> "Definitions":
         """Merges multiple Definitions objects into a single Definitions object.
@@ -687,13 +685,13 @@ class Definitions(IHaveNew):
         )
 
     @public
-    @experimental
+    @preview
     def get_all_asset_specs(self) -> Sequence[AssetSpec]:
         """Returns an AssetSpec object for every asset contained inside the Definitions object."""
         asset_graph = self.get_asset_graph()
         return [asset_node.to_asset_spec() for asset_node in asset_graph.asset_nodes]
 
-    @experimental
+    @preview
     def with_reconstruction_metadata(self, reconstruction_metadata: Mapping[str, str]) -> Self:
         """Add reconstruction metadata to the Definitions object. This is typically used to cache data
         loaded from some external API that is computed during initialization of a code server.

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -17,7 +17,7 @@ from typing import (  # noqa: UP035
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated, experimental_param, public
+from dagster._annotations import PublicAttr, beta_param, deprecated, public
 from dagster._core.definitions.asset_key import (
     AssetKey as AssetKey,
     CoercibleToAssetKey as CoercibleToAssetKey,
@@ -89,7 +89,7 @@ class EventWithMetadata(ABC):
 T = TypeVar("T")
 
 
-@experimental_param(param="data_version")
+@beta_param(param="data_version")
 class Output(Generic[T], EventWithMetadata):
     """Event corresponding to one of an op's outputs.
 

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from dagster import _check as check
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import deprecated
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
     SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
@@ -23,7 +23,6 @@ def external_asset_from_spec(spec: AssetSpec) -> AssetsDefinition:
 
 
 @deprecated(breaking_version="1.9.0", additional_warn_text="Directly use the AssetSpecs instead.")
-@experimental
 def external_assets_from_specs(specs: Sequence[AssetSpec]) -> list[AssetsDefinition]:
     """Create an external assets definition from a sequence of asset specs.
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -2,7 +2,7 @@ import datetime
 from typing import AbstractSet, NamedTuple, Optional  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated
+from dagster._annotations import confirmed_deprecated
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
@@ -21,7 +21,7 @@ class FreshnessMinutes(NamedTuple):
     lag_minutes: float
 
 
-@deprecated(
+@confirmed_deprecated(
     breaking_version="1.10.0",
     additional_warn_text="For monitoring freshness, use freshness checks instead. If using lazy "
     "auto-materialize, use AutomationCondition.cron() and AutomationCondition.any_downstream_conditions().",

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -15,7 +15,7 @@ from toposort import CircularDependencyError
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, public
+from dagster._annotations import confirmed_deprecated_param, public
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.definitions.dependency import (
@@ -123,7 +123,7 @@ def create_adjacency_lists(
     return (forward_edges, backward_edges)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="node_input_source_assets",
     breaking_version="2.0",
     additional_warn_text="Use `input_assets` instead.",

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -4,7 +4,7 @@ from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated_param, experimental_param
+from dagster._annotations import PublicAttr, deprecated_param, superseded
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.inference import InferredInputProps
 from dagster._core.definitions.metadata import (
@@ -49,8 +49,7 @@ def _check_default_value(input_name: str, dagster_type: DagsterType, default_val
     return default_value  # type: ignore  # (pyright bug)
 
 
-@experimental_param(param="asset_key")
-@experimental_param(param="asset_partitions")
+@superseded(additional_warn_text="Use `In` instead", emit_runtime_warning=False)
 class InputDefinition:
     """Defines an argument to an op's compute function.
 

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -4,7 +4,7 @@ from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated_param, superseded
+from dagster._annotations import PublicAttr, confirmed_deprecated_param, superseded
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.inference import InferredInputProps
 from dagster._core.definitions.metadata import (
@@ -330,7 +330,7 @@ class FanInInputPointer(
         )
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="dagster_type",
     breaking_version="2.0",
     additional_warn_text="Any defined `dagster_type` should come from the upstream op `Output`.",

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generic, List, NamedTuple, Optional, Union, cast  
 from typing_extensions import TypeAlias, TypeVar
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated, deprecated_param
+from dagster._annotations import PublicAttr, confirmed_deprecated, confirmed_deprecated_param
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.metadata.metadata_set import (
     NamespacedMetadataSet as NamespacedMetadataSet,
@@ -205,11 +205,11 @@ T_MetadataValue = TypeVar("T_MetadataValue", bound=MetadataValue, covariant=True
 # NOTE: MetadataEntry is no longer accessible via the public API-- all metadata APIs use metadata
 # dicts. This clas shas only been preserved to adhere strictly to our backcompat guarantees. It is
 # still instantiated in the above `MetadataFieldSerializer` but that can easily be changed.
-@deprecated(
+@confirmed_deprecated(
     breaking_version="2.0",
     additional_warn_text="Please use a dict with `MetadataValue` values instead.",
 )
-@deprecated_param(
+@confirmed_deprecated_param(
     param="entry_data", breaking_version="2.0", additional_warn_text="Use `value` instead."
 )
 @whitelist_for_serdes(storage_name="EventMetadataEntry")

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, TypeVar
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.metadata.table import (
     TableColumn as TableColumn,
@@ -402,7 +402,6 @@ class MetadataValue(ABC, Generic[T_Packable]):
 
     @public
     @staticmethod
-    @experimental
     def table(
         records: Sequence[TableRecord], schema: Optional[TableSchema] = None
     ) -> "TableMetadataValue":
@@ -883,7 +882,6 @@ class DagsterAssetMetadataValue(
 
 
 # This should be deprecated or fixed so that `value` does not return itself.
-@experimental
 @whitelist_for_serdes(storage_name="TableMetadataEntryData")
 class TableMetadataValue(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public
 from dagster._core.definitions.metadata.metadata_set import (
     NamespacedMetadataSet as NamespacedMetadataSet,
     TableMetadataSet as TableMetadataSet,
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 DEFAULT_SOURCE_FILE_KEY = "asset_definition"
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class LocalFileCodeReference(DagsterModel):
     """Represents a local file source location."""
@@ -33,7 +33,7 @@ class LocalFileCodeReference(DagsterModel):
     label: Optional[str] = None
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class UrlCodeReference(DagsterModel):
     """Represents a source location which points at a URL, for example
@@ -44,7 +44,7 @@ class UrlCodeReference(DagsterModel):
     label: Optional[str] = None
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class CodeReferencesMetadataValue(DagsterModel, MetadataValue["CodeReferencesMetadataValue"]):
     """Metadata value type which represents source locations (locally or otherwise)
@@ -149,7 +149,7 @@ def _with_code_source_single_definition(
     )
 
 
-@experimental
+@beta
 class FilePathMapping(ABC):
     """Base class which defines a file path mapping function. These functions are used to map local file paths
     to their corresponding paths in a source control repository.
@@ -173,7 +173,7 @@ class FilePathMapping(ABC):
         """
 
 
-@experimental
+@beta
 @dataclass
 class AnchorBasedFilePathMapping(FilePathMapping):
     """Specifies the mapping between local file paths and their corresponding paths in a source control repository,
@@ -292,7 +292,7 @@ def _build_gitlab_url(url: str, branch: str) -> str:
     return f"{url}/-/tree/{branch}"
 
 
-@experimental
+@beta
 def link_code_references_to_git(
     assets_defs: Sequence[
         Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition", "AssetSpec"]
@@ -354,7 +354,7 @@ def link_code_references_to_git(
     ]
 
 
-@experimental
+@beta
 def with_source_code_references(
     assets_defs: Sequence[
         Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition", "AssetSpec"]

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import NamedTuple, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
@@ -11,7 +11,6 @@ from dagster._serdes.serdes import whitelist_for_serdes
 # ########################
 
 
-@experimental
 @whitelist_for_serdes
 class TableRecord(
     NamedTuple(
@@ -268,7 +267,6 @@ class TableSchema(
 # ###########################
 
 
-@experimental(emit_runtime_warning=False)
 @whitelist_for_serdes
 class TableColumnDep(
     NamedTuple(
@@ -293,7 +291,6 @@ class TableColumnDep(
         )
 
 
-@experimental
 @whitelist_for_serdes
 class TableColumnLineage(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, public, superseded
+from dagster._annotations import confirmed_deprecated_param, public, superseded
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
@@ -150,7 +150,7 @@ class MultiAssetSensorContextCursor:
         return json.dumps(self._cursor_component_by_asset_key)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="last_completion_time",
     breaking_version="2.0",
     additional_warn_text="Use `last_tick_completion_time` instead.",

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, experimental, public
+from dagster._annotations import deprecated_param, public, superseded
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
@@ -155,7 +155,6 @@ class MultiAssetSensorContextCursor:
     breaking_version="2.0",
     additional_warn_text="Use `last_tick_completion_time` instead.",
 )
-@experimental
 class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
     """The context object available as the argument to the evaluation function of a
     :py:class:`dagster.MultiAssetSensorDefinition`.
@@ -980,7 +979,6 @@ def get_cursor_from_latest_materializations(
     return cursor_str
 
 
-@experimental
 def build_multi_asset_sensor_context(
     *,
     monitored_assets: Union[Sequence[AssetKey], AssetSelection],
@@ -1099,7 +1097,12 @@ MultiAssetMaterializationFunction = Callable[
 ]
 
 
-@experimental
+@superseded(
+    additional_warn_text="For most use cases, Declarative Automation should be used instead of "
+    "multi_asset_sensors to monitor the status of upstream assets and launch runs in response. "
+    "In cases where side effects are required, or a specific job must be targeted for execution, "
+    "multi_asset_sensors may be used."
+)
 class MultiAssetSensorDefinition(SensorDefinition):
     """Define an asset sensor that initiates a set of runs based on the materialization of a list of
     assets.

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -50,7 +50,7 @@ def observe(
 
     with disable_dagster_warnings():
         observation_job = define_asset_job(
-            "in_process_observation_job", selection=AssetSelection.all(include_sources=True)
+            "in_process_observation_job", selection=AssetSelection.all(include_external_assets=True)
         )
         defs = Definitions(
             assets=assets,

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Union, c
 from typing_extensions import TypeAlias, get_args, get_origin
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import confirmed_deprecated, confirmed_deprecated_param, public
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.definition_config_schema import (
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 OpComputeFunction: TypeAlias = Callable[..., Any]
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="version", breaking_version="2.0", additional_warn_text="Use `code_version` instead."
 )
 class OpDefinition(NodeDefinition, IHasInternalInit):
@@ -254,7 +254,9 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         return frozenset(self._required_resource_keys)
 
     @public
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `code_version` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `code_version` instead."
+    )
     @property
     def version(self) -> Optional[str]:
         """str: Version of the code encapsulated by the op. If set, this is used as a

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -20,7 +20,12 @@ from typing import (  # noqa: UP035
 from typing_extensions import TypeAlias, TypeVar
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated, deprecated_param, public
+from dagster._annotations import (
+    PublicAttr,
+    confirmed_deprecated,
+    confirmed_deprecated_param,
+    public,
+)
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.dynamic_partitions_request import (
     AddDynamicPartitionsRequest,
@@ -61,7 +66,9 @@ INVALID_PARTITION_SUBSTRINGS = ["...", "\a", "\b", "\f", "\n", "\r", "\t", "\v",
 PartitionConfigFn: TypeAlias = Callable[[str], Union[RunConfig, Mapping[str, Any]]]
 
 
-@deprecated(breaking_version="2.0", additional_warn_text="Use string partition keys instead.")
+@confirmed_deprecated(
+    breaking_version="2.0", additional_warn_text="Use string partition keys instead."
+)
 class Partition(Generic[T_cov]):
     """A Partition represents a single slice of the entire set of a job's possible work. It consists
     of a value, which is an object that represents that partition, and an optional name, which is
@@ -394,7 +401,7 @@ class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
         return self._instance.has_dynamic_partition(partitions_def_name, partition_key)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="partition_fn",
     breaking_version="2.0",
     additional_warn_text="Provide partition definition name instead.",
@@ -571,12 +578,12 @@ class DynamicPartitionsDefinition(
         return DeleteDynamicPartitionsRequest(validated_name, partition_keys)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="run_config_for_partition_fn",
     breaking_version="2.0",
     additional_warn_text="Use `run_config_for_partition_key_fn` instead.",
 )
-@deprecated_param(
+@confirmed_deprecated_param(
     param="tags_for_partition_fn",
     breaking_version="2.0",
     additional_warn_text="Use `tags_for_partition_key_fn` instead.",
@@ -632,7 +639,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
         """T_PartitionsDefinition: The partitions definition associated with this PartitionedConfig."""
         return self._partitions
 
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="2.0",
         additional_warn_text="Use `run_config_for_partition_key_fn` instead.",
     )
@@ -657,7 +664,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
         """
         return self._run_config_for_partition_key_fn
 
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="2.0", additional_warn_text="Use `tags_for_partition_key_fn` instead."
     )
     @public
@@ -783,7 +790,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             return self._decorated_fn(*args, **kwargs)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="tags_for_partition_fn",
     breaking_version="2.0",
     additional_warn_text="Use tags_for_partition_key_fn instead.",
@@ -874,7 +881,7 @@ def partitioned_config(
     return inner
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="tags_for_partition_fn",
     breaking_version="2.0",
     additional_warn_text="Use tags_for_partition_key_fn instead.",

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -9,7 +9,7 @@ from functools import cached_property, lru_cache
 from typing import NamedTuple, Optional, Union, cast
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, beta, public
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
@@ -605,7 +605,7 @@ class BaseMultiPartitionMapping(ABC):
         return result
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class MultiToSingleDimensionPartitionMapping(
     BaseMultiPartitionMapping,
@@ -694,7 +694,7 @@ class DimensionPartitionMapping(
         )
 
 
-@experimental
+@beta
 @whitelist_for_serdes
 class MultiPartitionMapping(
     BaseMultiPartitionMapping,

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -20,7 +20,6 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import experimental
 from dagster._core.code_pointer import (
     CodePointer,
     CustomPointer,
@@ -444,7 +443,6 @@ def reconstructable(target: Callable[..., "JobDefinition"]) -> ReconstructableJo
     return bootstrap_standalone_recon_job(pointer)
 
 
-@experimental
 def build_reconstructable_job(
     reconstructor_module_name: str,
     reconstructor_function_name: str,

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -14,7 +14,7 @@ from typing import (  # noqa: UP035
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import experimental_param, public
+from dagster._annotations import beta_param, public
 from dagster._core.decorator_utils import (
     format_docstring_for_description,
     get_function_params,
@@ -54,7 +54,7 @@ ResourceFunction: TypeAlias = Union[
 ]
 
 
-@experimental_param(param="version")
+@beta_param(param="version")
 class ResourceDefinition(AnonymousConfigurableDefinition, IHasInternalInit):
     """Core class for defining resources.
 

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import NamedTuple, Optional
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
@@ -75,7 +75,6 @@ class MaterializeResult(AssetResult):
     """
 
 
-@experimental
 class ObserveResult(AssetResult):
     """An object representing a successful observation of an asset. These can be returned from an
     @observable_source_asset decorated function to pass metadata.

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional, Union  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -343,9 +343,6 @@ class DagsterRunReaction(
         )
 
 
-@experimental_param(
-    param="asset_events", additional_warn_text="Runless asset events are experimental"
-)
 class SensorResult(
     NamedTuple(
         "_SensorResult",

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union, ca
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import beta_param, deprecated_param, public
+from dagster._annotations import beta_param, confirmed_deprecated_param, public
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -437,12 +437,12 @@ def run_failure_sensor(
 ]: ...
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="job_selection",
     breaking_version="2.0",
     additional_warn_text="Use `monitored_jobs` instead.",
 )
-@deprecated_param(
+@confirmed_deprecated_param(
     param="monitor_all_repositories",
     breaking_version="2.0",
     additional_warn_text="Use `monitor_all_code_locations` instead.",
@@ -1026,12 +1026,12 @@ class RunStatusSensorDefinition(SensorDefinition):
         return SensorType.RUN_STATUS
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="job_selection",
     breaking_version="2.0",
     additional_warn_text="Use `monitored_jobs` instead.",
 )
-@deprecated_param(
+@confirmed_deprecated_param(
     param="monitor_all_repositories",
     breaking_version="2.0",
     additional_warn_text="Use `monitor_all_code_locations` instead.",

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union, ca
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, experimental_param, public
+from dagster._annotations import beta_param, deprecated_param, public
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -331,7 +331,7 @@ class RunFailureSensorContext(RunStatusSensorContext):
         return [cast(DagsterEvent, record.event_log_entry.dagster_event) for record in records]
 
 
-@experimental_param(param="repository_def")
+@beta_param(param="repository_def")
 def build_run_status_sensor_context(
     sensor_name: str,
     dagster_event: DagsterEvent,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar, 
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import confirmed_deprecated, confirmed_deprecated_param, public
 from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -466,7 +466,7 @@ def validate_and_get_schedule_resource_dict(
     return {k: resources.original_resource_dict.get(k) for k in required_resource_keys}
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="environment_vars",
     breaking_version="2.0",
     additional_warn_text=(
@@ -877,7 +877,7 @@ class ScheduleDefinition(IHasInternalInit):
         return self._cron_schedule  # type: ignore
 
     @public
-    @deprecated(
+    @confirmed_deprecated(
         breaking_version="2.0",
         additional_warn_text="Setting this property no longer has any effect.",
     )

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, cast  # 
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, deprecated, experimental_param, public
+from dagster._annotations import PublicAttr, beta_param, deprecated, deprecated_param, public
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import (
@@ -158,9 +158,9 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
     return DecoratedOpFunction(fn)
 
 
-@experimental_param(param="resource_defs")
-@experimental_param(param="io_manager_def")
-@experimental_param(param="freshness_policy")
+@beta_param(param="resource_defs")
+@beta_param(param="io_manager_def")
+@deprecated_param(param="freshness_policy", breaking_version="1.11.0")
 @deprecated(
     breaking_version="2.0.0",
     additional_warn_text="Use AssetSpec instead. If using the SourceAsset io_manager_key property, "

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, cast  # 
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, beta_param, deprecated, deprecated_param, public
+from dagster._annotations import (
+    PublicAttr,
+    beta_param,
+    confirmed_deprecated_param,
+    deprecated,
+    public,
+)
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import (
@@ -160,7 +166,7 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
 @beta_param(param="resource_defs")
 @beta_param(param="io_manager_def")
-@deprecated_param(param="freshness_policy", breaking_version="1.11.0")
+@confirmed_deprecated_param(param="freshness_policy", breaking_version="1.11.0")
 @deprecated(
     breaking_version="2.0.0",
     additional_warn_text="Use AssetSpec instead. If using the SourceAsset io_manager_key property, "

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import NamedTuple, Optional, cast
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param
+from dagster._annotations import PublicAttr, beta_param
 from dagster._core.definitions.partition import (
     AllPartitionsSubset,
     PartitionsDefinition,
@@ -22,7 +22,7 @@ from dagster._time import add_absolute_time
 
 
 @whitelist_for_serdes
-@experimental_param(param="allow_nonexistent_upstream_partitions")
+@beta_param(param="allow_nonexistent_upstream_partitions")
 class TimeWindowPartitionMapping(
     PartitionMapping,
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -5,7 +5,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional, Union  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param
+from dagster._annotations import confirmed_deprecated_param, deprecated
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_job import build_asset_job, get_asset_graph_for_job
 from dagster._core.definitions.asset_selection import AssetSelection
@@ -239,7 +239,7 @@ class UnresolvedAssetJobDefinition(
         )
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="partitions_def",
     breaking_version="2.0.0",
     additional_warn_text="Partitioning is inferred from the selected assets, so setting this is redundant.",

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -374,7 +374,9 @@ def get_default_automation_condition_sensor_selection(
         # Use AssetSelection.all if the default sensor is the only sensor - otherwise
         # enumerate the assets that are not already included in some other
         # non-default sensor
-        default_sensor_asset_selection = AssetSelection.all(include_sources=has_auto_observe_keys)
+        default_sensor_asset_selection = AssetSelection.all(
+            include_external_assets=has_auto_observe_keys
+        )
 
         # if there are any asset checks, include checks in the selection
         if any(isinstance(k, AssetCheckKey) for k in default_sensor_keys):

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import AbstractSet, Any, Optional  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import DataProvenance, DataVersion
@@ -558,7 +558,6 @@ class AssetExecutionContext:
     #### data lineage related
 
     @public
-    @experimental
     @_copy_docs_from_op_execution_context
     def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
         return self.op_execution_context.get_asset_provenance(asset_key=asset_key)

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import AbstractSet, Any, Optional  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
+from dagster._annotations import confirmed_deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import DataProvenance, DataVersion
@@ -169,59 +169,59 @@ class AssetExecutionContext:
 
     ######## Deprecated methods
 
-    @deprecated(**_get_deprecation_kwargs("dagster_run"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("dagster_run"))
     @property
     @_copy_docs_from_op_execution_context
     def dagster_run(self) -> DagsterRun:
         return self.op_execution_context.dagster_run
 
-    @deprecated(**_get_deprecation_kwargs("run_id"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("run_id"))
     @property
     @_copy_docs_from_op_execution_context
     def run_id(self) -> str:
         return self.op_execution_context.run_id
 
-    @deprecated(**_get_deprecation_kwargs("run_config"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("run_config"))
     @property
     @_copy_docs_from_op_execution_context
     def run_config(self) -> Mapping[str, object]:
         return self.op_execution_context.run_config
 
-    @deprecated(**_get_deprecation_kwargs("run_tags"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("run_tags"))
     @property
     @_copy_docs_from_op_execution_context
     def run_tags(self) -> Mapping[str, str]:
         return self.op_execution_context.run_tags
 
-    @deprecated(**_get_deprecation_kwargs("has_tag"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("has_tag"))
     @public
     @_copy_docs_from_op_execution_context
     def has_tag(self, key: str) -> bool:
         return self.op_execution_context.has_tag(key)
 
-    @deprecated(**_get_deprecation_kwargs("get_tag"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("get_tag"))
     @public
     @_copy_docs_from_op_execution_context
     def get_tag(self, key: str) -> Optional[str]:
         return self.op_execution_context.get_tag(key)
 
-    @deprecated(**_get_deprecation_kwargs("get_op_execution_context"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("get_op_execution_context"))
     def get_op_execution_context(self) -> "OpExecutionContext":
         return self.op_execution_context
 
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         return self.op_execution_context.asset_partition_key_for_output(output_name=output_name)
 
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
         return self.op_execution_context.asset_partitions_time_window_for_output(output_name)
 
-    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_range_for_output(
@@ -229,50 +229,50 @@ class AssetExecutionContext:
     ) -> PartitionKeyRange:
         return self.op_execution_context.asset_partition_key_range_for_output(output_name)
 
-    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
         return self.op_execution_context.asset_partitions_def_for_output(output_name=output_name)
 
-    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
         return self.op_execution_context.asset_partition_keys_for_output(output_name=output_name)
 
-    @deprecated(**_get_deprecation_kwargs("op_config"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("op_config"))
     @public
     @property
     @_copy_docs_from_op_execution_context
     def op_config(self) -> Any:
         return self.op_execution_context.op_config
 
-    @deprecated(**_get_deprecation_kwargs("node_handle"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("node_handle"))
     @property
     @_copy_docs_from_op_execution_context
     def node_handle(self) -> NodeHandle:
         return self.op_execution_context.node_handle
 
-    @deprecated(**_get_deprecation_kwargs("op_handle"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("op_handle"))
     @property
     @_copy_docs_from_op_execution_context
     def op_handle(self) -> NodeHandle:
         return self.op_execution_context.op_handle
 
-    @deprecated(**_get_deprecation_kwargs("op"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("op"))
     @property
     @_copy_docs_from_op_execution_context
     def op(self) -> Node:
         return self.op_execution_context.op
 
-    @deprecated(**_get_deprecation_kwargs("get_mapping_key"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("get_mapping_key"))
     @public
     @_copy_docs_from_op_execution_context
     def get_mapping_key(self) -> Optional[str]:
         return self.op_execution_context.get_mapping_key()
 
-    @deprecated(**_get_deprecation_kwargs("selected_output_names"))
+    @confirmed_deprecated(**_get_deprecation_kwargs("selected_output_names"))
     @public
     @property
     @_copy_docs_from_op_execution_context
@@ -390,7 +390,9 @@ class AssetExecutionContext:
     def has_partition_key_range(self) -> bool:
         return self.op_execution_context.has_partition_key_range
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead."
+    )
     @public
     @property
     @_copy_docs_from_op_execution_context

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import confirmed_deprecated, confirmed_deprecated_param, public
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataValue
 from dagster._core.definitions.partition import PartitionsSubset
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from dagster._core.types.dagster_type import DagsterType
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="metadata",
     breaking_version="2.0",
     additional_warn_text="Use `definition_metadata` instead.",
@@ -180,7 +180,9 @@ class InputContext:
         """The config attached to the input that we're loading."""
         return self._config
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead")
+    @confirmed_deprecated(
+        breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead"
+    )
     @public
     @property
     def metadata(self) -> Optional[ArbitraryMetadataMapping]:
@@ -535,7 +537,7 @@ class InputContext:
         return result
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="metadata",
     breaking_version="2.0",
     additional_warn_text="Use `definition_metadata` instead.",

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import AbstractSet, Any, Optional, cast  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
+from dagster._annotations import confirmed_deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -304,7 +304,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             dynamic_partitions_store=self.instance,
         )
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead."
+    )
     @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
@@ -613,7 +615,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         else:
             return key
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_key` instead."
+    )
     @public
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         """Returns the asset partition key for the given output.
@@ -671,7 +675,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.asset_partition_key_for_output(output_name)
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_time_window` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_time_window` instead."
+    )
     @public
     def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
         """The time window for the partitions of the output asset.
@@ -747,7 +753,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.asset_partitions_time_window_for_output(output_name)
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead."
+    )
     @public
     def asset_partition_key_range_for_output(
         self, output_name: str = "result"
@@ -1005,7 +1013,9 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         return result
 
-    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_keys` instead.")
+    @confirmed_deprecated(
+        breaking_version="2.0", additional_warn_text="Use `partition_keys` instead."
+    )
     @public
     def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
         """Returns a list of the partition keys for the given output.

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import AbstractSet, Any, Optional, cast  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -1211,7 +1211,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self._step_execution_context.asset_partitions_time_window_for_input(input_name)
 
     @public
-    @experimental
     def get_asset_provenance(self, asset_key: AssetKey) -> Optional[DataProvenance]:
         """Return the provenance information for the most recent materialization of an asset.
 

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ContextManager, Optional, Union, cast  # noqa: UP035
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import confirmed_deprecated, confirmed_deprecated_param, public
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import (
     AssetKey,
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 RUN_ID_PLACEHOLDER = "__EPHEMERAL_RUN_ID"
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="metadata",
     breaking_version="2.0",
     additional_warn_text="Use `definition_metadata` instead.",
@@ -212,7 +212,9 @@ class OutputContext:
 
         return self._run_id
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead")
+    @confirmed_deprecated(
+        breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead"
+    )
     @public
     @property
     def metadata(self) -> Optional[ArbitraryMetadataMapping]:
@@ -814,7 +816,7 @@ def get_output_context(
     )
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="metadata",
     breaking_version="2.0",
     additional_warn_text="Use `definition_metadata` instead.",

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -30,7 +30,7 @@ import yaml
 from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checkable
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
     AssetCheckEvaluationPlanned,
@@ -3270,7 +3270,6 @@ class DagsterInstance(DynamicPartitionsStore):
 
         return result
 
-    @experimental
     @public
     def report_runless_asset_event(
         self,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -30,7 +30,7 @@ import yaml
 from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checkable
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
+from dagster._annotations import confirmed_deprecated, public
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
     AssetCheckEvaluationPlanned,
@@ -2013,7 +2013,7 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
     @traced
-    @deprecated(breaking_version="2.0")
+    @confirmed_deprecated(breaking_version="2.0")
     def get_event_records(
         self,
         event_records_filter: "EventRecordsFilter",
@@ -2082,7 +2082,7 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.fetch_materializations(records_filter, limit, cursor, ascending)
 
     @traced
-    @deprecated(breaking_version="2.0")
+    @confirmed_deprecated(breaking_version="2.0")
     def fetch_planned_materializations(
         self,
         records_filter: Union[AssetKey, "AssetRecordsFilter"],

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -3,7 +3,7 @@ from contextlib import ExitStack
 from typing import Any, Optional, cast
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, public
+from dagster._annotations import confirmed_deprecated_param, public
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.job_definition import (
@@ -66,7 +66,7 @@ class AssetValueLoader:
         ):
             self._resource_instance_cache[built_resource_key] = built_resource
 
-    @deprecated_param(
+    @confirmed_deprecated_param(
         param="metadata",
         breaking_version="2.0",
         additional_warn_text="Use `input_definition_metadata` instead.",

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional, Union 
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param, public
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.loader import LoadableBy, LoadingContext
@@ -611,7 +611,6 @@ class RunsFilter(IHaveNew):
     created_before: Optional[datetime]
     exclude_subruns: Optional[bool]
 
-    @experimental_param(param="exclude_subruns")
     def __new__(
         cls,
         run_ids: Optional[Sequence[str]] = None,

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -9,7 +9,7 @@ from dagster import (
     DagsterInvariantViolationError,
     Field as DagsterField,
 )
-from dagster._annotations import experimental
+from dagster._annotations import superseded
 from dagster._config import StringSource
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
@@ -137,6 +137,7 @@ class FilesystemIOManager(ConfigurableIOManagerFactory["PickledObjectFilesystemI
     config_schema=FilesystemIOManager.to_config_schema(),
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
 )
+@superseded(additional_warn_text="Use FilesystemIOManager directly instead")
 def fs_io_manager(init_context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
     """Built-in filesystem IO manager that stores and retrieves values using pickling.
 
@@ -339,7 +340,6 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
 
 @dagster_maintained_io_manager
 @io_manager(config_schema={"base_dir": DagsterField(StringSource, is_required=True)})
-@experimental
 def custom_path_fs_io_manager(
     init_context: InitResourceContext,
 ) -> CustomPathPickledObjectFilesystemIOManager:

--- a/python_modules/dagster/dagster/_utils/alert.py
+++ b/python_modules/dagster/dagster/_utils/alert.py
@@ -4,7 +4,7 @@ import ssl
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
-from dagster._annotations import deprecated_param
+from dagster._annotations import confirmed_deprecated_param
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
@@ -79,12 +79,12 @@ def send_email_via_starttls(
         server.sendmail(email_from, email_to, message)
 
 
-@deprecated_param(
+@confirmed_deprecated_param(
     param="job_selection",
     breaking_version="2.0",
     additional_warn_text="Use `monitored_jobs` instead.",
 )
-@deprecated_param(
+@confirmed_deprecated_param(
     param="monitor_all_repositories",
     breaking_version="2.0",
     additional_warn_text="Use `monitor_all_code_locations` instead.",

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -13,7 +13,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import deprecated
+from dagster._annotations import confirmed_deprecated
 from dagster._core.definitions.logger_definition import LoggerDefinition, logger
 from dagster._core.utils import coerce_valid_log_level
 
@@ -236,7 +236,7 @@ def get_structlog_json_formatter() -> structlog.stdlib.ProcessorFormatter:
     )
 
 
-@deprecated(
+@confirmed_deprecated(
     breaking_version="2.0",
     subject="loggers.dagit",
     emit_runtime_warning=False,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
@@ -74,7 +74,7 @@ from dagster._core.storage.tags import KIND_PREFIX
     ],
 )
 def test_antlr_tree(selection_str, expected_tree_str) -> None:
-    asset_selection = AntlrAssetSelectionParser(selection_str, include_sources=True)
+    asset_selection = AntlrAssetSelectionParser(selection_str, include_external_assets=True)
     assert asset_selection.tree_str == expected_tree_str
 
     generated_selection = asset_selection.asset_selection
@@ -82,7 +82,7 @@ def test_antlr_tree(selection_str, expected_tree_str) -> None:
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_sources=True,
+        include_external_assets=True,
     ).asset_selection
     assert regenerated_selection == generated_selection
 
@@ -115,7 +115,10 @@ def test_antlr_tree_invalid(selection_str):
         ('key:"*/a+"', AssetSelection.assets("*/a+")),
         ("key_substring:a", AssetSelection.key_substring("a")),
         ('key_substring:"*/a+"', AssetSelection.key_substring("*/a+")),
-        ("not key:a", AssetSelection.all(include_sources=True) - AssetSelection.assets("a")),
+        (
+            "not key:a",
+            AssetSelection.all(include_external_assets=True) - AssetSelection.assets("a"),
+        ),
         ("key:a and key:b", AssetSelection.assets("a") & AssetSelection.assets("b")),
         ("key:a or key:b", AssetSelection.assets("a") | AssetSelection.assets("b")),
         ("1+key:a", AssetSelection.assets("a").upstream(1)),
@@ -144,11 +147,14 @@ def test_antlr_tree_invalid(selection_str):
         ),
         ("sinks(key:a)", AssetSelection.assets("a").sinks()),
         ("roots(key:c)", AssetSelection.assets("c").roots()),
-        ("tag:foo", AssetSelection.tag("foo", "", include_sources=True)),
-        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_sources=True)),
+        ("tag:foo", AssetSelection.tag("foo", "", include_external_assets=True)),
+        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_external_assets=True)),
         ('owner:"owner@owner.com"', AssetSelection.owner("owner@owner.com")),
-        ("group:my_group", AssetSelection.groups("my_group", include_sources=True)),
-        ("kind:my_kind", AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_sources=True)),
+        ("group:my_group", AssetSelection.groups("my_group", include_external_assets=True)),
+        (
+            "kind:my_kind",
+            AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_external_assets=True),
+        ),
         (
             "code_location:my_location",
             CodeLocationAssetSelection(selected_code_location="my_location"),
@@ -170,14 +176,14 @@ def test_antlr_visit_basic(selection_str, expected_assets) -> None:
     def c(): ...
 
     generated_selection = AntlrAssetSelectionParser(
-        selection_str, include_sources=True
+        selection_str, include_external_assets=True
     ).asset_selection
     assert generated_selection == expected_assets
 
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_sources=True,
+        include_external_assets=True,
     ).asset_selection
     assert regenerated_selection == expected_assets
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -140,8 +140,8 @@ def test_asset_selection_all(all_assets: _AssetList):
     sel = AssetSelection.all()
     assert sel.resolve(all_assets) == _asset_keys_of(all_assets) - {earth.key}
 
-    sel_include_sources = AssetSelection.all(include_sources=True)
-    assert sel_include_sources.resolve(all_assets) == _asset_keys_of(all_assets)
+    sel_include_external_assets = AssetSelection.all(include_external_assets=True)
+    assert sel_include_external_assets.resolve(all_assets) == _asset_keys_of(all_assets)
 
 
 def test_asset_selection_and(all_assets: _AssetList):
@@ -165,7 +165,7 @@ def test_asset_selection_groups(all_assets: _AssetList):
     assert sel.resolve(all_assets) == _asset_keys_of({alice, candace, fiona})
 
     # includes source assets if flag set
-    sel = AssetSelection.groups("planets", include_sources=True)
+    sel = AssetSelection.groups("planets", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -196,7 +196,7 @@ def test_asset_selection_key_prefixes(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_prefixes("celestial", include_sources=True)
+    sel = AssetSelection.key_prefixes("celestial", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -212,7 +212,7 @@ def test_asset_selection_key_substring(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_substring("celestial/e", include_sources=True)
+    sel = AssetSelection.key_substring("celestial/e", include_external_assets=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -554,7 +554,9 @@ def test_asset_selection_type_checking():
     test = DownstreamAssetSelection(child=valid_asset_selection, depth=0, include_self=False)
     assert isinstance(test, DownstreamAssetSelection)
 
-    test = GroupsAssetSelection(selected_groups=valid_string_sequence, include_sources=False)
+    test = GroupsAssetSelection(
+        selected_groups=valid_string_sequence, include_external_assets=False
+    )
     assert isinstance(test, GroupsAssetSelection)
 
     with pytest.raises(CheckError):
@@ -563,13 +565,15 @@ def test_asset_selection_type_checking():
     assert isinstance(test, KeysAssetSelection)
 
     with pytest.raises(CheckError):
-        GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
+        GroupsAssetSelection(selected_groups=invalid_argument, include_external_assets=False)
 
     with pytest.raises(CheckError):
-        KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
+        KeyPrefixesAssetSelection(
+            selected_key_prefixes=invalid_argument, include_external_assets=False
+        )
 
     test = KeyPrefixesAssetSelection(
-        selected_key_prefixes=valid_string_sequence_sequence, include_sources=False
+        selected_key_prefixes=valid_string_sequence_sequence, include_external_assets=False
     )
     assert isinstance(test, KeyPrefixesAssetSelection)
 
@@ -771,11 +775,11 @@ def test_empty_namedtuple_truthy():
 def test_deserialize_old_all_asset_selection():
     old_serialized_value = '{"__class__": "AllSelection"}'
     new_unserialized_value = deserialize_value(old_serialized_value, AllSelection)
-    assert not new_unserialized_value.include_sources
+    assert not new_unserialized_value.include_external_assets
 
 
 def test_from_string():
-    assert AssetSelection.from_string("*") == AssetSelection.all(include_sources=False)
+    assert AssetSelection.from_string("*") == AssetSelection.all(include_external_assets=False)
     assert AssetSelection.from_string("my_asset") == AssetSelection.assets("my_asset")
     assert AssetSelection.from_string("*my_asset") == AssetSelection.assets("my_asset").upstream(
         depth=MAX_NUM, include_self=True

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -117,7 +117,9 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
+        include_external_assets=True
+    )
 
 
 def test_default_auto_materialize_sensors_without_observable(
@@ -147,7 +149,9 @@ def test_default_auto_materialize_sensors_without_observable(
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
+        include_external_assets=False
+    )
 
 
 def test_opt_out_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):


### PR DESCRIPTION
## Summary & Motivation

This does a simple pass over all things marked as `@deprecated`. For the ones that should remain `@deprecated`, it marks them with `@confirmed_deprecated` or `@confirmed_deprecated_param`.

This is a **temporary** measure, and they will be swapped out upstack. This is purely to mark the places in code where we're making a decision, and allows us to grep for any remaining unhandled APIs

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
