### PR TITLE
[dagster-azure] delete blobs after test in integration tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
@@ -79,6 +79,7 @@ def build_dagster_oss_nightly_steps() -> List[BuildkiteStep]:
                     "TEST_AZURE_CLIENT_SECRET",
                     "TEST_AZURE_STORAGE_ACCOUNT_ID",
                     "TEST_AZURE_CONTAINER_ID",
+                    "TEST_AZURE_ACCESS_KEY",
                 ],
                 always_run_if=lambda: True,
             ),

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -186,6 +186,7 @@ def build_azure_live_test_suite_steps() -> List[BuildkiteTopLevelStep]:
             "TEST_AZURE_CLIENT_SECRET",
             "TEST_AZURE_STORAGE_ACCOUNT_ID",
             "TEST_AZURE_CONTAINER_ID",
+            "TEST_AZURE_ACCESS_KEY",
         ],
     ).build_steps()
 

--- a/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
+++ b/integration_tests/test_suites/dagster-azure-live-tests/integration_tests/test_compute_log_manager.py
@@ -1,7 +1,5 @@
-import os
 import subprocess
 from pathlib import Path
-from typing import Generator
 
 import pytest
 from azure.identity import ClientSecretCredential
@@ -12,24 +10,6 @@ from dagster import (
     EventRecordsFilter,
     _check as check,
 )
-from dagster_azure.blob.utils import create_blob_client
-
-
-@pytest.fixture
-def credentials() -> ClientSecretCredential:
-    return ClientSecretCredential(
-        tenant_id=os.environ["TEST_AZURE_TENANT_ID"],
-        client_id=os.environ["TEST_AZURE_CLIENT_ID"],
-        client_secret=os.environ["TEST_AZURE_CLIENT_SECRET"],
-    )
-
-
-@pytest.fixture
-def container_client(credentials: ClientSecretCredential) -> Generator[ContainerClient, None, None]:
-    yield create_blob_client(
-        storage_account="chriscomplogmngr",
-        credential=credentials,
-    ).get_container_client("mycontainer")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation
This PR adds a step to delete all blobs created by the integration tests.

Previously they were just building up.
## How I Tested These Changes
Existing tests still pass