### PR TITLE
Add test case for step stats with a retry event before a step start event

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -805,6 +805,16 @@ class TestEventLogStorage:
         assert stats.start_time
         assert math.isclose(stats.start_time, start_time)
 
+    def test_event_log_step_stats_retry_with_no_start(
+        self, test_run_id: str, storage: EventLogStorage
+    ):
+        storage.store_event(
+            _event_record(test_run_id, "E", time.time() - 150, DagsterEventType.STEP_UP_FOR_RETRY),
+        )
+        step_stats = storage.get_step_stats_for_run(test_run_id)
+        assert len(step_stats) == 1
+        assert not step_stats[0].status
+
     def test_event_log_step_stats(
         self,
         test_run_id: str,


### PR DESCRIPTION
Summary:
This can happen if a step worker dies before the step starts. Not sure if what we are testing here is the desired behavior, but gives us a test case to change if we chagne the underlying behavior.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
