### PR TITLE
[components] Update resolution deferral logic

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolvable-field.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolvable-field.py
@@ -14,7 +14,7 @@ class ShellScriptSchema(ComponentSchemaBaseModel):
     script_runner: Annotated[
         str,
         ResolvableFieldInfo(
-            output_type=ScriptRunner, additional_scope={"get_script_runner"}
+            output_type=ScriptRunner, required_scope={"get_script_runner"}
         ),
     ]
     # highlight-end

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -211,7 +211,7 @@ def get_registered_component_types_in_module(module: ModuleType) -> Iterable[typ
             yield component
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=BaseModel)
 
 
 @dataclass

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -3,19 +3,14 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
-from dagster_components.core.schema.metadata import (
-    JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY,
-    get_resolution_metadata,
-)
+from dagster_components.core.schema.metadata import get_resolution_metadata
 from dagster_components.core.schema.resolver import TemplatedValueResolver
 
 
 class ComponentSchemaBaseModel(BaseModel):
     """Base class for models that are part of a component schema."""
 
-    model_config = ConfigDict(
-        json_schema_extra={JSON_SCHEMA_EXTRA_DEFER_RENDERING_KEY: True}, extra="forbid"
-    )
+    model_config = ConfigDict(extra="forbid")
 
     def resolve_properties(self, value_resolver: TemplatedValueResolver) -> Mapping[str, Any]:
         """Returns a dictionary of resolved properties for this class."""

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -30,7 +30,7 @@ class DbtProjectParams(BaseModel):
     dbt: DbtCliResource
     op: Optional[OpSpecBaseModel] = None
     asset_attributes: Annotated[
-        Optional[AssetAttributesModel], ResolvableFieldInfo(additional_scope={"node"})
+        Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"node"})
     ] = None
     transforms: Optional[Sequence[AssetSpecTransformModel]] = None
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -27,7 +27,7 @@ class SlingReplicationParams(BaseModel):
     path: str
     op: Optional[OpSpecBaseModel] = None
     asset_attributes: Annotated[
-        Optional[AssetAttributesModel], ResolvableFieldInfo(additional_scope={"stream_definition"})
+        Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"stream_definition"})
     ] = None
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -21,7 +21,7 @@ class ComplexAssetParams(BaseModel):
     value: str
     op: Optional[OpSpecBaseModel] = None
     asset_attributes: Annotated[
-        Optional[AssetAttributesModel], ResolvableFieldInfo(additional_scope={"node"})
+        Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"node"})
     ] = None
     asset_transforms: Optional[Sequence[AssetSpecTransformModel]] = None
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -34,16 +34,16 @@ def _commented_object_for_subschema(
     name: str,
     json_schema: Mapping[str, Any],
     subschema: Mapping[str, Any],
-    available_scope: Optional[Set[str]] = None,
+    required_scope: Optional[Set[str]] = None,
 ) -> Union[CommentedObject, Any]:
-    additional_scope = subschema.get("dagster_available_scope")
-    available_scope = (available_scope or set()) | set(additional_scope or [])
+    additional_scope = subschema.get("dagster_required_scope")
+    required_scope = (required_scope or set()) | set(additional_scope or [])
 
     subschema = _dereference_schema(json_schema, subschema)
     if "anyOf" in subschema:
         # TODO: handle anyOf fields more gracefully, for now just choose first option
         return _commented_object_for_subschema(
-            name, json_schema, subschema["anyOf"][0], available_scope=available_scope
+            name, json_schema, subschema["anyOf"][0], required_scope=required_scope
         )
 
     objtype = subschema["type"]
@@ -54,12 +54,12 @@ def _commented_object_for_subschema(
                 k: _commented_object_for_subschema(k, json_schema, v)
                 for k, v in subschema.get("properties", {}).items()
             },
-            comment=f"Available scope: {available_scope}" if available_scope else None,
+            comment=f"Available scope: {required_scope}" if required_scope else None,
         )
     elif objtype == "array":
         return [
             _commented_object_for_subschema(
-                name, json_schema, subschema["items"], available_scope=available_scope
+                name, json_schema, subschema["items"], required_scope=required_scope
             )
         ]
     elif objtype == "string":


### PR DESCRIPTION
## Summary & Motivation

This changes the logic for how we determine which fields to defer resolution for.

We want to eagerly resolve a field as long as it:

a) has no additional required scope
b) will not change its type if you resolve it

This allows us to eagerly resolve stuff like environment variables and simple string parameters (which makes resource construction simpler), while safely ignoring resolution for fancier structured objects, or objects that need to be resolved in a more complex scope

## How I Tested These Changes

## Changelog

NOCHANGELOG
