### PR TITLE
[integrations-api][ga] dagster-dlt

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/dlt_event_iterator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/dlt_event_iterator.py
@@ -80,7 +80,6 @@ class DltEventIterator(Iterator[T]):
         return self
 
     @public
-    @experimental
     def fetch_row_count(self) -> "DltEventIterator":
         """Fetches row count metadata for each resource loaded by dlt.
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/dlt_event_iterator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/dlt_event_iterator.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from typing import Optional, Union
 
 from dagster import AssetMaterialization, MaterializeResult
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.execution.context.op_execution_context import OpExecutionContext

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -26,7 +26,6 @@ from dagster_dlt.dlt_event_iterator import DltEventIterator, DltEventType
 from dagster_dlt.translator import DagsterDltTranslator, DltResourceTranslatorData
 
 
-@experimental
 class DagsterDltResource(ConfigurableResource):
     @classmethod
     def _is_dagster_maintained(cls) -> bool:

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -12,7 +12,7 @@ from dagster import (
     TableColumnConstraints,
     _check as check,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dlt.common.pipeline import LoadInfo


### PR DESCRIPTION
## Summary & Motivation

decision: experimental (beta) -> ga

reason: methods to fetch metadata in DltEventIterator are a commonly used pattern (fetch_row_count, etc.) in other integrations like dbt. DltResource is stable, adopted by many users and well documented.

docs exist: not for `fetch_row_count`, we would need a guide or section. Yes for the resource.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
