### PR TITLE
Make load_definitions_from_module public

### DIFF
--- a/docs/sphinx/sections/api/apidocs/definitions.rst
+++ b/docs/sphinx/sections/api/apidocs/definitions.rst
@@ -7,3 +7,5 @@ Definitions
     :members: get_job_def, get_sensor_def, get_schedule_def, load_asset_value, get_asset_value_loader
 
 .. autofunction:: create_repository_using_definitions_args
+
+.. autofunction:: load_definitions_from_module

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -309,6 +309,9 @@ from dagster._core.definitions.module_loaders.load_assets_from_modules import (
     load_assets_from_package_module as load_assets_from_package_module,
     load_assets_from_package_name as load_assets_from_package_name,
 )
+from dagster._core.definitions.module_loaders.load_defs_from_module import (
+    load_definitions_from_module as load_definitions_from_module,
+)
 from dagster._core.definitions.multi_asset_sensor_definition import (
     MultiAssetSensorDefinition as MultiAssetSensorDefinition,
     MultiAssetSensorEvaluationContext as MultiAssetSensorEvaluationContext,

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_defs_from_module.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_defs_from_module.py
@@ -1,6 +1,7 @@
 from types import ModuleType
 from typing import Any, Mapping, Optional, Union
 
+from dagster._annotations import experimental
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
@@ -8,6 +9,7 @@ from dagster._core.definitions.module_loaders.object_list import ModuleScopedDag
 from dagster._core.executor.base import Executor
 
 
+@experimental
 def load_definitions_from_module(
     module: ModuleType,
     resources: Optional[Mapping[str, Any]] = None,


### PR DESCRIPTION
## Summary & Motivation
Exposes load_definitions_from_module as a public API, and mark it as experimental for now

## How I Tested These Changes

Existing tests
## Changelog
- A new function `load_definitions_from_module`, which can load all the assets, checks, schedules, sensors, and job objects within a module scope into a single Definitions object. Check out the documentation to learn more: https://docs.dagster.io/_apidocs/definitions#dagster.load_definitions_from_module
