### PR TITLE
[dagster-sigma] Use Sigma translator instance in spec loader and state-backed defs

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator_legacy.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator_legacy.py
@@ -28,5 +28,6 @@ with environ({"SIGMA_CLIENT_ID": fake_client_id, "SIGMA_CLIENT_SECRET": fake_cli
         client_secret=EnvVar("SIGMA_CLIENT_SECRET"),
     )
 
-    sigma_specs = load_sigma_asset_specs(resource, dagster_sigma_translator=MyCoolTranslator())
+    # Pass the translator type
+    sigma_specs = load_sigma_asset_specs(resource, dagster_sigma_translator=MyCoolTranslator)
     defs = Definitions(assets=[*sigma_specs], jobs=[define_asset_job("all_asset_job")])

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
 import responses
 from click.testing import CliRunner
 from dagster._core.code_pointer import CodePointer
@@ -112,6 +113,29 @@ def test_load_assets_organization_data_translator(
                 str(Path(__file__).parent / "pending_repo_with_translator.py"), "defs", None
             ),
         )
+
+        assert len(repository_def.assets_defs_by_key) == 2
+        assert all(
+            key.path[0] == "my_prefix" for key in repository_def.assets_defs_by_key.keys()
+        ), repository_def.assets_defs_by_key
+
+
+@responses.activate
+def test_load_assets_organization_data_translator_legacy(
+    sigma_auth_token: str, sigma_sample_data: None
+) -> None:
+    with instance_for_test() as _instance:
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Support of `dagster_sigma_translator` as a Type\[DagsterSigmaTranslator\]",
+        ):
+            repository_def = initialize_repository_def_from_pointer(
+                CodePointer.from_python_file(
+                    str(Path(__file__).parent / "pending_repo_with_translator_legacy.py"),
+                    "defs",
+                    None,
+                ),
+            )
 
         assert len(repository_def.assets_defs_by_key) == 2
         assert all(


### PR DESCRIPTION
## Summary & Motivation

Same as #26734 but for Sigma.

## How I Tested These Changes

BK

## Changelog

[dagster-sigma] `load_sigma_asset_specs` is updated to accept an instance of `DagsterSigmaTranslator` or custom subclass.
