### PR TITLE
[dagster-pipes] support timestamp metadata

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -168,6 +168,7 @@ PipesMetadataType = Literal[
     "table",
     "table_schema",
     "table_column_lineage",
+    "timestamp",
 ]
 
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -202,7 +202,8 @@ class PipesMessageHandler:
                     }
                 )
             )
-
+        elif metadata_type == "timestamp":
+            return MetadataValue.timestamp(float(check.numeric_param(value, "timestamp")))
         elif metadata_type == "null":
             return MetadataValue.null()
         else:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -36,6 +36,7 @@ from dagster._core.definitions.metadata.metadata_value import (
     TableColumnLineageMetadataValue,
     TableMetadataValue,
     TableSchemaMetadataValue,
+    TimestampMetadataValue,
 )
 from dagster._core.definitions.metadata.table import (
     TableColumn,
@@ -304,6 +305,7 @@ def test_pipes_typed_metadata():
                         },
                         "type": "table_column_lineage",
                     },
+                    "timestamp_meta": {"raw_value": 111, "type": "timestamp"},
                 }
             )
 
@@ -380,6 +382,8 @@ def test_pipes_typed_metadata():
         assert metadata["table_column_lineage_meta"].value == TableColumnLineage(
             deps_by_column={"a": [TableColumnDep(asset_key="b", column_name="c")]}
         )
+        assert isinstance(metadata["timestamp_meta"], TimestampMetadataValue)
+        assert metadata["timestamp_meta"].value == 111
 
 
 def test_pipes_asset_failed():


### PR DESCRIPTION
## Summary & Motivation
Adds support for timestamp metadata, which also was unfortunately left behind by pipes.

## How I Tested These Changes
Additional assertions

## Changelog
- Timestamp metadata is now supported by `dagster-pipes`. It can be set like so:
```python
{"my_key": {"raw_value": 111, "type": "timestamp"}}
```
