### PR TITLE
add pull policy kwarg to execute_docker_container

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -127,7 +127,7 @@ def execute_docker_container(
     container_context = run_container_context.merge(op_container_context)
 
     client = _get_client(container_context)
-    existing_images = [tag for image in client.images for tag in image.tags]
+    existing_images = [tag for image in client.images.list() for tag in image.tags]
 
     if pull_policy == "always" or (
         pull_policy == "if_not_present" and image not in existing_images

--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -129,12 +129,12 @@ def execute_docker_container(
     client = _get_client(container_context)
     existing_images = [tag for image in client.images for tag in image.tags]
 
-    if pull_policy == "always" or (pull_policy == "if_not_present" and image not in existing_images):
+    if pull_policy == "always" or (
+        pull_policy == "if_not_present" and image not in existing_images
+    ):
         client.images.pull(image)
 
-    container = _create_container(
-        context, client, container_context, image, entrypoint, command
-    )
+    container = _create_container(context, client, container_context, image, entrypoint, command)
 
     if len(container_context.networks) > 1:
         for network_name in container_context.networks[1:]:

--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -1,5 +1,6 @@
+import enum
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import docker
 import docker.errors
@@ -73,6 +74,12 @@ def _create_container(
     )
 
 
+class DockerPullPolicy(enum.Enum):
+    ALWAYS = enum.auto()
+    IF_NOT_PRESENT = enum.auto()
+    NEVER = enum.auto()
+
+
 @experimental
 def execute_docker_container(
     context: OpExecutionContext,
@@ -82,7 +89,7 @@ def execute_docker_container(
     networks: Optional[Sequence[str]] = None,
     registry: Optional[Mapping[str, str]] = None,
     env_vars: Optional[Sequence[str]] = None,
-    pull_policy: Literal["always", "if_not_present", "never"] = "if_not_present",
+    pull_policy: DockerPullPolicy = DockerPullPolicy.IF_NOT_PRESENT,
     container_kwargs: Optional[Mapping[str, Any]] = None,
 ):
     """This function is a utility for executing a Docker container from within a Dagster op.
@@ -100,10 +107,10 @@ def execute_docker_container(
         env_vars (Optional[Sequence[str]]): List of environment variables to include in the launched
             container. Each can be of the form KEY=VALUE or just KEY (in which case the value will be
             pulled from the calling environment.
-        pull_policy (Literal["always", "if_not_present", "never"]): What pull policy to use.
-            `always` will always pull the image before launching the container, `if_not_present` will
-            only pull it if the image is not found, and `never` will never pull the image and relies
-            on the image already existing on the host. Default: `if_not_present`.
+        pull_policy (DockerPullPolicy): What pull policy to use.
+            `ALWAYS` will always pull the image before launching the container, `IF_NOT_PRESENT` will
+            only pull it if the image is not found, and `NEVER` will never pull the image and relies
+            on the image already existing on the host. Default: `IF_NOT_PRESENT`.
         container_kwargs (Optional[Dict[str[Any]]]): key-value pairs that can be passed into
             containers.create in the Docker Python API. See
             https://docker-py.readthedocs.io/en/stable/containers.html for the full list
@@ -127,14 +134,22 @@ def execute_docker_container(
     container_context = run_container_context.merge(op_container_context)
 
     client = _get_client(container_context)
-    existing_images = [tag for image in client.images.list() for tag in image.tags]
 
-    if pull_policy == "always" or (
-        pull_policy == "if_not_present" and image not in existing_images
-    ):
+    if pull_policy == DockerPullPolicy.ALWAYS:
         client.images.pull(image)
 
-    container = _create_container(context, client, container_context, image, entrypoint, command)
+    try:
+        container = _create_container(
+            context, client, container_context, image, entrypoint, command
+        )
+    except docker.errors.ImageNotFound as e:
+        if pull_policy == DockerPullPolicy.IF_NOT_PRESENT:
+            client.images.pull(image)
+            container = _create_container(
+                context, client, container_context, image, entrypoint, command
+            )
+        elif pull_policy == DockerPullPolicy.NEVER:
+            raise e
 
     if len(container_context.networks) > 1:
         for network_name in container_context.networks[1:]:


### PR DESCRIPTION
## Summary & Motivation

When using `execute_docker_container`, by default, it uses a "pull image if not present" policy. However, there are situations where a user might want to always pull an image, or never pull it (and error out if the image is not present).

I added an optional keyword argument `pull_policy` to `execute_docker_container` which controls this functionality.

## How I Tested These Changes

Edited my local install to apply this patch and used all three values for the kwarg + verified the behavior was as described in the added documentation.