### PR TITLE
[components] Fix component scaffolding when code location has hyphenated name

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/deployment.py
@@ -77,21 +77,24 @@ class CodeLocationProjectContext:
             )
 
         name = os.path.basename(path)
+        root_package = name.replace("-", "_")
         config = _load_code_location_config(path)
         components_package_name = (
-            config.component_package or f"{name}.{_DEFAULT_CODE_LOCATION_COMPONENTS_SUBMODULE}"
+            config.component_package
+            or f"{root_package}.{_DEFAULT_CODE_LOCATION_COMPONENTS_SUBMODULE}"
         )
         if not components_path:
             with ensure_loadable_path(path):
                 components_path = (
                     Path(get_path_for_package(config.component_package))
                     if config.component_package
-                    else path / name / _DEFAULT_CODE_LOCATION_COMPONENTS_SUBMODULE
+                    else path / root_package / _DEFAULT_CODE_LOCATION_COMPONENTS_SUBMODULE
                 )
 
         return cls(
             root_path=str(path),
             name=name,
+            root_package=root_package,
             component_registry=component_registry,
             components_path=components_path,
             components_package_name=components_package_name,
@@ -101,12 +104,14 @@ class CodeLocationProjectContext:
         self,
         root_path: str,
         name: str,
+        root_package: str,
         component_registry: "ComponentTypeRegistry",
         components_path: Path,
         components_package_name: str,
     ):
         self._root_path = root_path
         self._name = name
+        self._root_package = root_package
         self._component_registry = component_registry
         self._components_path = components_path
         self._components_package_name = components_package_name

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -32,6 +32,7 @@ def load_test_component_project_context() -> CodeLocationProjectContext:
     return CodeLocationProjectContext(
         root_path=str(Path(__file__).parent),
         name="test",
+        root_package=Path(__file__).parent.name.replace("-", "_"),
         component_registry=ComponentTypeRegistry(components),
         components_path=Path(__file__).parent / "components",
         components_package_name="dagster_components_tests.integration_tests.components",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -34,18 +34,18 @@ def test_code_location_scaffold_inside_deployment_success(monkeypatch) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
-        result = runner.invoke("code-location", "scaffold", "bar", "--use-editable-dagster")
+        result = runner.invoke("code-location", "scaffold", "foo-bar", "--use-editable-dagster")
         assert_runner_result(result)
-        assert Path("code_locations/bar").exists()
-        assert Path("code_locations/bar/bar").exists()
-        assert Path("code_locations/bar/bar/lib").exists()
-        assert Path("code_locations/bar/bar/components").exists()
-        assert Path("code_locations/bar/bar_tests").exists()
-        assert Path("code_locations/bar/pyproject.toml").exists()
+        assert Path("code_locations/foo-bar").exists()
+        assert Path("code_locations/foo-bar/foo_bar").exists()
+        assert Path("code_locations/foo-bar/foo_bar/lib").exists()
+        assert Path("code_locations/foo-bar/foo_bar/components").exists()
+        assert Path("code_locations/foo-bar/foo_bar_tests").exists()
+        assert Path("code_locations/foo-bar/pyproject.toml").exists()
 
         # Check venv created
-        assert Path("code_locations/bar/.venv").exists()
-        assert Path("code_locations/bar/uv.lock").exists()
+        assert Path("code_locations/foo-bar/.venv").exists()
+        assert Path("code_locations/foo-bar/uv.lock").exists()
 
         # Restore when we are able to test without editable install
         # with open("code_locations/bar/pyproject.toml") as f:
@@ -55,7 +55,7 @@ def test_code_location_scaffold_inside_deployment_success(monkeypatch) -> None:
         #     assert "uv" not in toml["tool"]
 
         # Check cache was populated
-        with pushd("code_locations/bar"):
+        with pushd("code_locations/foo-bar"):
             result = runner.invoke("component-type", "list", "--verbose")
             assert_runner_result(result)
             assert "CACHE [hit]" in result.output
@@ -67,18 +67,18 @@ def test_code_location_scaffold_outside_deployment_success(monkeypatch) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
     with ProxyRunner.test() as runner, runner.isolated_filesystem(), clear_module_from_cache("bar"):
-        result = runner.invoke("code-location", "scaffold", "bar", "--use-editable-dagster")
+        result = runner.invoke("code-location", "scaffold", "foo-bar", "--use-editable-dagster")
         assert_runner_result(result)
-        assert Path("bar").exists()
-        assert Path("bar/bar").exists()
-        assert Path("bar/bar/lib").exists()
-        assert Path("bar/bar/components").exists()
-        assert Path("bar/bar_tests").exists()
-        assert Path("bar/pyproject.toml").exists()
+        assert Path("foo-bar").exists()
+        assert Path("foo-bar/foo_bar").exists()
+        assert Path("foo-bar/foo_bar/lib").exists()
+        assert Path("foo-bar/foo_bar/components").exists()
+        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv created
-        assert Path("bar/.venv").exists()
-        assert Path("bar/uv.lock").exists()
+        assert Path("foo-bar/.venv").exists()
+        assert Path("foo-bar/uv.lock").exists()
 
 
 @pytest.mark.parametrize("mode", ["env_var", "arg"])
@@ -90,11 +90,11 @@ def test_code_location_scaffold_editable_dagster_success(mode: str, monkeypatch)
     else:
         editable_args = ["--use-editable-dagster", str(dagster_git_repo_dir)]
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
-        result = runner.invoke("code-location", "scaffold", *editable_args, "bar")
+        result = runner.invoke("code-location", "scaffold", *editable_args, "foo-bar")
         assert_runner_result(result)
-        assert Path("code_locations/bar").exists()
-        assert Path("code_locations/bar/pyproject.toml").exists()
-        with open("code_locations/bar/pyproject.toml") as f:
+        assert Path("code_locations/foo-bar").exists()
+        assert Path("code_locations/foo-bar/pyproject.toml").exists()
+        with open("code_locations/foo-bar/pyproject.toml") as f:
             toml = tomli.loads(f.read())
             assert toml["tool"]["uv"]["sources"]["dagster"] == {
                 "path": f"{dagster_git_repo_dir}/python_modules/dagster",
@@ -122,36 +122,36 @@ def test_code_location_scaffold_editable_dagster_success(mode: str, monkeypatch)
 
 def test_code_location_scaffold_skip_venv_success() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("code-location", "scaffold", "--skip-venv", "bar")
+        result = runner.invoke("code-location", "scaffold", "--skip-venv", "foo-bar")
         assert_runner_result(result)
-        assert Path("bar").exists()
-        assert Path("bar/bar").exists()
-        assert Path("bar/bar/lib").exists()
-        assert Path("bar/bar/components").exists()
-        assert Path("bar/bar_tests").exists()
-        assert Path("bar/pyproject.toml").exists()
+        assert Path("foo-bar").exists()
+        assert Path("foo-bar/foo_bar").exists()
+        assert Path("foo-bar/foo_bar/lib").exists()
+        assert Path("foo-bar/foo_bar/components").exists()
+        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv not created
-        assert not Path("bar/.venv").exists()
-        assert not Path("bar/uv.lock").exists()
+        assert not Path("foo-bar/.venv").exists()
+        assert not Path("foo-bar/uv.lock").exists()
 
 
 def test_code_location_scaffold_no_use_dg_managed_environment_success() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
-            "code-location", "scaffold", "--no-use-dg-managed-environment", "bar"
+            "code-location", "scaffold", "--no-use-dg-managed-environment", "foo-bar"
         )
         assert_runner_result(result)
-        assert Path("bar").exists()
-        assert Path("bar/bar").exists()
-        assert Path("bar/bar/lib").exists()
-        assert Path("bar/bar/components").exists()
-        assert Path("bar/bar_tests").exists()
-        assert Path("bar/pyproject.toml").exists()
+        assert Path("foo-bar").exists()
+        assert Path("foo-bar/foo_bar").exists()
+        assert Path("foo-bar/foo_bar/lib").exists()
+        assert Path("foo-bar/foo_bar/components").exists()
+        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv not created
-        assert not Path("bar/.venv").exists()
-        assert not Path("bar/uv.lock").exists()
+        assert not Path("foo-bar/.venv").exists()
+        assert not Path("foo-bar/uv.lock").exists()
 
 
 def test_code_location_scaffold_editable_dagster_no_env_var_no_value_fails(monkeypatch) -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
@@ -11,7 +11,7 @@ ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
-    isolated_example_code_location_bar,
+    isolated_example_code_location_foo_bar,
     isolated_example_deployment_foo,
     modify_pyproject_toml,
 )
@@ -22,7 +22,7 @@ from dagster_dg_tests.utils import (
 
 
 def test_component_scaffold_dynamic_subcommand_generation() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke("component", "scaffold", "--help")
         assert_runner_result(result)
         assert (
@@ -39,7 +39,10 @@ def test_component_scaffold_dynamic_subcommand_generation() -> None:
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_scaffold_no_params_success(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke(
             "component",
             "scaffold",
@@ -47,8 +50,8 @@ def test_component_scaffold_no_params_success(in_deployment: bool) -> None:
             "qux",
         )
         assert_runner_result(result)
-        assert Path("bar/components/qux").exists()
-        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert Path("foo_bar/components/qux").exists()
+        component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
             "type: dagster_components.test.all_metadata_empty_asset"
@@ -58,7 +61,10 @@ def test_component_scaffold_no_params_success(in_deployment: bool) -> None:
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_scaffold_json_params_success(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke(
             "component",
             "scaffold",
@@ -68,9 +74,9 @@ def test_component_scaffold_json_params_success(in_deployment: bool) -> None:
             '{"asset_key": "foo", "filename": "hello.py"}',
         )
         assert_runner_result(result)
-        assert Path("bar/components/qux").exists()
-        assert Path("bar/components/qux/hello.py").exists()
-        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert Path("foo_bar/components/qux").exists()
+        assert Path("foo_bar/components/qux/hello.py").exists()
+        component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
             "type: dagster_components.test.simple_pipes_script_asset"
@@ -80,7 +86,10 @@ def test_component_scaffold_json_params_success(in_deployment: bool) -> None:
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_scaffold_key_value_params_success(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke(
             "component",
             "scaffold",
@@ -90,9 +99,9 @@ def test_component_scaffold_key_value_params_success(in_deployment: bool) -> Non
             "--filename=hello.py",
         )
         assert_runner_result(result)
-        assert Path("bar/components/qux").exists()
-        assert Path("bar/components/qux/hello.py").exists()
-        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert Path("foo_bar/components/qux").exists()
+        assert Path("foo_bar/components/qux/hello.py").exists()
+        component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
             "type: dagster_components.test.simple_pipes_script_asset"
@@ -101,7 +110,7 @@ def test_component_scaffold_key_value_params_success(in_deployment: bool) -> Non
 
 
 def test_component_scaffold_json_params_and_key_value_params_fails() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component",
             "scaffold",
@@ -126,7 +135,10 @@ def test_component_scaffold_outside_code_location_fails() -> None:
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_scaffold_already_exists_fails(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke(
             "component",
             "scaffold",
@@ -145,11 +157,11 @@ def test_component_scaffold_already_exists_fails(in_deployment: bool) -> None:
 
 
 def test_component_scaffold_succeeds_non_default_component_package() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
-        alt_lib_path = Path("bar/_components")
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        alt_lib_path = Path("foo_bar/_components")
         alt_lib_path.mkdir(parents=True)
         with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_package"] = "bar._components"
+            pyproject_toml["tool"]["dg"]["component_package"] = "foo_bar._components"
         result = runner.invoke(
             "component",
             "scaffold",
@@ -157,8 +169,8 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
             "qux",
         )
         assert_runner_result(result)
-        assert Path("bar/_components/qux").exists()
-        component_yaml_path = Path("bar/_components/qux/component.yaml")
+        assert Path("foo_bar/_components/qux").exists()
+        component_yaml_path = Path("foo_bar/_components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
             "type: dagster_components.test.all_metadata_empty_asset"
@@ -167,7 +179,7 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
 
 
 def test_component_scaffold_fails_components_package_does_not_exist() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         with modify_pyproject_toml() as pyproject_toml:
             pyproject_toml["tool"]["dg"]["component_package"] = "bar._components"
         result = runner.invoke(
@@ -181,17 +193,17 @@ def test_component_scaffold_fails_components_package_does_not_exist() -> None:
 
 
 def test_component_scaffold_succeeds_scaffolded_component_type() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke("component-type", "scaffold", "baz")
         assert_runner_result(result)
-        assert Path("bar/lib/baz.py").exists()
+        assert Path("foo_bar/lib/baz.py").exists()
 
-        result = runner.invoke("component", "scaffold", "bar.baz", "qux")
+        result = runner.invoke("component", "scaffold", "foo_bar.baz", "qux")
         assert_runner_result(result)
-        assert Path("bar/components/qux").exists()
-        component_yaml_path = Path("bar/components/qux/component.yaml")
+        assert Path("foo_bar/components/qux").exists()
+        component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
-        assert "type: bar.baz" in component_yaml_path.read_text()
+        assert "type: foo_bar.baz" in component_yaml_path.read_text()
 
 
 # ##### REAL COMPONENTS
@@ -210,7 +222,7 @@ dbt_project_path = "../stub_code_locations/dbt_project_location/components/jaffl
 def test_scaffold_dbt_project_instance(params) -> None:
     with (
         ProxyRunner.test(use_test_component_lib=False) as runner,
-        isolated_example_code_location_bar(runner),
+        isolated_example_code_location_foo_bar(runner),
     ):
         # We need to add dagster-dbt also because we are using editable installs. Only
         # direct dependencies will be resolved by uv.tool.sources.
@@ -223,9 +235,9 @@ def test_scaffold_dbt_project_instance(params) -> None:
             *params,
         )
         assert_runner_result(result)
-        assert Path("bar/components/my_project").exists()
+        assert Path("foo_bar/components/my_project").exists()
 
-        component_yaml_path = Path("bar/components/my_project/component.yaml")
+        component_yaml_path = Path("foo_bar/components/my_project/component.yaml")
         assert component_yaml_path.exists()
         assert "type: dagster_components.dbt_project" in component_yaml_path.read_text()
         assert (
@@ -240,7 +252,7 @@ def test_scaffold_dbt_project_instance(params) -> None:
 
 
 def test_list_components_succeeds():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component",
             "scaffold",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -11,7 +11,7 @@ ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
-    isolated_example_code_location_bar,
+    isolated_example_code_location_foo_bar,
     isolated_example_deployment_foo,
     modify_pyproject_toml,
 )
@@ -23,13 +23,16 @@ from dagster_dg_tests.utils import (
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_type_scaffold_success(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke("component-type", "scaffold", "baz")
         assert_runner_result(result)
-        assert Path("bar/lib/baz.py").exists()
+        assert Path("foo_bar/lib/baz.py").exists()
         dg_context = DgContext.default()
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        assert registry.has("bar.baz")
+        assert registry.has("foo_bar.baz")
 
 
 def test_component_type_scaffold_outside_code_location_fails() -> None:
@@ -41,7 +44,10 @@ def test_component_type_scaffold_outside_code_location_fails() -> None:
 
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_type_scaffold_already_exists_fails(in_deployment: bool) -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, in_deployment):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, in_deployment),
+    ):
         result = runner.invoke("component-type", "scaffold", "baz")
         assert_runner_result(result)
         result = runner.invoke("component-type", "scaffold", "baz")
@@ -50,36 +56,36 @@ def test_component_type_scaffold_already_exists_fails(in_deployment: bool) -> No
 
 
 def test_component_type_scaffold_succeeds_non_default_component_lib_package() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
-        alt_lib_path = Path("bar/_lib")
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        alt_lib_path = Path("foo_bar/_lib")
         alt_lib_path.mkdir(parents=True)
         with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_lib_package"] = "bar._lib"
-            pyproject_toml["project"]["entry-points"]["dagster.components"]["bar"] = "bar._lib"
+            pyproject_toml["tool"]["dg"]["component_lib_package"] = "foo_bar._lib"
+            pyproject_toml["project"]["entry-points"]["dagster.components"]["bar"] = "foo_bar._lib"
         result = runner.invoke(
             "component-type",
             "scaffold",
             "baz",
         )
         assert_runner_result(result)
-        assert Path("bar/_lib/baz.py").exists()
+        assert Path("foo_bar/_lib/baz.py").exists()
         dg_context = DgContext.default()
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
         assert registry.has("bar.baz")
 
 
 def test_component_type_scaffold_fails_components_lib_package_does_not_exist() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_lib_package"] = "bar._lib"
-            pyproject_toml["project"]["entry-points"]["dagster.components"]["bar"] = "bar._lib"
+            pyproject_toml["tool"]["dg"]["component_lib_package"] = "foo_bar._lib"
+            pyproject_toml["project"]["entry-points"]["dagster.components"]["bar"] = "foo_bar._lib"
         result = runner.invoke(
             "component-type",
             "scaffold",
             "baz",
         )
         assert_runner_result(result, exit_0=False)
-        assert "Components lib package `bar._lib` is not installed" in str(result.exception)
+        assert "Components lib package `foo_bar._lib` is not installed" in str(result.exception)
 
 
 # ########################
@@ -88,7 +94,7 @@ def test_component_type_scaffold_fails_components_lib_package_does_not_exist() -
 
 
 def test_component_type_docs_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component-type",
             "docs",
@@ -155,7 +161,7 @@ _EXPECTED_COMPONENT_TYPE_INFO_FULL = textwrap.dedent("""
 
 
 def test_component_type_info_all_metadata_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component-type",
             "info",
@@ -166,7 +172,7 @@ def test_component_type_info_all_metadata_success():
 
 
 def test_component_type_info_all_metadata_empty_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component-type",
             "info",
@@ -182,7 +188,7 @@ def test_component_type_info_all_metadata_empty_success():
 
 
 def test_component_type_info_flag_fields_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component-type",
             "info",
@@ -275,7 +281,7 @@ def test_component_type_info_success_outside_code_location() -> None:
 
 
 def test_component_type_info_multiple_flags_fails() -> None:
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component-type",
             "info",
@@ -306,14 +312,17 @@ _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
 
 
 def test_list_component_types_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke("component-type", "list")
         assert_runner_result(result)
         assert result.output.strip() == _EXPECTED_COMPONENT_TYPES
 
 
 def test_list_component_types_success_with_unmanaged_environment():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner, skip_venv=True):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_code_location_foo_bar(runner, skip_venv=True),
+    ):
         result = runner.invoke("component-type", "list", "--no-use-dg-managed-environment")
         assert_runner_result(result)
         assert not Path("uv.lock").exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -9,7 +9,7 @@ ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
-    isolated_example_code_location_bar,
+    isolated_example_code_location_foo_bar,
 )
 
 # ########################
@@ -154,7 +154,7 @@ def test_sub_command_with_option_help_message():
 
 
 def test_dynamic_subcommand_help_message():
-    with ProxyRunner.test() as runner, isolated_example_code_location_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke(
             "component", "scaffold", "dagster_components.test.simple_pipes_script_asset", "--help"
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
-    isolated_example_code_location_bar,
+    isolated_example_code_location_foo_bar,
 )
 
 # For all cache tests, avoid setting up venv in example code location so we do not prepopulate the
 # cache (which is part of the venv setup routine).
-example_code_location = partial(isolated_example_code_location_bar, skip_venv=True)
+example_code_location = partial(isolated_example_code_location_foo_bar, skip_venv=True)
 
 
 def test_load_from_cache():
@@ -60,7 +60,7 @@ def test_cache_no_invalidation_modified_pkg():
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
-        Path("bar/submodule.py").write_text("print('hello')")
+        Path("foo_bar/submodule.py").write_text("print('hello')")
 
         result = runner.invoke("component-type", "list")
         assert_runner_result(result)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -22,14 +22,16 @@ from typing_extensions import Self
 @contextmanager
 def isolated_example_deployment_foo(runner: Union[CliRunner, "ProxyRunner"]) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
-    with runner.isolated_filesystem(), clear_module_from_cache("bar"):
+    with runner.isolated_filesystem(), clear_module_from_cache("foo_bar"):
         runner.invoke("deployment", "scaffold", "foo")
         with pushd("foo"):
             yield
 
 
+# Preferred example code location is foo-bar instead of a single word so that we can test the effect
+# of hyphenation.
 @contextmanager
-def isolated_example_code_location_bar(
+def isolated_example_code_location_foo_bar(
     runner: Union[CliRunner, "ProxyRunner"], in_deployment: bool = True, skip_venv: bool = False
 ) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
@@ -42,9 +44,9 @@ def isolated_example_code_location_bar(
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
                 *(["--no-use-dg-managed-environment"] if skip_venv else []),
-                "bar",
+                "foo-bar",
             )
-            with clear_module_from_cache("bar"), pushd("code_locations/bar"):
+            with clear_module_from_cache("foo_bar"), pushd("code_locations/foo-bar"):
                 yield
     else:
         with runner.isolated_filesystem():
@@ -54,9 +56,9 @@ def isolated_example_code_location_bar(
                 "--use-editable-dagster",
                 dagster_git_repo_dir,
                 *(["--no-use-dg-managed-environment"] if skip_venv else []),
-                "bar",
+                "foo-bar",
             )
-            with clear_module_from_cache("bar"), pushd("bar"):
+            with clear_module_from_cache("foo_bar"), pushd("foo-bar"):
                 yield
 
 


### PR DESCRIPTION
## Summary & Motivation

- Fix a bug when scaffolding components that would cause the scaffolded component to be generated at the wrong path when the code location had a hyphenated name (would end up at `foo-bar/components/xxx` instead of `foo_bar/components/xxx`).
- Update tests so that the default test code location is now named `foo-bar` instead of `bar` so that the hyphenated case is tested.

## How I Tested These Changes

Updated unit tests.