### PR TITLE
check MultiAssetSensorEvaluationContext.advance_cursor arg

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -788,7 +788,16 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 will not fetch this event again. If None is provided, the cursor for the AssetKey
                 will not be updated.
         """
-        self._cursor_advance_state_mutation.add_advanced_records(materialization_records_by_key)
+        from dagster._core.storage.event_log.base import EventLogRecord
+
+        self._cursor_advance_state_mutation.add_advanced_records(
+            check.mapping_param(
+                materialization_records_by_key,
+                "materialization_records_by_key",
+                key_type=AssetKey,
+                value_type=(type(None), EventLogRecord),
+            )
+        )
         self._cursor_updated = True
 
     @public


### PR DESCRIPTION
user tried passing something else and got confusing stack trace

## How I Tested These Changes

existing coverage