### PR TITLE
Raise error if run-pyright.py tried on Python 3.12

### DIFF
--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -556,6 +556,10 @@ def print_report(result: RunResult) -> None:
 
 
 if __name__ == "__main__":
+    assert sys.version_info < (3, 12), (
+        "This script is not currently compatible with Python 3.12+ "
+        "because of `dagster-airflow[test_airflow_2]`.",
+    )
     assert os.path.exists(".git"), "Must be run from the root of the repository"
     args = parser.parse_args()
     params = get_params(args)


### PR DESCRIPTION
## Summary & Motivation

I tried running `run-pyright.py` in my (Python 3.12) venv, and it only works for `alt-1` (not `master`).

## How I Tested These Changes

Created a Python 3.11 venv and made sure `run-pyright.py` executed cleanly there.
