### PR TITLE
[dagster-looker] Move contextual data from DagsterLookerApiTranslator to LookerApiTranslatorStructureData

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -18,7 +18,7 @@ looker_resource = LookerResource(
 class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
     def get_asset_spec(self, looker_structure: LookerStructureData) -> dg.AssetSpec:
         # We create the default asset spec using super()
-        default_spec = super().get_asset_spec(looker_structure)
+        default_spec = super().get_asset_spec(looker_structure)  # type: ignore
         # We customize the team owner tag for all assets,
         # and we customize the asset key prefix only for dashboards.
         return default_spec.replace_attributes(

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -5,6 +5,7 @@ from dagster._annotations import experimental
 
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator,
+    LookerApiTranslatorStructureData,
     LookerStructureData,
     LookerStructureType,
     LookmlView,
@@ -32,19 +33,22 @@ def build_looker_pdt_assets_definitions(
     Returns:
         AssetsDefinition: The AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
     """
-    translator = dagster_looker_translator(None)
+    translator = dagster_looker_translator()
     result = []
     for request_start_pdt_build in request_start_pdt_builds:
 
         @multi_asset(
             specs=[
                 translator.get_asset_spec(
-                    LookerStructureData(
-                        structure_type=LookerStructureType.VIEW,
-                        data=LookmlView(
-                            view_name=request_start_pdt_build.view_name,
-                            sql_table_name=None,
+                    LookerApiTranslatorStructureData(
+                        structure_data=LookerStructureData(
+                            structure_type=LookerStructureType.VIEW,
+                            data=LookmlView(
+                                view_name=request_start_pdt_build.view_name,
+                                sql_table_name=None,
+                            ),
                         ),
+                        instance_data=None,
                     )
                 )
             ],

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -8,7 +8,7 @@ from dagster_looker import LookerFilter
 from dagster_looker.api.assets import build_looker_pdt_assets_definitions
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator,
-    LookerStructureData,
+    LookerApiTranslatorStructureData,
     RequestStartPdtBuild,
 )
 from dagster_looker.api.resource import LookerResource, load_looker_asset_specs
@@ -196,7 +196,7 @@ def test_custom_asset_specs(
     looker_resource: LookerResource, looker_instance_data_mocks: responses.RequestsMock
 ) -> None:
     class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
-        def get_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
+        def get_asset_spec(self, looker_structure: LookerApiTranslatorStructureData) -> AssetSpec:
             default_spec = super().get_asset_spec(looker_structure)
             return default_spec.replace_attributes(
                 key=default_spec.key.with_prefix("my_prefix"),


### PR DESCRIPTION
## Summary & Motivation

Same as #26654 but for Looker.

## How I Tested These Changes

Updated tests with BK

## Changelog

[dagster-looker] Type hints in the signature of `DagsterLookerApiTranslator.get_asset_spec` have been updated - the parameter `looker_structure` is now of type `LookerApiTranslatorStructureData` instead of `LookerStructureData`. Custom Looker API translators should be updated.

