### PR TITLE
[utils] add preview warning and decorator

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -10,7 +10,12 @@ from dagster._core.decorator_utils import (
     get_decorator_target,
     is_resource_def,
 )
-from dagster._utils.warnings import deprecation_warning, experimental_warning, supersession_warning
+from dagster._utils.warnings import (
+    deprecation_warning,
+    experimental_warning,
+    preview_warning,
+    supersession_warning,
+)
 
 # For the time being, `Annotatable` is set to `Any` even though it should be set to `Decoratable` to
 # avoid choking the type checker. Choking happens because of a niche scenario where
@@ -57,6 +62,120 @@ T = TypeVar("T")
 PUBLIC: Final[str] = "public"
 
 PublicAttr: TypeAlias = Annotated[T, PUBLIC]
+
+# ########################
+# ##### Preview
+# ########################
+
+
+_PREVIEW_ATTR_NAME: Final[str] = "_preview"
+
+
+@dataclass
+class PreviewInfo:
+    additional_warn_text: Optional[str] = None
+    subject: Optional[str] = None
+
+
+@overload
+def preview(
+    __obj: T_Annotatable,
+    *,
+    additional_warn_text: Optional[str] = ...,
+    subject: Optional[str] = ...,
+    emit_runtime_warning: bool = ...,
+) -> T_Annotatable: ...
+
+
+@overload
+def preview(
+    __obj: None = ...,
+    *,
+    additional_warn_text: Optional[str] = ...,
+    subject: Optional[str] = ...,
+    emit_runtime_warning: bool = ...,
+) -> Callable[[T_Annotatable], T_Annotatable]: ...
+
+
+def preview(
+    __obj: Optional[T_Annotatable] = None,
+    *,
+    additional_warn_text: Optional[str] = None,
+    subject: Optional[str] = None,
+    emit_runtime_warning: bool = True,
+) -> Union[T_Annotatable, Callable[[T_Annotatable], T_Annotatable]]:
+    """Mark an object as preview. This appends some metadata to the object that causes it to be
+    rendered with a "preview" tag and associated warning in the docs.
+
+    If `emit_runtime_warning` is True, a warning will also be emitted when the function is called,
+    having the same text as is displayed in the docs. For consistency between docs and runtime
+    warnings, this decorator is preferred to manual calls to `preview_warning`.
+
+    Args:
+        additional_warn_text (Optional[str]): Additional text to display after the preview warning.
+            Typically, this should suggest a newer API.
+        subject (Optional[str]): The subject of the preview warning. Defaults to a string
+            representation of the decorated object. This is useful when marking usage of
+            a preview API inside an otherwise non-preview function, so
+            that it can be easily cleaned up later. It should only be used with
+            `emit_runtime_warning=False`, as we don't want to warn users when a
+            preview API is used internally.
+        emit_runtime_warning (bool): Whether to emit a warning when the function is called.
+
+    Usage:
+
+        .. code-block:: python
+
+            @preview
+            def my_preview_function(my_arg):
+                ...
+
+            @preview
+            class MyPreviewClass:
+                ...
+
+            @preview(subject="some_preview_function", emit_runtime_warning=False)
+            def not_preview_function():
+                ...
+                some_preview_function()
+                ...
+    """
+    if __obj is None:
+        return lambda obj: preview(
+            obj,
+            subject=subject,
+            emit_runtime_warning=emit_runtime_warning,
+            additional_warn_text=additional_warn_text,
+        )
+    else:
+        target = _get_annotation_target(__obj)
+        setattr(
+            target,
+            _PREVIEW_ATTR_NAME,
+            PreviewInfo(additional_warn_text, subject),
+        )
+
+        if emit_runtime_warning:
+            stack_level = _get_warning_stacklevel(__obj)
+            subject = subject or _get_subject(__obj)
+            warning_fn = lambda: preview_warning(
+                subject,
+                additional_warn_text=additional_warn_text,
+                stacklevel=stack_level,
+            )
+            return apply_pre_call_decorator(__obj, warning_fn)
+        else:
+            return __obj
+
+
+def is_preview(obj: Annotatable) -> bool:
+    target = _get_annotation_target(obj)
+    return hasattr(target, _PREVIEW_ATTR_NAME)
+
+
+def get_preview_info(obj: Annotatable) -> PreviewInfo:
+    target = _get_annotation_target(obj)
+    return getattr(target, _PREVIEW_ATTR_NAME)
 
 
 # ########################

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -113,7 +113,6 @@ def preview(
 
     Args:
         additional_warn_text (Optional[str]): Additional text to display after the preview warning.
-            Typically, this should suggest a newer API.
         subject (Optional[str]): The subject of the preview warning. Defaults to a string
             representation of the decorated object. This is useful when marking usage of
             a preview API inside an otherwise non-preview function, so

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -64,7 +64,7 @@ PUBLIC: Final[str] = "public"
 PublicAttr: TypeAlias = Annotated[T, PUBLIC]
 
 # ########################
-# ##### Preview
+# ##### PREVIEW
 # ########################
 
 

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -11,7 +11,7 @@ T = TypeVar("T")
 _warnings_on = ContextVar("_warnings_on", default=True)
 
 # ########################
-# ##### SUPERSEDED
+# ##### PREVIEW
 # ########################
 
 

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -15,7 +15,7 @@ _warnings_on = ContextVar("_warnings_on", default=True)
 # ########################
 
 
-class PreviewWarning(FutureWarning):
+class PreviewWarning(Warning):
     pass
 
 

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -15,6 +15,31 @@ _warnings_on = ContextVar("_warnings_on", default=True)
 # ########################
 
 
+class PreviewWarning(FutureWarning):
+    pass
+
+
+def preview_warning(
+    subject: str,
+    additional_warn_text: Optional[str] = None,
+    stacklevel: int = 3,
+):
+    if not _warnings_on.get():
+        return
+
+    warnings.warn(
+        f"{subject} is a preview in early testing phase with frequent changes, not recommended for production use."
+        + ((" " + additional_warn_text) if additional_warn_text else ""),
+        category=PreviewWarning,
+        stacklevel=stacklevel,
+    )
+
+
+# ########################
+# ##### SUPERSEDED
+# ########################
+
+
 class SupersessionWarning(FutureWarning):
     pass
 

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -28,8 +28,8 @@ def preview_warning(
         return
 
     warnings.warn(
-        f"{subject} is currently in preview, with ongoing updates, and not yet optimized for production use. "
-        f"This may break in future versions, even between dot releases."
+        f"{subject} is currently in preview, and may have breaking changes in patch version releases. "
+        f"This feature is not considered ready for production use."
         + ((" " + additional_warn_text) if additional_warn_text else ""),
         category=PreviewWarning,
         stacklevel=stacklevel,

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -28,7 +28,7 @@ def preview_warning(
         return
 
     warnings.warn(
-        f"{subject} is in currently, with ongoing updates, and not yet optimized for production use. "
+        f"{subject} is currently in preview, with ongoing updates, and not yet optimized for production use. "
         f"This may break in future versions, even between dot releases."
         + ((" " + additional_warn_text) if additional_warn_text else ""),
         category=PreviewWarning,

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -28,7 +28,8 @@ def preview_warning(
         return
 
     warnings.warn(
-        f"{subject} is a preview in early testing phase with frequent changes, not recommended for production use."
+        f"{subject} is in currently, with ongoing updates, and not yet optimized for production use. "
+        f"This may break in future versions, even between dot releases."
         + ((" " + additional_warn_text) if additional_warn_text else ""),
         category=PreviewWarning,
         stacklevel=stacklevel,


### PR DESCRIPTION
## Summary & Motivation

Fixes [AD-735](https://linear.app/dagster-labs/issue/AD-735/add-preview-annotation) in the API Lifecycle project.

Adding new Preview Python utils. Similar to #25363 

This is done in alignment with the new [API lifecycle](https://www.notion.so/dagster/API-Lifecycle-Refresh-f72f6e199da3409c8c5da297a109b3c8).

The raised warning is a `Warning`.

Docs to be updated in subsequent PR.