### PR TITLE
[integrations-api][beta] AWS Secrets Manager in dagster-aws

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -6,6 +6,7 @@ from dagster import (
     Field as LegacyDagsterField,
     resource,
 )
+from dagster._annotations import beta
 from dagster._config.field_utils import Shape
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     import botocore
 
 
+@beta
 class SecretsManagerResource(ResourceWithBoto3Configuration):
     """Resource that gives access to AWS SecretsManager.
 
@@ -74,6 +76,7 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
         )
 
 
+@beta
 @dagster_maintained_resource
 @resource(SecretsManagerResource.to_config_schema())
 def secretsmanager_resource(context) -> "botocore.client.SecretsManager":  # pyright: ignore (reportAttributeAccessIssue)
@@ -129,6 +132,7 @@ def secretsmanager_resource(context) -> "botocore.client.SecretsManager":  # pyr
     return SecretsManagerResource.from_resource_context(context).get_client()
 
 
+@beta
 class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
     """Resource that provides a dict which maps selected SecretsManager secrets to
     their string values. Also optionally sets chosen secrets as environment variables.
@@ -250,6 +254,7 @@ LEGACY_SECRETSMANAGER_SECRETS_SCHEMA = {
 }
 
 
+@beta
 @dagster_maintained_resource
 @resource(config_schema=LEGACY_SECRETSMANAGER_SECRETS_SCHEMA)
 @contextmanager

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import boto3.session
 import dagster._check as check
+from dagster._annotations import beta
 
 from dagster_aws.utils import construct_boto_client_retry_config
 
@@ -44,6 +45,7 @@ def construct_secretsmanager_client(
     return secrets_manager
 
 
+@beta
 def get_tagged_secrets(secrets_manager, secrets_tags: Sequence[str]) -> Mapping[str, str]:
     """Return a dictionary of AWS Secrets Manager names to arns
     for any secret tagged with `secrets_tag`.
@@ -65,6 +67,7 @@ def get_tagged_secrets(secrets_manager, secrets_tags: Sequence[str]) -> Mapping[
     return secrets
 
 
+@beta
 def get_secrets_from_arns(secrets_manager, secret_arns: Sequence[str]) -> Mapping[str, str]:
     """Return a dictionary of AWS Secrets Manager names to arns."""
     secrets = {}


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing. It has been out there for quite some time, but is not mature enough for GA.

Note: to be deprecated when the new pattern is implemented.

docs exist: API docs only, no guide

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
