### PR TITLE
[components] Separate out generator into separate class that can be dynamically imported

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/generate.py
@@ -11,7 +11,10 @@ from dagster_components.core.deployment import (
     find_enclosing_code_location_root_path,
     is_inside_code_location_project,
 )
-from dagster_components.generate import generate_component_instance
+from dagster_components.generate import (
+    ComponentGeneratorUnavailableReason,
+    generate_component_instance,
+)
 from dagster_components.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
 
 
@@ -54,8 +57,18 @@ def generate_component_command(
 
     component_type_cls = context.get_component_type(component_type)
     if json_params:
-        generate_params_schema = component_type_cls.generate_params_schema
-        generate_params = TypeAdapter(generate_params_schema).validate_json(json_params)
+        # TODO: when conversion to generator is complete, remove this block
+        if component_type_cls.generate_params_schema:
+            generate_params = TypeAdapter(component_type_cls.generate_params_schema).validate_json(
+                json_params
+            )
+        else:
+            generator = component_type_cls.get_generator()
+            if isinstance(generator, ComponentGeneratorUnavailableReason):
+                raise Exception(
+                    f"Component type {component_type} does not have a generator. Reason: {generator.message}."
+                )
+            generate_params = TypeAdapter(generator.generator_params).validate_json(json_params)
     else:
         generate_params = {}
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -27,28 +27,19 @@ import click
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterError
-from dagster._record import record
 from dagster._utils import pushd, snakecase
 from pydantic import TypeAdapter
 from typing_extensions import Self
 
+from dagster_components.core.component_generator import (
+    ComponentGenerateRequest,
+    ComponentGenerator,
+    ComponentGeneratorUnavailableReason,
+)
 from dagster_components.core.component_rendering import TemplatedValueResolver
 
 
 class ComponentDeclNode: ...
-
-
-@record
-class ComponentGenerateRequest:
-    component_type_name: str
-    component_instance_root_path: Path
-
-
-class ComponentGenerator:
-    generator_params: ClassVar = None
-
-    @abstractmethod
-    def generate_files(self, request: ComponentGenerateRequest, params: Any) -> None: ...
 
 
 # This calls the legacy classmethod `generate_files` on the component type. Will be removed
@@ -59,11 +50,6 @@ class ComponentGeneratorAdapter(ComponentGenerator):
 
     def generate_files(self, request, params):
         return self.component_type.generate_files(request, params)
-
-
-@dataclass
-class ComponentGeneratorUnavailableReason:
-    message: str
 
 
 class Component(ABC):
@@ -84,6 +70,7 @@ class Component(ABC):
 
     @classmethod
     def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None:
+        # This will be deleted once all components are converted to the new ComponentGenerator API
         from dagster_components.generate import generate_component_yaml
 
         generate_component_yaml(request, {})

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -20,6 +20,7 @@ from typing import (
     Type,
     TypedDict,
     TypeVar,
+    Union,
 )
 
 import click
@@ -43,20 +44,53 @@ class ComponentGenerateRequest:
     component_instance_root_path: Path
 
 
+class ComponentGenerator:
+    generator_params: ClassVar = None
+
+    @abstractmethod
+    def generate_files(self, request: ComponentGenerateRequest, params: Any) -> None: ...
+
+
+# This calls the legacy classmethod `generate_files` on the component type. Will be removed
+# once conversion to the new API is complete.
+class ComponentGeneratorAdapter(ComponentGenerator):
+    def __init__(self, comonent_type: Type["Component"]):
+        self.component_type = comonent_type
+
+    def generate_files(self, request, params):
+        return self.component_type.generate_files(request, params)
+
+
+@dataclass
+class ComponentGeneratorUnavailableReason:
+    message: str
+
+
 class Component(ABC):
     name: ClassVar[Optional[str]] = None
     params_schema: ClassVar = None
     generate_params_schema: ClassVar = None
 
     @classmethod
-    def get_rendering_scope(cls) -> Mapping[str, Any]:
-        return {}
+    def get_generator(cls) -> Union[ComponentGenerator, ComponentGeneratorUnavailableReason]:
+        """Subclasses should implement this method to override scaffolding behavior. If this component
+        is not meant to be scaffoled it returns a ComponetnGeneratorUnavailableReason with a message
+        This can be determined at runtime based on the environment or configuration. For example,
+        if generators are optionally installed as extras (for example to avoid heavy dependencies in production),
+        this method should return a ComponentGeneratorUnavailableReason with a message explaining
+        how to install the necessary extras.
+        """
+        return ComponentGeneratorAdapter(cls)
 
     @classmethod
     def generate_files(cls, request: ComponentGenerateRequest, params: Any) -> None:
         from dagster_components.generate import generate_component_yaml
 
         generate_component_yaml(request, {})
+
+    @classmethod
+    def get_rendering_scope(cls) -> Mapping[str, Any]:
+        return {}
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_generator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_generator.py
@@ -1,1 +1,24 @@
-class ComponentGenerator: ...
+from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from dagster._record import record
+
+
+@record
+class ComponentGenerateRequest:
+    component_type_name: str
+    component_instance_root_path: Path
+
+
+class ComponentGenerator:
+    generator_params: ClassVar = None
+
+    @abstractmethod
+    def generate_files(self, request: ComponentGenerateRequest, params: Any) -> None: ...
+
+
+@dataclass
+class ComponentGeneratorUnavailableReason:
+    message: str

--- a/python_modules/libraries/dagster-components/dagster_components/generate.py
+++ b/python_modules/libraries/dagster-components/dagster_components/generate.py
@@ -6,7 +6,11 @@ import click
 import yaml
 from dagster._utils import mkdir_p
 
-from dagster_components.core.component import Component, ComponentGenerateRequest
+from dagster_components.core.component import (
+    Component,
+    ComponentGenerateRequest,
+    ComponentGeneratorUnavailableReason,
+)
 
 
 class ComponentDumper(yaml.Dumper):
@@ -38,7 +42,14 @@ def generate_component_instance(
     component_instance_root_path = Path(os.path.join(root_path, name))
     click.echo(f"Creating a Dagster component instance folder at {component_instance_root_path}.")
     mkdir_p(str(component_instance_root_path))
-    component_type.generate_files(
+    generator = component_type.get_generator()
+
+    if isinstance(generator, ComponentGeneratorUnavailableReason):
+        raise Exception(
+            f"Component type {component_type_name} does not have a generator. Reason: {generator.message}."
+        )
+
+    generator.generate_files(
         ComponentGenerateRequest(
             component_type_name=component_type_name,
             component_instance_root_path=component_instance_root_path,


### PR DESCRIPTION
## Summary & Motivation

Beginning of a stack to separate out generator code from runtime component. This modularizes things and sets up to install generator/scaffolding code as an extra when appropriate.

## How I Tested These Changes

BK
