### PR TITLE
[dagster-azure]: AzureBlobComputeLogManager provides alternative way to retrieve logs

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1492,6 +1492,9 @@ class DagsterEvent(
             event_specific_data=ComputeLogsCaptureData(
                 step_keys=step_keys,
                 file_key=file_key,
+                log_manager_metadata=log_context.log_manager_metadata,
+                stdout_uri_or_path=log_context.stdout_uri_or_path,
+                stderr_uri_or_path=log_context.stderr_uri_or_path,
                 external_stdout_url=log_context.external_stdout_url,
                 external_stderr_url=log_context.external_stderr_url,
                 external_url=log_context.external_url,
@@ -1874,6 +1877,9 @@ class ComputeLogsCaptureData(
             ("external_url", Optional[str]),
             ("external_stdout_url", Optional[str]),
             ("external_stderr_url", Optional[str]),
+            ("log_manager_metadata", Optional[str]),
+            ("stdout_uri_or_path", Optional[str]),
+            ("stderr_uri_or_path", Optional[str]),
         ],
     )
 ):
@@ -1884,6 +1890,9 @@ class ComputeLogsCaptureData(
         external_url: Optional[str] = None,
         external_stdout_url: Optional[str] = None,
         external_stderr_url: Optional[str] = None,
+        log_manager_metadata: Optional[str] = None,
+        stdout_uri_or_path: Optional[str] = None,
+        stderr_uri_or_path: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -1892,6 +1901,9 @@ class ComputeLogsCaptureData(
             external_url=check.opt_str_param(external_url, "external_url"),
             external_stdout_url=check.opt_str_param(external_stdout_url, "external_stdout_url"),
             external_stderr_url=check.opt_str_param(external_stderr_url, "external_stderr_url"),
+            log_manager_metadata=check.opt_str_param(log_manager_metadata, "log_manager_metadata"),
+            stdout_uri_or_path=check.opt_str_param(stdout_uri_or_path, "stdout_uri_or_path"),
+            stderr_uri_or_path=check.opt_str_param(stderr_uri_or_path, "stderr_uri_or_path"),
         )
 
 

--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -51,6 +51,21 @@ class CloudStorageComputeLogManager(ComputeLogManager[T_DagsterInstance]):
     def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType) -> str:
         """Calculates a download url given a log key and compute io type."""
 
+    def uri_or_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType) -> Optional[str]:
+        """Calculates a download uri given a log key and compute io type."""
+        return None
+
+    def get_log_manager_metadata(self) -> dict[str, str]:
+        """Returns metadata about the log manager."""
+        return {"type": self.__class__.__name__}
+
+    def get_serialized_log_manager_metadata(self) -> Optional[str]:
+        """Returns serialized metadata about the log manager."""
+        metadata = self.get_log_manager_metadata()
+        if not metadata:
+            return None
+        return json.dumps(metadata)
+
     @abstractmethod
     def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType) -> str:
         """Returns a display path given a log key and compute io type."""
@@ -136,6 +151,9 @@ class CloudStorageComputeLogManager(ComputeLogManager[T_DagsterInstance]):
             stderr_location=self.display_path_for_type(log_key, ComputeIOType.STDERR),
             stdout_download_url=self.download_url_for_type(log_key, ComputeIOType.STDOUT),
             stderr_download_url=self.download_url_for_type(log_key, ComputeIOType.STDERR),
+            log_manager_metadata=self.get_serialized_log_manager_metadata(),
+            stdout_uri_or_path=self.uri_or_path_for_type(log_key, ComputeIOType.STDOUT),
+            stderr_uri_or_path=self.uri_or_path_for_type(log_key, ComputeIOType.STDERR),
         )
 
     def on_progress(self, log_key):

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -27,6 +27,9 @@ class CapturedLogContext(
             ("external_url", Optional[str]),
             ("external_stdout_url", Optional[str]),
             ("external_stderr_url", Optional[str]),
+            ("log_manager_metadata", Optional[str]),
+            ("stdout_uri_or_path", Optional[str]),
+            ("stderr_uri_or_path", Optional[str]),
         ],
     )
 ):
@@ -41,6 +44,9 @@ class CapturedLogContext(
         external_stdout_url: Optional[str] = None,
         external_stderr_url: Optional[str] = None,
         external_url: Optional[str] = None,
+        log_manager_metadata: Optional[str] = None,
+        stdout_uri_or_path: Optional[str] = None,
+        stderr_uri_or_path: Optional[str] = None,
     ):
         if external_url and (external_stdout_url or external_stderr_url):
             check.failed(
@@ -54,6 +60,9 @@ class CapturedLogContext(
             external_stdout_url=external_stdout_url,
             external_stderr_url=external_stderr_url,
             external_url=external_url,
+            log_manager_metadata=log_manager_metadata,
+            stdout_uri_or_path=stdout_uri_or_path,
+            stderr_uri_or_path=stderr_uri_or_path,
         )
 
 
@@ -90,11 +99,16 @@ class CapturedLogMetadata(
             ("stderr_location", Optional[str]),
             ("stdout_download_url", Optional[str]),
             ("stderr_download_url", Optional[str]),
+            ("log_manager_metadata", Optional[str]),
+            ("stdout_uri_or_path", Optional[str]),
+            ("stderr_uri_or_path", Optional[str]),
         ],
     )
 ):
-    """Object representing metadata info for the captured log data, containing a display string for
-    the location of the log data and a URL for direct download of the captured log data.
+    """Object representing metadata info for the captured log data.
+    It contains:
+     - a display string for the location of the log data,
+     - a URL for direct download of the captured log data.
     """
 
     def __new__(
@@ -103,6 +117,9 @@ class CapturedLogMetadata(
         stderr_location: Optional[str] = None,
         stdout_download_url: Optional[str] = None,
         stderr_download_url: Optional[str] = None,
+        log_manager_metadata: Optional[str] = None,
+        stdout_uri_or_path: Optional[str] = None,
+        stderr_uri_or_path: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -110,6 +127,9 @@ class CapturedLogMetadata(
             stderr_location=stderr_location,
             stdout_download_url=stdout_download_url,
             stderr_download_url=stderr_download_url,
+            log_manager_metadata=log_manager_metadata,
+            stdout_uri_or_path=stdout_uri_or_path,
+            stderr_uri_or_path=stderr_uri_or_path,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

External cloud storage based compute log managers are often configured to only collect and show the url. However, in the case of the AzureBlobComputeLogManager, the provided URL will not be clickable if the storage account or container are private, which is a reasonable choice for commercial users using this feature for security and compliance on Dagster+.

This supports these users by providing both a more easily readable path and a clickable shell command to retrieve the log locally.

How this is implemented is by adding new fields to CapturedLogData to pass the path as well as extra azure specific information so that the frontend can render the shell cmd.

## Notes to reviewers

- this a graphite top stack PR, feature built incrementally on up stack changesets.
- first iteration passing the log manager metadata as a json encoded string, #27000 converts to NamedTuple + Graphite ObjectType - isolated that change as unsure whether it is worthwhile.

## How I Tested These Changes

- `dagster dev` local (with the AzureBlobComputeLogManager as well as the default log manager to ensure other code paths aren't broken).
- added testing of new fields in integration tests

## Changelog

- [dagster-azure] AzureBlobComputeLogManager provides alternatives to retrieve logs in private containers.