### PR TITLE
[components] Replace RequiredScope with RenderedModel

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project.py
@@ -17,12 +17,12 @@ from dagster_components.core.component import (
     TemplatedValueResolver,
     component_type,
 )
-from dagster_components.core.component_rendering import RenderingScope
+from dagster_components.core.component_rendering import RenderedModel
 from dagster_components.core.dsl_schema import AssetAttributes, AssetSpecProcessor, OpSpecBaseModel
 from dagster_components.generate import generate_component_yaml
 
 
-class DbtNodeTranslatorParams(BaseModel):
+class DbtNodeTranslatorParams(RenderedModel):
     key: Optional[str] = None
     group: Optional[str] = None
 
@@ -30,9 +30,7 @@ class DbtNodeTranslatorParams(BaseModel):
 class DbtProjectParams(BaseModel):
     dbt: DbtCliResource
     op: Optional[OpSpecBaseModel] = None
-    translator: Optional[DbtNodeTranslatorParams] = RenderingScope(
-        Field(default=None), required_scope={"node"}
-    )
+    translator: Optional[DbtNodeTranslatorParams] = None
     asset_attributes: Optional[AssetAttributes] = None
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -52,7 +52,7 @@ class PipesSubprocessScriptCollection(Component):
             if not script_path.exists():
                 raise FileNotFoundError(f"Script {script_path} does not exist")
             path_specs[script_path] = [
-                AssetSpec(**asset.get_resolved_attributes(context.templated_value_resolver))
+                AssetSpec(**asset.render_properties(context.templated_value_resolver))
                 for asset in script.assets
             ]
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
@@ -1,64 +1,74 @@
-from typing import Optional, Sequence
+from typing import Annotated, Optional, Sequence
 
 import pytest
 from dagster_components.core.component_rendering import (
-    RenderingScope,
+    RenderedModel,
+    RenderingMetadata,
     TemplatedValueResolver,
-    has_rendering_scope,
+    can_render_with_default_scope,
 )
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 
-class Inner(BaseModel):
+class InnerRendered(RenderedModel):
     a: Optional[str] = None
-    deferred: Optional[str] = RenderingScope(required_scope={"foo", "bar", "baz"})
+
+
+class Container(BaseModel):
+    a: str
+    inner: InnerRendered
 
 
 class Outer(BaseModel):
     a: str
-    deferred: str = RenderingScope(required_scope={"a"})
-    inner: Sequence[Inner]
-    inner_deferred: Sequence[Inner] = RenderingScope(required_scope={"b"})
-
-    inner_optional: Optional[Sequence[Inner]] = None
-    inner_deferred_optional: Optional[Sequence[Inner]] = RenderingScope(
-        Field(default=None), required_scope={"b"}
-    )
+    inner: InnerRendered
+    container: Container
+    container_optional: Optional[Container] = None
+    inner_seq: Sequence[InnerRendered]
+    inner_optional: Optional[InnerRendered] = None
+    inner_optional_seq: Optional[Sequence[InnerRendered]] = None
 
 
 @pytest.mark.parametrize(
     "path,expected",
     [
         (["a"], True),
-        (["deferred"], False),
-        (["inner", 0, "a"], True),
-        (["inner", 0, "deferred"], False),
-        (["inner_deferred", 0, "a"], False),
-        (["inner_deferred", 0, "deferred"], False),
+        (["inner"], False),
+        (["inner", "a"], False),
+        (["container", "a"], True),
+        (["container", "inner"], False),
+        (["container", "inner", "a"], False),
+        (["container_optional", "a"], True),
+        (["container_optional", "inner"], False),
+        (["container_optional", "inner", "a"], False),
+        (["inner_seq"], True),
+        (["inner_seq", 0], False),
+        (["inner_seq", 0, "a"], False),
         (["inner_optional"], True),
-        (["inner_optional", 0, "a"], True),
-        (["inner_optional", 0, "deferred"], False),
-        (["inner_deferred_optional", 0], False),
-        (["inner_deferred_optional", 0, "a"], False),
+        (["inner_optional", "a"], False),
+        (["inner_optional_seq"], True),
+        (["inner_optional_seq", 0], False),
+        (["inner_optional_seq", 0, "a"], False),
     ],
 )
-def test_should_render(path, expected: bool) -> None:
+def test_can_render(path, expected: bool) -> None:
     assert (
-        has_rendering_scope(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
+        can_render_with_default_scope(path, Outer.model_json_schema(), Outer.model_json_schema())
+        == expected
     )
 
 
 def test_render() -> None:
     data = {
         "a": "{{ foo_val }}",
-        "deferred": "{{ deferred }}",
-        "inner": [
-            {"a": "{{ bar_val }}", "deferred": "{{ deferred }}"},
-            {"a": "zzz", "deferred": "zzz"},
+        "inner": {"a": "{{ deferred }}"},
+        "inner_seq": [
+            {"a": "{{ deferred }}"},
         ],
-        "inner_deferred": [
-            {"a": "{{ deferred }}", "deferred": "zzz"},
-        ],
+        "container": {
+            "a": "{{ bar_val }}",
+            "inner": {"a": "{{ deferred }}"},
+        },
     }
 
     renderer = TemplatedValueResolver(context={"foo_val": "foo", "bar_val": "bar"})
@@ -66,14 +76,55 @@ def test_render() -> None:
 
     assert rendered_data == {
         "a": "foo",
-        "deferred": "{{ deferred }}",
-        "inner": [
-            {"a": "bar", "deferred": "{{ deferred }}"},
-            {"a": "zzz", "deferred": "zzz"},
+        "inner": {"a": "{{ deferred }}"},
+        "inner_seq": [
+            {"a": "{{ deferred }}"},
         ],
-        "inner_deferred": [
-            {"a": "{{ deferred }}", "deferred": "zzz"},
-        ],
+        "container": {
+            "a": "bar",
+            "inner": {"a": "{{ deferred }}"},
+        },
     }
 
     TypeAdapter(Outer).validate_python(rendered_data)
+
+
+class RM(RenderedModel):
+    the_renderable_int: Annotated[str, RenderingMetadata(output_type=int)]
+    the_unrenderable_int: int
+
+    the_str: str
+    the_opt_int: Annotated[Optional[str], RenderingMetadata(output_type=Optional[int])] = None
+
+
+def test_valid_rendering() -> None:
+    rm = RM(
+        the_renderable_int="{{ some_int }}",
+        the_unrenderable_int=1,
+        the_str="{{ some_str }}",
+        the_opt_int="{{ some_int }}",
+    )
+    resolver = TemplatedValueResolver(context={"some_int": 1, "some_str": "aaa"})
+    resolved_properties = rm.render_properties(resolver)
+
+    assert resolved_properties == {
+        "the_renderable_int": 1,
+        "the_unrenderable_int": 1,
+        "the_str": "aaa",
+        "the_opt_int": 1,
+    }
+
+
+def test_invalid_rendering() -> None:
+    rm = RM(
+        the_renderable_int="{{ some_int }}",
+        the_unrenderable_int=1,
+        the_str="{{ some_str }}",
+        the_opt_int="{{ some_str }}",
+    )
+
+    resolver = TemplatedValueResolver(context={"some_int": 1, "some_str": "aaa"})
+
+    with pytest.raises(ValidationError):
+        # string is not a valid output type for the_opt_int
+        rm.render_properties(resolver)


### PR DESCRIPTION
## Summary & Motivation

This changes up how we manage marking objects as having deferred fields. The result is a lot more terse, and generally easier to work around.

The base class exposes a method to get all of the rendered properties, which can be overridden in scenarios where we want to customize this. For now, our only existing usage can just use this raw properties dictionary directly

## How I Tested These Changes

## Changelog

NOCHANGELOG
