### PR TITLE
[dg][cli] Properly augment top-level ComponentFileModel Pydantic errors

### DIFF
--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -41,13 +41,23 @@ def _parse_and_populate_model_with_annotated_errors(
         line_errors = []
         for error in e.errors():
             key_path_in_obj = list(error["loc"])
-            source_position = obj_parse_root.source_position_tree.lookup(key_path_in_obj)
+            source_position, source_position_path = (
+                obj_parse_root.source_position_tree.lookup_closest_and_path(key_path_in_obj, None)
+            )
 
             file_key_path: KeyPath = list(obj_key_path_prefix) + key_path_in_obj
             file_key_path_str = ".".join(str(part) for part in file_key_path)
+            ctx = {
+                **error.get("ctx", {}),
+                "source_position": source_position,
+                "source_position_path": source_position_path,
+            }
             line_errors.append(
-                {**error, "loc": [file_key_path_str + " at " + str(source_position)]}
+                {**error, "loc": [file_key_path_str + " at " + str(source_position)], "ctx": ctx}
             )
+
+            file_key_path: KeyPath = list(obj_key_path_prefix) + key_path_in_obj
+            file_key_path_str = ".".join(str(part) for part in file_key_path)
 
         raise ValidationError.from_exception_data(
             title=e.title,

--- a/python_modules/libraries/dagster-components/dagster_components/cli/check.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/check.py
@@ -1,7 +1,7 @@
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import click
 import typer
@@ -154,7 +154,7 @@ def check_component_command(ctx: click.Context, paths: Sequence[str]) -> None:
         )
         sys.exit(1)
 
-    validation_errors: list[tuple[type[Component], ValidationError]] = []
+    validation_errors: list[tuple[Union[type[Component], None], ValidationError]] = []
 
     context = CodeLocationProjectContext.from_code_location_path(
         find_enclosing_code_location_root_path(Path.cwd()),

--- a/python_modules/libraries/dagster-components/dagster_components/cli/check.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/check.py
@@ -72,7 +72,7 @@ OFFSET_LINES_AFTER = 3
 
 
 def error_dict_to_formatted_error(
-    component_type: type[Component], error_details: ErrorDetails
+    component_type: Optional[type[Component]], error_details: ErrorDetails
 ) -> str:
     ctx = error_details.get("ctx", {})
     source_position: SourcePosition = ctx["source_position"]
@@ -89,7 +89,7 @@ def error_dict_to_formatted_error(
             [
                 value
                 for value in reversed(list(source_position_path))
-                if value.start != source_position.start
+                if value.start.line < source_position.start.line
             ]
         ),
         source_position,
@@ -100,8 +100,9 @@ def error_dict_to_formatted_error(
 
         filtered_lines_with_line_numbers = (
             lines_with_line_numbers[
-                preceding_source_position.start.line
-                - OFFSET_LINES_BEFORE : source_position.start.line
+                max(
+                    0, preceding_source_position.start.line - OFFSET_LINES_BEFORE
+                ) : source_position.start.line
             ]
             + [
                 (
@@ -116,7 +117,6 @@ def error_dict_to_formatted_error(
                 source_position.start.line : source_position.end.line + OFFSET_LINES_AFTER
             ]
         )
-
         # Combine the filtered lines with the line numbers, and add empty lines before and after
         lines_with_line_numbers = prepend_lines_with_line_numbers(
             [(None, ""), *filtered_lines_with_line_numbers, (None, "")]
@@ -128,8 +128,10 @@ def error_dict_to_formatted_error(
         f":{typer.style(source_position.start.line, fg=typer.colors.GREEN)}"
     )
     fmt_location = typer.style(location, fg=typer.colors.BRIGHT_WHITE)
-    fmt_name = typer.style(get_component_type_name(component_type), fg=typer.colors.RED)
-    return f"{fmt_filename} - {fmt_name} {fmt_location} {error_details['msg']}\n{code_snippet}\n"
+    fmt_name = typer.style(
+        f"{get_component_type_name(component_type)} " if component_type else "", fg=typer.colors.RED
+    )
+    return f"{fmt_filename} - {fmt_name}{fmt_location} {error_details['msg']}\n{code_snippet}\n"
 
 
 @check_cli.command(name="component")
@@ -162,7 +164,12 @@ def check_component_command(ctx: click.Context, paths: Sequence[str]) -> None:
     )
 
     for instance_path in Path(context.components_path).iterdir():
-        decl_node = path_to_decl_node(path=instance_path)
+        try:
+            decl_node = path_to_decl_node(path=instance_path)
+        except ValidationError as e:
+            validation_errors.append((None, e))
+            continue
+
         if not decl_node:
             raise Exception(f"No component found at path {instance_path}")
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
@@ -1,4 +1,3 @@
 type: {}
 
-params:
-  asdfasdf
+params: asdfasdf

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
@@ -1,0 +1,4 @@
+type: {}
+
+params:
+  asdfasdf

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
@@ -95,4 +95,17 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "params.nested.baz.another_bool",
         ),
     ),
+    ComponentValidationTestCase(
+        component_path="validation/invalid_component_file_model",
+        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        should_error=True,
+        validate_error_msg=msg_includes_all_of(
+            "component.yaml:1",
+            "type",
+            "Input should be a valid string",
+            "component.yaml:4",
+            "params",
+            "Input should be an object",
+        ),
+    ),
 ]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
@@ -103,7 +103,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "component.yaml:1",
             "type",
             "Input should be a valid string",
-            "component.yaml:4",
+            "component.yaml:3",
             "params",
             "Input should be an object",
         ),


### PR DESCRIPTION
## Summary

We separately populate the Pydantic model for `ComponentFileModel` before processing the component decl itself. If we hit a yaml error here, we should print the enriched message, and handle it properly in `dg component check`

```python
/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/ingest_files/component.yaml:1 - type Input should be a valid string
     | 
   1 | type: {}
     |       ^ Input should be a valid string
   2 | 
   3 | params:
   4 |   rasdfasdf
     | 

/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/ingest_files/component.yaml:4 - params Input should be an object
     | 
   1 | type: {}
   2 | 
   3 | params:
   4 |   rasdfasdf
     |   ^ Input should be an object
     |
```

## How I Tested These Changes

New unit tests.
