### PR TITLE
[dagster-pipes] add references to metadata section

### DIFF
--- a/docs/content/concepts/dagster-pipes/aws-ecs.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-ecs.mdx
@@ -72,6 +72,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesECSClient to launch the task

--- a/docs/content/concepts/dagster-pipes/aws-emr-serverless.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-emr-serverless.mdx
@@ -98,6 +98,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesEMRServerlessClient to launch the job

--- a/docs/content/concepts/dagster-pipes/aws-emr.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-emr.mdx
@@ -130,6 +130,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Create an asset using the PipesEMRClient to launch the job

--- a/docs/content/concepts/dagster-pipes/aws-glue.mdx
+++ b/docs/content/concepts/dagster-pipes/aws-glue.mdx
@@ -71,6 +71,8 @@ if __name__ == "__main__":
     main()
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 ---
 
 ## Step 3: Add the PipesGlueClient to Dagster code

--- a/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
+++ b/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
@@ -288,6 +288,8 @@ with open_dagster_pipes(
     )
 ```
 
+Note: The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](/concepts/dagster-pipes/subprocess/reference#passing-rich-metadata-to-dagster).
+
 Above we see that <PyObject object="open_dagster_pipes" module="dagster_pipes"/> takes three parameters:
 
 - `params_loader`: A params loader responsible for loading the bootstrap payload injected into the external process at launch. The standard approach is to inject the bootstrap payload into predetermined environment variables that the <PyObject object="PipesEnvVarParamsLoader" module="dagster_pipes" /> knows how to read. However, a different bootstrap parameter loader can be substituted in environments where it is not possible to modify environment variables.

--- a/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
+++ b/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
@@ -126,6 +126,38 @@ Column lineage enables data and analytics engineers alike to understand how a co
 
 ---
 
+## Ensuring table schema consistency
+
+When column schemas are defined at runtime through materialization metadata, it can be helpful to detect and alert on schema changes between materializations. Dagster provides <PyObject object="build_column_schema_change_checks"/> API to help detect these changes.
+
+This function creates asset checks which compare the current materialization's schema against the schema from the previous materialization. These checks can detect:
+
+- Added columns
+- Removed columns
+- Changed column types
+
+Let's define a column schema change check for our asset from the example above that defines table schema at runtime, `my_other_asset`.
+
+```python file=/concepts/metadata-tags/schema_change_checks.py startafter=start_check endbefore=end_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(
+    assets=[my_other_asset]
+)
+```
+
+If any schema changes are detected between materializations, they will be reported in the asset's check results in the Dagster UI. This can help catch unexpected schema changes and prevent downstream issues.
+
+### Alerting on schema change (Dagster+ only)
+
+In Dagster+, you can set up alerts to notify you when assets have had a schema change. By default, schema change checks will fail with a severity of `WARN`, but you can override this to fail with `ERROR`.
+
+To alert on schema changes, create an alert policy with the following settings:
+
+<AssetCheckAlerts />
+
+---
+
 ## APIs in this guide
 
 | Name                                         | Description                                                      |

--- a/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
+++ b/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
@@ -1,0 +1,13 @@
+from dagster import asset
+
+
+@asset
+def my_other_asset(): ...
+
+
+# start_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(assets=[my_other_asset])
+
+# end_check

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
@@ -27,6 +27,18 @@ def build_column_schema_change_checks(
     """Returns asset checks that pass if the column schema of the asset's latest materialization
     is the same as the column schema of the asset's previous materialization.
 
+    The underlying materializations are expected to have a metadata entry with key `dagster/column_schema` and type :py:class:`TableSchema`.
+    To learn more about how to add column schema metadata and other forms of tabular metadata to assets, see
+    https://docs.dagster.io/concepts/metadata-tags/asset-metadata/table-metadata#attaching-column-schema.
+
+    The resulting checks will fail if any changes are detected in the column schema between
+    materializations, including:
+    - Added columns
+    - Removed columns
+    - Changes to column types
+
+    The check failure message will detail exactly what changed in the schema.
+
     Args:
         assets (Sequence[Union[AssetKey, str, AssetsDefinition, SourceAsset]]): The assets to create
             asset checks for.
@@ -34,6 +46,40 @@ def build_column_schema_change_checks(
 
     Returns:
         Sequence[AssetsChecksDefinition]
+
+    Examples:
+        First, define an asset with column schema metadata. You can attach schema metadata either as
+        definition metadata (when schema is known at definition time) or as materialization metadata
+        (when schema is only known at runtime):
+
+        .. code-block:: python
+
+            import dagster as dg
+
+            # Using definition metadata when schema is known upfront
+            @dg.asset
+            def people_table():
+                column_names = ...
+                column_types = ...
+
+                columns = [
+                    dg.TableColumn(name, column_type)
+                    for name, column_type in zip(column_names, column_types)
+                ]
+
+                yield dg.MaterializeResult(
+                    metadata={"dagster/column_schema": dg.TableSchema(columns=columns)}
+                )
+
+        Once you have assets with column schema metadata, you can create schema change checks to monitor
+        for changes in the schema between materializations:
+
+        .. code-block:: python
+
+            # Create schema change checks for one or more assets
+            schema_checks = dg.build_column_schema_change_checks(
+                assets=[people_table]
+            )
     """
     asset_keys = set()
     for el in assets:


### PR DESCRIPTION
## Summary & Motivation
This PR adds references to the rich metadata section from the previous PR; wherever we use the rich metadata in a previously undocumented way.

## How I Tested These Changes
Eyes in docs site.
## Changelog
- [dagster-pipes][docs] Added references to new pipes rich metadata section wherever we make use of the format.
