### PR TITLE
Use a single code server

### DIFF
--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -159,7 +159,7 @@ def code_server_cli():
     type=click.INT,
     required=False,
     default=DEFAULT_HEARTBEAT_TIMEOUT,
-    help="How long to wait for a heartbeat from the caller before timing out. Defaults to 30 seconds.",
+    help="How long to wait for a heartbeat from the caller before timing out. Only comes into play if --heartbeat is set. Defaults to 30 seconds.",
 )
 @click.option(
     "--instance-ref",

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -20,6 +20,8 @@ from dagster._serdes import deserialize_value
 from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
+DEFAULT_HEARTBEAT_TIMEOUT = 30
+
 
 @click.group(name="code-server")
 def code_server_cli():
@@ -145,6 +147,21 @@ def code_server_cli():
     envvar="DAGSTER_CODE_SERVER_STARTUP_TIMEOUT",
 )
 @click.option(
+    "--heartbeat",
+    is_flag=True,
+    help=(
+        "If set, the GRPC server will shut itself down when it fails to receive a heartbeat "
+        "after a timeout configurable with --heartbeat-timeout."
+    ),
+)
+@click.option(
+    "--heartbeat-timeout",
+    type=click.INT,
+    required=False,
+    default=DEFAULT_HEARTBEAT_TIMEOUT,
+    help="How long to wait for a heartbeat from the caller before timing out. Defaults to 30 seconds.",
+)
+@click.option(
     "--instance-ref",
     type=click.STRING,
     required=False,
@@ -165,6 +182,8 @@ def start_command(
     location_name: Optional[str] = None,
     inject_env_vars_from_instance: bool = False,
     startup_timeout: int = 0,
+    heartbeat: bool = False,
+    heartbeat_timeout: int = DEFAULT_HEARTBEAT_TIMEOUT,
     instance_ref=None,
     **kwargs,
 ):
@@ -231,6 +250,8 @@ def start_command(
         instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
         server_termination_event=server_termination_event,
         logger=logger,
+        server_heartbeat=heartbeat,
+        server_heartbeat_timeout=heartbeat_timeout,
     )
     server = DagsterGrpcServer(
         server_termination_event=server_termination_event,

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -2,13 +2,15 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import click
+import yaml
 
-import dagster._check as check
 from dagster._annotations import deprecated
 from dagster._cli.job import apply_click_params
 from dagster._cli.utils import get_possibly_temporary_instance_for_cli
@@ -21,6 +23,8 @@ from dagster._cli.workspace.cli_target import (
     working_directory_option,
     workspace_option,
 )
+from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._grpc.server import GrpcServerCommand
 from dagster._serdes import serialize_value
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
@@ -122,8 +126,7 @@ def dev_command(
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")
 
-    # Sanity check workspace args
-    get_workspace_load_target(kwargs)
+    workspace_target = get_workspace_load_target(kwargs)
 
     dagster_home_path = os.getenv("DAGSTER_HOME")
 
@@ -140,103 +143,100 @@ def dev_command(
             )
 
     with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
-        logger.info("Launching Dagster services...")
+        with WorkspaceProcessContext(
+            instance,
+            workspace_target,
+            code_server_log_level=code_server_log_level,
+            server_command=GrpcServerCommand.CODE_SERVER_START,
+        ) as context:
+            with _temp_grpc_socket_workspace_file(context) as workspace_file:
+                logger.info("Launching Dagster services...")
 
-        args = [
-            "--instance-ref",
-            serialize_value(instance.get_ref()),
-            "--code-server-log-level",
-            code_server_log_level,
-        ]
+                args = [
+                    "--instance-ref",
+                    serialize_value(instance.get_ref()),
+                    "--workspace",
+                    workspace_file,
+                    "--code-server-log-level",
+                    code_server_log_level,
+                ]
 
-        if kwargs.get("workspace"):
-            for workspace in check.tuple_elem(kwargs, "workspace"):
-                args.extend(["--workspace", workspace])
+                if kwargs.get("use_ssl"):
+                    args.extend(["--use-ssl"])
 
-        if kwargs.get("python_file"):
-            for python_file in check.tuple_elem(kwargs, "python_file"):
-                args.extend(["--python-file", python_file])
-
-        if kwargs.get("module_name"):
-            for module_name in check.tuple_elem(kwargs, "module_name"):
-                args.extend(["--module-name", module_name])
-
-        if kwargs.get("working_directory"):
-            args.extend(["--working-directory", check.str_elem(kwargs, "working_directory")])
-
-        if kwargs.get("grpc_port"):
-            args.extend(["--grpc-port", str(kwargs["grpc_port"])])
-
-        if kwargs.get("grpc_host"):
-            args.extend(["--grpc-host", str(kwargs["grpc_host"])])
-
-        if kwargs.get("grpc_socket"):
-            args.extend(["--grpc-socket", str(kwargs["grpc_socket"])])
-
-        if kwargs.get("use_ssl"):
-            args.extend(["--use-ssl"])
-
-        webserver_process = open_ipc_subprocess(
-            [sys.executable, "-m", "dagster_webserver"]
-            + (["--port", port] if port else [])
-            + (["--host", host] if host else [])
-            + (["--dagster-log-level", log_level])
-            + (["--log-format", log_format])
-            + (["--live-data-poll-rate", live_data_poll_rate] if live_data_poll_rate else [])
-            + args
-        )
-        daemon_process = open_ipc_subprocess(
-            [
-                sys.executable,
-                "-m",
-                "dagster._daemon",
-                "run",
-                "--log-level",
-                log_level,
-                "--log-format",
-                log_format,
-            ]
-            + args
-        )
-        try:
-            while True:
-                time.sleep(_CHECK_SUBPROCESS_INTERVAL)
-
-                if webserver_process.poll() is not None:
-                    raise Exception(
-                        "dagster-webserver process shut down unexpectedly with return code"
-                        f" {webserver_process.returncode}"
+                webserver_process = open_ipc_subprocess(
+                    [sys.executable, "-m", "dagster_webserver"]
+                    + (["--port", port] if port else [])
+                    + (["--host", host] if host else [])
+                    + (["--dagster-log-level", log_level])
+                    + (["--log-format", log_format])
+                    + (
+                        ["--live-data-poll-rate", live_data_poll_rate]
+                        if live_data_poll_rate
+                        else []
                     )
-
-                if daemon_process.poll() is not None:
-                    raise Exception(
-                        "dagster-daemon process shut down unexpectedly with return code"
-                        f" {daemon_process.returncode}"
-                    )
-
-        except KeyboardInterrupt:
-            logger.info("KeyboardInterrupt received")
-        except:
-            logger.exception("An unexpected exception has occurred")
-        finally:
-            logger.info("Shutting down Dagster services...")
-            interrupt_ipc_subprocess(daemon_process)
-            interrupt_ipc_subprocess(webserver_process)
-
-            try:
-                webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                logger.warning(
-                    "dagster-webserver process did not terminate cleanly, killing the process"
+                    + args
                 )
-                webserver_process.kill()
-
-            try:
-                daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                logger.warning(
-                    "dagster-daemon process did not terminate cleanly, killing the process"
+                daemon_process = open_ipc_subprocess(
+                    [
+                        sys.executable,
+                        "-m",
+                        "dagster._daemon",
+                        "run",
+                        "--log-level",
+                        log_level,
+                        "--log-format",
+                        log_format,
+                    ]
+                    + args
                 )
-                daemon_process.kill()
+                try:
+                    while True:
+                        time.sleep(_CHECK_SUBPROCESS_INTERVAL)
 
-            logger.info("Dagster services shut down.")
+                        if webserver_process.poll() is not None:
+                            raise Exception(
+                                "dagster-webserver process shut down unexpectedly with return code"
+                                f" {webserver_process.returncode}"
+                            )
+
+                        if daemon_process.poll() is not None:
+                            raise Exception(
+                                "dagster-daemon process shut down unexpectedly with return code"
+                                f" {daemon_process.returncode}"
+                            )
+
+                except KeyboardInterrupt:
+                    logger.info("KeyboardInterrupt received")
+                except:
+                    logger.exception("An unexpected exception has occurred")
+                finally:
+                    logger.info("Shutting down Dagster services...")
+                    interrupt_ipc_subprocess(daemon_process)
+                    interrupt_ipc_subprocess(webserver_process)
+
+                    try:
+                        webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            "dagster-webserver process did not terminate cleanly, killing the process"
+                        )
+                        webserver_process.kill()
+
+                    try:
+                        daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            "dagster-daemon process did not terminate cleanly, killing the process"
+                        )
+                        daemon_process.kill()
+
+                    logger.info("Dagster services shut down.")
+
+
+@contextmanager
+def _temp_grpc_socket_workspace_file(context: WorkspaceProcessContext) -> Iterator[str]:
+    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+        temp_file.write(yaml.dump({"load_from": context.code_server_specs}))
+        temp_file.flush()
+        yield temp_file.name

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -14,7 +14,7 @@ from dagster._core.remote_representation.origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._grpc.server import GrpcServerProcess
+from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
 from dagster._time import get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -67,6 +67,7 @@ class GrpcServerRegistry(AbstractContextManager):
     def __init__(
         self,
         instance_ref: Optional[InstanceRef],
+        server_command: GrpcServerCommand,
         # How long the process can live without a heartbeat before it dies. You should ensure
         # that any processes returned by this registry have at least one
         # GrpcServerCodeLocation hitting the server with a heartbeat while you want the
@@ -82,6 +83,7 @@ class GrpcServerRegistry(AbstractContextManager):
         additional_timeout_msg: Optional[str] = None,
     ):
         self.instance_ref = instance_ref
+        self.server_command = server_command
 
         # map of servers being currently returned, keyed by origin ID
         self._active_entries: Dict[str, Union[ServerRegistryEntry, ErrorRegistryEntry]] = {}
@@ -187,6 +189,7 @@ class GrpcServerRegistry(AbstractContextManager):
                 new_server_id = str(uuid.uuid4())
                 server_process = GrpcServerProcess(
                     instance_ref=self.instance_ref,
+                    server_command=self.server_command,
                     location_name=code_location_origin.location_name,
                     loadable_target_origin=loadable_target_origin,
                     heartbeat=True,

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -304,7 +304,8 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
 
 # Different storage name for backcompat
 @whitelist_for_serdes(
-    storage_name="GrpcServerRepositoryLocationOrigin", skip_when_empty_fields={"use_ssl"}
+    storage_name="GrpcServerRepositoryLocationOrigin",
+    skip_when_empty_fields={"use_ssl", "additional_metadata"},
 )
 class GrpcServerCodeLocationOrigin(
     NamedTuple(
@@ -315,6 +316,7 @@ class GrpcServerCodeLocationOrigin(
             ("socket", Optional[str]),
             ("location_name", str),
             ("use_ssl", Optional[bool]),
+            ("additional_metadata", Optional[Mapping[str, Any]]),
         ],
     ),
     CodeLocationOrigin,
@@ -330,6 +332,7 @@ class GrpcServerCodeLocationOrigin(
         socket: Optional[str] = None,
         location_name: Optional[str] = None,
         use_ssl: Optional[bool] = None,
+        additional_metadata: Optional[Mapping[str, Any]] = None,
     ):
         return super(GrpcServerCodeLocationOrigin, cls).__new__(
             cls,
@@ -342,6 +345,7 @@ class GrpcServerCodeLocationOrigin(
                 else _assign_grpc_location_name(port, socket, host)
             ),
             use_ssl if check.opt_bool_param(use_ssl, "use_ssl") else None,
+            additional_metadata=check.opt_mapping_param(additional_metadata, "additional_metadata"),
         )
 
     def get_display_metadata(self) -> Mapping[str, str]:
@@ -349,6 +353,7 @@ class GrpcServerCodeLocationOrigin(
             "host": self.host,
             "port": str(self.port) if self.port else None,
             "socket": self.socket,
+            **(self.additional_metadata if self.additional_metadata else {}),
         }
         return {key: value for key, value in metadata.items() if value is not None}
 

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -274,9 +274,11 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
         from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
         from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
         from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
+        from dagster._grpc.server import GrpcServerCommand
 
         with GrpcServerRegistry(
             instance_ref=instance.get_ref(),
+            server_command=GrpcServerCommand.API_GRPC,
             heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
             startup_timeout=(
                 instance.code_server_process_startup_timeout

--- a/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
+++ b/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
@@ -60,6 +60,10 @@ class LoadableTargetOrigin(
             )
         return ctx
 
+    @property
+    def as_dict(self) -> dict:
+        return {k: v for k, v in self._asdict().items() if v is not None}
+
 
 _current_loadable_target_origin: ContextVar[Optional[LoadableTargetOrigin]] = ContextVar(
     "_current_loadable_target_origin", default=None

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -11,6 +11,7 @@ from dagster._config import (
     StringSource,
     process_config,
 )
+from dagster._config.field_utils import Permissive
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.merger import merge_dicts
 
@@ -87,6 +88,7 @@ WORKSPACE_CONFIG_SCHEMA = {
                             "port": Field(IntSource, is_required=False),
                             "location_name": Field(StringSource, is_required=False),
                             "ssl": Field(bool, is_required=False),
+                            "additional_metadata": Field(Permissive(), is_required=False),
                         },
                     },
                 )

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -624,6 +624,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         read_only: bool = False,
         grpc_server_registry: Optional[GrpcServerRegistry] = None,
         code_server_log_level: str = "INFO",
+        server_command: GrpcServerCommand = GrpcServerCommand.API_GRPC,
     ):
         self._stack = ExitStack()
 
@@ -657,7 +658,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             self._grpc_server_registry = self._stack.enter_context(
                 GrpcServerRegistry(
                     instance_ref=self._instance.get_ref(),
-                    server_command=GrpcServerCommand.API_GRPC,
+                    server_command=server_command,
                     heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
@@ -681,6 +682,31 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
     @property
     def _origins(self) -> Sequence[CodeLocationOrigin]:
         return self._workspace_load_target.create_origins() if self._workspace_load_target else []
+
+    @property
+    def code_server_specs(self) -> Sequence[Mapping[str, Mapping[str, Any]]]:
+        result = []
+        for origin in self._origins:
+            if isinstance(origin, ManagedGrpcPythonEnvCodeLocationOrigin):
+                grpc_endpoint = self._grpc_server_registry.get_grpc_endpoint(origin)
+                server_spec = {
+                    "location_name": origin.location_name,
+                    "socket": grpc_endpoint.socket,
+                    "port": grpc_endpoint.port,
+                    "host": grpc_endpoint.host,
+                    "additional_metadata": origin.loadable_target_origin.as_dict,
+                }
+            elif isinstance(origin, GrpcServerCodeLocationOrigin):
+                server_spec = {
+                    "location_name": origin.location_name,
+                    "host": origin.host,
+                    "port": origin.port,
+                    "additional_metadata": origin.additional_metadata,
+                }
+            else:
+                check.failed(f"Unexpected origin type {origin}")
+            result.append({"grpc_server": {k: v for k, v in server_spec.items() if v is not None}})
+        return result
 
     def add_state_subscriber(self, subscriber: LocationStateSubscriber) -> int:
         token = next(self._state_subscriber_id_iter)

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -76,7 +76,7 @@ from dagster._core.workspace.workspace import (
     WorkspaceSnapshot,
     location_status_from_location_entry,
 )
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG
+from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
 from dagster._time import get_current_timestamp
 from dagster._utils.aiodataloader import DataLoader
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
@@ -657,6 +657,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             self._grpc_server_registry = self._stack.enter_context(
                 GrpcServerRegistry(
                     instance_ref=self._instance.get_ref(),
+                    server_command=GrpcServerCommand.API_GRPC,
                     heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -261,12 +261,13 @@ def _location_origin_from_grpc_server_config(
     check.mapping_param(grpc_server_config, "grpc_server_config")
     check.str_param(yaml_path, "yaml_path")
 
-    port, socket, host, location_name, use_ssl = (
+    port, socket, host, location_name, use_ssl, additional_metadata = (
         grpc_server_config.get("port"),
         grpc_server_config.get("socket"),
         grpc_server_config.get("host"),
         grpc_server_config.get("location_name"),
         grpc_server_config.get("ssl"),
+        grpc_server_config.get("additional_metadata"),
     )
 
     check.invariant(
@@ -282,6 +283,7 @@ def _location_origin_from_grpc_server_config(
         host=host,
         location_name=location_name,
         use_ssl=use_ssl,
+        additional_metadata=additional_metadata,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -26,7 +26,7 @@ from dagster._daemon.daemon import (
 )
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG
+from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.interrupts import raise_interrupts_as
 from dagster._utils.log import configure_loggers
@@ -74,6 +74,7 @@ def create_daemon_grpc_server_registry(
 ) -> GrpcServerRegistry:
     return GrpcServerRegistry(
         instance_ref=instance.get_ref(),
+        server_command=GrpcServerCommand.API_GRPC,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
         additional_timeout_msg=INCREASE_TIMEOUT_DAGSTER_YAML_MSG,

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -240,8 +240,12 @@ class DagsterProxyApiServicer(DagsterApiServicer):
     def Ping(self, request, context):
         return self._query("Ping", request, context)
 
-    def GetServerId(self, request, context):
-        return self._fixed_server_id or self._query("GetServerId", request, context)
+    def GetServerId(self, request, context) -> api_pb2.GetServerIdReply:
+        return (
+            api_pb2.GetServerIdReply(server_id=self._fixed_server_id)
+            if self._fixed_server_id
+            else self._query("GetServerId", request, context)
+        )
 
     def GetCurrentImage(self, request, context):
         return self._query("GetCurrentImage", request, context)

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -13,6 +13,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import api_pb2
 from dagster._grpc.__generated__.api_pb2_grpc import DagsterApiServicer
 from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
+from dagster._grpc.server import GrpcServerCommand
 from dagster._grpc.types import (
     CancelExecutionRequest,
     CancelExecutionResult,
@@ -75,6 +76,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         self._grpc_server_registry = self._exit_stack.enter_context(
             GrpcServerRegistry(
                 instance_ref=self._instance_ref,
+                server_command=GrpcServerCommand.API_GRPC,
                 heartbeat_ttl=30,
                 startup_timeout=startup_timeout,
                 log_level=self._log_level,
@@ -195,6 +197,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             if self._shutdown_once_executions_finish_event.is_set():
                 if self._grpc_server_registry.are_all_servers_shut_down():
                     self._server_termination_event.set()
+                    self._grpc_server_registry.shutdown_all_processes()
 
     def _get_grpc_client(self):
         return self._client
@@ -215,6 +218,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
 
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
                 self._shutdown_once_executions_finish_event.set()
+                self._grpc_server_registry.shutdown_all_processes()
 
     def _streaming_query(
         self, api_name: str, request, _context, timeout: int = DEFAULT_GRPC_TIMEOUT

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import threading
+import time
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Dict, Optional
 
@@ -48,9 +49,10 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         server_termination_event: threading.Event,
         instance_ref: Optional[InstanceRef],
         logger: logging.Logger,
+        server_heartbeat: bool,
+        server_heartbeat_timeout: int,
     ):
         super(DagsterProxyApiServicer, self).__init__()
-
         self._loadable_target_origin = loadable_target_origin
         self._fixed_server_id = fixed_server_id
         self._container_image = container_image
@@ -63,8 +65,8 @@ class DagsterProxyApiServicer(DagsterApiServicer):
 
         self._client = None
         self._load_error = None
-        self._heartbeat_shutdown_event = None
-        self._heartbeat_thread = None
+        self._client_heartbeat_shutdown_event = None
+        self._client_heartbeat_thread = None
 
         self._exit_stack = ExitStack()
 
@@ -100,6 +102,17 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             daemon=True,
         )
 
+        self.__last_heartbeat_time = time.time()
+        self.__server_heartbeat_thread = None
+        if server_heartbeat:
+            self.__server_heartbeat_thread = threading.Thread(
+                target=self._server_heartbeat_thread,
+                args=(server_heartbeat_timeout,),
+                name="grpc-server-heartbeat",
+                daemon=True,
+            )
+            self.__server_heartbeat_thread.start()
+
         self.__cleanup_thread.start()
 
         # Map runs to the client that launched them, so that we can route
@@ -121,22 +134,22 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             self._logger.exception("Failure while loading code")
 
         if self._client:
-            self._heartbeat_shutdown_event = threading.Event()
-            self._heartbeat_thread = threading.Thread(
+            self._client_heartbeat_shutdown_event = threading.Event()
+            self._client_heartbeat_thread = threading.Thread(
                 target=client_heartbeat_thread,
                 args=(
                     self._client,
-                    self._heartbeat_shutdown_event,
+                    self._client_heartbeat_shutdown_event,
                 ),
                 name="grpc-client-heartbeat",
                 daemon=True,
             )
-            self._heartbeat_thread.start()
+            self._client_heartbeat_thread.start()
 
     def ReloadCode(self, request, context):
         with self._reload_lock:  # can only call this method once at a time
-            old_heartbeat_shutdown_event = self._heartbeat_shutdown_event
-            old_heartbeat_thread = self._heartbeat_thread
+            old_heartbeat_shutdown_event = self._client_heartbeat_shutdown_event
+            old_heartbeat_thread = self._client_heartbeat_thread
             old_client = self._client
 
             self._reload_location()  # Creates and starts a new heartbeat thread
@@ -155,14 +168,19 @@ class DagsterProxyApiServicer(DagsterApiServicer):
     def cleanup(self):
         # In case ShutdownServer was not called
         self._shutdown_once_executions_finish_event.set()
+        self._grpc_server_registry.shutdown_all_processes()
 
-        if self._heartbeat_shutdown_event:
-            self._heartbeat_shutdown_event.set()
-            self._heartbeat_shutdown_event = None
+        if self._client_heartbeat_shutdown_event:
+            self._client_heartbeat_shutdown_event.set()
+            self._client_heartbeat_shutdown_event = None
 
-        if self._heartbeat_thread:
-            self._heartbeat_thread.join()
-            self._heartbeat_thread = None
+        if self._client_heartbeat_thread:
+            self._client_heartbeat_thread.join()
+            self._client_heartbeat_thread = None
+
+        if self.__server_heartbeat_thread:
+            self.__server_heartbeat_thread.join()
+            self.__server_heartbeat_thread = None
 
         self._exit_stack.close()
 
@@ -185,6 +203,18 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         if not self._client:
             raise Exception("No available client to code serer")
         return check.not_none(self._client)._get_response(api_name, request, timeout)  # noqa
+
+    def _server_heartbeat_thread(self, heartbeat_timeout: int) -> None:
+        while True:
+            if self._server_termination_event.is_set():
+                break
+
+            self._shutdown_once_executions_finish_event.wait(heartbeat_timeout)
+            if self._shutdown_once_executions_finish_event.is_set():
+                break
+
+            if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
+                self._shutdown_once_executions_finish_event.set()
 
     def _streaming_query(
         self, api_name: str, request, _context, timeout: int = DEFAULT_GRPC_TIMEOUT
@@ -216,7 +246,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         return self._streaming_query("StreamingExternalRepository", request, context)
 
     def Heartbeat(self, request, context):
-        return self._query("Heartbeat", request, context)
+        self.__last_heartbeat_time = time.time()
 
     def StreamingPing(self, request, context):
         return self._streaming_query("StreamingPing", request, context)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -10,6 +10,7 @@ import time
 import uuid
 import warnings
 from contextlib import ExitStack
+from enum import Enum
 from functools import update_wrapper
 from threading import Event as ThreadingEventType
 from time import sleep
@@ -1356,10 +1357,24 @@ def wait_for_grpc_server(
         sleep(0.1)
 
 
+class GrpcServerCommand(Enum):
+    API_GRPC = "api_grpc"
+    CODE_SERVER_START = "code_server_start"
+
+    @property
+    def server_command(self) -> Sequence[str]:
+        return (
+            ["api", "grpc", "--lazy-load-user-code"]
+            if self == GrpcServerCommand.API_GRPC
+            else ["code-server", "start"]
+        )
+
+
 def open_server_process(
     instance_ref: Optional[InstanceRef],
     port: Optional[int],
     socket: Optional[str],
+    server_command: GrpcServerCommand = GrpcServerCommand.API_GRPC,
     location_name: Optional[str] = None,
     loadable_target_origin: Optional[LoadableTargetOrigin] = None,
     max_workers: Optional[int] = None,
@@ -1382,10 +1397,10 @@ def open_server_process(
 
     executable_path = loadable_target_origin.executable_path if loadable_target_origin else None
 
+    entrypoint = get_python_environment_entry_point(executable_path or sys.executable)
     subprocess_args = [
-        *get_python_environment_entry_point(executable_path or sys.executable),
-        *["api", "grpc"],
-        *["--lazy-load-user-code"],
+        *entrypoint,
+        *server_command.server_command,
         *(["--port", str(port)] if port else []),
         *(["--socket", socket] if socket else []),
         *(["-n", str(max_workers)] if max_workers else []),
@@ -1467,6 +1482,7 @@ class GrpcServerProcess:
     def __init__(
         self,
         instance_ref: Optional[InstanceRef],
+        server_command: GrpcServerCommand = GrpcServerCommand.API_GRPC,
         location_name: Optional[str] = None,
         loadable_target_origin: Optional[LoadableTargetOrigin] = None,
         force_port: bool = False,
@@ -1533,6 +1549,7 @@ class GrpcServerProcess:
             server_process = open_server_process(
                 instance_ref=instance_ref,
                 location_name=location_name,
+                server_command=server_command,
                 port=None,
                 socket=self.socket,
                 loadable_target_origin=loadable_target_origin,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -134,6 +134,10 @@ _METRICS_LOCK = threading.Lock()
 METRICS_RETRIEVAL_FUNCTIONS = set()
 
 
+def get_auto_restart_code_server_interval() -> int:
+    return int(os.getenv("DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL", "30"))
+
+
 class GrpcApiMetrics(TypedDict):
     current_request_count: Optional[int]
 
@@ -1524,47 +1528,81 @@ class GrpcServerProcess:
             "If set to None, the server will use the gRPC default.",
         )
 
-        if seven.IS_WINDOWS or force_port:
+        self._server_command = server_command
+        self._force_port = force_port
+        self._instance_ref = instance_ref
+        self._location_name = location_name
+        self._max_retries = max_retries
+        self._max_workers = max_workers
+        self._loadable_target_origin = loadable_target_origin
+        self._heartbeat_timeout = heartbeat_timeout
+        self._fixed_server_id = fixed_server_id
+        self._startup_timeout = startup_timeout
+        self._cwd = cwd
+        self._log_level = log_level
+        self._env = env
+        self._inject_env_vars_from_instance = inject_env_vars_from_instance
+        self._container_image = container_image
+        self._container_context = container_context
+        self._additional_timeout_msg = additional_timeout_msg
+        self.socket = None
+        self.port = None
+        self.start_server_process()
+
+        self._wait_on_exit = wait_on_exit
+
+        # In the case of the `dagster code-server start` entrypoint, the proxy server will not automatically restart if it crashes. Thus, we need to implement a mechanism to automatically restart the server if it crashes.
+        self.__auto_restart_thread = None
+        self.__shutdown_event = threading.Event()
+        if server_command == GrpcServerCommand.CODE_SERVER_START:
+            self.__auto_restart_thread = threading.Thread(
+                target=self.auto_restart_thread, daemon=True
+            )
+            self.__auto_restart_thread.start()
+
+    def start_server_process(self):
+        if (seven.IS_WINDOWS or self._force_port) and self.port is None:
             server_process, self.port = _open_server_process_on_dynamic_port(
-                instance_ref=instance_ref,
-                location_name=location_name,
-                max_retries=max_retries,
-                loadable_target_origin=loadable_target_origin,
-                max_workers=max_workers,
-                heartbeat=heartbeat,
-                heartbeat_timeout=heartbeat_timeout,
-                fixed_server_id=fixed_server_id,
-                startup_timeout=startup_timeout,
-                cwd=cwd,
-                log_level=log_level,
-                env=env,
-                inject_env_vars_from_instance=inject_env_vars_from_instance,
-                container_image=container_image,
-                container_context=container_context,
-                additional_timeout_msg=additional_timeout_msg,
+                instance_ref=self._instance_ref,
+                location_name=self._location_name,
+                max_retries=self._max_retries,
+                loadable_target_origin=self._loadable_target_origin,
+                max_workers=self._max_workers,
+                heartbeat=self._heartbeat,
+                heartbeat_timeout=self._heartbeat_timeout,
+                fixed_server_id=self._fixed_server_id,
+                startup_timeout=self._startup_timeout,
+                cwd=self._cwd,
+                log_level=self._log_level,
+                env=self._env,
+                inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                container_image=self._container_image,
+                container_context=self._container_context,
+                additional_timeout_msg=self._additional_timeout_msg,
             )
         else:
-            self.socket = safe_tempfile_path_unmanaged()
+            if self.socket is None:
+                self.socket = safe_tempfile_path_unmanaged()
 
             server_process = open_server_process(
-                instance_ref=instance_ref,
-                location_name=location_name,
-                server_command=server_command,
-                port=None,
+                instance_ref=self._instance_ref,
+                location_name=self._location_name,
+                server_command=self._server_command,
+                port=self.port,
                 socket=self.socket,
-                loadable_target_origin=loadable_target_origin,
-                max_workers=max_workers,
-                heartbeat=heartbeat,
-                heartbeat_timeout=heartbeat_timeout,
-                fixed_server_id=fixed_server_id,
-                startup_timeout=startup_timeout,
-                cwd=cwd,
-                log_level=log_level,
-                env=env,
-                inject_env_vars_from_instance=inject_env_vars_from_instance,
-                container_image=container_image,
-                container_context=container_context,
-                additional_timeout_msg=additional_timeout_msg,
+                loadable_target_origin=self._loadable_target_origin,
+                max_workers=self._max_workers,
+                heartbeat=self._heartbeat,
+                heartbeat_timeout=self._heartbeat_timeout,
+                fixed_server_id=self._fixed_server_id,
+                startup_timeout=self._startup_timeout,
+                cwd=self._cwd,
+                log_level=self._log_level,
+                env=self._env,
+                inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                container_image=self._container_image,
+                container_context=self._container_context,
+                additional_timeout_msg=self._additional_timeout_msg,
             )
 
         if server_process is None:
@@ -1572,7 +1610,16 @@ class GrpcServerProcess:
         else:
             self._server_process = server_process
 
-        self._wait_on_exit = wait_on_exit
+    def auto_restart_thread(self):
+        while True:
+            time.sleep(get_auto_restart_code_server_interval())
+            if self.__shutdown_event.is_set():
+                break
+            if self._server_process and self._server_process.poll() is not None:
+                logging.getLogger(__name__).warning(
+                    f"Code server process has exited with code {self._server_process.poll()}. Restarting the code server process."
+                )
+                self.start_server_process()
 
     @property
     def server_process(self):
@@ -1597,6 +1644,9 @@ class GrpcServerProcess:
             self.wait()
 
     def shutdown_server(self):
+        self.__shutdown_event.set()
+        if self.__auto_restart_thread:
+            self.__auto_restart_thread.join()
         if self._server_process and not self._shutdown:
             self._shutdown = True
             if self.server_process.poll() is None:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -1,3 +1,5 @@
+import os
+import signal
 import sys
 import threading
 import time
@@ -6,6 +8,7 @@ from unittest import mock
 import pytest
 from dagster import file_relative_path, job, repository
 from dagster._core.errors import DagsterUserCodeProcessError
+from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.origin import (
@@ -15,6 +18,7 @@ from dagster._core.remote_representation.origin import (
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
+from dagster._utils.env import environ
 
 
 @job
@@ -97,6 +101,36 @@ def test_error_repo_in_registry(instance):
                 instance=instance,
             ):
                 pass
+
+
+def test_server_unexpectedly_killed(instance: DagsterInstance):
+    with environ({"DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL": "1"}):
+        origin = ManagedGrpcPythonEnvCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                attribute="repo",
+                python_file=file_relative_path(__file__, "test_grpc_server_registry.py"),
+            ),
+        )
+
+        with GrpcServerRegistry(
+            server_command=GrpcServerCommand.CODE_SERVER_START,
+            instance_ref=instance.get_ref(),
+            heartbeat_ttl=10,
+            startup_timeout=5,
+            wait_for_processes_on_shutdown=True,
+        ) as registry:
+            endpoint_one = registry.get_grpc_endpoint(origin)
+
+            assert _can_connect(origin, endpoint_one, instance)
+
+            # Kill the server process. A new server should be automatically started.
+            process = registry._all_processes[0]  # noqa: SLF001
+            pid = process.pid
+            os.kill(pid, signal.SIGKILL)
+            time.sleep(5)
+            endpoint_one = registry.get_grpc_endpoint(origin)
+            assert _can_connect(origin, endpoint_one, instance)
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -14,7 +14,7 @@ from dagster._core.remote_representation.origin import (
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._grpc.server import GrpcServerProcess
+from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
 
 
 @job
@@ -63,6 +63,7 @@ def test_error_repo_in_registry(instance):
         ),
     )
     with GrpcServerRegistry(
+        server_command=GrpcServerCommand.API_GRPC,
         instance_ref=instance.get_ref(),
         heartbeat_ttl=10,
         startup_timeout=5,
@@ -98,7 +99,10 @@ def test_error_repo_in_registry(instance):
                 pass
 
 
-def test_server_registry(instance):
+@pytest.mark.parametrize(
+    "server_command", [GrpcServerCommand.API_GRPC, GrpcServerCommand.CODE_SERVER_START]
+)
+def test_server_registry(instance, server_command: GrpcServerCommand):
     origin = ManagedGrpcPythonEnvCodeLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -108,6 +112,7 @@ def test_server_registry(instance):
     )
 
     with GrpcServerRegistry(
+        server_command=server_command,
         instance_ref=instance.get_ref(),
         heartbeat_ttl=10,
         startup_timeout=5,
@@ -147,7 +152,10 @@ def _registry_thread(origin, registry, endpoint, event):
         event.set()
 
 
-def test_registry_multithreading(instance):
+@pytest.mark.parametrize(
+    "server_command", [GrpcServerCommand.API_GRPC, GrpcServerCommand.CODE_SERVER_START]
+)
+def test_registry_multithreading(instance, server_command: GrpcServerCommand):
     origin = ManagedGrpcPythonEnvCodeLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -157,6 +165,7 @@ def test_registry_multithreading(instance):
     )
 
     with GrpcServerRegistry(
+        server_command=server_command,
         instance_ref=instance.get_ref(),
         heartbeat_ttl=600,
         startup_timeout=30,
@@ -190,6 +199,7 @@ class TestMockProcessGrpcServerRegistry(GrpcServerRegistry):
     def __init__(self, instance):
         self.mocked_loadable_target_origin = None
         super(TestMockProcessGrpcServerRegistry, self).__init__(
+            server_command=GrpcServerCommand.API_GRPC,
             instance_ref=instance.get_ref(),
             heartbeat_ttl=600,
             startup_timeout=30,
@@ -249,6 +259,7 @@ def test_failure_on_open_server_process(instance):
         mock_open_server_process.side_effect = Exception("OOPS")
         with pytest.raises(Exception, match="OOPS"):
             with GrpcServerProcess(
+                server_command=GrpcServerCommand.API_GRPC,
                 instance_ref=instance.get_ref(),
                 loadable_target_origin=loadable_target_origin,
             ):

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -25,7 +25,12 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import ExecuteExternalJobArgs, open_server_process, wait_for_grpc_server
+from dagster._grpc.server import (
+    ExecuteExternalJobArgs,
+    GrpcServerCommand,
+    open_server_process,
+    wait_for_grpc_server,
+)
 from dagster._grpc.types import (
     JobSubsetSnapshotArgs,
     ListRepositoriesResponse,
@@ -106,7 +111,11 @@ def test_python_environment_args():
         process = None
         try:
             process = open_server_process(
-                instance.get_ref(), port, socket=None, loadable_target_origin=loadable_target_origin
+                server_command=GrpcServerCommand.API_GRPC,
+                instance_ref=instance.get_ref(),
+                port=port,
+                socket=None,
+                loadable_target_origin=loadable_target_origin,
             )
             assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]  # pyright: ignore[reportIndexIssue]
         finally:
@@ -130,8 +139,9 @@ def test_env_var_port_collision():
             # env var that would cause a collision with port if we are not careful
             with environ({"DAGSTER_GRPC_SOCKET": str(socket)}):
                 process = open_server_process(
-                    instance.get_ref(),
-                    port,
+                    instance_ref=instance.get_ref(),
+                    port=port,
+                    server_command=GrpcServerCommand.API_GRPC,
                     socket=None,
                     loadable_target_origin=loadable_target_origin,
                 )
@@ -146,7 +156,8 @@ def test_env_var_port_collision():
             # env var that would cause a collision with socket if we are not careful
             with environ({"DAGSTER_GRPC_PORT": str(port)}):
                 process = open_server_process(
-                    instance.get_ref(),
+                    instance_ref=instance.get_ref(),
+                    server_command=GrpcServerCommand.API_GRPC,
                     port=None,
                     socket=socket,
                     loadable_target_origin=loadable_target_origin,
@@ -168,7 +179,11 @@ def test_empty_executable_args():
     with instance_for_test() as instance:
         try:
             process = open_server_process(
-                instance.get_ref(), port, socket=None, loadable_target_origin=loadable_target_origin
+                instance_ref=instance.get_ref(),
+                port=port,
+                server_command=GrpcServerCommand.API_GRPC,
+                socket=None,
+                loadable_target_origin=loadable_target_origin,
             )
             assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]  # pyright: ignore[reportIndexIssue]
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -16,6 +16,7 @@ from dagster._core.utils import FuturesAwareThreadPoolExecutor
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer, ephemeral_grpc_api_client
 from dagster._grpc.server import (
     DagsterCodeServerUtilizationMetrics,
+    GrpcServerCommand,
     GrpcServerProcess,
     open_server_process,
 )
@@ -65,7 +66,9 @@ def test_server_port_and_socket():
 def test_server_socket():
     with instance_for_test() as instance:
         with safe_tempfile_path() as skt:
-            server_process = open_server_process(instance.get_ref(), port=None, socket=skt)
+            server_process = open_server_process(
+                instance.get_ref(), port=None, socket=skt, server_command=GrpcServerCommand.API_GRPC
+            )
             try:
                 assert DagsterGrpcClient(socket=skt).ping("foobar") == {
                     "echo": "foobar",
@@ -106,7 +109,9 @@ def test_process_killed_after_server_finished():
 def test_server_port():
     with instance_for_test() as instance:
         port = find_free_port()
-        server_process = open_server_process(instance.get_ref(), port=port, socket=None)
+        server_process = open_server_process(
+            instance.get_ref(), port=port, socket=None, server_command=GrpcServerCommand.API_GRPC
+        )
         assert server_process is not None
 
         try:


### PR DESCRIPTION
## Summary & Motivation
Changes dagster dev to initialize a single code server instead of one per process (daemon, workspace).

As a result of this change, the grpc servers will no longer automatically start upon crash. To resolve this, introduce a "restart thread" which will automatically bring the proxy server back in the case of an unexpectedly dead proxy server.

## How I Tested These Changes
Existing dagster dev tests, a new grpcserverregistry test where we kill the proxy server and ensure a new one is spun up.

Additionally tested manually and killed the underlying proxy server, ensured that it spun the proxy server back up without issue.

## Changelog
- `dagster dev` command now spins up a single code server per code location.
