### PR TITLE
[helm] - add option for local compute log manager to helm chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -12,6 +12,7 @@ class ComputeLogManagerType(str, Enum):
     AZURE = "AzureBlobComputeLogManager"
     GCS = "GCSComputeLogManager"
     S3 = "S3ComputeLogManager"
+    LOCAL = "LocalComputeLogManager"
     CUSTOM = "CustomComputeLogManager"
 
 
@@ -51,10 +52,16 @@ class S3ComputeLogManager(BaseModel):
     region: Optional[StringSource] = None
 
 
+class LocalComputeLogManager(BaseModel):
+    baseDir: StringSource
+    pollingTimeout: Optional[int] = None
+
+
 class ComputeLogManagerConfig(BaseModel, extra="forbid"):
     azureBlobComputeLogManager: Optional[AzureBlobComputeLogManager] = None
     gcsComputeLogManager: Optional[GCSComputeLogManager] = None
     s3ComputeLogManager: Optional[S3ComputeLogManager] = None
+    localComputeLogManager: Optional[LocalComputeLogManager] = None
     customComputeLogManager: Optional[ConfigurableClass] = None
 
 
@@ -74,6 +81,7 @@ class ComputeLogManager(BaseModel):
                 ComputeLogManagerType.AZURE: "azureBlobComputeLogManager",
                 ComputeLogManagerType.GCS: "gcsComputeLogManager",
                 ComputeLogManagerType.S3: "s3ComputeLogManager",
+                ComputeLogManagerType.LOCAL: "localComputeLogManager",
                 ComputeLogManagerType.CUSTOM: "customComputeLogManager",
             }
         )

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -67,6 +67,8 @@ data:
         {{- include "dagsterYaml.computeLogManager.gcs" . | indent 6 -}}
       {{- else if eq $computeLogManagerType "S3ComputeLogManager" }}
         {{- include "dagsterYaml.computeLogManager.s3" . | indent 6 -}}
+      {{- else if eq $computeLogManagerType "LocalComputeLogManager" }}
+        {{- include "dagsterYaml.computeLogManager.local" . | indent 6 -}}
       {{- else if eq $computeLogManagerType "CustomComputeLogManager" }}
         {{- include "dagsterYaml.computeLogManager.custom" . | indent 6 -}}
       {{- end }}

--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -130,6 +130,18 @@ config:
   {{- end }}
 {{- end }}
 
+{{- define "dagsterYaml.computeLogManager.local" }}
+{{- $localComputeLogManagerConfig := .Values.computeLogManager.config.localComputeLogManager }}
+module: dagster.core.storage.local_compute_log_manager
+class: LocalComputeLogManager
+config:
+  base_dir: {{ include "stringSource" $localComputeLogManagerConfig.baseDir }}
+
+  {{- if $localComputeLogManagerConfig.pollingTimeout }}
+  polling_timeout: {{ $localComputeLogManagerConfig.pollingTimeout }}
+  {{- end }}
+{{- end }}
+
 {{- define "dagsterYaml.computeLogManager.custom" }}
 {{- $customComputeLogManagerConfig := .Values.computeLogManager.config.customComputeLogManager }}
 module: {{ $customComputeLogManagerConfig.module | quote }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -476,6 +476,24 @@
                     "if": {
                         "properties": {
                             "type": {
+                                "const": "LocalComputeLogManager"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "config": {
+                                "required": [
+                                    "localComputeLogManager"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
                                 "const": "CustomComputeLogManager"
                             }
                         }
@@ -542,6 +560,17 @@
                     ],
                     "default": null
                 },
+                "localComputeLogManager": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/LocalComputeLogManager"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
                 "customComputeLogManager": {
                     "anyOf": [
                         {
@@ -563,6 +592,7 @@
                 "AzureBlobComputeLogManager",
                 "GCSComputeLogManager",
                 "S3ComputeLogManager",
+                "LocalComputeLogManager",
                 "CustomComputeLogManager"
             ],
             "title": "ComputeLogManagerType",
@@ -1467,6 +1497,38 @@
             "additionalProperties": true,
             "properties": {},
             "title": "LivenessProbe",
+            "type": "object"
+        },
+        "LocalComputeLogManager": {
+            "properties": {
+                "baseDir": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        }
+                    ],
+                    "title": "Basedir"
+                },
+                "pollingTimeout": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Pollingtimeout"
+                }
+            },
+            "required": [
+                "baseDir"
+            ],
+            "title": "LocalComputeLogManager",
             "type": "object"
         },
         "Migrate": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -234,6 +234,7 @@ computeLogManager:
   #   AzureBlobComputeLogManager,
   #   GCSComputeLogManager,
   #   S3ComputeLogManager,
+  #   LocalComputeLogManager,
   #   CustomComputeLogManager,
   # ]
   type: NoOpComputeLogManager
@@ -268,6 +269,10 @@ computeLogManager:
   #     skipEmptyFiles: ~
   #     uploadInterval: ~
   #     uploadExtraArgs: {}
+  ##  Uncomment this configuration if the LocalComputeLogManager is selected
+  #   localComputeLogManager:
+  #     baseDir: ~
+  #     pollingTimeout: ~
   ##  Uncomment this configuration if the CustomComputeLogManager is selected.
   ##  Using this setting requires a custom webserver image that defines the user specified
   ##  compute log manager in an installed python module.


### PR DESCRIPTION
## Summary & Motivation

This adds the option to set the `LocalComputeLogManager` in the helm chart. Closes https://github.com/dagster-io/dagster/issues/27054

## How I Tested These Changes

Unit test