### PR TITLE
docs: extend sensors definition

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -5,11 +5,21 @@ description: Sensors allow you to instigate runs based on any external state cha
 
 # Sensors
 
-Sensors are definitions in Dagster that allow you to instigate runs based on some external state change. For example, you can:
+Sensors are definitions in Dagster that allow you to take action in response to events that happen both internally or at external systems.
 
-- Launch a run whenever a file appears in an s3 bucket
-- Launch a run whenever another job materializes a specific asset
-- Launch a run whenever an external system is down
+Example of events can be:
+
+- a run completes in Dagster
+- a run fails in Dagster
+- a job materializes a specific asset
+- a file appears in an s3 bucket
+- an external system is down
+
+Example of actions are:
+
+- launching a run
+- sending a Slack message
+- inserting a row into a database
 
 A sensor defines an evaluation function that returns either:
 

--- a/docs/docs-beta/docs/guides/automate/sensors.md
+++ b/docs/docs-beta/docs/guides/automate/sensors.md
@@ -3,7 +3,19 @@ title: Create event-based pipelines with sensors
 sidebar_position: 30
 ---
 
-Sensors enable you to trigger Dagster runs in response to events from external systems. They run at regular intervals, either triggering a run or explaining why a run was skipped. For example, you can trigger a run when a new file is added to an Amazon S3 bucket or when a database row is updated.
+Sensors enable you to take action in response to events that happen both internally or at external systems. They check for events at regular intervals, either performing an action or explaining why it was skipped.
+
+Example of events can be:
+- a run completes in Dagster
+- a run fails in Dagster
+- a job materializes a specific asset 
+- a file appears in an s3 bucket
+- an external system is down
+
+Example of actions are:
+- launching a run
+- sending a Slack message
+- inserting a row into a database
 
 :::tip
 An alternative to polling with sensors is to push events to Dagster using the [Dagster API](/guides/automate#graphql-endpoint).


### PR DESCRIPTION
## Summary & Motivation

Make it clearer that sensor can be used to act both on Dagster's and external events, and can both launch run & do other things

## How I Tested These Changes

Locally run both docs and docs-beta servers
