### PR TITLE
[dagster-looker] Use Looker API translator instance in spec loader and state-backed defs

### DIFF
--- a/docs/content/integrations/looker.mdx
+++ b/docs/content/integrations/looker.mdx
@@ -125,7 +125,8 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
 
 
 looker_specs = load_looker_asset_specs(
-    looker_resource, dagster_looker_translator=CustomDagsterLookerApiTranslator
+    looker_resource,
+    dagster_looker_translator=CustomDagsterLookerApiTranslator,
 )
 defs = dg.Definitions(assets=[*looker_specs], resources={"looker": looker_resource})
 ```

--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -32,6 +32,7 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
 
 
 looker_specs = load_looker_asset_specs(
-    looker_resource, dagster_looker_translator=CustomDagsterLookerApiTranslator  # type: ignore
+    looker_resource,
+    dagster_looker_translator=CustomDagsterLookerApiTranslator,  # type: ignore
 )
 defs = dg.Definitions(assets=[*looker_specs], resources={"looker": looker_resource})

--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -32,6 +32,6 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
 
 
 looker_specs = load_looker_asset_specs(
-    looker_resource, dagster_looker_translator=CustomDagsterLookerApiTranslator
+    looker_resource, dagster_looker_translator=CustomDagsterLookerApiTranslator  # type: ignore
 )
 defs = dg.Definitions(assets=[*looker_specs], resources={"looker": looker_resource})

--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -33,6 +33,6 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
 
 looker_specs = load_looker_asset_specs(
     looker_resource,
-    dagster_looker_translator=CustomDagsterLookerApiTranslator,  # type: ignore
+    dagster_looker_translator=CustomDagsterLookerApiTranslator,
 )
 defs = dg.Definitions(assets=[*looker_specs], resources={"looker": looker_resource})

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Type, cast
+from typing import Optional, Sequence, cast
 
 from dagster import AssetExecutionContext, AssetsDefinition, Failure, multi_asset
 from dagster._annotations import experimental
@@ -18,7 +18,7 @@ from dagster_looker.api.resource import LookerResource
 def build_looker_pdt_assets_definitions(
     resource_key: str,
     request_start_pdt_builds: Sequence[RequestStartPdtBuild],
-    dagster_looker_translator: Type[DagsterLookerApiTranslator] = DagsterLookerApiTranslator,
+    dagster_looker_translator: Optional[DagsterLookerApiTranslator] = None,
 ) -> Sequence[AssetsDefinition]:
     """Returns the AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
 
@@ -27,13 +27,14 @@ def build_looker_pdt_assets_definitions(
         request_start_pdt_builds (Optional[Sequence[RequestStartPdtBuild]]): A list of requests to start PDT builds.
             See https://developers.looker.com/api/explorer/4.0/types/DerivedTable/RequestStartPdtBuild?sdk=py
             for documentation on all available fields.
-        dagster_looker_translator (Optional[DagsterLookerApiTranslator]): The translator to
-            use to convert Looker structures into assets. Defaults to DagsterLookerApiTranslator.
+        dagster_looker_translator (Optional[DagsterLookerApiTranslator]): The translator to use
+            to convert Looker structures into :py:class:`dagster.AssetSpec`.
+            Defaults to :py:class:`DagsterLookerApiTranslator`.
 
     Returns:
         AssetsDefinition: The AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
     """
-    translator = dagster_looker_translator()
+    translator = dagster_looker_translator or DagsterLookerApiTranslator()
     result = []
     for request_start_pdt_build in request_start_pdt_builds:
 

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -1,7 +1,8 @@
-from typing import Optional, Sequence, cast
+from typing import Optional, Sequence, cast, Union, Type
 
 from dagster import AssetExecutionContext, AssetsDefinition, Failure, multi_asset
 from dagster._annotations import experimental
+from dagster._utils.warnings import deprecation_warning
 
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator,
@@ -18,7 +19,9 @@ from dagster_looker.api.resource import LookerResource
 def build_looker_pdt_assets_definitions(
     resource_key: str,
     request_start_pdt_builds: Sequence[RequestStartPdtBuild],
-    dagster_looker_translator: Optional[DagsterLookerApiTranslator] = None,
+    dagster_looker_translator: Optional[
+        Union[DagsterLookerApiTranslator, Type[DagsterLookerApiTranslator]]
+    ] = None,
 ) -> Sequence[AssetsDefinition]:
     """Returns the AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
 
@@ -27,13 +30,23 @@ def build_looker_pdt_assets_definitions(
         request_start_pdt_builds (Optional[Sequence[RequestStartPdtBuild]]): A list of requests to start PDT builds.
             See https://developers.looker.com/api/explorer/4.0/types/DerivedTable/RequestStartPdtBuild?sdk=py
             for documentation on all available fields.
-        dagster_looker_translator (Optional[DagsterLookerApiTranslator]): The translator to use
-            to convert Looker structures into :py:class:`dagster.AssetSpec`.
+        dagster_looker_translator (Optional[Union[DagsterLookerApiTranslator, Type[DagsterLookerApiTranslator]]]):
+            The translator to use to convert Looker structures into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterLookerApiTranslator`.
 
     Returns:
         AssetsDefinition: The AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
     """
+    if isinstance(dagster_looker_translator, type):
+        deprecation_warning(
+            subject="Support of `dagster_looker_translator` as a Type[DagsterLookerApiTranslator]",
+            breaking_version="1.10",
+            additional_warn_text=(
+                "Pass an instance of DagsterLookerApiTranslator or subclass to `dagster_looker_translator` instead."
+            ),
+        )
+        dagster_looker_translator = dagster_looker_translator()
+
     translator = dagster_looker_translator or DagsterLookerApiTranslator()
     result = []
     for request_start_pdt_build in request_start_pdt_builds:

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, cast, Union, Type
+from typing import Optional, Sequence, Type, Union, cast
 
 from dagster import AssetExecutionContext, AssetsDefinition, Failure, multi_asset
 from dagster._annotations import experimental

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -205,7 +205,7 @@ def test_custom_asset_specs(
     all_assets = (
         asset
         for asset in Definitions(
-            assets=[*load_looker_asset_specs(looker_resource, CustomDagsterLookerApiTranslator)],
+            assets=[*load_looker_asset_specs(looker_resource, CustomDagsterLookerApiTranslator())],
         )
         .get_asset_graph()
         .assets_defs

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -233,15 +233,21 @@ def test_custom_asset_specs_legacy(
             ).merge_attributes(metadata={"custom": "metadata"})
 
     # Pass the translator type
-    all_assets = (
-        asset
-        for asset in Definitions(
-            assets=[*load_looker_asset_specs(looker_resource, CustomDagsterLookerApiTranslator)],
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Support of `dagster_looker_translator` as a Type\[DagsterLookerApiTranslator\]",
+    ):
+        all_assets = (
+            asset
+            for asset in Definitions(
+                assets=[
+                    *load_looker_asset_specs(looker_resource, CustomDagsterLookerApiTranslator)
+                ],
+            )
+            .get_asset_graph()
+            .assets_defs
+            if not asset.is_auto_created_stub
         )
-        .get_asset_graph()
-        .assets_defs
-        if not asset.is_auto_created_stub
-    )
 
     for asset in all_assets:
         for metadata in asset.metadata_by_key.values():

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -232,6 +232,7 @@ def test_custom_asset_specs_legacy(
                 key=default_spec.key.with_prefix("my_prefix"),
             ).merge_attributes(metadata={"custom": "metadata"})
 
+    # Pass the translator type
     all_assets = (
         asset
         for asset in Definitions(

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -219,3 +219,33 @@ def test_custom_asset_specs(
         assert all(key.path[0] == "my_prefix" for key in asset.keys)
         for deps in asset.asset_deps.values():
             assert all(key.path[0] == "my_prefix" for key in deps), str(deps)
+
+
+@responses.activate
+def test_custom_asset_specs_legacy(
+    looker_resource: LookerResource, looker_instance_data_mocks: responses.RequestsMock
+) -> None:
+    class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
+        def get_asset_spec(self, looker_structure: LookerApiTranslatorStructureData) -> AssetSpec:
+            default_spec = super().get_asset_spec(looker_structure)
+            return default_spec.replace_attributes(
+                key=default_spec.key.with_prefix("my_prefix"),
+            ).merge_attributes(metadata={"custom": "metadata"})
+
+    all_assets = (
+        asset
+        for asset in Definitions(
+            assets=[*load_looker_asset_specs(looker_resource, CustomDagsterLookerApiTranslator)],
+        )
+        .get_asset_graph()
+        .assets_defs
+        if not asset.is_auto_created_stub
+    )
+
+    for asset in all_assets:
+        for metadata in asset.metadata_by_key.values():
+            assert "custom" in metadata
+            assert metadata["custom"] == "metadata"
+        assert all(key.path[0] == "my_prefix" for key in asset.keys)
+        for deps in asset.asset_deps.values():
+            assert all(key.path[0] == "my_prefix" for key in deps), str(deps)


### PR DESCRIPTION
## Summary & Motivation

Same as #26734 but for Looker.

## How I Tested These Changes

BK

## Changelog

[dagster-looker] `load_looker_asset_specs` and `build_looker_pdt_assets_definitions` are updated to accept an instance of `DagsterLookerApiTranslator` or custom subclass.
