### PR TITLE
[ui] Display currently-implicit code location selection in asset selection strings

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Sequence
 
 import graphene
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.asset_selection import AssetSelection, CodeLocationAssetSelection
 from dagster._core.remote_representation.handle import RepositoryHandle
 
 from dagster_graphql.implementation.fetch_assets import get_asset
@@ -30,7 +30,12 @@ class GrapheneAssetSelection(graphene.ObjectType):
         self._resolved_keys = None
 
     def resolve_assetSelectionString(self, _graphene_info) -> str:
-        return str(self._asset_selection)
+        return str(
+            self._asset_selection
+            & CodeLocationAssetSelection(
+                selected_code_location=self._repository_handle.code_location_origin.location_name
+            )
+        )
 
     def resolve_assetKeys(self, graphene_info: ResolveInfo):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -419,7 +419,7 @@ def test_jobless_asset_selection(graphql_context):
     assert result.data["scheduleOrError"]["__typename"] == "Schedule"
     assert (
         result.data["scheduleOrError"]["assetSelection"]["assetSelectionString"]
-        == 'key:"asset_one"'
+        == 'key:"asset_one" and code_location:"test_location"'
     )
     assert result.data["scheduleOrError"]["assetSelection"]["assetKeys"] == [
         {"path": ["asset_one"]}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1653,9 +1653,9 @@ def test_asset_selection(graphql_context):
     assert result.data
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
 
-    assert (
-        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
-        == 'key:"fresh_diamond_bottom" or key:"asset_with_automation_condition" or key:"asset_with_custom_automation_condition"'
+    assert result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == (
+        '(key:"fresh_diamond_bottom" or key:"asset_with_automation_condition"'
+        ' or key:"asset_with_custom_automation_condition") and code_location:"test_location"'
     )
     assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [
         {"path": ["asset_with_automation_condition"]},
@@ -1700,7 +1700,8 @@ def test_jobless_asset_selection(graphql_context):
     assert result.data
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
     assert (
-        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == 'key:"asset_one"'
+        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
+        == 'key:"asset_one" and code_location:"test_location"'
     )
     assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [{"path": ["asset_one"]}]
     assert result.data["sensorOrError"]["assetSelection"]["assets"] == [
@@ -1730,7 +1731,7 @@ def test_invalid_sensor_asset_selection(graphql_context):
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
     assert (
         result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
-        == 'key:"does_not_exist"'
+        == 'key:"does_not_exist" and code_location:"test_location"'
     )
     assert (
         result.data["sensorOrError"]["assetSelection"]["assetsOrError"]["__typename"]


### PR DESCRIPTION
## Summary

Updates the asset selection strings we return to the UI from GraphQL to implicitly include the code location they're targeting.

<img width="499" alt="Screenshot 2025-01-02 at 10 19 38 AM" src="https://github.com/user-attachments/assets/c316b220-8de9-4e15-9560-ee7612a74b72" />


## How I Tested These Changes

Tested locally - todo unit tests

