### PR TITLE
[dagster-pipes] rich metadata docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ scripts/.build
 
 # dbt .user files
 .user.yml
+
+# exponent config
+exponent.txt

--- a/docs/content/concepts/dagster-pipes/aws-ecs.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-ecs.mdx
@@ -72,6 +72,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesECSClient to launch the task

--- a/docs/content/concepts/dagster-pipes/aws-emr-serverless.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-emr-serverless.mdx
@@ -98,6 +98,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesEMRServerlessClient to launch the job

--- a/docs/content/concepts/dagster-pipes/aws-emr.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-emr.mdx
@@ -130,6 +130,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesEMRClient to launch the job

--- a/docs/content/concepts/dagster-pipes/aws-glue.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-glue.mdx
@@ -71,6 +71,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Add the PipesGlueClient to Dagster code

--- a/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
+++ b/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
@@ -288,6 +288,8 @@ with open_dagster_pipes(
     )
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 Above we see that <PyObject object="open_dagster_pipes" module="dagster_pipes"/> takes three parameters:
 
 - `params_loader`: A params loader responsible for loading the bootstrap payload injected into the external process at launch. The standard approach is to inject the bootstrap payload into predetermined environment variables that the <PyObject object="PipesEnvVarParamsLoader" module="dagster_pipes" /> knows how to read. However, a different bootstrap parameter loader can be substituted in environments where it is not possible to modify environment variables.

--- a/docs/content/concepts/dagster-pipes/subprocess/reference.mdx
+++ b/docs/content/concepts/dagster-pipes/subprocess/reference.mdx
@@ -355,3 +355,218 @@ defs = Definitions(
 
 </TabItem>
 </TabGroup>
+
+## Passing rich metadata to Dagster
+
+Dagster supports rich metadata types such as <PyObject object="TableMetadataValue"/>, <PyObject object="UrlMetadataValue"/>, and <PyObject object="JsonMetadataValue"/>. However, because the `dagster-pipes` package doesn't have a direct dependency on `dagster`, you'll need to pass a raw dictionary back to Dagster with a specific format. For a given metadata type, you will need to specify a dictionary with the following keys:
+
+- `type`: The type of metadata value, such as `table`, `url`, or `json`.
+- `raw_value`: The actual value of the metadata.
+
+Below are examples of specifying data for all supported metadata types. Float, integer, boolean, string, and null metadata objects can be passed directly without the need for a dictionary.
+
+### Examples for complex metadata types
+
+#### URL Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/url_metadata.py
+def get_url(args): ...
+
+
+context = ...
+
+# start_url
+# Within the Dagster pipes subprocess:
+url = "http://example.com"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"url_meta": {"type": "url", "raw_value": url}},
+)
+# end_url
+```
+
+#### Path Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/path_metadata.py
+def get_path(args): ...
+
+
+context = ...
+
+# start_path
+# Within the Dagster pipes subprocess:
+path = "/path/to/file.txt"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"path_meta": {"type": "path", "raw_value": path}},
+)
+# end_path
+```
+
+#### Notebook Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/notebook_metadata.py
+def get_notebook_path(args): ...
+
+
+context = ...
+
+# start_notebook
+# Within the Dagster pipes subprocess:
+notebook_path = "/path/to/notebook.ipynb"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"notebook_meta": {"type": "notebook", "raw_value": notebook_path}},
+)
+# end_notebook
+```
+
+#### JSON Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/json_metadata.py
+def get_json_data(args): ...
+
+
+context = ...
+
+# start_json
+# Within the Dagster pipes subprocess:
+json_data = ["item1", "item2", "item3"]
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"json_meta": {"type": "json", "raw_value": json_data}},
+)
+# end_json
+```
+
+#### Markdown Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/markdown_metadata.py
+def get_markdown_content(args): ...
+
+
+context = ...
+
+# start_markdown
+# Within the Dagster pipes subprocess:
+markdown_content = "# Header\nSome **bold** text"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"md_meta": {"type": "md", "raw_value": markdown_content}},
+)
+# end_markdown
+```
+
+#### Table Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_metadata.py
+context = ...
+
+# start_table
+# Within the Dagster pipes subprocess:
+schema = [
+    {
+        "name": "column1",
+        "type": "string",
+        "description": "The first column",
+        "tags": {"source": "source1"},
+        "constraints": {"unique": True},
+    },
+    {
+        "name": "column2",
+        "type": "int",
+        "description": "The second column",
+        "tags": {"source": "source2"},
+        "constraints": {"min": 0, "max": 100},
+    },
+]
+records = [
+    {"column1": "foo", "column2": 1},
+    {"column1": "bar", "column2": 2},
+]
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "table_meta": {
+            "type": "table",
+            "raw_value": {"schema": schema, "records": records},
+        }
+    },
+)
+# end_table
+```
+
+#### Table Schema Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_schema_metadata.py
+context = ...
+
+# start_table_schema
+# Within the Dagster pipes subprocess:
+schema = [
+    {
+        "name": "column1",
+        "type": "string",
+        "description": "The first column",
+        "tags": {"source": "source1"},
+        "constraints": {"unique": True},
+    },
+    {
+        "name": "column2",
+        "type": "int",
+        "description": "The second column",
+        "tags": {"source": "source2"},
+        "constraints": {"min": 0, "max": 100},
+    },
+]
+
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "table_meta": {
+            "type": "table_schema",
+            "raw_value": schema,
+        }
+    },
+)
+# end_table_schema
+```
+
+#### Table Column Lineage Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_column_lineage.py startafter=start_table_column_lineage endbefore=end_table_column_lineage
+# Within the Dagster pipes subprocess:
+lineage = {
+    "a": [{"asset_key": "upstream", "column": "column1"}],
+    "b": [{"asset_key": "upstream", "column": "column2"}],
+}
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "lineage_meta": {
+            "type": "table_column_lineage",
+            "raw_value": {"table_column_lineage": lineage},
+        }
+    },
+)
+```
+
+#### Timestamp Metadata
+
+```python file=/guides/dagster/dagster_pipes/subprocess/rich_metadata/timestamp_metadata.py startafter=start_timestamp endbefore=end_timestamp
+# Within the Dagster pipes subprocess:
+timestamp = 1234567890
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"timestamp_meta": {"type": "timestamp", "raw_value": timestamp}},
+)
+```

--- a/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
+++ b/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
@@ -126,6 +126,36 @@ Column lineage enables data and analytics engineers alike to understand how a co
 
 ---
 
+## Ensuring table schema consistency
+
+When column schemas are defined at runtime through materialization metadata, it can be helpful to detect and alert on schema changes between materializations. Dagster provides <PyObject object="build_column_schema_change_checks"/> API to help detect these changes.
+
+This function creates asset checks which compare the current materialization's schema against the schema from the previous materialization. These checks can detect:
+
+- Added columns
+- Removed columns
+- Changed column types
+
+Let's define a column schema change check for our asset from the example above that defines table schema at runtime, `my_other_asset`.
+
+```python file=/concepts/metadata-tags/schema_change_checks.py startafter=start_check endbefore=end_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(assets=[my_other_asset])
+```
+
+If any schema changes are detected between materializations, they will be reported in the asset's check results in the Dagster UI. This can help catch unexpected schema changes and prevent downstream issues.
+
+### Alerting on schema change (Dagster+ only)
+
+In Dagster+, you can set up alerts to notify you when assets have had a schema change. By default, schema change checks will fail with a severity of `WARN`, but you can override this to fail with `ERROR`.
+
+To alert on schema changes, create an alert policy with the following settings:
+
+<AssetCheckAlerts />
+
+---
+
 ## APIs in this guide
 
 | Name                                         | Description                                                      |

--- a/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
+++ b/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
@@ -1,0 +1,13 @@
+from dagster import asset
+
+
+@asset
+def my_other_asset(): ...
+
+
+# start_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(assets=[my_other_asset])
+
+# end_check

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/json_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/json_metadata.py
@@ -1,0 +1,14 @@
+def get_json_data(args): ...
+
+
+context = ...
+
+# start_json
+# Within the Dagster pipes subprocess:
+json_data = ["item1", "item2", "item3"]
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"json_meta": {"type": "json", "raw_value": json_data}},
+)
+# end_json

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/markdown_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/markdown_metadata.py
@@ -1,0 +1,14 @@
+def get_markdown_content(args): ...
+
+
+context = ...
+
+# start_markdown
+# Within the Dagster pipes subprocess:
+markdown_content = "# Header\nSome **bold** text"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"md_meta": {"type": "md", "raw_value": markdown_content}},
+)
+# end_markdown

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/notebook_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/notebook_metadata.py
@@ -1,0 +1,14 @@
+def get_notebook_path(args): ...
+
+
+context = ...
+
+# start_notebook
+# Within the Dagster pipes subprocess:
+notebook_path = "/path/to/notebook.ipynb"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"notebook_meta": {"type": "notebook", "raw_value": notebook_path}},
+)
+# end_notebook

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/path_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/path_metadata.py
@@ -1,0 +1,14 @@
+def get_path(args): ...
+
+
+context = ...
+
+# start_path
+# Within the Dagster pipes subprocess:
+path = "/path/to/file.txt"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"path_meta": {"type": "path", "raw_value": path}},
+)
+# end_path

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_column_lineage.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_column_lineage.py
@@ -1,0 +1,19 @@
+context = ...
+
+# start_table_column_lineage
+# Within the Dagster pipes subprocess:
+lineage = {
+    "a": [{"asset_key": "upstream", "column": "column1"}],
+    "b": [{"asset_key": "upstream", "column": "column2"}],
+}
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "lineage_meta": {
+            "type": "table_column_lineage",
+            "raw_value": {"table_column_lineage": lineage},
+        }
+    },
+)
+# end_table_column_lineage

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_metadata.py
@@ -1,0 +1,35 @@
+context = ...
+
+# start_table
+# Within the Dagster pipes subprocess:
+schema = [
+    {
+        "name": "column1",
+        "type": "string",
+        "description": "The first column",
+        "tags": {"source": "source1"},
+        "constraints": {"unique": True},
+    },
+    {
+        "name": "column2",
+        "type": "int",
+        "description": "The second column",
+        "tags": {"source": "source2"},
+        "constraints": {"min": 0, "max": 100},
+    },
+]
+records = [
+    {"column1": "foo", "column2": 1},
+    {"column1": "bar", "column2": 2},
+]
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "table_meta": {
+            "type": "table",
+            "raw_value": {"schema": schema, "records": records},
+        }
+    },
+)
+# end_table

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_schema_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/table_schema_metadata.py
@@ -1,0 +1,32 @@
+context = ...
+
+# start_table_schema
+# Within the Dagster pipes subprocess:
+schema = [
+    {
+        "name": "column1",
+        "type": "string",
+        "description": "The first column",
+        "tags": {"source": "source1"},
+        "constraints": {"unique": True},
+    },
+    {
+        "name": "column2",
+        "type": "int",
+        "description": "The second column",
+        "tags": {"source": "source2"},
+        "constraints": {"min": 0, "max": 100},
+    },
+]
+
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={
+        "table_meta": {
+            "type": "table_schema",
+            "raw_value": schema,
+        }
+    },
+)
+# end_table_schema

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/timestamp_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/timestamp_metadata.py
@@ -1,0 +1,14 @@
+def get_timestamp_data(args): ...
+
+
+context = ...
+
+# start_timestamp
+# Within the Dagster pipes subprocess:
+timestamp = 1234567890
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"timestamp_meta": {"type": "timestamp", "raw_value": timestamp}},
+)
+# end_timestamp

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/url_metadata.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/rich_metadata/url_metadata.py
@@ -1,0 +1,14 @@
+def get_url(args): ...
+
+
+context = ...
+
+# start_url
+# Within the Dagster pipes subprocess:
+url = "http://example.com"
+# Then, when reporting the asset materialization:
+context.report_asset_materialization(
+    asset_key="foo",
+    metadata={"url_meta": {"type": "url", "raw_value": url}},
+)
+# end_url

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
@@ -27,6 +27,18 @@ def build_column_schema_change_checks(
     """Returns asset checks that pass if the column schema of the asset's latest materialization
     is the same as the column schema of the asset's previous materialization.
 
+    The underlying materializations are expected to have a metadata entry with key `dagster/column_schema` and type :py:class:`TableSchema`.
+    To learn more about how to add column schema metadata and other forms of tabular metadata to assets, see
+    https://docs.dagster.io/concepts/metadata-tags/asset-metadata/table-metadata#attaching-column-schema.
+
+    The resulting checks will fail if any changes are detected in the column schema between
+    materializations, including:
+    - Added columns
+    - Removed columns
+    - Changes to column types
+
+    The check failure message will detail exactly what changed in the schema.
+
     Args:
         assets (Sequence[Union[AssetKey, str, AssetsDefinition, SourceAsset]]): The assets to create
             asset checks for.
@@ -34,6 +46,40 @@ def build_column_schema_change_checks(
 
     Returns:
         Sequence[AssetsChecksDefinition]
+
+    Examples:
+        First, define an asset with column schema metadata. You can attach schema metadata either as
+        definition metadata (when schema is known at definition time) or as materialization metadata
+        (when schema is only known at runtime):
+
+        .. code-block:: python
+
+            import dagster as dg
+
+            # Using definition metadata when schema is known upfront
+            @dg.asset
+            def people_table():
+                column_names = ...
+                column_types = ...
+
+                columns = [
+                    dg.TableColumn(name, column_type)
+                    for name, column_type in zip(column_names, column_types)
+                ]
+
+                yield dg.MaterializeResult(
+                    metadata={"dagster/column_schema": dg.TableSchema(columns=columns)}
+                )
+
+        Once you have assets with column schema metadata, you can create schema change checks to monitor
+        for changes in the schema between materializations:
+
+        .. code-block:: python
+
+            # Create schema change checks for one or more assets
+            schema_checks = dg.build_column_schema_change_checks(
+                assets=[people_table]
+            )
     """
     asset_keys = set()
     for el in assets:


### PR DESCRIPTION
## Summary & Motivation
Currently, the formats for setting rich metadata in `dagster-pipes` are undocumented. This PR adds docs for the rich metadata formats that are supported.

## How I Tested These Changes
Eyes on docs site

## Changelog
- [dagster-pipes][docs] A new section describing how to set rich metadata in dagster pipes that can display effectively in the Dagster UI.
