### PR TITLE
dont dockerignore .yarn

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .git/
 **/.tox/
-**/.yarn/
 **/__pycache__/
 **/*.egg-info/
 **/node_modules/


### PR DESCRIPTION
.yarn is checked in and should be copied over to access the yarn executable