### PR TITLE
Fix WorkspaceContext over-fetching code locations on cascading updates.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -115,7 +115,7 @@ interface FetchLocationDataParams
     React.SetStateAction<Record<string, WorkspaceLocationNodeFragment | PythonErrorFragment>>
   >;
   locationStatuses: Record<string, LocationStatusEntryFragment>;
-  fetchingStatusesRef: React.MutableRefObject<Record<string, Promise<any>>>;
+  fetchingStatusesRef: React.MutableRefObject<Record<string, Promise<any> | undefined>>;
 }
 
 const UNLOADED_CACHED_DATA = {};

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -116,6 +116,7 @@ interface FetchLocationDataParams
   >;
   locationStatuses: Record<string, LocationStatusEntryFragment>;
   fetchingStatusesRef: React.MutableRefObject<Record<string, Promise<any> | undefined>>;
+  previousLocationVersionsRef: React.MutableRefObject<Record<string, string>>;
 }
 
 const UNLOADED_CACHED_DATA = {};
@@ -204,6 +205,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
         setLocationEntryData,
         locationStatuses,
         fetchingStatusesRef,
+        previousLocationVersionsRef,
       };
       return await fetchLocationData(params);
     });
@@ -297,10 +299,9 @@ async function refreshLocationsIfNeeded(params: RefreshLocationsIfNeededParams):
         getData,
         setLocationEntryData,
         locationStatuses,
+        previousLocationVersionsRef,
         fetchingStatusesRef,
       });
-      previousLocationVersionsRef.current[location.name] =
-        locationStatuses[location.name]?.versionKey ?? '';
     }),
   );
 }
@@ -357,6 +358,7 @@ async function fetchLocationData(
     setLocationEntryData,
     locationStatuses,
     fetchingStatusesRef,
+    previousLocationVersionsRef,
   } = params;
 
   const localKey = name + '@' + (locationStatuses[name]?.versionKey ?? '');
@@ -376,6 +378,9 @@ async function fetchLocationData(
 
       const entry = data?.workspaceLocationEntryOrError;
       if (entry) {
+        if (entry.__typename === 'WorkspaceLocationEntry') {
+          previousLocationVersionsRef.current[name] = entry.versionKey;
+        }
         setLocationEntryData((prevData) => ({
           ...prevData,
           [name]: entry,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__fixtures__/Workspace.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__fixtures__/Workspace.fixtures.ts
@@ -33,7 +33,9 @@ export const buildCodeLocationsStatusQuery = (
 
 export const buildWorkspaceMocks = (
   entries: WorkspaceLocationEntry[],
-  options: Partial<Omit<MockedResponse, 'result' | 'query' | 'variables' | 'data'>> = {},
+  options: Partial<Omit<MockedResponse, 'result' | 'query' | 'variables' | 'data'>> & {
+    cascadingUpdates?: boolean;
+  } = {},
 ) => {
   return [
     buildCodeLocationsStatusQuery(
@@ -41,12 +43,13 @@ export const buildWorkspaceMocks = (
         buildWorkspaceLocationStatusEntry({
           ...entry,
           updateTimestamp: entry.updatedTimestamp,
+          versionKey: '' + entry.updatedTimestamp,
           __typename: 'WorkspaceLocationStatusEntry',
         }),
       ),
       options,
     ),
-    ...entries.map((entry) =>
+    ...entries.map((entry, index) =>
       buildQueryMock<LocationWorkspaceQuery, LocationWorkspaceQueryVariables>({
         query: LOCATION_WORKSPACE_QUERY,
         variables: {
@@ -56,6 +59,11 @@ export const buildWorkspaceMocks = (
           workspaceLocationEntryOrError: entry,
         },
         ...options,
+        ...(options.cascadingUpdates
+          ? {
+              delay: 100 * (1 + index),
+            }
+          : {}),
       }),
     ),
   ];

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -510,4 +510,39 @@ describe('WorkspaceContext', () => {
     expect(result.current.allRepos).toEqual([]);
     expect(result.current.data).toEqual({});
   });
+
+  it('Doesnt overfetch the same code location version on cascading location query responses', async () => {
+    const {location1, location2, location3, caches} = getLocationMocks(-1); // Initialize with outdated cache
+
+    caches.codeLocationStatusQuery.has.mockResolvedValue(false);
+    caches.location1.has.mockResolvedValue(false);
+
+    const mocks = buildWorkspaceMocks([location1, location2, location3], {
+      cascadingUpdates: true,
+      maxUsageCount: 9999,
+    });
+    const mockCbs = mocks.map(getMockResultFn);
+
+    // Include code location status mock a second time since we call runOnlyPendingTimersAsync twice
+    const {result} = renderWithMocks([...mocks, mocks[0]!]);
+
+    // Initial state
+    expect(result.current.allRepos).toEqual([]);
+    expect(result.current.data).toEqual({});
+    expect(result.current.loading).toEqual(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toEqual(false);
+    });
+
+    // Ensure no additional fetches were made
+    expect(mockCbs[1]).toHaveBeenCalledTimes(1);
+    expect(mockCbs[2]).toHaveBeenCalledTimes(1);
+    expect(mockCbs[3]).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      // Exhaust any remaining tasks so they don't affect the next test.
+      await jest.runAllTicks();
+    });
+  });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -511,8 +511,8 @@ describe('WorkspaceContext', () => {
     expect(result.current.data).toEqual({});
   });
 
-  it('Doesnt overfetch the same code location version on cascading location query responses', async () => {
-    const {location1, location2, location3, caches} = getLocationMocks(-1); // Initialize with outdated cache
+  it("Doesn't overfetch the same code location version on cascading location query responses", async () => {
+    const {location1, location2, location3, caches} = getLocationMocks(-1);
 
     caches.codeLocationStatusQuery.has.mockResolvedValue(false);
     caches.location1.has.mockResolvedValue(false);
@@ -523,10 +523,8 @@ describe('WorkspaceContext', () => {
     });
     const mockCbs = mocks.map(getMockResultFn);
 
-    // Include code location status mock a second time since we call runOnlyPendingTimersAsync twice
     const {result} = renderWithMocks([...mocks, mocks[0]!]);
 
-    // Initial state
     expect(result.current.allRepos).toEqual([]);
     expect(result.current.data).toEqual({});
     expect(result.current.loading).toEqual(true);


### PR DESCRIPTION
## Summary & Motivation

The main issue is that `previousLocationVersionsRef.current` was only being updated after ALL code locations were fetched. That means that whenever a code location was fetched, we'd think that all of the code locations were stale again, including the one we just fetched, because `previousLocationVersionsRef.current` was still pointing to the old version. To fix this I instead update `previousLocationVersionsRef.current` after each individual fetch. In addition, I added some extra guards within `fetchLocationData` itself to prevent overfetching due to someone calling `refetch` multiple times.

## How I Tested These Changes

Added a jest test that failed without these changes.