### PR TITLE
[dagster-looker] Fix wording in LookerApiTranslatorStructureData docstring

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -110,7 +110,7 @@ class LookerStructureData:
 @record
 class LookerApiTranslatorStructureData:
     """A record representing a structure in Looker and the Looker instance data.
-    Includes the content's type and data as returned from the API.
+    Includes the structure's type and data as returned from the API.
     """
 
     structure_data: "LookerStructureData"


### PR DESCRIPTION
## Summary & Motivation

As title - wording was incorrect (copy paste error). This is minor, but updating since the `LookerApiTranslatorStructureData` class is user facing.
