### PR TITLE
fix additional_deps not showing up on assetsdefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -951,6 +951,12 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         upstream_keys = {
             *(dep.asset_key for key in self.keys for dep in self._specs_by_key[key].deps),
             *(spec.asset_key for spec in self.check_specs if spec.asset_key not in self.keys),
+            *(
+                dep.asset_key
+                for spec in self.check_specs
+                for dep in spec.additional_deps
+                if dep.asset_key not in self.keys
+            ),
         }
 
         return {

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -163,13 +163,38 @@ def test_asset_check_additional_ins() -> None:
     def my_check(asset1: int, asset2: int) -> AssetCheckResult:
         return AssetCheckResult(passed=asset1 == 5 and asset2 == 4)
 
+    assert my_check.keys_by_input_name == {
+        "asset1": AssetKey("asset1"),
+        "asset2": AssetKey("asset2"),
+    }
+
     @asset_check(asset=asset1, additional_ins={"asset2": AssetIn(key=asset2.key)})
     def my_check2(asset2: int) -> AssetCheckResult:
         return AssetCheckResult(passed=asset2 == 4)
 
+    assert my_check2.keys_by_input_name == {
+        "asset1": AssetKey("asset1"),
+        "asset2": AssetKey("asset2"),
+    }
+
     @asset_check(asset=asset1, additional_ins={"asset2": AssetIn(key=asset2.key)})
     def my_check3(context, asset2: int) -> AssetCheckResult:
         return AssetCheckResult(passed=asset2 == 4)
+
+    assert my_check3.keys_by_input_name == {
+        "asset1": AssetKey("asset1"),
+        "asset2": AssetKey("asset2"),
+    }
+
+    # If the input name matches the asset key, then the asset in can be empty.
+    @asset_check(asset=asset1, additional_ins={"asset2": AssetIn()})
+    def my_check4(asset2: int) -> AssetCheckResult:
+        return AssetCheckResult(passed=asset2 == 4)
+
+    assert my_check4.keys_by_input_name == {
+        "asset1": AssetKey("asset1"),
+        "asset2": AssetKey("asset2"),
+    }
 
     # Error bc asset2 is in additional_ins but not in the function signature
     with pytest.raises(DagsterInvalidDefinitionError):


### PR DESCRIPTION
## Summary & Motivation
Previously, `keys_by_input_name` did not contain the ins specified by additional_ins or additional_deps in the @asset_check decorator. 

This fixes to include those keys as part of the property.

This was causing https://github.com/dagster-io/dagster/issues/27003#issuecomment-2583349296 in some yet to be determined way. We've been able to confirm the fix, but have not yet pinpointed a straightforward repro.

## How I Tested These Changes
- Fixes the problematic edge case. Add a bunch of new assertions to prevent regressions in the future.
## Changelog
- Fixed a bug with asset checks where additional_deps/additional_ins were not being threaded through properly in certain cases, and would result in errors at job creation.
