### PR TITLE
Sidecar Container Support (updated)

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -5,11 +5,7 @@ from pydantic import ConfigDict
 
 from schema.charts.dagster.subschema.config import IntSource
 from schema.charts.utils import kubernetes
-from schema.charts.utils.utils import (
-    BaseModel,
-    ConfigurableClass,
-    create_json_schema_conditionals,
-)
+from schema.charts.utils.utils import BaseModel, ConfigurableClass, create_json_schema_conditionals
 
 
 class RunCoordinatorType(str, Enum):

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -5,7 +5,11 @@ from pydantic import ConfigDict
 
 from schema.charts.dagster.subschema.config import IntSource
 from schema.charts.utils import kubernetes
-from schema.charts.utils.utils import BaseModel, ConfigurableClass, create_json_schema_conditionals
+from schema.charts.utils.utils import (
+    BaseModel,
+    ConfigurableClass,
+    create_json_schema_conditionals,
+)
 
 
 class RunCoordinatorType(str, Enum):
@@ -107,3 +111,5 @@ class Daemon(BaseModel, extra="forbid"):
     volumeMounts: Optional[List[kubernetes.VolumeMount]] = None
     volumes: Optional[List[kubernetes.Volume]] = None
     initContainerResources: Optional[kubernetes.Resources] = None
+    extraContainers: Optional[List[kubernetes.Container]] = None
+    extraPrependedInitContainers: Optional[List[kubernetes.InitContainer]] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/migrate.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/migrate.py
@@ -1,5 +1,11 @@
+from typing import List, Optional
+
 from pydantic import BaseModel
+
+from schema.charts.utils import kubernetes
 
 
 class Migrate(BaseModel):
     enabled: bool
+    extraContainers: Optional[List[kubernetes.Container]]
+    initContainers: Optional[List[kubernetes.Container]]

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,3 +48,5 @@ class Webserver(BaseModel, extra="forbid"):
     volumeMounts: Optional[List[kubernetes.VolumeMount]] = None
     volumes: Optional[List[kubernetes.Volume]] = None
     initContainerResources: Optional[kubernetes.Resources] = None
+    extraContainers: Optional[List[kubernetes.Container]] = None
+    extraPrependedInitContainers: Optional[List[kubernetes.InitContainer]] = None

--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -95,9 +95,7 @@ def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTempl
 
     helm_values_migrate_enabled = DagsterHelmValues.construct(
         migrate=Migrate(enabled=True, extraContainers=[], initContainers=[]),
-        dagsterWebserver=Webserver.construct(
-            volumes=volumes, volumeMounts=volume_mounts
-        ),
+        dagsterWebserver=Webserver.construct(volumes=volumes, volumeMounts=volume_mounts),
     )
 
     jobs = template.render(helm_values_migrate_enabled)

--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -23,7 +23,9 @@ def helm_template() -> HelmTemplate:
 
 def test_job_instance_migrate_does_not_render(template: HelmTemplate, capfd):
     with pytest.raises(subprocess.CalledProcessError):
-        helm_values_migrate_disabled = DagsterHelmValues.construct(migrate=Migrate(enabled=False))
+        helm_values_migrate_disabled = DagsterHelmValues.construct(
+            migrate=Migrate(enabled=False, extraContainers=[], initContainers=[])
+        )
 
         template.render(helm_values_migrate_disabled)
 
@@ -32,7 +34,9 @@ def test_job_instance_migrate_does_not_render(template: HelmTemplate, capfd):
 
 
 def test_job_instance_migrate_renders(template: HelmTemplate):
-    helm_values_migrate_enabled = DagsterHelmValues.construct(migrate=Migrate(enabled=True))
+    helm_values_migrate_enabled = DagsterHelmValues.construct(
+        migrate=Migrate(enabled=True, extraContainers=[], initContainers=[])
+    )
 
     jobs = template.render(helm_values_migrate_enabled)
 
@@ -41,7 +45,9 @@ def test_job_instance_migrate_renders(template: HelmTemplate):
 
 @pytest.mark.parametrize("chart_version", ["0.12.0", "0.12.1"])
 def test_job_instance_migrate_image(template: HelmTemplate, chart_version: str):
-    helm_values_migrate_enabled = DagsterHelmValues.construct(migrate=Migrate(enabled=True))
+    helm_values_migrate_enabled = DagsterHelmValues.construct(
+        migrate=Migrate(enabled=True, extraContainers=[], initContainers=[])
+    )
 
     [job] = template.render(helm_values_migrate_enabled, chart_version=chart_version)
     image = job.spec.template.spec.containers[0].image
@@ -54,7 +60,7 @@ def test_job_instance_migrate_keeps_annotations(template: HelmTemplate):
     annotations = {"annotation_1": "an_annotation_1", "annotation_2": "an_annotation_2"}
 
     helm_values_migrate_enabled = DagsterHelmValues.construct(
-        migrate=Migrate(enabled=True),
+        migrate=Migrate(enabled=True, extraContainers=[], initContainers=[]),
         dagsterWebserver=Webserver.construct(
             annotations=kubernetes.Annotations.parse_obj(annotations),
         ),
@@ -73,7 +79,10 @@ def test_job_instance_migrate_keeps_annotations(template: HelmTemplate):
 def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTemplate):
     volumes = [
         {"name": "test-volume", "configMap": {"name": "test-volume-configmap"}},
-        {"name": "test-pvc", "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False}},
+        {
+            "name": "test-pvc",
+            "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False},
+        },
     ]
 
     volume_mounts = [
@@ -85,8 +94,10 @@ def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTempl
     ]
 
     helm_values_migrate_enabled = DagsterHelmValues.construct(
-        migrate=Migrate(enabled=True),
-        dagsterWebserver=Webserver.construct(volumes=volumes, volumeMounts=volume_mounts),
+        migrate=Migrate(enabled=True, extraContainers=[], initContainers=[]),
+        dagsterWebserver=Webserver.construct(
+            volumes=volumes, volumeMounts=volume_mounts
+        ),
     )
 
     jobs = template.render(helm_values_migrate_enabled)
@@ -107,7 +118,8 @@ def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTempl
     job_volumes = job.spec.template.spec.volumes
     assert job_volumes[1:] == [
         k8s_model_from_dict(
-            k8s_client.models.V1Volume, k8s_snake_case_dict(k8s_client.models.V1Volume, volume)
+            k8s_client.models.V1Volume,
+            k8s_snake_case_dict(k8s_client.models.V1Volume, volume),
         )
         for volume in volumes
     ]

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -49,6 +49,11 @@ spec:
       securityContext:
         {{- toYaml .Values.dagsterDaemon.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if .Values.dagsterDaemon.extraPrependedInitContainers }}
+        {{- range $container := .Values.dagsterDaemon.extraPrependedInitContainers }}
+        - {{ toYaml $container | nindent 10 | trim }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.dagsterDaemon.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: {{ include "dagster.externalPostgresImage.name" $.Values.postgresql.image | quote }}
@@ -138,6 +143,11 @@ spec:
           startupProbe:
             {{- toYaml $startupProbe | nindent 12 }}
           {{- end }}
+        {{- if .Values.dagsterDaemon.extraContainers }}
+        {{- range $container := .Values.dagsterDaemon.extraContainers }}
+        - {{ toYaml $container | nindent 10 | trim }}
+        {{- end }}
+        {{- end }}
       nodeSelector:
         {{- toYaml .Values.dagsterDaemon.nodeSelector | nindent 8 }}
       volumes:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -47,6 +47,11 @@ spec:
       securityContext:
         {{- toYaml $_.Values.dagsterWebserver.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if $_.Values.dagsterWebserver.extraPrependedInitContainers }}
+        {{- range $container := $_.Values.dagsterWebserver.extraPrependedInitContainers }}
+        - {{ toYaml $container | nindent 10 | trim }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.dagsterWebserver.checkDbReadyInitContainer }}
         - name: check-db-ready
           image: {{ include "dagster.externalPostgresImage.name" .Values.postgresql.image | quote }}
@@ -139,6 +144,11 @@ spec:
           {{- $startupProbe := omit $_.Values.dagsterWebserver.startupProbe "enabled" }}
           startupProbe:
             {{- toYaml $startupProbe | nindent 12 }}
+        {{- end }}
+        {{- if $_.Values.dagsterWebserver.extraContainers }}
+        {{- range $container := $_.Values.dagsterWebserver.extraContainers }}
+        - {{ toYaml $container | nindent 10 | trim }}
+        {{- end }}
         {{- end }}
       {{- with $_.Values.dagsterWebserver.nodeSelector }}
       nodeSelector:

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -22,6 +22,12 @@ spec:
       automountServiceAccountToken: true
       securityContext: {{ $_.Values.dagsterWebserver.podSecurityContext | toYaml | nindent 8 }}
       restartPolicy: Never
+      {{- if .Values.migrate.initContainers }}
+      initContainers:
+      {{- range $container := .Values.migrate.initContainers }}
+      - {{ toYaml $container | nindent 8 | trim }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: dagster-instance-migrate
           securityContext: {{ $_.Values.dagsterWebserver.securityContext | toYaml | nindent 12 }}
@@ -58,6 +64,11 @@ spec:
             {{- end }}
             {{- end }}
           resources: {{ $_.Values.dagsterWebserver.resources | toYaml | nindent 12 }}
+      {{- if .Values.migrate.extraContainers }}
+      {{- range $container := .Values.migrate.extraContainers }}
+      - {{ toYaml $container | nindent 10 | trim }}
+      {{- end }}
+      {{- end }}
       volumes:
         - name: dagster-instance
           configMap:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -645,7 +645,7 @@
                 "extraContainers": {
                     "title": "Extracontainers",
                     "items": {
-                        "$ref": "#/definitions/Container"
+                        "$ref": "#/$defs/Container"
                     },
                     "anyOf": [
                         {
@@ -659,7 +659,7 @@
                 "extraPrependedInitContainers": {
                     "title": "Extraprependedinitcontainers",
                     "items": {
-                        "$ref": "#/definitions/InitContainer"
+                        "$ref": "#/$defs/InitContainer"
                     },
                     "anyOf": [
                         {
@@ -1457,14 +1457,14 @@
                     "title": "Extracontainers",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Container"
+                        "$ref": "#/$defs/Container"
                     }
                 },
                 "initContainers": {
                     "title": "Initcontainers",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Container"
+                        "$ref": "#/$defs/Container"
                     }
                 }
             },
@@ -3210,7 +3210,7 @@
                 "extraContainers": {
                     "title": "Extracontainers",
                     "items": {
-                        "$ref": "#/definitions/Container"
+                        "$ref": "#/$defs/Container"
                     },
                     "anyOf": [
                         {
@@ -3224,7 +3224,7 @@
                 "extraPrependedInitContainers": {
                     "title": "Extraprependedinitcontainers",
                     "items": {
-                        "$ref": "#/definitions/InitContainer"
+                        "$ref": "#/$defs/InitContainer"
                     },
                     "anyOf": [
                         {

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -642,34 +642,6 @@
                     "title": "Envsecrets",
                     "type": "array"
                 },
-                "extraContainers": {
-                    "title": "Extracontainers",
-                    "items": {
-                        "$ref": "#/$defs/Container"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "extraPrependedInitContainers": {
-                    "title": "Extraprependedinitcontainers",
-                    "items": {
-                        "$ref": "#/$defs/InitContainer"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
                 "deploymentLabels": {
                     "additionalProperties": {
                         "type": "string"
@@ -791,6 +763,36 @@
                         }
                     ],
                     "default": null
+                },
+                "extraContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Extracontainers"
+                },
+                "extraPrependedInitContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/InitContainer"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Extraprependedinitcontainers"
                 }
             },
             "required": [
@@ -1263,10 +1265,11 @@
             "type": "object"
         },
         "InitContainer": {
-            "title": "InitContainer",
-            "type": "object",
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "additionalProperties": true,
             "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+            "title": "InitContainer",
+            "type": "object"
         },
         "K8sRunLauncherConfig": {
             "additionalProperties": false,
@@ -1454,22 +1457,38 @@
                     "type": "boolean"
                 },
                 "extraContainers": {
-                    "title": "Extracontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/Container"
-                    }
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "title": "Extracontainers"
                 },
                 "initContainers": {
-                    "title": "Initcontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/Container"
-                    }
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "title": "Initcontainers"
                 }
             },
             "required": [
-                "enabled"
+                "enabled",
+                "extraContainers",
+                "initContainers"
             ],
             "title": "Migrate",
             "type": "object"
@@ -3207,34 +3226,6 @@
                     "title": "Envsecrets",
                     "type": "array"
                 },
-                "extraContainers": {
-                    "title": "Extracontainers",
-                    "items": {
-                        "$ref": "#/$defs/Container"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "extraPrependedInitContainers": {
-                    "title": "Extraprependedinitcontainers",
-                    "items": {
-                        "$ref": "#/$defs/InitContainer"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
                 "deploymentLabels": {
                     "additionalProperties": {
                         "type": "string"
@@ -3383,6 +3374,36 @@
                         }
                     ],
                     "default": null
+                },
+                "extraContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Extracontainers"
+                },
+                "extraPrependedInitContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/InitContainer"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Extraprependedinitcontainers"
                 }
             },
             "required": [

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -642,6 +642,34 @@
                     "title": "Envsecrets",
                     "type": "array"
                 },
+                "extraContainers": {
+                    "title": "Extracontainers",
+                    "items": {
+                        "$ref": "#/definitions/Container"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extraPrependedInitContainers": {
+                    "title": "Extraprependedinitcontainers",
+                    "items": {
+                        "$ref": "#/definitions/InitContainer"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "deploymentLabels": {
                     "additionalProperties": {
                         "type": "string"
@@ -1234,6 +1262,12 @@
             "title": "IngressTLSConfiguration",
             "type": "object"
         },
+        "InitContainer": {
+            "title": "InitContainer",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+        },
         "K8sRunLauncherConfig": {
             "additionalProperties": false,
             "properties": {
@@ -1418,6 +1452,20 @@
                 "enabled": {
                     "title": "Enabled",
                     "type": "boolean"
+                },
+                "extraContainers": {
+                    "title": "Extracontainers",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Container"
+                    }
+                },
+                "initContainers": {
+                    "title": "Initcontainers",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Container"
+                    }
                 }
             },
             "required": [
@@ -3158,6 +3206,34 @@
                     },
                     "title": "Envsecrets",
                     "type": "array"
+                },
+                "extraContainers": {
+                    "title": "Extracontainers",
+                    "items": {
+                        "$ref": "#/definitions/Container"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extraPrependedInitContainers": {
+                    "title": "Extraprependedinitcontainers",
+                    "items": {
+                        "$ref": "#/definitions/InitContainer"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "deploymentLabels": {
                     "additionalProperties": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -151,6 +151,28 @@ dagsterWebserver:
   #     subPath: test_file.yaml
   volumeMounts: []
 
+  # Additional containers that should run as sidecars to the webserver. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers
+  # For K8s versions after 1.29, prefer using extraPrependedInitContainers instead. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Example:
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  extraContainers: []
+
+  # Additional init containers that should run before the webserver's init container, such as sidecars.
+  # For K8s versions after 1.29, see:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Extra init containers are started **before** the connection to the database is tested. #
+  # Example:
+  # extraPrependedInitContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  extraPrependedInitContainers: []
+
   # Support Node, affinity and tolerations for webserver pod assignment. See:
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -1219,6 +1241,29 @@ dagsterDaemon:
   #     subPath: test_file.yaml
   volumeMounts: []
 
+  # Additional containers that should run as sidecars to the daemon. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers
+  # For K8s versions after 1.29, prefer using extraPrependedInitContainers instead. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Example:
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  extraContainers: []
+
+  # Additional init containers that should run before to the daemon's init container, such as sidecars.
+  # For K8s versions after 1.29, see:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Extra init containers are started **before** the connection to the database is tested.
+  #
+  # Example:
+  # extraPrependedInitContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  extraPrependedInitContainers: []
+
   annotations: {}
   nodeSelector: {}
   affinity: {}
@@ -1291,6 +1336,26 @@ extraManifests:
 ####################################################################################################
 migrate:
   enabled: false
+
+  # Additional containers that should be run as sidecars to the migration job. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers
+  # For K8s versions after 1.29, prefer using initContainers to use native sidecars instead. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Example:
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  extraContainers: []
+
+  # Init containers that should run before the main job container, such as native sidecars. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  #
+  # Example:
+  # initContainers:
+  #   - name: my-sidecar
+  #     image: busybox
+  initContainers: []
 
 ####################################################################################################
 # As an open source project, we collect usage statistics to better understand how users engage


### PR DESCRIPTION
## Summary & Motivation
This PR adds support for sidecar containers for all Dagster pods, for versions of K8s after 1.29 ([Native Sidecars](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)).

Note: This is a copy of the PR #24834 from September 2024. The original author @tdipadova3rd has submitted this feature but, unfortunately, hasn't responded to some follow-up comments. The CI/CD pipeline also failed due to code formatting issues. I reintegrated his changes into the latest upstream version while fixing the code formatting issues. 

Original summary: Google recommends using Cloud SQL Auth Proxy to connect to Cloud SQL from Kubernetes. The proxy is deployed as a sidecar container, allowing application pods to connect to PostgreSQL as localhost while the proxy handles authentication and encryption over private IP. There is a https://github.com/dagster-io/dagster/discussions/9086 requesting support for Cloud SQL Auth Proxy in self-hosted Dagster.

## How I Tested These Changes
I haven't tested the changes yet. I would like to check if the CI/CD pipeline passes first, and then I'll try to test the feature on a cluster.

## Changelog

- NEW (added new feature or capability)

Add support for sidecar containers for all Dagster pods, for versions of K8s after 1.29 ([Native Sidecars](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)).

Resolves #24834 

Original author @tdipadova3rd.
