### PR TITLE
[docs-beta] show no logo instead of placeholder if none is defined

### DIFF
--- a/docs/docs-beta/src/theme/DocCard/index.tsx
+++ b/docs/docs-beta/src/theme/DocCard/index.tsx
@@ -1,20 +1,14 @@
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import {
-  useDocById,
-  findFirstSidebarItemLink,
-} from '@docusaurus/plugin-content-docs/client';
+import {useDocById, findFirstSidebarItemLink} from '@docusaurus/plugin-content-docs/client';
 import {usePluralForm} from '@docusaurus/theme-common';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import {translate} from '@docusaurus/Translate';
 
 import type {Props} from '@theme/DocCard';
 import Heading from '@theme/Heading';
-import type {
-  PropSidebarItemCategory,
-  PropSidebarItemLink,
-} from '@docusaurus/plugin-content-docs';
+import type {PropSidebarItemCategory, PropSidebarItemLink} from '@docusaurus/plugin-content-docs';
 
 import styles from './styles.module.css';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -47,7 +41,6 @@ function CardContainer({href, children}: {href: string; children: ReactNode}): R
   );
 }
 
-
 function truncate(text: string, max: number) {
   return text.length > max ? text.slice(0, max).split(' ').slice(0, -1).join(' ') + ' ...' : text;
 }
@@ -63,15 +56,13 @@ function CardLayout({
   logo?: string;
   description?: string;
 }): ReactNode {
-  const logoUrl = logo || 'images/integrations/placeholder_64x64.svg';
-
   return (
     <CardContainer href={href}>
       <div style={{display: 'flex', flexDirection: 'row', gap: '12px'}}>
-        <div style={{flex: '0 0 64px'}}>
-          <img src={useBaseUrl(logoUrl)} style={{display: 'block', width: '64px', height: '64px'}} />
+        <div style={{flex: '0 0 64px', display: logo ? 'block' : 'none'}}>
+          <img src={useBaseUrl(logo)} style={{display: 'block', width: '64px', height: '64px'}} />
         </div>
-        <div style={{}}>
+        <div>
           <Heading as="h2" className={clsx('', styles.cardTitle)} title={title}>
             {title}
           </Heading>
@@ -85,7 +76,6 @@ function CardLayout({
     </CardContainer>
   );
 }
-
 
 function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
   const href = findFirstSidebarItemLink(item);

--- a/docs/docs-beta/static/images/integrations/placeholder_64x64.svg
+++ b/docs/docs-beta/static/images/integrations/placeholder_64x64.svg
@@ -1,1 +1,0 @@
-<svg width="64" height="64" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="2" width="60" height="60" style="fill:#DEDEDE;stroke:#555555;stroke-width:2"/><text x="50%" y="50%" font-size="18" text-anchor="middle" alignment-baseline="middle" font-family="monospace, sans-serif" fill="#555555"></text></svg>


### PR DESCRIPTION
## Summary & Motivation

Instead of showing a placeholder image, show no logo at all if one is not defined.

**Before**
<img width="533" alt="image" src="https://github.com/user-attachments/assets/29aa6a77-09fe-43d0-8d4d-84489ae51ad7" />

**After**
<img width="524" alt="image" src="https://github.com/user-attachments/assets/7a8adc3b-85dd-4d75-8922-cf75bd2a182a" />


## How I Tested These Changes

## Changelog

NOCHANGELOG
