### PR TITLE
Attempt to make dagster-dbt test failures retry on crashes

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     extras_require={
         "test": [
-            "flaky",
+            "pytest-rerunfailures",
             "dbt-duckdb",
             "dagster-duckdb",
             "dagster-duckdb-pandas",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -32,8 +32,8 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --numprocesses 6 --durations 10 --force-flaky --max-runs 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core-main: pytest --numprocesses 6 --durations 10 --force-flaky --max-runs 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --numprocesses 6 --durations 10 --force-flaky --max-runs 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  cloud: pytest --numprocesses 6 --durations 10  --reruns 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core-main: pytest --numprocesses 6 --durations 10  --reruns 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --numprocesses 6 --durations 10 --reruns 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
Summary:
This force-flaky business does not appear to retry if the test crashes. Try a new pytest setting that claims to do so.

BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
