### PR TITLE
[dagster-powerbi] Use Power BI translator instance in spec loader and state-backed defs

### DIFF
--- a/docs/content/integrations/powerbi.mdx
+++ b/docs/content/integrations/powerbi.mdx
@@ -122,7 +122,8 @@ class MyCustomPowerBITranslator(DagsterPowerBITranslator):
 
 
 power_bi_specs = load_powerbi_asset_specs(
-    power_bi_workspace, dagster_powerbi_translator=MyCustomPowerBITranslator
+    power_bi_workspace,
+    dagster_powerbi_translator=MyCustomPowerBITranslator,
 )
 defs = dg.Definitions(
     assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace}

--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
@@ -37,7 +37,8 @@ class MyCustomPowerBITranslator(DagsterPowerBITranslator):
 
 
 power_bi_specs = load_powerbi_asset_specs(
-    power_bi_workspace, dagster_powerbi_translator=MyCustomPowerBITranslator  # type: ignore
+    power_bi_workspace,
+    dagster_powerbi_translator=MyCustomPowerBITranslator,  # type: ignore
 )
 defs = dg.Definitions(
     assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace}

--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
@@ -37,7 +37,7 @@ class MyCustomPowerBITranslator(DagsterPowerBITranslator):
 
 
 power_bi_specs = load_powerbi_asset_specs(
-    power_bi_workspace, dagster_powerbi_translator=MyCustomPowerBITranslator
+    power_bi_workspace, dagster_powerbi_translator=MyCustomPowerBITranslator  # type: ignore
 )
 defs = dg.Definitions(
     assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace}

--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
@@ -38,7 +38,7 @@ class MyCustomPowerBITranslator(DagsterPowerBITranslator):
 
 power_bi_specs = load_powerbi_asset_specs(
     power_bi_workspace,
-    dagster_powerbi_translator=MyCustomPowerBITranslator,  # type: ignore
+    dagster_powerbi_translator=MyCustomPowerBITranslator,
 )
 defs = dg.Definitions(
     assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace}

--- a/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
+++ b/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
@@ -43,7 +43,7 @@ class CustomDagsterPowerBITranslator(DagsterPowerBITranslator):
 
 power_bi_specs = load_powerbi_asset_specs(
     power_bi_workspace,
-    dagster_powerbi_translator=CustomDagsterPowerBITranslator,
+    dagster_powerbi_translator=CustomDagsterPowerBITranslator,  # type: ignore
 )
 
 defs = dg.Definitions(assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace})

--- a/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
+++ b/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
@@ -44,5 +44,6 @@ class CustomDagsterPowerBITranslator(DagsterPowerBITranslator):
 power_bi_specs = load_powerbi_asset_specs(
     power_bi_workspace,
     dagster_powerbi_translator=CustomDagsterPowerBITranslator,
+)
 
 defs = dg.Definitions(assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace})

--- a/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
+++ b/examples/project_atproto_dashboard/project_atproto_dashboard/dashboard/definitions.py
@@ -43,7 +43,6 @@ class CustomDagsterPowerBITranslator(DagsterPowerBITranslator):
 
 power_bi_specs = load_powerbi_asset_specs(
     power_bi_workspace,
-    dagster_powerbi_translator=CustomDagsterPowerBITranslator,  # type: ignore
-)
+    dagster_powerbi_translator=CustomDagsterPowerBITranslator,
 
 defs = dg.Definitions(assets=[*power_bi_specs], resources={"power_bi": power_bi_workspace})

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -99,7 +99,9 @@ def test_translator_custom_metadata(workspace_data_api_mocks: None, workspace_id
         workspace_id=workspace_id,
     )
     all_asset_specs = load_powerbi_asset_specs(
-        workspace=resource, dagster_powerbi_translator=MyCustomTranslator, use_workspace_scan=False
+        workspace=resource,
+        dagster_powerbi_translator=MyCustomTranslator(),
+        use_workspace_scan=False,
     )
     asset_spec = next(spec for spec in all_asset_specs)
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -123,6 +123,7 @@ def test_translator_custom_metadata_legacy(
         DeprecationWarning,
         match=r"Support of `dagster_powerbi_translator` as a Type\[DagsterPowerBITranslator\]",
     ):
+        # Pass the translator type
         all_asset_specs = load_powerbi_asset_specs(
             workspace=resource,
             dagster_powerbi_translator=MyCustomTranslator,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -111,6 +111,27 @@ def test_translator_custom_metadata(workspace_data_api_mocks: None, workspace_id
     assert "dagster/kind/powerbi" in asset_spec.tags
 
 
+def test_translator_custom_metadata_legacy(
+    workspace_data_api_mocks: None, workspace_id: str
+) -> None:
+    fake_token = uuid.uuid4().hex
+    resource = PowerBIWorkspace(
+        credentials=PowerBIToken(api_token=fake_token),
+        workspace_id=workspace_id,
+    )
+    all_asset_specs = load_powerbi_asset_specs(
+        workspace=resource,
+        dagster_powerbi_translator=MyCustomTranslator,
+        use_workspace_scan=False,
+    )
+    asset_spec = next(spec for spec in all_asset_specs)
+
+    assert "custom" in asset_spec.metadata
+    assert asset_spec.metadata["custom"] == "metadata"
+    assert asset_spec.key.path == ["prefix", "dashboard", "Sales_Returns_Sample_v201912"]
+    assert "dagster/kind/powerbi" in asset_spec.tags
+
+
 @lazy_definitions
 def state_derived_defs_two_workspaces() -> Definitions:
     resource = PowerBIWorkspace(

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -119,11 +119,15 @@ def test_translator_custom_metadata_legacy(
         credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
     )
-    all_asset_specs = load_powerbi_asset_specs(
-        workspace=resource,
-        dagster_powerbi_translator=MyCustomTranslator,
-        use_workspace_scan=False,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Support of `dagster_powerbi_translator` as a Type\[DagsterPowerBITranslator\]",
+    ):
+        all_asset_specs = load_powerbi_asset_specs(
+            workspace=resource,
+            dagster_powerbi_translator=MyCustomTranslator,
+            use_workspace_scan=False,
+        )
     asset_spec = next(spec for spec in all_asset_specs)
 
     assert "custom" in asset_spec.metadata


### PR DESCRIPTION
## Summary & Motivation

Updates `load_powerbi_asset_specs()` and state-backed definitions to accept an instance of `DagsterPowerBITranslator`.

See #26133 for more details about the motivation.

## How I Tested These Changes

BK

## Changelog

[dagster-powerbi] `load_powerbi_asset_specs` is updated to accept an instance of `DagsterPowerBITranslator` or custom subclass.
