### PR TITLE
[dagster-airlift] Pin marshmallow

### DIFF
--- a/python_modules/libraries/dagster-airlift/setup.py
+++ b/python_modules/libraries/dagster-airlift/setup.py
@@ -26,6 +26,7 @@ pin = "" if ver == "1!0+dev" or "rc" in ver else f"=={ver}"
 AIRFLOW_REQUIREMENTS = [
     # Requirements for python versions under 3.12.
     "apache-airflow==2.7.3; python_version < '3.12'",
+    "marshmallow==3.20.1; python_version < '3.12'",
     "pendulum>=2.0.0,<3.0.0; python_version < '3.12'",
     # Requirements for python versions 3.12 and above.
     "apache-airflow>=2.9.0; python_version >= '3.12'",


### PR DESCRIPTION
## Summary & Motivation
Some magical dep change changed out the version of marshmallow we were installing for tests, which broke validation airflow-side for airflow 2.7.3. 
This fixes for Airflow 2.7.3 / python under 3.12. I'll also pin for python >= 3.12 if the error recurs there.
For posterity's sake, I found the correct pin via the relevant airflow constraints file: https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.11.txt

## How I Tested These Changes
Local tox

