### PR TITLE
Surface how to visualize import performance issues

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/test_import.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_import.py
@@ -23,9 +23,14 @@ def test_import_perf():
     import_profile = result.stderr.decode("utf-8")
 
     # ensure expensive libraries which should not be needed for basic definitions are not imported
-    assert "grpc" not in import_profile
-    assert "sqlalchemy" not in import_profile
-    assert "upath." not in import_profile  # dont conflate with import of upath_io_manager
-
-    # one way to debug imports is to `pip install tuna` then run
-    # python -X importtime python_modules/dagster/dagster_tests/general_tests/simple.py &> /tmp/import.txt && tuna /tmp/import.txt
+    try:
+        assert "grpc" not in import_profile
+        assert "sqlalchemy" not in import_profile
+        assert "upath." not in import_profile  # dont conflate with import of upath_io_manager
+    except AssertionError as exc:
+        # if `tuna` output is unfriendly, another way to debug imports is to open `/tmp/import.txt`
+        # using https://kmichel.github.io/python-importtime-graph/
+        raise AssertionError(
+            "Expensive library imported; to debug, `pip install tuna`, then run "
+            "python -X importtime python_modules/dagster/dagster_tests/general_tests/simple.py &> /tmp/import.txt && tuna /tmp/import.txt"
+        ) from exc


### PR DESCRIPTION
## Summary & Motivation

Make finding the instructions for debugging import performance issues more obvious.

## How I Tested These Changes

I ran code where I end up with an indirect `grpc` import, and the output now looks like:

```python
        expensive_imports = [f"`{lib}`" for lib in expensive_library if lib in import_profile]
    
        # if `tuna` output is unfriendly, another way to debug imports is to open `/tmp/import.txt`
        # using https://kmichel.github.io/python-importtime-graph/
>       assert not expensive_imports, (
            "The following expensive libraries were imported with the top-level `dagster` module, "
            f"slowing down any process that imports Dagster: {', '.join(expensive_imports)}; to debug, "
            "`pip install tuna`, then run "
            "`python -X importtime python_modules/dagster/dagster_tests/general_tests/simple.py &> /tmp/import.txt && tuna /tmp/import.txt`."
        )
E       AssertionError: The following expensive libraries were imported with the top-level `dagster` module, slowing down any process that imports Dagster: `grpc`; to debug, `pip install tuna`, then run `python -X importtime python_modules/dagster/dagster_tests/general_tests/simple.py &> /tmp/import.txt && tuna /tmp/import.txt`.
E       assert not ['`grpc`']

python_modules/dagster/dagster_tests/general_tests/test_import.py:35: AssertionError
```

Note that the https://kmichel.github.io/python-importtime-graph/ isn't directly raised, but it's placed in the code such that it gets displayed to somebody reading the output anyway.

## Possible Alternatives

Just moving the existing comment above the asserts could work, since that way the instructions would happen to appear in the output. I didn't think about that earlier.