### PR TITLE
[ui] Move usePrefixedCacheKey into its own file

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -3,7 +3,6 @@ import {WebSocketLink} from '@apollo/client/link/ws';
 import {getMainDefinition, isMutationOperation} from '@apollo/client/utilities';
 import {CustomTooltipProvider} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useContext} from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {CompatRouter} from 'react-router-dom-v5-compat';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
@@ -213,9 +212,4 @@ export const AppProvider = (props: AppProviderProps) => {
       </WebSocketProvider>
     </AppContext.Provider>
   );
-};
-
-export const usePrefixedCacheKey = (key: string) => {
-  const {localCacheIdPrefix} = useContext(AppContext);
-  return `${localCacheIdPrefix}/${key}`;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/usePrefixedCacheKey.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/usePrefixedCacheKey.tsx
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+
+import {AppContext} from './AppContext';
+
+export const usePrefixedCacheKey = (key: string) => {
+  const {localCacheIdPrefix} = useContext(AppContext);
+  return `${localCacheIdPrefix}/${key}`;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -17,9 +17,9 @@ import {
   AssetGraphQueryVersion,
   AssetNodeForGraphQueryFragment,
 } from './types/useAssetGraphData.types';
-import {usePrefixedCacheKey} from '../app/AppProvider';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {indexedDBAsyncMemoize} from '../app/Util';
+import {usePrefixedCacheKey} from '../app/usePrefixedCacheKey';
 import {AssetKey} from '../assets/types';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';


### PR DESCRIPTION
## Summary & Motivation

`usePrefixedCacheKey` currently lives in `AppProvider`, so callsites that import it are importing a big component with an increased risk of circular dependencies.

This is a pretty slim function that just needs `AppContext`, which is defined separately from the provider, so we can just move it out into its own file to mitigate the risk.

## How I Tested These Changes

Buildkite.