### PR TITLE
Remove slow validation code in get_partition_set_execution_param_data

### DIFF
--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -331,7 +331,9 @@ def test_dynamic_partition_set_grpc(instance: DagsterInstance):
             instance=instance,
         )
         assert isinstance(data, PartitionSetExecutionParamSnap)
-        assert data.partition_data == []
+
+        # non existant partitions can still return snapshots
+        assert len(data.partition_data) == 1
 
 
 def test_external_partition_tags_grpc_backcompat_no_job_name(instance: DagsterInstance):


### PR DESCRIPTION
Summary:
The current implementation here requires fetching every partition key in the set, which can be very slow. We don't appear to use that for anything other than filtering out keys that aren't in the set, which seems like a reasonable thing to require the callsite to check instead.

BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
