### PR TITLE
[integrations-api][beta] GCP Dataproc in dagster-gcp

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
@@ -7,6 +7,7 @@ from dagster import (
     Int,
     op,
 )
+from dagster._annotations import beta
 from dagster._seven import json
 from pydantic import Field
 
@@ -33,6 +34,7 @@ DATAPROC_CONFIG_SCHEMA = {
 }
 
 
+@beta
 class DataprocOpConfig(Config):
     job_timeout_in_seconds: int = Field(
         default=TWENTY_MINUTES,
@@ -92,11 +94,13 @@ def dataproc_solid(context):
 
 
 @op(required_resource_keys={"dataproc"}, config_schema=DATAPROC_CONFIG_SCHEMA)
+@beta
 def dataproc_op(context):
     return _dataproc_compute(context)
 
 
 @op
+@beta
 def configurable_dataproc_op(context, dataproc: DataprocResource, config: DataprocOpConfig):
     job_config = {"projectId": config.project_id, "region": config.region, "job": config.job_config}
     job_timeout = config.job_timeout_in_seconds

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import dagster._check as check
 import yaml
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
@@ -154,6 +155,7 @@ class DataprocClient:
             self.delete_cluster()
 
 
+@beta
 class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     """Resource for connecting to a Dataproc cluster.
 
@@ -272,6 +274,7 @@ class DataprocResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
         return self.get_client()
 
 
+@beta
 @dagster_maintained_resource
 @resource(
     config_schema=define_dataproc_create_cluster_config(),


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing. This integration may be a good fit for Pipes - so it should be beta and be superseded/deprecated if we implement it in Pipes.

docs exist: API docs only, a guide might not be required if we deprecate it in favor of Pipes.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
