### PR TITLE
Make EcsRunLauncher task definition deduping less strict

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -92,36 +92,9 @@ def task_definitions_match(
         existing_task_definition, container_name
     )
 
-    # sidecars are checked separately below
-    match_without_sidecars = existing_task_definition_config._replace(
-        sidecars=[],
-    ) == desired_task_definition_config._replace(
-        sidecars=[],
+    return existing_task_definition_config.matches_other_task_definition_config(
+        desired_task_definition_config
     )
-    if not match_without_sidecars:
-        return False
-
-    # Just match sidecars on certain fields
-    if not [
-        (
-            sidecar["name"],
-            sidecar["image"],
-            sidecar.get("environment", []),
-            sidecar.get("secrets", []),
-        )
-        for sidecar in existing_task_definition_config.sidecars
-    ] == [
-        (
-            sidecar["name"],
-            sidecar["image"],
-            sidecar.get("environment", []),
-            sidecar.get("secrets", []),
-        )
-        for sidecar in desired_task_definition_config.sidecars
-    ]:
-        return False
-
-    return True
 
 
 def get_task_logs(ecs, logs_client, cluster, task_arn, container_name, limit=10):


### PR DESCRIPTION
## Summary & Motivation
We observed an issue where subtly different formats of linuxParameters and/or specifying taskRoleArn in differnet formats was causing this logic to incorrectly create a new task definition for each run.

The risk of this is that you might encounter a situation where you try to make a config change and it isn't automatically propagated to runs until you redeploy. Plan is to separately address that by giving you a way to configure a prefix on the run launcher so that you can bump the task definition name when needed.

## How I Tested These Changes
New test cases

## Changelog
[dagster-aws] Fixed an issue with the EcsRunLauncher where it would sometimes create a new task definition revision for each run if the "task_role_arn" or "execution_role_arn" parameters were specified without the `arn:aws:iam:` prefix.
