### PR TITLE
[bugfix] Restart k8s log stream on urllib3 failure

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -18,7 +18,6 @@ from dagster import (
 from dagster._annotations import experimental
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._utils.merger import merge_dicts
-from urllib3.exceptions import ProtocolError
 
 from dagster_k8s.client import DEFAULT_JOB_POD_COUNT, DagsterKubernetesClient, k8s_api_retry
 from dagster_k8s.container_context import K8sContainerContext
@@ -378,43 +377,39 @@ def execute_k8s_job(
                 start_time=start_time,  # pyright: ignore[reportArgumentType]
             )
 
-            while True:
-                try:
-                    log_stream = watch.stream(
-                        api_client.core_api.read_namespaced_pod_log,
-                        name=pod_to_watch,
-                        namespace=namespace,
-                        container=container_name,
-                    )
-                    while True:
-                        if timeout and time.time() - start_time > timeout:
-                            watch.stop()
-                            raise Exception("Timed out waiting for pod to finish")
+            log_stream = watch.stream(
+                api_client.core_api.read_namespaced_pod_log,
+                name=pod_to_watch,
+                namespace=namespace,
+                container=container_name,
+            )
 
-                        log_entry = k8s_api_retry(
-                            lambda: next(log_stream),
-                            max_retries=int(
-                                os.getenv("DAGSTER_EXECUTE_K8S_JOB_STREAM_LOGS_RETRIES", "3")
-                            ),
-                            timeout=int(
-                                os.getenv(
-                                    "DAGSTER_EXECUTE_K8S_JOB_STREAM_LOGS_WAIT_BETWEEN_ATTEMPTS", "5"
-                                )
-                            ),
-                        )
-                        print(log_entry)  # noqa: T201
+            while True:
+                if timeout and time.time() - start_time > timeout:
+                    watch.stop()
+                    raise Exception("Timed out waiting for pod to finish")
+                try:
+                    log_entry = k8s_api_retry(
+                        lambda: next(log_stream),
+                        max_retries=int(
+                            os.getenv("DAGSTER_EXECUTE_K8S_JOB_STREAM_LOGS_RETRIES", "3")
+                        ),
+                        timeout=int(
+                            os.getenv(
+                                "DAGSTER_EXECUTE_K8S_JOB_STREAM_LOGS_WAIT_BETWEEN_ATTEMPTS", "5"
+                            )
+                        ),
+                    )
+                    print(log_entry)  # noqa: T201
                 except StopIteration:
                     break
-                except ProtocolError:
+                except Exception:
                     context.log.warning(
-                        "urllib3.exceptions.ProtocolError. Pausing and will reconnect.",
+                        "Error reading pod logs. Giving up and waiting for the pod to finish",
                         exc_info=True,
                     )
-                    time.sleep(
-                        int(
-                            os.getenv("DAGSTER_EXECUTE_K8S_JOB_WAIT_AFTER_STREAM_LOGS_FAILURE", "5")
-                        )
-                    )
+                    break
+        else:
             context.log.info("Pod logs are disabled, because restart_policy is not Never")
 
         if job_spec_config and job_spec_config.get("parallelism"):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -405,11 +405,16 @@ def execute_k8s_job(
                         print(log_entry)  # noqa: T201
                 except StopIteration:
                     break
-                except ProtocolError as e:
+                except ProtocolError:
                     context.log.warning(
-                        f"urllib3.exceptions.ProtocolError. Pausing and will reconnect. {e}"
+                        "urllib3.exceptions.ProtocolError. Pausing and will reconnect.",
+                        exc_info=True,
                     )
-                    time.sleep(5)
+                    time.sleep(
+                        int(
+                            os.getenv("DAGSTER_EXECUTE_K8S_JOB_WAIT_AFTER_STREAM_LOGS_FAILURE", "5")
+                        )
+                    )
             context.log.info("Pod logs are disabled, because restart_policy is not Never")
 
         if job_spec_config and job_spec_config.get("parallelism"):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -379,13 +379,13 @@ def execute_k8s_job(
             )
 
             while True:
-                log_stream = watch.stream(
-                    api_client.core_api.read_namespaced_pod_log,
-                    name=pod_to_watch,
-                    namespace=namespace,
-                    container=container_name,
-                )
                 try:
+                    log_stream = watch.stream(
+                        api_client.core_api.read_namespaced_pod_log,
+                        name=pod_to_watch,
+                        namespace=namespace,
+                        container=container_name,
+                    )
                     while True:
                         if timeout and time.time() - start_time > timeout:
                             watch.stop()


### PR DESCRIPTION
## Summary & Motivation
Should fix the bug described here - https://github.com/dagster-io/dagster/issues/26626

The `execute_k8s_job` method uses `watch.stream()` to stream logs from k8s pods. When the client enters a stale state, we should call `stream` again. See the bug report for more information.

## How I Tested These Changes
I was unable to fix a repeatable way for recreating the issue and there are not existing tests for `execute_k8s_job`.
I deployed a similar fix to our dev and prod environments, and the problem has not appear yet. At the very least I can say that it didn't degrade the stability of this method. 

## Changelog

> Insert changelog entry or delete this section.
