### PR TITLE
[components] Allow specification of rendering scope

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_rendering.py
@@ -1,7 +1,8 @@
 import functools
 import os
 import typing
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence, Set
+from dataclasses import dataclass
 from typing import Annotated, Any, Callable, Optional, TypeVar, Union, get_origin
 
 import dagster._check as check
@@ -11,13 +12,15 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._record import record
 from jinja2.nativetypes import NativeTemplate
 from pydantic import BaseModel, ConfigDict, TypeAdapter
+from pydantic.fields import FieldInfo
 
 T = TypeVar("T")
 
 REF_BASE = "#/$defs/"
 REF_TEMPLATE = f"{REF_BASE}{{model}}"
 
-JSON_SCHEMA_EXTRA_KEY = "requires_rendering_scope"
+JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY = "dagster_defer_rendering"
+JSON_SCHEMA_EXTRA_AVAILABLE_SCOPE_KEY = "dagster_available_scope"
 
 
 def automation_condition_scope() -> Mapping[str, Any]:
@@ -27,9 +30,14 @@ def automation_condition_scope() -> Mapping[str, Any]:
     }
 
 
-def requires_additional_scope(subschema: Mapping[str, Any]) -> bool:
-    raw = check.opt_inst(subschema.get(JSON_SCHEMA_EXTRA_KEY), bool)
+def _should_defer_render(subschema: Mapping[str, Any]) -> bool:
+    raw = check.opt_inst(subschema.get(JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY), bool)
     return raw or False
+
+
+def _get_available_scope(subschema: Mapping[str, Any]) -> Set[str]:
+    raw = check.opt_inst(subschema.get(JSON_SCHEMA_EXTRA_AVAILABLE_SCOPE_KEY), list)
+    return set(raw) if raw else set()
 
 
 def _env(key: str) -> Optional[str]:
@@ -39,35 +47,50 @@ def _env(key: str) -> Optional[str]:
 ShouldRenderFn = Callable[[Sequence[Union[str, int]]], bool]
 
 
-@record(checked=False)
-class RenderingMetadata:
-    """Stores metadata about how a field should be rendered.
-
-    Examples:
-    ```python
-    class MyModel(BaseModel):
-        some_field: Annotated[str, RenderingMetadata(output_type=MyOtherModel)]
-        opt_field: Annotated[Optional[str], RenderingMetadata(output_type=(None, MyOtherModel))]
-    ```
-    """
+@dataclass
+class ResolutionMetadata:
+    """Internal class that stores arbitrary metadata about a resolved field."""
 
     output_type: type
     post_process: Optional[Callable[[Any], Any]] = None
 
 
-def _get_rendering_metadata(annotation: type) -> RenderingMetadata:
+class ResolvedFieldInfo(FieldInfo):
+    """Wrapper class that stores additional resolution metadata within a pydantic FieldInfo object."""
+
+    def __init__(
+        self,
+        *,
+        output_type: Optional[type] = None,
+        post_process_fn: Optional[Callable[[Any], Any]] = None,
+        additional_scope: Optional[Set[str]] = None,
+    ):
+        self.resolution_metadata = (
+            ResolutionMetadata(output_type=output_type, post_process=post_process_fn)
+            if output_type
+            else None
+        )
+        super().__init__(
+            json_schema_extra={
+                JSON_SCHEMA_EXTRA_AVAILABLE_SCOPE_KEY: list(additional_scope or []),
+                JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY: True,
+            },
+        )
+
+
+def _get_resolution_metadata(annotation: type) -> ResolutionMetadata:
     origin = get_origin(annotation)
     if origin is Annotated:
         _, f_metadata, *_ = typing.get_args(annotation)
-        if isinstance(f_metadata, RenderingMetadata):
-            return f_metadata
-    return RenderingMetadata(output_type=annotation)
+        if isinstance(f_metadata, ResolvedFieldInfo) and f_metadata.resolution_metadata:
+            return f_metadata.resolution_metadata
+    return ResolutionMetadata(output_type=annotation)
 
 
 class RenderedModel(BaseModel):
     """Base class for models that get rendered lazily."""
 
-    model_config = ConfigDict(json_schema_extra={JSON_SCHEMA_EXTRA_KEY: True})
+    model_config = ConfigDict(json_schema_extra={JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY: True})
 
     def render_properties(self, value_renderer: "TemplatedValueRenderer") -> Mapping[str, Any]:
         """Returns a dictionary of rendered properties for this class."""
@@ -78,7 +101,7 @@ class RenderedModel(BaseModel):
         for k, v in raw_properties.items():
             rendered = value_renderer.render_obj(v)
             annotation = self.__annotations__[k]
-            rendering_metadata = _get_rendering_metadata(annotation)
+            rendering_metadata = _get_resolution_metadata(annotation)
 
             if rendering_metadata.post_process:
                 rendered = rendering_metadata.post_process(rendered)
@@ -149,33 +172,28 @@ class TemplatedValueRenderer:
             should_render = lambda _: True
         else:
             should_render = functools.partial(
-                can_render_with_default_scope, json_schema=json_schema, subschema=json_schema
+                allow_render, json_schema=json_schema, subschema=json_schema
             )
         return self._render_obj(val, [], should_render=should_render)
 
 
-def can_render_with_default_scope(
+def _subschemas_on_path(
     valpath: Sequence[Union[str, int]], json_schema: Mapping[str, Any], subschema: Mapping[str, Any]
-) -> bool:
-    """Given a valpath and the json schema of a given target type, determines if there is a rendering scope
-    required to render the value at the given path.
-    """
+) -> Iterator[Mapping[str, Any]]:
+    """Given a valpath and the json schema of a given target type, returns the subschemas at each step of the path."""
     # List[ComplexType] (e.g.) will contain a reference to the complex type schema in the
     # top-level $defs, so we dereference it here.
     if "$ref" in subschema:
         subschema = json_schema["$defs"].get(subschema["$ref"][len(REF_BASE) :])
 
-    if requires_additional_scope(subschema):
-        return False
-    elif len(valpath) == 0:
-        return True
+    yield subschema
+    if len(valpath) == 0:
+        return
 
     # Optional[ComplexType] (e.g.) will contain multiple schemas in the "anyOf" field
     if "anyOf" in subschema:
-        return all(
-            can_render_with_default_scope(valpath, json_schema, inner)
-            for inner in subschema["anyOf"]
-        )
+        for inner in subschema["anyOf"]:
+            yield from _subschemas_on_path(valpath, json_schema, inner)
 
     el = valpath[0]
     if isinstance(el, str):
@@ -191,7 +209,29 @@ def can_render_with_default_scope(
 
     # the path wasn't valid, or unspecified
     if not inner:
-        return subschema.get("additionalProperties", True)
+        return
 
     _, *rest = valpath
-    return can_render_with_default_scope(rest, json_schema, inner)
+    yield from _subschemas_on_path(rest, json_schema, inner)
+
+
+def allow_render(
+    valpath: Sequence[Union[str, int]], json_schema: Mapping[str, Any], subschema: Mapping[str, Any]
+) -> bool:
+    """Given a valpath and the json schema of a given target type, determines if there is a rendering scope
+    required to render the value at the given path.
+    """
+    for subschema in _subschemas_on_path(valpath, json_schema, subschema):
+        if _should_defer_render(subschema):
+            return False
+    return True
+
+
+def get_available_scope(
+    valpath: Sequence[Union[str, int]], json_schema: Mapping[str, Any], subschema: Mapping[str, Any]
+) -> Set[str]:
+    """Given a valpath and the json schema of a given target type, determines the available rendering scope."""
+    available_scope = set()
+    for subschema in _subschemas_on_path(valpath, json_schema, subschema):
+        available_scope |= _get_available_scope(subschema)
+    return available_scope

--- a/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/dsl_schema.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 
 from dagster_components.core.component_rendering import (
     RenderedModel,
-    RenderingMetadata,
+    ResolvedFieldInfo,
     TemplatedValueRenderer,
 )
 
@@ -33,22 +33,22 @@ def _post_process_key(rendered: Optional[str]) -> Optional[AssetKey]:
 class AssetAttributesModel(RenderedModel):
     key: Annotated[
         Optional[str],
-        RenderingMetadata(output_type=AssetKey, post_process=_post_process_key),
+        ResolvedFieldInfo(output_type=AssetKey, post_process=_post_process_key),
     ] = None
     deps: Sequence[str] = []
     description: Optional[str] = None
     metadata: Annotated[
-        Union[str, Mapping[str, Any]], RenderingMetadata(output_type=Mapping[str, Any])
+        Union[str, Mapping[str, Any]], ResolvedFieldInfo(output_type=Mapping[str, Any])
     ] = {}
     group_name: Optional[str] = None
     skippable: bool = False
     code_version: Optional[str] = None
     owners: Sequence[str] = []
     tags: Annotated[
-        Union[str, Mapping[str, str]], RenderingMetadata(output_type=Mapping[str, str])
+        Union[str, Mapping[str, str]], ResolvedFieldInfo(output_type=Mapping[str, str])
     ] = {}
     automation_condition: Annotated[
-        Optional[str], RenderingMetadata(output_type=Optional[AutomationCondition])
+        Optional[str], ResolvedFieldInfo(output_type=Optional[AutomationCondition])
     ] = None
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Sequence
-from typing import Optional
+from typing import Annotated, Optional
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
@@ -9,6 +9,7 @@ from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import component_type
+from dagster_components.core.component_rendering import ResolvedFieldInfo
 from dagster_components.core.dsl_schema import (
     AssetAttributesModel,
     AssetSpecTransform,
@@ -21,7 +22,9 @@ from dagster_components.utils import ResolvingInfo, get_wrapped_translator_class
 class DbtProjectParams(BaseModel):
     dbt: DbtCliResource
     op: Optional[OpSpecBaseModel] = None
-    asset_attributes: Optional[AssetAttributesModel] = None
+    asset_attributes: Annotated[
+        Optional[AssetAttributesModel], ResolvedFieldInfo(additional_scope={"node"})
+    ] = None
     transforms: Optional[Sequence[AssetSpecTransform]] = None
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Optional, Union
+from typing import Annotated, Optional, Union
 
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
@@ -14,6 +14,7 @@ from typing_extensions import Self
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import component_type
 from dagster_components.core.component_generator import ComponentGenerator
+from dagster_components.core.component_rendering import ResolvedFieldInfo
 from dagster_components.core.dsl_schema import (
     AssetAttributesModel,
     AssetSpecTransform,
@@ -25,7 +26,9 @@ from dagster_components.utils import ResolvingInfo, get_wrapped_translator_class
 class SlingReplicationParams(BaseModel):
     path: str
     op: Optional[OpSpecBaseModel] = None
-    asset_attributes: Optional[AssetAttributesModel] = None
+    asset_attributes: Annotated[
+        Optional[AssetAttributesModel], ResolvedFieldInfo(additional_scope={"stream_definition"})
+    ] = None
 
 
 class SlingReplicationCollectionParams(BaseModel):

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_component_rendering.py
@@ -1,14 +1,15 @@
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 from typing import Annotated, Optional
 
 import pytest
 from dagster_components.core.component_rendering import (
     RenderedModel,
-    RenderingMetadata,
+    ResolvedFieldInfo,
     TemplatedValueRenderer,
-    can_render_with_default_scope,
+    allow_render,
+    get_available_scope,
 )
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 
 class InnerRendered(RenderedModel):
@@ -18,6 +19,9 @@ class InnerRendered(RenderedModel):
 class Container(BaseModel):
     a: str
     inner: InnerRendered
+    inner_scoped: Annotated[InnerRendered, ResolvedFieldInfo(additional_scope={"c", "d"})] = Field(
+        default_factory=InnerRendered
+    )
 
 
 class Outer(BaseModel):
@@ -25,6 +29,9 @@ class Outer(BaseModel):
     inner: InnerRendered
     container: Container
     container_optional: Optional[Container] = None
+    container_optional_scoped: Annotated[
+        Optional[Container], ResolvedFieldInfo(additional_scope={"a", "b"})
+    ] = None
     inner_seq: Sequence[InnerRendered]
     inner_optional: Optional[InnerRendered] = None
     inner_optional_seq: Optional[Sequence[InnerRendered]] = None
@@ -42,6 +49,9 @@ class Outer(BaseModel):
         (["container_optional", "a"], True),
         (["container_optional", "inner"], False),
         (["container_optional", "inner", "a"], False),
+        (["container_optional_scoped"], False),
+        (["container_optional_scoped", "inner", "a"], False),
+        (["container_optional_scoped", "inner_scoped", "a"], False),
         (["inner_seq"], True),
         (["inner_seq", 0], False),
         (["inner_seq", 0, "a"], False),
@@ -52,10 +62,26 @@ class Outer(BaseModel):
         (["inner_optional_seq", 0, "a"], False),
     ],
 )
-def test_can_render(path, expected: bool) -> None:
+def test_allow_render(path, expected: bool) -> None:
+    assert allow_render(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (["a"], set()),
+        (["inner", "a"], set()),
+        (["container_optional", "inner", "a"], set()),
+        (["inner_seq"], set()),
+        (["container_optional_scoped"], {"a", "b"}),
+        (["container_optional_scoped", "inner"], {"a", "b"}),
+        (["container_optional_scoped", "inner_scoped"], {"a", "b", "c", "d"}),
+        (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d"}),
+    ],
+)
+def test_get_available_scope(path, expected: Set[str]) -> None:
     assert (
-        can_render_with_default_scope(path, Outer.model_json_schema(), Outer.model_json_schema())
-        == expected
+        get_available_scope(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
     )
 
 
@@ -91,11 +117,11 @@ def test_render() -> None:
 
 
 class RM(RenderedModel):
-    the_renderable_int: Annotated[str, RenderingMetadata(output_type=int)]
+    the_renderable_int: Annotated[str, ResolvedFieldInfo(output_type=int)]
     the_unrenderable_int: int
 
     the_str: str
-    the_opt_int: Annotated[Optional[str], RenderingMetadata(output_type=Optional[int])] = None
+    the_opt_int: Annotated[Optional[str], ResolvedFieldInfo(output_type=Optional[int])] = None
 
 
 def test_valid_rendering() -> None:


### PR DESCRIPTION
## Summary & Motivation

This creates a new FieldInfo subclass, which carries additional metadata about what the resolved field will look like, and what data will be available to resolve it.

We have to create a subclass of FieldInfo because pydantic will only recognize things inside of the `Annotated[]` block if they are instances of FieldInfo, and the base FieldInfo does not have any fields that we can stash arbitrary objects in.


## How I Tested These Changes

## Changelog

NOCHANGELOG
