### PR TITLE
Add project_ask_ai_dagster to available examples

### DIFF
--- a/python_modules/dagster/dagster/_generate/download.py
+++ b/python_modules/dagster/dagster/_generate/download.py
@@ -37,6 +37,7 @@ AVAILABLE_EXAMPLES = [
     "feature_graph_backed_assets",
     "getting_started_etl_tutorial",
     "project_analytics",
+    "project_ask_ai_dagster",
     "project_atproto_dashboard",
     "project_dagster_modal_pipes",
     "project_dagster_university_start",


### PR DESCRIPTION
Fixes
https://buildkite.com/dagster/dagster-dagster/builds/106984#019441db-3189-4954-90d0-98297bbc4174/805-1256 and makes the example available via:

```
dagster project from-example --example project_ask_ai_dagster
```

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
