### PR TITLE
[dagster-aws] add PipesEMRContainersClient

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -167,6 +167,7 @@ multidict==6.1.0
 mypy==1.14.1
 mypy-boto3-ecs==1.35.93
 mypy-boto3-emr==1.35.93
+mypy-boto3-emr-containers==1.35.93
 mypy-boto3-emr-serverless==1.35.93
 mypy-boto3-glue==1.35.93
 mypy-boto3-logs==1.35.93

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -384,6 +384,7 @@ msgpack==1.1.0
 multidict==6.1.0
 mypy-boto3-ecs==1.35.93
 mypy-boto3-emr==1.35.93
+mypy-boto3-emr-containers==1.35.93
 mypy-boto3-emr-serverless==1.35.93
 mypy-boto3-glue==1.35.93
 mypy-boto3-logs==1.35.93

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/__init__.py
@@ -1,6 +1,7 @@
 from dagster_aws.pipes.clients import (
     PipesECSClient,
     PipesEMRClient,
+    PipesEMRContainersClient,
     PipesEMRServerlessClient,
     PipesGlueClient,
     PipesLambdaClient,
@@ -22,6 +23,7 @@ __all__ = [
     "PipesCloudWatchMessageReader",
     "PipesECSClient",
     "PipesEMRClient",
+    "PipesEMRContainersClient",
     "PipesEMRServerlessClient",
     "PipesGlueClient",
     "PipesLambdaClient",

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/__init__.py
@@ -1,5 +1,6 @@
 from dagster_aws.pipes.clients.ecs import PipesECSClient
 from dagster_aws.pipes.clients.emr import PipesEMRClient
+from dagster_aws.pipes.clients.emr_containers import PipesEMRContainersClient
 from dagster_aws.pipes.clients.emr_serverless import PipesEMRServerlessClient
 from dagster_aws.pipes.clients.glue import PipesGlueClient
 from dagster_aws.pipes.clients.lambda_ import PipesLambdaClient
@@ -7,6 +8,7 @@ from dagster_aws.pipes.clients.lambda_ import PipesLambdaClient
 __all__ = [
     "PipesECSClient",
     "PipesEMRClient",
+    "PipesEMRContainersClient",
     "PipesEMRServerlessClient",
     "PipesGlueClient",
     "PipesLambdaClient",

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr.py
@@ -132,7 +132,9 @@ class PipesEMRClient(PipesClient, TreatAsResourceParam):
         self, session: PipesSession, params: "RunJobFlowInputRequestTypeDef"
     ) -> "RunJobFlowInputRequestTypeDef":
         params["Configurations"] = emr_inject_pipes_env_vars(
-            session, cast(list["ConfigurationUnionTypeDef"], params.get("Configurations", []))
+            session,
+            cast(list["ConfigurationUnionTypeDef"], params.get("Configurations", [])),
+            emr_flavor="standard",
         )
 
         tags = list(params.get("Tags", []))

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
@@ -1,0 +1,242 @@
+import time
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+
+import boto3
+import dagster._check as check
+from dagster import PipesClient
+from dagster._annotations import experimental, public
+from dagster._core.definitions.metadata import RawMetadataMapping
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+from dagster._core.errors import DagsterExecutionInterruptedError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.pipes.client import (
+    PipesClientCompletedInvocation,
+    PipesContextInjector,
+    PipesMessageReader,
+)
+from dagster._core.pipes.context import PipesSession
+from dagster._core.pipes.utils import PipesEnvContextInjector, open_pipes_session
+
+from dagster_aws.pipes.clients.utils import WaiterConfig, emr_inject_pipes_env_vars
+from dagster_aws.pipes.message_readers import PipesCloudWatchMessageReader
+
+if TYPE_CHECKING:
+    from mypy_boto3_emr_containers.client import EMRContainersClient
+    from mypy_boto3_emr_containers.type_defs import (
+        DescribeJobRunResponseTypeDef,
+        StartJobRunRequestRequestTypeDef,
+        StartJobRunResponseTypeDef,
+    )
+
+AWS_SERVICE_NAME = "EMR Containers"
+
+
+@public
+@experimental
+class PipesEMRContainersClient(PipesClient, TreatAsResourceParam):
+    """A pipes client for running workloads on AWS EMR Containers.
+
+    Args:
+        client (Optional[boto3.client]): The boto3 AWS EMR containers client used to interact with AWS EMR Containers.
+        context_injector (Optional[PipesContextInjector]): A context injector to use to inject
+            context into AWS EMR containers workload. Defaults to :py:class:`PipesEnvContextInjector`.
+        message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
+            from the AWS EMR containers workload. It's recommended to use :py:class:`PipesS3MessageReader`.
+        forward_termination (bool): Whether to cancel the AWS EMR containers workload if the Dagster process receives a termination signal.
+        pipes_params_bootstrap_method (Literal["args", "env"]): The method to use to inject parameters into the AWS EMR containers workload. Defaults to "args".
+        waiter_config (Optional[WaiterConfig]): Optional waiter configuration to use. Defaults to 70 days (Delay: 6, MaxAttempts: 1000000).
+    """
+
+    AWS_SERVICE_NAME = AWS_SERVICE_NAME
+
+    def __init__(
+        self,
+        client: Optional["EMRContainersClient"] = None,
+        context_injector: Optional[PipesContextInjector] = None,
+        message_reader: Optional[PipesMessageReader] = None,
+        forward_termination: bool = True,
+        pipes_params_bootstrap_method: Literal["args", "env"] = "env",
+        waiter_config: Optional[WaiterConfig] = None,
+    ):
+        self._client = client or boto3.client("emr-containers")
+        self._context_injector = context_injector or PipesEnvContextInjector()
+        self._message_reader = message_reader or PipesCloudWatchMessageReader()
+        self.forward_termination = check.bool_param(forward_termination, "forward_termination")
+        self.pipes_params_bootstrap_method = pipes_params_bootstrap_method
+        self.waiter_config = waiter_config or WaiterConfig(Delay=6, MaxAttempts=1000000)
+
+    @property
+    def client(self) -> "EMRContainersClient":
+        return self._client
+
+    @property
+    def context_injector(self) -> PipesContextInjector:
+        return self._context_injector
+
+    @property
+    def message_reader(self) -> PipesMessageReader:
+        return self._message_reader
+
+    @classmethod
+    def _is_dagster_maintained(cls) -> bool:
+        return True
+
+    @public
+    def run(
+        self,
+        *,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        start_job_run_params: "StartJobRunRequestRequestTypeDef",
+        extras: Optional[dict[str, Any]] = None,
+    ) -> PipesClientCompletedInvocation:
+        """Run a workload on AWS EMR Containers, enriched with the pipes protocol.
+
+        Args:
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context of the currently executing Dagster op or asset.
+            params (dict): Parameters for the ``start_job_run`` boto3 AWS EMR Containers client call.
+                See `Boto3 EMR Containers API Documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr-containers/client/start_job_run.html>`_
+            extras (Optional[Dict[str, Any]]): Additional information to pass to the Pipes session in the external process.
+
+        Returns:
+            PipesClientCompletedInvocation: Wrapper containing results reported by the external
+            process.
+        """
+        with open_pipes_session(
+            context=context,
+            message_reader=self.message_reader,
+            context_injector=self.context_injector,
+            extras=extras,
+        ) as session:
+            start_job_run_params = self._enrich_start_params(context, session, start_job_run_params)
+            start_response = self._start(context, start_job_run_params)
+            try:
+                completion_response = self._wait_for_completion(context, start_response)
+                context.log.info(f"[pipes] {self.AWS_SERVICE_NAME} workload is complete!")
+                return PipesClientCompletedInvocation(
+                    session, metadata=self._extract_dagster_metadata(completion_response)
+                )
+
+            except DagsterExecutionInterruptedError:
+                if self.forward_termination:
+                    context.log.warning(
+                        f"[pipes] Dagster process interrupted! Will terminate external {self.AWS_SERVICE_NAME} workload."
+                    )
+                    self._terminate(context, start_response)
+                raise
+
+    def _enrich_start_params(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        session: PipesSession,
+        params: "StartJobRunRequestRequestTypeDef",
+    ) -> "StartJobRunRequestRequestTypeDef":
+        # inject Dagster tags
+        tags = params.get("tags", {})
+        params["tags"] = {**tags, **session.default_remote_invocation_info}
+
+        params["jobDriver"] = params.get("jobDriver", {})
+
+        if self.pipes_params_bootstrap_method == "env":
+            params["configurationOverrides"] = params.get("configurationOverrides", {})
+            params["configurationOverrides"]["applicationConfiguration"] = params[
+                "configurationOverrides"
+            ].get("applicationConfiguration", [])
+            # we can reuse the same method as in standard EMR
+            # since configurations format is the same
+            params["configurationOverrides"]["applicationConfiguration"] = (
+                emr_inject_pipes_env_vars(
+                    session,
+                    params["configurationOverrides"]["applicationConfiguration"],
+                    emr_flavor="containers",
+                )
+            )
+
+        # the other option is sparkSqlJobDriver - in this case there won't be a remote Pipes session
+        # and no Pipes messages will arrive from the job
+        # but we can still run it and get the logs
+        if spark_submit_job_driver := params["jobDriver"].get("sparkSubmitJobDriver"):
+            if self.pipes_params_bootstrap_method == "args":
+                spark_submit_job_driver["sparkSubmitParameters"] = spark_submit_job_driver.get(
+                    "sparkSubmitParameters", ""
+                )
+
+                for key, value in session.get_bootstrap_cli_arguments().items():
+                    spark_submit_job_driver["sparkSubmitParameters"] += f" {key} {value}"
+
+            params["jobDriver"]["sparkSubmitJobDriver"] = spark_submit_job_driver
+
+        return cast("StartJobRunRequestRequestTypeDef", params)
+
+    def _start(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        params: "StartJobRunRequestRequestTypeDef",
+    ) -> "StartJobRunResponseTypeDef":
+        response = self.client.start_job_run(**params)
+
+        virtual_cluster_id = response["virtualClusterId"]
+        job_run_id = response["id"]
+
+        context.log.info(
+            f"[pipes] {self.AWS_SERVICE_NAME} job started with job_run_id {job_run_id} on virtual cluster {virtual_cluster_id}."
+        )
+
+        return response
+
+    def _wait_for_completion(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        start_response: "StartJobRunResponseTypeDef",
+    ) -> "DescribeJobRunResponseTypeDef":
+        job_run_id = start_response["id"]
+        virtual_cluster_id = start_response["virtualClusterId"]
+
+        # TODO: use a native boto3 waiter instead of a while loop
+        # once it's available (it does not exist at the time of writing)
+        attempts = 0
+        while attempts < self.waiter_config.get("MaxAttempts", 1000000):
+            response = self.client.describe_job_run(
+                id=job_run_id, virtualClusterId=virtual_cluster_id
+            )
+            state = response["jobRun"].get("state")
+
+            if state in ["COMPLETED", "FAILED", "CANCELLED"]:
+                break
+
+            time.sleep(self.waiter_config.get("Delay", 6))
+
+        if state in ["FAILED", "CANCELLED"]:
+            raise RuntimeError(
+                f"EMR Containers job run {job_run_id} failed with state {state}. Reason: {response['jobRun'].get('failureReason')}, details: {response['jobRun'].get('stateDetails')}"
+            )
+
+        return self.client.describe_job_run(virtualClusterId=virtual_cluster_id, id=job_run_id)
+
+    def _extract_dagster_metadata(
+        self, response: "DescribeJobRunResponseTypeDef"
+    ) -> RawMetadataMapping:
+        metadata: RawMetadataMapping = {}
+
+        metadata["AWS EMR Containers Virtual Cluster ID"] = response["jobRun"].get(
+            "virtualClusterId"
+        )
+        metadata["AWS EMR Containers Job Run ID"] = response["jobRun"].get("id")
+
+        # TODO: it would be great to add a url to EMR Studio page for this run
+        # such urls look like: https://es-638xhdetxum2td9nc3a45evmn.emrstudio-prod.eu-north-1.amazonaws.com/#/containers-applications/00fm4oe0607u5a1d
+        # but we need to get the Studio ID from the application_id
+        # which is not possible with the current AWS API
+
+        return metadata
+
+    def _terminate(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        start_response: "StartJobRunResponseTypeDef",
+    ):
+        virtual_cluster_id = start_response["virtualClusterId"]
+        job_run_id = start_response["id"]
+        context.log.info(f"[pipes] Terminating {self.AWS_SERVICE_NAME} job run {job_run_id}")
+        self.client.cancel_job_run(virtualClusterId=virtual_cluster_id, id=job_run_id)
+        context.log.info(f"[pipes] {self.AWS_SERVICE_NAME} job run {job_run_id} terminated.")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_emr.py
@@ -14,19 +14,6 @@ if TYPE_CHECKING:
     from mypy_boto3_emr import EMRClient
 
 
-# @pytest.fixture
-# def emr_setup(
-#     moto_server, external_s3_glue_script, s3_client
-# ) -> tuple["EMRClient", str]:
-#     client: "EMRClient" = boto3.client("emr", region_name="us-east-1", endpoint_url=_MOTO_SERVER_URL)
-#     resp = client.create_application(
-#         type="SPARK",
-#         releaseLabel="emr-7.2.0-latest",
-#         clientToken=str(uuid4()),
-#     )
-#     return client, resp["applicationId"]
-
-
 @pytest.fixture
 def emr_client(moto_server) -> "EMRClient":
     return boto3.client("emr", region_name="us-east-1", endpoint_url=_MOTO_SERVER_URL)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_emr_containers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_emr_containers.py
@@ -1,0 +1,136 @@
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import boto3
+import pytest
+import pytest_cases
+from dagster import asset, materialize, open_pipes_session
+from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.instance_for_test import instance_for_test
+
+from dagster_aws.pipes import PipesEMRContainersClient, PipesS3MessageReader
+from dagster_aws_tests.pipes_tests.utils import _MOTO_SERVER_URL, _S3_TEST_BUCKET
+
+if TYPE_CHECKING:
+    from mypy_boto3_emr_containers import EMRContainersClient
+
+
+@pytest.fixture
+def emr_containers_client(moto_server) -> "EMRContainersClient":
+    return boto3.client("emr-containers", region_name="us-east-1", endpoint_url=_MOTO_SERVER_URL)
+
+
+@pytest_cases.fixture  # pyright: ignore
+@pytest_cases.parametrize(pipes_params_bootstrap_method=["args", "env"])
+def pipes_emr_containers_client(
+    emr_containers_client, s3_client, pipes_params_bootstrap_method
+) -> PipesEMRContainersClient:
+    return PipesEMRContainersClient(
+        client=emr_containers_client,
+        message_reader=PipesS3MessageReader(bucket=_S3_TEST_BUCKET, client=s3_client),
+        pipes_params_bootstrap_method=pipes_params_bootstrap_method,
+    )
+
+
+@asset
+def manual_asset(
+    context: AssetExecutionContext, pipes_emr_containers_client: PipesEMRContainersClient
+):
+    with open_pipes_session(
+        context=context,
+        message_reader=pipes_emr_containers_client.message_reader,
+        context_injector=pipes_emr_containers_client.context_injector,
+    ) as session:
+        params = pipes_emr_containers_client._enrich_start_params(  # noqa: SLF001
+            context=context,
+            session=session,
+            params={
+                "virtualClusterId": "test",
+                "executionRoleArn": "arn:aws:iam::123456789012:role/EMRServerlessRole",
+                "jobDriver": {
+                    "sparkSubmitJobDriver": {
+                        "entryPoint": "s3://my-bucket/my-script.py",
+                        "entryPointArguments": ["arg1", "arg2"],
+                        "sparkSubmitParameters": "--conf spark.executor.instances=2",
+                    }
+                },
+                "clientToken": str(uuid4()),
+            },
+        )
+        assert params.get("tags", {}).get("dagster/run-id") == context.run_id
+
+        pipes_emr_containers_client._start(context, params)  # noqa: SLF001
+
+        pipes_emr_containers_client._client.start_job_run.assert_called_once()  # noqa: SLF001
+        assert (
+            pipes_emr_containers_client._client.start_job_run.call_args.kwargs["virtualClusterId"]  # noqa: SLF001
+            == "test"
+        )
+
+        if pipes_emr_containers_client.pipes_params_bootstrap_method == "args":
+            assert (
+                "--dagster-pipes-context"
+                in pipes_emr_containers_client._client.start_job_run.call_args.kwargs["jobDriver"][  # noqa: SLF001
+                    "sparkSubmitJobDriver"
+                ]["sparkSubmitParameters"]
+            )
+
+            assert (
+                "--dagster-pipes-messages"
+                in pipes_emr_containers_client._client.start_job_run.call_args.kwargs["jobDriver"][  # noqa: SLF001
+                    "sparkSubmitJobDriver"
+                ]["sparkSubmitParameters"]
+            )
+
+        elif pipes_emr_containers_client.pipes_params_bootstrap_method == "env":
+            configurations = pipes_emr_containers_client._client.start_job_run.call_args.kwargs[  # noqa: SLF001
+                "configurationOverrides"
+            ]["applicationConfiguration"]
+
+            spark_defaults_injected = False
+            for configuration in configurations:
+                if configuration.get("classification") == "spark-defaults":
+                    if (
+                        "spark.yarn.appMasterEnv.DAGSTER_PIPES_CONTEXT"
+                        in configuration["properties"]
+                        and "spark.yarn.appMasterEnv.DAGSTER_PIPES_MESSAGES"
+                        in configuration["properties"]
+                    ):
+                        spark_defaults_injected = True
+
+            assert spark_defaults_injected
+
+        return session.get_results()
+
+
+def test_emr_containers_manual(pipes_emr_containers_client: "PipesEMRContainersClient"):
+    pipes_emr_containers_client._client = MagicMock()  # noqa: SLF001
+    with instance_for_test() as instance:
+        materialize(
+            [manual_asset],
+            resources={"pipes_emr_containers_client": pipes_emr_containers_client},
+            instance=instance,
+        )
+
+
+@asset
+def emr_containers_asset(
+    context: AssetExecutionContext, pipes_emr_containers_client: PipesEMRContainersClient
+):
+    return pipes_emr_containers_client.run(
+        context=context,
+        extras={"bar": "baz"},
+        start_job_run_params={
+            "virtualClusterId": "test",
+            "executionRoleArn": "arn:aws:iam::123456789012:role/EMRServerlessRole",
+            "jobDriver": {
+                "sparkSubmitJobDriver": {
+                    "entryPoint": "s3://my-bucket/my-script.py",
+                    "entryPointArguments": ["arg1", "arg2"],
+                    "sparkSubmitParameters": "--conf spark.executor.instances=2",
+                }
+            },
+            "clientToken": str(uuid4()),
+        },
+    ).get_materialize_result()

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -43,14 +43,15 @@ setup(
         "redshift": ["psycopg2-binary"],
         "pyspark": ["dagster-pyspark"],
         "stubs": [
-            "boto3-stubs-lite[s3,logs,ecs,glue,emr-serverless,emr]",
+            "boto3-stubs-lite[s3,logs,ecs,glue,emr-serverless,emr,emr-containers]",
         ],
         "test": [
             "botocore!=1.32.1",
-            "moto[s3,server,glue,emrserverless,logs]>=2.2.8,<5.0",
+            "moto[s3,server,glue,emrserverless,logs,emrcontainers]>=2.2.8,<5.0",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
             "flaky",
+            "pytest-cases",
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

This PR adds `PipesEMRContainersClient` - a Pipes client for running workloads on AWS [EMR on EKS](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks.html) with Dagster. 

`emr-containers` is the correct AWS service name for EMR on EKS.

The only supported message reader is `PipesS3MessageReader`. 
CloudWatch logs appear under "random" prefixes (the internal container id is injected) and are not reliable enough. 

## How I Tested These Changes

1. Mock which checks the correctness of the `start_job_run` call
2. Manual tests against a real AWS EMR Containers cluster. Tested a few combinations of parameters. Tested reading messages from S3.

## Changelog

[dagster-aws] Added `PipesEMRContainersClient` - a Dagster Pipes client for running and monitoring workloads on [AWS EMR on EKS](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks.html) with Dagster. 