### PR TITLE
[perf] Skip expensive `PIPELINE_EXPLORER_ROOT_QUERY` query if viewing an asset job and prefer asset rendering is enabled

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.oss.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {explodeCompositesInHandleGraph} from './CompositeSupport';
@@ -26,7 +26,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useOpenInNewTab} from '../hooks/useOpenInNewTab';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {Loading} from '../ui/Loading';
-import {buildPipelineSelector} from '../workspace/WorkspaceContext/util';
+import {buildPipelineSelector, useJob} from '../workspace/WorkspaceContext/util';
 import {RepoAddress} from '../workspace/types';
 
 export const PipelineExplorerSnapshotRoot = () => {
@@ -58,13 +58,7 @@ export const PipelineExplorerSnapshotRoot = () => {
   );
 };
 
-export const PipelineExplorerContainer = ({
-  explorerPath,
-  repoAddress,
-  onChangeExplorerPath,
-  onNavigateToSourceAssetNode,
-  isGraph = false,
-}: {
+export const PipelineExplorerContainer = (props: {
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onNavigateToSourceAssetNode: (
@@ -74,11 +68,50 @@ export const PipelineExplorerContainer = ({
   repoAddress?: RepoAddress;
   isGraph?: boolean;
 }) => {
+  const {explorerPath, repoAddress} = props;
   const [options, setOptions] = useState<GraphExplorerOptions>({
     explodeComposites: explorerPath.explodeComposites ?? false,
     preferAssetRendering: true,
   });
+  const job = useJob(repoAddress, explorerPath.pipelineName);
+  const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
+  if (job && job.isAssetJob && options.preferAssetRendering) {
+    return (
+      <AssetGraphExplorer
+        options={options}
+        setOptions={setOptions}
+        fetchOptions={{pipelineSelector}}
+        explorerPath={explorerPath}
+        onChangeExplorerPath={props.onChangeExplorerPath}
+        onNavigateToSourceAssetNode={props.onNavigateToSourceAssetNode}
+        viewType={AssetGraphViewType.JOB}
+      />
+    );
+  }
 
+  return <PipelineOpGraphExplorer {...props} options={options} setOptions={setOptions} />;
+};
+
+const PipelineOpGraphExplorer = ({
+  explorerPath,
+  repoAddress,
+  onChangeExplorerPath,
+  onNavigateToSourceAssetNode,
+  isGraph = false,
+  options,
+  setOptions,
+}: {
+  explorerPath: ExplorerPath;
+  onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+  onNavigateToSourceAssetNode: (
+    e: Pick<React.MouseEvent<any>, 'metaKey'>,
+    node: AssetLocation,
+  ) => void;
+  repoAddress?: RepoAddress;
+  isGraph?: boolean;
+  options: GraphExplorerOptions;
+  setOptions: React.Dispatch<React.SetStateAction<GraphExplorerOptions>>;
+}) => {
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.oss.tsx
@@ -74,8 +74,8 @@ export const PipelineExplorerContainer = (props: {
     preferAssetRendering: true,
   });
   const job = useJob(repoAddress, explorerPath.pipelineName);
-  const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
   if (job && job.isAssetJob && options.preferAssetRendering) {
+    const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
     return (
       <AssetGraphExplorer
         options={options}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
@@ -121,7 +121,7 @@ export const useRepository = (repoAddress: RepoAddress | null) => {
   return findRepositoryAmongOptions(options, repoAddress) || null;
 };
 
-export const useJob = (repoAddress: RepoAddress | null, jobName: string | null) => {
+export const useJob = (repoAddress: RepoAddress | null | undefined, jobName: string | null) => {
   const repo = useRepository(repoAddress);
   return repo?.repository.pipelines.find((pipelineOrJob) => pipelineOrJob.name === jobName) || null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
@@ -116,7 +116,7 @@ export const useRepositoryOptions = () => {
   return {options, loading};
 };
 
-export const useRepository = (repoAddress: RepoAddress | null) => {
+export const useRepository = (repoAddress: RepoAddress | null | undefined) => {
   const {options} = useRepositoryOptions();
   return findRepositoryAmongOptions(options, repoAddress) || null;
 };
@@ -128,7 +128,7 @@ export const useJob = (repoAddress: RepoAddress | null | undefined, jobName: str
 
 export const findRepositoryAmongOptions = (
   options: DagsterRepoOption[],
-  repoAddress: RepoAddress | null,
+  repoAddress: RepoAddress | null | undefined,
 ) => {
   return repoAddress
     ? options.find(


### PR DESCRIPTION
## Summary & Motivation

When viewing an asset job as an asset graph the `PIPELINE_EXPLORER_ROOT_QUERY` is unused. This is slowing down the default case unnecessarily. Short circuit to bypass it. 

Note that this uses the `useJob` hook which relies on our workspace fetching abstraction. If the workspace isn't fetched then we go down the slow path and its effectively a race between the query and the workspace fetching.

## How I Tested These Changes

app-proxy

rum: https://app.datadoghq.com/rum/sessions?query=%40view.id%3A8063e1a8-0612-4aae-8992-0c5ff1623c88%20%40type%3Aview&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZRH7cXuh-qITwAAABhBWlJIN2NYdUFBQ2RXOTdVUDVxYWFMc2gAAAAkMDE5NDQ3ZWQtZWM0OC00ZTQxLWJjOWUtNDcyN2VhNzBhMjMwAAAAGQ&fromUser=false&track=rum&viz=stream&from_ts=1736287373547&to_ts=1736373773547&live=true
