### PR TITLE
[integrations-api][beta][superseded] dagster-fivetran

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable, Optional
 
 from dagster import AssetsDefinition, multi_asset
-from dagster._annotations import experimental
+from dagster._annotations import beta
 
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
 
 
-@experimental
+@beta
 def fivetran_assets(
     *,
     connector_id: str,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -14,7 +14,7 @@ from dagster import (
     _check as check,
     multi_asset,
 )
-from dagster._annotations import experimental
+from dagster._annotations import beta, superseded
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -239,6 +239,7 @@ def _build_fivetran_assets(
     return [_assets]
 
 
+@superseded(additional_warn_text="Use the `fivetran_assets` decorator instead.")
 def build_fivetran_assets(
     connector_id: str,
     destination_tables: Sequence[str],
@@ -600,6 +601,9 @@ def _clean_name(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", name.lower())
 
 
+@superseded(
+    additional_warn_text="Use the `build_fivetran_assets_definitions` factory instead.",
+)
 def load_assets_from_fivetran_instance(
     fivetran: Union[FivetranResource, ResourceDefinition],
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
@@ -724,7 +728,7 @@ def load_assets_from_fivetran_instance(
 # -----------------------
 
 
-@experimental
+@beta
 def build_fivetran_assets_definitions(
     *,
     workspace: FivetranWorkspace,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/fivetran_event_iterator.py
@@ -10,7 +10,7 @@ from dagster import (
     OpExecutionContext,
     _check as check,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.utils import imap
 from typing_extensions import TypeVar
@@ -87,7 +87,7 @@ class FivetranEventIterator(Iterator[T]):
     def __iter__(self) -> "FivetranEventIterator[T]":
         return self
 
-    @experimental
+    @beta
     @public
     def fetch_column_metadata(self) -> "FivetranEventIterator":
         """Fetches column metadata for each table synced with the Fivetran API.

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import dagster._check as check
 from dagster import ResourceDefinition
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import beta, deprecated
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster_managed_elements import ManagedElementCheckResult, ManagedElementDiff
 from dagster_managed_elements.types import ManagedElementReconciler, is_key_secret
@@ -332,7 +332,7 @@ def reconcile_config(
     return ManagedElementDiff().join(dests_diff).join(connectors_diff)  # type: ignore
 
 
-@experimental
+@beta
 @deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class FivetranManagedElementReconciler(ManagedElementReconciler):
     def __init__(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dagster import AssetKey, Config, In, Nothing, Out, Output, op
+from dagster._annotations import superseded
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from pydantic import Field
 
@@ -55,6 +56,12 @@ class SyncConfig(Config):
         ),
     ),
     tags={COMPUTE_KIND_TAG: "fivetran"},
+)
+@superseded(
+    additional_warn_text=(
+        "Fivetran ops are no longer best practice. "
+        "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."
+    ),
 )
 def fivetran_sync_op(config: SyncConfig, fivetran: FivetranResource) -> Any:
     """Executes a Fivetran sync for a given ``connector_id``, and polls until that sync
@@ -124,6 +131,12 @@ class FivetranResyncConfig(SyncConfig):
         ),
     ),
     tags={COMPUTE_KIND_TAG: "fivetran"},
+)
+@superseded(
+    additional_warn_text=(
+        "Fivetran ops are no longer best practice. "
+        "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."
+    ),
 )
 def fivetran_resync_op(
     config: FivetranResyncConfig,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -22,7 +22,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public, superseded
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
@@ -67,6 +67,7 @@ DEFAULT_POLL_INTERVAL = 10
 FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX = "dagster-fivetran/reconstruction_metadata"
 
 
+@superseded(additional_warn_text="Use `FivetranWorkspace` instead.")
 class FivetranResource(ConfigurableResource):
     """This class exposes methods on top of the Fivetran REST API."""
 
@@ -433,6 +434,7 @@ class FivetranResource(ConfigurableResource):
         return self.make_request("GET", f"destinations/{destination_id}")
 
 
+@superseded(additional_warn_text="Use `FivetranWorkspace` instead.")
 @dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:
@@ -473,7 +475,7 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
 # ------------------
 
 
-@experimental
+@beta
 class FivetranClient:
     """This class exposes methods on top of the Fivetran REST API."""
 
@@ -832,7 +834,7 @@ class FivetranClient:
         return FivetranOutput(connector_details=final_details, schema_config=schema_config_details)
 
 
-@experimental
+@beta
 class FivetranWorkspace(ConfigurableResource):
     """This class represents a Fivetran workspace and provides utilities
     to interact with Fivetran APIs.
@@ -1015,7 +1017,7 @@ class FivetranWorkspace(ConfigurableResource):
                 )
 
     @public
-    @experimental
+    @beta
     def sync_and_poll(
         self, context: AssetExecutionContext
     ) -> FivetranEventIterator[Union[AssetMaterialization, MaterializeResult]]:
@@ -1070,7 +1072,7 @@ class FivetranWorkspace(ConfigurableResource):
             context.log.warning(f"Assets were not materialized: {unmaterialized_asset_keys}")
 
 
-@experimental
+@beta
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,


### PR DESCRIPTION
## Summary & Motivation

decision: 
- new pattern (asset decorator, translator): experimental -> beta
- old pattern (cacheable assets, load fns): ga -> superseded

reason: the new Fivetran pattern is not mature enough to be GA, but since the behavior is very similar to the previous pattern, we can say it's not preview. The old pattern is superseded by the new one.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
