### PR TITLE
change default run coordinator to be the queued run coordinator

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -620,7 +620,7 @@ def test_queued_run_coordinator_config(
 
     _check_valid_run_coordinator_yaml(instance)
 
-    assert ("run_coordinator" in instance) == enabled
+    # assert ("run_coordinator" in instance) == enabled
     if enabled:
         assert instance["run_coordinator"]["module"] == "dagster.core.run_coordinator"
         assert instance["run_coordinator"]["class"] == "QueuedRunCoordinator"
@@ -646,6 +646,12 @@ def test_queued_run_coordinator_config(
             ]
             == 0
         )
+    else:
+        assert (
+            instance["run_coordinator"]["module"]
+            == "dagster._core.run_coordinator.immediately_launch_run_coordinator"
+        )
+        assert instance["run_coordinator"]["class"] == "ImmediatelyLaunchRunCoordinator"
 
 
 def test_custom_run_coordinator_config(template: HelmTemplate):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -620,7 +620,6 @@ def test_queued_run_coordinator_config(
 
     _check_valid_run_coordinator_yaml(instance)
 
-    # assert ("run_coordinator" in instance) == enabled
     if enabled:
         assert instance["run_coordinator"]["module"] == "dagster.core.run_coordinator"
         assert instance["run_coordinator"]["class"] == "QueuedRunCoordinator"
@@ -649,9 +648,9 @@ def test_queued_run_coordinator_config(
     else:
         assert (
             instance["run_coordinator"]["module"]
-            == "dagster._core.run_coordinator.immediately_launch_run_coordinator"
+            == "dagster._core.run_coordinator.synchronous_run_coordinator"
         )
-        assert instance["run_coordinator"]["class"] == "ImmediatelyLaunchRunCoordinator"
+        assert instance["run_coordinator"]["class"] == "SynchronousRunCoordinator"
 
 
 def test_custom_run_coordinator_config(template: HelmTemplate):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -648,9 +648,9 @@ def test_queued_run_coordinator_config(
     else:
         assert (
             instance["run_coordinator"]["module"]
-            == "dagster._core.run_coordinator.synchronous_run_coordinator"
+            == "dagster._core.run_coordinator.sync_in_memory_run_coordinator"
         )
-        assert instance["run_coordinator"]["class"] == "SynchronousRunCoordinator"
+        assert instance["run_coordinator"]["class"] == "SyncInMemoryRunCoordinator"
 
 
 def test_custom_run_coordinator_config(template: HelmTemplate):

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -55,6 +55,10 @@ data:
       {{- else if eq $runCoordinatorType "CustomRunCoordinator" }}
         {{- include "dagsterYaml.runCoordinator.custom" . | indent 6 -}}
       {{- end }}
+    {{- else if (.Values.dagsterDaemon.enabled) }}
+    run_coordinator:
+      module: dagster._core.run_coordinator.immediately_launch_run_coordinator
+      class: ImmediatelyLaunchRunCoordinator
     {{- end }}
 
     {{- $computeLogManagerType := .Values.computeLogManager.type }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -57,8 +57,8 @@ data:
       {{- end }}
     {{- else if (.Values.dagsterDaemon.enabled) }}
     run_coordinator:
-      module: dagster._core.run_coordinator.synchronous_run_coordinator
-      class: SynchronousRunCoordinator
+      module: dagster._core.run_coordinator.sync_in_memory_run_coordinator
+      class: SyncInMemoryRunCoordinator
     {{- end }}
 
     {{- $computeLogManagerType := .Values.computeLogManager.type }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -57,8 +57,8 @@ data:
       {{- end }}
     {{- else if (.Values.dagsterDaemon.enabled) }}
     run_coordinator:
-      module: dagster._core.run_coordinator.immediately_launch_run_coordinator
-      class: ImmediatelyLaunchRunCoordinator
+      module: dagster._core.run_coordinator.synchronous_run_coordinator
+      class: SynchronousRunCoordinator
     {{- end }}
 
     {{- $computeLogManagerType := .Values.computeLogManager.type }}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
@@ -19,7 +19,11 @@ def graphql_context():
                     "module": "dagster.utils.test",
                     "class": "FilesystemTestScheduler",
                     "config": {"base_dir": temp_dir},
-                }
+                },
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
             },
         ) as instance:
             with define_test_out_of_process_context(instance) as context:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
@@ -21,8 +21,8 @@ def graphql_context():
                     "config": {"base_dir": temp_dir},
                 },
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
             },
         ) as instance:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/conftest.py
@@ -20,11 +20,8 @@ def graphql_context():
                     "class": "FilesystemTestScheduler",
                     "config": {"base_dir": temp_dir},
                 },
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
             },
+            synchronous_run_coordinator=True,
         ) as instance:
             with define_test_out_of_process_context(instance) as context:
                 yield context

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -109,6 +109,10 @@ class InstanceManagers:
                 with instance_for_test(
                     temp_dir=temp_dir,
                     overrides={
+                        "run_coordinator": {
+                            "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                            "class": "ImmediatelyLaunchRunCoordinator",
+                        },
                         "scheduler": {
                             "module": "dagster.utils.test",
                             "class": "FilesystemTestScheduler",
@@ -132,10 +136,14 @@ class InstanceManagers:
         def _non_launchable_postgres_instance():
             with graphql_postgres_instance(
                 overrides={
+                    "run_coordinator": {
+                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                        "class": "ImmediatelyLaunchRunCoordinator",
+                    },
                     "run_launcher": {
                         "module": "dagster._core.test_utils",
                         "class": "ExplodingRunLauncher",
-                    }
+                    },
                 }
             ) as instance:
                 yield instance
@@ -203,6 +211,10 @@ class InstanceManagers:
                 with instance_for_test(
                     temp_dir=temp_dir,
                     overrides={
+                        "run_coordinator": {
+                            "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                            "class": "ImmediatelyLaunchRunCoordinator",
+                        },
                         "scheduler": {
                             "module": "dagster.utils.test",
                             "class": "FilesystemTestScheduler",
@@ -223,10 +235,14 @@ class InstanceManagers:
         def _postgres_instance():
             with graphql_postgres_instance(
                 overrides={
+                    "run_coordinator": {
+                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                        "class": "ImmediatelyLaunchRunCoordinator",
+                    },
                     "run_launcher": {
                         "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                         "class": "SyncInMemoryRunLauncher",
-                    }
+                    },
                 }
             ) as instance:
                 yield instance
@@ -240,7 +256,14 @@ class InstanceManagers:
     def postgres_instance_with_default_run_launcher():
         @contextmanager
         def _postgres_instance_with_default_hijack():
-            with graphql_postgres_instance() as instance:
+            with graphql_postgres_instance(
+                overrides={
+                    "run_coordinator": {
+                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                        "class": "ImmediatelyLaunchRunCoordinator",
+                    },
+                }
+            ) as instance:
                 yield instance
 
         return MarkedManager(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -110,8 +110,8 @@ class InstanceManagers:
                     temp_dir=temp_dir,
                     overrides={
                         "run_coordinator": {
-                            "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                            "class": "ImmediatelyLaunchRunCoordinator",
+                            "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                            "class": "SynchronousRunCoordinator",
                         },
                         "scheduler": {
                             "module": "dagster.utils.test",
@@ -137,8 +137,8 @@ class InstanceManagers:
             with graphql_postgres_instance(
                 overrides={
                     "run_coordinator": {
-                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                        "class": "ImmediatelyLaunchRunCoordinator",
+                        "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                        "class": "SynchronousRunCoordinator",
                     },
                     "run_launcher": {
                         "module": "dagster._core.test_utils",
@@ -212,8 +212,8 @@ class InstanceManagers:
                     temp_dir=temp_dir,
                     overrides={
                         "run_coordinator": {
-                            "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                            "class": "ImmediatelyLaunchRunCoordinator",
+                            "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                            "class": "SynchronousRunCoordinator",
                         },
                         "scheduler": {
                             "module": "dagster.utils.test",
@@ -236,8 +236,8 @@ class InstanceManagers:
             with graphql_postgres_instance(
                 overrides={
                     "run_coordinator": {
-                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                        "class": "ImmediatelyLaunchRunCoordinator",
+                        "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                        "class": "SynchronousRunCoordinator",
                     },
                     "run_launcher": {
                         "module": "dagster._core.launcher.sync_in_memory_run_launcher",
@@ -259,8 +259,8 @@ class InstanceManagers:
             with graphql_postgres_instance(
                 overrides={
                     "run_coordinator": {
-                        "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                        "class": "ImmediatelyLaunchRunCoordinator",
+                        "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                        "class": "SynchronousRunCoordinator",
                     },
                 }
             ) as instance:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3452,7 +3452,14 @@ def get_partitioned_asset_repo():
 
 
 def test_1d_subset_backcompat():
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         instance.can_read_asset_status_cache = lambda: False
         assert instance.can_read_asset_status_cache() is False
 
@@ -3535,7 +3542,14 @@ def test_1d_subset_backcompat():
 
 
 def test_2d_subset_backcompat():
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         instance.can_read_asset_status_cache = lambda: False
         assert instance.can_read_asset_status_cache() is False
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3452,14 +3452,7 @@ def get_partitioned_asset_repo():
 
 
 def test_1d_subset_backcompat():
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         instance.can_read_asset_status_cache = lambda: False
         assert instance.can_read_asset_status_cache() is False
 
@@ -3542,14 +3535,7 @@ def test_1d_subset_backcompat():
 
 
 def test_2d_subset_backcompat():
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         instance.can_read_asset_status_cache = lambda: False
         assert instance.can_read_asset_status_cache() is False
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3455,8 +3455,8 @@ def test_1d_subset_backcompat():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:
@@ -3545,8 +3545,8 @@ def test_2d_subset_backcompat():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -70,7 +70,14 @@ def test_dependencies_changed():
     repo_v1 = get_repo_v1()
     repo_v2 = get_repo_v2()
 
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
             assert _materialize_assets(context_v1, repo_v1)
             wait_for_runs_to_finish(context_v1.instance)
@@ -81,7 +88,14 @@ def test_dependencies_changed():
 def test_stale_status():
     repo = get_repo_v1()
 
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
             foo = _get_asset_node(result, "foo")
@@ -141,7 +155,14 @@ def get_repo_partitioned():
 def test_stale_status_partitioned():
     repo = get_repo_partitioned()
 
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         with define_out_of_process_context(__file__, "get_repo_partitioned", instance) as context:
             for key in ["foo", "bar"]:
                 result = _fetch_partition_data_versions(context, AssetKey([key]))
@@ -224,7 +245,14 @@ def test_stale_status_partitioned():
 
 def test_data_version_from_tags():
     repo_v1 = get_repo_v1()
-    with instance_for_test() as instance:
+    with instance_for_test(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        }
+    ) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
             assert _materialize_assets(context_v1, repo_v1)
             wait_for_runs_to_finish(context_v1.instance)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -73,8 +73,8 @@ def test_dependencies_changed():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:
@@ -91,8 +91,8 @@ def test_stale_status():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:
@@ -158,8 +158,8 @@ def test_stale_status_partitioned():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:
@@ -248,8 +248,8 @@ def test_data_version_from_tags():
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -70,14 +70,7 @@ def test_dependencies_changed():
     repo_v1 = get_repo_v1()
     repo_v2 = get_repo_v2()
 
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
             assert _materialize_assets(context_v1, repo_v1)
             wait_for_runs_to_finish(context_v1.instance)
@@ -88,14 +81,7 @@ def test_dependencies_changed():
 def test_stale_status():
     repo = get_repo_v1()
 
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
             foo = _get_asset_node(result, "foo")
@@ -155,14 +141,7 @@ def get_repo_partitioned():
 def test_stale_status_partitioned():
     repo = get_repo_partitioned()
 
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         with define_out_of_process_context(__file__, "get_repo_partitioned", instance) as context:
             for key in ["foo", "bar"]:
                 result = _fetch_partition_data_versions(context, AssetKey([key]))
@@ -245,14 +224,7 @@ def test_stale_status_partitioned():
 
 def test_data_version_from_tags():
     repo_v1 = get_repo_v1()
-    with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
-    ) as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
             assert _materialize_assets(context_v1, repo_v1)
             wait_for_runs_to_finish(context_v1.instance)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
@@ -9,26 +9,12 @@ from dagster_graphql_tests.graphql.repo import (
 
 
 def test_sync_run_launcher_from_configurable_class():
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            }
-        },
-    ) as instance_no_hijack:
+    with instance_for_test(synchronous_run_launcher=True) as instance_no_hijack:
         assert isinstance(instance_no_hijack.run_launcher, SyncInMemoryRunLauncher)
 
 
 def test_sync_run_launcher_run():
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            }
-        },
-    ) as instance:
+    with instance_for_test(synchronous_run_launcher=True) as instance:
         with get_main_workspace(instance) as workspace:
             location = workspace.get_code_location(main_repo_location_name())
             repo = location.get_repository(main_repo_name())

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -19,10 +19,14 @@ def dagster_cli_runner():
         with instance_for_test(
             temp_dir=dagster_home_temp,
             overrides={
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
-                }
+                },
             },
         ):
             yield CliRunner(env={"DAGSTER_HOME": dagster_home_temp})
@@ -68,10 +72,14 @@ def test_async_resolver():
         with instance_for_test(
             temp_dir=dagster_home_temp,
             overrides={
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
-                }
+                },
             },
         ) as instance:
             result = my_job.execute_in_process(instance=instance)
@@ -328,10 +336,14 @@ def test_logs_in_start_execution_predefined():
         with instance_for_test(
             temp_dir=temp_dir,
             overrides={
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
-                }
+                },
             },
         ) as instance:
             runner = CliRunner(env={"DAGSTER_HOME": temp_dir})

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -20,8 +20,8 @@ def dagster_cli_runner():
             temp_dir=dagster_home_temp,
             overrides={
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
@@ -73,8 +73,8 @@ def test_async_resolver():
             temp_dir=dagster_home_temp,
             overrides={
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
@@ -337,8 +337,8 @@ def test_logs_in_start_execution_predefined():
             temp_dir=temp_dir,
             overrides={
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -18,16 +18,8 @@ def dagster_cli_runner():
     with tempfile.TemporaryDirectory() as dagster_home_temp:
         with instance_for_test(
             temp_dir=dagster_home_temp,
-            overrides={
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-            },
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ):
             yield CliRunner(env={"DAGSTER_HOME": dagster_home_temp})
 
@@ -71,16 +63,8 @@ def test_async_resolver():
     with tempfile.TemporaryDirectory() as dagster_home_temp:
         with instance_for_test(
             temp_dir=dagster_home_temp,
-            overrides={
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-            },
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ) as instance:
             result = my_job.execute_in_process(instance=instance)
             run_id = result.dagster_run.run_id
@@ -335,16 +319,8 @@ def test_logs_in_start_execution_predefined():
     with tempfile.TemporaryDirectory() as temp_dir:
         with instance_for_test(
             temp_dir=temp_dir,
-            overrides={
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-            },
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ) as instance:
             runner = CliRunner(env={"DAGSTER_HOME": temp_dir})
             result = runner.invoke(

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -305,7 +305,9 @@ class InstanceRef(
                 yaml.dump({}),
             ),
             "run_coordinator": ConfigurableClassData(
-                "dagster._core.run_coordinator", "DefaultRunCoordinator", yaml.dump({})
+                "dagster.core.run_coordinator",
+                "QueuedRunCoordinator",
+                yaml.dump({}),
             ),
             "run_launcher": ConfigurableClassData(
                 "dagster",

--- a/python_modules/dagster/dagster/_core/instance_for_test.py
+++ b/python_modules/dagster/dagster/_core/instance_for_test.py
@@ -59,8 +59,8 @@ def instance_for_test(
             },
             {
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
+                    "module": "dagster._core.run_coordinator.sync_in_memory_run_coordinator",
+                    "class": "SyncInMemoryRunCoordinator",
                 },
             }
             if synchronous_run_coordinator

--- a/python_modules/dagster/dagster/_core/instance_for_test.py
+++ b/python_modules/dagster/dagster/_core/instance_for_test.py
@@ -18,6 +18,8 @@ def instance_for_test(
     overrides: Optional[Mapping[str, Any]] = None,
     set_dagster_home: bool = True,
     temp_dir: Optional[str] = None,
+    synchronous_run_coordinator: bool = False,
+    synchronous_run_launcher: bool = False,
 ) -> Iterator[DagsterInstance]:
     """Creates a persistent :py:class:`~dagster.DagsterInstance` available within a context manager.
 
@@ -55,6 +57,22 @@ def instance_for_test(
                 "telemetry": {"enabled": False},
                 "code_servers": {"wait_for_local_processes_on_shutdown": True},
             },
+            {
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
+                },
+            }
+            if synchronous_run_coordinator
+            else {},
+            {
+                "run_launcher": {
+                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                    "class": "SyncInMemoryRunLauncher",
+                },
+            }
+            if synchronous_run_launcher
+            else {},
             (overrides if overrides else {}),
         )
 

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -1,53 +1,6 @@
-import logging
-from collections.abc import Mapping
-from typing import Optional
+from dagster._core.run_coordinator.immediately_launch_run_coordinator import (
+    ImmediatelyLaunchRunCoordinator,
+)
 
-from typing_extensions import Self
-
-import dagster._check as check
-from dagster._config.config_schema import UserConfigSchema
-from dagster._core.run_coordinator.base import RunCoordinator, SubmitRunContext
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
-from dagster._serdes import ConfigurableClass, ConfigurableClassData
-
-
-class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
-    """Immediately send runs to the run launcher."""
-
-    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
-        self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._logger = logging.getLogger("dagster.run_coordinator.default_run_coordinator")
-        super().__init__()
-
-    @property
-    def inst_data(self) -> Optional[ConfigurableClassData]:
-        return self._inst_data
-
-    @classmethod
-    def config_type(cls) -> UserConfigSchema:
-        return {}
-
-    @classmethod
-    def from_config_value(
-        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, object]
-    ) -> Self:
-        return cls(inst_data=inst_data, **config_value)
-
-    def submit_run(self, context: SubmitRunContext) -> DagsterRun:
-        dagster_run = context.dagster_run
-
-        if dagster_run.status == DagsterRunStatus.NOT_STARTED:
-            self._instance.launch_run(dagster_run.run_id, context.workspace)
-        else:
-            self._logger.warning(
-                f"submit_run called for run {dagster_run.run_id} with status "
-                f"{dagster_run.status.value}, skipping launch."
-            )
-
-        run = self._instance.get_run_by_id(dagster_run.run_id)
-        if run is None:
-            check.failed(f"Failed to reload run {dagster_run.run_id}")
-        return run
-
-    def cancel_run(self, run_id: str) -> bool:
-        return self._instance.run_launcher.terminate(run_id)
+# for backwards compatibility, we need to keep the old DefaultRunCoordinator
+DefaultRunCoordinator = ImmediatelyLaunchRunCoordinator

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -1,6 +1,4 @@
-from dagster._core.run_coordinator.immediately_launch_run_coordinator import (
-    ImmediatelyLaunchRunCoordinator,
-)
+from dagster._core.run_coordinator.synchronous_run_coordinator import SynchronousRunCoordinator
 
 # for backwards compatibility, we need to keep the old DefaultRunCoordinator
-DefaultRunCoordinator = ImmediatelyLaunchRunCoordinator
+DefaultRunCoordinator = SynchronousRunCoordinator

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -1,4 +1,4 @@
-from dagster._core.run_coordinator.synchronous_run_coordinator import SynchronousRunCoordinator
+from dagster._core.run_coordinator.sync_in_memory_run_coordinator import SyncInMemoryRunCoordinator
 
 # for backwards compatibility, we need to keep the old DefaultRunCoordinator
-DefaultRunCoordinator = SynchronousRunCoordinator
+DefaultRunCoordinator = SyncInMemoryRunCoordinator

--- a/python_modules/dagster/dagster/_core/run_coordinator/immediately_launch_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/immediately_launch_run_coordinator.py
@@ -1,0 +1,53 @@
+import logging
+from collections.abc import Mapping
+from typing import Optional
+
+from typing_extensions import Self
+
+import dagster._check as check
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.run_coordinator.base import RunCoordinator, SubmitRunContext
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._serdes import ConfigurableClass, ConfigurableClassData
+
+
+class ImmediatelyLaunchRunCoordinator(RunCoordinator, ConfigurableClass):
+    """Immediately send runs to the run launcher."""
+
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
+        self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
+        self._logger = logging.getLogger("dagster.run_coordinator.default_run_coordinator")
+        super().__init__()
+
+    @property
+    def inst_data(self) -> Optional[ConfigurableClassData]:
+        return self._inst_data
+
+    @classmethod
+    def config_type(cls) -> UserConfigSchema:
+        return {}
+
+    @classmethod
+    def from_config_value(
+        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, object]
+    ) -> Self:
+        return cls(inst_data=inst_data, **config_value)
+
+    def submit_run(self, context: SubmitRunContext) -> DagsterRun:
+        dagster_run = context.dagster_run
+
+        if dagster_run.status == DagsterRunStatus.NOT_STARTED:
+            self._instance.launch_run(dagster_run.run_id, context.workspace)
+        else:
+            self._logger.warning(
+                f"submit_run called for run {dagster_run.run_id} with status "
+                f"{dagster_run.status.value}, skipping launch."
+            )
+
+        run = self._instance.get_run_by_id(dagster_run.run_id)
+        if run is None:
+            check.failed(f"Failed to reload run {dagster_run.run_id}")
+        return run
+
+    def cancel_run(self, run_id: str) -> bool:
+        return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
@@ -11,12 +11,12 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 
-class ImmediatelyLaunchRunCoordinator(RunCoordinator, ConfigurableClass):
+class SynchronousRunCoordinator(RunCoordinator, ConfigurableClass):
     """Immediately send runs to the run launcher."""
 
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._logger = logging.getLogger("dagster.run_coordinator.default_run_coordinator")
+        self._logger = logging.getLogger("dagster.run_coordinator.sync_in_memory_coordinator")
         super().__init__()
 
     @property

--- a/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
@@ -16,7 +16,7 @@ class SynchronousRunCoordinator(RunCoordinator, ConfigurableClass):
 
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._logger = logging.getLogger("dagster.run_coordinator.sync_in_memory_coordinator")
+        self._logger = logging.getLogger("dagster.run_coordinator.synchronous_coordinator")
         super().__init__()
 
     @property

--- a/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/sync_in_memory_run_coordinator.py
@@ -11,12 +11,12 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 
-class SynchronousRunCoordinator(RunCoordinator, ConfigurableClass):
+class SyncInMemoryRunCoordinator(RunCoordinator, ConfigurableClass):
     """Immediately send runs to the run launcher."""
 
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._logger = logging.getLogger("dagster.run_coordinator.synchronous_coordinator")
+        self._logger = logging.getLogger("dagster.run_coordinator.sync_in_memory_run_coordinator")
         super().__init__()
 
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -372,12 +372,14 @@ def test_get_required_daemon_types():
         SchedulerDaemon,
         SensorDaemon,
     )
+    from dagster._daemon.run_coordinator import QueuedRunCoordinatorDaemon
 
     with instance_for_test() as instance:
         assert instance.get_required_daemon_types() == [
             SensorDaemon.daemon_type(),
             BackfillDaemon.daemon_type(),
             SchedulerDaemon.daemon_type(),
+            QueuedRunCoordinatorDaemon.daemon_type(),
             AssetDaemon.daemon_type(),
         ]
 
@@ -394,6 +396,7 @@ def test_get_required_daemon_types():
             SensorDaemon.daemon_type(),
             BackfillDaemon.daemon_type(),
             SchedulerDaemon.daemon_type(),
+            QueuedRunCoordinatorDaemon.daemon_type(),
             MonitoringDaemon.daemon_type(),
             AssetDaemon.daemon_type(),
         ]
@@ -407,6 +410,7 @@ def test_get_required_daemon_types():
             SensorDaemon.daemon_type(),
             BackfillDaemon.daemon_type(),
             SchedulerDaemon.daemon_type(),
+            QueuedRunCoordinatorDaemon.daemon_type(),
         ]
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -45,7 +45,8 @@ def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
         with instance_for_test(
             overrides={
                 "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"}
-            }
+            },
+            synchronous_run_coordinator=True,
         ) as instance:
             yield instance
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -49,9 +49,15 @@ from dagster_tests.daemon_sensor_tests.test_sensor_run import (
 @pytest.fixture(name="instance_module_scoped", scope="module")
 def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
     # Overridden from conftest.py, uses DefaultRunLauncher since we care about
-    # runs actually completing for run status sensors
+    # runs actually completing for run status sensors.
+    # Still uses DefaultRunCoordinator, since we don't need to check dequeuing logic.
     with instance_for_test(
-        overrides={},
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
+        },
     ) as instance:
         yield instance
 
@@ -826,7 +832,13 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
     job_defs_name = "dagster_tests.daemon_sensor_tests.locations_for_xlocation_sensor_test.job_defs"
 
     with instance_with_multiple_code_locations(
-        workspace_load_target=workspace_load_target
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+        workspace_load_target=workspace_load_target,
     ) as location_infos:
         assert len(location_infos) == 2
 
@@ -913,7 +925,13 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
     job_defs_name = "dagster_tests.daemon_sensor_tests.locations_for_xlocation_sensor_test.job_defs"
 
     with instance_with_multiple_code_locations(
-        workspace_load_target=workspace_load_target
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+        workspace_load_target=workspace_load_target,
     ) as location_infos:
         assert len(location_infos) == 2
 
@@ -1002,7 +1020,13 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
     )
 
     with instance_with_multiple_code_locations(
-        workspace_load_target=workspace_load_target
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+        workspace_load_target=workspace_load_target,
     ) as location_infos:
         assert len(location_infos) == 2
 
@@ -1101,7 +1125,13 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
     )
 
     with instance_with_multiple_code_locations(
-        workspace_load_target=workspace_load_target
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+        workspace_load_target=workspace_load_target,
     ) as location_infos:
         assert len(location_infos) == 2
 
@@ -1248,7 +1278,13 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
     code_location_with_dupe_job_name = "dagster_tests.daemon_sensor_tests.locations_for_code_location_scoped_sensor_test.code_location_with_duplicate_job_name"
 
     with instance_with_multiple_code_locations(
-        workspace_load_target=workspace_load_target
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+        workspace_load_target=workspace_load_target,
     ) as location_infos:
         assert len(location_infos) == 2
 
@@ -1368,7 +1404,14 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
 def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     freeze_datetime = get_current_datetime()
-    with instance_with_single_code_location_multiple_repos_with_sensors() as (
+    with instance_with_single_code_location_multiple_repos_with_sensors(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+    ) as (
         instance,
         workspace_context,
         repos,
@@ -1426,7 +1469,14 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
 
 def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     freeze_datetime = get_current_datetime()
-    with instance_with_single_code_location_multiple_repos_with_sensors() as (
+    with instance_with_single_code_location_multiple_repos_with_sensors(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+    ) as (
         instance,
         workspace_context,
         repos,
@@ -1580,12 +1630,27 @@ def test_partitioned_job_run_status_sensor(
 
 def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     freeze_datetime = get_current_datetime()
-    with instance_with_sensors() as (
+    with instance_with_sensors(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+    ) as (
         instance,
         workspace_context,
         the_repo,
     ):
-        with instance_with_sensors(attribute="the_other_repo") as (
+        with instance_with_sensors(
+            overrides={
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                }
+            },
+            attribute="the_other_repo",
+        ) as (
             the_other_instance,
             the_other_workspace_context,
             the_other_repo,
@@ -1643,7 +1708,14 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
 
 def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     freeze_datetime = get_current_datetime()
-    with instance_with_single_code_location_multiple_repos_with_sensors() as (
+    with instance_with_single_code_location_multiple_repos_with_sensors(
+        overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            }
+        },
+    ) as (
         instance,
         workspace_context,
         repos,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -54,8 +54,8 @@ def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         },
     ) as instance:
@@ -834,8 +834,8 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
     with instance_with_multiple_code_locations(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
         workspace_load_target=workspace_load_target,
@@ -927,8 +927,8 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
     with instance_with_multiple_code_locations(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
         workspace_load_target=workspace_load_target,
@@ -1022,8 +1022,8 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
     with instance_with_multiple_code_locations(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
         workspace_load_target=workspace_load_target,
@@ -1127,8 +1127,8 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
     with instance_with_multiple_code_locations(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
         workspace_load_target=workspace_load_target,
@@ -1280,8 +1280,8 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
     with instance_with_multiple_code_locations(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
         workspace_load_target=workspace_load_target,
@@ -1407,8 +1407,8 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     with instance_with_single_code_location_multiple_repos_with_sensors(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
     ) as (
@@ -1472,8 +1472,8 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
     with instance_with_single_code_location_multiple_repos_with_sensors(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
     ) as (
@@ -1633,8 +1633,8 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
     with instance_with_sensors(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
     ) as (
@@ -1645,8 +1645,8 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
         with instance_with_sensors(
             overrides={
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 }
             },
             attribute="the_other_repo",
@@ -1711,8 +1711,8 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
     with instance_with_single_code_location_multiple_repos_with_sensors(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             }
         },
     ) as (

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1605,6 +1605,10 @@ def test_launch_failure(caplog, executor, workspace_context, remote_repo):
                 "module": "dagster._core.test_utils",
                 "class": "ExplodingRunLauncher",
             },
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
         },
     ) as instance:
         with freeze_time(freeze_datetime):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1606,8 +1606,8 @@ def test_launch_failure(caplog, executor, workspace_context, remote_repo):
                 "class": "ExplodingRunLauncher",
             },
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         },
     ) as instance:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1605,11 +1605,8 @@ def test_launch_failure(caplog, executor, workspace_context, remote_repo):
                 "module": "dagster._core.test_utils",
                 "class": "ExplodingRunLauncher",
             },
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
         },
+        synchronous_run_coordinator=True,
     ) as instance:
         with freeze_time(freeze_datetime):
             exploding_workspace_context = workspace_context.copy_for_test_instance(instance)

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -30,6 +30,10 @@ def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
                 },
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
                 "event_log_storage": {
                     "module": "dagster._core.storage.event_log",
                     "class": "ConsolidatedSqliteEventLogStorage",

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -31,8 +31,8 @@ def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
                     "class": "SyncInMemoryRunLauncher",
                 },
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
                 "event_log_storage": {
                     "module": "dagster._core.storage.event_log",

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -26,21 +26,15 @@ def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
     with tempfile.TemporaryDirectory() as temp_dir:
         with instance_for_test(
             overrides={
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
                 "event_log_storage": {
                     "module": "dagster._core.storage.event_log",
                     "class": "ConsolidatedSqliteEventLogStorage",
                     "config": {"base_dir": temp_dir},
                 },
                 "run_retries": {"enabled": True},
-            }
+            },
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ) as instance:
             yield instance
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -33,7 +33,7 @@ def test_scheduler_instance():
         ) as controller:
             daemons = controller.daemons
 
-            assert len(daemons) == 4
+            assert len(daemons) == 5
 
             assert any(isinstance(daemon, SchedulerDaemon) for daemon in daemons)
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -97,8 +97,8 @@ def get_daemon_instance(
                     "class": "SyncInMemoryRunLauncher",
                 },
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
                 **(extra_overrides or {}),
             }

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -96,6 +96,10 @@ def get_daemon_instance(
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
                 },
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
+                },
                 **(extra_overrides or {}),
             }
         ) as instance:

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -91,17 +91,9 @@ def get_daemon_instance(
         return_value=1,
     ):
         with instance_for_test(
-            overrides={
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
-                **(extra_overrides or {}),
-            }
+            overrides=extra_overrides,
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ) as instance:
             set_auto_materialize_paused(instance, paused)
             yield instance

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
@@ -61,12 +61,9 @@ def instance():
 def daemon_paused_instance():
     with instance_for_test(
         overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
             "auto_materialize": {"max_tick_retries": 2, "use_sensors": False},
-        }
+        },
+        synchronous_run_launcher=True,
     ) as the_instance:
         yield the_instance
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -98,6 +98,10 @@ def get_workspace_request_context(
 ):
     with instance_for_test(
         overrides={
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
             "run_launcher": {
                 "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                 "class": "SyncInMemoryRunLauncher",
@@ -598,6 +602,10 @@ def test_toggle_user_code() -> None:
                 "run_launcher": {
                     "module": "dagster._core.launcher.sync_in_memory_run_launcher",
                     "class": "SyncInMemoryRunLauncher",
+                },
+                "run_coordinator": {
+                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                    "class": "ImmediatelyLaunchRunCoordinator",
                 },
             }
         ) as instance,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -97,17 +97,9 @@ def get_workspace_request_context(
     filenames: Sequence[str], overrides: Optional[dict[str, Any]] = None
 ):
     with instance_for_test(
-        overrides={
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-            **(overrides or {}),
-        }
+        overrides=overrides,
+        synchronous_run_launcher=True,
+        synchronous_run_coordinator=True,
     ) as instance:
         target = InProcessTestWorkspaceLoadTarget(
             [get_code_location_origin(filename) for filename in filenames]
@@ -598,16 +590,8 @@ def test_backfill_with_runs_and_checks() -> None:
 def test_toggle_user_code() -> None:
     with (
         instance_for_test(
-            overrides={
-                "run_launcher": {
-                    "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                    "class": "SyncInMemoryRunLauncher",
-                },
-                "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                    "class": "SynchronousRunCoordinator",
-                },
-            }
+            synchronous_run_launcher=True,
+            synchronous_run_coordinator=True,
         ) as instance,
         get_threadpool_executor() as executor,
     ):

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -99,8 +99,8 @@ def get_workspace_request_context(
     with instance_for_test(
         overrides={
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
             "run_launcher": {
                 "module": "dagster._core.launcher.sync_in_memory_run_launcher",
@@ -604,8 +604,8 @@ def test_toggle_user_code() -> None:
                     "class": "SyncInMemoryRunLauncher",
                 },
                 "run_coordinator": {
-                    "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                    "class": "ImmediatelyLaunchRunCoordinator",
+                    "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                    "class": "SynchronousRunCoordinator",
                 },
             }
         ) as instance,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -29,7 +29,11 @@ def submit_executor(request):
 def instance_session_scoped_fixture() -> Iterator[DagsterInstance]:
     with instance_for_test(
         overrides={
-            "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"}
+            "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"},
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
         }
     ) as instance:
         yield instance

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -31,8 +31,8 @@ def instance_session_scoped_fixture() -> Iterator[DagsterInstance]:
         overrides={
             "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"},
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         }
     ) as instance:

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -30,11 +30,8 @@ def instance_session_scoped_fixture() -> Iterator[DagsterInstance]:
     with instance_for_test(
         overrides={
             "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"},
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
-        }
+        },
+        synchronous_run_coordinator=True,
     ) as instance:
         yield instance
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1321,6 +1321,10 @@ def test_launch_failure(
                 "module": "dagster._core.test_utils",
                 "class": "ExplodingRunLauncher",
             },
+            "run_coordinator": {
+                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
+                "class": "ImmediatelyLaunchRunCoordinator",
+            },
         },
     ) as scheduler_instance:
         schedule = remote_repo.get_schedule("simple_schedule")

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1321,11 +1321,8 @@ def test_launch_failure(
                 "module": "dagster._core.test_utils",
                 "class": "ExplodingRunLauncher",
             },
-            "run_coordinator": {
-                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
-                "class": "SynchronousRunCoordinator",
-            },
         },
+        synchronous_run_coordinator=True,
     ) as scheduler_instance:
         schedule = remote_repo.get_schedule("simple_schedule")
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1322,8 +1322,8 @@ def test_launch_failure(
                 "class": "ExplodingRunLauncher",
             },
             "run_coordinator": {
-                "module": "dagster._core.run_coordinator.immediately_launch_run_coordinator",
-                "class": "ImmediatelyLaunchRunCoordinator",
+                "module": "dagster._core.run_coordinator.synchronous_run_coordinator",
+                "class": "SynchronousRunCoordinator",
             },
         },
     ) as scheduler_instance:

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -11,7 +11,7 @@ from dagster_graphql.test.utils import (
 
 
 def test_execute_hammer_through_webserver():
-    with instance_for_test() as instance:
+    with instance_for_test(synchronous_run_coordinator=True) as instance:
         with WorkspaceProcessContext(
             instance,
             version="",


### PR DESCRIPTION
## Summary & Motivation
We want the default instance to support run concurrency features.

Planning on deferring this until the 1.10 branch is cut, but putting up for review now.

## How I Tested These Changes
BK

## Changelog
- Changed the default run coordinator to be the queued run coordinator
