### PR TITLE
Allow concurrency limits to handle changing the default limit

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -1,13 +1,17 @@
 import time
 from collections import defaultdict
+from collections.abc import Sequence
 from types import TracebackType
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self
 
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.storage.tags import PRIORITY_TAG
+
+if TYPE_CHECKING:
+    from dagster._core.storage.event_log.base import PoolLimit
 
 INITIAL_INTERVAL_VALUE = 1
 STEP_UP_BASE = 1.1
@@ -33,7 +37,7 @@ class InstanceConcurrencyContext:
     def __init__(self, instance: DagsterInstance, dagster_run: DagsterRun):
         self._instance = instance
         self._run_id = dagster_run.run_id
-        self._global_concurrency_keys = None
+        self._pools = None
         self._pending_timeouts = defaultdict(float)
         self._pending_claim_counts = defaultdict(int)
         self._pending_claims = set()
@@ -69,27 +73,29 @@ class InstanceConcurrencyContext:
         self._context_guard = False
 
     @property
-    def global_concurrency_keys(self) -> set[str]:
+    def pools(self) -> Sequence["PoolLimit"]:
         # lazily load the global concurrency keys, to avoid the DB fetch for plans that do not
         # have global concurrency limited keys
-        if self._global_concurrency_keys is None:
+        if self._pools is None:
             if not self._instance.event_log_storage.supports_global_concurrency_limits:
-                self._global_concurrency_keys = set()
+                self._pools = []
             else:
-                self._global_concurrency_keys = (
-                    self._instance.event_log_storage.get_concurrency_keys()
-                )
+                self._pools = self._instance.event_log_storage.get_pool_limits()
 
-        return self._global_concurrency_keys
+        return self._pools
 
-    def _sync_global_concurrency_keys(self) -> None:
-        self._global_concurrency_keys = self._instance.event_log_storage.get_concurrency_keys()
+    @property
+    def configured_pools(self) -> set[str]:
+        return set(pool.name for pool in self.pools if not pool.from_default)
+
+    def _sync_pools(self) -> None:
+        self._pools = self._instance.event_log_storage.get_pool_limits()
 
     def claim(self, concurrency_key: str, step_key: str, step_priority: int = 0):
         if not self._instance.event_log_storage.supports_global_concurrency_limits:
             return True
 
-        if concurrency_key not in self.global_concurrency_keys:
+        if concurrency_key not in self.configured_pools:
             # The initialization call will be a no-op if the limit is set by another process,
             # mitigating any race condition concerns
             if not self._instance.event_log_storage.initialize_concurrency_limit_to_default(
@@ -99,7 +105,7 @@ class InstanceConcurrencyContext:
                 return True
             else:
                 # sync the global concurrency keys to ensure we have the latest
-                self._sync_global_concurrency_keys()
+                self._sync_pools()
 
         if step_key in self._pending_claims:
             if time.time() > self._pending_timeouts[step_key]:

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -73,7 +73,8 @@ class GlobalOpConcurrencyLimitsCounter:
         # runs
         all_run_concurrency_keys = set()
 
-        configured_concurrency_keys = instance.event_log_storage.get_concurrency_keys()
+        pools = instance.event_log_storage.get_pool_limits()
+        configured_pools = set(pool.name for pool in pools if pool.from_default is False)
         for run in queued_runs:
             if run.run_op_concurrency:
                 all_run_concurrency_keys.update(run.run_op_concurrency.root_key_counts.keys())
@@ -82,7 +83,7 @@ class GlobalOpConcurrencyLimitsCounter:
             if key is None:
                 continue
 
-            if key not in configured_concurrency_keys:
+            if key not in configured_pools:
                 instance.event_log_storage.initialize_concurrency_limit_to_default(key)
 
             self._concurrency_info_by_key[key] = instance.event_log_storage.get_concurrency_info(

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/048_7e2f3204cf8e_add_column_concurrency_default_limit.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/048_7e2f3204cf8e_add_column_concurrency_default_limit.py
@@ -1,0 +1,33 @@
+"""add column concurrency default limit
+
+Revision ID: 7e2f3204cf8e
+Revises: 6b7fb194ff9c
+Create Date: 2025-01-13 15:19:19.331752
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dagster._core.storage.migration.utils import has_column, has_table
+
+# revision identifiers, used by Alembic.
+revision = "7e2f3204cf8e"
+down_revision = "6b7fb194ff9c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if has_table("concurrency_limits"):
+        if not has_column("concurrency_limits", "using_default_limit"):
+            op.add_column(
+                "concurrency_limits", sa.Column("using_default_limit", sa.Boolean(), nullable=True)
+            )
+
+
+def downgrade():
+    if has_table("concurrency_limits"):
+        if has_column("concurrency_limits", "using_default_limit"):
+            op.drop_column(
+                "concurrency_limits", sa.Column("using_default_limit", sa.Boolean(), nullable=True)
+            )

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -35,6 +35,7 @@ from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.partition_status_cache import get_and_update_asset_status_cache_value
 from dagster._core.storage.sql import AlembicVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX
+from dagster._record import record
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
 from dagster._utils.warnings import deprecation_warning
@@ -183,6 +184,13 @@ class PlannedMaterializationInfo(NamedTuple):
 
     storage_id: int
     run_id: str
+
+
+@record
+class PoolLimit:
+    name: str
+    limit: int
+    from_default: bool
 
 
 class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
@@ -558,6 +566,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_concurrency_info(self, concurrency_key: str) -> ConcurrencyKeyInfo:
         """Get concurrency info for key."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_pool_limits(self) -> Sequence[PoolLimit]:
+        """Get the set of concurrency limited keys and limits."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -114,6 +114,7 @@ ConcurrencyLimitsTable = db.Table(
     ),
     db.Column("concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True),
     db.Column("limit", db.Integer, nullable=False),
+    db.Column("using_default_limit", db.Boolean),
     db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -72,6 +72,7 @@ from dagster._core.storage.event_log.base import (
     EventLogStorage,
     EventRecordsFilter,
     PlannedMaterializationInfo,
+    PoolLimit,
 )
 from dagster._core.storage.event_log.migration import (
     ASSET_DATA_MIGRATIONS,
@@ -2145,6 +2146,19 @@ class SqlEventLogStorage(EventLogStorage):
         return self.has_table(ConcurrencySlotsTable.name)
 
     @cached_property
+    def has_default_pool_limit_col(self) -> bool:
+        # This table was added later, and to avoid forcing a migration
+        # we handle in the code if its been added or not.
+        if not self.has_table(ConcurrencyLimitsTable.name):
+            return False
+
+        with self.index_connection() as conn:
+            column_names = [
+                x.get("name") for x in db.inspect(conn).get_columns(ConcurrencyLimitsTable.name)
+            ]
+            return "from_default_limit" in column_names
+
+    @cached_property
     def has_concurrency_limits_table(self) -> bool:
         # This table was added later, and to avoid forcing a migration
         # we handle in the code if its been added or not.
@@ -2208,16 +2222,38 @@ class SqlEventLogStorage(EventLogStorage):
         if default_limit is None:
             return False
 
+        has_default_col = self.has_default_pool_limit_col
+
         with self.index_transaction() as conn:
             try:
-                conn.execute(
-                    ConcurrencyLimitsTable.insert().values(
-                        concurrency_key=concurrency_key, limit=default_limit
+                if has_default_col:
+                    conn.execute(
+                        ConcurrencyLimitsTable.insert().values(
+                            concurrency_key=concurrency_key,
+                            limit=default_limit,
+                            from_default_limit=True,
+                        )
                     )
-                )
-                self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+                else:
+                    conn.execute(
+                        ConcurrencyLimitsTable.insert().values(
+                            concurrency_key=concurrency_key, limit=default_limit
+                        )
+                    )
             except db_exc.IntegrityError:
-                pass
+                if has_default_col:
+                    conn.execute(
+                        ConcurrencyLimitsTable.update()
+                        .values(limit=default_limit)
+                        .where(
+                            db.and_(
+                                ConcurrencyLimitsTable.c.concurrency_key == concurrency_key,
+                                ConcurrencyLimitsTable.c.limit != default_limit,
+                            )
+                        )
+                    )
+            self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+
         return True
 
     def _upsert_and_lock_limit_row(self, conn, concurrency_key: str, num: int):
@@ -2637,6 +2673,46 @@ class SqlEventLogStorage(EventLogStorage):
                 return ConcurrencySlotStatus.BLOCKED
 
             return ConcurrencySlotStatus.CLAIMED
+
+    def get_pool_limits(self) -> Sequence[PoolLimit]:
+        self._reconcile_concurrency_limits_from_slots()
+        has_default_col = self.has_default_pool_limit_col
+        with self.index_connection() as conn:
+            if self.has_concurrency_limits_table and has_default_col:
+                query = db_select(
+                    [
+                        ConcurrencyLimitsTable.c.concurrency_key,
+                        ConcurrencyLimitsTable.c.limit,
+                        ConcurrencyLimitsTable.c.from_default_limit,
+                    ]
+                ).select_from(ConcurrencyLimitsTable)
+                rows = conn.execute(query).fetchall()
+                return [PoolLimit(name=row[0], limit=row[1], from_default=row[2]) for row in rows]
+
+            if self.has_concurrency_limits_table:
+                query = db_select(
+                    [
+                        ConcurrencyLimitsTable.c.concurrency_key,
+                        ConcurrencyLimitsTable.c.limit,
+                    ]
+                ).select_from(ConcurrencyLimitsTable)
+            else:
+                query = (
+                    db_select(
+                        [
+                            ConcurrencySlotsTable.c.concurrency_key,
+                            db.func.count().label("count"),
+                        ]
+                    )
+                    .where(
+                        ConcurrencySlotsTable.c.deleted == False,  # noqa: E712
+                    )
+                    .group_by(
+                        ConcurrencySlotsTable.c.concurrency_key,
+                    )
+                )
+            rows = conn.execute(query).fetchall()
+            return [PoolLimit(name=row[0], limit=row[1], from_default=False) for row in rows]
 
     def get_concurrency_keys(self) -> set[str]:
         self._reconcile_concurrency_limits_from_slots()

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5260,6 +5260,26 @@ class TestEventLogStorage:
         assert storage.get_concurrency_keys() == set(["foo"])
         assert storage.get_concurrency_info("foo").slot_count == 1
 
+    def test_changing_default_concurrency_key(
+        self, storage: EventLogStorage, instance: DagsterInstance
+    ):
+        assert storage
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if not self.can_set_concurrency_defaults():
+            pytest.skip("storage does not support setting global op concurrency defaults")
+
+        self.set_default_op_concurrency(instance, storage, 1)
+
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 1
+
+        self.set_default_op_concurrency(instance, storage, 2)
+
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
     def test_asset_checks(
         self,
         storage: EventLogStorage,


### PR DESCRIPTION
## Summary & Motivation
This PR adds a default flag to the storage layer, to help track which limits inherit from the default versus limits that are explicitly set.  This allows us to change the default and helps us to change those limit values.

## How I Tested These Changes
BK

## Changelog
- Adds the ability to distinguish between explicitly set pool limits and default-set pool limits.  Requires a schema migration using `dagster instance migrate`.