### PR TITLE
[docs] add redirect for /integrations/fivetran

### DIFF
--- a/docs/next/util/redirectUrls.json
+++ b/docs/next/util/redirectUrls.json
@@ -776,7 +776,7 @@
   },
   {
     "source": "/integrations/fivetran",
-    "destination": "/integrations/fivetran/fivetran-legacy",
+    "destination": "/integrations/fivetran/fivetran",
     "statusCode": 302
   }
 ]

--- a/docs/next/util/redirectUrls.json
+++ b/docs/next/util/redirectUrls.json
@@ -773,5 +773,10 @@
     "source": "/_apidocs/libraries/dagster-embedded-elt",
     "destination": "/integrations/embedded-elt",
     "statusCode": 302
+  },
+  {
+    "source": "/integrations/fivetran",
+    "destination": "/integrations/fivetran/fivetran-legacy",
+    "statusCode": 302
   }
 ]


### PR DESCRIPTION
## Summary & Motivation

From Izzy:
> The fivetran [Docs overview](https://dagster.io/integrations/dagster-fivetran) button leads to a [404](https://docs.dagster.io/integrations/fivetran)

## How I Tested These Changes

## Changelog

NOCHANGELOG
