### PR TITLE
[dagster-sigma] Add ability to filter to specific workbooks

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -63,6 +63,28 @@ class SigmaMaterializationStatus(str, enum.Enum):
     READY = "ready"
 
 
+def build_folder_path_err(folder: Any, idx: int, param_name: str):
+    return (
+        f"{param_name} at index {idx} is not a sequence: `{folder!r}`.\n"
+        "Paths should be specified as a list of folder names, starting from the root folder."
+    )
+
+
+def validate_folder_path_input(folder_input: Optional[Sequence[Sequence[str]]], param_name: str):
+    check.opt_sequence_param(folder_input, param_name, of_type=Sequence)
+    if folder_input:
+        for idx, folder in enumerate(folder_input):
+            check.invariant(
+                not isinstance(folder, str),
+                build_folder_path_err(folder, idx, param_name),
+            )
+            check.is_iterable(
+                folder,
+                of_type=str,
+                additional_message=build_folder_path_err(folder, idx, param_name),
+            )
+
+
 @record_custom
 class SigmaFilter(IHaveNew):
     """Filters the set of Sigma objects to fetch.
@@ -71,21 +93,34 @@ class SigmaFilter(IHaveNew):
         workbook_folders (Optional[Sequence[Sequence[str]]]): A list of folder paths to fetch workbooks from.
             Each folder path is a list of folder names, starting from the root folder. All workbooks
             contained in the specified folders will be fetched. If not provided, all workbooks will be fetched.
+        workbooks (Optional[Sequence[Sequence[str]]]): A list of fully qualified workbook paths to fetch.
+            Each workbook path is a list of folder names, starting from the root folder, and ending
+            with the workbook name. If not provided, all workbooks will be fetched.
         include_unused_datasets (bool): Whether to include datasets that are not used in any workbooks.
             Defaults to True.
     """
 
     workbook_folders: Optional[Sequence[Sequence[str]]] = None
+    workbooks: Optional[Sequence[Sequence[str]]] = None
     include_unused_datasets: bool = True
 
     def __new__(
         cls,
         workbook_folders: Optional[Sequence[Sequence[str]]] = None,
+        workbooks: Optional[Sequence[Sequence[str]]] = None,
         include_unused_datasets: bool = True,
     ):
+        validate_folder_path_input(workbook_folders, "workbook_folders")
+        validate_folder_path_input(workbooks, "workbooks")
+        check.invariant(
+            not (workbook_folders and workbooks),
+            "Only one of workbook_folders or workbooks can be provided",
+        )
+
         return super().__new__(
             cls,
             workbook_folders=tuple([tuple(folder) for folder in workbook_folders or []]),
+            workbooks=tuple([tuple(workbook) for workbook in workbooks or []]),
             include_unused_datasets=include_unused_datasets,
         )
 
@@ -578,6 +613,14 @@ class SigmaOrganization(ConfigurableResource):
                 if any(
                     workbook_path.startswith(folder_str) for folder_str in workbook_filter_strings
                 ):
+                    workbooks_to_fetch.append(workbook)
+        elif sigma_filter.workbooks:
+            workbook_strings = ["/".join(folder).lower() for folder in sigma_filter.workbooks]
+            for workbook in raw_workbooks:
+                workbook_path_and_name = (
+                    f"{str(workbook['path']).lower()}/{str(workbook['name']).lower()}"
+                )
+                if workbook_path_and_name in workbook_strings:
                     workbooks_to_fetch.append(workbook)
         else:
             workbooks_to_fetch = raw_workbooks

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -95,8 +95,11 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
     assert data.datasets[0].inputs == {"TESTDB.JAFFLE_SHOP.STG_ORDERS"}
 
 
+@pytest.mark.parametrize("filter_type", ["workbook_folders", "workbook_names"])
 @responses.activate
-def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data: None) -> None:
+def test_model_organization_data_filter(
+    sigma_auth_token: str, sigma_sample_data: None, filter_type: str
+) -> None:
     fake_client_id = uuid.uuid4().hex
     fake_client_secret = uuid.uuid4().hex
 
@@ -111,9 +114,16 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
         "_fetch_pages_for_workbook",
         wraps=resource._fetch_pages_for_workbook,  # noqa: SLF001
     ) as mock_fetch_pages:
+        sigma_filter = (
+            SigmaFilter(
+                workbook_folders=[("My Documents", "Test Folder")],
+            )
+            if filter_type == "workbook_folders"
+            else SigmaFilter(workbooks=[("My Documents", "Test Folder", "Sample Workbook")])
+        )
         data = asyncio.run(
             resource.build_organization_data(
-                sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "Test Folder")]),
+                sigma_filter=sigma_filter,
                 fetch_column_data=True,
             )
         )
@@ -123,12 +133,19 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
         # We don't fetch the workbooks, so we shouldn't have made any calls
         assert len(mock_fetch_pages.mock_calls) == 0
 
+        sigma_filter = (
+            SigmaFilter(
+                workbook_folders=[("My Documents", "Test Folder")], include_unused_datasets=False
+            )
+            if filter_type == "workbook_folders"
+            else SigmaFilter(
+                workbooks=[("My Documents", "Test Folder", "Sample Workbook")],
+                include_unused_datasets=False,
+            )
+        )
         data = asyncio.run(
             resource.build_organization_data(
-                sigma_filter=SigmaFilter(
-                    workbook_folders=[("My Documents", "Test Folder")],
-                    include_unused_datasets=False,
-                ),
+                sigma_filter=sigma_filter,
                 fetch_column_data=True,
             )
         )
@@ -138,12 +155,20 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
         # We still don't fetch the workbooks, so we shouldn't have made any calls
         assert len(mock_fetch_pages.mock_calls) == 0
 
+        sigma_filter = (
+            SigmaFilter(
+                workbook_folders=[("My Documents", "My Subfolder")],
+                include_unused_datasets=False,
+            )
+            if filter_type == "workbook_folders"
+            else SigmaFilter(
+                workbooks=[("My Documents", "My Subfolder", "Sample Workbook")],
+                include_unused_datasets=False,
+            )
+        )
         data = asyncio.run(
             resource.build_organization_data(
-                sigma_filter=SigmaFilter(
-                    workbook_folders=[("My Documents", "My Subfolder")],
-                    include_unused_datasets=False,
-                ),
+                sigma_filter=sigma_filter,
                 fetch_column_data=True,
             )
         )


### PR DESCRIPTION
## Summary

Adds an option to the `SigmaFilter` which lets users filter to specific workbooks rather than folders.

## How I Tested These Changes

New unit test.

## Changelog

> [dagster-sigma] Added the option to filter to specific workbooks in addition to folders.