### PR TITLE
Validate reserved metadata value types

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -177,6 +177,7 @@ class AssetSpec(
         **kwargs,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
+        from dagster._core.definitions.metadata.metadata_set import validate_metadata_values
 
         only_allow_hidden_params_in_kwargs(AssetSpec, kwargs)
 
@@ -199,12 +200,15 @@ class AssetSpec(
         }
         validate_kind_tags(kind_tags)
 
+        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
+        validate_metadata_values(metadata)
+
         return super().__new__(
             cls,
             key=key,
             deps=asset_deps,
             description=check.opt_str_param(description, "description"),
-            metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
+            metadata=metadata,
             skippable=check.bool_param(skippable, "skippable"),
             group_name=check.opt_str_param(group_name, "group_name"),
             code_version=check.opt_str_param(code_version, "code_version"),

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.metadata import RawMetadataMapping
+from dagster._core.definitions.metadata.metadata_set import validate_metadata_values
 
 
 class AssetResult(
@@ -35,14 +36,19 @@ class AssetResult(
 
         asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
 
+        metadata = check.opt_nullable_mapping_param(
+            metadata,
+            "metadata",
+            key_type=str,
+        )
+
+        if metadata:
+            validate_metadata_values(metadata)
+
         return super().__new__(
             cls,
             asset_key=asset_key,
-            metadata=check.opt_nullable_mapping_param(
-                metadata,
-                "metadata",
-                key_type=str,
-            ),
+            metadata=metadata,
             check_results=check.opt_sequence_param(
                 check_results, "check_results", of_type=AssetCheckResult
             ),


### PR DESCRIPTION
## Summary & Motivation

Validate dagster-reserved metadata value types upon construction. Our code assumes that reserved metadata values have the correct type (i.e. `dagster/column_schema` is a `TableSchema` object), let's enforce that.

## How I Tested These Changes
BK

## Changelog
Adds type validation for reserved metadata keys defined in asset definitions and `MaterializeResult`.
