### PR TITLE
[ui] Virtualize timeline run popover list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -6,6 +6,7 @@ import {
   MiddleTruncate,
   Mono,
   Popover,
+  Row,
   Spinner,
   Tag,
   Tooltip,
@@ -810,8 +811,19 @@ interface RunHoverContentProps {
 
 const RunHoverContent = (props: RunHoverContentProps) => {
   const {row, batch} = props;
-  const sliced = batch.runs.slice(0, 50);
-  const remaining = batch.runs.length - sliced.length;
+  const count = batch.runs.length;
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (_: number) => ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  const totalHeight = virtualizer.getTotalSize();
+  const items = virtualizer.getVirtualItems();
+  const height = Math.min(count * ROW_HEIGHT, 240);
 
   return (
     <Box style={{width: '260px'}}>
@@ -819,37 +831,49 @@ const RunHoverContent = (props: RunHoverContentProps) => {
         <RunTimelineRowIcon type={row.type} />
         <HoverContentRowName>{row.name}</HoverContentRowName>
       </Box>
-      <div style={{maxHeight: '240px', overflowY: 'auto'}}>
-        {sliced.map((run, ii) => (
-          <Box
-            key={run.id}
-            border={ii > 0 ? 'top' : null}
-            flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-            padding={{vertical: 8, horizontal: 12}}
-          >
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <RunStatusDot status={run.status} size={8} />
-              {run.status === 'SCHEDULED' ? (
-                'Scheduled'
-              ) : (
-                <Link to={`/runs/${run.id}`}>
-                  <Mono>{run.id.slice(0, 8)}</Mono>
-                </Link>
-              )}
-            </Box>
-            <Mono>
-              {run.status === 'SCHEDULED' ? (
-                <TimestampDisplay timestamp={run.startTime / 1000} />
-              ) : (
-                <TimeElapsed startUnix={run.startTime / 1000} endUnix={run.endTime / 1000} />
-              )}
-            </Mono>
-          </Box>
-        ))}
+      <div style={{height, overflowY: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const run = batch.runs[index]!;
+              return (
+                <Row key={key} $height={size} $start={start}>
+                  <Box
+                    key={key}
+                    border={index > 0 ? 'top' : null}
+                    flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+                    padding={{vertical: 8, horizontal: 12}}
+                  >
+                    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                      <RunStatusDot status={run.status} size={8} />
+                      {run.status === 'SCHEDULED' ? (
+                        'Scheduled'
+                      ) : (
+                        <Link to={`/runs/${run.id}`}>
+                          <Mono>{run.id.slice(0, 8)}</Mono>
+                        </Link>
+                      )}
+                    </Box>
+                    <Mono>
+                      {run.status === 'SCHEDULED' ? (
+                        <TimestampDisplay timestamp={run.startTime / 1000} />
+                      ) : (
+                        <TimeElapsed
+                          startUnix={run.startTime / 1000}
+                          endUnix={run.endTime / 1000}
+                        />
+                      )}
+                    </Mono>
+                  </Box>
+                </Row>
+              );
+            })}
+          </Inner>
+        </Container>
       </div>
-      {remaining > 0 ? (
-        <Box padding={12} border="top">
-          <Link to={`${row.path}/runs`}>+ {remaining} more</Link>
+      {row.path ? (
+        <Box padding={12} border="top" flex={{direction: 'row', justifyContent: 'center'}}>
+          <Link to={`${row.path}/runs`}>View all</Link>
         </Box>
       ) : null}
     </Box>


### PR DESCRIPTION
## Summary & Motivation

The "+X more" link in the timeline popover is broken for segments for  "Ad hoc materializations" and automations without specific code objects.

Remove the link and virtualize the list instead.

## How I Tested These Changes

View a timeline that has chunks with lots of runs in them. Hover, verify that the virtualized list renders and behaves properly.

Find a chunk with just a couple of runs, verify that the popover height is not excessive.

## Changelog

[ui] In the run timeline, replace the "+ more" link in the hover popover by displaying all run IDs and timings in the list.