### PR TITLE
[dg][cli] augment Exceptions thrown during component load

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -218,6 +218,16 @@ def conditional_assets_repository():
 
 @repository
 def data_versions_repository():
+    from dagster import job, op
+
     from dagster_test.toys import data_versions
 
-    return cast(Sequence[AssetsDefinition], load_assets_from_modules([data_versions]))
+    @op
+    def my_op():
+        pass
+
+    @job
+    def branch():
+        pass
+
+    return cast(Sequence[AssetsDefinition], [*load_assets_from_modules([data_versions]), branch])

--- a/python_modules/libraries/dagster-components/dagster_components/cli/check.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/check.py
@@ -77,15 +77,15 @@ def stacktrace_to_formatted_error(path: str, exception_msg: str, trace: list[str
 
     idx_of_type_error = next(
         (
-            idx + 2
+            idx + 3
             for idx, line in enumerate(trace)
             if "validate_python" in line and "type_adapter.py" in line
         ),
         0,
     )
-    trace_str = "\n".join(trace[idx_of_type_error:])
-
-    return f"{path} - {exception_msg}\n{trace_str}\n{exception_msg}\n"
+    trace_str = typer.style("\n".join(trace[idx_of_type_error:]), fg=typer.colors.RED)
+    fmt_exception_msg = typer.style(exception_msg, fg=typer.colors.RED, bold=True)
+    return f"{path} - {fmt_exception_msg}\n\n{trace_str}\n{fmt_exception_msg}\n"
 
 
 def error_dict_to_formatted_error(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/load_error_component/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/load_error_component/__init__.py
@@ -1,0 +1,30 @@
+"""Sample local components for testing validation. Paired with test cases
+in integration_tests/components/validation.
+"""
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component, component_type
+from dagster_components.core.component import ComponentLoadContext
+from pydantic import BaseModel
+from typing_extensions import Self
+
+
+class LoadErrorComponentSchema(BaseModel):
+    a_string: str
+
+
+@component_type
+class LoadErrorComponent(Component):
+    name = "load_error_component"
+    params_schema = LoadErrorComponentSchema
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> Self:
+        context.load_params(cls.params_schema)
+
+        raise Exception("uh oh, something unexpected happened")
+
+        return cls()
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/load_error_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/load_error_component/component.yaml
@@ -1,0 +1,4 @@
+type: .load_error_component
+
+params:
+  a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_cases.py
@@ -10,8 +10,8 @@ class ComponentValidationTestCase:
     """
 
     component_path: str
-    component_type_filepath: Path
     should_error: bool
+    local_component_defn_to_inject: Optional[Path] = None
     validate_error_msg: Optional[Callable[[str], None]] = None
     validate_error_msg_additional_cli: Optional[Callable[[str], None]] = None
 
@@ -26,7 +26,7 @@ def msg_includes_all_of(*substrings: str) -> Callable[[str], None]:
 
 BASIC_INVALID_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_invalid_value",
-    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
     should_error=True,
     validate_error_msg=msg_includes_all_of(
         "component.yaml:5", "params.an_int", "Input should be a valid integer"
@@ -35,7 +35,7 @@ BASIC_INVALID_VALUE = ComponentValidationTestCase(
 
 BASIC_MISSING_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_missing_value",
-    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
     should_error=True,
     validate_error_msg=msg_includes_all_of("component.yaml:4", "params.an_int", "required"),
     validate_error_msg_additional_cli=msg_includes_all_of(
@@ -46,14 +46,14 @@ BASIC_MISSING_VALUE = ComponentValidationTestCase(
 COMPONENT_VALIDATION_TEST_CASES = [
     ComponentValidationTestCase(
         component_path="validation/basic_component_success",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=False,
     ),
     BASIC_INVALID_VALUE,
     BASIC_MISSING_VALUE,
     ComponentValidationTestCase(
         component_path="validation/basic_component_extra_value",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:7", "params.a_bool", "Extra inputs are not permitted"
@@ -61,7 +61,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_invalid_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:7",
@@ -74,7 +74,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_missing_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:6", "params.nested.foo.an_int", "required"
@@ -85,7 +85,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_extra_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:8",
@@ -97,7 +97,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/invalid_component_file_model",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        local_component_defn_to_inject=Path(__file__).parent / "basic_components.py",
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:1",
@@ -107,5 +107,14 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "params",
             "Input should be an object",
         ),
+    ),
+    # Handle that we can provide some extra context to non-ValidationError exception which occur
+    # in the user's load() implementation
+    ComponentValidationTestCase(
+        component_path="validation/load_error_component",
+        should_error=True,
+        validate_error_msg=msg_includes_all_of("uh oh, something unexpected happened"),
+        # The CLI is able to link the error to the component file
+        validate_error_msg_additional_cli=msg_includes_all_of("component.yaml"),
     ),
 ]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -5,7 +5,6 @@ from click.testing import CliRunner
 from dagster._core.test_utils import new_cwd
 from dagster_components.cli import cli
 from dagster_components.utils import ensure_dagster_components_tests_import
-from pydantic import ValidationError
 
 from dagster_components_tests.integration_tests.validation_tests.test_cases import (
     BASIC_INVALID_VALUE,
@@ -31,10 +30,10 @@ def test_validation_messages(test_case: ComponentValidationTestCase) -> None:
     errors.
     """
     if test_case.should_error:
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(Exception) as e:
             load_test_component_defs_inject_component(
                 str(test_case.component_path),
-                test_case.component_type_filepath,
+                test_case.local_component_defn_to_inject,
             )
 
         assert test_case.validate_error_msg
@@ -42,7 +41,7 @@ def test_validation_messages(test_case: ComponentValidationTestCase) -> None:
     else:
         load_test_component_defs_inject_component(
             str(test_case.component_path),
-            test_case.component_type_filepath,
+            test_case.local_component_defn_to_inject,
         )
 
 
@@ -58,7 +57,8 @@ def test_validation_cli(test_case: ComponentValidationTestCase) -> None:
     runner = CliRunner()
 
     with create_code_location_from_components(
-        test_case.component_path, local_component_defn_to_inject=test_case.component_type_filepath
+        test_case.component_path,
+        local_component_defn_to_inject=test_case.local_component_defn_to_inject,
     ) as tmpdir:
         with new_cwd(str(tmpdir)):
             result = runner.invoke(
@@ -100,7 +100,7 @@ def test_validation_cli_multiple_components(scope_check_run: bool) -> None:
     with create_code_location_from_components(
         BASIC_MISSING_VALUE.component_path,
         BASIC_INVALID_VALUE.component_path,
-        local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+        local_component_defn_to_inject=BASIC_MISSING_VALUE.local_component_defn_to_inject,
     ) as tmpdir:
         with new_cwd(str(tmpdir)):
             result = runner.invoke(
@@ -139,7 +139,7 @@ def test_validation_cli_multiple_components_filter() -> None:
     with create_code_location_from_components(
         BASIC_MISSING_VALUE.component_path,
         BASIC_INVALID_VALUE.component_path,
-        local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+        local_component_defn_to_inject=BASIC_MISSING_VALUE.local_component_defn_to_inject,
     ) as tmpdir:
         with new_cwd(str(tmpdir)):
             result = runner.invoke(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/utils.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
+from typing import Optional
 
 from dagster._core.definitions.definitions_class import Definitions
 
@@ -14,17 +15,18 @@ from dagster_components_tests.utils import generate_component_lib_pyproject_toml
 
 
 def _setup_component_in_folder(
-    src_path: str, dst_path: str, local_component_defn_to_inject: Path
+    src_path: str, dst_path: str, local_component_defn_to_inject: Optional[Path]
 ) -> None:
     origin_path = Path(__file__).parent.parent / "components" / src_path
 
     shutil.copytree(origin_path, dst_path, dirs_exist_ok=True)
-    shutil.copy(local_component_defn_to_inject, Path(dst_path) / "__init__.py")
+    if local_component_defn_to_inject:
+        shutil.copy(local_component_defn_to_inject, Path(dst_path) / "__init__.py")
 
 
 @contextlib.contextmanager
 def inject_component(
-    src_path: str, local_component_defn_to_inject: Path
+    src_path: str, local_component_defn_to_inject: Optional[Path]
 ) -> Generator[str, None, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
         _setup_component_in_folder(src_path, tmpdir, local_component_defn_to_inject)
@@ -33,7 +35,7 @@ def inject_component(
 
 @contextlib.contextmanager
 def create_code_location_from_components(
-    *src_paths: str, local_component_defn_to_inject: Path
+    *src_paths: str, local_component_defn_to_inject: Optional[Path]
 ) -> Generator[Path, None, None]:
     """Scaffolds a code location with the given components in a temporary directory,
     injecting the provided local component defn into each component's __init__.py.
@@ -60,7 +62,7 @@ def create_code_location_from_components(
 
 
 def load_test_component_defs_inject_component(
-    src_path: str, local_component_defn_to_inject: Path
+    src_path: str, local_component_defn_to_inject: Optional[Path]
 ) -> Definitions:
     """Loads a component from a test component project, making the provided local component defn
     available in that component's __init__.py.

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 
 class InnerRendered(ComponentSchemaBaseModel):
-    a: Optional[str] = None
+    a: Annotated[Optional[str], ResolvableFieldInfo(additional_scope={"deferred"})] = None
 
 
 class Container(BaseModel):
@@ -65,13 +65,13 @@ def test_allow_render(path, expected: bool) -> None:
     "path,expected",
     [
         (["a"], set()),
-        (["inner", "a"], set()),
-        (["container_optional", "inner", "a"], set()),
+        (["inner", "a"], {"deferred"}),
+        (["container_optional", "inner", "a"], {"deferred"}),
         (["inner_seq"], set()),
         (["container_optional_scoped"], {"a", "b"}),
         (["container_optional_scoped", "inner"], {"a", "b"}),
         (["container_optional_scoped", "inner_scoped"], {"a", "b", "c", "d"}),
-        (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d"}),
+        (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d", "deferred"}),
     ],
 )
 def test_get_available_scope(path, expected: Set[str]) -> None:


### PR DESCRIPTION
## Summary

It's possible for some components to raise errors on `load()` calls which are not related to validating fields. For example, if an invalid `project_dir` is passed to the dbt component, it will try and fail to open the file. This PR makes it so that `dg component check` can gracefully catch these exceptions, raising them with the `.yaml` file context, alongside other validation errors:

```python
/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/jdbt/component.yaml - TypeError: expected str, bytes or os.PathLike object, not NoneType
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py", line 225, in __init__
    project_dir = os.fspath(project_dir)
                  ^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not NoneType

/Users/ben/repos/components_demo/jaffle_platform/jaffle_platform/components/ingest_files/component.yaml:5 - sling_replication_collection params.replications.0.path Field required
     | 
   4 |   replications:
   5 |     - bar: 12
     |       ^ Field `path` is required but not provided
     |
```

## How I Tested These Changes

New unit test.