### PR TITLE
[embedded-elt][sling] Correctly get an object_key when a stream has an empty config

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -403,7 +403,7 @@ class SlingResource(ConfigurableResource):
             for stream in stream_definitions:
                 asset_key = dagster_sling_translator.get_asset_key(stream)
 
-                object_key = stream.get("config", {}).get("object")
+                object_key = (stream.get("config") or {}).get("object")
                 destination_stream_name = object_key or stream["name"]
                 table_name = None
                 if destination_name and destination_stream_name:


### PR DESCRIPTION
## Summary & Motivation
This fixes an issue where Sling materialisations fail if a stream has an empty config.

A fix for #25515 and #25925

Original code by @Westm7

## How I Tested These Changes
I had a failing config, which no longer fails after this change.