### PR TITLE
Add a "consecutive_failure_count" field to TickData

### DIFF
--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -417,6 +417,10 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         return self.tick_data.log_key
 
     @property
+    def consecutive_failure_count(self) -> int:
+        return self.tick_data.consecutive_failure_count
+
+    @property
     def is_completed(self) -> bool:
         return (
             self.tick_data.status == TickStatus.SUCCESS
@@ -564,6 +568,7 @@ class TickData(
             ("run_requests", Optional[Sequence[RunRequest]]),  # run requests created by the tick
             ("auto_materialize_evaluation_id", Optional[int]),
             ("reserved_run_ids", Optional[Sequence[str]]),
+            ("consecutive_failure_count", int),
         ],
     )
 ):
@@ -597,6 +602,11 @@ class TickData(
         reserved_run_ids (Optional[Sequence[str]]): A list of run IDs to use for each of the
             run_requests. Used to ensure that if the tick fails partway through, we don't create
             any duplicate runs for the tick. Currently only used by AUTO_MATERIALIZE ticks.
+        consecutive_failure_count (Optional[int]): The number of times this sensor has failed
+            consecutively. Differs from failure_count in that it spans multiple ticks, whereas
+            failure_count measures the number of times that a particular tick should retry.  If the
+            status is not FAILED, this is the number of previous consecutive failures across
+            multiple ticks before it reached the current state.
     """
 
     def __new__(
@@ -622,6 +632,7 @@ class TickData(
         run_requests: Optional[Sequence[RunRequest]] = None,
         auto_materialize_evaluation_id: Optional[int] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
+        consecutive_failure_count: Optional[int] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -650,6 +661,9 @@ class TickData(
             run_requests=check.opt_sequence_param(run_requests, "run_requests"),
             auto_materialize_evaluation_id=auto_materialize_evaluation_id,
             reserved_run_ids=check.opt_sequence_param(reserved_run_ids, "reserved_run_ids"),
+            consecutive_failure_count=check.opt_int_param(
+                consecutive_failure_count, "consecutive_failure_count", 0
+            ),
         )
 
     def with_status(
@@ -703,16 +717,6 @@ class TickData(
                     "run_requests": run_requests,
                     "reserved_run_ids": reserved_run_ids,
                     "cursor": cursor,
-                },
-            )
-        )
-
-    def with_failure_count(self, failure_count: int) -> "TickData":
-        return TickData(
-            **merge_dicts(
-                self._asdict(),
-                {
-                    "failure_count": failure_count,
                 },
             )
         )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -265,6 +265,10 @@ class AutoMaterializeLaunchContext:
         return self._tick
 
     def update_state(self, status: TickStatus, **kwargs: object):
+        if status in {TickStatus.SKIPPED, TickStatus.SUCCESS}:
+            kwargs["failure_count"] = 0
+            kwargs["consecutive_failure_count"] = 0
+
         self._tick = self._tick.with_status(status=status, **kwargs)
 
     def __enter__(self):

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -278,6 +278,7 @@ class SensorLaunchContext(AbstractContextManager):
                         error=error_data,
                         # don't increment the failure count - retry until the server is available again
                         failure_count=self._tick.failure_count,
+                        consecutive_failure_count=self._tick.consecutive_failure_count + 1,
                     )
             else:
                 error_data = DaemonErrorCapture.process_exception(
@@ -286,7 +287,10 @@ class SensorLaunchContext(AbstractContextManager):
                     log_message="Sensor tick caught an error",
                 )
                 self.update_state(
-                    TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
+                    TickStatus.FAILURE,
+                    error=error_data,
+                    failure_count=self._tick.failure_count + 1,
+                    consecutive_failure_count=self._tick.consecutive_failure_count + 1,
                 )
 
         self._write()
@@ -467,51 +471,49 @@ def _get_evaluation_tick(
     origin_id = sensor.get_remote_origin_id()
     selector_id = sensor.get_remote_origin().get_selector().get_id()
 
+    consecutive_failure_count = 0
+
     if instigator_data and instigator_data.last_tick_success_timestamp:
-        # if a last tick end timestamp was set, then the previous tick could not have been
+        # if a last tick success timestamp was set, then the previous tick could not have been
         # interrupted, so there is no need to fetch the previous tick
-        potentially_interrupted_tick = None
+        most_recent_tick = None
     else:
-        potentially_interrupted_tick = next(
-            iter(instance.get_ticks(origin_id, selector_id, limit=1)), None
-        )
+        most_recent_tick = next(iter(instance.get_ticks(origin_id, selector_id, limit=1)), None)
 
     # check for unfinished work on the previous tick
-    if potentially_interrupted_tick is not None:
-        has_unrequested_runs = (
-            len(potentially_interrupted_tick.unsubmitted_run_ids_with_requests) > 0
-        )
-        if potentially_interrupted_tick.status == TickStatus.STARTED:
+    if most_recent_tick is not None:
+        if most_recent_tick.status in {TickStatus.FAILURE, TickStatus.STARTED}:
+            consecutive_failure_count = (
+                most_recent_tick.consecutive_failure_count or most_recent_tick.failure_count
+            )
+
+        has_unrequested_runs = len(most_recent_tick.unsubmitted_run_ids_with_requests) > 0
+        if most_recent_tick.status == TickStatus.STARTED:
             # if the previous tick was interrupted before it was able to request all of its runs,
             # and it hasn't been too long, then resume execution of that tick
             if (
-                evaluation_timestamp - potentially_interrupted_tick.timestamp
-                <= MAX_TIME_TO_RESUME_TICK_SECONDS
+                evaluation_timestamp - most_recent_tick.timestamp <= MAX_TIME_TO_RESUME_TICK_SECONDS
                 and has_unrequested_runs
             ):
                 logger.warn(
-                    f"Tick {potentially_interrupted_tick.tick_id} was interrupted part-way through, resuming"
+                    f"Tick {most_recent_tick.tick_id} was interrupted part-way through, resuming"
                 )
-                return potentially_interrupted_tick
+                return most_recent_tick
+
             else:
                 # previous tick won't be resumed - move it into a SKIPPED state so it isn't left
                 # dangling in STARTED, but don't return it
-                logger.warn(
-                    f"Moving dangling STARTED tick {potentially_interrupted_tick.tick_id} into SKIPPED"
-                )
-                potentially_interrupted_tick = potentially_interrupted_tick.with_status(
-                    status=TickStatus.SKIPPED
-                )
-                instance.update_tick(potentially_interrupted_tick)
+                logger.warn(f"Moving dangling STARTED tick {most_recent_tick.tick_id} into SKIPPED")
+                most_recent_tick = most_recent_tick.with_status(status=TickStatus.SKIPPED)
+                instance.update_tick(most_recent_tick)
         elif (
-            potentially_interrupted_tick.status == TickStatus.FAILURE
-            and potentially_interrupted_tick.tick_data.failure_count
-            <= MAX_FAILURE_RESUBMISSION_RETRIES
+            most_recent_tick.status == TickStatus.FAILURE
+            and most_recent_tick.tick_data.failure_count <= MAX_FAILURE_RESUBMISSION_RETRIES
             and has_unrequested_runs
         ):
-            logger.info(f"Retrying failed tick {potentially_interrupted_tick.tick_id}")
+            logger.info(f"Retrying failed tick {most_recent_tick.tick_id}")
             return instance.create_tick(
-                potentially_interrupted_tick.tick_data.with_status(
+                most_recent_tick.tick_data.with_status(
                     TickStatus.STARTED,
                     error=None,
                     timestamp=evaluation_timestamp,
@@ -528,6 +530,7 @@ def _get_evaluation_tick(
             status=TickStatus.STARTED,
             timestamp=evaluation_timestamp,
             selector_id=selector_id,
+            consecutive_failure_count=consecutive_failure_count,
         )
     )
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -142,6 +142,10 @@ class SensorLaunchContext(AbstractContextManager):
         ]
 
     def update_state(self, status: TickStatus, **kwargs: object):
+        if status in {TickStatus.SKIPPED, TickStatus.SUCCESS}:
+            kwargs["failure_count"] = 0
+            kwargs["consecutive_failure_count"] = 0
+
         skip_reason = cast(Optional[str], kwargs.get("skip_reason"))
         cursor = cast(Optional[str], kwargs.get("cursor"))
         origin_run_id = cast(Optional[str], kwargs.get("origin_run_id"))

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -106,6 +106,10 @@ class _ScheduleLaunchContext(AbstractContextManager):
         ]
 
     def update_state(self, status, error=None, **kwargs):
+        if status in {TickStatus.SKIPPED, TickStatus.SUCCESS}:
+            kwargs["failure_count"] = 0
+            kwargs["consecutive_failure_count"] = 0
+
         skip_reason = kwargs.get("skip_reason")
         if "skip_reason" in kwargs:
             del kwargs["skip_reason"]
@@ -655,11 +659,7 @@ def launch_scheduled_runs_for_schedule_iterator(
             check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
 
         with _ScheduleLaunchContext(
-            remote_schedule,
-            tick,
-            instance,
-            logger,
-            tick_retention_settings,
+            remote_schedule, tick, instance, logger, tick_retention_settings
         ) as tick_context:
             try:
                 check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -90,6 +90,10 @@ class _ScheduleLaunchContext(AbstractContextManager):
         return self._tick.tick_data.failure_count
 
     @property
+    def consecutive_failure_count(self) -> int:
+        return self._tick.tick_data.consecutive_failure_count or self._tick.tick_data.failure_count
+
+    @property
     def tick_id(self) -> str:
         return str(self._tick.tick_id)
 
@@ -620,6 +624,13 @@ def launch_scheduled_runs_for_schedule_iterator(
     for schedule_time in tick_times:
         schedule_timestamp = schedule_time.timestamp()
         schedule_time_str = schedule_time.strftime(default_date_format_string())
+
+        consecutive_failure_count = 0
+        if latest_tick and latest_tick.status in {TickStatus.FAILURE, TickStatus.STARTED}:
+            consecutive_failure_count = (
+                latest_tick.consecutive_failure_count or latest_tick.failure_count
+            )
+
         if latest_tick and latest_tick.timestamp == schedule_timestamp:
             tick = latest_tick
             if latest_tick.status == TickStatus.FAILURE:
@@ -637,13 +648,18 @@ def launch_scheduled_runs_for_schedule_iterator(
                     status=TickStatus.STARTED,
                     timestamp=schedule_timestamp,
                     selector_id=remote_schedule.selector_id,
+                    consecutive_failure_count=consecutive_failure_count,
                 )
             )
 
             check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
 
         with _ScheduleLaunchContext(
-            remote_schedule, tick, instance, logger, tick_retention_settings
+            remote_schedule,
+            tick,
+            instance,
+            logger,
+            tick_retention_settings,
         ) as tick_context:
             try:
                 check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")
@@ -678,6 +694,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                             # don't increment the failure count - retry forever until the server comes back up
                             # or the schedule is turned off
                             failure_count=tick_context.failure_count,
+                            consecutive_failure_count=tick_context.consecutive_failure_count + 1,
                         )
                         yield error_data
                 else:
@@ -690,6 +707,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                         TickStatus.FAILURE,
                         error=error_data,
                         failure_count=tick_context.failure_count + 1,
+                        consecutive_failure_count=tick_context.consecutive_failure_count + 1,
                     )
                     yield error_data
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -234,6 +234,17 @@ def error_sensor(context):
     raise Exception("womp womp")
 
 
+NUM_CALLS = {"calls": 0}
+
+
+@sensor(job_name="the_job")
+def passes_on_retry_sensor(context):
+    NUM_CALLS["calls"] = NUM_CALLS["calls"] + 1
+    if NUM_CALLS["calls"] > 1:
+        return RunRequest()
+    raise Exception("womp womp")
+
+
 @sensor(job_name="the_job")
 def wrong_config_sensor(_context):
     return RunRequest(run_key="bad_config_key", run_config={"bad_key": "bad_val"}, tags={})
@@ -839,6 +850,7 @@ def the_repo():
         many_request_sensor,
         simple_sensor,
         error_sensor,
+        passes_on_retry_sensor,
         wrong_config_sensor,
         always_on_sensor,
         run_key_sensor,
@@ -1351,6 +1363,8 @@ def test_error_sensor(caplog, executor, instance, workspace_context, remote_repo
             [],
             "Error occurred during the execution of evaluation_fn for sensor error_sensor",
         )
+        assert ticks[0].tick_data.failure_count == 1
+        assert ticks[0].tick_data.consecutive_failure_count == 1
 
         assert (
             "Error occurred during the execution of evaluation_fn for sensor error_sensor"
@@ -1362,6 +1376,87 @@ def test_error_sensor(caplog, executor, instance, workspace_context, remote_repo
         assert state.instigator_data.sensor_type == SensorType.STANDARD
         assert state.instigator_data.cursor is None
         assert state.instigator_data.last_tick_timestamp == freeze_datetime.timestamp()
+
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    caplog.clear()
+    with freeze_time(freeze_datetime):
+        evaluate_sensors(workspace_context, executor)
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            sensor,
+            freeze_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of evaluation_fn for sensor error_sensor",
+        )
+        assert ticks[0].tick_data.failure_count == 1
+        assert ticks[0].tick_data.consecutive_failure_count == 2
+
+
+def test_passes_on_retry_sensor(caplog, instance, workspace_context, remote_repo):
+    freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
+    with freeze_time(freeze_datetime):
+        sensor = remote_repo.get_sensor("passes_on_retry_sensor")
+        instance.add_instigator_state(
+            InstigatorState(
+                sensor.get_remote_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+
+        state = instance.get_instigator_state(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert state.instigator_data is None
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert len(ticks) == 0
+
+        evaluate_sensors(workspace_context, None)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            sensor,
+            freeze_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of evaluation_fn for sensor passes_on_retry_sensor",
+        )
+        assert ticks[0].tick_data.failure_count == 1
+        assert ticks[0].tick_data.consecutive_failure_count == 1
+
+        assert (
+            "Error occurred during the execution of evaluation_fn for sensor passes_on_retry_sensor"
+            in caplog.text
+        )
+
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    caplog.clear()
+    with freeze_time(freeze_datetime):
+        evaluate_sensors(workspace_context, None)
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert len(ticks) == 2
+        assert ticks[0].status == TickStatus.SUCCESS
+        assert ticks[0].tick_data.failure_count == 0
+        assert ticks[0].tick_data.consecutive_failure_count == 0
+
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    caplog.clear()
+    with freeze_time(freeze_datetime):
+        evaluate_sensors(workspace_context, None)
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
+        assert len(ticks) == 3
+        assert ticks[0].status == TickStatus.SUCCESS
+        assert ticks[0].tick_data.failure_count == 0
+        assert ticks[0].tick_data.consecutive_failure_count == 0
 
 
 def test_wrong_config_sensor(caplog, executor, instance, workspace_context, remote_repo):

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
@@ -221,9 +221,7 @@ def test_error_loop_before_cursor_written(daemon_not_paused_instance, crash_loca
     assert ticks[0].automation_condition_evaluation_id == 1  # finally finishes
 
     assert ticks[0].tick_data.failure_count == 0
-    assert (
-        ticks[0].tick_data.consecutive_failure_count == 3
-    )  # because it failed three times before succeeding
+    assert ticks[0].tick_data.consecutive_failure_count == 0
 
     runs = instance.get_runs()
     assert len(runs) == 5
@@ -338,6 +336,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
             # failure count only increases if the cursor was written - otherwise
             # each tick is considered a brand new retry
             assert ticks[0].tick_data.failure_count == trial_num + 1
+            assert ticks[0].tick_data.consecutive_failure_count == trial_num + 2
 
             assert f"Oops {trial_num}" in str(ticks[0].tick_data.error)
 
@@ -376,6 +375,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
         assert "Oops new tick" in str(ticks[0].tick_data.error)
 
         assert ticks[0].tick_data.failure_count == 1  # starts over
+        assert ticks[0].tick_data.consecutive_failure_count == 5  # does not start over
 
         # Cursor has moved on
         moved_on_cursor = _get_pre_sensor_auto_materialize_cursor(instance, None)
@@ -400,6 +400,29 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
     assert ticks[0].timestamp == test_time.timestamp()
     assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
     assert ticks[0].automation_condition_evaluation_id == 5  # finishes
+    assert ticks[0].tick_data.failure_count == 0
+    assert ticks[0].tick_data.consecutive_failure_count == 0
+
+    test_time = test_time + datetime.timedelta(seconds=45)
+    with freeze_time(test_time):
+        # Next successful tick recovers
+        error_asset_scenario.do_daemon_scenario(
+            instance,
+            scenario_name="auto_materialize_policy_max_materializations_not_exceeded",
+            debug_crash_flags={},
+        )
+
+    ticks = instance.get_ticks(
+        origin_id=_PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
+        selector_id=_PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,
+    )
+
+    assert len(ticks) == 7
+    assert ticks[0].status != TickStatus.FAILURE
+    assert ticks[0].timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.end_timestamp == test_time.timestamp()
+    assert ticks[0].tick_data.failure_count == 0  # resets
+    assert ticks[0].tick_data.consecutive_failure_count == 0  # resets
 
 
 spawn_ctx = multiprocessing.get_context("spawn")

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -653,8 +653,13 @@ def validate_tick(
     expected_error: Optional[str] = None,
     expected_failure_count: int = 0,
     expected_skip_reason: Optional[str] = None,
+    expected_consecutive_failure_count=None,
 ) -> None:
     tick_data = tick.tick_data
+
+    if expected_consecutive_failure_count is None:
+        expected_consecutive_failure_count = expected_failure_count
+
     assert tick_data.instigator_origin_id == remote_schedule.get_remote_origin_id()
     assert tick_data.instigator_name == remote_schedule.name
     assert tick_data.timestamp == expected_datetime.timestamp()
@@ -666,6 +671,7 @@ def validate_tick(
         assert expected_error in str(tick_data.error)
     assert tick_data.failure_count == expected_failure_count
     assert tick_data.skip_reason == expected_skip_reason
+    assert tick_data.consecutive_failure_count == expected_consecutive_failure_count
 
 
 def validate_run_exists(
@@ -1751,6 +1757,7 @@ class TestSchedulerRun:
                 [],
                 "DagsterInvalidConfigError",
                 expected_failure_count=1,
+                expected_consecutive_failure_count=1,
             )
 
         freeze_datetime = freeze_datetime + relativedelta(days=1)
@@ -1769,6 +1776,7 @@ class TestSchedulerRun:
                 [],
                 "DagsterInvalidConfigError",
                 expected_failure_count=1,
+                expected_consecutive_failure_count=2,
             )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
@@ -1857,6 +1865,7 @@ class TestSchedulerRun:
                 [],
                 "Missing required config entry",
                 expected_failure_count=1,
+                expected_consecutive_failure_count=4,
             )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
@@ -1938,7 +1947,6 @@ class TestSchedulerRun:
                 expected_schedule_time,
                 TickStatus.SUCCESS,
                 [run.run_id for run in scheduler_instance.get_runs()],
-                expected_failure_count=1,
             )
 
         freeze_datetime = freeze_datetime + relativedelta(days=1)
@@ -2176,6 +2184,8 @@ class TestSchedulerRun:
             assert len(bad_ticks) == 1
 
             assert bad_ticks[0].status == TickStatus.FAILURE
+            assert bad_ticks[0].tick_data.consecutive_failure_count == 1
+            assert bad_ticks[0].tick_data.failure_count == 1
 
             assert (
                 "Error occurred during the execution of should_execute for schedule bad_should_execute_on_odd_days_schedule"
@@ -2241,6 +2251,18 @@ class TestSchedulerRun:
                 unloadable_origin.get_id(), "fake_selector"
             )
             assert len(unloadable_ticks) == 0
+
+        freeze_datetime = (
+            freeze_datetime + relativedelta(days=2)
+        )  # 2 days to ensure its an odd day so the next tick will pass too and the consecutive failure count will recover
+        with freeze_time(freeze_datetime):
+            new_now = get_current_datetime()
+            evaluate_schedules(workspace_context, executor, new_now)
+            bad_ticks = scheduler_instance.get_ticks(bad_origin.get_id(), bad_schedule.selector_id)
+            assert len(bad_ticks) == 3
+            assert bad_ticks[0].status == TickStatus.SUCCESS
+            assert bad_ticks[0].tick_data.failure_count == 0
+            assert bad_ticks[0].consecutive_failure_count == 0
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_run_scheduled_on_time_boundary(


### PR DESCRIPTION
## Summary & Motivation
Add a field to TickData capturing the number of consecutive times that this schedule or sensor has failed (across multiple ticks). This differs from the existing failure_count field, which tracks whether or not a particular tick should retry or not before moving on. This allows you to determine when a given sensor has failed more than a certain number of times consecutively.

## How I Tested These Changes
New test cases

## Changelog
NOCHANGELOG 
