### PR TITLE
Implement `AutomationCondition.replace()` function

### DIFF
--- a/docs/content/concepts/automation/declarative-automation/customizing-automation-conditions.mdx
+++ b/docs/content/concepts/automation/declarative-automation/customizing-automation-conditions.mdx
@@ -61,8 +61,8 @@ five_days_ago_condition = AutomationCondition.in_latest_time_window(
     timedelta(days=5)
 ) & ~AutomationCondition.in_latest_time_window(timedelta(days=4))
 
-condition = five_days_ago_condition & AutomationCondition.eager().without(
-    AutomationCondition.in_latest_time_window(),
+condition = AutomationCondition.eager().replace(
+    "in_latest_time_window", five_days_ago_condition
 )
 ```
 

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_automation/update_specific_older_partition.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_automation/update_specific_older_partition.py
@@ -6,6 +6,6 @@ five_days_ago_condition = AutomationCondition.in_latest_time_window(
     timedelta(days=5)
 ) & ~AutomationCondition.in_latest_time_window(timedelta(days=4))
 
-condition = five_days_ago_condition & AutomationCondition.eager().without(
-    AutomationCondition.in_latest_time_window(),
+condition = AutomationCondition.eager().replace(
+    "in_latest_time_window", five_days_ago_condition
 )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -255,9 +255,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
 
     @public
     def replace(
-        self,
-        old: Union["AutomationCondition", str],
-        new: "AutomationCondition",
+        self, old: Union["AutomationCondition", str], new: "AutomationCondition"
     ) -> "AutomationCondition":
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -2,7 +2,7 @@ import datetime
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Generic, Optional
+from typing import TYPE_CHECKING, Generic, Optional, Union
 
 from typing_extensions import Self
 
@@ -252,6 +252,23 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
                     | AutomationCondition.initial_evaluation()
                 ).with_label("handled")
             )
+
+    @public
+    def replace(
+        self,
+        old: Union["AutomationCondition", str],
+        new: "AutomationCondition",
+    ) -> "AutomationCondition":
+        """Replaces all instances of ``old`` across any sub-conditions with ``new``.
+
+        If ``old`` is a string, then conditions with a label matching
+        that string will be replaced.
+
+        Args:
+            old (Union[AutomationCondition, str]): The condition to replace.
+            new (AutomationCondition): The condition to replace with.
+        """
+        return new if old in [self, self.get_label()] else self
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import Union
 
 from typing_extensions import Self
 
@@ -66,11 +66,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
 
     @public
-    def replace(
-        self,
-        old: Union[AutomationCondition, str],
-        new: Optional[AutomationCondition],
-    ) -> Self:
+    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -129,11 +125,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return AutomationResult(context, true_subset, child_results=child_results)
 
     @public
-    def replace(
-        self,
-        old: Union[AutomationCondition, str],
-        new: Optional[AutomationCondition],
-    ) -> Self:
+    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -180,11 +172,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return AutomationResult(context, true_subset, child_results=[child_result])
 
     @public
-    def replace(
-        self,
-        old: Union[AutomationCondition, str],
-        new: Optional[AutomationCondition],
-    ) -> Self:
+    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -2,6 +2,8 @@ import asyncio
 from collections.abc import Sequence
 from typing import Optional, Union
 
+from typing_extensions import Self
+
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_key import T_EntityKey
@@ -68,7 +70,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         self,
         old: Union[AutomationCondition, str],
         new: Optional[AutomationCondition],
-    ) -> "AndAutomationCondition":
+    ) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -131,7 +133,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         self,
         old: Union[AutomationCondition, str],
         new: Optional[AutomationCondition],
-    ) -> "OrAutomationCondition":
+    ) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -182,7 +184,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         self,
         old: Union[AutomationCondition, str],
         new: Optional[AutomationCondition],
-    ) -> "NotAutomationCondition":
+    ) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -2,8 +2,6 @@ import asyncio
 from collections.abc import Sequence
 from typing import Union
 
-from typing_extensions import Self
-
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_key import T_EntityKey
@@ -66,7 +64,9 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
 
     @public
-    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
+    def replace(
+        self, old: Union[AutomationCondition, str], new: AutomationCondition
+    ) -> AutomationCondition:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -125,7 +125,9 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return AutomationResult(context, true_subset, child_results=child_results)
 
     @public
-    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
+    def replace(
+        self, old: Union[AutomationCondition, str], new: AutomationCondition
+    ) -> AutomationCondition:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -172,7 +174,9 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return AutomationResult(context, true_subset, child_results=[child_result])
 
     @public
-    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
+    def replace(
+        self, old: Union[AutomationCondition, str], new: AutomationCondition
+    ) -> AutomationCondition:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional, Union  # noqa: UP035
 
-from typing_extensions import Self
-
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.asset_graph_view.asset_graph_view import U_EntityKey
@@ -61,7 +59,9 @@ class EntityMatchesCondition(
         return AutomationResult(context=context, true_subset=true_subset, child_results=[to_result])
 
     @public
-    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
+    def replace(
+        self, old: Union[AutomationCondition, str], new: AutomationCondition
+    ) -> AutomationCondition:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -142,7 +142,9 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return dep_keys
 
     @public
-    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
+    def replace(
+        self, old: Union[AutomationCondition, str], new: AutomationCondition
+    ) -> AutomationCondition:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional, Union  # noqa: UP035
 
+from typing_extensions import Self
+
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.asset_graph_view.asset_graph_view import U_EntityKey
@@ -63,7 +65,7 @@ class EntityMatchesCondition(
         self,
         old: Union[AutomationCondition, str],
         new: Optional[AutomationCondition],
-    ) -> "EntityMatchesCondition":
+    ) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -148,7 +150,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         self,
         old: Union[AutomationCondition, str],
         new: Optional[AutomationCondition],
-    ) -> "DepsAutomationCondition":
+    ) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional  # noqa: UP035
+from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional, Union  # noqa: UP035
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.asset_graph_view.asset_graph_view import U_EntityKey
 from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
@@ -56,6 +57,27 @@ class EntityMatchesCondition(
             context.key, direction=directions[1]
         )
         return AutomationResult(context=context, true_subset=true_subset, child_results=[to_result])
+
+    @public
+    def replace(
+        self,
+        old: Union[AutomationCondition, str],
+        new: Optional[AutomationCondition],
+    ) -> "EntityMatchesCondition":
+        """Replaces all instances of ``old`` across any sub-conditions with ``new``.
+
+        If ``old`` is a string, then conditions with a label matching
+        that string will be replaced.
+
+        Args:
+            old (Union[AutomationCondition, str]): The condition to replace.
+            new (AutomationCondition): The condition to replace with.
+        """
+        return (
+            new
+            if old in [self, self.get_label()]
+            else copy(self, operand=self.operand.replace(old, new))
+        )
 
 
 @record
@@ -120,6 +142,27 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         if self.ignore_selection is not None:
             dep_keys -= self.ignore_selection.resolve(asset_graph)
         return dep_keys
+
+    @public
+    def replace(
+        self,
+        old: Union[AutomationCondition, str],
+        new: Optional[AutomationCondition],
+    ) -> "DepsAutomationCondition":
+        """Replaces all instances of ``old`` across any sub-conditions with ``new``.
+
+        If ``old`` is a string, then conditions with a label matching
+        that string will be replaced.
+
+        Args:
+            old (Union[AutomationCondition, str]): The condition to replace.
+            new (AutomationCondition): The condition to replace with.
+        """
+        return (
+            new
+            if old in [self, self.get_label()]
+            else copy(self, operand=self.operand.replace(old, new))
+        )
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -61,11 +61,7 @@ class EntityMatchesCondition(
         return AutomationResult(context=context, true_subset=true_subset, child_results=[to_result])
 
     @public
-    def replace(
-        self,
-        old: Union[AutomationCondition, str],
-        new: Optional[AutomationCondition],
-    ) -> Self:
+    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -146,11 +142,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return dep_keys
 
     @public
-    def replace(
-        self,
-        old: Union[AutomationCondition, str],
-        new: Optional[AutomationCondition],
-    ) -> Self:
+    def replace(self, old: Union[AutomationCondition, str], new: AutomationCondition) -> Self:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching


### PR DESCRIPTION
## Summary & Motivation

Users often want to make small changes to the existing policies. There is an existing utility to remove a sub-condition (`.without(…)`), and you can add a new sub-condition with `&`.

However, these utilities aren't always the most ergonomic for certain use cases.

This would allow the following types of changes to our examples:

[Older time window partitions](https://docs.dagster.io/concepts/automation/declarative-automation/customizing-automation-conditions#update-an-older-time-partition-when-using-automationconditionon_cron)

before:

```python
condition = five_days_ago_condition & AutomationCondition.eager().without(
    AutomationCondition.in_latest_time_window(),
)
```

after:

```python
AutomationCondition.eager().replace(
    "in_latest_time_window", five_days_ago_condition
)
```

## How I Tested These Changes

Added unit tests.

## Changelog

Implemented `AutomationCondition.replace()` function to improve ergonomics of updating sub-conditions.
