### PR TITLE
Load individual asset nodes in AssetGraphDiffer instead of the entire asset graph

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -393,11 +393,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         if base_deployment_context is None:
             return None
 
-        self._asset_graph_differ = AssetGraphDiffer.from_remote_repositories(
-            code_location_name=self._repository_selector.location_name,
-            repository_name=self._repository_selector.repository_name,
-            branch_workspace=graphene_info.context,
-            base_workspace=base_deployment_context,
+        self._asset_graph_differ = AssetGraphDiffer(
+            branch_asset_graph=graphene_info.context.asset_graph,
+            base_asset_graph=base_deployment_context.asset_graph,
         )
         return self._asset_graph_differ
 

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -49,7 +49,6 @@ from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.selector import RepositorySelector
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
 
 
@@ -312,19 +311,6 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
     @property
     def backfill_policy(self) -> Optional[BackfillPolicy]:
         return self._materializable_node_snap.backfill_policy if self.is_materializable else None
-
-    def get_repo_scoped_node(
-        self,
-        repo_selector: "RepositorySelector",
-    ) -> Optional[RemoteRepositoryAssetNode]:
-        return next(
-            (
-                info.asset_node
-                for info in self.repo_scoped_asset_infos
-                if info.asset_node.repository_handle.to_selector() == repo_selector
-            ),
-            None,
-        )
 
     ##### REMOTE-SPECIFIC INTERFACE
     @cached_method

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -49,6 +49,7 @@ from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.selector import RepositorySelector
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
 
 
@@ -311,6 +312,19 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
     @property
     def backfill_policy(self) -> Optional[BackfillPolicy]:
         return self._materializable_node_snap.backfill_policy if self.is_materializable else None
+
+    def get_repo_scoped_node(
+        self,
+        repo_selector: "RepositorySelector",
+    ) -> Optional[RemoteRepositoryAssetNode]:
+        return next(
+            (
+                info.asset_node
+                for info in self.repo_scoped_asset_infos
+                if info.asset_node.repository_handle.to_selector() == repo_selector
+            ),
+            None,
+        )
 
     ##### REMOTE-SPECIFIC INTERFACE
     @cached_method

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -46,7 +46,7 @@ def _make_location_entry(scenario_name: str, definitions_file: str, instance: Da
         container_image=None,
         entry_point=None,
         container_context=None,
-        location_name=None,
+        location_name=scenario_name,
     )
 
     code_location = origin.create_location(instance)

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -14,9 +14,6 @@ from dagster._core.definitions.asset_graph_differ import (
     ValueDiff,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.repository_definition.valid_definitions import (
-    SINGLETON_REPOSITORY_NAME,
-)
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
@@ -109,11 +106,9 @@ def get_asset_graph_differ(
         instance, {code_location: "base_asset_graph" for code_location in base_code_locations}
     )
 
-    return AssetGraphDiffer.from_remote_repositories(
-        code_location_name=code_location_to_diff,
-        repository_name=SINGLETON_REPOSITORY_NAME,
-        branch_workspace=branch_workspace_ctx,
-        base_workspace=base_workspace_ctx,
+    return AssetGraphDiffer(
+        branch_asset_graph=branch_workspace_ctx.asset_graph,
+        base_asset_graph=base_workspace_ctx.asset_graph,
     )
 
 


### PR DESCRIPTION
Summary:
Advances in asset graph technology have allowed us to accomplish the goal of this original code (fetching only the repo-scoped asset node) without having to fetch the whole asset graph for that repository.

Test Plan: BK

NOCHANGELOG
