### PR TITLE
[bug] Fix issue when passing in a top-level partitions definition with specs that have a group name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -600,7 +600,7 @@ class DecoratorAssetsDefinitionBuilder:
 
         return [
             spec.replace_attributes(
-                group_name=self.group_name,
+                group_name=spec.group_name or self.group_name,
                 partitions_def=spec.partitions_def or self.args.partitions_def,
             )
             for spec in specs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -548,6 +548,22 @@ def test_with_partition_mappings(
         )
 
 
+def test_partitioned_with_group_name(test_jaffle_shop_manifest: dict[str, Any]) -> None:
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> str:
+            return "THE_GROUP"
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        dagster_dbt_translator=CustomDagsterDbtTranslator(),
+        partitions_def=DailyPartitionsDefinition(start_date="2023-10-01"),
+    )
+    def my_dbt_assets(): ...
+
+    for spec in my_dbt_assets.specs:
+        assert spec.group_name == "THE_GROUP"
+
+
 def test_with_description_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
     expected_description = "customized description"
 


### PR DESCRIPTION
## Summary & Motivation

In the case that a partitions_def was passed in, the previous logic would override both the group name and the partitions def. This handles those two cases separately

## How I Tested These Changes

New unit tests

## Changelog

[dagster-dbt] Fixed an issue where group names set on partitioned dbt assets created using the `@dbt_assets` decorator would be ignored
