### PR TITLE
feat(dagster-duckdb): ignore delete operation exception if it's due to a view

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -262,6 +262,14 @@ class DuckDbClient(DbClient):
         except duckdb.CatalogException:
             # table doesn't exist yet, so ignore the error
             pass
+        except duckdb.BinderException as ex:
+            if "Can only delete from base table" not in str(
+                ex
+            ) and "Contents of view were altered" not in str(ex):
+                raise ex
+
+            # it's a view, so ignore the error
+            pass
 
     @staticmethod
     def ensure_schema_exists(context: OutputContext, table_slice: TableSlice, connection) -> None:


### PR DESCRIPTION
## Summary & Motivation

we are using an additional type handler for the duckdb io_manager which uses views to link data into the duckdb database to avaoid copying the data. unfrotunately the current io_manager always tries to delete the data in a table even when it's a view. this change ignores exceptions due to views.

## How I Tested These Changes

i made this changes locally in our dagster instance and it work's with our custom type handler.

## Changelog

dagster-duckdb: gracefully handle table cleanup exceptions on views
