### PR TITLE
[dagster-graphql] Add shell cmd to the LogsCapturedData payload

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1240,8 +1240,14 @@ type LogsCapturedEvent implements MessageEvent {
   externalUrl: String
   externalStdoutUrl: String
   externalStderrUrl: String
+  shellCmd: LogRetrievalShellCommand
   pid: Int
   logKey: String!
+}
+
+type LogRetrievalShellCommand {
+  stdout: String
+  stderr: String
 }
 
 type AlertStartEvent implements MessageEvent & RunEvent {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2409,6 +2409,12 @@ export type LogMessageEvent = MessageEvent & {
   timestamp: Scalars['String']['output'];
 };
 
+export type LogRetrievalShellCommand = {
+  __typename: 'LogRetrievalShellCommand';
+  stderr: Maybe<Scalars['String']['output']>;
+  stdout: Maybe<Scalars['String']['output']>;
+};
+
 export type LogTelemetryMutationResult = LogTelemetrySuccess | PythonError;
 
 export type LogTelemetrySuccess = {
@@ -2435,6 +2441,7 @@ export type LogsCapturedEvent = MessageEvent & {
   message: Scalars['String']['output'];
   pid: Maybe<Scalars['Int']['output']>;
   runId: Scalars['String']['output'];
+  shellCmd: Maybe<LogRetrievalShellCommand>;
   solidHandleID: Maybe<Scalars['String']['output']>;
   stepKey: Maybe<Scalars['String']['output']>;
   stepKeys: Maybe<Array<Scalars['String']['output']>>;
@@ -9783,6 +9790,19 @@ export const buildLogMessageEvent = (
   };
 };
 
+export const buildLogRetrievalShellCommand = (
+  overrides?: Partial<LogRetrievalShellCommand>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'LogRetrievalShellCommand'} & LogRetrievalShellCommand => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('LogRetrievalShellCommand');
+  return {
+    __typename: 'LogRetrievalShellCommand',
+    stderr: overrides && overrides.hasOwnProperty('stderr') ? overrides.stderr! : 'adipisci',
+    stdout: overrides && overrides.hasOwnProperty('stdout') ? overrides.stdout! : 'voluptas',
+  };
+};
+
 export const buildLogTelemetrySuccess = (
   overrides?: Partial<LogTelemetrySuccess>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -9843,6 +9863,12 @@ export const buildLogsCapturedEvent = (
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'ex',
     pid: overrides && overrides.hasOwnProperty('pid') ? overrides.pid! : 7623,
     runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'modi',
+    shellCmd:
+      overrides && overrides.hasOwnProperty('shellCmd')
+        ? overrides.shellCmd!
+        : relationshipsToOmit.has('LogRetrievalShellCommand')
+          ? ({} as LogRetrievalShellCommand)
+          : buildLogRetrievalShellCommand({}, relationshipsToOmit),
     solidHandleID:
       overrides && overrides.hasOwnProperty('solidHandleID')
         ? overrides.solidHandleID!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -419,7 +419,17 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             **basic_params,
         )
     elif dagster_event.event_type == DagsterEventType.LOGS_CAPTURED:
+        from dagster_graphql.schema.logs.events import GrapheneLogRetrievalShellCommand
+
         data = dagster_event.logs_captured_data
+        shell_cmd = (
+            GrapheneLogRetrievalShellCommand(
+                stdout=data.shell_cmd.stdout,
+                stderr=data.shell_cmd.stderr,
+            )
+            if data.shell_cmd
+            else None
+        )
         return GrapheneLogsCapturedEvent(
             fileKey=data.file_key,
             logKey=data.file_key,
@@ -427,6 +437,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             externalUrl=data.external_url,
             externalStdoutUrl=data.external_stdout_url or data.external_url,
             externalStderrUrl=data.external_stderr_url or data.external_url,
+            shellCmd=shell_cmd,
             pid=dagster_event.pid,
             **basic_params,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -299,6 +299,14 @@ class GrapheneHookErroredEvent(graphene.ObjectType):
         name = "HookErroredEvent"
 
 
+class GrapheneLogRetrievalShellCommand(graphene.ObjectType):
+    class Meta:
+        name = "LogRetrievalShellCommand"
+
+    stdout = graphene.String()
+    stderr = graphene.String()
+
+
 class GrapheneLogsCapturedEvent(graphene.ObjectType):
     class Meta:
         interfaces = (GrapheneMessageEvent,)
@@ -309,6 +317,7 @@ class GrapheneLogsCapturedEvent(graphene.ObjectType):
     externalUrl = graphene.String()
     externalStdoutUrl = graphene.String()
     externalStderrUrl = graphene.String()
+    shellCmd = graphene.Field(GrapheneLogRetrievalShellCommand)
     pid = graphene.Int()
     # legacy name for compute log file key... required for back-compat reasons, but has been
     # renamed to fileKey for newer versions of the Dagster UI


### PR DESCRIPTION
## Summary & Motivation

Added support for shell commands in log retrieval by introducing a new `GrapheneLogRetrievalShellCommand` type and extending the `GrapheneLogsCapturedEvent` to include stdout and stderr shell command information.

## Note to reviewers

- Rework of #26983 with requested changes

## How I Tested These Changes

- See top stack PR.