### PR TITLE
[docs] use CodeExample props as cache key

### DIFF
--- a/docs/docs-beta/src/components/CodeExample.tsx
+++ b/docs/docs-beta/src/components/CodeExample.tsx
@@ -51,7 +51,7 @@ function processModule({
   contentCache[cacheKey] = {content: lines.join('\n')};
 }
 
-function loadModule(cacheKey: string, path: string, lineStart: number, lineEnd: number) {
+function useLoadModule(cacheKey: string, path: string, lineStart: number, lineEnd: number) {
   const isServer = typeof window === 'undefined';
   if (isServer) {
     /**
@@ -104,7 +104,7 @@ const CodeExampleInner: React.FC<CodeExampleProps> = (props) => {
 
   const path = pathPrefix + '/' + filePath;
   const cacheKey = JSON.stringify(props);
-  const {content, error} = loadModule(cacheKey, path, lineStart, lineEnd);
+  const {content, error} = useLoadModule(cacheKey, path, lineStart, lineEnd);
 
   if (error) {
     return <div style={{color: 'red', padding: '1rem', border: '1px solid red'}}>{error}</div>;


### PR DESCRIPTION
## Summary & Motivation

- We need to include `props`, notable `lineStart` and `lineEnd` in the content cache for code blocks to render the correct content, otherwise the first value will be used without line filtering
- This also refactors the logic into `loadModule`

## How I Tested These Changes

`yarn start`

## Changelog

NO CHANGELOG