### PR TITLE
[dagster-azure]: Add extra log manager information to GraphQL LogsCapturedEvent

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -427,6 +427,9 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             externalUrl=data.external_url,
             externalStdoutUrl=data.external_stdout_url or data.external_url,
             externalStderrUrl=data.external_stderr_url or data.external_url,
+            logManagerMetadata=data.log_manager_metadata,
+            stdoutUriOrPath=data.stdout_uri_or_path,
+            stderrUriOrPath=data.stderr_uri_or_path,
             pid=dagster_event.pid,
             **basic_params,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -309,6 +309,9 @@ class GrapheneLogsCapturedEvent(graphene.ObjectType):
     externalUrl = graphene.String()
     externalStdoutUrl = graphene.String()
     externalStderrUrl = graphene.String()
+    logManagerMetadata = graphene.String()  # TODO - replace with union?
+    stderrUriOrPath = graphene.String()
+    stdoutUriOrPath = graphene.String()
     pid = graphene.Int()
     # legacy name for compute log file key... required for back-compat reasons, but has been
     # renamed to fileKey for newer versions of the Dagster UI


### PR DESCRIPTION
## Summary & Motivation

See #26982 - this PR adds the fields to GraphQL 

## Notes for reviewer

- upstack #27000 converts json to namedtuple
