### PR TITLE
[integrations-api][beta][superseded] Airbyte Cloud in dagster-airbyte

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable, Optional
 
 from dagster import AssetsDefinition, multi_asset
-from dagster._annotations import experimental
+from dagster._annotations import beta
 
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteMetadataSet, DagsterAirbyteTranslator
 
 
-@experimental
+@beta
 def airbyte_assets(
     *,
     connection_id: str,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -20,7 +20,7 @@ from dagster import (
     SourceAsset,
     _check as check,
 )
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions import AssetsDefinition, multi_asset
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -1030,7 +1030,7 @@ def load_assets_from_airbyte_instance(
 # -----------------------
 
 
-@experimental
+@beta
 def build_airbyte_assets_definitions(
     *,
     workspace: AirbyteCloudWorkspace,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Union, cast
 
 import dagster._check as check
 from dagster import AssetKey
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import beta, deprecated, public
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -624,7 +624,7 @@ def reconcile_connections_post(
                 )
 
 
-@experimental
+@beta
 @deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class AirbyteManagedElementReconciler(ManagedElementReconciler):
     """Reconciles Python-specified Airbyte connections with an Airbyte instance.
@@ -727,7 +727,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
         return super()._get_connections()
 
 
-@experimental
+@beta
 @deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 def load_assets_from_connections(
     airbyte: Union[AirbyteResource, ResourceDefinition],

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -22,7 +22,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public, superseded
 from dagster._config.pythonic_config import infer_schema_from_config_class
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
@@ -286,6 +286,12 @@ class BaseAirbyteResource(ConfigurableResource):
         return AirbyteOutput(job_details=job_details, connection_details=connection_details)
 
 
+@superseded(
+    additional_warn_text=(
+        "Using `AirbyteCloudResource` with `build_airbyte_assets`is no longer best practice. "
+        "Use `AirbyteCloudWorkspace` with `build_airbyte_assets_definitions` instead."
+    )
+)
 class AirbyteCloudResource(BaseAirbyteResource):
     """This resource allows users to programmatically interface with the Airbyte Cloud API to launch
     syncs and monitor their progress.
@@ -823,6 +829,7 @@ def airbyte_resource(context) -> AirbyteResource:
     return AirbyteResource.from_resource_context(context)
 
 
+@superseded(additional_warn_text=("Use `AirbyteCloudWorkspace` instead."))
 @dagster_maintained_resource
 @resource(config_schema=infer_schema_from_config_class(AirbyteCloudResource))
 def airbyte_cloud_resource(context) -> AirbyteCloudResource:
@@ -839,7 +846,7 @@ def airbyte_cloud_resource(context) -> AirbyteCloudResource:
 # -------------
 
 
-@experimental
+@beta
 class AirbyteCloudClient(DagsterModel):
     """This class exposes methods on top of the Airbyte APIs for Airbyte Cloud."""
 
@@ -1109,7 +1116,7 @@ class AirbyteCloudClient(DagsterModel):
         return AirbyteOutput(job_details=poll_job_details, connection_details=connection_details)
 
 
-@experimental
+@beta
 class AirbyteCloudWorkspace(ConfigurableResource):
     """This class represents a Airbyte Cloud workspace and provides utilities
     to interact with Airbyte APIs.
@@ -1260,7 +1267,7 @@ class AirbyteCloudWorkspace(ConfigurableResource):
                 )
 
     @public
-    @experimental
+    @beta
     def sync_and_poll(self, context: AssetExecutionContext):
         """Executes a sync and poll process to materialize Airbyte Cloud assets.
             This method can only be used in the context of an asset execution.
@@ -1308,7 +1315,7 @@ class AirbyteCloudWorkspace(ConfigurableResource):
             context.log.warning(f"Assets were not materialized: {unmaterialized_asset_keys}")
 
 
-@experimental
+@beta
 def load_airbyte_cloud_asset_specs(
     workspace: AirbyteCloudWorkspace,
     dagster_airbyte_translator: Optional[DagsterAirbyteTranslator] = None,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/translator.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from enum import Enum
 from typing import Any, Optional
 
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import beta, deprecated
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet, TableMetadataSet
@@ -202,7 +202,7 @@ class AirbyteMetadataSet(NamespacedMetadataSet):
         return "dagster-airbyte"
 
 
-@experimental
+@beta
 class DagsterAirbyteTranslator:
     """Translator class which converts a `AirbyteConnectionTableProps` object into AssetSpecs.
     Subclass this class to implement custom logic how to translate Airbyte content into asset spec.


### PR DESCRIPTION
## Summary & Motivation

decision: 
- new pattern (asset decorator, translator): experimental -> beta
- old pattern (cacheable assets, load fns): ga -> superseded

reason: the new Airbyte cloud pattern is not mature enough to be GA, but since the behavior is very similar to the previous pattern, we can say it's not preview. The old pattern is superseded by the new one.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
