### PR TITLE
[integrations-api][beta] dbt Cloud in dagster-dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -18,7 +18,7 @@ from dagster import (
     multi_asset,
     with_resources,
 )
-from dagster._annotations import experimental_param, superseded
+from dagster._annotations import beta, experimental_param
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -530,12 +530,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         return _assets
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 @experimental_param(param="partitions_def")
 @experimental_param(param="partition_key_to_vars_fn")
 def load_assets_from_dbt_cloud_job(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -18,7 +18,7 @@ from dagster import (
     multi_asset,
     with_resources,
 )
-from dagster._annotations import experimental, experimental_param
+from dagster._annotations import experimental_param, superseded
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -530,7 +530,12 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         return _assets
 
 
-@experimental
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 @experimental_param(param="partitions_def")
 @experimental_param(param="partition_key_to_vars_fn")
 def load_assets_from_dbt_cloud_job(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
@@ -47,17 +47,17 @@ class DbtCloudRunOpConfig(Config):
     )
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
 @op(
     required_resource_keys={"dbt_cloud"},
     ins={"start_after": In(Nothing)},
     out=Out(DbtCloudOutput, description="Parsed output from running the dbt Cloud job."),
     tags={COMPUTE_KIND_TAG: "dbt_cloud"},
+)
+@superseded(
+    additional_warn_text=(
+            "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+            "Use `dagster-dlift` instead."
+    )
 )
 def dbt_cloud_run_op(context, config: DbtCloudRunOpConfig):
     """Initiates a run for a dbt Cloud job, then polls until the run completes. If the job

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
@@ -55,8 +55,8 @@ class DbtCloudRunOpConfig(Config):
 )
 @superseded(
     additional_warn_text=(
-            "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-            "Use `dagster-dlift` instead."
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
     )
 )
 def dbt_cloud_run_op(context, config: DbtCloudRunOpConfig):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from dagster import Config, In, Nothing, Out, Output, op
-from dagster._annotations import superseded
+from dagster._annotations import beta
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from pydantic import Field
 
@@ -53,12 +53,7 @@ class DbtCloudRunOpConfig(Config):
     out=Out(DbtCloudOutput, description="Parsed output from running the dbt Cloud job."),
     tags={COMPUTE_KIND_TAG: "dbt_cloud"},
 )
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 def dbt_cloud_run_op(context, config: DbtCloudRunOpConfig):
     """Initiates a run for a dbt Cloud job, then polls until the run completes. If the job
     fails or is otherwised stopped before succeeding, a `dagster.Failure` exception will be raised,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/ops.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from dagster import Config, In, Nothing, Out, Output, op
+from dagster._annotations import superseded
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from pydantic import Field
 
@@ -46,6 +47,12 @@ class DbtCloudRunOpConfig(Config):
     )
 
 
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 @op(
     required_resource_keys={"dbt_cloud"},
     ins={"start_after": In(Nothing)},

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -18,7 +18,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import superseded
+from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
@@ -588,22 +588,12 @@ class DbtCloudClient:
         )
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 class DbtCloudResource(DbtCloudClient):
     pass
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     """This resource helps interact with dbt Cloud connectors."""
 
@@ -669,12 +659,7 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_dbt_client()
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 @dagster_maintained_resource
 @resource(
     config_schema=DbtCloudClientResource.to_config_schema(),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -18,6 +18,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
+from dagster._annotations import superseded
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
@@ -587,10 +588,22 @@ class DbtCloudClient:
         )
 
 
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 class DbtCloudResource(DbtCloudClient):
     pass
 
 
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     """This resource helps interact with dbt Cloud connectors."""
 
@@ -656,6 +669,12 @@ class DbtCloudClientResource(ConfigurableResource, IAttachDifferentObjectToOpCon
         return self.get_dbt_client()
 
 
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 @dagster_maintained_resource
 @resource(
     config_schema=DbtCloudClientResource.to_config_schema(),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
@@ -3,16 +3,11 @@ from datetime import datetime
 from typing import Any, Optional
 
 import dagster._check as check
-from dagster._annotations import superseded
+from dagster._annotations import beta
 from dagster._vendored.dateutil.parser import isoparse
 
 
-@superseded(
-    additional_warn_text=(
-        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
-        "Use `dagster-dlift` instead."
-    )
-)
+@beta
 class DbtCloudOutput:
     """The results of executing a dbt Cloud job, along with additional metadata produced from the
     job run.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
@@ -3,9 +3,16 @@ from datetime import datetime
 from typing import Any, Optional
 
 import dagster._check as check
+from dagster._annotations import superseded
 from dagster._vendored.dateutil.parser import isoparse
 
 
+@superseded(
+    additional_warn_text=(
+        "The dbt Cloud APIs of the `dagster-dbt` library are no longer best practice. "
+        "Use `dagster-dlift` instead."
+    )
+)
 class DbtCloudOutput:
     """The results of executing a dbt Cloud job, along with additional metadata produced from the
     job run.


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator (preview/beta?) -> ~~superseded~~ beta

reason: ~~dbt Cloud in dagster-dbt is no longer best practice, Dlift is. Since Dlift is still in preview, dbt Cloud in dagster-dbt should be superseded and not deprecated. Once Dlift is GA, we can deprecate dbt Cloud.~~ Dlift is not ready to be marked as an alternative to dbt cloud. Decorator was initially missing, so using the beta decorator here.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
