### PR TITLE
[components] Use AssetAttributesModel instead of DbtTranslatorParams

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -24,8 +24,15 @@ class OpSpecBaseModel(BaseModel):
     tags: Optional[Dict[str, str]] = None
 
 
+def _post_process_key(rendered: Optional[str]) -> Optional[AssetKey]:
+    return AssetKey.from_user_string(rendered) if rendered else None
+
+
 class AssetAttributesModel(RenderedModel):
-    key: Optional[str] = None
+    key: Annotated[
+        Optional[str],
+        RenderingMetadata(output_type=AssetKey, post_process=_post_process_key),
+    ] = None
     deps: Sequence[str] = []
     description: Optional[str] = None
     metadata: Annotated[

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -9,20 +9,19 @@ from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import TemplatedValueResolver, component_type
-from dagster_components.core.component_rendering import RenderedModel
-from dagster_components.core.dsl_schema import AssetAttributes, AssetSpecProcessor, OpSpecBaseModel
+from dagster_components.core.dsl_schema import (
+    AssetAttributes,
+    AssetAttributesModel,
+    AssetSpecProcessor,
+    OpSpecBaseModel,
+)
 from dagster_components.lib.dbt_project.generator import DbtProjectComponentGenerator
-
-
-class DbtNodeTranslatorParams(RenderedModel):
-    key: Optional[str] = None
-    group: Optional[str] = None
 
 
 class DbtProjectParams(BaseModel):
     dbt: DbtCliResource
     op: Optional[OpSpecBaseModel] = None
-    translator: Optional[DbtNodeTranslatorParams] = None
+    translator: Optional[AssetAttributesModel] = None
     asset_attributes: Optional[AssetAttributes] = None
 
 
@@ -30,28 +29,37 @@ class DbtProjectComponentTranslator(DagsterDbtTranslator):
     def __init__(
         self,
         *,
+        params: Optional[AssetAttributesModel],
         value_resolver: TemplatedValueResolver,
-        translator_params: Optional[DbtNodeTranslatorParams] = None,
     ):
+        self.params = params or AssetAttributesModel()
         self.value_resolver = value_resolver
-        self.translator_params = translator_params
 
-    def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-        if not self.translator_params or not self.translator_params.key:
-            return super().get_asset_key(dbt_resource_props)
-
-        return AssetKey.from_user_string(
-            self.value_resolver.with_context(node=dbt_resource_props).render_obj(
-                self.translator_params.key
-            )
+    def _get_rendered_attribute(
+        self, attribute: str, dbt_resource_props: Mapping[str, Any], default_method
+    ) -> Any:
+        resolver = self.value_resolver.with_context(node=dbt_resource_props)
+        rendered_attribute = self.params.render_properties(resolver).get(attribute)
+        return (
+            rendered_attribute
+            if rendered_attribute is not None
+            else default_method(dbt_resource_props)
         )
 
-    def get_group_name(self, dbt_resource_props) -> Optional[str]:
-        if not self.translator_params or not self.translator_params.group:
-            return super().get_group_name(dbt_resource_props)
+    def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
+        return self._get_rendered_attribute("key", dbt_resource_props, super().get_asset_key)
 
-        return self.value_resolver.with_context(node=dbt_resource_props).render_obj(
-            self.translator_params.group
+    def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        return self._get_rendered_attribute(
+            "group_name", dbt_resource_props, super().get_group_name
+        )
+
+    def get_tags(self, dbt_resource_props):
+        return self._get_rendered_attribute("tags", dbt_resource_props, super().get_tags)
+
+    def get_automation_condition(self, dbt_resource_props):
+        return self._get_rendered_attribute(
+            "automation_condition", dbt_resource_props, super().get_automation_condition
         )
 
 
@@ -83,7 +91,7 @@ class DbtProjectComponent(Component):
             dbt_resource=loaded_params.dbt,
             op_spec=loaded_params.op,
             dbt_translator=DbtProjectComponentTranslator(
-                translator_params=loaded_params.translator,
+                params=loaded_params.translator,
                 value_resolver=context.templated_value_resolver,
             ),
             asset_processors=loaded_params.asset_attributes or [],

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -87,7 +87,7 @@ def test_python_params_group(dbt_path: Path) -> None:
             params={
                 "dbt": {"project_dir": "jaffle_shop"},
                 "translator": {
-                    "group": "some_group",
+                    "group_name": "some_group",
                 },
             },
         ),
@@ -126,7 +126,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
                 params={
                     "dbt": {"project_dir": "jaffle_shop"},
                     "translator": {
-                        "group": "{{ env('GROUP_AS_ENV') }}",
+                        "group_name": "{{ env('GROUP_AS_ENV') }}",
                     },
                 },
             ),


### PR DESCRIPTION
## Summary & Motivation

This converts to using the AssetAttributesModel inside the translator. This is nice because it reduces duplicated code (e.g. the AssetKey.from_user_string() conversion), and in general having fewer distinct types flying around is good. (note: the `group_name` key was erroneously called just `group` before, this is something that we now no longer need to worry about)

Unfortunately, the translator code is still a mess on account of not having a unified `get_asset_spec()` method, meaning we have to implement a bunch of individual fns. However, once that's implemented, the translator can become as simple as:

```python

class XComponentTranslator(XTranslator):

    def __init__(self, params: AssetAttributes, resolver): ...

    def get_asset_spec(self, x: ...) -> AssetSpec:
        base_spec = super().get_asset_spec(x)
        rendered_props = params.get_rendered_properties(resolver.with_context(x=x))
        return base_spec.replace_attributes(**rendered_props)

```

## How I Tested These Changes

## Changelog

NOCHANGELOG
