### PR TITLE
[dg][cli] augment certain pyright errors for dg check

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
@@ -13,6 +13,7 @@ class ComponentValidationTestCase:
     component_type_filepath: Path
     should_error: bool
     validate_error_msg: Optional[Callable[[str], None]] = None
+    validate_error_msg_additional_cli: Optional[Callable[[str], None]] = None
 
 
 def msg_includes_all_of(*substrings: str) -> Callable[[str], None]:
@@ -36,7 +37,10 @@ BASIC_MISSING_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_missing_value",
     component_type_filepath=Path(__file__).parent / "basic_components.py",
     should_error=True,
-    validate_error_msg=msg_includes_all_of("component.yaml:4", "params.an_int", "Field required"),
+    validate_error_msg=msg_includes_all_of("component.yaml:4", "params.an_int", "required"),
+    validate_error_msg_additional_cli=msg_includes_all_of(
+        "Field `an_int` is required but not provided"
+    ),
 )
 
 COMPONENT_VALIDATION_TEST_CASES = [
@@ -73,7 +77,10 @@ COMPONENT_VALIDATION_TEST_CASES = [
         component_type_filepath=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
-            "component.yaml:6", "params.nested.foo.an_int", "Field required"
+            "component.yaml:6", "params.nested.foo.an_int", "required"
+        ),
+        validate_error_msg_additional_cli=msg_includes_all_of(
+            "Field `a_string` is required but not provided"
         ),
     ),
     ComponentValidationTestCase(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -76,6 +76,9 @@ def test_validation_cli(test_case: ComponentValidationTestCase) -> None:
 
                 assert test_case.validate_error_msg
                 test_case.validate_error_msg(str(result.stdout))
+
+                if test_case.validate_error_msg_additional_cli:
+                    test_case.validate_error_msg_additional_cli(str(result.stdout))
             else:
                 assert result.exit_code == 0, str(result.stdout)
 


### PR DESCRIPTION
## Summary

Some of the raw pyright errors are not very clear when displayed inline - in particular the "missing field" error, which with `dg check` renders pointing at the preceding field.

This PR updates that error message to be more direct:

Before:
```python
/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/ingest_files/component.yaml:5 - sling_replication_collection params.replications.0.path Field required
     | 
   4 |   replications:
   5 |     - {}
     |       ^ Field required
     | 
```

After:
```python
/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/ingest_files/component.yaml:5 - sling_replication_collection params.replications.0.path Field required
     | 
   4 |   replications:
   5 |     - {}
     |       ^ Field `path` is required but not provided
     |
```

## How I Tested These Changes

Update unit tests.
