### PR TITLE
Fix spec error conditions in loaders

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_asset_checks_from_modules.py
@@ -35,7 +35,7 @@ def load_asset_checks_from_modules(
         asset_key_prefix, "asset_key_prefix"
     )
     return (
-        ModuleScopedDagsterDefs.from_modules(modules)
+        ModuleScopedDagsterDefs.from_modules(modules, allow_spec_collisions=True)
         .get_object_list()
         .with_attributes(
             key_prefix=asset_key_prefix,

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
@@ -96,7 +96,7 @@ def load_assets_from_modules(
 
     return cast(
         Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec]],
-        ModuleScopedDagsterDefs.from_modules(modules)
+        ModuleScopedDagsterDefs.from_modules(modules, allow_spec_collisions=not include_specs)
         .get_object_list()
         .with_attributes(
             key_prefix=check_opt_coercible_to_asset_key_prefix_param(key_prefix, "key_prefix"),

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
@@ -47,12 +47,16 @@ class ModuleScopedDagsterDefs:
     def __init__(
         self,
         objects_per_module: Mapping[str, Sequence[LoadableDagsterDef]],
+        allow_spec_collisions: bool,
     ):
         self.objects_per_module = objects_per_module
+        self.allow_spec_collisions = allow_spec_collisions
         self._do_collision_detection()
 
     @classmethod
-    def from_modules(cls, modules: Iterable[ModuleType]) -> "ModuleScopedDagsterDefs":
+    def from_modules(
+        cls, modules: Iterable[ModuleType], allow_spec_collisions: bool = False
+    ) -> "ModuleScopedDagsterDefs":
         return cls(
             {
                 module.__name__: list(
@@ -63,6 +67,7 @@ class ModuleScopedDagsterDefs:
                 )
                 for module in modules
             },
+            allow_spec_collisions,
         )
 
     @cached_property
@@ -134,13 +139,22 @@ class ModuleScopedDagsterDefs:
     def _do_collision_detection(self) -> None:
         # Collision detection on module-scoped asset objects. This does not include CacheableAssetsDefinitions, which don't have their keys defined until runtime.
         for key, asset_objects in self.asset_objects_by_key.items():
+            # In certain cases, we allow asset specs to collide because we know we aren't loading them.
+            asset_objects_to_check = [
+                asset_object
+                for asset_object in asset_objects
+                if (not isinstance(asset_object, AssetSpec) if self.allow_spec_collisions else True)
+            ]
             # If there is more than one asset_object in the list for a given key, and the objects do not refer to the same asset_object in memory, we have a collision.
             num_distinct_objects_for_key = len(
-                set(id(asset_object) for asset_object in asset_objects)
+                set(id(asset_object) for asset_object in asset_objects_to_check)
             )
-            if len(asset_objects) > 1 and num_distinct_objects_for_key > 1:
+            if len(asset_objects_to_check) > 1 and num_distinct_objects_for_key > 1:
                 asset_objects_str = ", ".join(
-                    set(self.module_name_by_id[id(asset_object)] for asset_object in asset_objects)
+                    set(
+                        self.module_name_by_id[id(asset_object)]
+                        for asset_object in asset_objects_to_check
+                    )
                 )
                 raise DagsterInvalidDefinitionError(
                     f"Asset key {key.to_user_string()} is defined multiple times. Definitions found in modules: {asset_objects_str}."

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/checks_module/__init__.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/checks_module/__init__.py
@@ -1,4 +1,4 @@
-from dagster import AssetCheckResult, AssetCheckSpec, Output, asset, asset_check
+from dagster import AssetCheckResult, AssetCheckSpec, AssetSpec, Output, asset, asset_check
 
 
 @asset(check_specs=[AssetCheckSpec(name="in_op_check", asset="asset_1")])
@@ -10,3 +10,7 @@ def asset_1():
 @asset_check(asset=asset_1)
 def asset_check_1(asset_1):
     return AssetCheckResult(passed=True)
+
+
+# duplicate asset specs in scope shouldn't error
+asset_specs = [AssetSpec("asset_1"), AssetSpec("asset_1")]

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
@@ -178,6 +178,17 @@ def test_load_assets_from_modules(monkeypatch):
         ):
             load_assets_from_modules([asset_package, module_with_assets], include_specs=True)
 
+    # Create an asset spec with an identical key to a full fledged assetsdef. Won't cause an error unless include_specs=True
+    with monkeypatch.context() as m:
+        spec = AssetSpec("chuck_berry")
+        m.setattr(asset_package, "chuck_berry_spec", spec, raising=False)
+        assets = load_assets_from_modules([asset_package, module_with_assets])
+        assert [get_unique_asset_identifier(asset) for asset in assets] == assets_1
+        with pytest.raises(
+            DagsterInvalidDefinitionError,
+        ):
+            load_assets_from_modules([asset_package, module_with_assets], include_specs=True)
+
 
 @asset(group_name="my_group")
 def asset_in_current_module():


### PR DESCRIPTION
## Summary & Motivation
Previously, even when specs weren't getting loaded, we began erroring on collisions involving them.

This fixes by excluding specs from collision detection if they aren't getting loaded. This is still a bit hacky - ideally we can specify up front exactly what we want to load in a more principled manner.

## How I Tested These Changes
Added new test case for the expected behavior - that when include_specs is not set, we don't error when a duplicate spec exists, and do error when it does.

## Changelog
- Fixed a bug with load_assets_from_x functions where we began erroring when a spec and AssetsDefinition had the same key in a given module. We now only error in this case if include_specs=True.
