### PR TITLE
[helm] - Make max runtime seconds configurable in the helm chart

### DIFF
--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -300,6 +300,23 @@ def test_run_monitoring_set_max_resume_run_attempts(
     assert instance["run_monitoring"]["max_resume_run_attempts"] == 2
 
 
+def test_run_monitoring_set_max_runtime_seconds(
+    instance_template: HelmTemplate,
+):
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(runMonitoring={"enabled": True, "maxRuntimeSeconds": 2})
+    )
+
+    configmaps = instance_template.render(helm_values)
+
+    assert len(configmaps) == 1
+
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["run_monitoring"]["enabled"] is True
+    assert instance["run_monitoring"]["max_runtime_seconds"] == 2
+
+
 def test_sensor_schedule_threading_default(
     instance_template: HelmTemplate,
 ):

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -93,6 +93,9 @@ data:
       {{- if not (kindIs "invalid" $runMonitoring.cancelTimeoutSeconds) }}
       cancel_timeout_seconds:  {{ $runMonitoring.cancelTimeoutSeconds }}
       {{- end }}
+      {{- if not (kindIs "invalid" $runMonitoring.maxRuntimeSeconds) }}
+      max_runtime_seconds:  {{ $runMonitoring.maxRuntimeSeconds }}
+      {{- end }}
       {{- if not (kindIs "invalid" $runMonitoring.maxResumeRunAttempts) }}
       max_resume_run_attempts: {{ $runMonitoring.maxResumeRunAttempts }}
       {{- end }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1139,6 +1139,8 @@ dagsterDaemon:
     startTimeoutSeconds: 300
     # Timeout for runs to cancel (avoids runs hanging in CANCELING)
     # cancelTimeoutSeconds: 300
+    # Timeout for runs to finish (avoids runs hanging in RUNNING)
+    # maxRuntimeSeconds: 7200
     # How often to check on in progress runs
     pollIntervalSeconds: 120
     # [Experimental] Max number of times to attempt to resume a run with a new run worker instead


### PR DESCRIPTION
## Summary & Motivation

Adds parameter to configure run monitoring with max_runtime_seconds in the helm chart.

Closes https://github.com/dagster-io/dagster/issues/26641

## How I Tested These Changes

Added a test
