### PR TITLE
[docs-beta] fix broken pyobject API references

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/management/managing-compute-logs-and-error-messages.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/management/managing-compute-logs-and-error-messages.md
@@ -55,7 +55,7 @@ computeLogs:
 
 ### Disabling compute log upload
 
-If your organization has its own logging solution which ingests `stdout` and `stderr` from your compute environment, you may want to disable compute log upload entirely. You can do this with the <PyObject module="dagster._core.storage.noop_compute_log_manager" object="NoOpComputeLogManager" />.
+If your organization has its own logging solution which ingests `stdout` and `stderr` from your compute environment, you may want to disable compute log upload entirely. You can do this with the <PyObject section="internals" module="dagster._core.storage.noop_compute_log_manager" object="NoOpComputeLogManager" />.
 
 {/* You can configure the `NoOpComputeLogManager` in your [`dagster.yaml` file](/dagster-plus/deployment/agents/customizing-configuration): */}
 You can configure the `NoOpComputeLogManager` in your [`dagster.yaml` file](/todo):

--- a/docs/docs-beta/docs/dagster-plus/features/ci-cd/branch-deployments/change-tracking.md
+++ b/docs/docs-beta/docs/dagster-plus/features/ci-cd/branch-deployments/change-tracking.md
@@ -76,7 +76,7 @@ def customers(): ...
 
 Change Tracking can detect when an asset's upstream dependencies have changed, whether they've been added or removed.
 
-**Note**: If an asset is marked as having changed dependencies, it means that the <PyObject object="AssetKey" pluralize /> defining its upstream dependencies have changed. It doesn't mean that an upstream dependency has new data.
+**Note**: If an asset is marked as having changed dependencies, it means that the <PyObject section="assets" module="dagster" object="AssetKey" pluralize /> defining its upstream dependencies have changed. It doesn't mean that an upstream dependency has new data.
 
 <Tabs>
 <TabItem value="Asset in the Dagster UI">
@@ -97,7 +97,7 @@ def returns(): ...
 
 ### Partitions definitions
 
-Change Tracking can detect if an asset's <PyObject object="PartitionsDefinition" /> has been changed, whether it's been added, removed, or updated.
+Change Tracking can detect if an asset's <PyObject section="partitions" object="PartitionsDefinition" /> has been changed, whether it's been added, removed, or updated.
 
 <Tabs>
 <TabItem value="Asset in the Dagster UI">
@@ -118,7 +118,7 @@ Click the **Asset definition** tab to see the code change that created this labe
 def weekly_orders(): ...
 ```
 
-**In the pull request**, we updated the <PyObject object="WeeklyPartitionsDefinition" /> to start one year earlier:
+**In the pull request**, we updated the <PyObject section="partitions" object="WeeklyPartitionsDefinition" /> to start one year earlier:
 
 ```python file=/dagster_cloud/branch_deployments/change_tracking_partitions_definition.py startafter=start_branch_deployment endbefore=end_branch_deployment dedent=4
 @asset(partitions_def=WeeklyPartitionsDefinition(start_date="2023-01-01"))

--- a/docs/docs-beta/docs/dagster-plus/features/ci-cd/branch-deployments/testing.md
+++ b/docs/docs-beta/docs/dagster-plus/features/ci-cd/branch-deployments/testing.md
@@ -25,8 +25,8 @@ Here’s an overview of the main concepts we'll be using:
 - [Graphs](/todo) - We'll build graphs that define the order our ops should run.
 {/* - [Jobs](/concepts/assets/asset-jobs) - We'll define jobs by binding our graphs to resources. */}
 - [Jobs](/todo) - We'll define jobs by binding our graphs to resources.
-{/* - [Resources](/concepts/resources) - We'll use the <PyObject object="SnowflakeResource" module="dagster_snowflake" /> to swap in different Snowflake connections to our jobs depending on environment. */}
-- [Resources](/todo) - We'll use the <PyObject object="SnowflakeResource" module="dagster_snowflake" /> to swap in different Snowflake connections to our jobs depending on environment.
+{/* - [Resources](/concepts/resources) - We'll use the <PyObject section="libraries" module="dagster_snowflake" object="SnowflakeResource"  /> to swap in different Snowflake connections to our jobs depending on environment. */}
+- [Resources](/todo) - We'll use the <PyObject section="libraries" module="dagster_snowflake" object="SnowflakeResource" /> to swap in different Snowflake connections to our jobs depending on environment.
 {/* - [I/O managers](/concepts/io-management/io-managers) - We'll use a Snowflake I/O manager to persist asset outputs to Snowflake. */}
 - [I/O managers](/todo) - We'll use a Snowflake I/O manager to persist asset outputs to Snowflake.
 
@@ -232,7 +232,7 @@ def drop_prod_clone():
     drop_database_clone()
 ```
 
-We've defined `drop_database_clone` and `clone_production_database` to utilize the <PyObject object="SnowflakeResource" module="dagster_snowflake" />. The Snowflake resource will use the same configuration as the Snowflake I/O manager to generate a connection to Snowflake. However, while our I/O manager writes outputs to Snowflake, the Snowflake resource executes queries against Snowflake.
+We've defined `drop_database_clone` and `clone_production_database` to utilize the <PyObject section="libraries" object="SnowflakeResource" module="dagster_snowflake" />. The Snowflake resource will use the same configuration as the Snowflake I/O manager to generate a connection to Snowflake. However, while our I/O manager writes outputs to Snowflake, the Snowflake resource executes queries against Snowflake.
 
 We now need to define resources that configure our jobs to the current environment. We can modify the resource mapping by environment as follows:
 

--- a/docs/docs-beta/docs/guides/operate/io-managers.md
+++ b/docs/docs-beta/docs/guides/operate/io-managers.md
@@ -67,18 +67,18 @@ Dagster offers built-in library implementations for I/O managers for popular dat
 
 | Name                                                                                       | Description                                                                   |
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="FilesystemIOManager" />                                 | Default I/O manager. Stores outputs as pickle files on the local file system. |
-| <PyObject module="dagster" object="InMemoryIOManager" />                                   | Stores outputs in memory. Primarily useful for unit testing.                  |
-| <PyObject module="dagster_aws.s3" object="S3PickleIOManager" />                            | Stores outputs as pickle files in Amazon Web Services S3.                     |
-| <PyObject module="dagster_azure.adls2" object="ConfigurablePickledObjectADLS2IOManager" /> | Stores outputs as pickle files in Azure ADLS2.                                |
-| <PyObject module="dagster_gcp" object="GCSPickleIOManager" />                              | Stores outputs as pickle files in Google Cloud Platform GCS.                  |
-| <PyObject module="dagster_gcp_pandas" object="BigQueryPandasIOManager" />                  | Stores Pandas DataFrame outputs in Google Cloud Platform BigQuery.            |
-| <PyObject module="dagster_gcp_pyspark" object="BigQueryPySparkIOManager" />                | Stores PySpark DataFrame outputs in Google Cloud Platform BigQuery.           |
-| <PyObject module="dagster_snowflake_pandas" object="SnowflakePandasIOManager" />           | Stores Pandas DataFrame outputs in Snowflake.                                 |
-| <PyObject module="dagster_snowflake_pyspark" object="SnowflakePySparkIOManager" />         | Stores PySpark DataFrame outputs in Snowflake.                                |
-| <PyObject module="dagster_duckdb_pandas" object="DuckDBPandasIOManager" />                 | Stores Pandas DataFrame outputs in DuckDB.                                    |
-| <PyObject module="dagster_duckdb_pyspark" object="DuckDBPySparkIOManager" />               | Stores PySpark DataFrame outputs in DuckDB.                                   |
-| <PyObject module="dagster_duckdb_polars" object="DuckDBPolarsIOManager" />                 | Stores Polars DataFrame outputs in DuckDB.                                    |                                       |
+| <PyObject section="io-managers" module="dagster" object="FilesystemIOManager" />                                 | Default I/O manager. Stores outputs as pickle files on the local file system. |
+| <PyObject section="io-managers" module="dagster" object="InMemoryIOManager" />                                   | Stores outputs in memory. Primarily useful for unit testing.                  |
+| <PyObject section="libraries" module="dagster_aws" object="s3.S3PickleIOManager" />                            | Stores outputs as pickle files in Amazon Web Services S3.                     |
+| <PyObject section="libraries" module="dagster_azure" object="adls2.ConfigurablePickledObjectADLS2IOManager" /> | Stores outputs as pickle files in Azure ADLS2.                                |
+| <PyObject section="libraries" module="dagster_gcp" object="GCSPickleIOManager" />                              | Stores outputs as pickle files in Google Cloud Platform GCS.                  |
+| <PyObject section="libraries" module="dagster_gcp_pandas" object="BigQueryPandasIOManager" />                  | Stores Pandas DataFrame outputs in Google Cloud Platform BigQuery.            |
+| <PyObject section="libraries" module="dagster_gcp_pyspark" object="BigQueryPySparkIOManager" />                | Stores PySpark DataFrame outputs in Google Cloud Platform BigQuery.           |
+| <PyObject section="libraries" module="dagster_snowflake_pandas" object="SnowflakePandasIOManager" />           | Stores Pandas DataFrame outputs in Snowflake.                                 |
+| <PyObject section="libraries" module="dagster_snowflake_pyspark" object="SnowflakePySparkIOManager" />         | Stores PySpark DataFrame outputs in Snowflake.                                |
+| <PyObject section="libraries" module="dagster_duckdb_pandas" object="DuckDBPandasIOManager" />                 | Stores Pandas DataFrame outputs in DuckDB.                                    |
+| <PyObject section="libraries" module="dagster_duckdb_pyspark" object="DuckDBPySparkIOManager" />               | Stores PySpark DataFrame outputs in DuckDB.                                   |
+| <PyObject section="libraries" module="dagster_duckdb_polars" object="DuckDBPolarsIOManager" />                 | Stores Polars DataFrame outputs in DuckDB.                                    |                                       |
 
 ## Next steps
 

--- a/docs/docs-beta/docs/integrations/libraries/airbyte/airbyte-cloud.md
+++ b/docs/docs-beta/docs/integrations/libraries/airbyte/airbyte-cloud.md
@@ -48,36 +48,36 @@ pip install dagster dagster-airbyte
 
 ## Represent Airbyte Cloud assets in the asset graph
 
-To load Airbyte Cloud assets into the Dagster asset graph, you must first construct a <PyObject module="dagster_airbyte" object="AirbyteCloudWorkspace" /> resource, which allows Dagster to communicate with your Airbyte Cloud workspace. You'll need to supply your workspace ID, client ID and client secret. See [Configuring API Access](https://docs.airbyte.com/using-airbyte/configuring-api-access) in the Airbyte Cloud REST API documentation for more information on how to create your client ID and client secret.
+To load Airbyte Cloud assets into the Dagster asset graph, you must first construct a <PyObject section="libraries" module="dagster_airbyte" object="AirbyteCloudWorkspace" /> resource, which allows Dagster to communicate with your Airbyte Cloud workspace. You'll need to supply your workspace ID, client ID and client secret. See [Configuring API Access](https://docs.airbyte.com/using-airbyte/configuring-api-access) in the Airbyte Cloud REST API documentation for more information on how to create your client ID and client secret.
 
-Dagster can automatically load all connection tables from your Airbyte Cloud workspace as asset specs. Call the <PyObject module="dagster_airbyte" method="load_airbyte_cloud_asset_specs" /> function, which returns list of <PyObject object="AssetSpec" />s representing your Airbyte Cloud assets. You can then include these asset specs in your <PyObject object="Definitions" /> object:
+Dagster can automatically load all connection tables from your Airbyte Cloud workspace as asset specs. Call the <PyObject section="libraries" module="dagster_airbyte" object="load_airbyte_cloud_asset_specs" /> function, which returns list of <PyObject section="assets" object="AssetSpec" />s representing your Airbyte Cloud assets. You can then include these asset specs in your <PyObject section="definitions" module="dagster" object="Definitions" /> object:
 
 <CodeExample filePath="integrations/airbyte_cloud/representing_airbyte_cloud_assets.py" language="python" />
 
 ### Sync and materialize Airbyte Cloud assets
 
-You can use Dagster to sync Airbyte Cloud connections and materialize Airbyte Cloud connection tables. You can use the <PyObject module="dagster_airbyte" method="build_airbyte_assets_definitions" /> factory to create all assets definitions for your Airbyte Cloud workspace.
+You can use Dagster to sync Airbyte Cloud connections and materialize Airbyte Cloud connection tables. You can use the <PyObject section="libraries" module="dagster_airbyte" object="build_airbyte_assets_definitions" /> factory to create all assets definitions for your Airbyte Cloud workspace.
 
 <CodeExample filePath="integrations/airbyte_cloud/sync_and_materialize_airbyte_cloud_assets.py" language="python" />
 
 ### Customize the materialization of Airbyte Cloud assets
 
-If you want to customize the sync of your connections, you can use the <PyObject module="dagster_airbyte" method="airbyte_assets" /> decorator to do so. This allows you to execute custom code before and after the call to the Airbyte Cloud sync.
+If you want to customize the sync of your connections, you can use the <PyObject section="libraries" module="dagster_airbyte" object="airbyte_assets" /> decorator to do so. This allows you to execute custom code before and after the call to the Airbyte Cloud sync.
 
 <CodeExample filePath="integrations/airbyte_cloud/customize_airbyte_cloud_asset_defs.py" language="python" />
 
 ### Customize asset definition metadata for Airbyte Cloud assets
 
-By default, Dagster will generate asset specs for each Airbyte Cloud asset and populate default metadata. You can further customize asset properties by passing an instance of the custom <PyObject module="dagster_airbyte" object="DagsterAirbyteTranslator" /> to the <PyObject module="dagster_airbyte" method="load_airbyte_cloud_asset_specs" /> function.
+By default, Dagster will generate asset specs for each Airbyte Cloud asset and populate default metadata. You can further customize asset properties by passing an instance of the custom <PyObject section="libraries" module="dagster_airbyte" object="DagsterAirbyteTranslator" /> to the <PyObject section="libraries" module="dagster_airbyte" object="load_airbyte_cloud_asset_specs" /> function.
 
 <CodeExample filePath="integrations/airbyte_cloud/customize_airbyte_cloud_translator_asset_spec.py" language="python" />
 
 Note that `super()` is called in each of the overridden methods to generate the default asset spec. It is best practice to generate the default asset spec before customizing it.
 
-You can pass an instance of the custom <PyObject module="dagster_airbyte" object="DagsterAirbyteTranslator" /> to the <PyObject module="dagster_airbyte" method="airbyte_assets" /> decorator or the <PyObject module="dagster_airbyte" method="build_airbyte_assets_definitions" /> factory.
+You can pass an instance of the custom <PyObject section="libraries" module="dagster_airbyte" object="DagsterAirbyteTranslator" /> to the <PyObject section="libraries" module="dagster_airbyte" object="airbyte_assets" /> decorator or the <PyObject section="libraries" module="dagster_airbyte" object="build_airbyte_assets_definitions" /> factory.
 
 ### Load Airbyte Cloud assets from multiple workspaces
 
-Definitions from multiple Airbyte Cloud workspaces can be combined by instantiating multiple <PyObject module="dagster_airbyte" object="AirbyteCloudWorkspace" /> resources and merging their specs. This lets you view all your Airbyte Cloud assets in a single asset graph:
+Definitions from multiple Airbyte Cloud workspaces can be combined by instantiating multiple <PyObject section="libraries" module="dagster_airbyte" object="AirbyteCloudWorkspace" /> resources and merging their specs. This lets you view all your Airbyte Cloud assets in a single asset graph:
 
 <CodeExample filePath="integrations/airbyte_cloud/multiple_airbyte_cloud_workspaces.py" language="python" />

--- a/docs/docs-beta/docs/integrations/libraries/fivetran.md
+++ b/docs/docs-beta/docs/integrations/libraries/fivetran.md
@@ -48,33 +48,33 @@ pip install dagster dagster-fivetran
 
 ## Represent Fivetran assets in the asset graph
 
-To load Fivetran assets into the Dagster asset graph, you must first construct a <PyObject module="dagster_fivetran" object="FivetranWorkspace" /> resource, which allows Dagster to communicate with your Fivetran workspace. You'll need to supply your account ID, API key and API secret. See [Getting Started](https://fivetran.com/docs/rest-api/getting-started) in the Fivetran REST API documentation for more information on how to create your API key and API secret.
+To load Fivetran assets into the Dagster asset graph, you must first construct a <PyObject section="libraries" module="dagster_fivetran" object="FivetranWorkspace" /> resource, which allows Dagster to communicate with your Fivetran workspace. You'll need to supply your account ID, API key and API secret. See [Getting Started](https://fivetran.com/docs/rest-api/getting-started) in the Fivetran REST API documentation for more information on how to create your API key and API secret.
 
-Dagster can automatically load all connector tables from your Fivetran workspace as asset specs. Call the <PyObject module="dagster_fivetran" method="load_fivetran_asset_specs" /> function, which returns list of <PyObject object="AssetSpec" />s representing your Fivetran assets. You can then include these asset specs in your <PyObject object="Definitions" /> object:
+Dagster can automatically load all connector tables from your Fivetran workspace as asset specs. Call the <PyObject section="libraries" module="dagster_fivetran" object="load_fivetran_asset_specs" /> function, which returns list of <PyObject section="assets" module="dagster" object="AssetSpec" />s representing your Fivetran assets. You can then include these asset specs in your <PyObject section="definitions" module="dagster" object="Definitions" /> object:
 
 <CodeExample filePath="integrations/fivetran/representing_fivetran_assets.py" language="python" />
 
 ### Sync and materialize Fivetran assets
 
-You can use Dagster to sync Fivetran connectors and materialize Fivetran connector tables. You can use the <PyObject module="dagster_fivetran" method="build_fivetran_assets_definitions" /> factory to create all assets definitions for your Fivetran workspace.
+You can use Dagster to sync Fivetran connectors and materialize Fivetran connector tables. You can use the <PyObject section="libraries" module="dagster_fivetran" object="build_fivetran_assets_definitions" /> factory to create all assets definitions for your Fivetran workspace.
 
 <CodeExample filePath="integrations/fivetran/sync_and_materialize_fivetran_assets.py" language="python" />
 
 ### Customize the materialization of Fivetran assets
 
-If you want to customize the sync of your connectors, you can use the <PyObject module="dagster_fivetran" method="fivetran_assets" /> decorator to do so. This allows you to execute custom code before and after the call to the Fivetran sync.
+If you want to customize the sync of your connectors, you can use the <PyObject section="libraries" module="dagster_fivetran" object="fivetran_assets" /> decorator to do so. This allows you to execute custom code before and after the call to the Fivetran sync.
 
 <CodeExample filePath="integrations/fivetran/customize_fivetran_asset_defs.py" language="python" />
 
 ### Customize asset definition metadata for Fivetran assets
 
-By default, Dagster will generate asset specs for each Fivetran asset and populate default metadata. You can further customize asset properties by passing an instance of the custom <PyObject module="dagster_fivetran" object="DagsterFivetranTranslator" /> to the <PyObject module="dagster_fivetran" method="load_fivetran_asset_specs" /> function.
+By default, Dagster will generate asset specs for each Fivetran asset and populate default metadata. You can further customize asset properties by passing an instance of the custom <PyObject section="libraries" module="dagster_fivetran" object="DagsterFivetranTranslator" /> to the <PyObject section="libraries" module="dagster_fivetran" object="load_fivetran_asset_specs" /> function.
 
 <CodeExample filePath="integrations/fivetran/customize_fivetran_translator_asset_spec.py" language="python" />
 
 Note that `super()` is called in each of the overridden methods to generate the default asset spec. It is best practice to generate the default asset spec before customizing it.
 
-You can pass an instance of the custom <PyObject module="dagster_fivetran" object="DagsterFivetranTranslator" /> to the <PyObject module="dagster_fivetran" method="fivetran_assets" /> decorator or the <PyObject module="dagster_fivetran" method="build_fivetran_assets_definitions" /> factory.
+You can pass an instance of the custom <PyObject section="libraries" module="dagster_fivetran" object="DagsterFivetranTranslator" /> to the <PyObject section="libraries" module="dagster_fivetran" object="fivetran_assets" /> decorator or the <PyObject section="libraries" module="dagster_fivetran" object="build_fivetran_assets_definitions" /> factory.
 
 ### Fetching column-level metadata for Fivetran assets
 
@@ -82,13 +82,13 @@ Dagster allows you to emit column-level metadata, like [column schema](/guides/b
 
 With this metadata, you can view documentation in Dagster for all columns in your Fivetran connector tables.
 
-To enable this feature, call <PyObject object="fetch_column_metadata" module="dagster_fivetran.fivetran_event_iterator.FivetranEventIterator" displayText="fetch_column_metadata()" /> on the <PyObject object="FivetranEventIterator" module="dagster_fivetran.fivetran_event_iterator" /> returned by the `sync_and_poll()` call on the <PyObject module="dagster_fivetran" object="FivetranWorkspace" /> resource.
+To enable this feature, call <PyObject section="libraries" object="fivetran_event_iterator.FivetranEventIterator.fetch_column_metadata" module="dagster_fivetran" displayText="fetch_column_metadata()" /> on the <PyObject section="libraries" object="fivetran_event_iterator.FivetranEventIterator" module="dagster_fivetran" /> returned by the `sync_and_poll()` call on the <PyObject section="libraries" module="dagster_fivetran" object="FivetranWorkspace" /> resource.
 
 <CodeExample filePath="integrations/fivetran/fetch_column_metadata_fivetran_assets.py" language="python" />
 
 ### Load Fivetran assets from multiple workspaces
 
-Definitions from multiple Fivetran workspaces can be combined by instantiating multiple <PyObject module="dagster_fivetran" object="FivetranWorkspace" /> resources and merging their specs. This lets you view all your Fivetran assets in a single asset graph:
+Definitions from multiple Fivetran workspaces can be combined by instantiating multiple <PyObject section="libraries" module="dagster_fivetran" object="FivetranWorkspace" /> resources and merging their specs. This lets you view all your Fivetran assets in a single asset graph:
 
 <CodeExample filePath="integrations/fivetran/multiple_fivetran_workspaces.py" language="python" />
 


### PR DESCRIPTION
## Summary & Motivation

Fixes broken `<Link>` hrefs created by `PyObject` instances.

This PR is stacked on https://github.com/dagster-io/dagster/pull/26942

## How I Tested These Changes

`yarn build` locally; waiting for BK

## Changelog

NOCHANGELOG
