### PR TITLE
[integrations-api][beta] dagster-ssh

### DIFF
--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -35,7 +35,7 @@ def key_from_str(key_str):
     return result
 
 
-@deprecated(breaking_version="1.11.0")
+@deprecated(breaking_version="0.26")
 class SSHResource(ConfigurableResource):
     """Resource for ssh remote execution using Paramiko.
 
@@ -242,7 +242,7 @@ class SSHResource(ConfigurableResource):
         return local_filepath
 
 
-@deprecated(breaking_version="1.11.0")
+@deprecated(breaking_version="0.26")
 @dagster_maintained_resource
 @resource(
     config_schema={

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -35,7 +35,7 @@ def key_from_str(key_str):
     return result
 
 
-@deprecated(breaking_version="0.26")
+@deprecated(breaking_version="0.27")
 class SSHResource(ConfigurableResource):
     """Resource for ssh remote execution using Paramiko.
 
@@ -242,7 +242,7 @@ class SSHResource(ConfigurableResource):
         return local_filepath
 
 
-@deprecated(breaking_version="0.26")
+@deprecated(breaking_version="0.27")
 @dagster_maintained_resource
 @resource(
     config_schema={

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -13,7 +13,7 @@ from dagster import (
     _check as check,
     resource,
 )
-from dagster._annotations import deprecated
+from dagster._annotations import beta
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
@@ -35,7 +35,7 @@ def key_from_str(key_str):
     return result
 
 
-@deprecated(breaking_version="0.27")
+@beta
 class SSHResource(ConfigurableResource):
     """Resource for ssh remote execution using Paramiko.
 
@@ -242,7 +242,7 @@ class SSHResource(ConfigurableResource):
         return local_filepath
 
 
-@deprecated(breaking_version="0.27")
+@beta
 @dagster_maintained_resource
 @resource(
     config_schema={

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -13,6 +13,7 @@ from dagster import (
     _check as check,
     resource,
 )
+from dagster._annotations import deprecated
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
@@ -34,6 +35,7 @@ def key_from_str(key_str):
     return result
 
 
+@deprecated(breaking_version="1.11.0")
 class SSHResource(ConfigurableResource):
     """Resource for ssh remote execution using Paramiko.
 
@@ -240,6 +242,7 @@ class SSHResource(ConfigurableResource):
         return local_filepath
 
 
+@deprecated(breaking_version="1.11.0")
 @dagster_maintained_resource
 @resource(
     config_schema={


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing and we don't consider this integration mature enough to be GA.

Note: we consider deprecating and replacing with guide on how to customize resources.

docs exist: the API docs [page](https://docs.dagster.io/_apidocs/libraries/dagster-ssh#ssh-sftp-dagster-ssh) is empty 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
