### PR TITLE
[integrations-api][beta] K8s old pattern in dagster-k8s

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -15,7 +15,7 @@ from dagster import (
     StringSource,
     op,
 )
-from dagster._annotations import experimental
+from dagster._annotations import beta
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._utils.merger import merge_dicts
 
@@ -135,7 +135,7 @@ K8S_JOB_OP_CONFIG = merge_dicts(
 )
 
 
-@experimental
+@beta
 def execute_k8s_job(
     context: OpExecutionContext,
     image: str,
@@ -448,7 +448,7 @@ def execute_k8s_job(
 
 
 @op(ins={"start_after": In(Nothing)}, config_schema=K8S_JOB_OP_CONFIG)
-@experimental
+@beta
 def k8s_job_op(context):
     """An op that runs a Kubernetes job using the k8s API.
 


### PR DESCRIPTION
## Summary & Motivation

decision: experimental -> beta

reason: rename the decorator to use the new API lifecycle language.

docs exist: yes

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
