### PR TITLE
[integrations-api][ga] SlingEventIterator in dagster-sling

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
@@ -7,7 +7,7 @@ from dagster import (
     MaterializeResult,
     _check as check,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import (
     TableColumn,

--- a/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
@@ -191,7 +191,6 @@ class SlingEventIterator(Iterator[T]):
     def __iter__(self) -> "SlingEventIterator[T]":
         return self
 
-    @experimental
     @public
     def fetch_column_metadata(self) -> "SlingEventIterator":
         """Fetches column metadata for each table synced by the Sling CLI.
@@ -214,7 +213,6 @@ class SlingEventIterator(Iterator[T]):
             _fetch_column_metadata(), self._sling_cli, self._replication_config, self._context
         )
 
-    @experimental
     @public
     def fetch_row_count(self) -> "SlingEventIterator":
         """Fetches row count metadata for each table synced by the Sling CLI.


### PR DESCRIPTION
## Summary & Motivation

decision: experimental (beta) -> ga

reason: methods to fetch metadata in SlingEventIterator are a commonly used pattern (fetch_column_metadata, etc.) in other integrations like dbt.

docs exist: no, we would need a guide or section.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
