### PR TITLE
[integrations-api][beta][ga] dbt in dagster-dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from typing import Optional
 
 from dagster import AssetSpec
-from dagster._annotations import experimental
 
 from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
@@ -10,7 +9,6 @@ from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
 
 
-@experimental
 def build_dbt_asset_specs(
     *,
     manifest: DbtManifestParam,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -10,7 +10,7 @@ from dagster import (
     _check as check,
     get_dagster_logger,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.metadata import TableMetadataSet, TextMetadataValue
 from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.utils import exhaust_iterator_and_yield_results_with_exception, imap
@@ -206,7 +206,6 @@ class DbtEventIterator(Iterator[T]):
         return self
 
     @public
-    @experimental
     def fetch_row_counts(
         self,
     ) -> (
@@ -224,7 +223,6 @@ class DbtEventIterator(Iterator[T]):
         return self._attach_metadata(_fetch_row_count_metadata)
 
     @public
-    @experimental
     def fetch_column_metadata(
         self,
         with_column_lineage: bool = True,
@@ -305,7 +303,6 @@ class DbtEventIterator(Iterator[T]):
         )
 
     @public
-    @experimental
     def with_insights(
         self,
         skip_config_check: bool = False,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -10,7 +10,7 @@ from dagster import (
     PartitionMapping,
     _check as check,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import beta, public
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._utils.tags import is_valid_tag_key
 
@@ -125,7 +125,7 @@ class DagsterDbtTranslator:
         return default_asset_key_fn(dbt_resource_props)
 
     @public
-    @experimental(emit_runtime_warning=False)
+    @beta(emit_runtime_warning=False)
     def get_partition_mapping(
         self,
         dbt_resource_props: Mapping[str, Any],
@@ -356,7 +356,7 @@ class DagsterDbtTranslator:
         return default_owners_from_dbt_resource_props(dbt_resource_props)
 
     @public
-    @experimental(emit_runtime_warning=False)
+    @beta(emit_runtime_warning=False)
     def get_freshness_policy(
         self, dbt_resource_props: Mapping[str, Any]
     ) -> Optional[FreshnessPolicy]:
@@ -410,7 +410,7 @@ class DagsterDbtTranslator:
         return default_freshness_policy_fn(dbt_resource_props)
 
     @public
-    @experimental(emit_runtime_warning=False)
+    @beta(emit_runtime_warning=False)
     def get_auto_materialize_policy(
         self, dbt_resource_props: Mapping[str, Any]
     ) -> Optional[AutoMaterializePolicy]:
@@ -465,7 +465,7 @@ class DagsterDbtTranslator:
         return default_auto_materialize_policy_fn(dbt_resource_props)
 
     @public
-    @experimental(emit_runtime_warning=False)
+    @beta(emit_runtime_warning=False)
     def get_automation_condition(
         self, dbt_resource_props: Mapping[str, Any]
     ) -> Optional[AutomationCondition]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/freshness_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/freshness_builder.py
@@ -6,7 +6,7 @@ from dagster import (
     AssetsDefinition,
     _check as check,
 )
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.asset_check_factories.freshness_checks.last_update import (
     build_last_update_freshness_checks,
 )
@@ -33,7 +33,7 @@ from dagster_dbt.asset_utils import (
 )
 
 
-@experimental
+@beta
 def build_freshness_checks_from_dbt_assets(
     *,
     dbt_assets: Sequence[AssetsDefinition],


### PR DESCRIPTION
## Summary & Motivation

decision:

- event iterator: experimental (beta) -> ga
- asset spec builder: experimental (beta) -> ga
- freshness check builder: experimental (beta) -> beta
- translator methods: experimental (beta) -> beta

reason: methods to fetch metadata in DbtEventIterator are commonly used and stable(fetch_row_count, etc.). The asset spec builder is also stable. The freshness check builder could be tested more before going to GA. Translator methods will soon be deprecated.

docs exist: Yes, but we could have more examples for the asset spec and freshness check builders.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
