### PR TITLE
Support table metadata in pipes

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -165,6 +165,7 @@ PipesMetadataType = Literal[
     "dagster_run",
     "asset",
     "null",
+    "table",
 ]
 
 

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -166,6 +166,8 @@ PipesMetadataType = Literal[
     "asset",
     "null",
     "table",
+    "table_schema",
+    "table_column_lineage",
 ]
 
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental, public
-from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
 # ########################
@@ -274,7 +274,7 @@ class TableColumnDep(
     NamedTuple(
         "_TableColumnDep",
         [
-            ("asset_key", PublicAttr[AssetKey]),
+            ("asset_key", PublicAttr[CoercibleToAssetKey]),
             ("column_name", PublicAttr[str]),
         ],
     )
@@ -283,12 +283,12 @@ class TableColumnDep(
 
     def __new__(
         cls,
-        asset_key: AssetKey,
+        asset_key: CoercibleToAssetKey,
         column_name: str,
     ):
         return super().__new__(
             cls,
-            asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
+            asset_key=AssetKey.from_coercible(asset_key),
             column_name=check.str_param(column_name, "column_name"),
         )
 


### PR DESCRIPTION
## Summary & Motivation
Right now most of the table metadata types are not supported in pipes. The support for "TableMetadataValue" actually doesn't work right now.

This PR adds support for table-related metadata values: table, table schema, and table column lineage.

## Considerations

One important consideration is what the format should be for nested metadata values; something like TableColumn, for example. Should you have to specify the "type": and "raw_value": keys? My hunch is no, that should only be required at the top level.


Ultimately, in a downstream, I'd like to move all this implementation onto the metadata values themselves so that this can be used more broadly than just pipes.


## How I Tested These Changes
Added to existing tests.

