### PR TITLE
[dagster-dbt] Refactor UnitTestDefinition instantiation in utils.py to use `from_dict` method

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -548,7 +548,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt17", "dbt18"]
+            for deps_factor in ["dbt17", "dbt18", "dbt19"]
             for command_factor in ["cloud", "core-main", "core-derived-metadata"]
         ],
     ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -51,7 +51,7 @@ def select_unique_ids_from_manifest(
             {
                 "unit_tests": {
                     # unit test nodes must be of type UnitTestDefinition
-                    unique_id: UnitTestDefinition(**info)
+                    unique_id: UnitTestDefinition.from_dict(info)
                     for unique_id, info in manifest_json["unit_tests"].items()
                 },
             }

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -26,6 +26,10 @@ deps =
   dbt18: dbt-duckdb==1.8.*
   dbt18: dbt-snowflake==1.8.*
   dbt18: dbt-bigquery==1.8.*
+  dbt19: dbt-core==1.9.*
+  dbt19: dbt-duckdb==1.9.*
+  dbt19: dbt-snowflake==1.9.*
+  dbt19: dbt-bigquery==1.9.*
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
Fixed: https://github.com/dagster-io/dagster/issues/27007

## Summary & Motivation

Today I upgraded dbt to 1.9.1 but encountered an error while running dagster.
In the end, I found that UnitTestDefinition was not properly parsed.

In dbt, [this is also how they create UnitTestDefinition](https://github.com/dbt-labs/dbt-core/blob/8a8857a85c0cc66c7e3de9eb7e9ca7fd63d553a4/core/dbt/parser/unit_tests.py#L609).

Here are the details:

Updated the instantiation of UnitTestDefinition in the `__getattr__`
method to utilize the from_dict method instead of the constructor. This
change enhances the clarity and consistency of the code when handling
unit test nodes from the manifest JSON.


## How I Tested These Changes

Verified `test_dbt_with_unit_tests()` passes with both `fqn:*` and `tag:test` selectors.

https://github.com/dagster-io/dagster/blob/652af9acd0495eea8b66646cad2db5fce9079151/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py#L1145-L1162
