### PR TITLE
Section on schema change

### DIFF
--- a/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
+++ b/docs/content/concepts/metadata-tags/asset-metadata/table-metadata.mdx
@@ -126,6 +126,38 @@ Column lineage enables data and analytics engineers alike to understand how a co
 
 ---
 
+## Ensuring table schema consistency
+
+When column schemas are defined at runtime through materialization metadata, it can be helpful to detect and alert on schema changes between materializations. Dagster provides <PyObject object="build_column_schema_change_checks"/> API to help detect these changes.
+
+This function creates asset checks which compare the current materialization's schema against the schema from the previous materialization. These checks can detect:
+
+- Added columns
+- Removed columns
+- Changed column types
+
+Let's define a column schema change check for our asset from the example above that defines table schema at runtime, `my_other_asset`.
+
+```python file=/concepts/metadata-tags/schema_change_checks.py startafter=start_check endbefore=end_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(
+    assets=[my_other_asset]
+)
+```
+
+If any schema changes are detected between materializations, they will be reported in the asset's check results in the Dagster UI. This can help catch unexpected schema changes and prevent downstream issues.
+
+### Alerting on schema change (Dagster+ only)
+
+In Dagster+, you can set up alerts to notify you when assets have had a schema change. By default, schema change checks will fail with a severity of `WARN`, but you can override this to fail with `ERROR`.
+
+To alert on schema changes, create an alert policy with the following settings:
+
+<AssetCheckAlerts />
+
+---
+
 ## APIs in this guide
 
 | Name                                         | Description                                                      |

--- a/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
+++ b/examples/docs_snippets/docs_snippets/concepts/metadata-tags/schema_change_checks.py
@@ -1,0 +1,13 @@
+from dagster import asset
+
+
+@asset
+def my_other_asset(): ...
+
+
+# start_check
+from dagster import build_column_schema_change_checks
+
+schema_checks = build_column_schema_change_checks(assets=[my_other_asset])
+
+# end_check


### PR DESCRIPTION
## Summary & Motivation
Adds a section to the "table metadata" doc on column schema change checks, which are highly relevant to the section but not otherwise mentioned in the documentation.
## How I Tested These Changes
Docs site + eyes
## Changelog
- A new docs section has been added on checking for columnar schema changes. This can be found in: https://docs.dagster.io/concepts/metadata-tags/asset-metadata/table-metadata#table-metadata
