### PR TITLE
Remove debug console logging feature flag.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -1,9 +1,7 @@
 import {cache} from 'idb-lru-cache';
 import memoize from 'lodash/memoize';
 import LRU from 'lru-cache';
-import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
-import {featureEnabled} from './Flags';
 import {timeByParts} from './timeByParts';
 
 function twoDigit(v: number) {
@@ -233,12 +231,6 @@ export function weakmapMemoize<T extends object, R>(
 
 export function assertUnreachable(value: never): never {
   throw new Error(`Didn't expect to get here with value: ${JSON.stringify(value)}`);
-}
-
-export function debugLog(...args: any[]) {
-  if (featureEnabled(FeatureFlag.flagDebugConsoleLogging)) {
-    console.log(...args);
-  }
 }
 
 export function colorHash(str: string) {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/apolloLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/apolloLinks.tsx
@@ -1,4 +1,3 @@
-import {debugLog, formatElapsedTimeWithMsec} from './Util';
 import {ApolloLink} from '../apollo-client';
 
 const getCalls = (response: any) => {
@@ -15,11 +14,6 @@ export const logLink = new ApolloLink((operation, forward) =>
     const elapsedTime = performance.now() - context.start;
     const calls = getCalls(context.response);
     operation.setContext({elapsedTime, calls});
-    debugLog(`${operation.operationName} took ${formatElapsedTimeWithMsec(elapsedTime)}`, {
-      operation,
-      data,
-      calls,
-    });
     return data;
   }),
 );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -17,10 +17,6 @@ export const useVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableAutoLoadDefaults,
   },
   {
-    key: 'Debug console logging',
-    flagType: FeatureFlag.flagDebugConsoleLogging,
-  },
-  {
     key: 'Revert to legacy Runs page',
     flagType: FeatureFlag.flagLegacyRunsPage,
     label: (


### PR DESCRIPTION
We're not really using this feature flag and the one call site using it is logging operation information that we can easily see in the network tab now that we include the operation name in the URL.

