### PR TITLE
[components] Allow dg component-type list to function outside code location

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -1,11 +1,14 @@
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
 import click
 
-from dagster_components.core.component import ComponentTypeMetadata, ComponentTypeRegistry
+from dagster_components.core.component import (
+    Component,
+    ComponentTypeMetadata,
+    ComponentTypeRegistry,
+)
 from dagster_components.core.deployment import (
     CodeLocationProjectContext,
     find_enclosing_code_location_root_path,
@@ -24,26 +27,32 @@ def list_cli():
 def list_component_types_command(ctx: click.Context) -> None:
     """List registered Dagster components."""
     builtin_component_lib = ctx.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
-    if not is_inside_code_location_project(Path.cwd()):
-        click.echo(
-            click.style(
-                "This command must be run inside a Dagster code location project.", fg="red"
-            )
-        )
-        sys.exit(1)
-
-    context = CodeLocationProjectContext.from_code_location_path(
-        find_enclosing_code_location_root_path(Path.cwd()),
-        ComponentTypeRegistry.from_entry_point_discovery(
-            builtin_component_lib=builtin_component_lib
-        ),
-    )
     output: dict[str, Any] = {}
-    for key, component_type in context.list_component_types():
-        package, name = key.rsplit(".", 1)
-        output[key] = ComponentTypeMetadata(
-            name=name,
-            package=package,
-            **component_type.get_metadata(),
+    if not is_inside_code_location_project(Path.cwd()):
+        registry = ComponentTypeRegistry.from_entry_point_discovery(
+            builtin_component_lib=builtin_component_lib
         )
+        for key in sorted(registry.keys()):
+            _add_component_type_to_output(output, key, registry.get(key))
+    else:
+        context = CodeLocationProjectContext.from_code_location_path(
+            find_enclosing_code_location_root_path(Path.cwd()),
+            ComponentTypeRegistry.from_entry_point_discovery(
+                builtin_component_lib=builtin_component_lib
+            ),
+        )
+        for key, component_type in context.list_component_types():
+            _add_component_type_to_output(output, key, component_type)
+
     click.echo(json.dumps(output))
+
+
+def _add_component_type_to_output(
+    output: dict[str, Any], key: str, component_type: type[Component]
+) -> None:
+    package, name = key.rsplit(".", 1)
+    output[key] = ComponentTypeMetadata(
+        name=name,
+        package=package,
+        **component_type.get_metadata(),
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -118,7 +118,8 @@ def _rebuild_component_registry(dg_context: DgContext):
     key = make_cache_key(root_path, "component_registry_data")
     dg_context.cache.clear_key(key)
     # This will trigger a rebuild of the component registry
-    fetch_component_registry(Path.cwd(), dg_context)
+    code_location_root = resolve_code_location_root_directory(Path.cwd())
+    fetch_component_registry(code_location_root, dg_context)
 
 
 ENV_PREFIX = "DAGSTER_DG"

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -177,15 +177,13 @@ def ensure_uv_lock(root_path: Path) -> None:
 
 
 def fetch_component_registry(path: Path, dg_context: DgContext) -> RemoteComponentRegistry:
-    root_path = resolve_code_location_root_directory(path)
-
     if dg_context.has_cache:
-        cache_key = make_cache_key(root_path, "component_registry_data")
+        cache_key = make_cache_key(path, "component_registry_data")
 
     raw_registry_data = dg_context.cache.get(cache_key) if dg_context.has_cache else None
     if not raw_registry_data:
         raw_registry_data = execute_code_location_command(
-            root_path, ["list", "component-types"], dg_context
+            path, ["list", "component-types"], dg_context
         )
         if dg_context.has_cache:
             dg_context.cache.set(cache_key, raw_registry_data)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -30,11 +30,12 @@ CLI_CONFIG_KEY = "config"
 
 
 def execute_code_location_command(path: Path, cmd: Sequence[str], dg_context: "DgContext") -> str:
-    code_location_command_prefix = (
-        ["uv", "run", "dagster-components"]
-        if dg_context.config.use_dg_managed_environment
-        else ["dagster-components"]
-    )
+    if dg_context.config.use_dg_managed_environment:
+        code_location_command_prefix = ["dagster-components"]
+        env = None
+    else:
+        code_location_command_prefix = ["uv", "run", "dagster-components"]
+        env = get_uv_command_env()
     full_cmd = [
         *code_location_command_prefix,
         *(
@@ -45,9 +46,7 @@ def execute_code_location_command(path: Path, cmd: Sequence[str], dg_context: "D
         *cmd,
     ]
     with pushd(path):
-        result = subprocess.run(
-            full_cmd, stdout=subprocess.PIPE, env=get_uv_command_env(), check=True
-        )
+        result = subprocess.run(full_cmd, stdout=subprocess.PIPE, env=env, check=True)
         return result.stdout.decode("utf-8")
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -83,6 +83,58 @@ def test_component_type_generate_fails_components_lib_package_does_not_exist() -
 # ##### INFO
 # ########################
 
+_EXPECTED_COMPONENT_TYPE_INFO_FULL = textwrap.dedent("""
+    dagster_components.test.simple_pipes_script_asset
+
+    Description:
+
+    A simple asset that runs a Python script with the Pipes subprocess client.
+
+    Because it is a pipes asset, no value is returned.
+
+    Generate params schema:
+
+    {
+        "properties": {
+            "asset_key": {
+                "title": "Asset Key",
+                "type": "string"
+            },
+            "filename": {
+                "title": "Filename",
+                "type": "string"
+            }
+        },
+        "required": [
+            "asset_key",
+            "filename"
+        ],
+        "title": "SimplePipesScriptAssetParams",
+        "type": "object"
+    }
+
+    Component params schema:
+
+    {
+        "properties": {
+            "asset_key": {
+                "title": "Asset Key",
+                "type": "string"
+            },
+            "filename": {
+                "title": "Filename",
+                "type": "string"
+            }
+        },
+        "required": [
+            "asset_key",
+            "filename"
+        ],
+        "title": "SimplePipesScriptAssetParams",
+        "type": "object"
+    }
+""").strip()
+
 
 def test_component_type_info_all_metadata_success():
     with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
@@ -92,60 +144,7 @@ def test_component_type_info_all_metadata_success():
             "dagster_components.test.simple_pipes_script_asset",
         )
         assert_runner_result(result)
-        assert (
-            result.output.strip()
-            == textwrap.dedent("""
-            dagster_components.test.simple_pipes_script_asset
-
-            Description:
-
-            A simple asset that runs a Python script with the Pipes subprocess client.
-
-            Because it is a pipes asset, no value is returned.
-
-            Generate params schema:
-
-            {
-                "properties": {
-                    "asset_key": {
-                        "title": "Asset Key",
-                        "type": "string"
-                    },
-                    "filename": {
-                        "title": "Filename",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "asset_key",
-                    "filename"
-                ],
-                "title": "SimplePipesScriptAssetParams",
-                "type": "object"
-            }
-
-            Component params schema:
-
-            {
-                "properties": {
-                    "asset_key": {
-                        "title": "Asset Key",
-                        "type": "string"
-                    },
-                    "filename": {
-                        "title": "Filename",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "asset_key",
-                    "filename"
-                ],
-                "title": "SimplePipesScriptAssetParams",
-                "type": "object"
-            }
-        """).strip()
-        )
+        assert result.output.strip() == _EXPECTED_COMPONENT_TYPE_INFO_FULL
 
 
 def test_component_type_info_all_metadata_empty_success():
@@ -245,16 +244,16 @@ def test_component_type_info_flag_fields_success():
         )
 
 
-def test_component_type_info_outside_code_location_fails() -> None:
+def test_component_type_info_success_outside_code_location() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
             "component-type",
             "info",
             "dagster_components.test.simple_pipes_script_asset",
-            "--component-params-schema",
+            "--disable-uv",
         )
-        assert_runner_result(result, exit_0=False)
-        assert "must be run inside a Dagster code location directory" in result.output
+        assert_runner_result(result)
+        assert result.output.strip() == _EXPECTED_COMPONENT_TYPE_INFO_FULL
 
 
 def test_component_type_info_multiple_flags_fails() -> None:
@@ -301,8 +300,7 @@ def test_list_component_types_success_with_unmanaged_environment():
         assert result.output.strip() == _EXPECTED_COMPONENT_TYPES
 
 
-def test_list_component_types_outside_code_location_fails() -> None:
+def test_component_type_list_success_outside_code_location():
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("component-type", "list")
-        assert_runner_result(result, exit_0=False)
-        assert "must be run inside a Dagster code location directory" in result.output
+        result = runner.invoke("component-type", "list", "--disable-uv")
+        assert_runner_result(result)


### PR DESCRIPTION
## Summary & Motivation

Remove the restrictions on `dg component-type list` and `dg component-type info` that they function inside a code location directory.

`dg component-type generate` still requires a code location directory, since without it we don't know where to place the generated component type.

## How I Tested These Changes

New unit tests.
