### PR TITLE
Add a "scheduled_execution_timestamp" field to schedule tick data

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2621,6 +2621,7 @@ type InstigationTick {
   requestedMaterializationsForAssets: [RequestedMaterializationsForAsset!]!
   autoMaterializeAssetEvaluationId: ID
   instigationType: InstigationType!
+  scheduledExecutionTimestamp: Float
 }
 
 type InstigationEventConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2002,6 +2002,7 @@ export type InstigationTick = {
   runIds: Array<Scalars['String']['output']>;
   runKeys: Array<Scalars['String']['output']>;
   runs: Array<Run>;
+  scheduledExecutionTimestamp: Maybe<Scalars['Float']['output']>;
   skipReason: Maybe<Scalars['String']['output']>;
   status: InstigationTickStatus;
   tickId: Scalars['ID']['output'];
@@ -9148,6 +9149,10 @@ export const buildInstigationTick = (
     runIds: overrides && overrides.hasOwnProperty('runIds') ? overrides.runIds! : [],
     runKeys: overrides && overrides.hasOwnProperty('runKeys') ? overrides.runKeys! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],
+    scheduledExecutionTimestamp:
+      overrides && overrides.hasOwnProperty('scheduledExecutionTimestamp')
+        ? overrides.scheduledExecutionTimestamp!
+        : 9.95,
     skipReason:
       overrides && overrides.hasOwnProperty('skipReason') ? overrides.skipReason! : 'maxime',
     status:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -252,6 +252,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     requestedMaterializationsForAssets = non_null_list(GrapheneRequestedMaterializationsForAsset)
     autoMaterializeAssetEvaluationId = graphene.Field(graphene.ID)
     instigationType = graphene.NonNull(GrapheneInstigationType)
+    scheduledExecutionTimestamp = graphene.Field(graphene.Float)
 
     class Meta:
         name = "InstigationTick"
@@ -279,6 +280,13 @@ class GrapheneInstigationTick(graphene.ObjectType):
 
     def resolve_tickId(self, _: ResolveInfo) -> str:
         return str(self._tick.tick_id)
+
+    def resolve_scheduledExecutionTimestamp(self, _: ResolveInfo) -> Optional[float]:
+        return (
+            self._tick.scheduled_execution_time
+            if self._tick.instigator_type == InstigatorType.SCHEDULE
+            else None
+        )
 
     def resolve_runs(self, graphene_info: ResolveInfo):
         from dagster_graphql.schema.pipelines.pipeline import GrapheneRun

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -298,6 +298,9 @@ class AutoMaterializeLaunchContext:
                         error=error_data,
                         # don't increment the failure count - retry until the server is available again
                         failure_count=self._tick.failure_count,
+                        consecutive_failure_count=(
+                            (self._tick.consecutive_failure_count or self._tick.failure_count) + 1
+                        ),
                     )
             else:
                 error_data = DaemonErrorCapture.process_exception(
@@ -306,7 +309,12 @@ class AutoMaterializeLaunchContext:
                     log_message="Asset daemon tick caught an error",
                 )
                 self.update_state(
-                    TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
+                    TickStatus.FAILURE,
+                    error=error_data,
+                    failure_count=self._tick.failure_count + 1,
+                    consecutive_failure_count=(
+                        (self._tick.consecutive_failure_count or self._tick.failure_count) + 1
+                    ),
                 )
 
         check.invariant(
@@ -764,10 +772,16 @@ class AssetDaemon(DagsterDaemon):
             # Determine if the most recent tick requires retrying
             retry_tick: Optional[InstigatorTick] = None
             override_evaluation_id: Optional[int] = None
+            consecutive_failure_count: int = 0
             if latest_tick:
                 can_resume = (
                     get_current_timestamp() - latest_tick.timestamp
                 ) <= MAX_TIME_TO_RESUME_TICK_SECONDS
+
+                if latest_tick.status in {TickStatus.FAILURE, TickStatus.STARTED}:
+                    consecutive_failure_count = (
+                        latest_tick.consecutive_failure_count or latest_tick.failure_count
+                    )
 
                 # the evaluation ids not matching indicates that the tick failed or crashed before
                 # the cursor could be written, so no new runs could have been launched and it's
@@ -833,6 +847,7 @@ class AssetDaemon(DagsterDaemon):
                         status=TickStatus.STARTED,
                         timestamp=evaluation_time.timestamp(),
                         selector_id=instigator_selector_id,
+                        consecutive_failure_count=consecutive_failure_count,
                         # we only set the auto_materialize_evaluation_id if it is not equal to the
                         # current tick id
                         auto_materialize_evaluation_id=override_evaluation_id,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -289,6 +289,7 @@ class SensorLaunchContext(AbstractContextManager):
                         error=error_data,
                         # don't increment the failure count - retry until the server is available again
                         failure_count=self._tick.failure_count,
+                        consecutive_failure_count=self._tick.consecutive_failure_count + 1,
                     )
             else:
                 error_data = DaemonErrorCapture.process_exception(
@@ -297,7 +298,10 @@ class SensorLaunchContext(AbstractContextManager):
                     log_message="Sensor tick caught an error",
                 )
                 self.update_state(
-                    TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
+                    TickStatus.FAILURE,
+                    error=error_data,
+                    failure_count=self._tick.failure_count + 1,
+                    consecutive_failure_count=self._tick.consecutive_failure_count + 1,
                 )
 
         self._write()
@@ -478,51 +482,49 @@ def _get_evaluation_tick(
     origin_id = sensor.get_remote_origin_id()
     selector_id = sensor.get_remote_origin().get_selector().get_id()
 
+    consecutive_failure_count = 0
+
     if instigator_data and instigator_data.last_tick_success_timestamp:
-        # if a last tick end timestamp was set, then the previous tick could not have been
+        # if a last tick success timestamp was set, then the previous tick could not have been
         # interrupted, so there is no need to fetch the previous tick
-        potentially_interrupted_tick = None
+        most_recent_tick = None
     else:
-        potentially_interrupted_tick = next(
-            iter(instance.get_ticks(origin_id, selector_id, limit=1)), None
-        )
+        most_recent_tick = next(iter(instance.get_ticks(origin_id, selector_id, limit=1)), None)
 
     # check for unfinished work on the previous tick
-    if potentially_interrupted_tick is not None:
-        has_unrequested_runs = (
-            len(potentially_interrupted_tick.unsubmitted_run_ids_with_requests) > 0
-        )
-        if potentially_interrupted_tick.status == TickStatus.STARTED:
+    if most_recent_tick is not None:
+        if most_recent_tick.status in {TickStatus.FAILURE, TickStatus.STARTED}:
+            consecutive_failure_count = (
+                most_recent_tick.consecutive_failure_count or most_recent_tick.failure_count
+            )
+
+        has_unrequested_runs = len(most_recent_tick.unsubmitted_run_ids_with_requests) > 0
+        if most_recent_tick.status == TickStatus.STARTED:
             # if the previous tick was interrupted before it was able to request all of its runs,
             # and it hasn't been too long, then resume execution of that tick
             if (
-                evaluation_timestamp - potentially_interrupted_tick.timestamp
-                <= MAX_TIME_TO_RESUME_TICK_SECONDS
+                evaluation_timestamp - most_recent_tick.timestamp <= MAX_TIME_TO_RESUME_TICK_SECONDS
                 and has_unrequested_runs
             ):
                 logger.warn(
-                    f"Tick {potentially_interrupted_tick.tick_id} was interrupted part-way through, resuming"
+                    f"Tick {most_recent_tick.tick_id} was interrupted part-way through, resuming"
                 )
-                return potentially_interrupted_tick
+                return most_recent_tick
+
             else:
                 # previous tick won't be resumed - move it into a SKIPPED state so it isn't left
                 # dangling in STARTED, but don't return it
-                logger.warn(
-                    f"Moving dangling STARTED tick {potentially_interrupted_tick.tick_id} into SKIPPED"
-                )
-                potentially_interrupted_tick = potentially_interrupted_tick.with_status(
-                    status=TickStatus.SKIPPED
-                )
-                instance.update_tick(potentially_interrupted_tick)
+                logger.warn(f"Moving dangling STARTED tick {most_recent_tick.tick_id} into SKIPPED")
+                most_recent_tick = most_recent_tick.with_status(status=TickStatus.SKIPPED)
+                instance.update_tick(most_recent_tick)
         elif (
-            potentially_interrupted_tick.status == TickStatus.FAILURE
-            and potentially_interrupted_tick.tick_data.failure_count
-            <= MAX_FAILURE_RESUBMISSION_RETRIES
+            most_recent_tick.status == TickStatus.FAILURE
+            and most_recent_tick.tick_data.failure_count <= MAX_FAILURE_RESUBMISSION_RETRIES
             and has_unrequested_runs
         ):
-            logger.info(f"Retrying failed tick {potentially_interrupted_tick.tick_id}")
+            logger.info(f"Retrying failed tick {most_recent_tick.tick_id}")
             return instance.create_tick(
-                potentially_interrupted_tick.tick_data.with_status(
+                most_recent_tick.tick_data.with_status(
                     TickStatus.STARTED,
                     error=None,
                     timestamp=evaluation_timestamp,
@@ -539,6 +541,7 @@ def _get_evaluation_tick(
             status=TickStatus.STARTED,
             timestamp=evaluation_timestamp,
             selector_id=selector_id,
+            consecutive_failure_count=consecutive_failure_count,
         )
     )
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -665,11 +665,7 @@ def launch_scheduled_runs_for_schedule_iterator(
             check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
 
         with _ScheduleLaunchContext(
-            remote_schedule,
-            tick,
-            instance,
-            logger,
-            tick_retention_settings,
+            remote_schedule, tick, instance, logger, tick_retention_settings
         ) as tick_context:
             try:
                 check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -560,14 +560,14 @@ def launch_scheduled_runs_for_schedule_iterator(
             # Scheduler was interrupted while performing this tick, re-do it
             start_timestamp_utc = max(
                 start_timestamp_utc,
-                latest_tick.timestamp,
+                latest_tick.scheduled_execution_time,
                 instigator_data.last_iteration_timestamp or 0.0,
                 in_memory_last_iteration_timestamp or 0.0,
             )
         else:
             start_timestamp_utc = max(
                 start_timestamp_utc,
-                latest_tick.timestamp + 1,
+                latest_tick.scheduled_execution_time + 1,
                 instigator_data.last_iteration_timestamp or 0.0,
                 in_memory_last_iteration_timestamp or 0.0,
             )
@@ -641,7 +641,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                 latest_tick.consecutive_failure_count or latest_tick.failure_count
             )
 
-        if latest_tick and latest_tick.timestamp == schedule_timestamp:
+        if latest_tick and latest_tick.scheduled_execution_time == schedule_timestamp:
             tick = latest_tick
             if latest_tick.status == TickStatus.FAILURE:
                 logger.info(f"Retrying previously failed schedule execution at {schedule_time_str}")
@@ -659,6 +659,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                     timestamp=schedule_timestamp,
                     selector_id=remote_schedule.selector_id,
                     consecutive_failure_count=consecutive_failure_count,
+                    scheduled_execution_time=schedule_timestamp,
                 )
             )
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -661,6 +661,7 @@ def validate_tick(
 
     assert tick_data.instigator_origin_id == remote_schedule.get_remote_origin_id()
     assert tick_data.instigator_name == remote_schedule.name
+    assert tick_data.scheduled_execution_time == expected_datetime.timestamp()
     assert tick_data.timestamp == expected_datetime.timestamp()
     assert tick_data.status == expected_status
     assert len(tick_data.run_ids) == len(expected_run_ids) and set(tick_data.run_ids) == set(


### PR DESCRIPTION
Summary:
This paves the way to make schedule retry behavior more like sensor retry behavior. Right now if a schedule fails, it retries for the same time using the same tick, and the timestamp of that tick is synonymous with the scheduled time in the cron schedule. This differs from sensor retries. This divergence in behavior is confusing and leads to issues like schedule failure alerts leading nowhere, since the schedule tick retried and succeeded.

By adding this field, we can eventually change this behavior so that a retried schedule tick keeps the scheduled_execution_timestamp field, but updates the timestamp field and creates a new tick on the timeline.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
