### PR TITLE
[integrations-api][ga] PipesECSClient and ECS executors in dagster-aws

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
@@ -13,7 +13,6 @@ from dagster import (
     _check as check,
     executor,
 )
-from dagster._annotations import experimental
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.events import DagsterEvent, EngineEventData
@@ -77,7 +76,6 @@ _ECS_EXECUTOR_CONFIG_SCHEMA = {
     config_schema=_ECS_EXECUTOR_CONFIG_SCHEMA,
     requirements=multiple_process_executor_requirements(),
 )
-@experimental
 def ecs_executor(init_context: InitExecutorContext) -> Executor:
     """Executor which launches steps as ECS tasks.
 
@@ -139,7 +137,6 @@ def ecs_executor(init_context: InitExecutorContext) -> Executor:
     )
 
 
-@experimental
 class EcsStepHandler(StepHandler):
     @property
     def name(self):

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
@@ -5,7 +5,7 @@ import boto3
 import botocore
 import dagster._check as check
 from dagster import DagsterInvariantViolationError, MetadataValue, PipesClient
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     )
 
 
-@experimental
 class PipesECSClient(PipesClient, TreatAsResourceParam):
     """A pipes client for running AWS ECS tasks.
 


### PR DESCRIPTION
## Summary & Motivation

decision:

pipes: experimental -> ga

executor: experimental -> ga

reason: the pipes client has been around for quite some time now. It is well documented and adopted. The executor should have been GA already, removing the experimental decorator.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
