### PR TITLE
[integrations-api][superseded] dagster-airflow

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -98,7 +98,7 @@ def _build_asset_dependencies(
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`load_assets_from_airflow_dag` has been superseded by the functionality in the `dagster-airlift` library."
     )
 )
 def load_assets_from_airflow_dag(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -11,6 +11,7 @@ from dagster import (
     TimeWindowPartitionsDefinition,
     _check as check,
 )
+from dagster._annotations import superseded
 from dagster._core.definitions.graph_definition import create_adjacency_lists
 from dagster._utils.schedules import is_valid_cron_schedule
 
@@ -95,6 +96,11 @@ def _build_asset_dependencies(
     return (output_mappings, keys_by_output_name, internal_asset_deps)
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 def load_assets_from_airflow_dag(
     dag: DAG,
     task_ids_by_asset_key: Mapping[AssetKey, AbstractSet[str]] = {},

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -29,7 +29,7 @@ from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. "
+        "The `dagster-airflow` library is no longer best practice. "
         "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
     )
 )
@@ -80,7 +80,7 @@ def make_dagster_definitions_from_airflow_dag_bag(
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. "
+        "The `dagster-airflow` library is no longer best practice. "
         "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
     )
 )
@@ -158,7 +158,7 @@ def make_dagster_definitions_from_airflow_dags_path(
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. "
+        "The `dagster-airflow` library is no longer best practice. "
         "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
     )
 )
@@ -201,7 +201,8 @@ def make_dagster_definitions_from_airflow_example_dags(
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`make_schedules_and_jobs_from_airflow_dag_bag` has been superseded "
+        "by the functionality in the `dagster-airlift` library."
     )
 )
 def make_schedules_and_jobs_from_airflow_dag_bag(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -11,6 +11,7 @@ from dagster import (
     ScheduleDefinition,
     _check as check,
 )
+from dagster._annotations import superseded
 
 from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
 from dagster_airflow.dagster_schedule_factory import (
@@ -26,6 +27,12 @@ from dagster_airflow.resources.airflow_persistent_db import AirflowPersistentDat
 from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. "
+        "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
+    )
+)
 def make_dagster_definitions_from_airflow_dag_bag(
     dag_bag: DagBag,
     connections: Optional[list[Connection]] = None,
@@ -71,6 +78,12 @@ def make_dagster_definitions_from_airflow_dag_bag(
     )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. "
+        "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
+    )
+)
 def make_dagster_definitions_from_airflow_dags_path(
     dag_path: str,
     safe_mode: bool = True,
@@ -143,6 +156,12 @@ def make_dagster_definitions_from_airflow_dags_path(
     )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. "
+        "Use `build_defs_from_airflow_instance` in the `dagster-airlift` library instead."
+    )
+)
 def make_dagster_definitions_from_airflow_example_dags(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = {},
 ) -> Definitions:
@@ -180,6 +199,11 @@ def make_dagster_definitions_from_airflow_example_dags(
     )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 def make_schedules_and_jobs_from_airflow_dag_bag(
     dag_bag: DagBag,
     connections: Optional[list[Connection]] = None,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -22,7 +22,7 @@ from dagster_airflow.utils import normalized_name
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`make_dagster_job_from_airflow_dag` has been superseded by the functionality in the `dagster-airlift` library."
     )
 )
 def make_dagster_job_from_airflow_dag(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -9,6 +9,7 @@ from dagster import (
     ResourceDefinition,
     _check as check,
 )
+from dagster._annotations import superseded
 from dagster._core.instance import IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._utils.tags import normalize_tags
 
@@ -19,6 +20,11 @@ from dagster_airflow.resources import (
 from dagster_airflow.utils import normalized_name
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 def make_dagster_job_from_airflow_dag(
     dag: DAG,
     tags: Optional[Mapping[str, str]] = None,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -18,7 +18,7 @@ from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`DagsterHook` has been superseded by the functionality in the `dagster-airlift` library."
     )
 )
 class DagsterHook(BaseHook):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -10,11 +10,17 @@ import requests
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook  # type: ignore
 from airflow.models import Connection
+from dagster._annotations import superseded
 from dagster._core.storage.dagster_run import DagsterRunStatus
 
 from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 class DagsterHook(BaseHook):
     conn_name_attr = "dagster_conn_id"
     default_conn_name = "dagster_default"

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
@@ -1,8 +1,14 @@
 from airflow.models import BaseOperatorLink, TaskInstance
+from dagster._annotations import superseded
 
 LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/runs/{run_id}"
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 class DagsterLink(BaseOperatorLink):
     name = "Dagster Cloud"  # type: ignore  # (airflow 1 compat)
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
@@ -6,7 +6,7 @@ LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/runs/{run_
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`DagsterLink` has been superseded by the functionality in the `dagster-airlift` library."
     )
 )
 class DagsterLink(BaseOperatorLink):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
@@ -2,12 +2,18 @@ import json
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from dagster._annotations import superseded
 
 from dagster_airflow.hooks.dagster_hook import DagsterHook
 from dagster_airflow.links.dagster_link import LINK_FMT, DagsterLink
 from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 class DagsterOperator(BaseOperator):
     """DagsterOperator.
 
@@ -125,6 +131,11 @@ class DagsterOperator(BaseOperator):
         )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 class DagsterCloudOperator(DagsterOperator):
     """DagsterCloudOperator.
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
@@ -11,7 +11,7 @@ from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`DagsterOperator` has been superseded by the functionality in the `dagster-airlift` library."
     )
 )
 class DagsterOperator(BaseOperator):
@@ -133,7 +133,8 @@ class DagsterOperator(BaseOperator):
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`DagsterCloudOperator` has been superseded "
+        "by the functionality in the `dagster-airlift` library."
     )
 )
 class DagsterCloudOperator(DagsterOperator):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -15,6 +15,7 @@ from dagster import (
     ResourceDefinition,
     _check as check,
 )
+from dagster._annotations import superseded
 
 from dagster_airflow.resources.airflow_db import AirflowDatabase
 from dagster_airflow.utils import (
@@ -68,6 +69,11 @@ class AirflowEphemeralDatabase(AirflowDatabase):
         )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 def make_ephemeral_airflow_db_resource(
     connections: list[Connection] = [], dag_run_config: Optional[dict] = None
 ) -> ResourceDefinition:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -71,7 +71,8 @@ class AirflowEphemeralDatabase(AirflowDatabase):
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`make_ephemeral_airflow_db_resource` has been superseded "
+        "by the functionality in the `dagster-airlift` library."
     )
 )
 def make_ephemeral_airflow_db_resource(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -57,7 +57,8 @@ class AirflowPersistentDatabase(AirflowDatabase):
 
 @superseded(
     additional_warn_text=(
-        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+        "`make_persistent_airflow_db_resource` has been superseded "
+        "by the functionality in the `dagster-airlift` library."
     )
 )
 def make_persistent_airflow_db_resource(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -13,6 +13,7 @@ from dagster import (
     StringSource,
     _check as check,
 )
+from dagster._annotations import superseded
 
 from dagster_airflow.resources.airflow_db import AirflowDatabase
 from dagster_airflow.utils import (
@@ -54,6 +55,11 @@ class AirflowPersistentDatabase(AirflowDatabase):
         )
 
 
+@superseded(
+    additional_warn_text=(
+        "The `dagster-airlift` library is no longer best practice. Use the `dagster-airlift` library instead."
+    )
+)
 def make_persistent_airflow_db_resource(
     uri: str = "",
     connections: list[Connection] = [],


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator (preview/beta?) -> superseded

reason: dagster-airflow is no longer best practice, Airlift is. Since Airlift is still beta, dagster-airflow should be superseded and not deprecated. Once Airlift is GA, we can deprecate dagster-airflow.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
