### PR TITLE
[dagster-aws] remove stubs from runtime dependencies

### DIFF
--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -35,7 +35,6 @@ setup(
     python_requires=">=3.9,<3.13",
     install_requires=[
         "boto3",
-        "boto3-stubs-lite[ecs,glue,emr,emr-serverless]",
         f"dagster{pin}",
         "packaging",
         "requests",


### PR DESCRIPTION
## Summary & Motivation

Somehow I forgot to remove `boto3-stubs` from the main runtime dependencies when moving them to `stubs` extras. 

Fixing this issue.
