### PR TITLE
[docs-beta] Map API lifecycle flags to style levels for docs beta

### DIFF
--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -972,6 +972,12 @@ class MdxTranslator(SphinxTranslator):
         level = "info"
         if flag_type == "experimental":
             level = "warning"
+        if flag_type == "preview":
+            level = "warning"
+        if flag_type == "beta":
+            level = "warning"
+        if flag_type == "superseded":
+            level = "warning"
         if flag_type == "deprecated":
             level = "danger"
         return level


### PR DESCRIPTION
## Summary & Motivation

Map the Preview, Beta and Superseded flags to warning level for Docusaurus/docs beta styling. See comment [here](https://github.com/dagster-io/dagster/pull/26821#issuecomment-2573210418).