### PR TITLE
[dagster-azure]: Add Azure specific information to captured logs

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -47,7 +47,7 @@ from dagster._core.execution.plan.inputs import StepInputData
 from dagster._core.execution.plan.objects import StepFailureData, StepRetryData, StepSuccessData
 from dagster._core.execution.plan.outputs import StepOutputData
 from dagster._core.log_manager import DagsterLogManager
-from dagster._core.storage.compute_log_manager import CapturedLogContext
+from dagster._core.storage.compute_log_manager import CapturedLogContext, LogRetrievalShellCommand
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._serdes import NamedTupleSerializer, whitelist_for_serdes
 from dagster._serdes.serdes import EnumSerializer, UnpackContext, is_whitelisted_for_serdes_object
@@ -1494,6 +1494,7 @@ class DagsterEvent(
                 file_key=file_key,
                 external_stdout_url=log_context.external_stdout_url,
                 external_stderr_url=log_context.external_stderr_url,
+                shell_cmd=log_context.shell_cmd,
                 external_url=log_context.external_url,
             ),
         )
@@ -1874,6 +1875,7 @@ class ComputeLogsCaptureData(
             ("external_url", Optional[str]),
             ("external_stdout_url", Optional[str]),
             ("external_stderr_url", Optional[str]),
+            ("shell_cmd", Optional[LogRetrievalShellCommand]),
         ],
     )
 ):
@@ -1884,6 +1886,7 @@ class ComputeLogsCaptureData(
         external_url: Optional[str] = None,
         external_stdout_url: Optional[str] = None,
         external_stderr_url: Optional[str] = None,
+        shell_cmd: Optional[LogRetrievalShellCommand] = None,
     ):
         return super().__new__(
             cls,
@@ -1892,6 +1895,7 @@ class ComputeLogsCaptureData(
             external_url=check.opt_str_param(external_url, "external_url"),
             external_stdout_url=check.opt_str_param(external_stdout_url, "external_stdout_url"),
             external_stderr_url=check.opt_str_param(external_stderr_url, "external_stderr_url"),
+            shell_cmd=check.opt_inst_param(shell_cmd, "shell_cmd", LogRetrievalShellCommand),
         )
 
 

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -19,7 +19,11 @@ from dagster._core.storage.cloud_storage_compute_log_manager import (
     CloudStorageComputeLogManager,
     PollingComputeLogSubscriptionManager,
 )
-from dagster._core.storage.compute_log_manager import CapturedLogContext, ComputeIOType
+from dagster._core.storage.compute_log_manager import (
+    CapturedLogContext,
+    ComputeIOType,
+    LogRetrievalShellCommand,
+)
 from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
@@ -284,6 +288,10 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         self._download_urls[blob_key] = url
         return url
 
+    def _get_shell_cmd_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        blob_key = self._blob_key(log_key, io_type)
+        return f"az storage blob download --account-name {self._storage_account} --container-name {self._container} --name {blob_key}"
+
     @contextmanager
     def capture_logs(self, log_key: Sequence[str]) -> Iterator[CapturedLogContext]:
         with super().capture_logs(log_key) as local_context:
@@ -296,7 +304,13 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
                 out_url = f"{azure_base_url}/{out_key}"
                 err_url = f"{azure_base_url}/{err_key}"
                 yield CapturedLogContext(
-                    local_context.log_key, external_stdout_url=out_url, external_stderr_url=err_url
+                    local_context.log_key,
+                    external_stdout_url=out_url,
+                    external_stderr_url=err_url,
+                    shell_cmd=LogRetrievalShellCommand(
+                        stdout=self._get_shell_cmd_for_type(log_key, ComputeIOType.STDOUT),
+                        stderr=self._get_shell_cmd_for_type(log_key, ComputeIOType.STDERR),
+                    ),
                 )
 
     def _request_user_delegation_key(


### PR DESCRIPTION
## Summary & Motivation

External cloud storage based compute log managers are often configured to only collect and show the url. However, in the case of the AzureBlobComputeLogManager, the provided URL will not be clickable if the storage account or container are private, which is a reasonable choice for commercial users using this feature for security and compliance on Dagster+.

This supports these users by providing both a more easily readable path and a clickable shell command to retrieve the log locally.

How this is implemented is by adding new fields to CapturedLogData to pass the path as well as extra azure specific information so that the frontend can render the shell cmd.

## Note to reviewers

This is a rework of #26982 - applying the changes requested and discussed. 

## How I Tested These Changes
- dagster dev local (with the AzureBlobComputeLogManager as well as the default log manager to ensure other code paths aren't broken).
- added testing of new fields in integration tests

## Changelog

- [dagster-azure] AzureBlobComputeLogManager provides shell command to download logs.
