### PR TITLE
[ui] Fix incorrect “Run are queued” copy in the current run banner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -50,12 +50,12 @@ export const CurrentRunsBanner = ({
                   {inProgressRunIds.length && unstartedRunIds.length ? ' ' : ''}
                   {unstartedRunIds.length > 1 && (
                     <>
-                      Runs <RunIdLinks ids={unstartedRunIds} /> that target this asset are queued.
+                      Runs <RunIdLinks ids={unstartedRunIds} /> are queued and target this asset.
                     </>
                   )}
                   {unstartedRunIds.length === 1 && (
                     <>
-                      Run <RunIdLinks ids={unstartedRunIds} /> that targets this asset are queued.
+                      Run <RunIdLinks ids={unstartedRunIds} /> is queued and targets this asset.
                     </>
                   )}
                 </div>


### PR DESCRIPTION
As titled - I also changed this text slightly to make it more direct.
