### PR TITLE
docs: update AutomationConditionSensorDefinition docstring example

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -116,6 +116,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
                 sensors=[
                     dg.AutomationConditionSensorDefinition(
                         name="automation_condition_sensor",
+                        target=dg.AssetSelection.all(),
                         default_status=dg.DefaultSensorStatus.RUNNING,
                     ),
                 ]


### PR DESCRIPTION
## Summary & Motivation

Added the target parameter in the AutomationConditionSensorDefinition docstring since it is required. 
Implementing the example as-is raises the following error:

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/52b13342-b912-4912-bfed-1aa238d2c773" />


## How I Tested These Changes

Run the documentation locally