### PR TITLE
[integrations-api][beta] dagster-datadog

### DIFF
--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource, resource
+from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from datadog import DogStatsd, api, initialize, statsd
 from pydantic import Field
@@ -36,6 +37,7 @@ class DatadogClient:
         self.api = api
 
 
+@beta
 class DatadogResource(ConfigurableResource):
     """This resource is a thin wrapper over the
     `dogstatsd library <https://datadogpy.readthedocs.io/en/latest/>`_.
@@ -97,6 +99,7 @@ class DatadogResource(ConfigurableResource):
         return DatadogClient(self.api_key, self.app_key)
 
 
+@beta
 @dagster_maintained_resource
 @resource(
     config_schema=DatadogResource.to_config_schema(),


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing and we don't consider this integration mature enough to be GA.

Note: we consider deprecating and replacing with guide on how to write/customize resources.

docs exist: the API docs [page](https://docs.dagster.io/_apidocs/libraries/dagster-datad) only, no guide - the guide may not be required since we consider deprecating this. Let's focus on the guide on how to write/customize resources.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
