### PR TITLE
[components] [rfc] Skeleton of autodocs

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -1,0 +1,43 @@
+import tempfile
+import webbrowser
+
+import markdown
+
+from dagster_dg.context import RemoteComponentType
+
+
+def render_markdown_in_browser(markdown_content: str) -> None:
+    # Convert the markdown string to HTML
+    html_content = markdown.markdown(markdown_content)
+
+    # Add basic HTML structure
+    full_html = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Markdown Preview</title>
+    </head>
+    <body>
+        {html_content}
+    </body>
+    </html>
+    """
+
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as temp_file:
+        temp_file.write(full_html.encode("utf-8"))
+        temp_file_path = temp_file.name
+
+    # Open the temporary file in the default web browser
+    webbrowser.open(f"file://{temp_file_path}")
+
+
+def markdown_for_component_type(component_type_metadata: RemoteComponentType) -> str:
+    return f"""
+## Component: `{component_type_metadata.package}`.`{component_type_metadata.name}`
+ 
+### Description: 
+`{component_type_metadata.description}`
+                               """

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -37,6 +37,7 @@ setup(
         "tomli",
         "click>=8",
         "typing_extensions>=4.4.0,<5",
+        "markdown",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

This is just throwing up a skeleton of how we can build autogenerated documentation from component-types. This is barebones but we can start to fill this out. In particular as we develop templating I want to think about how we document the yaml schema and available templating options.

## How I Tested These Changes

`dg component-type docs dagster_components.pipes_subprocess_script_collection`

![Screenshot 2025-01-03 at 6.42.56 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/d633a67d-bc49-40c8-8474-372120832183.png)

## Changelog

> Insert changelog entry or delete this section.
