### PR TITLE
[components] Update component type generation and test components

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -11,6 +11,7 @@ from dagster_components.core.component_generator import (
     ComponentGenerateRequest as ComponentGenerateRequest,
     ComponentGenerator as ComponentGenerator,
     ComponentGeneratorUnavailableReason as ComponentGeneratorUnavailableReason,
+    DefaultComponentGenerator as DefaultComponentGenerator,
 )
 from dagster_components.core.schema.base import ComponentSchemaBaseModel as ComponentSchemaBaseModel
 from dagster_components.core.schema.metadata import ResolvableFieldInfo as ResolvableFieldInfo

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -42,7 +42,7 @@ class Component(ABC):
     @classmethod
     def get_generator(cls) -> Union[ComponentGenerator, ComponentGeneratorUnavailableReason]:
         """Subclasses should implement this method to override scaffolding behavior. If this component
-        is not meant to be scaffoled it returns a ComponetnGeneratorUnavailableReason with a message
+        is not meant to be scaffolded it returns a ComponetnGeneratorUnavailableReason with a message
         This can be determined at runtime based on the environment or configuration. For example,
         if generators are optionally installed as extras (for example to avoid heavy dependencies in production),
         this method should return a ComponentGeneratorUnavailableReason with a message explaining

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
@@ -1,30 +1,20 @@
-from typing import TYPE_CHECKING
-
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext, component_type
-from dagster_components.core.component import ComponentGenerator
-from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.core.component_generator import DefaultComponentGenerator
-
-if TYPE_CHECKING:
-    from dagster_components.core.component import ComponentDeclNode
 
 
 @component_type(name="all_metadata_empty_asset")
 class AllMetadataEmptyAsset(Component):
     @classmethod
-    def from_decl_node(
-        cls, context: "ComponentLoadContext", decl_node: "ComponentDeclNode"
-    ) -> Self:
-        assert isinstance(decl_node, YamlComponentDecl)
+    def load(cls, context: "ComponentLoadContext") -> Self:
         return cls()
 
     @classmethod
-    def get_generator(cls) -> ComponentGenerator:
+    def get_generator(cls) -> DefaultComponentGenerator:
         return DefaultComponentGenerator()
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
@@ -1,21 +1,15 @@
-from typing import TYPE_CHECKING
-
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext, component_type
-from dagster_components.core.component_decl_builder import YamlComponentDecl
 from dagster_components.core.component_generator import (
     ComponentGenerator,
     DefaultComponentGenerator,
 )
-
-if TYPE_CHECKING:
-    from dagster_components.core.component import ComponentDeclNode
 
 
 class SimpleAssetParams(BaseModel):
@@ -36,13 +30,8 @@ class SimpleAsset(Component):
         return DefaultComponentGenerator()
 
     @classmethod
-    def from_decl_node(
-        cls, context: "ComponentLoadContext", decl_node: "ComponentDeclNode"
-    ) -> Self:
-        assert isinstance(decl_node, YamlComponentDecl)
-        loaded_params = TypeAdapter(cls.get_component_schema_type()).validate_python(
-            decl_node.component_file_model.params
-        )
+    def load(cls, context: "ComponentLoadContext") -> Self:
+        loaded_params = context.load_params(cls.get_component_schema_type())
         return cls(
             asset_key=AssetKey.from_user_string(loaded_params.asset_key),
             value=loaded_params.value,

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -2,15 +2,37 @@ from dagster import Definitions
 from dagster_components import (
     Component,
     ComponentLoadContext,
+    DefaultComponentGenerator,
     component_type,
 )
+from pydantic import BaseModel
+
+class {{ component_type_class_name }}Params(BaseModel):
+    ...
 
 @component_type(name="{{ name }}")
 class {{ component_type_class_name }}(Component):
+    """COMPONENT SUMMARY HERE.
+
+    COMPONENT DESCRIPTION HERE.
+    """
 
     @classmethod
-    def generate_files(cls) -> None:
-        ...
+    def get_component_schema_type(cls):
+        return {{ component_type_class_name }}Params
+
+    @classmethod
+    def get_generator(cls) -> DefaultComponentGenerator:
+        return DefaultComponentGenerator()
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> "{{ component_type_class_name }}":
+        loaded_params = context.load_params(cls.get_component_schema_type())
+
+        # Add logic for mapping schema parameters to constructor args here.
+        return cls()
+
 
     def build_defs(self, load_context: ComponentLoadContext) -> Definitions:
-        ...
+        # Add definition construction logic here.
+        return Definitions()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
@@ -180,6 +180,20 @@ def test_component_generate_fails_components_package_does_not_exist() -> None:
         assert "Components package `bar._components` is not installed" in str(result.exception)
 
 
+def test_component_generate_succeeds_scaffolded_component_type() -> None:
+    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+        result = runner.invoke("component-type", "generate", "baz")
+        assert_runner_result(result)
+        assert Path("bar/lib/baz.py").exists()
+
+        result = runner.invoke("component", "generate", "bar.baz", "qux")
+        assert_runner_result(result)
+        assert Path("bar/components/qux").exists()
+        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert component_yaml_path.exists()
+        assert "type: bar.baz" in component_yaml_path.read_text()
+
+
 # ##### REAL COMPONENTS
 
 


### PR DESCRIPTION
## Summary & Motivation

This updates `dg component-type generate` to use the newer generation format and generally polishes its output. It also adds a test to make sure that a generated component type can successfully generate a component instance right out of the gate.

Also updates test lib components to new component format.

## How I Tested These Changes

New unit tests, manually generated component type, component instance from type, loaded via `dagster dev`.