### PR TITLE
[ui] Add tabs to evaluation dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
@@ -14,6 +14,7 @@ import {AutomaterializeRunsTable} from './AutomaterializeRunsTable';
 import {PartitionSubsetList} from './PartitionSubsetList';
 import {PartitionTagSelector} from './PartitionTagSelector';
 import {PolicyEvaluationTable} from './PolicyEvaluationTable';
+import {runTableFiltersForEvaluation} from './runTableFiltersForEvaluation';
 import {
   AssetConditionEvaluationRecordFragment,
   GetEvaluationsSpecificPartitionQuery,
@@ -22,7 +23,6 @@ import {usePartitionsForAssetKey} from './usePartitionsForAssetKey';
 import {useFeatureFlags} from '../../app/Flags';
 import {formatElapsedTimeWithMsec} from '../../app/Util';
 import {Timestamp} from '../../app/time/Timestamp';
-import {RunsFilter} from '../../graphql/types';
 import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
@@ -111,21 +111,8 @@ export const AutomaterializeMiddlePanelWithData = ({
 
   const {partitions: allPartitions} = usePartitionsForAssetKey(definition?.assetKey.path || []);
 
-  // For a single asset for a single tick, DA will either request a list of runs or a single backfill.
-  // When DA requests a backfill we want to show a row for that backfill in the table, so we need to
-  // construct the RunsFilter differently. Backfill IDs are 8 characters long, so we can use that to
-  // determine if a backfill was requested. If DA is updated to request multiple backfills in a
-  // single evaluation, or emit a combination of runs and backfills in a single evaluation, this
-  // logic will need to be updated.
-  const backfillIdLength = 8;
-  const runsFilter: RunsFilter | null = useMemo(
-    () =>
-      selectedEvaluation?.runIds.length
-        ? selectedEvaluation.runIds.length === 1 &&
-          selectedEvaluation.runIds[0]?.length === backfillIdLength
-          ? {tags: [{key: 'dagster/backfill', value: selectedEvaluation.runIds[0]}]}
-          : {runIds: selectedEvaluation.runIds}
-        : null,
+  const runsFilter = useMemo(
+    () => runTableFiltersForEvaluation(selectedEvaluation?.runIds || []),
     [selectedEvaluation],
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
@@ -1,22 +1,11 @@
-import {
-  Box,
-  Button,
-  ButtonLink,
-  Colors,
-  Dialog,
-  DialogFooter,
-  DialogHeader,
-  Mono,
-} from '@dagster-io/ui-components';
+import {ButtonLink, Colors} from '@dagster-io/ui-components';
 import {useState} from 'react';
-import {Link} from 'react-router-dom';
 
 import {AssetKey} from '../types';
-import {EvaluationDetailDialog} from './EvaluationDetailDialog';
+import {EvaluationDetailDialog, Tab} from './EvaluationDetailDialog';
 import {EvaluationStatusTag} from './EvaluationStatusTag';
 import {AssetConditionEvaluationRecordFragment} from './types/GetEvaluationsQuery.types';
 import {DEFAULT_TIME_FORMAT} from '../../app/time/TimestampFormat';
-import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 
 interface Props {
@@ -28,12 +17,18 @@ interface Props {
 
 export const EvaluationListRow = ({evaluation, assetKey, assetCheckName, isPartitioned}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>('evaluation');
 
   return (
     <>
       <tr>
         <td style={{verticalAlign: 'middle'}}>
-          <ButtonLink onClick={() => setIsOpen(true)}>
+          <ButtonLink
+            onClick={() => {
+              setTab('evaluation');
+              setIsOpen(true);
+            }}
+          >
             <TimestampDisplay
               timestamp={evaluation.timestamp}
               timeFormat={{...DEFAULT_TIME_FORMAT, showSeconds: true}}
@@ -49,7 +44,18 @@ export const EvaluationListRow = ({evaluation, assetKey, assetCheckName, isParti
           />
         </td>
         <td style={{verticalAlign: 'middle'}}>
-          <EvaluationRunInfo runIds={evaluation.runIds} timestamp={evaluation.timestamp} />
+          {evaluation.runIds.length > 0 ? (
+            <ButtonLink
+              onClick={() => {
+                setTab('runs');
+                setIsOpen(true);
+              }}
+            >
+              {evaluation.runIds.length > 1 ? `${evaluation.runIds.length} runs` : '1 run'}
+            </ButtonLink>
+          ) : (
+            <span style={{color: Colors.textDisabled()}}>None</span>
+          )}
         </td>
       </tr>
       <EvaluationDetailDialog
@@ -58,78 +64,8 @@ export const EvaluationListRow = ({evaluation, assetKey, assetCheckName, isParti
         evaluationID={evaluation.evaluationId}
         assetKeyPath={assetKey.path}
         assetCheckName={assetCheckName}
+        initialTab={tab}
       />
-    </>
-  );
-};
-
-interface EvaluationRunInfoProps {
-  runIds: string[];
-  timestamp: number;
-}
-
-const EvaluationRunInfo = ({runIds, timestamp}: EvaluationRunInfoProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const firstRun = runIds[0];
-
-  if (!firstRun) {
-    return <span style={{color: Colors.textDisabled()}}>None</span>;
-  }
-
-  if (runIds.length === 1) {
-    const truncated = firstRun.slice(0, 8);
-
-    // This looks like a backfill ID. Link there.
-    if (truncated === firstRun) {
-      return (
-        <Link to={`/runs/b/${firstRun}`}>
-          <Mono>{firstRun}</Mono>
-        </Link>
-      );
-    }
-
-    return (
-      <Link to={`/runs/${firstRun}`}>
-        <Mono>{truncated}</Mono>
-      </Link>
-    );
-  }
-
-  return (
-    <>
-      <ButtonLink onClick={() => setIsOpen(true)}>{runIds.length} runs</ButtonLink>
-      <Dialog
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
-        style={{
-          width: '80vw',
-          maxWidth: '1400px',
-          minWidth: '800px',
-          height: '80vh',
-          minHeight: '400px',
-          maxHeight: '1400px',
-        }}
-      >
-        <Box flex={{direction: 'column'}} style={{height: '100%'}}>
-          <DialogHeader
-            label={
-              <>
-                Runs at{' '}
-                <TimestampDisplay
-                  timestamp={timestamp}
-                  timeFormat={{...DEFAULT_TIME_FORMAT, showSeconds: true}}
-                />
-              </>
-            }
-          />
-          <div style={{flex: 1, overflowY: 'auto'}}>
-            <RunsFeedTableWithFilters filter={{runIds}} includeRunsFromBackfills={true} />
-          </div>
-          <DialogFooter topBorder>
-            <Button onClick={() => setIsOpen(false)}>Done</Button>
-          </DialogFooter>
-        </Box>
-      </Dialog>
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/runTableFiltersForEvaluation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/runTableFiltersForEvaluation.tsx
@@ -1,0 +1,22 @@
+import {RunsFilter} from '../../graphql/types';
+
+const BACKFILL_ID_LENGTH = 8;
+
+/**
+ * For a single asset for a single tick, DA will either request a list of runs or a single backfill.
+ * When DA requests a backfill we want to show a row for that backfill in the table, so we need to
+ * construct the RunsFilter differently. Backfill IDs are 8 characters long, so we can use that to
+ * determine if a backfill was requested. If DA is updated to request multiple backfills in a
+ * single evaluation, or emit a combination of runs and backfills in a single evaluation, this
+ * logic will need to be updated.
+ */
+export const runTableFiltersForEvaluation = (runIds: string[]): RunsFilter | null => {
+  const firstRunId = runIds[0];
+  if (firstRunId) {
+    if (firstRunId.length === BACKFILL_ID_LENGTH) {
+      return {tags: [{key: 'dagster/backfill', value: firstRunId}]};
+    }
+    return {runIds};
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary & Motivation

Update `EvaluationDetailDialog` to have two tabs: Evaluation and Runs. The first shows what the dialog currently shows, which is the details of the evaluation itself. The second is a filtered Runs table with the runs associated with the evaluation.

<img width="1259" alt="Screenshot 2025-01-14 at 10 52 53" src="https://github.com/user-attachments/assets/8e075249-38ad-417d-9fa4-0dd6c2661d4e" />

<img width="1252" alt="Screenshot 2025-01-14 at 10 52 48" src="https://github.com/user-attachments/assets/76858c12-d840-4ead-841f-065c35ddec4c" />


## How I Tested These Changes

View dialog from automation sensor and asset automations list. Verify that the tabs behave and render correctly.

## Changelog

[ui] When viewing details of an automation evaluation, show the relevant runs in a tab within the same dialog.
