### PR TITLE
[project_dagster_modal_pipes] rename dagster-contrib-modal to dagster-modal

### DIFF
--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -305,7 +305,7 @@ Explore integration libraries that are maintained by the Dagster community.
   ></ArticleListItem>
   <ArticleListItem
     title="Modal"
-    href="https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-contrib-modal"
+    href="https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-modal"
   ></ArticleListItem>
   <ArticleListItem
     title="Dingtalk"

--- a/examples/project_dagster_modal_pipes/project_dagster_modal_pipes/pipeline_factory.py
+++ b/examples/project_dagster_modal_pipes/project_dagster_modal_pipes/pipeline_factory.py
@@ -6,7 +6,7 @@ import dagster as dg
 import feedparser
 import yagmail
 from dagster_aws.s3 import S3Resource
-from dagster_contrib_modal import ModalClient
+from dagster_modal import ModalClient
 from dagster_openai import OpenAIResource
 
 from project_dagster_modal_pipes.constants import DEFAULT_POLLING_INTERVAL, R2_BUCKET_NAME

--- a/examples/project_dagster_modal_pipes/project_dagster_modal_pipes/resources.py
+++ b/examples/project_dagster_modal_pipes/project_dagster_modal_pipes/resources.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import dagster as dg
 from dagster_aws.s3 import S3Resource
-from dagster_contrib_modal import ModalClient
+from dagster_modal import ModalClient
 from dagster_openai import OpenAIResource
 
 modal_resource = ModalClient(project_directory=Path(__file__).parent.parent)

--- a/examples/project_dagster_modal_pipes/setup.py
+++ b/examples/project_dagster_modal_pipes/setup.py
@@ -6,7 +6,7 @@ setup(
     install_requires=[
         "dagster",
         "dagster-aws",
-        "dagster-contrib-modal>=0.0.2",
+        "dagster-modal>=0.0.2",
         "dagster-openai",
         "feedparser",
         "ffmpeg-python",

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -113,7 +113,7 @@ daff==1.3.46
 -e python_modules/libraries/dagster-celery-k8s
 -e python_modules/libraries/dagster-census
 -e python_modules/libraries/dagster-components
-dagster-contrib-modal==0.0.2
+dagster-modal==0.0.2
 -e python_modules/libraries/dagster-dask
 -e python_modules/libraries/dagster-databricks
 -e python_modules/libraries/dagster-datadog


### PR DESCRIPTION
## Summary & Motivation

It was determined that the `-contrib-` differentiator in package names is not necessary, so the `dagster-contrib-modal` has been refactored and re-published as `dagster-modal`. This updates the example project using the package.

## How I Tested These Changes

## Changelog

NOCHANGELOG
