### PR TITLE
separate configured limit from slot count

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2504,6 +2504,8 @@ type ConcurrencyKeyInfo {
   pendingStepRunIds: [String!]!
   assignedStepCount: Int!
   assignedStepRunIds: [String!]!
+  limit: Int
+  usingDefaultLimit: Boolean
 }
 
 type ClaimedConcurrencySlot {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -847,10 +847,12 @@ export type ConcurrencyKeyInfo = {
   assignedStepRunIds: Array<Scalars['String']['output']>;
   claimedSlots: Array<ClaimedConcurrencySlot>;
   concurrencyKey: Scalars['String']['output'];
+  limit: Maybe<Scalars['Int']['output']>;
   pendingStepCount: Scalars['Int']['output'];
   pendingStepRunIds: Array<Scalars['String']['output']>;
   pendingSteps: Array<PendingConcurrencyStep>;
   slotCount: Scalars['Int']['output'];
+  usingDefaultLimit: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type ConfigType = {
@@ -7357,6 +7359,7 @@ export const buildConcurrencyKeyInfo = (
       overrides && overrides.hasOwnProperty('claimedSlots') ? overrides.claimedSlots! : [],
     concurrencyKey:
       overrides && overrides.hasOwnProperty('concurrencyKey') ? overrides.concurrencyKey! : 'quasi',
+    limit: overrides && overrides.hasOwnProperty('limit') ? overrides.limit! : 703,
     pendingStepCount:
       overrides && overrides.hasOwnProperty('pendingStepCount') ? overrides.pendingStepCount! : 370,
     pendingStepRunIds:
@@ -7366,6 +7369,10 @@ export const buildConcurrencyKeyInfo = (
     pendingSteps:
       overrides && overrides.hasOwnProperty('pendingSteps') ? overrides.pendingSteps! : [],
     slotCount: overrides && overrides.hasOwnProperty('slotCount') ? overrides.slotCount! : 455,
+    usingDefaultLimit:
+      overrides && overrides.hasOwnProperty('usingDefaultLimit')
+        ? overrides.usingDefaultLimit!
+        : true,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -142,6 +142,8 @@ class GrapheneConcurrencyKeyInfo(graphene.ObjectType):
     pendingStepRunIds = non_null_list(graphene.String)
     assignedStepCount = graphene.NonNull(graphene.Int)
     assignedStepRunIds = non_null_list(graphene.String)
+    limit = graphene.Int()
+    usingDefaultLimit = graphene.Boolean()
 
     class Meta:
         name = "ConcurrencyKeyInfo"
@@ -192,6 +194,12 @@ class GrapheneConcurrencyKeyInfo(graphene.ObjectType):
 
     def resolve_assignedStepRunIds(self, graphene_info: ResolveInfo):
         return list(self._get_concurrency_key_info(graphene_info).assigned_run_ids)
+
+    def resolve_limit(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).limit
+
+    def resolve_usingDefaultLimit(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).using_default_limit
 
 
 class GrapheneRunQueueConfig(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
@@ -19,7 +19,34 @@ query InstanceDetailSummaryQuery {
 """
 
 GET_CONCURRENCY_LIMITS_QUERY = """
-query InstanceConcurrencyLimitsQuery {
+query InstanceConcurrencyLimitsQuery($concurrencyKey: String!) {
+    instance {
+        concurrencyLimit(concurrencyKey: $concurrencyKey) {
+            concurrencyKey
+            slotCount
+            activeSlotCount
+            activeRunIds
+            claimedSlots {
+                runId
+                stepKey
+            }
+            pendingSteps {
+                runId
+                stepKey
+                enqueuedTimestamp
+                assignedTimestamp
+                priority
+            }
+            limit
+            usingDefaultLimit
+        }
+    }
+}
+
+"""
+
+ALL_CONCURRENCY_LIMITS_QUERY = """
+query AllConcurrencyLimitsQuery {
     instance {
         concurrencyLimits {
             concurrencyKey
@@ -37,6 +64,8 @@ query InstanceConcurrencyLimitsQuery {
                 assignedTimestamp
                 priority
             }
+            limit
+            usingDefaultLimit
         }
     }
 }
@@ -67,6 +96,40 @@ BaseTestSuite: Any = make_graphql_context_test_suite(
 )
 
 
+def fetch_concurrency_limit(graphql_context, key: str):
+    results = execute_dagster_graphql(
+        graphql_context,
+        GET_CONCURRENCY_LIMITS_QUERY,
+        {"concurrencyKey": key},
+    )
+    assert results.data
+    assert "instance" in results.data
+    assert "concurrencyLimit" in results.data["instance"]
+    return results.data["instance"]["concurrencyLimit"]
+
+
+def set_concurrency_limit(graphql_context, key: str, limit: int):
+    execute_dagster_graphql(
+        graphql_context,
+        SET_CONCURRENCY_LIMITS_MUTATION,
+        variables={
+            "concurrencyKey": key,
+            "limit": limit,
+        },
+    )
+
+
+def fetch_all_concurrency_limits(graphql_context):
+    results = execute_dagster_graphql(
+        graphql_context,
+        ALL_CONCURRENCY_LIMITS_QUERY,
+    )
+    assert results.data
+    assert "instance" in results.data
+    assert "concurrencyLimits" in results.data["instance"]
+    return [limit for limit in results.data["instance"]["concurrencyLimits"]]
+
+
 class TestInstanceSettings(BaseTestSuite):
     def test_instance_settings(self, graphql_context):
         results = execute_dagster_graphql(graphql_context, INSTANCE_QUERY)
@@ -81,78 +144,56 @@ class TestInstanceSettings(BaseTestSuite):
     def test_concurrency_limits(self, graphql_context):
         instance = graphql_context.instance
 
-        def _fetch_limits(key: str):
-            results = execute_dagster_graphql(
-                graphql_context,
-                GET_CONCURRENCY_LIMITS_QUERY,
-            )
-            assert results.data
-            assert "instance" in results.data
-            assert "concurrencyLimits" in results.data["instance"]
-            limit_info = results.data["instance"]["concurrencyLimits"]
-            return next(iter([info for info in limit_info if info["concurrencyKey"] == key]), None)
-
-        def _set_limits(key: str, limit: int):
-            execute_dagster_graphql(
-                graphql_context,
-                SET_CONCURRENCY_LIMITS_MUTATION,
-                variables={
-                    "concurrencyKey": key,
-                    "limit": limit,
-                },
-            )
-
         # default limits are empty
-        assert _fetch_limits("foo") is None
+        all_limits = fetch_all_concurrency_limits(graphql_context)
+        assert len(all_limits) == 0
 
         # set a limit
-        _set_limits("foo", 10)
-        foo = _fetch_limits("foo")
-        assert foo["concurrencyKey"] == "foo"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["slotCount"] == 10  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeSlotCount"] == 0  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeRunIds"] == []  # pyright: ignore[reportOptionalSubscript]
-        assert foo["claimedSlots"] == []  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"] == []  # pyright: ignore[reportOptionalSubscript]
+        set_concurrency_limit(graphql_context, "foo", 10)
+        foo = fetch_concurrency_limit(graphql_context, "foo")
+        assert foo["concurrencyKey"] == "foo"
+        assert foo["slotCount"] == 10
+        assert foo["activeSlotCount"] == 0
+        assert foo["activeRunIds"] == []
+        assert foo["claimedSlots"] == []
+        assert foo["pendingSteps"] == []
 
         # claim a slot
         run_id = make_new_run_id()
         instance.event_log_storage.claim_concurrency_slot("foo", run_id, "fake_step_key")
-        foo = _fetch_limits("foo")
-        assert foo["concurrencyKey"] == "foo"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["slotCount"] == 10  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeSlotCount"] == 1  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeRunIds"] == [run_id]  # pyright: ignore[reportOptionalSubscript]
-        assert foo["claimedSlots"] == [{"runId": run_id, "stepKey": "fake_step_key"}]  # pyright: ignore[reportOptionalSubscript]
-        assert len(foo["pendingSteps"]) == 1  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["runId"] == run_id  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["stepKey"] == "fake_step_key"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["assignedTimestamp"] is not None  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["priority"] == 0  # pyright: ignore[reportOptionalSubscript]
+        foo = fetch_concurrency_limit(graphql_context, "foo")
+        assert foo["concurrencyKey"] == "foo"
+        assert foo["slotCount"] == 10
+        assert foo["activeSlotCount"] == 1
+        assert foo["activeRunIds"] == [run_id]
+        assert foo["claimedSlots"] == [{"runId": run_id, "stepKey": "fake_step_key"}]
+        assert len(foo["pendingSteps"]) == 1
+        assert foo["pendingSteps"][0]["runId"] == run_id
+        assert foo["pendingSteps"][0]["stepKey"] == "fake_step_key"
+        assert foo["pendingSteps"][0]["assignedTimestamp"] is not None
+        assert foo["pendingSteps"][0]["priority"] == 0
 
-        # set a new limit
-        _set_limits("foo", 5)
-        foo = _fetch_limits("foo")
-        assert foo["concurrencyKey"] == "foo"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["slotCount"] == 5  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeSlotCount"] == 1  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeRunIds"] == [run_id]  # pyright: ignore[reportOptionalSubscript]
-        assert foo["claimedSlots"] == [{"runId": run_id, "stepKey": "fake_step_key"}]  # pyright: ignore[reportOptionalSubscript]
-        assert len(foo["pendingSteps"]) == 1  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["runId"] == run_id  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["stepKey"] == "fake_step_key"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["assignedTimestamp"] is not None  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"][0]["priority"] == 0  # pyright: ignore[reportOptionalSubscript]
+        set_concurrency_limit(graphql_context, "foo", 5)
+        foo = fetch_concurrency_limit(graphql_context, "foo")
+        assert foo["concurrencyKey"] == "foo"
+        assert foo["slotCount"] == 5
+        assert foo["activeSlotCount"] == 1
+        assert foo["activeRunIds"] == [run_id]
+        assert foo["claimedSlots"] == [{"runId": run_id, "stepKey": "fake_step_key"}]
+        assert len(foo["pendingSteps"]) == 1
+        assert foo["pendingSteps"][0]["runId"] == run_id
+        assert foo["pendingSteps"][0]["stepKey"] == "fake_step_key"
+        assert foo["pendingSteps"][0]["assignedTimestamp"] is not None
+        assert foo["pendingSteps"][0]["priority"] == 0
 
-        # free a slot
         instance.event_log_storage.free_concurrency_slots_for_run(run_id)
-        foo = _fetch_limits("foo")
-        assert foo["concurrencyKey"] == "foo"  # pyright: ignore[reportOptionalSubscript]
-        assert foo["slotCount"] == 5  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeSlotCount"] == 0  # pyright: ignore[reportOptionalSubscript]
-        assert foo["activeRunIds"] == []  # pyright: ignore[reportOptionalSubscript]
-        assert foo["claimedSlots"] == []  # pyright: ignore[reportOptionalSubscript]
-        assert foo["pendingSteps"] == []  # pyright: ignore[reportOptionalSubscript]
+        foo = fetch_concurrency_limit(graphql_context, "foo")
+        assert foo["concurrencyKey"] == "foo"
+        assert foo["slotCount"] == 5
+        assert foo["activeSlotCount"] == 0
+        assert foo["activeRunIds"] == []
+        assert foo["claimedSlots"] == []
+        assert foo["pendingSteps"] == []
 
     def test_concurrency_free(self, graphql_context):
         storage = graphql_context.instance.event_log_storage
@@ -243,3 +284,33 @@ class TestInstanceSettings(BaseTestSuite):
         assert foo_info.pending_run_ids == set()
         assert foo_info.assigned_step_count == 1
         assert foo_info.assigned_run_ids == {run_id_2}
+
+
+ConcurrencyTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[
+        GraphQLContextVariant.sqlite_with_default_concurrency_managed_grpc_env(),
+    ]
+)
+
+
+class TestConcurrencyInstanceSettings(ConcurrencyTestSuite):
+    def test_default_concurrency(self, graphql_context):
+        # no limits
+        all_limits = fetch_all_concurrency_limits(graphql_context)
+        assert len(all_limits) == 0
+
+        # default limits are empty
+        limit = fetch_concurrency_limit(graphql_context, "foo")
+        assert limit is not None
+        assert limit["slotCount"] == 0
+        assert limit["limit"] == 1
+        assert limit["usingDefaultLimit"]
+
+        # set a limit
+        set_concurrency_limit(graphql_context, "foo", 0)
+
+        limit = fetch_concurrency_limit(graphql_context, "foo")
+        assert limit is not None
+        assert limit["slotCount"] == 0
+        assert limit["limit"] == 0
+        assert not limit["usingDefaultLimit"]

--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -1,13 +1,16 @@
 import time
 from collections import defaultdict
 from types import TracebackType
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self
 
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.storage.tags import PRIORITY_TAG
+
+if TYPE_CHECKING:
+    from dagster._core.storage.event_log.base import PoolLimit
 
 INITIAL_INTERVAL_VALUE = 1
 STEP_UP_BASE = 1.1
@@ -33,10 +36,11 @@ class InstanceConcurrencyContext:
     def __init__(self, instance: DagsterInstance, dagster_run: DagsterRun):
         self._instance = instance
         self._run_id = dagster_run.run_id
-        self._global_concurrency_keys = None
+        self._pools: Optional[dict[str, PoolLimit]] = None
         self._pending_timeouts = defaultdict(float)
         self._pending_claim_counts = defaultdict(int)
         self._pending_claims = set()
+        self._default_limit = instance.global_op_concurrency_default_limit
         self._claims = set()
         try:
             self._run_priority = int(dagster_run.tags.get(PRIORITY_TAG, "0"))
@@ -68,38 +72,39 @@ class InstanceConcurrencyContext:
 
         self._context_guard = False
 
-    @property
-    def global_concurrency_keys(self) -> set[str]:
-        # lazily load the global concurrency keys, to avoid the DB fetch for plans that do not
-        # have global concurrency limited keys
-        if self._global_concurrency_keys is None:
-            if not self._instance.event_log_storage.supports_global_concurrency_limits:
-                self._global_concurrency_keys = set()
-            else:
-                self._global_concurrency_keys = (
-                    self._instance.event_log_storage.get_concurrency_keys()
-                )
+    def get_pool_info(self, pool_name: str) -> Optional["PoolLimit"]:
+        if not self._instance.event_log_storage.supports_global_concurrency_limits:
+            return None
 
-        return self._global_concurrency_keys
+        if self._pools is None:
+            self._sync_pools()
 
-    def _sync_global_concurrency_keys(self) -> None:
-        self._global_concurrency_keys = self._instance.event_log_storage.get_concurrency_keys()
+        assert self._pools is not None
+        return self._pools.get(pool_name)
+
+    def _sync_pools(self) -> None:
+        pool_limits = self._instance.event_log_storage.get_pool_limits()
+        self._pools = {pool.name: pool for pool in pool_limits}
 
     def claim(self, concurrency_key: str, step_key: str, step_priority: int = 0):
         if not self._instance.event_log_storage.supports_global_concurrency_limits:
             return True
 
-        if concurrency_key not in self.global_concurrency_keys:
-            # The initialization call will be a no-op if the limit is set by another process,
-            # mitigating any race condition concerns
-            if not self._instance.event_log_storage.initialize_concurrency_limit_to_default(
+        pool_info = self.get_pool_info(concurrency_key)
+        if (pool_info is None and self._default_limit is not None) or (
+            pool_info is not None
+            and pool_info.from_default
+            and pool_info.limit != self._default_limit
+        ):
+            self._instance.event_log_storage.initialize_concurrency_limit_to_default(
                 concurrency_key
-            ):
-                # still default open if the limit table has not been initialized
-                return True
-            else:
-                # sync the global concurrency keys to ensure we have the latest
-                self._sync_global_concurrency_keys()
+            )
+            self._sync_pools()
+            # refetch the pool info
+            pool_info = self.get_pool_info(concurrency_key)
+
+        if pool_info is None:
+            return True
 
         if step_key in self._pending_claims:
             if time.time() > self._pending_timeouts[step_key]:

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -75,18 +75,19 @@ class GlobalOpConcurrencyLimitsCounter:
             os.getenv("DAGSTER_OP_CONCURRENCY_KEYS_ALLOTTED_FOR_STARTED_RUN_SECONDS", "5")
         )
 
+        queued_pool_names = self._get_queued_pool_names(runs)
+        # initialize all the pool limits to the default if necessary
+        self._initialize_pool_limits(instance, queued_pool_names)
+
         # fetch all the concurrency info for all of the runs at once, so we can claim in the correct
         # priority order
-        self._fetch_concurrency_info(instance, runs)
+        self._fetch_concurrency_info(instance, queued_pool_names)
 
         # fetch all the outstanding pools for in-progress runs
         self._process_in_progress_runs(in_progress_run_records)
 
-    def _fetch_concurrency_info(self, instance: DagsterInstance, queued_runs: Sequence[DagsterRun]):
-        # fetch all the concurrency slot information for all the queued runs
-        all_pools = set()
-
-        configured_pools = instance.event_log_storage.get_concurrency_keys()
+    def _get_queued_pool_names(self, queued_runs: Sequence[DagsterRun]) -> set[str]:
+        queued_pool_names = set()
         for run in queued_runs:
             if run.run_op_concurrency:
                 # if using run granularity, consider all the concurrency keys required by the run
@@ -96,17 +97,32 @@ class GlobalOpConcurrencyLimitsCounter:
                     if self._pool_granularity == PoolGranularity.OP
                     else run.run_op_concurrency.all_pools or []
                 )
-                all_pools.update(run_pools)
+                queued_pool_names.update(run_pools)
+        return queued_pool_names
 
-        for pool in all_pools:
-            if pool is None:
+    def _initialize_pool_limits(self, instance: DagsterInstance, pool_names: set[str]):
+        default_limit = instance.global_op_concurrency_default_limit
+        pool_limits_by_name = {
+            pool.name: pool for pool in instance.event_log_storage.get_pool_limits()
+        }
+        for pool_name in pool_names:
+            if pool_name is None:
                 continue
 
-            if pool not in configured_pools:
-                instance.event_log_storage.initialize_concurrency_limit_to_default(pool)
+            if (pool_name not in pool_limits_by_name and default_limit) or (
+                pool_name in pool_limits_by_name
+                and pool_limits_by_name[pool_name].from_default
+                and pool_limits_by_name[pool_name].limit != default_limit
+            ):
+                instance.event_log_storage.initialize_concurrency_limit_to_default(pool_name)
 
-            self._concurrency_info_by_key[pool] = instance.event_log_storage.get_concurrency_info(
-                pool
+    def _fetch_concurrency_info(self, instance: DagsterInstance, pool_names: set[str]):
+        for pool_name in pool_names:
+            if pool_name is None:
+                continue
+
+            self._concurrency_info_by_key[pool_name] = (
+                instance.event_log_storage.get_concurrency_info(pool_name)
             )
 
     def _should_allocate_slots_for_in_progress_run(self, record: RunRecord):

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/048_7e2f3204cf8e_add_column_concurrency_default_limit.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/048_7e2f3204cf8e_add_column_concurrency_default_limit.py
@@ -1,0 +1,32 @@
+"""add column concurrency default limit
+
+Revision ID: 7e2f3204cf8e
+Revises: 6b7fb194ff9c
+Create Date: 2025-01-13 15:19:19.331752
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dagster._core.storage.migration.utils import has_column, has_table
+
+# revision identifiers, used by Alembic.
+revision = "7e2f3204cf8e"
+down_revision = "6b7fb194ff9c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if has_table("concurrency_limits"):
+        if not has_column("concurrency_limits", "using_default_limit"):
+            op.add_column(
+                "concurrency_limits",
+                sa.Column("using_default_limit", sa.Boolean(), nullable=False, default=False),
+            )
+
+
+def downgrade():
+    if has_table("concurrency_limits"):
+        if has_column("concurrency_limits", "using_default_limit"):
+            op.drop_column("concurrency_limits", "using_default_limit")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -35,6 +35,7 @@ from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.partition_status_cache import get_and_update_asset_status_cache_value
 from dagster._core.storage.sql import AlembicVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX
+from dagster._record import record
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
 from dagster._utils.warnings import deprecation_warning
@@ -183,6 +184,13 @@ class PlannedMaterializationInfo(NamedTuple):
 
     storage_id: int
     run_id: str
+
+
+@record
+class PoolLimit:
+    name: str
+    limit: int
+    from_default: bool
 
 
 class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
@@ -558,6 +566,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_concurrency_info(self, concurrency_key: str) -> ConcurrencyKeyInfo:
         """Get concurrency info for key."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_pool_limits(self) -> Sequence[PoolLimit]:
+        """Get the set of concurrency limited keys and limits."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -114,6 +114,7 @@ ConcurrencyLimitsTable = db.Table(
     ),
     db.Column("concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True),
     db.Column("limit", db.Integer, nullable=False),
+    db.Column("using_default_limit", db.Boolean, nullable=False, default=False),
     db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -24,6 +24,7 @@ from dagster._core.storage.event_log.base import (
     EventRecordsFilter,
     EventRecordsResult,
     PlannedMaterializationInfo,
+    PoolLimit,
 )
 from dagster._core.storage.runs.base import RunStorage
 from dagster._core.storage.schedules.base import ScheduleStorage
@@ -674,6 +675,9 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_concurrency_keys(self) -> set[str]:
         return self._storage.event_log_storage.get_concurrency_keys()
+
+    def get_pool_limits(self) -> Sequence[PoolLimit]:
+        return self._storage.event_log_storage.get_pool_limits()
 
     def get_concurrency_info(self, concurrency_key: str) -> ConcurrencyKeyInfo:
         return self._storage.event_log_storage.get_concurrency_info(concurrency_key)

--- a/python_modules/dagster/dagster/_utils/concurrency.py
+++ b/python_modules/dagster/dagster/_utils/concurrency.py
@@ -74,6 +74,9 @@ class ConcurrencyKeyInfo:
     slot_count: int
     claimed_slots: list[ClaimedSlotInfo]
     pending_steps: list[PendingStepInfo]
+    # limit: None means no slots and no default limit.  `limit` will return the instance-configured default even if the slots have not yet been initialized.
+    limit: Optional[int] = None
+    using_default_limit: bool = False
 
     ###################################################
     # Fields that we need to keep around for backcompat

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1543,7 +1543,7 @@ def test_add_run_tags_run_id_idx():
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
             instance.upgrade()
 
-        assert get_current_alembic_version(db_path) == "6b7fb194ff9c"
+        assert get_current_alembic_version(db_path) != "16e3655b4d9b"
         assert "run_tags" in get_sqlite3_tables(db_path)
         assert "idx_run_tags" not in get_sqlite3_indexes(db_path, "run_tags")
         assert "idx_run_tags_run_id" in get_sqlite3_indexes(db_path, "run_tags")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5260,6 +5260,34 @@ class TestEventLogStorage:
         assert storage.get_concurrency_keys() == set(["foo"])
         assert storage.get_concurrency_info("foo").slot_count == 1
 
+    def test_changing_default_concurrency_key(
+        self, storage: EventLogStorage, instance: DagsterInstance
+    ):
+        assert storage
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if not self.can_set_concurrency_defaults():
+            pytest.skip("storage does not support setting global op concurrency defaults")
+
+        self.set_default_op_concurrency(instance, storage, 1)
+        assert instance.global_op_concurrency_default_limit == 1
+
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 1
+
+        self.set_default_op_concurrency(instance, storage, 2)
+        assert instance.global_op_concurrency_default_limit == 2
+
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        self.set_default_op_concurrency(instance, storage, None)
+        assert instance.global_op_concurrency_default_limit is None
+
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 0
+
     def test_asset_checks(
         self,
         storage: EventLogStorage,


### PR DESCRIPTION
## Summary & Motivation
Currently, the event log storage returns a `ConcurrencyKeyInfo` to represent the information about a particular pool.  This info includes the number of slots available, but it doesn't have enough information to distinguish between the following cases:

1. no pool limit is explicitly set and there is no default value
2. no pool limit is explicitly set but there is a default value
3. a pool limit is explicitly set to 0

This PR adds more information to the returned object to help distinguish between cases 1 and 2.  Specifically, there's a new nullable `limit` value, which returns the configured limit regardless of whether the pool has been initialized to create the corresponding slot rows.  A limit value of `None` indicates an unconfigured pool, with no default limit.

## How I Tested These Changes
BK

