### PR TITLE
[2/n][dagster-sling] Move logic to default fns in DagsterSlingTranslator

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -196,9 +196,7 @@ class DagsterSlingTranslator:
         """
         return self._default_deps_fn(stream_definition)
 
-    def _default_deps_fn(
-        self, stream_definition: Mapping[str, Any]
-    ) -> Iterable[AssetKey]:
+    def _default_deps_fn(self, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -194,9 +194,9 @@ class DagsterSlingTranslator:
                         return AssetKey(map[stream_name])
 
         """
-        return self._default_deps_asset_key_fn(stream_definition)
+        return self._default_deps_fn(stream_definition)
 
-    def _default_deps_asset_key_fn(
+    def _default_deps_fn(
         self, stream_definition: Mapping[str, Any]
     ) -> Iterable[AssetKey]:
         """A function that takes a stream name from a Sling replication config and returns a

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -101,9 +101,9 @@ class DagsterSlingTranslator:
                         map = {"stream1": "asset1", "stream2": "asset2"}
                         return AssetKey(map[stream_name])
         """
-        return self.default_asset_key_fn(stream_definition)
+        return self._default_asset_key_fn(stream_definition)
 
-    def default_asset_key_fn(self, stream_definition: Mapping[str, Any]) -> AssetKey:
+    def _default_asset_key_fn(self, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey.
 

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -101,6 +101,45 @@ class DagsterSlingTranslator:
                         map = {"stream1": "asset1", "stream2": "asset2"}
                         return AssetKey(map[stream_name])
         """
+        return self.default_asset_key_fn(stream_definition)
+
+    def default_asset_key_fn(self, stream_definition: Mapping[str, Any]) -> AssetKey:
+        """A function that takes a stream definition from a Sling replication config and returns a
+        Dagster AssetKey.
+
+        The stream definition is a dictionary key/value pair where the key is the stream name and
+        the value is a dictionary representing the Sling Replication Stream Config.
+
+        For example:
+
+        .. code-block:: python
+
+            stream_definition = {"public.users":
+                {'sql': 'select all_user_id, name from public."all_Users"',
+                'object': 'public.all_users'}
+            }
+
+        By default, this returns the class's target_prefix paramater concatenated with the stream name.
+        A stream named "public.accounts" will create an AssetKey named "target_public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster AssetKey.
+
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        .. code-block:: yaml
+
+            public.users:
+               meta:
+                 dagster:
+                   asset_key: "mydb_users"
+
+        Args:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
+
+        Returns:
+            AssetKey: The Dagster AssetKey for the replication stream.
+        """
         config = stream_definition.get("config", {}) or {}
         object_key = config.get("object")
         meta = config.get("meta", {})
@@ -155,6 +194,34 @@ class DagsterSlingTranslator:
                         return AssetKey(map[stream_name])
 
         """
+        return self._default_deps_asset_key_fn(stream_definition)
+
+    def _default_deps_asset_key_fn(
+        self, stream_definition: Mapping[str, Any]
+    ) -> Iterable[AssetKey]:
+        """A function that takes a stream name from a Sling replication config and returns a
+        Dagster AssetKey for the dependencies of the replication stream.
+
+        By default, this returns the stream name. For example, a stream named "public.accounts"
+        will create an AssetKey named "target_public_accounts" and a dependency named "public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster depenency.
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        .. code-block:: yaml
+
+            public.users:
+                meta:
+                    dagster:
+                        deps: "sourcedb_users"
+
+        Args:
+            stream_name (str): The name of the stream.
+
+        Returns:
+            AssetKey: The Dagster AssetKey dependency for the replication stream.
+        """
         config = stream_definition.get("config", {}) or {}
         meta = config.get("meta", {})
         deps = meta.get("dagster", {}).get("deps")
@@ -191,6 +258,22 @@ class DagsterSlingTranslator:
         Returns:
             Optional[str]: The description of the stream if found, otherwise None.
         """
+        return self._default_description_fn(stream_definition)
+
+    def _default_description_fn(self, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        """Retrieves the description for a given stream definition.
+
+        This method checks the provided stream definition for a description. It first looks
+        for an "sql" key in the configuration and returns its value if found. If not, it looks
+        for a description in the metadata under the "dagster" key.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Optional[str]: The description of the stream if found, otherwise None.
+        """
         config = stream_definition.get("config", {}) or {}
         if "sql" in config:
             return config["sql"]
@@ -200,6 +283,21 @@ class DagsterSlingTranslator:
 
     @public
     def get_metadata(self, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Retrieves the metadata for a given stream definition.
+
+        This method extracts the configuration from the provided stream definition and returns
+        it as a JSON metadata value.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Mapping[str, Any]: A dictionary containing the stream configuration as JSON metadata.
+        """
+        return self._default_metadata_fn(stream_definition)
+
+    def _default_metadata_fn(self, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
         """Retrieves the metadata for a given stream definition.
 
         This method extracts the configuration from the provided stream definition and returns
@@ -228,6 +326,21 @@ class DagsterSlingTranslator:
         Returns:
             Mapping[str, Any]: An empty dictionary.
         """
+        return self._default_tags_fn(stream_definition)
+
+    def _default_tags_fn(self, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Retrieves the tags for a given stream definition.
+
+        This method returns an empty dictionary, indicating that no tags are associated with
+        the stream definition by default. This method can be overridden to provide custom tags.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Mapping[str, Any]: An empty dictionary.
+        """
         return {}
 
     @public
@@ -243,10 +356,39 @@ class DagsterSlingTranslator:
         Returns:
             Set[str]: A set containing kinds for the stream's assets.
         """
+        return self._default_kinds_fn(stream_definition)
+
+    def _default_kinds_fn(self, stream_definition: Mapping[str, Any]) -> set[str]:
+        """Retrieves the kinds for a given stream definition.
+
+        This method returns "sling" by default. This method can be overridden to provide custom kinds.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Set[str]: A set containing kinds for the stream's assets.
+        """
         return {"sling"}
 
     @public
     def get_group_name(self, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        """Retrieves the group name for a given stream definition.
+
+        This method checks the provided stream definition for a group name in the metadata
+        under the "dagster" key.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Optional[str]: The group name if found, otherwise None.
+        """
+        return self._default_group_name_fn(stream_definition)
+
+    def _default_group_name_fn(self, stream_definition: Mapping[str, Any]) -> Optional[str]:
         """Retrieves the group name for a given stream definition.
 
         This method checks the provided stream definition for a group name in the metadata
@@ -282,6 +424,26 @@ class DagsterSlingTranslator:
             Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
             otherwise None.
         """
+        return self._default_freshness_policy_fn(stream_definition)
+
+    def _default_freshness_policy_fn(
+        self, stream_definition: Mapping[str, Any]
+    ) -> Optional[FreshnessPolicy]:
+        """Retrieves the freshness policy for a given stream definition.
+
+        This method checks the provided stream definition for a specific configuration
+        indicating a freshness policy. If the configuration is found, it constructs and
+        returns a FreshnessPolicy object based on the provided parameters. Otherwise,
+        it returns None.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
+            otherwise None.
+        """
         config = stream_definition.get("config", {}) or {}
         meta = config.get("meta", {})
         freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
@@ -294,6 +456,25 @@ class DagsterSlingTranslator:
 
     @public
     def get_auto_materialize_policy(
+        self, stream_definition: Mapping[str, Any]
+    ) -> Optional[AutoMaterializePolicy]:
+        """Defines the auto-materialize policy for a given stream definition.
+
+        This method checks the provided stream definition for a specific configuration
+        indicating an auto-materialize policy. If the configuration is found, it returns
+        an eager auto-materialize policy. Otherwise, it returns None.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Optional[AutoMaterializePolicy]: An eager auto-materialize policy if the configuration
+            is found, otherwise None.
+        """
+        return self._default_auto_materialize_policy_fn(stream_definition)
+
+    def _default_auto_materialize_policy_fn(
         self, stream_definition: Mapping[str, Any]
     ) -> Optional[AutoMaterializePolicy]:
         """Defines the auto-materialize policy for a given stream definition.

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -119,10 +119,8 @@ class DagsterSlingTranslator:
                 'object': 'public.all_users'}
             }
 
-        By default, this returns the class's target_prefix paramater concatenated with the stream name.
+        This returns the class's target_prefix parameter concatenated with the stream name.
         A stream named "public.accounts" will create an AssetKey named "target_public_accounts".
-
-        Override this function to customize how to map a Sling stream to a Dagster AssetKey.
 
         Alternatively, you can provide metadata in your Sling replication config to specify the
         Dagster AssetKey for a stream as follows:
@@ -166,7 +164,7 @@ class DagsterSlingTranslator:
         By default, this returns the stream name. For example, a stream named "public.accounts"
         will create an AssetKey named "target_public_accounts" and a dependency named "public_accounts".
 
-        Override this function to customize how to map a Sling stream to a Dagster depenency.
+        Override this function to customize how to map a Sling stream to a Dagster dependency.
         Alternatively, you can provide metadata in your Sling replication config to specify the
         Dagster AssetKey for a stream as follows:
 
@@ -178,7 +176,7 @@ class DagsterSlingTranslator:
                         deps: "sourcedb_users"
 
         Args:
-            stream_name (str): The name of the stream.
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
 
         Returns:
             AssetKey: The Dagster AssetKey dependency for the replication stream.
@@ -200,10 +198,9 @@ class DagsterSlingTranslator:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
-        By default, this returns the stream name. For example, a stream named "public.accounts"
+        This returns the stream name. For example, a stream named "public.accounts"
         will create an AssetKey named "target_public_accounts" and a dependency named "public_accounts".
 
-        Override this function to customize how to map a Sling stream to a Dagster depenency.
         Alternatively, you can provide metadata in your Sling replication config to specify the
         Dagster AssetKey for a stream as follows:
 
@@ -215,7 +212,7 @@ class DagsterSlingTranslator:
                         deps: "sourcedb_users"
 
         Args:
-            stream_name (str): The name of the stream.
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
 
         Returns:
             AssetKey: The Dagster AssetKey dependency for the replication stream.

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -97,9 +97,9 @@ class DagsterSlingTranslator:
             .. code-block:: python
 
                 class CustomSlingTranslator(DagsterSlingTranslator):
-                    def get_asset_key_for_target(self, stream_definition) -> AssetKey:
+                    def get_asset_key_for_target(self, stream_definition: Mapping[str, Any]) -> AssetKey:
                         map = {"stream1": "asset1", "stream2": "asset2"}
-                        return AssetKey(map[stream_name])
+                        return AssetKey(map[stream_definition["name"]])
         """
         return self._default_asset_key_fn(stream_definition)
 
@@ -187,15 +187,15 @@ class DagsterSlingTranslator:
             .. code-block:: python
 
                 class CustomSlingTranslator(DagsterSlingTranslator):
-                    def get_deps_asset_key(self, stream_name: str) -> AssetKey:
+                    def get_deps_asset_key(self, stream_definition: Mapping[str, Any]) -> AssetKey:
                         map = {"stream1": "asset1", "stream2": "asset2"}
-                        return AssetKey(map[stream_name])
+                        return AssetKey(map[stream_definition["name"]])
 
         """
         return self._default_deps_fn(stream_definition)
 
     def _default_deps_fn(self, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
-        """A function that takes a stream name from a Sling replication config and returns a
+        """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
         This returns the stream name. For example, a stream named "public.accounts"


### PR DESCRIPTION
## Summary & Motivation

Move the logic in `DagsterSlingTranslator.get_*` methods to `DagsterSlingTranslator._default_*_fn` methods

This is motivated by two main reasons: 
1. To keep `get_asset_spec` implementation as clean as possible in subsequent PR.
2. `DagsterSlingTranslator.get_*` methods will be deprecated in a subsequent PR, but it would be great to keep to docstrings in the code after these will be removed, to help users if needed.

## How I Tested These Changes

Existing tests with BK

