### PR TITLE
Fix 404ing Fivetran page

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -1132,8 +1132,12 @@
       },
       {
         "title": "Fivetran",
-        "path": "/integrations/fivetran/fivetran",
+        "path": "/integrations/fivetran",
         "children": [
+          {
+            "title": "Fivetran",
+            "path": "/integrations/fivetran/fivetran"
+          },
           {
             "title": "Fivetran (Legacy)",
             "path": "/integrations/fivetran/fivetran-legacy"

--- a/docs/content/integrations/fivetran.mdx
+++ b/docs/content/integrations/fivetran.mdx
@@ -7,5 +7,5 @@ description: Represent your Fivetran connectors in Dagster
 
 There are two guides to using Fivetran with Dagster:
 
-* **[Fivetran](/integrations/fivetran/fivetran):** This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library.
-* **[Fivetran legacy](integrations/fivetran/fivetran-legacy):** This guide focuses on how to work with Fivetran connectors using Dagster's [software-defined asset (SDA)](/concepts/assets/software-defined-assets) framework. If you are just getting started with Dagster and Fivetran, use the [Fivetran guide](/integrations/fivetran/fivetran) instead.
+- **[Fivetran](/integrations/fivetran/fivetran):** This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library.
+- **[Fivetran legacy](/integrations/fivetran/fivetran-legacy):** This guide focuses on how to work with Fivetran connectors using Dagster's [software-defined asset (SDA)](/concepts/assets/software-defined-assets) framework. If you are just getting started with Dagster and Fivetran, use the [Fivetran guide](/integrations/fivetran/fivetran) instead.

--- a/docs/content/integrations/fivetran.mdx
+++ b/docs/content/integrations/fivetran.mdx
@@ -1,0 +1,9 @@
+---
+title: "Fivetran & Dagster | Dagster Docs"
+description: Represent your Fivetran connectors in Dagster
+---
+
+There are two guides to using Fivetran with Dagster:
+
+* **[Fivetran](/integrations/fivetran/fivetran)**: This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library.
+* **[Fivetran legacy](integrations/fivetran/fivetran-legacy):** This guide focuses on how to work with Fivetran connectors using Dagster's [software-defined asset (SDA)](/concepts/assets/software-defined-assets) framework. If you are just getting started with Dagster and Fivetran, use the [Fivetran guide](/integrations/fivetran/fivetran) instead.

--- a/docs/content/integrations/fivetran.mdx
+++ b/docs/content/integrations/fivetran.mdx
@@ -3,7 +3,9 @@ title: "Fivetran & Dagster | Dagster Docs"
 description: Represent your Fivetran connectors in Dagster
 ---
 
+# Fivetran & Dagster
+
 There are two guides to using Fivetran with Dagster:
 
-* **[Fivetran](/integrations/fivetran/fivetran)**: This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library.
+* **[Fivetran](/integrations/fivetran/fivetran):** This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library.
 * **[Fivetran legacy](integrations/fivetran/fivetran-legacy):** This guide focuses on how to work with Fivetran connectors using Dagster's [software-defined asset (SDA)](/concepts/assets/software-defined-assets) framework. If you are just getting started with Dagster and Fivetran, use the [Fivetran guide](/integrations/fivetran/fivetran) instead.

--- a/docs/content/integrations/fivetran/fivetran.mdx
+++ b/docs/content/integrations/fivetran/fivetran.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Using Dagster with Fivetran"
+title: "Using Dagster with the Fivetran library"
 description: Represent your Fivetran connectors in Dagster
 ---
 
-# Using Dagster with Fivetran
+# Using Dagster with the Fivetran library
 
 This guide provides instructions for using Dagster with Fivetran using the `dagster-fivetran` library. Your Fivetran connector tables can be represented as assets in the Dagster asset graph, allowing you to track lineage and dependencies between Fivetran assets and data assets you are already modeling in Dagster. You can also use Dagster to orchestrate Fivetran connectors, allowing you to trigger syncs for these on a cadence or based on upstream data changes.
 


### PR DESCRIPTION
## Summary & Motivation

Fivetran docs were moved to /integrations/fivetran/fivetran and /integrations/fivetran/fivetran-legacy, which means /integrations/fivetran is currently 404ing. This PR adds a landing page for the Fivetran section in docs.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
