### PR TITLE
make the partition names argument to get_partition_set_execution_param_data a set

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -636,7 +636,7 @@ class InProcessCodeLocation(CodeLocation):
         return get_partition_set_execution_param_data(
             self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
-            partition_names=partition_names,
+            partition_names=set(partition_names),
             instance_ref=instance.get_ref(),
         )
 

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -525,7 +525,7 @@ def get_external_execution_plan_snapshot(
 def get_partition_set_execution_param_data(
     repo_def: RepositoryDefinition,
     partition_set_name: str,
-    partition_names: Sequence[str],
+    partition_names: AbstractSet[str],
     instance_ref: Optional[InstanceRef] = None,
 ) -> Union[PartitionSetExecutionParamSnap, PartitionExecutionErrorSnap]:
     (

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -691,7 +691,7 @@ class DagsterApiServer(DagsterApiServicer):
                 get_partition_set_execution_param_data(
                     self._get_repo_for_origin(args.repository_origin),
                     partition_set_name=args.partition_set_name,
-                    partition_names=args.partition_names,
+                    partition_names=set(args.partition_names),
                     instance_ref=instance_ref,
                 )
             )


### PR DESCRIPTION
Summary:
Unlikely to actually be the main bottleneck, but a simple way to make this logic O(n) instead of O(m*n), where n is the number of partitions in the partition set and m is the number of partition names being asked for.

Test Plan: BK

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
