### PR TITLE
[integrations-api][beta] AWS SSM in dagster-aws

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -7,6 +7,7 @@ from dagster import (
     Field as LegacyDagsterField,
     resource,
 )
+from dagster._annotations import beta
 from dagster._config.field_utils import Shape
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     import botocore
 
 
+@beta
 class SSMResource(ResourceWithBoto3Configuration):
     """Resource that gives access to AWS Systems Manager Parameter Store.
 
@@ -77,6 +79,7 @@ class SSMResource(ResourceWithBoto3Configuration):
         )
 
 
+@beta
 @dagster_maintained_resource
 @resource(config_schema=SSMResource.to_config_schema())
 def ssm_resource(context) -> "botocore.client.ssm":  # pyright: ignore (reportAttributeAccessIssue)
@@ -132,11 +135,13 @@ def ssm_resource(context) -> "botocore.client.ssm":  # pyright: ignore (reportAt
     return SSMResource.from_resource_context(context).get_client()
 
 
+@beta
 class ParameterStoreTag(Config):
     key: str = Field(description="Tag key to search for.")
     values: Optional[list[str]] = Field(default=None, description="List")
 
 
+@beta
 class ParameterStoreResource(ResourceWithBoto3Configuration):
     """Resource that provides a dict which maps selected SSM Parameter Store parameters to
     their string values. Optionally sets selected parameters as environment variables.
@@ -297,6 +302,7 @@ LEGACY_PARAMETERSTORE_SCHEMA = {
 }
 
 
+@beta
 @dagster_maintained_resource
 @resource(config_schema=LEGACY_PARAMETERSTORE_SCHEMA)
 @contextmanager


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing. It has been out there for quite some time, but is not mature enough for GA.

Note: to be deprecated when the new pattern is implemented.

docs exist: no, we would need a guide

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
