### PR TITLE
[components] Add `--[no-]-use-dg-managed-environment` option to `dagster-dg`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -100,9 +100,17 @@ def _rebuild_component_registry(dg_context: DgContext):
             )
         )
         sys.exit(1)
-    if not dg_context.has_cache:
+    elif not dg_context.has_cache:
         click.echo(
             click.style("Cache is disabled. This command cannot be run without a cache.", fg="red")
+        )
+        sys.exit(1)
+    elif not dg_context.config.use_dg_managed_environment:
+        click.echo(
+            click.style(
+                "Cannot rebuild the component registry with environment management disabled.",
+                fg="red",
+            )
         )
         sys.exit(1)
     root_path = resolve_code_location_root_directory(Path.cwd())

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
@@ -97,7 +97,9 @@ def code_location_generate_command(
     else:
         editable_dagster_root = None
 
-    generate_code_location(code_location_path, dg_context, editable_dagster_root, skip_venv)
+    generate_code_location(
+        code_location_path, dg_context, editable_dagster_root, skip_venv=skip_venv
+    )
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
@@ -36,6 +36,12 @@ GLOBAL_OPTIONS = {
             default=DgConfig.builtin_component_lib,
             help="Specify a builitin component library to use.",
         ),
+        click.Option(
+            ["--use-dg-managed-environment/--no-use-dg-managed-environment"],
+            is_flag=True,
+            default=DgConfig.use_dg_managed_environment,
+            help="Enable management of the virtual environment with uv.",
+        ),
     ]
 }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -36,12 +36,15 @@ class DgConfig:
             be used.
         verbose (bool): If True, log debug information.
         builitin_component_lib (str): The name of the builtin component library to load.
+        use_dg_managed_environment (bool): If True, `dg` will build and manage a virtual environment
+            using `uv`. Note that disabling the managed enviroment will also disable caching.
     """
 
     disable_cache: bool = False
     cache_dir: Path = DEFAULT_CACHE_DIR
     verbose: bool = False
     builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
+    use_dg_managed_environment: bool = True
 
     @classmethod
     def from_cli_global_options(cls, global_options: Mapping[str, object]) -> Self:
@@ -51,6 +54,9 @@ class DgConfig:
             verbose=_validate_global_option(global_options, "verbose", bool),
             builtin_component_lib=_validate_global_option(
                 global_options, "builtin_component_lib", str
+            ),
+            use_dg_managed_environment=_validate_global_option(
+                global_options, "use_dg_managed_environment", bool
             ),
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -106,7 +106,10 @@ class DgContext:
 
     @classmethod
     def from_config(cls, config: DgConfig) -> Self:
-        cache = None if config.disable_cache else DgCache.from_config(config)
+        if config.disable_cache or not config.use_dg_managed_environment:
+            cache = None
+        else:
+            cache = DgCache.from_config(config)
         return cls(config=config, _cache=cache)
 
     @classmethod
@@ -217,7 +220,8 @@ class CodeLocationDirectoryContext:
     @classmethod
     def from_path(cls, path: Path, dg_context: DgContext) -> Self:
         root_path = resolve_code_location_root_directory(path)
-        ensure_uv_lock(root_path)
+        if dg_context.config.use_dg_managed_environment:
+            ensure_uv_lock(root_path)
 
         code_location_config = _load_code_location_config(root_path)
         components_lib_package_name = (

--- a/python_modules/libraries/dagster-dg/dagster_dg/generate.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/generate.py
@@ -125,7 +125,7 @@ def generate_code_location(
     )
 
     # Build the venv
-    if not skip_venv:
+    if dg_context.config.use_dg_managed_environment and not skip_venv:
         ensure_uv_lock(path)
         fetch_component_registry(path, dg_context)  # Populate the cache
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import Iterator, Mapping, Sequence
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 import click
 import jinja2
@@ -29,12 +29,14 @@ if TYPE_CHECKING:
 CLI_CONFIG_KEY = "config"
 
 
-_CODE_LOCATION_COMMAND_PREFIX: Final = ["uv", "run", "dagster-components"]
-
-
 def execute_code_location_command(path: Path, cmd: Sequence[str], dg_context: "DgContext") -> str:
+    code_location_command_prefix = (
+        ["uv", "run", "dagster-components"]
+        if dg_context.config.use_dg_managed_environment
+        else ["dagster-components"]
+    )
     full_cmd = [
-        *_CODE_LOCATION_COMMAND_PREFIX,
+        *code_location_command_prefix,
         *(
             ["--builtin-component-lib", dg_context.config.builtin_component_lib]
             if dg_context.config.builtin_component_lib

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -119,8 +119,6 @@ def test_code_location_generate_editable_dagster_success(mode: str, monkeypatch)
 
 
 def test_code_location_generate_skip_venv_success() -> None:
-    # Don't use the test component lib because it is not present in published dagster-components,
-    # which this test is currently accessing since we are not doing an editable install.
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("code-location", "generate", "--skip-venv", "bar")
         assert_runner_result(result)
@@ -131,7 +129,25 @@ def test_code_location_generate_skip_venv_success() -> None:
         assert Path("bar/bar_tests").exists()
         assert Path("bar/pyproject.toml").exists()
 
-        # Check venv created
+        # Check venv not created
+        assert not Path("bar/.venv").exists()
+        assert not Path("bar/uv.lock").exists()
+
+
+def test_code_location_generate_no_use_dg_managed_environment_success() -> None:
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke(
+            "code-location", "generate", "--no-use-dg-managed-environment", "bar"
+        )
+        assert_runner_result(result)
+        assert Path("bar").exists()
+        assert Path("bar/bar").exists()
+        assert Path("bar/bar/lib").exists()
+        assert Path("bar/bar/components").exists()
+        assert Path("bar/bar_tests").exists()
+        assert Path("bar/pyproject.toml").exists()
+
+        # Check venv not created
         assert not Path("bar/.venv").exists()
         assert not Path("bar/uv.lock").exists()
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -277,21 +277,28 @@ def test_component_type_info_multiple_flags_fails() -> None:
 # ##### LIST
 # ########################
 
+_EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
+    dagster_components.test.all_metadata_empty_asset
+    dagster_components.test.simple_asset
+        A simple asset that returns a constant string value.
+    dagster_components.test.simple_pipes_script_asset
+        A simple asset that runs a Python script with the Pipes subprocess client.
+""").strip()
+
 
 def test_list_component_types_success():
     with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
         result = runner.invoke("component-type", "list")
         assert_runner_result(result)
-        assert (
-            result.output.strip()
-            == textwrap.dedent("""
-            dagster_components.test.all_metadata_empty_asset
-            dagster_components.test.simple_asset
-                A simple asset that returns a constant string value.
-            dagster_components.test.simple_pipes_script_asset
-                A simple asset that runs a Python script with the Pipes subprocess client.
-        """).strip()
-        )
+        assert result.output.strip() == _EXPECTED_COMPONENT_TYPES
+
+
+def test_list_component_types_success_with_unmanaged_environment():
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, skip_venv=True):
+        result = runner.invoke("component-type", "list", "--no-use-dg-managed-environment")
+        assert_runner_result(result)
+        assert not Path("uv.lock").exists()
+        assert result.output.strip() == _EXPECTED_COMPONENT_TYPES
 
 
 def test_list_component_types_outside_code_location_fails() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -170,9 +170,11 @@ def test_dynamic_subcommand_help_message():
               -h, --help          Show this message and exit.
 
             Global options:
-              --builtin-component-lib TEXT  Specify a builitin component library to use.
-              --verbose                     Enable verbose output for debugging.
-              --disable-cache               Disable the cache..
-              --cache-dir PATH              Specify a directory to use for the cache.
+              --use-dg-managed-environment / --no-use-dg-managed-environment
+                                              Enable management of the virtual environment with uv.
+              --builtin-component-lib TEXT    Specify a builitin component library to use.
+              --verbose                       Enable verbose output for debugging.
+              --disable-cache                 Disable the cache..
+              --cache-dir PATH                Specify a directory to use for the cache.
         """).strip()
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -41,7 +41,7 @@ def isolated_example_code_location_bar(
                 "generate",
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
-                *(["--skip-venv"] if skip_venv else []),
+                *(["--no-use-dg-managed-environment"] if skip_venv else []),
                 "bar",
             )
             with clear_module_from_cache("bar"), pushd("code_locations/bar"):
@@ -53,7 +53,7 @@ def isolated_example_code_location_bar(
                 "generate",
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
-                *(["--skip-venv"] if skip_venv else []),
+                *(["--no-use-dg-managed-environment"] if skip_venv else []),
                 "bar",
             )
             with clear_module_from_cache("bar"), pushd("bar"):

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -45,6 +45,6 @@ setup(
         ]
     },
     extras_require={
-        "test": ["click", "pydantic", "pytest", "tomli-w"],
+        "test": ["click", "dagster-components", "pydantic", "pytest", "tomli-w"],
     },
 )

--- a/python_modules/libraries/dagster-dg/tox.ini
+++ b/python_modules/libraries/dagster-dg/tox.ini
@@ -11,6 +11,10 @@ passenv =
 install_command = uv pip install {opts} {packages}
 deps =
   -e .[test]
+  -e ../../../python_modules/dagster[test]
+  -e ../../../python_modules/dagster-test
+  -e ../../../python_modules/dagster-pipes
+  -e ../../../python_modules/libraries/dagster-components
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary & Motivation

Add a global option to disable manage of environment with `uv` (`--[no-]dg-managed-environment`) to `dagster-dg`. This has a few effects:

- Prevent any `dg` command from automatically creating a venv in the root directory and corresponding `uv.lock`.
- Causes all calls to the `dagster-components` CLI (which is used to retrieve registered components) to use the current python environment instead of `uv run`.
- Disables the cache.

NOTE: The reason we disable the cache is that caching logic currently depends on `uv.lock` to generate the cache key. It is possible we will later introduce support for the cache without `uv` by falling back to an alternative mechanism to derive a cache key from the python environment.

## How I Tested These Changes

New unit tests.