### PR TITLE
[components] Enrich pydantic validation errors with filepaths, line numbers

### DIFF
--- a/examples/experimental/dagster-blueprints/examples/builtin-blueprints/builtin_blueprints/pipelines/process_customers.yaml
+++ b/examples/experimental/dagster-blueprints/examples/builtin-blueprints/builtin_blueprints/pipelines/process_customers.yaml
@@ -3,6 +3,6 @@
     - key: customers
 
 - command: "python customer_stats.py"
-  asszets:
+  assets:
     - key: customer_stats
       deps: [customers]

--- a/examples/experimental/dagster-blueprints/examples/builtin-blueprints/builtin_blueprints/pipelines/process_customers.yaml
+++ b/examples/experimental/dagster-blueprints/examples/builtin-blueprints/builtin_blueprints/pipelines/process_customers.yaml
@@ -3,6 +3,6 @@
     - key: customers
 
 - command: "python customer_stats.py"
-  assets:
+  asszets:
     - key: customer_stats
       deps: [customers]

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -1,11 +1,13 @@
-from collections.abc import Sequence
-from typing import TypeVar
+import contextlib
+from collections.abc import Generator, Sequence
+from typing import Optional, TypeVar
 
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._utils.source_position import (
     KeyPath,
+    SourcePositionTree,
     ValueAndSourcePositionTree,
     populate_source_position_and_key_paths,
 )
@@ -85,6 +87,36 @@ def parse_yaml_file_to_pydantic(cls: type[T], src: str, filename: str = "<string
     return _parse_and_populate_model_with_annotated_errors(
         cls=cls, obj_parse_root=parsed, obj_key_path_prefix=[]
     )
+
+
+@contextlib.contextmanager
+def enrich_validation_errors_with_source_position(
+    source_position_tree: SourcePositionTree, obj_key_path_prefix: KeyPath
+) -> Generator[None, None, None]:
+    err: Optional[ValidationError] = None
+    try:
+        yield
+    except ValidationError as e:
+        line_errors = []
+        for error in e.errors():
+            key_path_in_obj = list(error["loc"])
+            source_position = source_position_tree.lookup_nearest(key_path_in_obj)
+
+            file_key_path: KeyPath = list(obj_key_path_prefix) + key_path_in_obj
+            file_key_path_str = ".".join(str(part) for part in file_key_path)
+            line_errors.append(
+                {**error, "loc": [file_key_path_str + " at " + str(source_position)]}
+            )
+
+        err = ValidationError.from_exception_data(
+            title=e.title,
+            line_errors=line_errors,
+            input_type="json",
+            hide_input=False,
+        )
+    finally:
+        if err:
+            raise err from None
 
 
 def parse_yaml_file_to_pydantic_sequence(

--- a/python_modules/dagster/dagster/_utils/source_position.py
+++ b/python_modules/dagster/dagster/_utils/source_position.py
@@ -40,6 +40,17 @@ class SourcePositionTree(NamedTuple):
             return None
         return self.children[head].lookup(tail)
 
+    def lookup_nearest(self, key_path: KeyPath) -> Optional[SourcePosition]:
+        """Returns the source position of the descendant at the given path. If the path does not
+        exist, returns the source position of the nearest ancestor.
+        """
+        if len(key_path) == 0:
+            return self.position
+        head, *tail = key_path
+        if head not in self.children:
+            return self.position
+        return self.children[head].lookup_nearest(tail)
+
 
 class ValueAndSourcePositionTree(NamedTuple):
     """A tree-like object (like a JSON-structured dict) and an accompanying SourcePositionTree.

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -259,21 +259,16 @@ class ComponentLoadContext:
         return self.decl_node.component_file_model.params
 
     def load_params(self, params_schema: type[T]) -> T:
-        from dagster_components.core.component_decl_builder import (
-            ComponentFileModelWithSourceInfo,
-            YamlComponentDecl,
-        )
+        from dagster_components.core.component_decl_builder import YamlComponentDecl
 
         with pushd(str(self.path)):
             preprocessed_params = self.templated_value_resolver.render_params(
                 self._raw_params(), params_schema
             )
-            component_file_model = cast(YamlComponentDecl, self.decl_node).component_file_model
+            yaml_decl = cast(YamlComponentDecl, self.decl_node)
 
-            if isinstance(component_file_model, ComponentFileModelWithSourceInfo):
-                source_position_tree_of_params = component_file_model.source_position_tree.children[
-                    "params"
-                ]
+            if yaml_decl.source_position_tree:
+                source_position_tree_of_params = yaml_decl.source_position_tree.children["params"]
                 with enrich_validation_errors_with_source_position(
                     source_position_tree_of_params, ["params"]
                 ):

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -259,18 +259,21 @@ class ComponentLoadContext:
         return self.decl_node.component_file_model.params
 
     def load_params(self, params_schema: type[T]) -> T:
+        from dagster_components.core.component_decl_builder import (
+            ComponentFileModelWithSourceInfo,
+            YamlComponentDecl,
+        )
+
         with pushd(str(self.path)):
             preprocessed_params = self.templated_value_resolver.render_params(
                 self._raw_params(), params_schema
             )
-            from dagster_components.core.component_decl_builder import YamlComponentDecl
+            component_file_model = cast(YamlComponentDecl, self.decl_node).component_file_model
 
-            source_position_tree = cast(
-                YamlComponentDecl, self.decl_node
-            ).component_file_model.source_position_tree
-
-            if source_position_tree:
-                source_position_tree_of_params = source_position_tree.children["params"]
+            if isinstance(component_file_model, ComponentFileModelWithSourceInfo):
+                source_position_tree_of_params = component_file_model.source_position_tree.children[
+                    "params"
+                ]
                 with enrich_validation_errors_with_source_position(
                     source_position_tree_of_params, []
                 ):

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -268,8 +268,14 @@ class ComponentLoadContext:
             source_position_tree = cast(
                 YamlComponentDecl, self.decl_node
             ).component_file_model.source_position_tree
-            source_position_tree_of_params = source_position_tree.children["params"]
-            with enrich_validation_errors_with_source_position(source_position_tree_of_params, []):
+
+            if source_position_tree:
+                source_position_tree_of_params = source_position_tree.children["params"]
+                with enrich_validation_errors_with_source_position(
+                    source_position_tree_of_params, []
+                ):
+                    return TypeAdapter(params_schema).validate_python(preprocessed_params)
+            else:
                 return TypeAdapter(params_schema).validate_python(preprocessed_params)
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -275,7 +275,7 @@ class ComponentLoadContext:
                     "params"
                 ]
                 with enrich_validation_errors_with_source_position(
-                    source_position_tree_of_params, []
+                    source_position_tree_of_params, ["params"]
                 ):
                     return TypeAdapter(params_schema).validate_python(preprocessed_params)
             else:

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -14,10 +14,10 @@ from dagster_components.core.component import ComponentDeclNode
 class ComponentFileModel(BaseModel):
     type: str
     params: Optional[Mapping[str, Any]] = None
-    _source_position_tree: SourcePositionTree
+    _source_position_tree: Optional[SourcePositionTree] = None
 
     @property
-    def source_position_tree(self) -> SourcePositionTree:
+    def source_position_tree(self) -> Optional[SourcePositionTree]:
         return self._source_position_tree
 
     @staticmethod

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -14,21 +14,23 @@ from dagster_components.core.component import ComponentDeclNode
 class ComponentFileModel(BaseModel):
     type: str
     params: Optional[Mapping[str, Any]] = None
-    _source_position_tree: Optional[SourcePositionTree] = None
 
-    @property
-    def source_position_tree(self) -> Optional[SourcePositionTree]:
-        return self._source_position_tree
+
+class ComponentFileModelWithSourceInfo(ComponentFileModel):
+    source_position_tree: SourcePositionTree
 
     @staticmethod
-    def from_file(contents: str, filepath: str) -> "ComponentFileModel":
+    def from_file(contents: str, filepath: str) -> "ComponentFileModelWithSourceInfo":
         parsed = parse_yaml_with_source_positions(contents, filepath)
         obj = _parse_and_populate_model_with_annotated_errors(
             cls=ComponentFileModel, obj_parse_root=parsed, obj_key_path_prefix=[]
         )
 
-        obj._source_position_tree = parsed.source_position_tree  # noqa: SLF001
-        return obj
+        return ComponentFileModelWithSourceInfo(
+            type=obj.type,
+            params=obj.params,
+            source_position_tree=parsed.source_position_tree,
+        )
 
 
 @record
@@ -54,11 +56,13 @@ def path_to_decl_node(path: Path) -> Optional[ComponentDeclNode]:
     component_path = path / "component.yaml"
 
     if component_path.exists():
-        component_file_model = ComponentFileModel.from_file(
+        component_file_model_and_source_position = ComponentFileModelWithSourceInfo.from_file(
             component_path.read_text(), str(component_path)
         )
 
-        return YamlComponentDecl(path=path, component_file_model=component_file_model)
+        return YamlComponentDecl(
+            path=path, component_file_model=component_file_model_and_source_position
+        )
 
     subs = []
     for subpath in path.iterdir():

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
@@ -1,0 +1,4 @@
+type: dagster_components.definitions
+
+params:
+  definitions_path: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/definitions.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
@@ -1,0 +1,5 @@
+type: .my_component
+
+params:
+  a_string: "test"
+  an_int: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
@@ -1,0 +1,4 @@
+type: .my_component
+
+params:
+  a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
@@ -1,0 +1,5 @@
+type: .my_component
+
+params:
+  a_string: "a string"
+  an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
@@ -1,0 +1,13 @@
+type: .my_nested_component
+
+params:
+  nested:
+    foo:
+      a_string: "test"
+      an_int: {}
+    bar:
+      a_string: "test"
+      an_int: 5
+    baz:
+      a_string: {}
+      an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
@@ -1,0 +1,11 @@
+type: .my_nested_component
+
+params:
+  nested:
+    foo:
+      a_string: "test"
+    bar:
+      a_string: "test"
+      an_int: 5
+    baz:
+      an_int: 10

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
@@ -1,4 +1,6 @@
+import pytest
 from dagster._core.definitions.asset_key import AssetKey
+from pydantic import ValidationError
 
 from dagster_components_tests.integration_tests.component_loader import load_test_component_defs
 
@@ -11,3 +13,10 @@ def test_definitions_component_with_default_file() -> None:
 def test_definitions_component_with_explicit_file() -> None:
     defs = load_test_component_defs("definitions/explicit_file")
     assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("asset_in_some_file")}
+
+
+def test_definitions_component_validation_error() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs("definitions/validation_error_file")
+
+        assert "component.yaml:4" in str(e)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
@@ -19,4 +19,4 @@ def test_definitions_component_validation_error() -> None:
     with pytest.raises(ValidationError) as e:
         load_test_component_defs("definitions/validation_error_file")
 
-        assert "component.yaml:4" in str(e)
+    assert "component.yaml:4" in str(e.value)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component, component_type
 from dagster_components.core.component import ComponentLoadContext
@@ -32,7 +30,7 @@ class MyNestedModel(BaseModel):
 
 
 class MyNestedComponentSchema(BaseModel):
-    nested: Dict[str, MyNestedModel]
+    nested: dict[str, MyNestedModel]
 
 
 @component_type

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
@@ -1,0 +1,49 @@
+from typing import Dict
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component, component_type
+from dagster_components.core.component import ComponentLoadContext
+from pydantic import BaseModel
+from typing_extensions import Self
+
+
+class MyComponentSchema(BaseModel):
+    a_string: str
+    an_int: int
+
+
+@component_type
+class MyComponent(Component):
+    name = "my_component"
+    params_schema = MyComponentSchema
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> Self:
+        context.load_params(cls.params_schema)
+        return cls()
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions()
+
+
+class MyNestedModel(BaseModel):
+    a_string: str
+    an_int: int
+
+
+class MyNestedComponentSchema(BaseModel):
+    nested: Dict[str, MyNestedModel]
+
+
+@component_type
+class MyNestedComponent(Component):
+    name = "my_nested_component"
+    params_schema = MyNestedComponentSchema
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> Self:
+        context.load_params(cls.params_schema)
+        return cls()
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -1,0 +1,10 @@
+from dagster_components import Component, component_type
+from dagster_components.core.component import get_component_type_name, is_registered_component_type
+
+
+def test_registered_component_with_default_name() -> None:
+    @component_type
+    class RegisteredComponent(Component): ...
+
+    assert is_registered_component_type(RegisteredComponent)
+    assert get_component_type_name(RegisteredComponent) == "registered_component"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -1,10 +1,81 @@
-from dagster_components import Component, component_type
-from dagster_components.core.component import get_component_type_name, is_registered_component_type
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from dagster._core.definitions.definitions_class import Definitions
+from pydantic import ValidationError
+
+from dagster_components_tests.integration_tests.component_loader import (
+    build_defs_from_component_path,
+    load_test_component_project_context,
+)
 
 
-def test_registered_component_with_default_name() -> None:
-    @component_type
-    class RegisteredComponent(Component): ...
+def load_test_component_defs_inject_component(path: str, component_to_inject: Path) -> Definitions:
+    origin_path = Path(__file__).parent.parent / "components" / path
 
-    assert is_registered_component_type(RegisteredComponent)
-    assert get_component_type_name(RegisteredComponent) == "registered_component"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.copytree(origin_path, tmpdir, dirs_exist_ok=True)
+        shutil.copy(component_to_inject, Path(tmpdir) / "__init__.py")
+
+        context = load_test_component_project_context()
+        return build_defs_from_component_path(
+            path=Path(tmpdir),
+            registry=context.component_registry,
+            resources={},
+        )
+
+
+def test_basic_component_success() -> None:
+    load_test_component_defs_inject_component(
+        "validation/basic_component_success", Path(__file__).parent / "basic_components.py"
+    )
+
+
+def test_basic_component_invalid_value() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/basic_component_invalid_value",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    assert "component.yaml:5" in str(e.value)
+    assert "Input should be a valid integer" in str(e.value)
+
+
+def test_basic_component_missing_value() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/basic_component_missing_value",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    # Points to the lowest element in the hierarchy which is missing a required field
+    assert "component.yaml:4" in str(e.value)
+    assert "Field required" in str(e.value)
+
+
+def test_nested_component_invalid_values() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/nested_component_invalid_values",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    assert "component.yaml:7" in str(e.value)
+    assert "Input should be a valid integer" in str(e.value)
+    assert "component.yaml:12" in str(e.value)
+    assert "Input should be a valid string" in str(e.value)
+
+
+def test_nested_component_missing_value() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/nested_component_missing_values",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    assert "component.yaml:6" in str(e.value)
+    assert "Field required" in str(e.value)
+    assert "component.yaml:11" in str(e.value)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -41,6 +41,7 @@ def test_basic_component_invalid_value() -> None:
         )
 
     assert "component.yaml:5" in str(e.value)
+    assert "params.an_int" in str(e.value)
     assert "Input should be a valid integer" in str(e.value)
 
 
@@ -53,6 +54,7 @@ def test_basic_component_missing_value() -> None:
 
     # Points to the lowest element in the hierarchy which is missing a required field
     assert "component.yaml:4" in str(e.value)
+    assert "params.an_int" in str(e.value)
     assert "Field required" in str(e.value)
 
 
@@ -65,6 +67,7 @@ def test_nested_component_invalid_values() -> None:
 
     assert "component.yaml:7" in str(e.value)
     assert "Input should be a valid integer" in str(e.value)
+    assert "params.nested.foo.an_int" in str(e.value)
     assert "component.yaml:12" in str(e.value)
     assert "Input should be a valid string" in str(e.value)
 


### PR DESCRIPTION
## Summary

Ports over the YAML line tracking functionality to enrich Pydantic `ValidationErrors` thrown when instantiating components. The filepath of the loaded YAML file & offending line number are appended to the error message.

```python
E       ValidationError: 2 validation errors for MyNestedComponentSchema
E         `nested.foo.an_int at /var/folders/bc/4npnrqyd46l4vbbkdsdsw3_h0000gn/T/tmpte2ox0bw/component.yaml:6`
E           Field required [type=missing, input_value={'a_string': 'test'}, input_type=dict]
E             For further information visit https://errors.pydantic.dev/2.8/v/missing
E         `nested.baz.a_string at /var/folders/bc/4npnrqyd46l4vbbkdsdsw3_h0000gn/T/tmpte2ox0bw/component.yaml:11`
E           Field required [type=missing, input_value={'an_int': 10}, input_type=dict]
E             For further information visit https://errors.pydantic.dev/2.8/v/missing
```

## Test Plan

New set of validation integration tests.