### PR TITLE
[pipes] PySpark tutorial

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -382,6 +382,10 @@
                   }
                 ]
               },
+	      {
+                "title": "Dagster Pipes + PySpark",
+                "path": "/concepts/dagster-pipes/pyspark"
+              },
               {
                 "title": "Dagster Pipes + AWS ECS",
                 "path": "/concepts/dagster-pipes/aws-ecs"

--- a/docs/content/concepts/dagster-pipes/pyspark.mdx
+++ b/docs/content/concepts/dagster-pipes/pyspark.mdx
@@ -5,9 +5,9 @@ description: "Learn to integrate Dagster Pipes with PySpark to orchestrate PySpa
 
 # PySpark & Dagster Pipes
 
-This tutorial is focused on using Dagster Pipes to launch & monitor general PySpark jobs. The [Spark integration page](/integrations/spark) provides more information on using Pipes with specific Spark provides (such as AWS EMR or Databricks).
+This tutorial is focused on using Dagster Pipes to launch & monitor general PySpark jobs. The [Spark integration page](/integrations/spark) provides more information on using Pipes with specific Spark providers, such as AWS EMR or Databricks.
 
-Spark is often used with object stores such as Amazon S3. We are going to simulate this setup locally with [MinIO](https://min.io/) which has an API compatible with AWS S3. All communication between Dagster and the Spark job (metadata and logs collection) will happen through a MinIO bucket.
+Spark is often used with object stores such as Amazon S3. We are going to simulate this setup locally with [MinIO](https://min.io/), which has an API compatible with AWS S3. All communication between Dagster and the Spark job (metadata and logs collection) will happen through a MinIO bucket.
 
 ---
 
@@ -19,43 +19,43 @@ We are going to use [Docker](https://docs.docker.com/get-started/get-docker/) to
 
 For demonstration purposes, this tutorial makes a few simplifications that you should consider when deploying in production:
 
-- We are going to be running Spark in local mode, sharing the same container with Dagster. In production, consider having two separate environments.
+- We are going to be running Spark in local mode, sharing the same container with Dagster. In production, consider having two separate environments:
 
-   - **In the Dagster environment**, you'll need to have the following Python packages:
+  - **In the Dagster environment**, you'll need to have the following Python packages:
 
-     - `dagster`
-     - `dagster-webserver` --- to run the Dagster UI
-     - `dagster-aws` --- when using S3
+    - `dagster`
+    - `dagster-webserver` --- to run the Dagster UI
+    - `dagster-aws` --- when using S3
 
-     And make the orchestration code available to Dagster (typically via a code location).
+    You will also need to make the orchestration code available to Dagster (typically via a [code location](concepts/code-locations)).
 
-   - **In the PySpark environment**, you'll need to install the `dagster-pipes` Python package, and typically the Java AWS S3 SDK packages. For example:
+  - **In the PySpark environment**, you'll need to install the `dagster-pipes` Python package, and typically the Java AWS S3 SDK packages. For example:
 
-     ```shell
-     curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.5.1/hadoop-aws-3.5.1.jar" \
-       -o /opt/bitnami/spark/jars/hadoop-aws-3.5.1.jar
+    ```shell
+    curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.5.1/hadoop-aws-3.5.1.jar" \
+      -o /opt/bitnami/spark/jars/hadoop-aws-3.5.1.jar
 
-     curl -fSL "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.780/aws-java-sdk-bundle-1.12.780.jar" \
-       -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.780.jar
-     ```
+    curl -fSL "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.780/aws-java-sdk-bundle-1.12.780.jar" \
+      -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.780.jar
+    ```
 
-     Make sure `hadoop-aws` JAR and AWS Java SDK bundle versions match your Spark/Hadoop build.
+    Make sure `hadoop-aws` JAR and AWS Java SDK versions are compatible with your Spark/Hadoop build.
 
 - We are going to upload the PySpark script to the S3 bucket directly inside the Dagster asset. In production, consider doing this via CI/CD instead.
 
 ---
 
-## Step 1: Writing the Dagster orchestration code
+## Step 1: Writing the Dagster orchestration code (dagster_code.py)
 
 We will set up a few non-default Pipes components to streamline the otherwise challenging problem of orchestrating Spark jobs.
 
-1. Let's start by creating the asset and opening a Pipes session. We will be using S3 to pass Pipes messages from the Spark job to Dagster, so we will create `PipesS3MessageReader` and `PipesS3ContextInjector` objects. (Technically, it's not strictly required to use S3 for passing the Dagster context, but storing it there will decrease the CLI arguments size.)
+1. Let's start by creating the asset and opening a Pipes session. We will be using S3 to pass Pipes messages from the Spark job to Dagster, so we will create `PipesS3MessageReader` and `PipesS3ContextInjector` objects. (Technically, it's not strictly required to use S3 for passing the Dagster context, but storing it there will decrease the CLI arguments size).
 
 ```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=start_pipes_session_marker endbefore=end_pipes_session_marker
 import os
 import subprocess
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Mapping, Sequence
 
 import boto3
 from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
@@ -89,22 +89,21 @@ def pipes_spark_asset(context: dg.AssetExecutionContext):
         # and send them to Dagster via Pipes
         include_stdio_in_messages=True,
     )
+```
 
+Notice how `PipesS3MessageReader` has `include_stdio_in_messages=True`. This setting will configure the Pipes **message writer** in the Spark job to collect logs from the Spark driver and send them to Dagster via Pipes messages.
+
+2. We will be using CLI arguments to pass the bootstrap information from Dagster to the Spark job. We will fetch them from the `session.get_bootstrap_cli_arguments` method. We pass these arguments to `spark-submit` along with a few other settings.
+
+```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=end_pipes_session_marker endbefore=start_definitions_marker
+# pipes_spark_asset body continues below
     with dg.open_pipes_session(
         context=context,
         message_reader=message_reader,
         context_injector=context_injector,
     ) as session:
-```
-
-Notice how `PipesS3MessageReader` has `include_stdio_in_messages=True`. This setting will configure the Pipes message writer in the Spark job to collect logs from the Spark driver and send them to Dagster via Pipes messages.
-
-2. We will be using CLI arguments to pass the bootstrap information from Dagster to the Spark job. In other Pipes workflows this is typically done via environment variables, but setting them for Spark jobs can be complicated (the exact way of doing this depends on the Spark deployment) or not possible at all. CLI arguments are a convenient alternative. We will fetch them from the `session.get_bootstrap_cli_arguments` method. We pass these arguments to `spark-submit` along with a few other settings.
-
-```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=end_pipes_session_marker endbefore=start_definitions_marker
-# prepare Pipes bootstrap CLI arguments
-
         dagster_pipes_args = " ".join(
+            # prepare Pipes bootstrap CLI arguments
             [
                 f"{key} {value}"
                 for key, value in session.get_bootstrap_cli_arguments().items()
@@ -114,7 +113,7 @@ Notice how `PipesS3MessageReader` has `include_stdio_in_messages=True`. This set
         cmd = " ".join(
             [
                 "spark-submit",
-                # change --master and --deploy-mode according to Spark setup
+                # change --master and --deploy-mode according to specific Spark setup
                 "--master",
                 "local[*]",
                 "--conf",
@@ -133,23 +132,23 @@ Notice how `PipesS3MessageReader` has `include_stdio_in_messages=True`. This set
             # we do not forward stdio on purpose to demonstrate how Pipes collect logs from the driver
             cmd,
             shell=True,
-            check=True,  # stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            check=True,
         )
 
         return session.get_results()
 ```
 
-3. At last, let's add the new asset to `Definitions`:
+<Note>
+  In other Pipes workflows, passing the bootstrap information from Dagster to
+  the remote Pipes session is typically done via environment variables, but
+  setting environment variables for Spark jobs can be complicated (the exact way
+  of doing this depends on the Spark deployment) or not possible at all. CLI
+  arguments are a convenient alternative.
+</Note>
 
-```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=start_definitions_marker endbefore=end_definitions_marker
-defs = dg.Definitions(
-    assets=[pipes_spark_asset],
-)
-```
+## Step 2: Use Pipes in the PySpark job (script.py)
 
-## Step 2: Use Pipes in the PySpark job
-
-Call `open_dagster_pipes` in the PySpark job script to create a context that can be used to send messages to Dagster:
+First, create a new file named `script.py`, then add the following code to create a context that can be used to send messages to Dagster:
 
 ```python file=/guides/dagster/dagster_pipes/pyspark/script.py startafter
 import boto3
@@ -201,7 +200,7 @@ Because the Dagster code has `include_stdio_in_messages=True`, the message write
 
 ## Step 3: Running the pipeline with Docker
 
-1. Place the PySpark code to `script.py` and the Dagster orchestration code to `dagster_code.py` in the same directory.
+1. Place the PySpark code for `script.py` and the Dagster orchestration code for `dagster_code.py` in the same directory.
 
 2. Create a `Dockerfile`:
 
@@ -217,9 +216,6 @@ ARG SPARK_VERSION=3.4.1
 COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
 
 RUN install_packages curl
-
-# Download the matching hadoop-aws JAR and AWS Java SDK bundle
-# Make sure versions match your Spark/Hadoop build.
 
 RUN curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/$SPARK_VERSION/hadoop-aws-$SPARK_VERSION.jar" \
     -o /opt/bitnami/spark/jars/hadoop-aws-$SPARK_VERSION.jar
@@ -241,6 +237,8 @@ COPY dagster_code.py script.py ./
 # this docker compose file creates a mini Spark cluster with 1 master and 2 workers to simulate a distributed environment
 
 volumes:
+  spark-logs:
+  spark-data:
   minio-data:
   dagster_home:
 
@@ -299,18 +297,18 @@ services:
       - spark
 ```
 
-4. Start the Dagster dev instance inside docker:
+4. Start the Dagster dev instance inside Docker:
 
 ```shell
 docker compose up --build --watch
 ```
 
 <Note>
-  `--watch` will automatically sync the changes in the local filesystem
-  to the Docker container which is useful for live code updates without volume mounts.
+  `--watch` will automatically sync the changes in the local filesystem to the
+  Docker container, which is useful for live code updates without volume mounts.
 </Note>
 
-5. Navigate to [http://localhost:3000](http://localhost:3000) to open the Dagster UI and materialize the asset. Metadata and stdio logs emitted in the PySpark job will become available in Dagster.
+5. Navigate to <http://localhost:3000> to open the Dagster UI and materialize the asset. Metadata and stdio logs emitted in the PySpark job will become available in Dagster.
 
 ---
 

--- a/docs/content/concepts/dagster-pipes/pyspark.mdx
+++ b/docs/content/concepts/dagster-pipes/pyspark.mdx
@@ -1,0 +1,328 @@
+---
+title: "Integrating PySpark with Dagster Pipes | Dagster Docs"
+description: "Learn to integrate Dagster Pipes with PySpark to orchestrate PySpark jobs in a Dagster pipeline."
+---
+
+# PySpark & Dagster Pipes
+
+This tutorial is focused on using Dagster Pipes to launch & monitor general PySpark jobs. The [Spark integration page](/integrations/spark) provides more information on using Pipes with specific Spark provides (such as AWS EMR or Databricks).
+
+Spark is often used with object stores such as Amazon S3. We are going to simulate this setup locally with [MinIO](https://min.io/) which has an API compatible with AWS S3. All communication between Dagster and the Spark job (metadata and logs collection) will happen through a MinIO bucket.
+
+---
+
+## Prerequisites
+
+We are going to use [Docker](https://docs.docker.com/get-started/get-docker/) to emulate a typical Spark setup locally. Therefore, only Docker is required to reproduce this example.
+
+## Production considerations
+
+For demonstration purposes, this tutorial makes a few simplifications that you should consider when deploying in production:
+
+- We are going to be running Spark in local mode, sharing the same container with Dagster. In production, consider having two separate environments.
+
+   - **In the Dagster environment**, you'll need to have the following Python packages:
+
+     - `dagster`
+     - `dagster-webserver` --- to run the Dagster UI
+     - `dagster-aws` --- when using S3
+
+     And make the orchestration code available to Dagster (typically via a code location).
+
+   - **In the PySpark environment**, you'll need to install the `dagster-pipes` Python package, and typically the Java AWS S3 SDK packages. For example:
+
+     ```shell
+     curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.5.1/hadoop-aws-3.5.1.jar" \
+       -o /opt/bitnami/spark/jars/hadoop-aws-3.5.1.jar
+
+     curl -fSL "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.780/aws-java-sdk-bundle-1.12.780.jar" \
+       -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.780.jar
+     ```
+
+     Make sure `hadoop-aws` JAR and AWS Java SDK bundle versions match your Spark/Hadoop build.
+
+- We are going to upload the PySpark script to the S3 bucket directly inside the Dagster asset. In production, consider doing this via CI/CD instead.
+
+---
+
+## Step 1: Writing the Dagster orchestration code
+
+We will set up a few non-default Pipes components to streamline the otherwise challenging problem of orchestrating Spark jobs.
+
+1. Let's start by creating the asset and opening a Pipes session. We will be using S3 to pass Pipes messages from the Spark job to Dagster, so we will create `PipesS3MessageReader` and `PipesS3ContextInjector` objects. (Technically, it's not strictly required to use S3 for passing the Dagster context, but storing it there will decrease the CLI arguments size.)
+
+```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=start_pipes_session_marker endbefore=end_pipes_session_marker
+import os
+import subprocess
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import boto3
+from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
+
+import dagster as dg
+
+LOCAL_SCRIPT_PATH = Path(__file__).parent / "script.py"
+
+
+@dg.asset
+def pipes_spark_asset(context: dg.AssetExecutionContext):
+    s3_client = boto3.client("s3")
+
+    bucket = os.environ["DAGSTER_PIPES_BUCKET"]
+
+    # upload the script to S3
+    # ideally, this should be done via CI/CD processes and not in the asset body
+    # but for the sake of this example we are doing it here
+    s3_script_path = f"{context.dagster_run.run_id}/pyspark_script.py"
+    s3_client.upload_file(LOCAL_SCRIPT_PATH, bucket, s3_script_path)
+
+    context_injector = PipesS3ContextInjector(
+        client=s3_client,
+        bucket=bucket,
+    )
+
+    message_reader = PipesS3MessageReader(
+        client=s3_client,
+        bucket=bucket,
+        # the following setting will configure the Spark job to collect logs from the driver
+        # and send them to Dagster via Pipes
+        include_stdio_in_messages=True,
+    )
+
+    with dg.open_pipes_session(
+        context=context,
+        message_reader=message_reader,
+        context_injector=context_injector,
+    ) as session:
+```
+
+Notice how `PipesS3MessageReader` has `include_stdio_in_messages=True`. This setting will configure the Pipes message writer in the Spark job to collect logs from the Spark driver and send them to Dagster via Pipes messages.
+
+2. We will be using CLI arguments to pass the bootstrap information from Dagster to the Spark job. In other Pipes workflows this is typically done via environment variables, but setting them for Spark jobs can be complicated (the exact way of doing this depends on the Spark deployment) or not possible at all. CLI arguments are a convenient alternative. We will fetch them from the `session.get_bootstrap_cli_arguments` method. We pass these arguments to `spark-submit` along with a few other settings.
+
+```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=end_pipes_session_marker endbefore=start_definitions_marker
+# prepare Pipes bootstrap CLI arguments
+
+        dagster_pipes_args = " ".join(
+            [
+                f"{key} {value}"
+                for key, value in session.get_bootstrap_cli_arguments().items()
+            ]
+        )
+
+        cmd = " ".join(
+            [
+                "spark-submit",
+                # change --master and --deploy-mode according to Spark setup
+                "--master",
+                "local[*]",
+                "--conf",
+                "spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem",
+                # custom S3 endpoint for MinIO
+                "--conf",
+                "spark.hadoop.fs.s3a.endpoint=http://minio:9000",
+                "--conf",
+                "spark.hadoop.fs.s3a.path.style.access=true",
+                f"s3a://{bucket}/{s3_script_path}",
+                dagster_pipes_args,
+            ]
+        )
+
+        subprocess.run(
+            # we do not forward stdio on purpose to demonstrate how Pipes collect logs from the driver
+            cmd,
+            shell=True,
+            check=True,  # stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        return session.get_results()
+```
+
+3. At last, let's add the new asset to `Definitions`:
+
+```python file=/guides/dagster/dagster_pipes/pyspark/dagster_code.py startafter=start_definitions_marker endbefore=end_definitions_marker
+defs = dg.Definitions(
+    assets=[pipes_spark_asset],
+)
+```
+
+## Step 2: Use Pipes in the PySpark job
+
+Call `open_dagster_pipes` in the PySpark job script to create a context that can be used to send messages to Dagster:
+
+```python file=/guides/dagster/dagster_pipes/pyspark/script.py startafter
+import boto3
+from dagster_pipes import (
+    PipesCliArgsParamsLoader,
+    PipesS3ContextLoader,
+    PipesS3MessageWriter,
+    open_dagster_pipes,
+)
+from pyspark.sql import SparkSession
+
+
+def main():
+    with open_dagster_pipes(
+        message_writer=PipesS3MessageWriter(client=boto3.client("s3")),
+        context_loader=PipesS3ContextLoader(client=boto3.client("s3")),
+        params_loader=PipesCliArgsParamsLoader(),
+    ) as pipes:
+        print("Hello from the Spark driver!")
+
+        pipes.log.info("I am logging a Dagster message from the Spark driver!")
+
+        spark = SparkSession.builder.appName("HelloWorld").getOrCreate()
+
+        df = spark.createDataFrame(
+            [(1, "Alice", 34), (2, "Bob", 45), (3, "Charlie", 56)],
+            ["id", "name", "age"],
+        )
+
+        # calculate a really important statistic
+        avg_age = float(df.agg({"age": "avg"}).collect()[0][0])
+
+        # attach it to the asset materialization in Dagster
+        pipes.report_asset_materialization(
+            metadata={"average_age": {"raw_value": avg_age, "type": "float"}},
+            data_version="alpha",
+        )
+
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Note how `PipesCliArgsParamsLoader` is used to load the CLI arguments passed by Dagster. This information will be used to automatically configure `PipesS3MessageWriter` and `PipesS3ContextLoader`.
+
+Because the Dagster code has `include_stdio_in_messages=True`, the message writer will collect logs from the driver and send them to Dagster via Pipes messages.
+
+## Step 3: Running the pipeline with Docker
+
+1. Place the PySpark code to `script.py` and the Dagster orchestration code to `dagster_code.py` in the same directory.
+
+2. Create a `Dockerfile`:
+
+```dockerfile file=/guides/dagster/dagster_pipes/pyspark/Dockerfile
+ARG SPARK_VERSION=3.5.1
+
+FROM bitnami/spark:${SPARK_VERSION}
+
+USER root
+
+ARG SPARK_VERSION=3.4.1
+
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
+
+RUN install_packages curl
+
+# Download the matching hadoop-aws JAR and AWS Java SDK bundle
+# Make sure versions match your Spark/Hadoop build.
+
+RUN curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/$SPARK_VERSION/hadoop-aws-$SPARK_VERSION.jar" \
+    -o /opt/bitnami/spark/jars/hadoop-aws-$SPARK_VERSION.jar
+
+RUN curl -fSL "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.780/aws-java-sdk-bundle-1.12.780.jar" \
+    -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.780.jar
+
+# install Python dependencies
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system dagster dagster-webserver dagster-aws pyspark
+
+WORKDIR /src
+ENV DAGSTER_HOME=/dagster_home
+COPY dagster_code.py script.py ./
+```
+
+3. Create a `docker-compose.yml`:
+
+```yaml file=/guides/dagster/dagster_pipes/pyspark/docker-compose.yml
+# this docker compose file creates a mini Spark cluster with 1 master and 2 workers to simulate a distributed environment
+
+volumes:
+  minio-data:
+  dagster_home:
+
+networks:
+  spark:
+
+services:
+  minio:
+    image: bitnami/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+      MINIO_DEFAULT_BUCKETS: "dagster-pipes:public"
+    volumes:
+      - minio-data:/data
+    networks:
+      - spark
+
+  dagster-dev:
+    develop:
+      watch:
+        - action: sync
+          path: .
+          target: /src
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command:
+      - "dagster"
+      - "dev"
+      - "-f"
+      - "/src/dagster_code.py"
+      - "--host"
+      - "0.0.0.0"
+      - "--port"
+      - "3000"
+    ports:
+      - "3000:3000"
+    volumes:
+      - spark-logs:/spark/logs
+      - spark-data:/spark/data
+      - dagster_home:/dagster_home
+    environment:
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: minio123
+      AWS_ENDPOINT_URL: http://minio:9000
+      DAGSTER_PIPES_BUCKET: dagster-pipes
+
+    depends_on:
+      - minio
+
+    networks:
+      - spark
+```
+
+4. Start the Dagster dev instance inside docker:
+
+```shell
+docker compose up --build --watch
+```
+
+<Note>
+  `--watch` will automatically sync the changes in the local filesystem
+  to the Docker container which is useful for live code updates without volume mounts.
+</Note>
+
+5. Navigate to [http://localhost:3000](http://localhost:3000) to open the Dagster UI and materialize the asset. Metadata and stdio logs emitted in the PySpark job will become available in Dagster.
+
+---
+
+## Related
+
+<ArticleList>
+  <ArticleListItem
+    title="Dagster Pipes"
+    href="/concepts/dagster-pipes"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Dagster + Spark"
+    href="/integrations/spark"
+  ></ArticleListItem>
+</ArticleList>

--- a/docs/next/next-env.d.ts
+++ b/docs/next/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/Dockerfile
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/Dockerfile
@@ -1,0 +1,22 @@
+FROM 895885662937.dkr.ecr.us-west-2.amazonaws.com/spark/emr-7.5.0:latest
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+USER root
+RUN mkdir /python && chown hadoop:hadoop /python
+
+USER hadoop
+ENV UV_PYTHON_INSTALL_DIR=/python
+
+RUN uv python install --python-preference only-managed 3.9.16
+ENV PATH="${UV_PYTHON_INSTALL_DIR}/cpython-3.9.16-linux-x86_64-gnu/bin:${PATH}"
+ENV UV_PYTHON="${UV_PYTHON_INSTALL_DIR}/cpython-3.9.16-linux-x86_64-gnu/bin/python" \
+    UV_BREAK_SYSTEM_PACKAGES=1 \
+    PYSPARK_PYTHON="${UV_PYTHON_INSTALL_DIR}/cpython-3.9.16-linux-x86_64-gnu/bin/python" \
+    PYSPARK_DRIVER_PYTHON="${UV_PYTHON_INSTALL_DIR}/cpython-3.9.16-linux-x86_64-gnu/bin/python" \
+    PYTHONPATH="${UV_PYTHON_INSTALL_DIR}/cpython-3.9.16-linux-x86_64-gnu/lib/python3.9/site-packages"
+
+RUN uv pip install --system dagster-pipes boto3 pyspark
+
+WORKDIR /app
+COPY script.py .

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/dagster_code.py
@@ -1,0 +1,77 @@
+# start_asset_marker
+
+from dagster_aws.pipes import PipesEMRContainersClient
+
+from dagster import AssetExecutionContext, asset
+
+
+@asset
+def emr_containers_asset(
+    context: AssetExecutionContext,
+    pipes_emr_containers_client: PipesEMRContainersClient,
+):
+    return pipes_emr_containers_client.run(
+        context=context,
+        start_job_run_params={
+            "releaseLabel": "emr-7.5.0-latest",
+            "virtualClusterId": "uqcja50dzo7v1meie1wa47wa3",
+            "clientToken": context.run_id,  # idempotency identifier for the job run
+            "executionRoleArn": "arn:aws:iam::467123434025:role/emr-dagster-pipes-20250109135314655100000001",
+            "jobDriver": {
+                "sparkSubmitJobDriver": {
+                    "entryPoint": "local:///app/script.py",
+                    # --conf spark.kubernetes.container.image=
+                    "sparkSubmitParameters": "--conf spark.kubernetes.file.upload.path=/tmp/spark --conf spark.kubernetes.container.image=467123434025.dkr.ecr.eu-north-1.amazonaws.com/dagster/emr-containers:12",  # --conf spark.pyspark.python=/home/hadoop/.local/share/uv/python/cpython-3.9.16-linux-x86_64-gnu/bin/python --conf spark.pyspark.driver.python=/home/hadoop/.local/share/uv/python/cpython-3.9.16-linux-x86_64-gnu/bin/python",
+                }
+            },
+            "configurationOverrides": {
+                "monitoringConfiguration": {
+                    "cloudWatchMonitoringConfiguration": {
+                        "logGroupName": "/aws/emr/containers/pipes",
+                        "logStreamNamePrefix": str(context.run_id),
+                    }
+                },
+                # "applicationConfiguration": [
+                #     {
+                #         "Classification": "spark-env",
+                #         "Configurations": [
+                #         {
+                #             "Classification": "export",
+                #             "Properties": {
+                #             "PYSPARK_PYTHON": "/home/hadoop/.local/share/uv/python/cpython-3.9.16-linux-x86_64-gnu/bin/python",
+                #             "PYSPARK_DRIVER_PYTHON": "/home/hadoop/.local/share/uv/python/cpython-3.9.16-linux-x86_64-gnu/bin/python",
+                #             }
+                #         }
+                #     ]
+                #       }
+                # ]
+            },
+        },
+    ).get_materialize_result()
+
+
+# end_asset_marker
+
+# start_definitions_marker
+import boto3
+from dagster_aws.pipes import PipesCloudWatchMessageReader, PipesS3ContextInjector
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[emr_containers_asset],
+    resources={
+        "pipes_emr_containers_client": PipesEMRContainersClient(
+            message_reader=PipesCloudWatchMessageReader(
+                client=boto3.client("logs"),
+                include_stdio_in_messages=True,
+            ),
+            # context_injector=PipesS3ContextInjector(
+            #     bucket="dagster-pipes-20250109123428055900000004",
+            #     client=boto3.client("s3"),
+            # )
+        )
+    },
+)
+
+# end_definitions_marker

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/script.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/script.py
@@ -1,0 +1,46 @@
+import sys
+
+import boto3
+from dagster_pipes import PipesS3ContextLoader, PipesS3MessageWriter, open_dagster_pipes
+from pyspark.sql import SparkSession
+
+
+def main():
+    s3_client = boto3.client("s3")
+
+    with open_dagster_pipes(
+        message_writer=PipesS3MessageWriter(client=s3_client),
+        context_loader=PipesS3ContextLoader(client=s3_client),
+    ) as pipes:
+        pipes.log.info("Hello from AWS EMR Containers!")
+
+        spark = SparkSession.builder.appName("HelloWorld").getOrCreate()
+
+        df = spark.createDataFrame(
+            [(1, "Alice", 34), (2, "Bob", 45), (3, "Charlie", 56)],
+            ["id", "name", "age"],
+        )
+
+        # calculate a really important statistic
+        avg_age = float(df.agg({"age": "avg"}).collect()[0][0])
+
+        # attach it to the asset materialization in Dagster
+        pipes.report_asset_materialization(
+            metadata={"average_age": {"raw_value": avg_age, "type": "float"}},
+            data_version="alpha",
+        )
+
+        print("Hello from stdout!")  # noqa: T201
+        print("Hello from stderr!", file=sys.stderr)  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()
+
+# import os
+# import sys
+
+# print(os.getcwd())
+# print(os.environ)
+# print(sys.path)
+# print(sys.executable)

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/Dockerfile
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/Dockerfile
@@ -1,0 +1,27 @@
+ARG SPARK_VERSION=3.5.1
+
+FROM bitnami/spark:${SPARK_VERSION}
+
+USER root
+
+ARG SPARK_VERSION=3.4.1
+
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
+
+RUN install_packages curl
+
+# Download the matching hadoop-aws JAR and AWS Java SDK bundle
+# Make sure versions match your Spark/Hadoop build.
+
+RUN curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/$SPARK_VERSION/hadoop-aws-$SPARK_VERSION.jar" \
+    -o /opt/bitnami/spark/jars/hadoop-aws-$SPARK_VERSION.jar
+
+RUN curl -fSL "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.780/aws-java-sdk-bundle-1.12.780.jar" \
+    -o /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.780.jar
+
+# install Python dependencies
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system dagster dagster-webserver dagster-aws pyspark
+
+WORKDIR /src
+ENV DAGSTER_HOME=/dagster_home
+COPY dagster_code.py script.py ./

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/Dockerfile
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/Dockerfile
@@ -10,9 +10,6 @@ COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
 
 RUN install_packages curl
 
-# Download the matching hadoop-aws JAR and AWS Java SDK bundle
-# Make sure versions match your Spark/Hadoop build.
-
 RUN curl -fSL "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/$SPARK_VERSION/hadoop-aws-$SPARK_VERSION.jar" \
     -o /opt/bitnami/spark/jars/hadoop-aws-$SPARK_VERSION.jar
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
@@ -1,0 +1,92 @@
+# start_pipes_session_marker
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import boto3
+from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
+
+import dagster as dg
+
+LOCAL_SCRIPT_PATH = Path(__file__).parent / "script.py"
+
+
+@dg.asset
+def pipes_spark_asset(context: dg.AssetExecutionContext):
+    s3_client = boto3.client("s3")
+
+    bucket = os.environ["DAGSTER_PIPES_BUCKET"]
+
+    # upload the script to S3
+    # ideally, this should be done via CI/CD processes and not in the asset body
+    # but for the sake of this example we are doing it here
+    s3_script_path = f"{context.dagster_run.run_id}/pyspark_script.py"
+    s3_client.upload_file(LOCAL_SCRIPT_PATH, bucket, s3_script_path)
+
+    context_injector = PipesS3ContextInjector(
+        client=s3_client,
+        bucket=bucket,
+    )
+
+    message_reader = PipesS3MessageReader(
+        client=s3_client,
+        bucket=bucket,
+        # the following setting will configure the Spark job to collect logs from the driver
+        # and send them to Dagster via Pipes
+        include_stdio_in_messages=True,
+    )
+
+    with dg.open_pipes_session(
+        context=context,
+        message_reader=message_reader,
+        context_injector=context_injector,
+    ) as session:
+        # end_pipes_session_marker
+
+        # prepare Pipes bootstrap CLI arguments
+
+        dagster_pipes_args = " ".join(
+            [
+                f"{key} {value}"
+                for key, value in session.get_bootstrap_cli_arguments().items()
+            ]
+        )
+
+        cmd = " ".join(
+            [
+                "spark-submit",
+                # change --master and --deploy-mode according to Spark setup
+                "--master",
+                "local[*]",
+                "--conf",
+                "spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem",
+                # custom S3 endpoint for MinIO
+                "--conf",
+                "spark.hadoop.fs.s3a.endpoint=http://minio:9000",
+                "--conf",
+                "spark.hadoop.fs.s3a.path.style.access=true",
+                f"s3a://{bucket}/{s3_script_path}",
+                dagster_pipes_args,
+            ]
+        )
+
+        subprocess.run(
+            # we do not forward stdio on purpose to demonstrate how Pipes collect logs from the driver
+            cmd,
+            shell=True,
+            check=True,  # stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        return session.get_results()
+
+
+# start_definitions_marker
+
+
+defs = dg.Definitions(
+    assets=[pipes_spark_asset],
+)
+
+# end_definitions_marker

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
@@ -2,8 +2,8 @@
 
 import os
 import subprocess
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Mapping, Sequence
 
 import boto3
 from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
@@ -38,16 +38,16 @@ def pipes_spark_asset(context: dg.AssetExecutionContext):
         include_stdio_in_messages=True,
     )
 
+    # end_pipes_session_marker
+
+    # pipes_spark_asset body continues below
     with dg.open_pipes_session(
         context=context,
         message_reader=message_reader,
         context_injector=context_injector,
     ) as session:
-        # end_pipes_session_marker
-
-        # prepare Pipes bootstrap CLI arguments
-
         dagster_pipes_args = " ".join(
+            # prepare Pipes bootstrap CLI arguments
             [
                 f"{key} {value}"
                 for key, value in session.get_bootstrap_cli_arguments().items()
@@ -57,7 +57,7 @@ def pipes_spark_asset(context: dg.AssetExecutionContext):
         cmd = " ".join(
             [
                 "spark-submit",
-                # change --master and --deploy-mode according to Spark setup
+                # change --master and --deploy-mode according to specific Spark setup
                 "--master",
                 "local[*]",
                 "--conf",
@@ -76,7 +76,7 @@ def pipes_spark_asset(context: dg.AssetExecutionContext):
             # we do not forward stdio on purpose to demonstrate how Pipes collect logs from the driver
             cmd,
             shell=True,
-            check=True,  # stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            check=True,
         )
 
         return session.get_results()

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/docker-compose.yml
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/docker-compose.yml
@@ -1,0 +1,61 @@
+# this docker compose file creates a mini Spark cluster with 1 master and 2 workers to simulate a distributed environment
+
+volumes:
+    spark-logs:
+    spark-data:
+    minio-data:
+    dagster_home:
+
+networks:
+    spark:
+
+services:
+    minio:
+        image: bitnami/minio
+        ports:
+            - "9000:9000"
+            - "9001:9001"
+        environment:
+            MINIO_ROOT_USER: minio
+            MINIO_ROOT_PASSWORD: minio123
+            MINIO_DEFAULT_BUCKETS: "dagster-pipes:public"
+        volumes:
+            - minio-data:/data
+        networks:
+            - spark
+
+    dagster-dev:
+        develop:
+            watch:
+                - action: sync
+                  path: .
+                  target: /src
+        build:
+            context: .
+            dockerfile: Dockerfile
+        command:
+            - "dagster"
+            - "dev"
+            - "-f"
+            - "/src/dagster_code.py"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "3000"
+        ports:
+            - "3000:3000"
+        volumes:
+            - spark-logs:/spark/logs
+            - spark-data:/spark/data
+            - dagster_home:/dagster_home
+        environment:
+            AWS_ACCESS_KEY_ID: minio
+            AWS_SECRET_ACCESS_KEY: minio123
+            AWS_ENDPOINT_URL: http://minio:9000
+            DAGSTER_PIPES_BUCKET: dagster-pipes
+
+        depends_on:
+            - minio
+
+        networks:
+            - spark

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/script.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/script.py
@@ -1,0 +1,41 @@
+import boto3
+from dagster_pipes import (
+    PipesCliArgsParamsLoader,
+    PipesS3ContextLoader,
+    PipesS3MessageWriter,
+    open_dagster_pipes,
+)
+from pyspark.sql import SparkSession
+
+
+def main():
+    with open_dagster_pipes(
+        message_writer=PipesS3MessageWriter(client=boto3.client("s3")),
+        context_loader=PipesS3ContextLoader(client=boto3.client("s3")),
+        params_loader=PipesCliArgsParamsLoader(),
+    ) as pipes:
+        print("Hello from the Spark driver!")  # noqa: T201
+
+        pipes.log.info("I am logging a Dagster message from the Spark driver!")
+
+        spark = SparkSession.builder.appName("HelloWorld").getOrCreate()
+
+        df = spark.createDataFrame(
+            [(1, "Alice", 34), (2, "Bob", 45), (3, "Charlie", 56)],
+            ["id", "name", "age"],
+        )
+
+        # calculate a really important statistic
+        avg_age = float(df.agg({"age": "avg"}).collect()[0][0])
+
+        # attach it to the asset materialization in Dagster
+        pipes.report_asset_materialization(
+            metadata={"average_age": {"raw_value": avg_age, "type": "float"}},
+            data_version="alpha",
+        )
+
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary & Motivation

This PR adds a detailed tutorial for using Dagster Pipes with (most likely self-hosted) PySpark. 

## How I Tested These Changes

Everything can be run with `docker compose up`. 

## Changelog

[docs] added a tutorial for using Dagster Pipes with PySpark

