### PR TITLE
[components] Default disallow extra inputs

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -13,7 +13,9 @@ from dagster_components.core.schema.resolver import TemplatedValueResolver
 class ComponentSchemaBaseModel(BaseModel):
     """Base class for models that are part of a component schema."""
 
-    model_config = ConfigDict(json_schema_extra={JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY: True})
+    model_config = ConfigDict(
+        json_schema_extra={JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY: True}, extra="forbid"
+    )
 
     def render_properties(self, value_resolver: TemplatedValueResolver) -> Mapping[str, Any]:
         """Returns a dictionary of resolved properties for this class."""

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
@@ -1,0 +1,7 @@
+type: .my_component
+
+params:
+  a_string: "a string"
+  an_int: 5
+  # doesn't exist
+  a_bool: false

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
@@ -1,0 +1,15 @@
+type: .my_nested_component
+
+params:
+  nested:
+    foo:
+      a_string: "test"
+      an_int: 15
+      a_bool: true
+    bar:
+      a_string: "test"
+      an_int: 5
+    baz:
+      a_string: "test"
+      an_int: 10
+      another_bool: false

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/basic_components.py
@@ -1,11 +1,11 @@
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component, component_type
 from dagster_components.core.component import ComponentLoadContext
-from pydantic import BaseModel
+from dagster_components.core.schema.base import ComponentSchemaBaseModel
 from typing_extensions import Self
 
 
-class MyComponentSchema(BaseModel):
+class MyComponentSchema(ComponentSchemaBaseModel):
     a_string: str
     an_int: int
 
@@ -24,12 +24,12 @@ class MyComponent(Component):
         return Definitions()
 
 
-class MyNestedModel(BaseModel):
+class MyNestedModel(ComponentSchemaBaseModel):
     a_string: str
     an_int: int
 
 
-class MyNestedComponentSchema(BaseModel):
+class MyNestedComponentSchema(ComponentSchemaBaseModel):
     nested: dict[str, MyNestedModel]
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -58,6 +58,18 @@ def test_basic_component_missing_value() -> None:
     assert "Field required" in str(e.value)
 
 
+def test_basic_component_extra_value() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/basic_component_extra_value",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    assert "component.yaml:7" in str(e.value)
+    assert "params.a_bool" in str(e.value)
+    assert "Extra inputs are not permitted" in str(e.value)
+
+
 def test_nested_component_invalid_values() -> None:
     with pytest.raises(ValidationError) as e:
         load_test_component_defs_inject_component(
@@ -82,3 +94,17 @@ def test_nested_component_missing_value() -> None:
     assert "component.yaml:6" in str(e.value)
     assert "Field required" in str(e.value)
     assert "component.yaml:11" in str(e.value)
+
+
+def test_nested_component_extra_value() -> None:
+    with pytest.raises(ValidationError) as e:
+        load_test_component_defs_inject_component(
+            "validation/nested_component_extra_values",
+            Path(__file__).parent / "basic_components.py",
+        )
+
+    assert "component.yaml:8" in str(e.value)
+    assert "params.nested.foo.a_bool" in str(e.value)
+    assert "Extra inputs are not permitted" in str(e.value)
+    assert "component.yaml:15" in str(e.value)
+    assert "params.nested.baz.another_bool" in str(e.value)


### PR DESCRIPTION
## Summary

Updates `ComponentSchemaBaseModel` to explicitly disallow extra inputs (though users can override this in their own component schema classes). We augment extra input errors like other validation errors.

## Test Plan

New test cases.
