### PR TITLE
[dagster-embedded-elt] Mark dagster-embedded-elt as deprecated

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/__init__.py
@@ -1,5 +1,12 @@
 from dagster._core.libraries import DagsterLibraryRegistry
+from dagster._utils.warnings import deprecation_warning
 
 from dagster_embedded_elt.version import __version__
+
+deprecation_warning(
+    "The `dagster-embedded-elt` library",
+    "0.26",
+    additional_warn_text="Use `dagster-dlt` and `dagster-sling` instead.",
+)
 
 DagsterLibraryRegistry.register("dagster-embedded-elt", __version__)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/__init__.py
@@ -1,5 +1,13 @@
+from dagster._utils.warnings import deprecation_warning
+
 from dagster_embedded_elt.dlt.asset_decorator import build_dlt_asset_specs, dlt_assets
 from dagster_embedded_elt.dlt.resource import DagsterDltResource
 from dagster_embedded_elt.dlt.translator import DagsterDltTranslator
+
+deprecation_warning(
+    "The `dagster-embedded-elt` library",
+    "0.26",
+    additional_warn_text="Use `dagster-dlt` instead.",
+)
 
 __all__ = ["DagsterDltResource", "DagsterDltTranslator", "build_dlt_asset_specs", "dlt_assets"]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
@@ -1,7 +1,15 @@
+from dagster._utils.warnings import deprecation_warning
+
 from dagster_embedded_elt.sling.asset_decorator import sling_assets
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingMode, SlingResource
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam
+
+deprecation_warning(
+    "The `dagster-embedded-elt` library",
+    "0.26",
+    additional_warn_text="Use `dagster-sling` instead.",
+)
 
 __all__ = [
     "DagsterSlingTranslator",


### PR DESCRIPTION
## Summary & Motivation

Deprecate dagster-embedded-elt in favor of dagster-dlt and dagster-sling. Both libraries are added in subsequent PRs to avoid PRs with substantial number of files changes.

## Changelog

[dagster-embedded-elt] the `dagster-embedded-elt` library is deprecated in favor of `dagster-dlt` and `dagster-sling`.
