### PR TITLE
Remove asset key iteration from backfill daemon, part 2

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -273,8 +273,7 @@ def _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_
     updated_backfill = backfill.with_asset_backfill_data(
         result.backfill_data.with_run_requests_submitted(
             result.run_requests,
-            asset_graph=graphql_context.asset_graph,
-            instance_queryer=asset_graph_view.get_inner_queryer_for_back_compat(),
+            asset_graph_view=asset_graph_view,
         ),
         dynamic_partitions_store=graphql_context.instance,
         asset_graph=graphql_context.asset_graph,

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     )
     from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.partition import PartitionsDefinition
+    from dagster._core.definitions.partition_key_range import PartitionKeyRange
     from dagster._core.instance import DagsterInstance
     from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
     from dagster._core.storage.dagster_run import RunRecord
@@ -192,6 +193,20 @@ class AssetGraphView(LoadingContext):
         partitions_def = self._get_partitions_def(key)
         value = partitions_def.empty_subset() if partitions_def else False
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
+
+    def get_entity_subset_in_range(
+        self, asset_key: AssetKey, partition_key_range: "PartitionKeyRange"
+    ) -> EntitySubset[AssetKey]:
+        partitions_def = check.not_none(
+            self._get_partitions_def(asset_key), "Must have partitions def"
+        )
+        partition_subset_in_range = partitions_def.get_subset_in_range(
+            partition_key_range=partition_key_range,
+            dynamic_partitions_store=self._queryer,
+        )
+        return EntitySubset(
+            self, key=asset_key, value=_ValidatedEntitySubsetValue(partition_subset_in_range)
+        )
 
     def get_entity_subset_from_asset_graph_subset(
         self, asset_graph_subset: AssetGraphSubset, key: AssetKey

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -167,6 +167,17 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         partition_keys = self.get_partition_keys(current_time, dynamic_partitions_store)
         return partition_keys[0] if partition_keys else None
 
+    def get_subset_in_range(
+        self,
+        partition_key_range: PartitionKeyRange,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> "PartitionsSubset":
+        return self.empty_subset().with_partition_key_range(
+            partitions_def=self,
+            partition_key_range=partition_key_range,
+            dynamic_partitions_store=dynamic_partitions_store,
+        )
+
     def get_partition_keys_in_range(
         self,
         partition_key_range: PartitionKeyRange,


### PR DESCRIPTION
## Summary & Motivation
Clears out the other places in the asset backfill daemon where we were iterating through AssetKeyPartitionKeys, in favor of using AssetGraphSubsets.

## How I Tested These Changes
BK

## Changelog
NOCHANGELOG