### PR TITLE
[integrations-api][beta] dagster-ge

### DIFF
--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -17,6 +17,7 @@ from dagster import (
     op,
     resource,
 )
+from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
@@ -27,6 +28,7 @@ from great_expectations.render.view import DefaultMarkdownPageView
 from pydantic import Field
 
 
+@beta
 class GEContextResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     ge_root_dir: Optional[str] = Field(
         default=None,
@@ -42,12 +44,14 @@ class GEContextResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return self.get_data_context()
 
 
+@beta
 @dagster_maintained_resource
 @resource(config_schema=GEContextResource.to_config_schema())
 def ge_data_context(context: InitResourceContext) -> GEContextResource:
     return GEContextResource.from_resource_context(context).get_data_context()
 
 
+@beta
 def ge_validation_op_factory(
     name: str,
     datasource_name: str,


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing and we don't consider this integration mature enough to be GA.

Note: we consider deprecating and replacing with guide on how to write/customize resources.

docs exist: the API docs [page](https://docs.dagster.io/_apidocs/libraries/dagster-ge) only, no guide - the guide may not be required since we consider deprecating this. Let's focus on the guide on how to write/customize resources.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
