### PR TITLE
[components][docs] Schema viewer

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/__init__.py
@@ -1,6 +1,9 @@
 from dagster_components.lib.test.all_metadata_empty_asset import (
     AllMetadataEmptyAsset as AllMetadataEmptyAsset,
 )
+from dagster_components.lib.test.complex_schema_asset import (
+    ComplexSchemaAsset as ComplexSchemaAsset,
+)
 from dagster_components.lib.test.simple_asset import SimpleAsset as SimpleAsset
 from dagster_components.lib.test.simple_pipes_script_asset import (
     SimplePipesScriptAsset as SimplePipesScriptAsset,

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -1,11 +1,10 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Annotated, Optional
+from typing import Annotated, Optional
 
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from pydantic import BaseModel, TypeAdapter
-from typing_extensions import Self
+from pydantic import BaseModel
 
 from dagster_components import (
     AssetSpecTransformModel,
@@ -14,15 +13,11 @@ from dagster_components import (
     ResolvableFieldInfo,
     component_type,
 )
-from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.core.component_generator import (
     ComponentGenerator,
     DefaultComponentGenerator,
 )
 from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecBaseModel
-
-if TYPE_CHECKING:
-    from dagster_components.core.component import ComponentDeclNode
 
 
 class ComplexAssetParams(BaseModel):
@@ -39,27 +34,12 @@ class ComplexSchemaAsset(Component):
     """An asset that has a complex params schema."""
 
     @classmethod
-    def get_params_schema_type(cls):
+    def get_component_schema_type(cls):
         return ComplexAssetParams
 
     @classmethod
     def get_generator(cls) -> ComponentGenerator:
         return DefaultComponentGenerator()
-
-    @classmethod
-    def from_decl_node(
-        cls, context: "ComponentLoadContext", decl_node: "ComponentDeclNode"
-    ) -> Self:
-        assert isinstance(decl_node, YamlComponentDecl)
-        loaded_params = TypeAdapter(cls.get_params_schema_type()).validate_python(
-            decl_node.component_file_model.params
-        )
-        return cls(
-            value=loaded_params.value,
-            op_spec=loaded_params.op,
-            asset_attributes=loaded_params.asset_attributes,
-            asset_transforms=loaded_params.asset_transforms or [],
-        )
 
     def __init__(
         self,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -41,6 +41,7 @@ def test_list_component_types_command():
 
     assert list(result.keys()) == [
         "dagster_components.test.all_metadata_empty_asset",
+        "dagster_components.test.complex_schema_asset",
         "dagster_components.test.simple_asset",
         "dagster_components.test.simple_pipes_script_asset",
     ]

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -10,6 +10,7 @@ from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
+from dagster_dg.docs import markdown_for_component_type, render_markdown_in_browser
 from dagster_dg.generate import generate_component_type
 from dagster_dg.utils import DgClickCommand, DgClickGroup
 
@@ -52,6 +53,33 @@ def component_type_generate_command(
         sys.exit(1)
 
     generate_component_type(dg_context, name)
+
+
+# ########################
+# ##### DOCS
+# ########################
+
+
+@component_type_group.command(name="docs", cls=DgClickCommand)
+@click.argument("component_type", type=str)
+@dg_global_options
+@click.pass_context
+def component_type_docs_command(
+    context: click.Context,
+    component_type: str,
+    **global_options: object,
+) -> None:
+    """Get detailed information on a registered Dagster component type."""
+    cli_config = normalize_cli_config(global_options, context)
+    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+    registry = RemoteComponentRegistry.from_dg_context(dg_context)
+    if not registry.has(component_type):
+        click.echo(
+            click.style(f"No component type `{component_type}` could be resolved.", fg="red")
+        )
+        sys.exit(1)
+
+    render_markdown_in_browser(markdown_for_component_type(registry.get(component_type)))
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -1,0 +1,171 @@
+import tempfile
+import webbrowser
+from collections.abc import Mapping, Sequence, Set
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+import markdown
+import yaml
+
+from dagster_dg.component import RemoteComponentType
+
+REF_BASE = "#/$defs/"
+COMMENTED_MAPPING_TAG = "!commented_mapping"
+
+
+@dataclass(frozen=True)
+class CommentedObject:
+    key: str
+    value: Union[Sequence["CommentedObject"], Any]
+    comment: Optional[str]
+    top_level: bool = False
+
+
+def _dereference_schema(
+    json_schema: Mapping[str, Any], subschema: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    if "$ref" in subschema:
+        return json_schema["$defs"].get(subschema["$ref"][len(REF_BASE) :])
+    else:
+        return subschema
+
+
+def _commented_object_for_subschema(
+    name: str,
+    json_schema: Mapping[str, Any],
+    subschema: Mapping[str, Any],
+    available_scope: Optional[Set[str]] = None,
+) -> Union[CommentedObject, Any]:
+    additional_scope = subschema.get("dagster_available_scope")
+    available_scope = (available_scope or set()) | set(additional_scope or [])
+
+    subschema = _dereference_schema(json_schema, subschema)
+    if "anyOf" in subschema:
+        # TODO: handle anyOf fields more gracefully, for now just choose first option
+        return _commented_object_for_subschema(
+            name, json_schema, subschema["anyOf"][0], available_scope=available_scope
+        )
+
+    objtype = subschema["type"]
+    if objtype == "object":
+        return CommentedObject(
+            key=name,
+            value={
+                k: _commented_object_for_subschema(k, json_schema, v)
+                for k, v in subschema.get("properties", {}).items()
+            },
+            comment=f"Available scope: {available_scope}" if available_scope else None,
+        )
+    elif objtype == "array":
+        return [
+            _commented_object_for_subschema(
+                name, json_schema, subschema["items"], available_scope=available_scope
+            )
+        ]
+    elif objtype == "string":
+        return "..."
+    elif objtype == "integer":
+        return 0
+    elif objtype == "boolean":
+        return False
+    else:
+        return f"({objtype})"
+
+
+class ComponentDumper(yaml.SafeDumper):
+    def increase_indent(self, flow=False, *args, **kwargs):
+        # makes the output somewhat prettier by forcing lists to be indented
+        return super().increase_indent(flow=flow, indentless=False)
+
+    def write_line_break(self) -> None:
+        # add an extra line break between top-level keys
+        if self.indent == 0:
+            super().write_line_break()
+        super().write_line_break()
+
+    def _get_tag(self) -> str:
+        return getattr(self.event, "tag", "")
+
+    def expect_node(self, root=False, sequence=False, mapping=False, simple_key=False):
+        # for commented mappings, emit comment above the value
+        tag = self._get_tag()
+        if tag.startswith(COMMENTED_MAPPING_TAG):
+            self.write_indicator(f"# {tag[len(COMMENTED_MAPPING_TAG) + 1:]}", True)
+            self.write_line_break()
+
+        return super().expect_node(root, sequence, mapping, simple_key)
+
+    def process_tag(self):
+        tag = self._get_tag()
+        # ignore the mapping tag as it's handled specially
+        if tag.startswith(COMMENTED_MAPPING_TAG):
+            return
+        else:
+            super().process_tag()
+
+
+def commented_object_representer(dumper: yaml.SafeDumper, obj: CommentedObject) -> yaml.nodes.Node:
+    mapping = obj.value if isinstance(obj.value, dict) else {obj.key: obj.value}
+
+    if obj.comment is not None:
+        return dumper.represent_mapping(f"{COMMENTED_MAPPING_TAG}|{obj.comment}", mapping)
+    else:
+        return dumper.represent_dict(mapping)
+
+
+ComponentDumper.add_representer(CommentedObject, commented_object_representer)
+
+
+def generate_sample_yaml(component_type: str, json_schema: Mapping[str, Any]) -> str:
+    params_obj = _commented_object_for_subschema("params", json_schema, json_schema)
+    return yaml.dump(
+        {"type": component_type, "params": params_obj}, Dumper=ComponentDumper, sort_keys=False
+    )
+
+
+def render_markdown_in_browser(markdown_content: str) -> None:
+    # Convert the markdown string to HTML
+    html_content = markdown.markdown(markdown_content)
+
+    # Add basic HTML structure
+    full_html = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Markdown Preview</title>
+    </head>
+    <body>
+        {html_content}
+    </body>
+    </html>
+    """
+
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as temp_file:
+        temp_file.write(full_html.encode("utf-8"))
+        temp_file_path = temp_file.name
+
+    # Open the temporary file in the default web browser
+    webbrowser.open(f"file://{temp_file_path}")
+
+
+def markdown_for_component_type(remote_component_type: RemoteComponentType) -> str:
+    component_type_name = f"{remote_component_type.package}.{remote_component_type.name}"
+    sample_yaml = generate_sample_yaml(
+        component_type_name, remote_component_type.component_params_schema or {}
+    )
+    rows = len(sample_yaml.split("\n")) + 1
+    return f"""
+## Component: `{component_type_name}`
+ 
+### Description: 
+{remote_component_type.description}
+
+### Sample Component Params:
+
+<textarea rows={rows} cols=100>
+{sample_yaml}
+</textarea>
+"""

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
@@ -29,6 +29,7 @@ def test_component_generate_dynamic_subcommand_generation() -> None:
             textwrap.dedent("""
             Commands:
               dagster_components.test.all_metadata_empty_asset
+              dagster_components.test.complex_schema_asset
               dagster_components.test.simple_asset
               dagster_components.test.simple_pipes_script_asset
         """).strip()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -83,6 +83,21 @@ def test_component_type_generate_fails_components_lib_package_does_not_exist() -
 
 
 # ########################
+# ##### DOCS
+# ########################
+
+
+def test_component_type_docs_success():
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke(
+            "component-type",
+            "docs",
+            "dagster_components.test.complex_schema_asset",
+        )
+        assert_runner_result(result)
+
+
+# ########################
 # ##### INFO
 # ########################
 
@@ -281,6 +296,8 @@ def test_component_type_info_multiple_flags_fails() -> None:
 
 _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
     dagster_components.test.all_metadata_empty_asset
+    dagster_components.test.complex_schema_asset
+        An asset that has a complex params schema.
     dagster_components.test.simple_asset
         A simple asset that returns a constant string value.
     dagster_components.test.simple_pipes_script_asset

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -1,0 +1,38 @@
+from collections.abc import Sequence
+from typing import Annotated
+
+from dagster_components import ComponentSchemaBaseModel, ResolvableFieldInfo
+from dagster_dg.docs import generate_sample_yaml
+
+
+class SampleSubSchema(ComponentSchemaBaseModel):
+    str_field: str
+    int_field: int
+
+
+class SampleSchema(ComponentSchemaBaseModel):
+    sub_scoped: Annotated[SampleSubSchema, ResolvableFieldInfo(additional_scope={"outer_scope"})]
+    sub_optional: SampleSubSchema
+    sub_list: Sequence[SampleSubSchema]
+
+
+def test_generate_sample_yaml():
+    yaml = generate_sample_yaml(
+        component_type=".sample", json_schema=SampleSchema.model_json_schema()
+    )
+    assert (
+        yaml
+        == """type: .sample
+
+params:
+  sub_scoped: # Available scope: {'outer_scope'}
+    str_field: '...'
+    int_field: 0
+  sub_optional:
+    str_field: '...'
+    int_field: 0
+  sub_list:
+    - str_field: '...'
+      int_field: 0
+"""
+    )

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -36,6 +36,7 @@ setup(
         "tomli",
         "click>=8",
         "typing_extensions>=4.4.0,<5",
+        "markdown",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

Extremely bare-bones sample yaml schema generator.

Currently this spits out a "maximal" version of the schema, including all optional parameters, which is better suited for docs usecases.

If we adapt this to be used in the component generation sequence, we'll probably want to use a minimal example.

The one thing here that adds an unfortunate amount of complexity is the injection of comments into the generated yaml (particularly to denote the available scope). Yaml libraries don't handle comments very nicely and so we need to do some fancy stuff to get this to work.


![Screenshot 2025-01-09 at 2.45.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/801959df-41bf-4b4b-b81f-22b15f212dd8.png)

## How I Tested These Changes

## Changelog

NOCHANGELOG
