### PR TITLE
[ui] When clicking backfill header links to runs, expand runs within backfills

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatuses.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatuses.tsx
@@ -9,6 +9,7 @@ export const inProgressStatuses = new Set([
 ]);
 
 export const successStatuses = new Set([RunStatus.SUCCESS]);
+
 export const failedStatuses = new Set([RunStatus.FAILURE, RunStatus.CANCELED]);
 
 export const doneStatuses = new Set([RunStatus.FAILURE, RunStatus.SUCCESS, RunStatus.CANCELED]);


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-717/fix-links-to-runs-page-from-backfill-overview-page

## How I Tested These Changes

- With the "legacy runs page" FF turned on, clicking the header links go to the main runs list, with the filters applied
- With the new run feed, the backfill has it's own Runs tab. The header link takes you to that run tab which expands the runs within the backfill by default and keeps you within the backfill nav.

I also updated this code to re-use the RunStatus lists we use elsewhere, and made a note indicating why the "in progress" column includes queued in this case to match the backend calculation.

## Changelog

[ui] Clicking to view runs with a specific status from the backfill overview switches to the new backfill runs tab with your filters applied, instead of the global runs page.
