### PR TITLE
[integrations-api][beta][ga] Docker old pattern and pipes in dagster-docker

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -5,7 +5,7 @@ import dagster._check as check
 import docker
 import docker.errors
 from dagster import Field, IntSource, executor
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
 from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.retries import RetryMode, get_retries_config
@@ -46,7 +46,7 @@ from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, v
     ),
     requirements=multiple_process_executor_requirements(),
 )
-@experimental
+@beta
 def docker_executor(init_context: InitExecutorContext) -> Executor:
     """Executor which launches steps as Docker containers.
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import docker
 import docker.errors
 from dagster import Field, In, Nothing, OpExecutionContext, StringSource, op
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.utils import parse_env_var
 from dagster._serdes.utils import hash_str
 
@@ -73,7 +73,7 @@ def _create_container(
     )
 
 
-@experimental
+@beta
 def execute_docker_container(
     context: OpExecutionContext,
     image: str,
@@ -150,7 +150,7 @@ def execute_docker_container(
 
 
 @op(ins={"start_after": In(Nothing)}, config_schema=DOCKER_CONTAINER_OP_CONFIG)
-@experimental
+@beta
 def docker_container_op(context):
     """An op that runs a Docker container using the docker Python API.
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -8,7 +8,6 @@ from dagster import (
     OpExecutionContext,
     _check as check,
 )
-from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import (
@@ -26,7 +25,6 @@ from dagster._core.pipes.utils import (
 from dagster_pipes import DagsterPipesError, PipesDefaultMessageWriter, PipesExtras, PipesParams
 
 
-@experimental
 class PipesDockerLogsMessageReader(PipesMessageReader):
     @contextmanager
     def read_messages(
@@ -57,7 +55,6 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
         return "Attempted to read messages by extracting them from docker logs directly."
 
 
-@experimental
 class PipesDockerClient(PipesClient, TreatAsResourceParam):
     """A pipes client that runs external processes in docker containers.
 


### PR DESCRIPTION
## Summary & Motivation

pipes: experimental -> ga

old pattern: ga -> deprecated

reason: new pipes pattern has been around for quite some time and should be GA like other pipes for 1.9. Old pattern is deprecated now that the new pattern is GA.

docs exist: API docs only, we would need a guide.


## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
