### PR TITLE
[integrations-api][deprecated][ga] Cloudwatch old pattern and pipes in dagster-aws

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -10,6 +10,7 @@ from dagster import (
     _seven,
     logger,
 )
+from dagster._annotations import deprecated
 from dagster._core.utils import coerce_valid_log_level
 
 # The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event
@@ -29,6 +30,7 @@ def millisecond_timestamp(dt):
     return int(microsecond_timestamp / 1000)
 
 
+@deprecated(breaking_version="0.27", additional_warn_text="Use `PipesCloudWatchLogReader` instead.")
 class CloudwatchLogsHandler(logging.Handler):
     def __init__(
         self,
@@ -200,6 +202,7 @@ class CloudwatchLogsHandler(logging.Handler):
     },
     description="The default colored console logger.",
 )
+@deprecated(breaking_version="0.27", additional_warn_text="Use `PipesCloudWatchLogReader` instead.")
 def cloudwatch_logger(init_context):
     """This logger provides support for sending Dagster logs to AWS CloudWatch.
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
@@ -14,7 +14,6 @@ import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster import DagsterInvariantViolationError
-from dagster._annotations import experimental
 from dagster._core.pipes.client import PipesLaunchedData, PipesMessageReader, PipesParams
 from dagster._core.pipes.context import PipesMessageHandler
 from dagster._core.pipes.utils import (
@@ -263,7 +262,6 @@ def tail_cloudwatch_events(
         response = get_log_events(client=client, max_retries=max_retries, **params)
 
 
-@experimental
 class PipesCloudWatchLogReader(PipesLogReader):
     def __init__(
         self,
@@ -343,7 +341,6 @@ class PipesCloudWatchLogReader(PipesLogReader):
         return self.thread is not None and self.thread.is_alive()
 
 
-@experimental
 class PipesCloudWatchMessageReader(PipesThreadedMessageReader):
     """Message reader that consumes AWS CloudWatch logs to read pipes messages."""
 


### PR DESCRIPTION
## Summary & Motivation

pipes: experimental -> ga

old pattern:  ga -> deprecated

reason: new pipes pattern has been around for quite some time and should be GA like other pipes for 1.9. Old pattern is deprecated now that the new pattern is GA.

docs exist:
- message read: no, we would need a guide
- log reader: only API docs, we would need a guide

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
