### PR TITLE
[graphql] Remove the unused `GrapheneCursor` class

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2799,8 +2799,6 @@ type TimestampMetadataEntry implements MetadataEntry {
   timestamp: Float!
 }
 
-scalar Cursor
-
 type Partition {
   name: String!
   partitionSetName: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -16,7 +16,6 @@ export type Scalars = {
   Boolean: {input: boolean; output: boolean};
   Int: {input: number; output: number};
   Float: {input: number; output: number};
-  Cursor: {input: any; output: any};
   GenericScalar: {input: any; output: any};
   RunConfigData: {input: any; output: any};
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/__init__.py
@@ -27,7 +27,6 @@ def types():
     from dagster_graphql.schema.instigation import types as instigation_types
     from dagster_graphql.schema.logs import types as log_types
     from dagster_graphql.schema.metadata import types as metadata_types
-    from dagster_graphql.schema.paging import GrapheneCursor
     from dagster_graphql.schema.partition_sets import types as partition_sets_types
     from dagster_graphql.schema.pipelines import types as pipelines_types
     from dagster_graphql.schema.repository_origin import (
@@ -64,7 +63,6 @@ def types():
         + [GrapheneDaemonHealth, GrapheneDaemonStatus, GrapheneInstance, GrapheneRunLauncher]
         + instigation_types
         + metadata_types()
-        + [GrapheneCursor]
         + partition_sets_types
         + [GrapheneRepositoryOrigin, GrapheneRepositoryMetadata]
         + [GrapheneRunConfigSchema, GrapheneRunConfigSchemaOrError]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/paging.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/paging.py
@@ -1,6 +1,0 @@
-import graphene
-
-
-class GrapheneCursor(graphene.Int, graphene.Scalar):
-    class Meta:
-        name = "Cursor"


### PR DESCRIPTION
## Summary & Motivation

Remove a class with no references (that also happens to be one of the few "questionable" `graphene.Int` uses left in the codebase).

## How I Tested These Changes

BK