### PR TITLE
DOC-680 Update rst files with missing classes and update PyObjects in docs

### DIFF
--- a/docs/docs-beta/docs/guides/build/external-pipelines/aws-lambda-pipeline.md
+++ b/docs/docs-beta/docs/guides/build/external-pipelines/aws-lambda-pipeline.md
@@ -119,15 +119,13 @@ def lambda_handler(event, _context):
 
 Let's review what this code does:
 
-{/* TODO change `PipesMappingParamsLoader` to <PyObject section="libraries" module="dagster_pipes" object="PipesMappingParamsLoader" /> */}
-
-- Imports `PipesMappingParamsLoader` and <PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" /> from `dagster_pipes`
+- Imports <PyObject section="libraries" module="dagster_pipes" object="PipesMappingParamsLoader" /> and <PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" /> from `dagster_pipes`
 
 - **Defines a [Lambda function handler](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html), which is a method in function code that processes events**. This method accepts `event` and `context` arguments, which map to the `event` payload and `context` we'll define in our Dagster asset.
 
 - **Initializes the Dagster Pipes context (<PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" />), which yields an instance of <PyObject section="libraries" object="PipesContext" module="dagster_pipes" /> called `pipes`.**
 
-  On the orchestration side - which we'll discuss in the next section - we'll set up a Dagster asset that uses the <PyObject section="libraries" module="dagster_aws" object="pipes.PipesLambdaClient" /> to inject information needed for Pipes in an `event` payload. In this code on the AWS Lambda side, we're passing this payload to `PipesMappingParamsLoader` and using it in <PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" />.
+  On the orchestration side - which we'll discuss in the next section - we'll set up a Dagster asset that uses the <PyObject section="libraries" module="dagster_aws" object="pipes.PipesLambdaClient" /> to inject information needed for Pipes in an `event` payload. In this code on the AWS Lambda side, we're passing this payload to <PyObject section="libraries" module="dagster_pipes" object="PipesMappingParamsLoader" /> and using it in <PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" />.
 
   We're using the default context loader (<PyObject section="libraries" object="PipesDefaultContextLoader" module="dagster_pipes" />) and message writer (<PyObject section="libraries" object="PipesDefaultMessageWriter" module="dagster_pipes" />) in this example. These objects establish communication between the orchestration and external process. On the orchestration end, these match a corresponding `PipesLambdaEventContextInjector` and `PipesLambdaLogsMessageReader`, which are instantiated inside the <PyObject section="libraries" module="dagster_aws" object="pipes.PipesLambdaClient" />.
 

--- a/docs/docs-beta/docs/guides/build/external-pipelines/databricks-pipeline.md
+++ b/docs/docs-beta/docs/guides/build/external-pipelines/databricks-pipeline.md
@@ -115,12 +115,10 @@ Let's review what's happening in this code:
 
   The submitted task must:
 
-  {/* TODO change `PipesDbfsLogReader` to <PyObject section="libraries" object="PipesDbfsLogReader" module="dagster_databricks" /> */}
-
   - **Specify `dagster-pipes` as a PyPI dependency**. You can include a version pin (e.g. `dagster-pipes==1.5.4`) if desired.
   - Use a `spark_python_task`.
   - Specify either `new_cluster` (this is the **recommended approach**) or `existing_cluster_id`. The `new_cluster` field is used in this example.
-    - If `new_cluster` is set, then setting `new_cluster.cluster_log_conf.dbfs` enables the <PyObject section="libraries" object="PipesDatabricksClient" module="dagster_databricks" /> to automatically set up `PipesDbfsLogReader` objects for `stdout` and `stderr` of the driver process. These will periodically forward the `stdout` and `stderr` logs written by Databricks back to Dagster. **Note**: Because Databricks only updates these log files every five minutes, that is the maximum frequency at which Dagster can forward the logs.
+    - If `new_cluster` is set, then setting `new_cluster.cluster_log_conf.dbfs` enables the <PyObject section="libraries" object="PipesDatabricksClient" module="dagster_databricks" /> to automatically set up <PyObject section="libraries" object="PipesDbfsLogReader" module="dagster_databricks" />  objects for `stdout` and `stderr` of the driver process. These will periodically forward the `stdout` and `stderr` logs written by Databricks back to Dagster. **Note**: Because Databricks only updates these log files every five minutes, that is the maximum frequency at which Dagster can forward the logs.
     - If `existing_cluster_id` is set, <PyObject section="libraries" object="PipesDatabricksClient" module="dagster_databricks" /> won't be able to forward `stdout` and `stderr` driver logs to Dagster. Using an existing cluster **requires passing an instance of <PyObject section="libraries" object="PipesCliArgsParamsLoader" module="dagster_pipes" /> to <PyObject section="libraries" object="open_dagster_pipes" module="dagster_pipes" />** in the Python script which is executed on Databricks. This is because setting environment variables is only possible when creating a new cluster, so we have to use the alternative method of passing Pipes parameters as command-line arguments.
 
 - **Defines an `extras` dictionary containing some arbitrary data (`some_parameter`).** This is where you can put various data, e.g. from the Dagster run config, that you want to be available in Databricks. Anything added here must be JSON-serializable.

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-databricks.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-databricks.rst
@@ -52,6 +52,8 @@ Pipes
 
 .. autoclass:: PipesDbfsMessageReader
 
+.. autoclass:: PipesDbfsLogReader
+
 Other
 =====
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
@@ -53,6 +53,8 @@ Params loaders load the bootstrap payload from some globally accessible key-valu
 
 .. autoclass:: PipesCliArgsParamsLoader
 
+.. autoclass:: PipesMappingParamsLoader
+
 ----
 
 Message writers


### PR DESCRIPTION
## Summary & Motivation

While working on new "build" docs, I noticed that some classes were missing from our API docs. This PR updates the relevant `rst` files and corresponding `<PyObject /> `  components in markdown docs.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
