### PR TITLE
Don't backfill observable assets during flood fill

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -230,6 +230,9 @@ def _build_backfill_request(
         visited.add(k)
         if isinstance(k, AssetKey):
             node = asset_graph.get(k)
+            if not node.is_materializable:
+                # if the asset is not materializable, we should not backfill it
+                return
             subset = cast(EntitySubset[AssetKey], entity_subsets_by_key.pop(k))
             backfill_subsets.append(subset)
             for sk in [

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -231,7 +231,7 @@ def _build_backfill_request(
         if isinstance(k, AssetKey):
             node = asset_graph.get(k)
             if not node.is_materializable:
-                # if the asset is not materializable, we should not backfill it
+                # if the asset is not materializable, it cannot be included in a backfill
                 return
             subset = cast(EntitySubset[AssetKey], entity_subsets_by_key.pop(k))
             backfill_subsets.append(subset)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/hourly_observable_with_partitions.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/hourly_observable_with_partitions.py
@@ -1,0 +1,21 @@
+import dagster as dg
+
+static_partitions1 = dg.StaticPartitionsDefinition(["x", "y", "z"])
+
+
+@dg.observable_source_asset(
+    automation_condition=dg.AutomationCondition.on_cron("@hourly"),
+    partitions_def=static_partitions1,
+)
+def obs() -> None: ...
+
+
+@dg.asset(
+    deps=[obs],
+    automation_condition=dg.AutomationCondition.on_cron("@hourly"),
+    partitions_def=static_partitions1,
+)
+def mat() -> None: ...
+
+
+defs = dg.Definitions(assets=[obs, mat])

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -753,3 +753,31 @@ def test_observable_source_asset() -> None:
             _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
             runs = _get_runs_for_latest_ticks(context)
             assert len(runs) == 0
+
+
+def test_observable_source_asset_is_not_backfilled() -> None:
+    with (
+        get_grpc_workspace_request_context("hourly_observable_with_partitions") as context,
+        get_threadpool_executor() as executor,
+    ):
+        asset_graph = context.create_request_context().asset_graph
+
+        time = datetime.datetime(2024, 8, 16, 1, 35)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            backfills = _get_backfills_for_latest_ticks(context)
+            assert len(backfills) == 0
+
+        time += datetime.timedelta(hours=1)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            backfills = _get_backfills_for_latest_ticks(context)
+            assert len(backfills) == 1
+            subsets_by_key = _get_subsets_by_key(backfills[0], asset_graph)
+            assert subsets_by_key.keys() == {AssetKey("mat")}
+
+        time += datetime.timedelta(minutes=1)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            backfills = _get_backfills_for_latest_ticks(context)
+            assert len(backfills) == 0

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -765,12 +765,17 @@ def test_observable_source_asset_is_not_backfilled() -> None:
         time = datetime.datetime(2024, 8, 16, 1, 35)
         with freeze_time(time):
             _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 0
             backfills = _get_backfills_for_latest_ticks(context)
             assert len(backfills) == 0
 
         time += datetime.timedelta(hours=1)
         with freeze_time(time):
             _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 3
+            assert all(run.asset_selection == {AssetKey("obs")} for run in runs)
             backfills = _get_backfills_for_latest_ticks(context)
             assert len(backfills) == 1
             subsets_by_key = _get_subsets_by_key(backfills[0], asset_graph)
@@ -779,5 +784,7 @@ def test_observable_source_asset_is_not_backfilled() -> None:
         time += datetime.timedelta(minutes=1)
         with freeze_time(time):
             _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 0
             backfills = _get_backfills_for_latest_ticks(context)
             assert len(backfills) == 0


### PR DESCRIPTION
## Summary & Motivation

DA currently creates invalid backfills that never complete when using observable source assets. The simple DA-specific workaround is we just don't do backfills from DA if there are observable source assets.

## How I Tested These Changes

Added e2e test.

## Changelog

Fix issue wherein declarative automation created (invalid) backfills for observable source assets.
