### PR TITLE
[module-loaders] Add load_definitions_from_package_name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_defs_from_module.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_defs_from_module.py
@@ -1,5 +1,6 @@
 import inspect
 from collections.abc import Iterable, Mapping
+from importlib import import_module
 from types import ModuleType
 from typing import Any, Optional, Union
 
@@ -116,6 +117,40 @@ def load_definitions_from_package_module(
     """
     return load_definitions_from_modules(
         modules=[*find_modules_in_package(package_module)],
+        resources=resources,
+        loggers=loggers,
+        executor=executor,
+    )
+
+
+@experimental
+def load_definitions_from_package_name(
+    package_name: str,
+    resources: Optional[Mapping[str, Any]] = None,
+    loggers: Optional[Mapping[str, LoggerDefinition]] = None,
+    executor: Optional[Union[Executor, ExecutorDefinition]] = None,
+) -> Definitions:
+    """Constructs the :py:class:`dagster.Definitions` from the package module for the given package name.
+
+    Args:
+        package_name (str):
+            The name of the package module to look for :py:class:`dagster.Definitions` inside.
+        resources (Optional[Mapping[str, Any]]):
+            Dictionary of resources to bind to assets in the loaded :py:class:`dagster.Definitions`.
+        loggers (Optional[Mapping[str, LoggerDefinition]]):
+            Default loggers for jobs in the loaded :py:class:`dagster.Definitions`. Individual jobs
+            can define their own loggers by setting them explicitly.
+        executor (Optional[Union[Executor, ExecutorDefinition]]):
+            Default executor for jobs in the loaded :py:class:`dagster.Definitions`. Individual jobs
+            can define their own executors by setting them explicitly.
+
+    Returns:
+        Definitions:
+            The :py:class:`dagster.Definitions` defined in the package module for the given package name.
+    """
+    package_module = import_module(package_name)
+    return load_definitions_from_package_module(
+        package_module=package_module,
         resources=resources,
         loggers=loggers,
         executor=executor,

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_module_loaders.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_module_loaders.py
@@ -13,6 +13,7 @@ from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
     load_definitions_from_modules,
     load_definitions_from_package_module,
+    load_definitions_from_package_name,
 )
 from dagster._core.definitions.module_loaders.object_list import (
     LoadableDagsterDef,
@@ -267,6 +268,30 @@ def test_load_from_definitions_from_package_module(
         error_expected=error_expected, exception_cls=dg.DagsterInvalidDefinitionError
     ):
         defs = load_definitions_from_package_module(package_fake)
+        obj_ids = {id(obj) for obj in all_loadable_objects_from_defs(defs)}
+        expected_obj_ids = {id(obj) for obj in objects.values()}
+        assert len(obj_ids) == len(expected_obj_ids)
+
+
+@pytest.mark.parametrize(**ModuleScopeTestSpec.as_parametrize_kwargs(MODULE_TEST_SPECS))
+@patch("dagster._core.definitions.module_loaders.load_defs_from_module.find_modules_in_package")
+@patch("dagster._core.definitions.module_loaders.load_defs_from_module.import_module")
+def test_load_from_definitions_from_package_name(
+    mock_module_importer: MagicMock,
+    mock_module_finder: MagicMock,
+    objects: Mapping[str, Any],
+    error_expected: bool,
+) -> None:
+    package_name_fake = "fake_package"
+    package_fake = build_module_fake(package_name_fake, {})
+    module_fake = build_module_fake("fake", objects)
+
+    mock_module_importer.return_value = package_fake
+    mock_module_finder.return_value = [module_fake]
+    with optional_pytest_raise(
+        error_expected=error_expected, exception_cls=dg.DagsterInvalidDefinitionError
+    ):
+        defs = load_definitions_from_package_name(package_name_fake)
         obj_ids = {id(obj) for obj in all_loadable_objects_from_defs(defs)}
         expected_obj_ids = {id(obj) for obj in objects.values()}
         assert len(obj_ids) == len(expected_obj_ids)


### PR DESCRIPTION
## Summary & Motivation

Same as https://github.com/dagster-io/dagster/pull/26546 but for a package module given its name. 

## How I Tested These Changes

Additional test with BK