### PR TITLE
New BFS method for use in asset backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -6,6 +6,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     Literal,
     NamedTuple,
     Optional,
@@ -17,6 +18,7 @@ from typing import (
 from dagster import _check as check
 from dagster._core.asset_graph_view.entity_subset import EntitySubset, _ValidatedEntitySubsetValue
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.multi_dimensional_partitions import (
@@ -192,6 +194,34 @@ class AssetGraphView(LoadingContext):
         partitions_def = self._get_partitions_def(key)
         value = partitions_def.empty_subset() if partitions_def else False
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
+
+    def get_entity_subset_from_asset_graph_subset(
+        self, asset_graph_subset: AssetGraphSubset, key: AssetKey
+    ) -> EntitySubset[AssetKey]:
+        check.invariant(
+            self.asset_graph.has(key), f"Asset graph does not contain {key.to_user_string()}"
+        )
+
+        serializable_subset = asset_graph_subset.get_asset_subset(key, self.asset_graph)
+        check.invariant(
+            serializable_subset.is_compatible_with_partitions_def(
+                self._get_partitions_def(key),
+            ),
+            f"Partitions definition for {key.to_user_string()} is not compatible with the passed in AssetGraphSubset",
+        )
+
+        return EntitySubset(
+            self, key=key, value=_ValidatedEntitySubsetValue(serializable_subset.value)
+        )
+
+    def iterate_asset_subsets(
+        self, asset_graph_subset: AssetGraphSubset
+    ) -> Iterable[EntitySubset[AssetKey]]:
+        """Returns an Iterable of EntitySubsets representing the subset of each asset that this
+        AssetGraphSubset contains.
+        """
+        for asset_key in asset_graph_subset.asset_keys:
+            yield self.get_entity_subset_from_asset_graph_subset(asset_graph_subset, asset_key)
 
     def get_subset_from_serializable_subset(
         self, serializable_subset: SerializableEntitySubset[T_EntityKey]

--- a/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
@@ -1,0 +1,221 @@
+from functools import total_ordering
+from heapq import heapify, heappop, heappush
+from typing import TYPE_CHECKING, Callable, Iterable, NamedTuple, Optional, Sequence, Tuple
+
+import dagster._check as check
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._core.definitions.time_window_partitions import get_time_partitions_def
+
+if TYPE_CHECKING:
+    from dagster._core.asset_graph_view.entity_subset import EntitySubset
+    from dagster._core.definitions.asset_key import AssetKey
+
+
+class AssetGraphViewBfsFilterConditionResult(NamedTuple):
+    passed_asset_graph_subset: AssetGraphSubset
+    excluded_asset_graph_subsets_and_reasons: Sequence[Tuple[AssetGraphSubset, str]]
+
+
+def bfs_filter_asset_graph_view(
+    asset_graph_view: AssetGraphView,
+    condition_fn: Callable[
+        ["AssetGraphSubset", "AssetGraphSubset"],
+        AssetGraphViewBfsFilterConditionResult,
+    ],
+    initial_asset_graph_subset: "AssetGraphSubset",
+    include_full_execution_set: bool,
+) -> Tuple[AssetGraphSubset, Sequence[Tuple[AssetGraphSubset, str]]]:
+    """Returns the subset of the graph that satisfy supplied criteria.
+
+    - Are >= initial_asset_graph_subset
+    - Match the condition_fn
+    - Any of their ancestors >= initial_asset_graph_subset match the condition_fn
+
+    Also returns a list of tuples, where each tuple is an asset subset that did not
+    satisfy the condition and the reason they were filtered out.
+
+    The condition_fn takes in:
+    - a subset of the asset graph to evaluate the condition for. If include_full_execution_set=True,
+    the asset keys are all part of the same execution set (i.e. non-subsettable multi-asset). If
+    include_full_execution_set=False, only a single asset key will be in the subset.
+
+    - An AssetGraphSubset for the portion of the graph that has so far been visited and passed
+    the condition.
+
+    The condition_fn should return a object with an AssetGraphSubset indicating the portion
+    of the subset that passes the condition, and a list of (AssetGraphSubset, str)
+    tuples with more information about why certain subsets were excluded.
+
+    Visits parents before children.
+    """
+    initial_subsets = list(asset_graph_view.iterate_asset_subsets(initial_asset_graph_subset))
+
+    # invariant: we never consider an asset partition before considering its ancestors
+    queue = ToposortedPriorityQueue(
+        asset_graph_view, initial_subsets, include_full_execution_set=include_full_execution_set
+    )
+
+    visited_graph_subset = initial_asset_graph_subset
+
+    result: AssetGraphSubset = AssetGraphSubset.empty()
+    failed_reasons: Sequence[Tuple[AssetGraphSubset, str]] = []
+
+    asset_graph = asset_graph_view.asset_graph
+
+    while len(queue) > 0:
+        candidate_subset = queue.dequeue()
+        condition_result = condition_fn(candidate_subset, result)
+
+        subset_that_meets_condition = condition_result.passed_asset_graph_subset
+        failed_reasons.extend(condition_result.excluded_asset_graph_subsets_and_reasons)
+
+        result = result | subset_that_meets_condition
+
+        for matching_entity_subset in asset_graph_view.iterate_asset_subsets(
+            subset_that_meets_condition
+        ):
+            # Add any child subsets that have not yet been visited to the queue
+            for child_key in asset_graph.get(matching_entity_subset.key).child_keys:
+                child_subset = asset_graph_view.compute_child_subset(
+                    child_key, matching_entity_subset
+                )
+                unvisited_child_subset = child_subset.compute_difference(
+                    asset_graph_view.get_entity_subset_from_asset_graph_subset(
+                        visited_graph_subset, child_key
+                    )
+                )
+                if not unvisited_child_subset.is_empty:
+                    queue.enqueue(unvisited_child_subset)
+                    visited_graph_subset = (
+                        visited_graph_subset
+                        | AssetGraphSubset.from_entity_subsets([unvisited_child_subset])
+                    )
+
+    return result, failed_reasons
+
+
+def sort_key_for_asset_key(asset_graph: BaseAssetGraph, asset_key: "AssetKey") -> float:
+    """Returns an integer sort key such that asset partition ranges are sorted in
+    the order in which they should be materialized. For assets without a time
+    window partition dimension, this is always 0.
+    Assets with a time window partition dimension will be sorted from newest to oldest, unless they
+    have a self-dependency, in which case they are sorted from oldest to newest.
+    """
+    partitions_def = asset_graph.get(asset_key).partitions_def
+    time_partitions_def = get_time_partitions_def(partitions_def)
+    if time_partitions_def is None:
+        return 0
+
+    # A sort key such that time window partitions are sorted from oldest start time to newest start time
+    start_timestamp = time_partitions_def.start_ts.timestamp
+
+    if asset_graph.get(asset_key).has_self_dependency:
+        # sort self dependencies from oldest to newest, as older partitions must exist before
+        # new ones can execute
+        return start_timestamp
+    else:
+        # sort non-self dependencies from newest to oldest, as newer partitions are more relevant
+        # than older ones
+        return -1 * start_timestamp
+
+
+class ToposortedPriorityQueue:
+    """Queue that returns parents before their children."""
+
+    @total_ordering
+    class QueueItem(NamedTuple):
+        level: int
+        partition_sort_key: Optional[float]
+        asset_graph_subset: AssetGraphSubset
+
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, ToposortedPriorityQueue.QueueItem):
+                return (
+                    self.level == other.level
+                    and self.partition_sort_key == other.partition_sort_key
+                )
+            return False
+
+        def __lt__(self, other: object) -> bool:
+            if isinstance(other, ToposortedPriorityQueue.QueueItem):
+                return self.level < other.level or (
+                    self.level == other.level
+                    and self.partition_sort_key is not None
+                    and other.partition_sort_key is not None
+                    and self.partition_sort_key < other.partition_sort_key
+                )
+            raise TypeError()
+
+    def __init__(
+        self,
+        asset_graph_view: AssetGraphView,
+        items: Iterable["EntitySubset"],
+        include_full_execution_set: bool,
+    ):
+        self._asset_graph_view = asset_graph_view
+        self._include_full_execution_set = include_full_execution_set
+
+        self._toposort_level_by_asset_key = {
+            asset_key: i
+            for i, asset_keys in enumerate(
+                asset_graph_view.asset_graph.toposorted_asset_keys_by_level
+            )
+            for asset_key in asset_keys
+        }
+        self._heap = [self._queue_item(entity_subset) for entity_subset in items]
+        heapify(self._heap)
+
+    def enqueue(self, entity_subset: "EntitySubset") -> None:
+        heappush(self._heap, self._queue_item(entity_subset))
+
+    def dequeue(self) -> AssetGraphSubset:
+        # For multi-assets, will include all required multi-asset keys if
+        # include_full_execution_set is set to True, or just the passed in
+        # asset key if it was not. If there are multiple assets in the subset
+        # the subset will have the same partitions included for each asset.
+        heap_value = heappop(self._heap)
+        return heap_value.asset_graph_subset
+
+    def _queue_item(self, entity_subset: "EntitySubset") -> "ToposortedPriorityQueue.QueueItem":
+        asset_key = entity_subset.key
+
+        if self._include_full_execution_set:
+            execution_set_keys = self._asset_graph_view.asset_graph.get(
+                asset_key
+            ).execution_set_asset_keys
+        else:
+            execution_set_keys = {asset_key}
+
+        level = max(
+            self._toposort_level_by_asset_key[asset_key] for asset_key in execution_set_keys
+        )
+
+        serializable_entity_subset = entity_subset.convert_to_serializable_subset()
+
+        serializable_entity_subsets = [
+            SerializableEntitySubset(key=asset_key, value=serializable_entity_subset.value)
+            for asset_key in execution_set_keys
+        ]
+
+        entity_subsets = [
+            check.not_none(
+                self._asset_graph_view.get_subset_from_serializable_subset(
+                    serializable_entity_subset
+                )
+            )
+            for serializable_entity_subset in serializable_entity_subsets
+        ]
+
+        asset_graph_subset = AssetGraphSubset.from_entity_subsets(entity_subsets)
+
+        return ToposortedPriorityQueue.QueueItem(
+            level,
+            sort_key_for_asset_key(self._asset_graph_view.asset_graph, asset_key),
+            asset_graph_subset=asset_graph_subset,
+        )
+
+    def __len__(self) -> int:
+        return len(self._heap)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -269,6 +269,10 @@ class AssetGraphSubset(NamedTuple):
         )
 
     @classmethod
+    def empty(cls) -> "AssetGraphSubset":
+        return AssetGraphSubset({}, set())
+
+    @classmethod
     def from_entity_subsets(
         cls, entity_subsets: Iterable[EntitySubset[AssetKey]]
     ) -> "AssetGraphSubset":

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -1,0 +1,253 @@
+from dagster import AssetKey, AssetSpec, Definitions, asset, multi_asset
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
+from dagster._core.asset_graph_view.bfs import (
+    AssetGraphViewBfsFilterConditionResult,
+    bfs_filter_asset_graph_view,
+)
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
+
+
+def _get_subset_with_keys(graph_view, keys):
+    return AssetGraphSubset.from_entity_subsets(
+        [graph_view.get_full_subset(key=key) for key in keys]
+    )
+
+
+def test_bfs_filter_empty_graph():
+    """Test BFS filter on empty graph returns empty result."""
+    graph_view = AssetGraphView.for_test(Definitions())
+    initial_subset = AssetGraphSubset.empty()
+
+    def condition_fn(subset, _visited):
+        return AssetGraphViewBfsFilterConditionResult(subset, [])
+
+    result, failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=False
+    )
+
+    assert result == AssetGraphSubset.empty()
+    assert failed == []
+
+
+def test_bfs_filter_dependency_chain():
+    """Test BFS filter on linear dependency chain."""
+
+    @asset
+    def asset1():
+        return 1
+
+    @asset
+    def asset2(asset1):
+        return asset1 + 1
+
+    @asset
+    def asset3(asset2):
+        return asset2 + 1
+
+    @asset
+    def asset4(asset3):
+        return asset3 + 1
+
+    graph_view = AssetGraphView.for_test(Definitions(assets=[asset1, asset2, asset3, asset4]))
+    initial_subset = AssetGraphSubset.from_entity_subsets(
+        [graph_view.get_full_subset(key=asset1.key)]
+    )
+
+    def condition_fn(subset, visited):
+        # Only allow asset1 and asset3
+        if AssetKey("asset3") in subset.asset_keys:
+            assert visited == AssetGraphSubset.from_entity_subsets(
+                [
+                    graph_view.get_full_subset(key=asset1.key),
+                    graph_view.get_full_subset(key=asset2.key),
+                ]
+            )
+
+            return AssetGraphViewBfsFilterConditionResult(
+                AssetGraphSubset.empty(),
+                [(subset, "asset3 not allowed")],
+            )
+        return AssetGraphViewBfsFilterConditionResult(subset, [])
+
+    result, failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=False
+    )
+
+    assert result == AssetGraphSubset.from_entity_subsets(
+        [graph_view.get_full_subset(key=asset1.key), graph_view.get_full_subset(key=asset2.key)]
+    )
+    assert len(failed) == 1
+    assert failed[0][0] == AssetGraphSubset.from_entity_subsets(
+        [graph_view.get_full_subset(key=asset3.key)]
+    )
+    assert failed[0][1] == "asset3 not allowed"
+
+
+def test_bfs_filter_multi_asset():
+    """Test BFS filter with multi-asset."""
+
+    @asset
+    def a():
+        return 1
+
+    @asset
+    def b():
+        return 2
+
+    @multi_asset(
+        specs=[AssetSpec("c", deps=["a"]), AssetSpec("d", deps=["b"])]
+    )  # d is level 1, e is level 3, gets assigned 3
+    def my_multi_asset():
+        pass
+
+    @asset
+    def e(d):
+        pass
+
+    graph_view = AssetGraphView.for_test(Definitions(assets=[a, b, my_multi_asset, e]))
+    initial_subset = _get_subset_with_keys(graph_view, [a.key])
+
+    def condition_fn(subset, _visited):
+        return AssetGraphViewBfsFilterConditionResult(subset, [])
+
+    result_without_full_execution_set, _failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=False
+    )
+
+    assert result_without_full_execution_set == _get_subset_with_keys(
+        graph_view, [a.key, AssetKey(["c"])]
+    )
+
+    result_with_full_execution_set, _failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=True
+    )
+
+    assert result_with_full_execution_set == _get_subset_with_keys(
+        graph_view, [a.key, AssetKey(["c"]), AssetKey(["d"]), e.key]
+    )
+
+
+def test_bfs_filter_diamond():
+    """Test BFS filter with a diamond-shaped graph to ensure bottom node is visited once."""
+
+    @asset
+    def top():
+        return 1
+
+    @asset
+    def left(top):
+        return top + 1
+
+    @asset
+    def right(top):
+        return top + 2
+
+    @asset
+    def bottom(left, right):
+        return left + right
+
+    graph_view = AssetGraphView.for_test(Definitions(assets=[top, left, right, bottom]))
+    initial_subset = _get_subset_with_keys(graph_view, [AssetKey("top")])
+
+    visit_count = {}
+
+    def condition_fn(subset, _visited):
+        for key in subset.asset_keys:
+            visit_count[key] = visit_count.get(key, 0) + 1
+        return AssetGraphViewBfsFilterConditionResult(subset, [])
+
+    result, failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=True
+    )
+
+    # Each node should be visited exactly once
+    assert visit_count == {
+        AssetKey("bottom"): 1,
+        AssetKey("left"): 1,
+        AssetKey("right"): 1,
+        AssetKey("top"): 1,
+    }
+    assert result == _get_subset_with_keys(
+        graph_view, [AssetKey("top"), AssetKey("left"), AssetKey("right"), AssetKey("bottom")]
+    )
+    assert failed == []
+
+
+from dagster import AssetIn, StaticPartitionsDefinition
+
+
+def test_bfs_filter_with_partitions():
+    """Test BFS filter with partitioned assets where condition filters some partitions."""
+
+    @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
+    def upstream():
+        return 1
+
+    @asset(
+        partitions_def=StaticPartitionsDefinition(["a", "b", "c"]),
+        ins={"upstream": AssetIn(partition_mapping=IdentityPartitionMapping())},
+    )
+    def downstream(upstream):
+        return upstream + 1
+
+    graph_view = AssetGraphView.for_test(Definitions(assets=[upstream, downstream]))
+    initial_subset = AssetGraphSubset.from_asset_partition_set(
+        {
+            AssetKeyPartitionKey(AssetKey(["upstream"]), "a"),
+            AssetKeyPartitionKey(AssetKey(["upstream"]), "b"),
+        },
+        graph_view.asset_graph,
+    )
+
+    def condition_fn(subset, _visited):
+        # Only allow partition "a" for upstream and corresponding mapped partition "x" for downstream
+        included = set()
+        excluded = set()
+
+        for entity_subset in graph_view.iterate_asset_subsets(subset):
+            for asset_partition in entity_subset.expensively_compute_asset_partitions():
+                if asset_partition.partition_key == "b":
+                    excluded.add(asset_partition)
+                else:
+                    included.add(asset_partition)
+
+        return AssetGraphViewBfsFilterConditionResult(
+            AssetGraphSubset.from_asset_partition_set(included, graph_view.asset_graph),
+            (
+                [
+                    (
+                        AssetGraphSubset.from_asset_partition_set(excluded, graph_view.asset_graph),
+                        "b is not welcome here",
+                    )
+                ]
+                if excluded
+                else []
+            ),
+        )
+
+    result, failed = bfs_filter_asset_graph_view(
+        graph_view, condition_fn, initial_subset, include_full_execution_set=True
+    )
+
+    # Should only include partition "a" for upstream and "x" for downstream
+    assert result == AssetGraphSubset.from_asset_partition_set(
+        {
+            AssetKeyPartitionKey(AssetKey(["upstream"]), "a"),
+            AssetKeyPartitionKey(AssetKey(["downstream"]), "a"),
+        },
+        graph_view.asset_graph,
+    )
+
+    assert failed == [
+        (
+            AssetGraphSubset.from_asset_partition_set(
+                {
+                    AssetKeyPartitionKey(AssetKey(["upstream"]), "b"),
+                },
+                graph_view.asset_graph,
+            ),
+            "b is not welcome here",
+        ),
+    ]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -56,7 +56,7 @@ def test_bfs_filter_dependency_chain():
     )
 
     def condition_fn(subset, visited):
-        # Only allow asset1 and asset3
+        # Only allow asset1 and asset2
         if AssetKey("asset3") in subset.asset_keys:
             assert visited == AssetGraphSubset.from_entity_subsets(
                 [


### PR DESCRIPTION
Summary:
Pulling out the new BFS utility added in https://github.com/dagster-io/dagster/pull/25997 to its own function with its own tests to keep the PR size manageable.

Test Plan: New tests

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
