### PR TITLE
Lazily load AssetGraphDfifer in GrapheneAssetNode

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -22,7 +22,6 @@ from dagster import (
     MultiPartitionsDefinition,
     _check as check,
 )
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
@@ -177,22 +176,10 @@ def _graphene_asset_node(
 ):
     from dagster_graphql.schema.asset_graph import GrapheneAssetNode
 
-    handle = remote_node.resolve_to_singular_repo_scoped_node().repository_handle
-    base_deployment_context = graphene_info.context.get_base_deployment_context()
-
     return GrapheneAssetNode(
         remote_node=remote_node,
         stale_status_loader=stale_status_loader,
         dynamic_partitions_loader=dynamic_partitions_loader,
-        # base_deployment_context will be None if we are not in a branch deployment
-        asset_graph_differ=AssetGraphDiffer.from_remote_repositories(
-            code_location_name=handle.location_name,
-            repository_name=handle.repository_name,
-            branch_workspace=graphene_info.context,
-            base_workspace=base_deployment_context,
-        )
-        if base_deployment_context is not None
-        else None,
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import graphene
 from dagster import _check as check
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation import (
@@ -372,17 +371,6 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_assetNodes(self, graphene_info: ResolveInfo):
         remote_nodes = self.get_repository(graphene_info).asset_graph.asset_nodes
 
-        asset_graph_differ = None
-        base_deployment_context = graphene_info.context.get_base_deployment_context()
-        if base_deployment_context is not None:
-            # then we are in a branch deployment
-            asset_graph_differ = AssetGraphDiffer.from_remote_repositories(
-                code_location_name=self._handle.location_name,
-                repository_name=self._handle.repository_name,
-                branch_workspace=graphene_info.context,
-                base_workspace=base_deployment_context,
-            )
-
         dynamic_partitions_loader = CachingDynamicPartitionsLoader(
             graphene_info.context.instance,
         )
@@ -397,7 +385,6 @@ class GrapheneRepository(graphene.ObjectType):
                 remote_node=remote_node,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
-                asset_graph_differ=asset_graph_differ,
             )
             for remote_node in remote_nodes
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
 import dagster._check as check
 import graphene
 from dagster import AssetCheckKey
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
@@ -1093,22 +1092,11 @@ class GrapheneQuery(graphene.ObjectType):
             loading_context=graphene_info.context,
         )
 
-        base_deployment_context = graphene_info.context.get_base_deployment_context()
-
         nodes = [
             GrapheneAssetNode(
                 remote_node=remote_node,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
-                # base_deployment_context will be None if we are not in a branch deployment
-                asset_graph_differ=AssetGraphDiffer.from_remote_repositories(
-                    code_location_name=remote_node.resolve_to_singular_repo_scoped_node().repository_handle.location_name,
-                    repository_name=remote_node.resolve_to_singular_repo_scoped_node().repository_handle.repository_name,
-                    branch_workspace=graphene_info.context,
-                    base_workspace=base_deployment_context,
-                )
-                if base_deployment_context is not None
-                else None,
             )
             for remote_node in results
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
 import dagster._check as check
 import graphene
 from dagster._core.definitions import NodeHandle
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.remote_representation import RepresentedJob
 from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.historical import HistoricalJob
@@ -446,20 +445,10 @@ class ISolidDefinitionMixin:
                     )
                 )
             ]
-            differ = None
-            base_deployment_context = graphene_info.context.get_base_deployment_context()
-            if base_deployment_context:
-                differ = AssetGraphDiffer.from_remote_repositories(
-                    code_location_name=self._represented_pipeline.handle.location_name,
-                    repository_name=self._represented_pipeline.handle.repository_name,
-                    branch_workspace=graphene_info.context,
-                    base_workspace=base_deployment_context,
-                )
 
             return [
                 GrapheneAssetNode(
                     remote_node=remote_node,
-                    asset_graph_differ=differ,
                 )
                 for remote_node in remote_nodes
             ]


### PR DESCRIPTION
Summary:
AssetGraphDiffer does non-trivial data fetching so defer loading it until we actually fetch the field that uses it.

BK, load asset graph in and out of branch deployment context

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
