### PR TITLE
Support configuration of Postgresql secret password key

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -61,7 +61,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
-                  key: postgresql-password
+                  key: {{ include "dagsterUserDeployments.postgresql.secretPasswordKey" $ }}
             {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
             {{- if $includeConfigInLaunchedRuns.enabled }}
             {{- if $deployment.dagsterApiGrpcArgs }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -79,6 +79,11 @@ Create the name of the service account to use
 {{- $global.postgresqlSecretName | default .Values.postgresqlSecretName }}
 {{- end -}}
 
+{{- define "dagsterUserDeployments.postgresql.secretPasswordKey" -}}
+{{- $global := .Values.global | default dict }}
+{{- $global.postgresqlSecretPasswordKey | default .Values.postgresqlSecretPasswordKey }}
+{{- end -}}
+
 {{/*
 This environment shared across all User Code containers
 */}}

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -69,7 +69,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
-                  key: postgresql-password
+                  key: {{ include "dagster.postgresql.secretPasswordKey" $ | quote }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" $ }}-celery-worker-env

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -88,7 +88,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
-                  key: postgresql-password
+                  key: {{ include "dagster.postgresql.secretPasswordKey" $ | quote }}
             - name: DAGSTER_DAEMON_HEARTBEAT_TOLERANCE
               value: "{{ .Values.dagsterDaemon.heartbeatTolerance }}"
             # This is a list by default, but for backcompat it can be a map. As a map it's written to the daemon-env

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -88,7 +88,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ include "dagster.postgresql.secretPasswordKey" $ | quote }}
             # This is a list by default, but for backcompat it can be a map. As
             # a map it's written to the webserver-env configmap.
             {{- if and ($_.Values.dagsterWebserver.env) (kindIs "slice" $_.Values.dagsterWebserver.env) }}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -166,6 +166,14 @@ See: https://github.com/helm/charts/blob/61c2cc0db49b06b948f90c8e44e9143d7bab430
 {{- end }}
 {{- end }}
 
+{{- define "dagster.postgresql.secretPasswordKey" -}}
+{{- if .Values.global.postgresqlSecretPasswordKey }}
+{{- .Values.global.postgresqlSecretPasswordKey }}
+{{- else }}
+{{- printf "postgresql-password" }}
+{{- end }}
+{{- end }}
+
 {{/*
 Celery options
 */}}

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -34,7 +34,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ include "dagster.postgresql.secretPasswordKey" $ | quote }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" . }}-webserver-env

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1058,6 +1058,10 @@
                     "title": "Postgresqlsecretname",
                     "type": "string"
                 },
+                "postgresqlSecretPasswordKey": {
+                    "title": "Postgresqlsecretpasswordkey",
+                    "type": "string"
+                },
                 "dagsterHome": {
                     "title": "Dagsterhome",
                     "type": "string"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -6,6 +6,7 @@
 ---
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
+  postgresqlSecretPasswordKey: "postgresql-password"
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 


### PR DESCRIPTION
## Summary & Motivation

When postgresql is deployed by an operator, the password key name is defined by the operator. 

## How I Tested These Changes

I deployed a cluster using the modified helm chart.

## Changelog

Helm chart: Support configuration of Postgresql secret password key
