### PR TITLE
[components][fix] Fix issue with additional scope determination

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/metadata.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/metadata.py
@@ -65,7 +65,9 @@ def _subschemas_on_path(
     # List[ComplexType] (e.g.) will contain a reference to the complex type schema in the
     # top-level $defs, so we dereference it here.
     if "$ref" in subschema:
-        subschema = json_schema["$defs"].get(subschema["$ref"][len(REF_BASE) :])
+        # depending on the pydantic version, the extras may be stored with the reference or not
+        extras = {k: v for k, v in subschema.items() if k != "$ref"}
+        subschema = {**json_schema["$defs"].get(subschema["$ref"][len(REF_BASE) :]), **extras}
 
     yield subschema
     if len(valpath) == 0:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
@@ -70,8 +70,8 @@ def test_allow_render(path, expected: bool) -> None:
         (["inner_seq"], set()),
         (["container_optional_scoped"], {"a", "b"}),
         (["container_optional_scoped", "inner"], {"a", "b"}),
-        # (["container_optional_scoped", "inner_scoped"], {"a", "b", "c", "d"}),
-        # (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d"}),
+        (["container_optional_scoped", "inner_scoped"], {"a", "b", "c", "d"}),
+        (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d"}),
     ],
 )
 def test_get_available_scope(path, expected: Set[str]) -> None:


### PR DESCRIPTION
## Summary & Motivation

Fixes a weird issue I ran into. In essence, in pydantic 3.8.x, the generated json schema will have the `json_schema_extras` stored on dereferenced json schemas of any subtype, whereas in 3.10.x, the extras will be stored on the reference itself. No idea why this is different but it is what it is.


## How I Tested These Changes

## Changelog

NOCHANGELOG
