### PR TITLE
Change tag collection size-to-fit timing to avoid jank

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -148,8 +148,13 @@ export function useAdjustChildVisibilityToFill(moreLabelFn: (count: number) => s
     }
   });
 
-  React.useEffect(() => {
-    window.requestAnimationFrame(evaluate);
+  // This should technically be a useEffect with a requestAnimationFrame,
+  // but React Virtualizer doesn't use that combo. Kicking out to the next animation frame
+  // causes the row height calculation to run first. If the row is already sized when we
+  // run this size-to-fit logic, we modify the height of the row and the virtualizer
+  // calculation has to run a second time. Doing that x many rows results in visible jank.
+  React.useLayoutEffect(() => {
+    evaluate();
   }, [evaluate]);
 
   return {containerRef, moreLabelRef};


### PR DESCRIPTION
## Summary & Motivation


We discussed this previously in https://github.com/dagster-io/dagster/pull/26122 — using a `useEffect + requestAnimationFrame` is technically the ideal time to perform the DOM sizing code in the asset tag collections, but it performs really badly on the runs page.

This is because the tag collection appears within each row of a virtualized table, and the `useEffect + requestAnimationFrame` combo causes our layout to happen _after_ the rows have been measured, and the changes cause them to be re-measured.

## How I Tested These Changes

This results in traces that looked like this, with the Virtualizer running >1 cycle:
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/c5cc0837-5019-4093-80e3-dd2b2c5362fd" />

After:

(note this is a key-up event causing a big scroll to lots of new rows all at once)

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/036c4b16-2590-42ab-be79-a3bd2a72a118" />

