### PR TITLE
docs(helm): fix the label component=dagster-webserver

### DIFF
--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
@@ -505,7 +505,7 @@ Running into issues deploying on Helm? Use these commands to help with debugging
 
 ```shell
 DAGSTER_WEBSERVER_POD_NAME=$(kubectl get pods --namespace default \
-      -l "app.kubernetes.io/name=dagster,app.kubernetes.io/instance=dagster,component=webserver" \
+      -l "app.kubernetes.io/name=dagster,app.kubernetes.io/instance=dagster,component=dagster-webserver" \
       -o jsonpath="{.items[0].metadata.name}")
 ```
 


### PR DESCRIPTION
## Summary & Motivation

The command to retrieve webserver pod doesn't return anything if the filter on label is incorrect
https://docs.dagster.io/deployment/guides/kubernetes/deploying-with-helm#get-the-name-of-the-webserver-pod

I think the value comes from here https://github.com/dagster-io/dagster/blob/master/helm/dagster/values.yaml#L41

There is a small typo

Merry Christmas 🎅 🎁 🎄 

