### PR TITLE
[integrations-api][beta] dagster-prometheus

### DIFF
--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -1,5 +1,6 @@
 import prometheus_client
 from dagster import ConfigurableResource, resource
+from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from prometheus_client.exposition import default_handler
@@ -10,6 +11,7 @@ class PrometheusClient:
     """Integrates with Prometheus via the prometheus_client library."""
 
 
+@beta
 class PrometheusResource(ConfigurableResource):
     """This resource is used to send metrics to a Prometheus Pushgateway.
 
@@ -147,6 +149,7 @@ class PrometheusResource(ConfigurableResource):
         )
 
 
+@beta
 @dagster_maintained_resource
 @resource(
     config_schema=PrometheusResource.to_config_schema(),


### PR DESCRIPTION
## Summary & Motivation

decision: no decorator -> beta

reason: decorator was missing and we don't consider this integration mature enough to be GA.

Note: we consider deprecating and replacing with guide on how to write/customize resources.

docs exist: the API docs [page](https://docs.dagster.io/_apidocs/libraries/dagster-prometheus) only, no guide - the guide may not be required since we consider deprecating this. Let's focus on the guide on how to write/customize resources.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
