### PR TITLE
[components] Add generator to SlingReplicationComponentCollection

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
@@ -9,7 +9,7 @@ if _has_dagster_dbt:
     )
 
 if _has_dagster_embedded_elt:
-    from dagster_components.lib.sling_replication_collection import (
+    from dagster_components.lib.sling_replication_collection.component import (
         SlingReplicationCollectionComponent as SlingReplicationCollectionComponent,
     )
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import TemplatedValueRenderer, component_type
+from dagster_components.core.component_generator import ComponentGenerator
 from dagster_components.core.dsl_schema import (
     AssetAttributes,
     AssetAttributesModel,
@@ -90,6 +91,14 @@ class SlingReplicationCollectionComponent(Component):
         self.resource = resource
         self.sling_replications = sling_replications
         self.asset_attributes = asset_attributes
+
+    @classmethod
+    def get_generator(cls) -> ComponentGenerator:
+        from dagster_components.lib.sling_replication_collection.generator import (
+            SlingReplicationComponentGenerator,
+        )
+
+        return SlingReplicationComponentGenerator()
 
     @classmethod
     def load(cls, context: ComponentLoadContext) -> Self:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/generator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/generator.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dagster_components.core.component_generator import ComponentGenerateRequest, ComponentGenerator
+from dagster_components.generate import generate_component_yaml
+
+
+class SlingReplicationComponentGenerator(ComponentGenerator):
+    def generate_files(self, request: ComponentGenerateRequest, params: Any) -> None:
+        generate_component_yaml(request, {"replications": [{"path": "replication.yaml"}]})
+        replication_path = Path(os.getcwd()) / "replication.yaml"
+        with open(replication_path, "w") as f:
+            yaml.dump({"source": {}, "target": {}, "streams": {}}, f)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
@@ -2,7 +2,9 @@ from typing import Iterator
 
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import component_type
-from dagster_components.lib.sling_replication_collection import SlingReplicationCollectionComponent
+from dagster_components.lib.sling_replication_collection.component import (
+    SlingReplicationCollectionComponent,
+)
 from dagster_embedded_elt.sling import SlingResource
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -17,7 +17,9 @@ from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
     build_components_from_component_folder,
 )
-from dagster_components.lib.sling_replication_collection import SlingReplicationCollectionComponent
+from dagster_components.lib.sling_replication_collection.component import (
+    SlingReplicationCollectionComponent,
+)
 from dagster_embedded_elt.sling import SlingResource
 
 from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context


### PR DESCRIPTION
## Summary & Motivation

Add a component generator the sling replication component collection. Produces a `replication.yaml` file and a `component.yaml` file that points to that one replication.yaml file.

In addition to the default/demo case being easier, if you want to rename `replication.yaml` or add a new one, I think this is still a better user experience.

## How I Tested These Changes

Ran through Components README
