### PR TITLE
[single-grpc-server][rfc] introduce a heartbeat to proxy server

### DIFF
--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -159,7 +159,7 @@ def code_server_cli():
     type=click.INT,
     required=False,
     default=DEFAULT_HEARTBEAT_TIMEOUT,
-    help="How long to wait for a heartbeat from the caller before timing out. Defaults to 30 seconds.",
+    help="How long to wait for a heartbeat from the caller before timing out. Only comes into play if --heartbeat is set. Defaults to 30 seconds.",
 )
 @click.option(
     "--instance-ref",

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -20,6 +20,8 @@ from dagster._serdes import deserialize_value
 from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
+DEFAULT_HEARTBEAT_TIMEOUT = 30
+
 
 @click.group(name="code-server")
 def code_server_cli():
@@ -145,6 +147,21 @@ def code_server_cli():
     envvar="DAGSTER_CODE_SERVER_STARTUP_TIMEOUT",
 )
 @click.option(
+    "--heartbeat",
+    is_flag=True,
+    help=(
+        "If set, the GRPC server will shut itself down when it fails to receive a heartbeat "
+        "after a timeout configurable with --heartbeat-timeout."
+    ),
+)
+@click.option(
+    "--heartbeat-timeout",
+    type=click.INT,
+    required=False,
+    default=DEFAULT_HEARTBEAT_TIMEOUT,
+    help="How long to wait for a heartbeat from the caller before timing out. Defaults to 30 seconds.",
+)
+@click.option(
     "--instance-ref",
     type=click.STRING,
     required=False,
@@ -165,6 +182,8 @@ def start_command(
     location_name: Optional[str] = None,
     inject_env_vars_from_instance: bool = False,
     startup_timeout: int = 0,
+    heartbeat: bool = False,
+    heartbeat_timeout: int = DEFAULT_HEARTBEAT_TIMEOUT,
     instance_ref=None,
     **kwargs,
 ):
@@ -231,6 +250,8 @@ def start_command(
         instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
         server_termination_event=server_termination_event,
         logger=logger,
+        server_heartbeat=heartbeat,
+        server_heartbeat_timeout=heartbeat_timeout,
     )
     server = DagsterGrpcServer(
         server_termination_event=server_termination_event,

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -14,7 +14,7 @@ from dagster._core.remote_representation.origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._grpc.server import GrpcServerProcess
+from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
 from dagster._time import get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -67,6 +67,7 @@ class GrpcServerRegistry(AbstractContextManager):
     def __init__(
         self,
         instance_ref: Optional[InstanceRef],
+        server_command: GrpcServerCommand,
         # How long the process can live without a heartbeat before it dies. You should ensure
         # that any processes returned by this registry have at least one
         # GrpcServerCodeLocation hitting the server with a heartbeat while you want the
@@ -82,6 +83,7 @@ class GrpcServerRegistry(AbstractContextManager):
         additional_timeout_msg: Optional[str] = None,
     ):
         self.instance_ref = instance_ref
+        self.server_command = server_command
 
         # map of servers being currently returned, keyed by origin ID
         self._active_entries: dict[str, Union[ServerRegistryEntry, ErrorRegistryEntry]] = {}
@@ -187,6 +189,7 @@ class GrpcServerRegistry(AbstractContextManager):
                 new_server_id = str(uuid.uuid4())
                 server_process = GrpcServerProcess(
                     instance_ref=self.instance_ref,
+                    server_command=self.server_command,
                     location_name=code_location_origin.location_name,
                     loadable_target_origin=loadable_target_origin,
                     heartbeat=True,

--- a/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
+++ b/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
@@ -62,6 +62,10 @@ class LoadableTargetOrigin(
             )
         return ctx
 
+    @property
+    def as_dict(self) -> dict:
+        return {k: v for k, v in self._asdict().items() if v is not None}
+
 
 _current_loadable_target_origin: ContextVar[Optional[LoadableTargetOrigin]] = (
     ContextVar("_current_loadable_target_origin", default=None)

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -12,6 +12,7 @@ from dagster._config import (
     StringSource,
     process_config,
 )
+from dagster._config.field_utils import Permissive
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.merger import merge_dicts
 
@@ -88,6 +89,7 @@ WORKSPACE_CONFIG_SCHEMA = {
                             "port": Field(IntSource, is_required=False),
                             "location_name": Field(StringSource, is_required=False),
                             "ssl": Field(bool, is_required=False),
+                            "additional_metadata": Field(Permissive(), is_required=False),
                         },
                     },
                 )

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -262,12 +262,13 @@ def _location_origin_from_grpc_server_config(
     check.mapping_param(grpc_server_config, "grpc_server_config")
     check.str_param(yaml_path, "yaml_path")
 
-    port, socket, host, location_name, use_ssl = (
+    port, socket, host, location_name, use_ssl, additional_metadata = (
         grpc_server_config.get("port"),
         grpc_server_config.get("socket"),
         grpc_server_config.get("host"),
         grpc_server_config.get("location_name"),
         grpc_server_config.get("ssl"),
+        grpc_server_config.get("additional_metadata"),
     )
 
     check.invariant(
@@ -283,6 +284,7 @@ def _location_origin_from_grpc_server_config(
         host=host,
         location_name=location_name,
         use_ssl=use_ssl,
+        additional_metadata=additional_metadata,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -27,7 +27,7 @@ from dagster._daemon.daemon import (
 )
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG
+from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.interrupts import raise_interrupts_as
 from dagster._utils.log import configure_loggers
@@ -75,6 +75,7 @@ def create_daemon_grpc_server_registry(
 ) -> GrpcServerRegistry:
     return GrpcServerRegistry(
         instance_ref=instance.get_ref(),
+        server_command=GrpcServerCommand.API_GRPC,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
         additional_timeout_msg=INCREASE_TIMEOUT_DAGSTER_YAML_MSG,

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -13,6 +13,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import api_pb2
 from dagster._grpc.__generated__.api_pb2_grpc import DagsterApiServicer
 from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
+from dagster._grpc.server import GrpcServerCommand
 from dagster._grpc.types import (
     CancelExecutionRequest,
     CancelExecutionResult,
@@ -76,6 +77,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         self._grpc_server_registry = self._exit_stack.enter_context(
             GrpcServerRegistry(
                 instance_ref=self._instance_ref,
+                server_command=GrpcServerCommand.API_GRPC,
                 heartbeat_ttl=30,
                 startup_timeout=startup_timeout,
                 log_level=self._log_level,
@@ -196,6 +198,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             if self._shutdown_once_executions_finish_event.is_set():
                 if self._grpc_server_registry.are_all_servers_shut_down():
                     self._server_termination_event.set()
+                    self._grpc_server_registry.shutdown_all_processes()
 
     def _get_grpc_client(self):
         return self._client
@@ -216,6 +219,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
 
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
                 self._shutdown_once_executions_finish_event.set()
+                self._grpc_server_registry.shutdown_all_processes()
 
     def _streaming_query(
         self, api_name: str, request, _context, timeout: int = DEFAULT_GRPC_TIMEOUT
@@ -237,8 +241,12 @@ class DagsterProxyApiServicer(DagsterApiServicer):
     def Ping(self, request, context):
         return self._query("Ping", request, context)
 
-    def GetServerId(self, request, context):
-        return self._fixed_server_id or self._query("GetServerId", request, context)
+    def GetServerId(self, request, context) -> api_pb2.GetServerIdReply:
+        return (
+            api_pb2.GetServerIdReply(server_id=self._fixed_server_id)
+            if self._fixed_server_id
+            else self._query("GetServerId", request, context)
+        )
 
     def GetCurrentImage(self, request, context):
         return self._query("GetCurrentImage", request, context)

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -25,7 +25,12 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import ExecuteExternalJobArgs, open_server_process, wait_for_grpc_server
+from dagster._grpc.server import (
+    ExecuteExternalJobArgs,
+    GrpcServerCommand,
+    open_server_process,
+    wait_for_grpc_server,
+)
 from dagster._grpc.types import (
     JobSubsetSnapshotArgs,
     ListRepositoriesResponse,
@@ -106,7 +111,11 @@ def test_python_environment_args():
         process = None
         try:
             process = open_server_process(
-                instance.get_ref(), port, socket=None, loadable_target_origin=loadable_target_origin
+                server_command=GrpcServerCommand.API_GRPC,
+                instance_ref=instance.get_ref(),
+                port=port,
+                socket=None,
+                loadable_target_origin=loadable_target_origin,
             )
             assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]  # pyright: ignore[reportIndexIssue]
         finally:
@@ -130,8 +139,9 @@ def test_env_var_port_collision():
             # env var that would cause a collision with port if we are not careful
             with environ({"DAGSTER_GRPC_SOCKET": str(socket)}):
                 process = open_server_process(
-                    instance.get_ref(),
-                    port,
+                    instance_ref=instance.get_ref(),
+                    port=port,
+                    server_command=GrpcServerCommand.API_GRPC,
                     socket=None,
                     loadable_target_origin=loadable_target_origin,
                 )
@@ -146,7 +156,8 @@ def test_env_var_port_collision():
             # env var that would cause a collision with socket if we are not careful
             with environ({"DAGSTER_GRPC_PORT": str(port)}):
                 process = open_server_process(
-                    instance.get_ref(),
+                    instance_ref=instance.get_ref(),
+                    server_command=GrpcServerCommand.API_GRPC,
                     port=None,
                     socket=socket,
                     loadable_target_origin=loadable_target_origin,
@@ -168,7 +179,11 @@ def test_empty_executable_args():
     with instance_for_test() as instance:
         try:
             process = open_server_process(
-                instance.get_ref(), port, socket=None, loadable_target_origin=loadable_target_origin
+                instance_ref=instance.get_ref(),
+                port=port,
+                server_command=GrpcServerCommand.API_GRPC,
+                socket=None,
+                loadable_target_origin=loadable_target_origin,
             )
             assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]  # pyright: ignore[reportIndexIssue]
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -16,6 +16,7 @@ from dagster._core.utils import FuturesAwareThreadPoolExecutor
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer, ephemeral_grpc_api_client
 from dagster._grpc.server import (
     DagsterCodeServerUtilizationMetrics,
+    GrpcServerCommand,
     GrpcServerProcess,
     open_server_process,
 )
@@ -65,7 +66,9 @@ def test_server_port_and_socket():
 def test_server_socket():
     with instance_for_test() as instance:
         with safe_tempfile_path() as skt:
-            server_process = open_server_process(instance.get_ref(), port=None, socket=skt)
+            server_process = open_server_process(
+                instance.get_ref(), port=None, socket=skt, server_command=GrpcServerCommand.API_GRPC
+            )
             try:
                 assert DagsterGrpcClient(socket=skt).ping("foobar") == {
                     "echo": "foobar",
@@ -106,7 +109,9 @@ def test_process_killed_after_server_finished():
 def test_server_port():
     with instance_for_test() as instance:
         port = find_free_port()
-        server_process = open_server_process(instance.get_ref(), port=port, socket=None)
+        server_process = open_server_process(
+            instance.get_ref(), port=port, socket=None, server_command=GrpcServerCommand.API_GRPC
+        )
         assert server_process is not None
 
         try:


### PR DESCRIPTION
## Summary & Motivation
Pre-emptive work before switching the grpc entrypoint of the workspace context from `dagster api grpc` to `dagster code-server start`.

Previously, if the calling process of `dagster code-server start` never explicitly terminated the process, the proxy server could become orphaned. This fixes by introducing a heartbeat mechanism which will automatically shut down the proxy server if a heartbeat hasn't happened in X amount of time.

## How I Tested These Changes
Added a test for the termination behavior - terminate the underlying grpc server, and then after the requisite amount of time has elapsed, the proxy server should automatically shut down as well.