### PR TITLE
Allow specifying up front which objects to load

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_asset_checks_from_modules.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.asset_key import (
     CoercibleToAssetKeyPrefix,
     check_opt_coercible_to_asset_key_prefix_param,
 )
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.module_loaders.object_list import ModuleScopedDagsterDefs
 from dagster._core.definitions.module_loaders.utils import find_modules_in_package
 
@@ -35,7 +36,7 @@ def load_asset_checks_from_modules(
         asset_key_prefix, "asset_key_prefix"
     )
     return (
-        ModuleScopedDagsterDefs.from_modules(modules, allow_spec_collisions=True)
+        ModuleScopedDagsterDefs.from_modules(modules, types_to_load=(AssetsDefinition,))
         .get_object_list()
         .with_attributes(
             key_prefix=asset_key_prefix,


### PR DESCRIPTION
## Summary & Motivation
Fixes https://github.com/dagster-io/dagster/issues/27051.

Previously, even when we weren't actually going to return them, `DagsterObjectList` would load all objects of loadable type.

This PR allows you to specify up front which types to load. This allows us to avoid making changes to objects which we aren't actually loading.

## How I Tested These Changes
A new test which showcases prefix behavior with load_assets_from_module with and without asset specs.

## Changelog
- Fixed a bug with `load_assets_from_modules` where AssetSpec objects were being given the key_prefix instead of the source_key_prefix. Going forward, when load_specs is set to True, only the source_key_prefix will affect AssetSpec objects.
