### PR TITLE
Keep label upon `AndAutomationCondition.without()`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._record import record
+from dagster._record import copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
@@ -57,9 +57,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         operands = [child for child in self.operands if child != condition]
         if len(operands) < 2:
             check.failed("Cannot have fewer than 2 operands in an AndAutomationCondition")
-        return AndAutomationCondition(
-            operands=[child for child in self.operands if child != condition]
-        )
+        return copy(self, operands=[child for child in self.operands if child != condition])
 
 
 @whitelist_for_serdes(storage_name="OrAssetCondition")

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -161,6 +161,9 @@ def test_without_automation_condition() -> None:
     assert orig.without(AutomationCondition.in_latest_time_window()) == b & c
     assert orig.without(~AutomationCondition.any_deps_in_progress()) == a & b
 
+    # ensure label is preserved
+    assert orig.with_label("my_label").without(a) == (b & c).with_label("my_label")
+
     # make sure it errors if an invalid condition is passed
     with pytest.raises(CheckError, match="Condition not found"):
         orig.without(AutomationCondition.in_progress())


### PR DESCRIPTION
## Summary & Motivation

If I have `my_big_complex_condition` and I modify a small piece, I can always relabel, but maybe I don't want to automatically lose the label.

## How I Tested These Changes

One new unit test + existing tests.

## Changelog

Using `AndAutomationCondition.without()` no longer removes the condition's label.