### PR TITLE
[windows] Use a single code server

### DIFF
--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -2,13 +2,16 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
 import click
+import yaml
 
-import dagster._check as check
 from dagster._annotations import deprecated
 from dagster._cli.job import apply_click_params
 from dagster._cli.utils import get_possibly_temporary_instance_for_cli
@@ -21,6 +24,8 @@ from dagster._cli.workspace.cli_target import (
     working_directory_option,
     workspace_option,
 )
+from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._grpc.server import GrpcServerCommand
 from dagster._serdes import serialize_value
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
@@ -122,8 +127,7 @@ def dev_command(
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")
 
-    # Sanity check workspace args
-    get_workspace_load_target(kwargs)
+    workspace_target = get_workspace_load_target(kwargs)
 
     dagster_home_path = os.getenv("DAGSTER_HOME")
 
@@ -140,103 +144,100 @@ def dev_command(
             )
 
     with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
-        logger.info("Launching Dagster services...")
+        with WorkspaceProcessContext(
+            instance,
+            workspace_target,
+            code_server_log_level=code_server_log_level,
+            server_command=GrpcServerCommand.CODE_SERVER_START,
+        ) as context:
+            with _temp_grpc_socket_workspace_file(context) as workspace_file:
+                logger.info("Launching Dagster services...")
 
-        args = [
-            "--instance-ref",
-            serialize_value(instance.get_ref()),
-            "--code-server-log-level",
-            code_server_log_level,
-        ]
+                args = [
+                    "--instance-ref",
+                    serialize_value(instance.get_ref()),
+                    "--workspace",
+                    workspace_file,
+                    "--code-server-log-level",
+                    code_server_log_level,
+                ]
 
-        if kwargs.get("workspace"):
-            for workspace in check.tuple_elem(kwargs, "workspace"):
-                args.extend(["--workspace", workspace])
+                if kwargs.get("use_ssl"):
+                    args.extend(["--use-ssl"])
 
-        if kwargs.get("python_file"):
-            for python_file in check.tuple_elem(kwargs, "python_file"):
-                args.extend(["--python-file", python_file])
-
-        if kwargs.get("module_name"):
-            for module_name in check.tuple_elem(kwargs, "module_name"):
-                args.extend(["--module-name", module_name])
-
-        if kwargs.get("working_directory"):
-            args.extend(["--working-directory", check.str_elem(kwargs, "working_directory")])
-
-        if kwargs.get("grpc_port"):
-            args.extend(["--grpc-port", str(kwargs["grpc_port"])])
-
-        if kwargs.get("grpc_host"):
-            args.extend(["--grpc-host", str(kwargs["grpc_host"])])
-
-        if kwargs.get("grpc_socket"):
-            args.extend(["--grpc-socket", str(kwargs["grpc_socket"])])
-
-        if kwargs.get("use_ssl"):
-            args.extend(["--use-ssl"])
-
-        webserver_process = open_ipc_subprocess(
-            [sys.executable, "-m", "dagster_webserver"]
-            + (["--port", port] if port else [])
-            + (["--host", host] if host else [])
-            + (["--dagster-log-level", log_level])
-            + (["--log-format", log_format])
-            + (["--live-data-poll-rate", live_data_poll_rate] if live_data_poll_rate else [])
-            + args
-        )
-        daemon_process = open_ipc_subprocess(
-            [
-                sys.executable,
-                "-m",
-                "dagster._daemon",
-                "run",
-                "--log-level",
-                log_level,
-                "--log-format",
-                log_format,
-            ]
-            + args
-        )
-        try:
-            while True:
-                time.sleep(_CHECK_SUBPROCESS_INTERVAL)
-
-                if webserver_process.poll() is not None:
-                    raise Exception(
-                        "dagster-webserver process shut down unexpectedly with return code"
-                        f" {webserver_process.returncode}"
+                webserver_process = open_ipc_subprocess(
+                    [sys.executable, "-m", "dagster_webserver"]
+                    + (["--port", port] if port else [])
+                    + (["--host", host] if host else [])
+                    + (["--dagster-log-level", log_level])
+                    + (["--log-format", log_format])
+                    + (
+                        ["--live-data-poll-rate", live_data_poll_rate]
+                        if live_data_poll_rate
+                        else []
                     )
-
-                if daemon_process.poll() is not None:
-                    raise Exception(
-                        "dagster-daemon process shut down unexpectedly with return code"
-                        f" {daemon_process.returncode}"
-                    )
-
-        except KeyboardInterrupt:
-            logger.info("KeyboardInterrupt received")
-        except:
-            logger.exception("An unexpected exception has occurred")
-        finally:
-            logger.info("Shutting down Dagster services...")
-            interrupt_ipc_subprocess(daemon_process)
-            interrupt_ipc_subprocess(webserver_process)
-
-            try:
-                webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                logger.warning(
-                    "dagster-webserver process did not terminate cleanly, killing the process"
+                    + args
                 )
-                webserver_process.kill()
-
-            try:
-                daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                logger.warning(
-                    "dagster-daemon process did not terminate cleanly, killing the process"
+                daemon_process = open_ipc_subprocess(
+                    [
+                        sys.executable,
+                        "-m",
+                        "dagster._daemon",
+                        "run",
+                        "--log-level",
+                        log_level,
+                        "--log-format",
+                        log_format,
+                    ]
+                    + args
                 )
-                daemon_process.kill()
+                try:
+                    while True:
+                        time.sleep(_CHECK_SUBPROCESS_INTERVAL)
 
-            logger.info("Dagster services shut down.")
+                        if webserver_process.poll() is not None:
+                            raise Exception(
+                                "dagster-webserver process shut down unexpectedly with return code"
+                                f" {webserver_process.returncode}"
+                            )
+
+                        if daemon_process.poll() is not None:
+                            raise Exception(
+                                "dagster-daemon process shut down unexpectedly with return code"
+                                f" {daemon_process.returncode}"
+                            )
+
+                except KeyboardInterrupt:
+                    logger.info("KeyboardInterrupt received")
+                except:
+                    logger.exception("An unexpected exception has occurred")
+                finally:
+                    logger.info("Shutting down Dagster services...")
+                    interrupt_ipc_subprocess(daemon_process)
+                    interrupt_ipc_subprocess(webserver_process)
+
+                    try:
+                        webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            "dagster-webserver process did not terminate cleanly, killing the process"
+                        )
+                        webserver_process.kill()
+
+                    try:
+                        daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            "dagster-daemon process did not terminate cleanly, killing the process"
+                        )
+                        daemon_process.kill()
+
+                    logger.info("Dagster services shut down.")
+
+
+@contextmanager
+def _temp_grpc_socket_workspace_file(context: WorkspaceProcessContext) -> Iterator[str]:
+    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+        temp_file.write(yaml.dump({"load_from": context.get_code_server_specs()}))
+        temp_file.flush()
+        yield temp_file.name

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
@@ -12,6 +12,7 @@ from typing import Optional
 import click
 import yaml
 
+from dagster import _check as check
 from dagster._annotations import deprecated
 from dagster._cli.job import apply_click_params
 from dagster._cli.utils import get_possibly_temporary_instance_for_cli
@@ -24,6 +25,7 @@ from dagster._cli.workspace.cli_target import (
     working_directory_option,
     workspace_option,
 )
+from dagster._core.instance import DagsterInstance
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._grpc.server import GrpcServerCommand
 from dagster._serdes import serialize_value
@@ -100,6 +102,13 @@ def dev_command_options(f):
     show_default=True,
     required=False,
 )
+@click.option(
+    "--use-legacy-code-server-behavior",
+    help="Use the legacy behavior of the daemon and webserver each starting up their own code server",
+    is_flag=True,
+    required=False,
+    default=False,
+)
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
 )
@@ -110,6 +119,7 @@ def dev_command(
     port: Optional[str],
     host: Optional[str],
     live_data_poll_rate: Optional[str],
+    use_legacy_code_server_behavior: bool,
     **kwargs: ClickArgValue,
 ) -> None:
     # check if dagster-webserver installed, crash if not
@@ -127,8 +137,6 @@ def dev_command(
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")
 
-    workspace_target = get_workspace_load_target(kwargs)
-
     dagster_home_path = os.getenv("DAGSTER_HOME")
 
     dagster_yaml_path = os.path.join(os.getcwd(), "dagster.yaml")
@@ -144,95 +152,89 @@ def dev_command(
             )
 
     with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
-        with WorkspaceProcessContext(
-            instance,
-            workspace_target,
+        with _optionally_create_temp_workspace(
+            use_legacy_code_server_behavior=use_legacy_code_server_behavior,
+            orig_kwargs=kwargs,
+            instance=instance,
             code_server_log_level=code_server_log_level,
-            server_command=GrpcServerCommand.CODE_SERVER_START,
-        ) as context:
-            with _temp_grpc_socket_workspace_file(context) as workspace_file:
-                logger.info("Launching Dagster services...")
+        ) as workspace_args:
+            logger.info("Launching Dagster services...")
 
-                args = [
-                    "--instance-ref",
-                    serialize_value(instance.get_ref()),
-                    "--workspace",
-                    workspace_file,
-                    "--code-server-log-level",
-                    code_server_log_level,
+            args = [
+                "--instance-ref",
+                serialize_value(instance.get_ref()),
+                "--code-server-log-level",
+                code_server_log_level,
+                *workspace_args,
+            ]
+
+            if kwargs.get("use_ssl"):
+                args.extend(["--use-ssl"])
+
+            webserver_process = open_ipc_subprocess(
+                [sys.executable, "-m", "dagster_webserver"]
+                + (["--port", port] if port else [])
+                + (["--host", host] if host else [])
+                + (["--dagster-log-level", log_level])
+                + (["--log-format", log_format])
+                + (["--live-data-poll-rate", live_data_poll_rate] if live_data_poll_rate else [])
+                + args
+            )
+            daemon_process = open_ipc_subprocess(
+                [
+                    sys.executable,
+                    "-m",
+                    "dagster._daemon",
+                    "run",
+                    "--log-level",
+                    log_level,
+                    "--log-format",
+                    log_format,
                 ]
+                + args
+            )
+            try:
+                while True:
+                    time.sleep(_CHECK_SUBPROCESS_INTERVAL)
 
-                if kwargs.get("use_ssl"):
-                    args.extend(["--use-ssl"])
+                    if webserver_process.poll() is not None:
+                        raise Exception(
+                            "dagster-webserver process shut down unexpectedly with return code"
+                            f" {webserver_process.returncode}"
+                        )
 
-                webserver_process = open_ipc_subprocess(
-                    [sys.executable, "-m", "dagster_webserver"]
-                    + (["--port", port] if port else [])
-                    + (["--host", host] if host else [])
-                    + (["--dagster-log-level", log_level])
-                    + (["--log-format", log_format])
-                    + (
-                        ["--live-data-poll-rate", live_data_poll_rate]
-                        if live_data_poll_rate
-                        else []
-                    )
-                    + args
-                )
-                daemon_process = open_ipc_subprocess(
-                    [
-                        sys.executable,
-                        "-m",
-                        "dagster._daemon",
-                        "run",
-                        "--log-level",
-                        log_level,
-                        "--log-format",
-                        log_format,
-                    ]
-                    + args
-                )
+                    if daemon_process.poll() is not None:
+                        raise Exception(
+                            "dagster-daemon process shut down unexpectedly with return code"
+                            f" {daemon_process.returncode}"
+                        )
+
+            except KeyboardInterrupt:
+                logger.info("KeyboardInterrupt received")
+            except:
+                logger.exception("An unexpected exception has occurred")
+            finally:
+                logger.info("Shutting down Dagster services...")
+                interrupt_ipc_subprocess(daemon_process)
+                interrupt_ipc_subprocess(webserver_process)
+
                 try:
-                    while True:
-                        time.sleep(_CHECK_SUBPROCESS_INTERVAL)
+                    webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "dagster-webserver process did not terminate cleanly, killing the process"
+                    )
+                    webserver_process.kill()
 
-                        if webserver_process.poll() is not None:
-                            raise Exception(
-                                "dagster-webserver process shut down unexpectedly with return code"
-                                f" {webserver_process.returncode}"
-                            )
+                try:
+                    daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "dagster-daemon process did not terminate cleanly, killing the process"
+                    )
+                    daemon_process.kill()
 
-                        if daemon_process.poll() is not None:
-                            raise Exception(
-                                "dagster-daemon process shut down unexpectedly with return code"
-                                f" {daemon_process.returncode}"
-                            )
-
-                except KeyboardInterrupt:
-                    logger.info("KeyboardInterrupt received")
-                except:
-                    logger.exception("An unexpected exception has occurred")
-                finally:
-                    logger.info("Shutting down Dagster services...")
-                    interrupt_ipc_subprocess(daemon_process)
-                    interrupt_ipc_subprocess(webserver_process)
-
-                    try:
-                        webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-                    except subprocess.TimeoutExpired:
-                        logger.warning(
-                            "dagster-webserver process did not terminate cleanly, killing the process"
-                        )
-                        webserver_process.kill()
-
-                    try:
-                        daemon_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)
-                    except subprocess.TimeoutExpired:
-                        logger.warning(
-                            "dagster-daemon process did not terminate cleanly, killing the process"
-                        )
-                        daemon_process.kill()
-
-                    logger.info("Dagster services shut down.")
+                logger.info("Dagster services shut down.")
 
 
 @contextmanager
@@ -241,3 +243,57 @@ def _temp_grpc_socket_workspace_file(context: WorkspaceProcessContext) -> Iterat
         temp_file.write(yaml.dump({"load_from": context.get_code_server_specs()}))
         temp_file.flush()
         yield temp_file.name
+
+
+@contextmanager
+def _optionally_create_temp_workspace(
+    *,
+    use_legacy_code_server_behavior: bool,
+    orig_kwargs: Mapping[str, ClickArgValue],
+    instance: DagsterInstance,
+    code_server_log_level: str,
+) -> Iterator[Sequence[str]]:
+    """If not in legacy mode, spin up grpc servers and write a workspace file pointing at them.
+    If in legacy mode, do nothing and return the target args.
+    """
+    if not use_legacy_code_server_behavior:
+        workspace_target = get_workspace_load_target(orig_kwargs)
+        with WorkspaceProcessContext(
+            instance,
+            workspace_target,
+            server_command=GrpcServerCommand.CODE_SERVER_START,
+        ) as context:
+            with _temp_grpc_socket_workspace_file(context) as workspace_file:
+                yield ["--workspace", workspace_file]
+    else:
+        # sanity check workspace args
+        get_workspace_load_target(orig_kwargs)
+        yield _find_targets_in_kwargs(orig_kwargs)
+
+
+def _find_targets_in_kwargs(kwargs: Mapping[str, ClickArgValue]) -> Sequence[str]:
+    args = []
+    if kwargs.get("workspace"):
+        for workspace in check.tuple_elem(kwargs, "workspace"):
+            args.extend(("--workspace", workspace))
+
+    if kwargs.get("python_file"):
+        for python_file in check.tuple_elem(kwargs, "python_file"):
+            args.extend(("--python-file", python_file))
+
+    if kwargs.get("module_name"):
+        for module_name in check.tuple_elem(kwargs, "module_name"):
+            args.extend(("--module-name", module_name))
+
+    if kwargs.get("working_directory"):
+        args.extend(("--working-directory", check.str_elem(kwargs, "working_directory")))
+
+    if kwargs.get("grpc_port"):
+        args.extend(("--grpc-port", str(kwargs["grpc_port"])))
+
+    if kwargs.get("grpc_host"):
+        args.extend(("--grpc-host", str(kwargs["grpc_host"])))
+
+    if kwargs.get("grpc_socket"):
+        args.extend(("--grpc-socket", str(kwargs["grpc_socket"])))
+    return args

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -295,7 +295,8 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
 
 # Different storage name for backcompat
 @whitelist_for_serdes(
-    storage_name="GrpcServerRepositoryLocationOrigin", skip_when_empty_fields={"use_ssl"}
+    storage_name="GrpcServerRepositoryLocationOrigin",
+    skip_when_empty_fields={"use_ssl", "additional_metadata"},
 )
 class GrpcServerCodeLocationOrigin(
     NamedTuple(
@@ -306,6 +307,7 @@ class GrpcServerCodeLocationOrigin(
             ("socket", Optional[str]),
             ("location_name", str),
             ("use_ssl", Optional[bool]),
+            ("additional_metadata", Optional[Mapping[str, Any]]),
         ],
     ),
     CodeLocationOrigin,
@@ -321,6 +323,7 @@ class GrpcServerCodeLocationOrigin(
         socket: Optional[str] = None,
         location_name: Optional[str] = None,
         use_ssl: Optional[bool] = None,
+        additional_metadata: Optional[Mapping[str, Any]] = None,
     ):
         return super().__new__(
             cls,
@@ -333,6 +336,7 @@ class GrpcServerCodeLocationOrigin(
                 else _assign_grpc_location_name(port, socket, host)
             ),
             use_ssl if check.opt_bool_param(use_ssl, "use_ssl") else None,
+            additional_metadata=check.opt_mapping_param(additional_metadata, "additional_metadata"),
         )
 
     def get_display_metadata(self) -> Mapping[str, str]:
@@ -340,6 +344,7 @@ class GrpcServerCodeLocationOrigin(
             "host": self.host,
             "port": str(self.port) if self.port else None,
             "socket": self.socket,
+            **(self.additional_metadata if self.additional_metadata else {}),
         }
         return {key: value for key, value in metadata.items() if value is not None}
 

--- a/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
+++ b/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
@@ -62,6 +62,10 @@ class LoadableTargetOrigin(
             )
         return ctx
 
+    @property
+    def as_dict(self) -> dict:
+        return {k: v for k, v in self._asdict().items() if v is not None}
+
 
 _current_loadable_target_origin: ContextVar[Optional[LoadableTargetOrigin]] = (
     ContextVar("_current_loadable_target_origin", default=None)

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -12,6 +12,7 @@ from dagster._config import (
     StringSource,
     process_config,
 )
+from dagster._config.field_utils import Permissive
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.merger import merge_dicts
 
@@ -88,6 +89,7 @@ WORKSPACE_CONFIG_SCHEMA = {
                             "port": Field(IntSource, is_required=False),
                             "location_name": Field(StringSource, is_required=False),
                             "ssl": Field(bool, is_required=False),
+                            "additional_metadata": Field(Permissive(), is_required=False),
                         },
                     },
                 )

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -613,6 +613,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         read_only: bool = False,
         grpc_server_registry: Optional[GrpcServerRegistry] = None,
         code_server_log_level: str = "INFO",
+        server_command: GrpcServerCommand = GrpcServerCommand.API_GRPC,
     ):
         self._stack = ExitStack()
 
@@ -646,7 +647,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             self._grpc_server_registry = self._stack.enter_context(
                 GrpcServerRegistry(
                     instance_ref=self._instance.get_ref(),
-                    server_command=GrpcServerCommand.API_GRPC,
+                    server_command=server_command,
                     heartbeat_ttl=WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
@@ -670,6 +671,31 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
     @property
     def _origins(self) -> Sequence[CodeLocationOrigin]:
         return self._workspace_load_target.create_origins() if self._workspace_load_target else []
+
+    def get_code_server_specs(self) -> Sequence[Mapping[str, Mapping[str, Any]]]:
+        result = []
+        for origin in self._origins:
+            if isinstance(origin, ManagedGrpcPythonEnvCodeLocationOrigin):
+                grpc_endpoint = self._grpc_server_registry.get_grpc_endpoint(origin)
+                server_spec = {
+                    "location_name": origin.location_name,
+                    "socket": grpc_endpoint.socket,
+                    "port": grpc_endpoint.port,
+                    "host": grpc_endpoint.host,
+                    "additional_metadata": origin.loadable_target_origin.as_dict,
+                }
+            elif isinstance(origin, GrpcServerCodeLocationOrigin):
+                server_spec = {
+                    "location_name": origin.location_name,
+                    "host": origin.host,
+                    "port": origin.port,
+                    "socket": origin.socket,
+                    "additional_metadata": origin.additional_metadata,
+                }
+            else:
+                check.failed(f"Unexpected origin type {origin}")
+            result.append({"grpc_server": {k: v for k, v in server_spec.items() if v is not None}})
+        return result
 
     def add_state_subscriber(self, subscriber: LocationStateSubscriber) -> int:
         token = next(self._state_subscriber_id_iter)

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -262,12 +262,13 @@ def _location_origin_from_grpc_server_config(
     check.mapping_param(grpc_server_config, "grpc_server_config")
     check.str_param(yaml_path, "yaml_path")
 
-    port, socket, host, location_name, use_ssl = (
+    port, socket, host, location_name, use_ssl, additional_metadata = (
         grpc_server_config.get("port"),
         grpc_server_config.get("socket"),
         grpc_server_config.get("host"),
         grpc_server_config.get("location_name"),
         grpc_server_config.get("ssl"),
+        grpc_server_config.get("additional_metadata"),
     )
 
     check.invariant(
@@ -283,6 +284,7 @@ def _location_origin_from_grpc_server_config(
         host=host,
         location_name=location_name,
         use_ssl=use_ssl,
+        additional_metadata=additional_metadata,
     )
 
 

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -241,8 +241,12 @@ class DagsterProxyApiServicer(DagsterApiServicer):
     def Ping(self, request, context):
         return self._query("Ping", request, context)
 
-    def GetServerId(self, request, context):
-        return self._fixed_server_id or self._query("GetServerId", request, context)
+    def GetServerId(self, request, context) -> api_pb2.GetServerIdReply:
+        return (
+            api_pb2.GetServerIdReply(server_id=self._fixed_server_id)
+            if self._fixed_server_id
+            else self._query("GetServerId", request, context)
+        )
 
     def GetCurrentImage(self, request, context):
         return self._query("GetCurrentImage", request, context)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -121,6 +121,10 @@ _METRICS_LOCK = threading.Lock()
 METRICS_RETRIEVAL_FUNCTIONS = set()
 
 
+def get_auto_restart_code_server_interval() -> int:
+    return int(os.getenv("DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL", "30"))
+
+
 class GrpcApiMetrics(TypedDict):
     current_request_count: Optional[int]
 
@@ -1511,47 +1515,81 @@ class GrpcServerProcess:
             "If set to None, the server will use the gRPC default.",
         )
 
-        if seven.IS_WINDOWS or force_port:
+        self._server_command = server_command
+        self._force_port = force_port
+        self._instance_ref = instance_ref
+        self._location_name = location_name
+        self._max_retries = max_retries
+        self._max_workers = max_workers
+        self._loadable_target_origin = loadable_target_origin
+        self._heartbeat_timeout = heartbeat_timeout
+        self._fixed_server_id = fixed_server_id
+        self._startup_timeout = startup_timeout
+        self._cwd = cwd
+        self._log_level = log_level
+        self._env = env
+        self._inject_env_vars_from_instance = inject_env_vars_from_instance
+        self._container_image = container_image
+        self._container_context = container_context
+        self._additional_timeout_msg = additional_timeout_msg
+        self.socket = None
+        self.port = None
+        self.start_server_process()
+
+        self._wait_on_exit = wait_on_exit
+
+        # In the case of the `dagster code-server start` entrypoint, the proxy server will not automatically restart if it crashes. Thus, we need to implement a mechanism to automatically restart the server if it crashes.
+        self.__auto_restart_thread = None
+        self.__shutdown_event = threading.Event()
+        if server_command == GrpcServerCommand.CODE_SERVER_START:
+            self.__auto_restart_thread = threading.Thread(
+                target=self.auto_restart_thread, daemon=True
+            )
+            self.__auto_restart_thread.start()
+
+    def start_server_process(self):
+        if (seven.IS_WINDOWS or self._force_port) and self.port is None:
             server_process, self.port = _open_server_process_on_dynamic_port(
-                instance_ref=instance_ref,
-                location_name=location_name,
-                max_retries=max_retries,
-                loadable_target_origin=loadable_target_origin,
-                max_workers=max_workers,
-                heartbeat=heartbeat,
-                heartbeat_timeout=heartbeat_timeout,
-                fixed_server_id=fixed_server_id,
-                startup_timeout=startup_timeout,
-                cwd=cwd,
-                log_level=log_level,
-                env=env,
-                inject_env_vars_from_instance=inject_env_vars_from_instance,
-                container_image=container_image,
-                container_context=container_context,
-                additional_timeout_msg=additional_timeout_msg,
+                instance_ref=self._instance_ref,
+                location_name=self._location_name,
+                max_retries=self._max_retries,
+                loadable_target_origin=self._loadable_target_origin,
+                max_workers=self._max_workers,
+                heartbeat=self._heartbeat,
+                heartbeat_timeout=self._heartbeat_timeout,
+                fixed_server_id=self._fixed_server_id,
+                startup_timeout=self._startup_timeout,
+                cwd=self._cwd,
+                log_level=self._log_level,
+                env=self._env,
+                inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                container_image=self._container_image,
+                container_context=self._container_context,
+                additional_timeout_msg=self._additional_timeout_msg,
             )
         else:
-            self.socket = safe_tempfile_path_unmanaged()
+            if self.socket is None and self.port is None:
+                self.socket = safe_tempfile_path_unmanaged()
 
             server_process = open_server_process(
-                instance_ref=instance_ref,
-                location_name=location_name,
-                server_command=server_command,
-                port=None,
+                instance_ref=self._instance_ref,
+                location_name=self._location_name,
+                server_command=self._server_command,
+                port=self.port,
                 socket=self.socket,
-                loadable_target_origin=loadable_target_origin,
-                max_workers=max_workers,
-                heartbeat=heartbeat,
-                heartbeat_timeout=heartbeat_timeout,
-                fixed_server_id=fixed_server_id,
-                startup_timeout=startup_timeout,
-                cwd=cwd,
-                log_level=log_level,
-                env=env,
-                inject_env_vars_from_instance=inject_env_vars_from_instance,
-                container_image=container_image,
-                container_context=container_context,
-                additional_timeout_msg=additional_timeout_msg,
+                loadable_target_origin=self._loadable_target_origin,
+                max_workers=self._max_workers,
+                heartbeat=self._heartbeat,
+                heartbeat_timeout=self._heartbeat_timeout,
+                fixed_server_id=self._fixed_server_id,
+                startup_timeout=self._startup_timeout,
+                cwd=self._cwd,
+                log_level=self._log_level,
+                env=self._env,
+                inject_env_vars_from_instance=self._inject_env_vars_from_instance,
+                container_image=self._container_image,
+                container_context=self._container_context,
+                additional_timeout_msg=self._additional_timeout_msg,
             )
 
         if server_process is None:
@@ -1559,7 +1597,16 @@ class GrpcServerProcess:
         else:
             self._server_process = server_process
 
-        self._wait_on_exit = wait_on_exit
+    def auto_restart_thread(self):
+        while True:
+            time.sleep(get_auto_restart_code_server_interval())
+            if self.__shutdown_event.is_set():
+                break
+            if self._server_process and self._server_process.poll() is not None:
+                logging.getLogger(__name__).warning(
+                    f"Code server process has exited with code {self._server_process.poll()}. Restarting the code server process."
+                )
+                self.start_server_process()
 
     @property
     def server_process(self):
@@ -1584,6 +1631,9 @@ class GrpcServerProcess:
             self.wait()
 
     def shutdown_server(self):
+        self.__shutdown_event.set()
+        if self.__auto_restart_thread:
+            self.__auto_restart_thread.join()
         if self._server_process and not self._shutdown:
             self._shutdown = True
             if self.server_process.poll() is None:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import threading
 import time
@@ -6,6 +7,7 @@ from unittest import mock
 import pytest
 from dagster import file_relative_path, job, repository
 from dagster._core.errors import DagsterUserCodeProcessError
+from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.origin import (
@@ -15,6 +17,8 @@ from dagster._core.remote_representation.origin import (
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
+from dagster._utils import get_terminate_signal
+from dagster._utils.env import environ
 
 
 @job
@@ -97,6 +101,36 @@ def test_error_repo_in_registry(instance):
                 instance=instance,
             ):
                 pass
+
+
+def test_server_unexpectedly_killed(instance: DagsterInstance):
+    with environ({"DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL": "1"}):
+        origin = ManagedGrpcPythonEnvCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                attribute="repo",
+                python_file=file_relative_path(__file__, "test_grpc_server_registry.py"),
+            ),
+        )
+
+        with GrpcServerRegistry(
+            server_command=GrpcServerCommand.CODE_SERVER_START,
+            instance_ref=instance.get_ref(),
+            heartbeat_ttl=10,
+            startup_timeout=5,
+            wait_for_processes_on_shutdown=True,
+        ) as registry:
+            endpoint_one = registry.get_grpc_endpoint(origin)
+
+            assert _can_connect(origin, endpoint_one, instance)
+
+            # Kill the server process. A new server should be automatically started.
+            process = registry._all_processes[0]  # noqa: SLF001
+            pid = process.pid
+            os.kill(pid, get_terminate_signal())
+            time.sleep(5)
+            endpoint_one = registry.get_grpc_endpoint(origin)
+            assert _can_connect(origin, endpoint_one, instance)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Same as https://app.graphite.dev/github/pr/dagster-io/dagster/26818/Use-a-single-code-server just for running windows tests

## Changelog
- Previously, the `dagster dev` command would spin up two separate processes for each code location - one for the daemon, and one for the webserver. We've consolidated this to spin up a single set of processes that are used across both the daemon and webserver.