### PR TITLE
[docs-beta] make sync-api-docs directive platform agnostic

### DIFF
--- a/docs/docs-beta/scripts/vercel-sync-api-docs.sh
+++ b/docs/docs-beta/scripts/vercel-sync-api-docs.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 #
-# **NOTE: this script is intended to by used from Vercel only!**
-#
-# Description: Builds and synchronizes MDX API docs from Sphinx
-# Usage: yarn sync-api-docs
+# Description: Builds and synchronizes MDX API docs from Sphinx Usage: yarn sync-api-docs
 #
 
 set -e
 
 cd ..
 
-export LC_ALL=C.UTF-8
+# only set local when running in Vercel, not local execution
+if ! [[ "$OSTYPE" =~ "darwin"* ]]; then
+    export LC_ALL=C.UTF-8
+fi
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source "$HOME/.local/bin/env"
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    source "$HOME/.local/bin/env"
+fi
 
 uv python install 3.11
 uv venv


### PR DESCRIPTION
## Summary & Motivation

- The `sync-api-docs` previously only worked on Linux (Vercel) due to locale settings
- This makes the script platform agnostic for easier local building of API docs

## How I Tested These Changes

`yarn sync-api-docs`

## Changelog

NOCHANGELOG
