### PR TITLE
[3/n][dagster-sling] Leverage get_asset_spec in DagsterSlingTranslator.get_*

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -154,7 +154,7 @@ def test_load_from_path(sling_path: Path) -> None:
     assert len(components) == 1
     assert get_asset_keys(components[0]) == {
         AssetKey("input_csv"),
-        AssetKey(["foo", "input_duckdb"]),
+        AssetKey(["input_duckdb"]),
     }
 
     assert_assets(components[0], 2)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -154,7 +154,7 @@ def test_load_from_path(sling_path: Path) -> None:
     assert len(components) == 1
     assert get_asset_keys(components[0]) == {
         AssetKey("input_csv"),
-        AssetKey(["input_duckdb"]),
+        AssetKey(["foo", "input_duckdb"]),
     }
 
     assert_assets(components[0], 2)

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -20,15 +20,15 @@ class DagsterSlingTranslator:
         the value is a dictionary representing the Sling Replication Stream Config.
         """
         return AssetSpec(
-            key=self.get_asset_key(stream_definition),
-            deps=self.get_deps_asset_key(stream_definition),
-            description=self.get_description(stream_definition),
-            metadata=self.get_metadata(stream_definition),
-            tags=self.get_tags(stream_definition),
-            kinds=self.get_kinds(stream_definition),
-            group_name=self.get_group_name(stream_definition),
-            freshness_policy=self.get_freshness_policy(stream_definition),
-            auto_materialize_policy=self.get_auto_materialize_policy(stream_definition),
+            key=self._default_asset_key_fn(stream_definition),
+            deps=self._default_deps_fn(stream_definition),
+            description=self._default_description_fn(stream_definition),
+            metadata=self._default_metadata_fn(stream_definition),
+            tags=self._default_tags_fn(stream_definition),
+            kinds=self._default_kinds_fn(stream_definition),
+            group_name=self._default_group_name_fn(stream_definition),
+            freshness_policy=self._default_freshness_policy_fn(stream_definition),
+            auto_materialize_policy=self._default_auto_materialize_policy_fn(stream_definition),
         )
 
     @public
@@ -101,7 +101,7 @@ class DagsterSlingTranslator:
                         map = {"stream1": "asset1", "stream2": "asset2"}
                         return AssetKey(map[stream_definition["name"]])
         """
-        return self._default_asset_key_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).key
 
     def _default_asset_key_fn(self, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream definition from a Sling replication config and returns a
@@ -192,7 +192,7 @@ class DagsterSlingTranslator:
                         return AssetKey(map[stream_definition["name"]])
 
         """
-        return self._default_deps_fn(stream_definition)
+        return [dep.asset_key for dep in self.get_asset_spec(stream_definition).deps]
 
     def _default_deps_fn(self, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
         """A function that takes a stream definition from a Sling replication config and returns a
@@ -253,7 +253,7 @@ class DagsterSlingTranslator:
         Returns:
             Optional[str]: The description of the stream if found, otherwise None.
         """
-        return self._default_description_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).description
 
     def _default_description_fn(self, stream_definition: Mapping[str, Any]) -> Optional[str]:
         """Retrieves the description for a given stream definition.
@@ -290,7 +290,7 @@ class DagsterSlingTranslator:
         Returns:
             Mapping[str, Any]: A dictionary containing the stream configuration as JSON metadata.
         """
-        return self._default_metadata_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).metadata
 
     def _default_metadata_fn(self, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
         """Retrieves the metadata for a given stream definition.
@@ -321,7 +321,7 @@ class DagsterSlingTranslator:
         Returns:
             Mapping[str, Any]: An empty dictionary.
         """
-        return self._default_tags_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).tags
 
     def _default_tags_fn(self, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
         """Retrieves the tags for a given stream definition.
@@ -351,7 +351,7 @@ class DagsterSlingTranslator:
         Returns:
             Set[str]: A set containing kinds for the stream's assets.
         """
-        return self._default_kinds_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).kinds
 
     def _default_kinds_fn(self, stream_definition: Mapping[str, Any]) -> set[str]:
         """Retrieves the kinds for a given stream definition.
@@ -381,7 +381,7 @@ class DagsterSlingTranslator:
         Returns:
             Optional[str]: The group name if found, otherwise None.
         """
-        return self._default_group_name_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).group_name
 
     def _default_group_name_fn(self, stream_definition: Mapping[str, Any]) -> Optional[str]:
         """Retrieves the group name for a given stream definition.
@@ -419,7 +419,7 @@ class DagsterSlingTranslator:
             Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
             otherwise None.
         """
-        return self._default_freshness_policy_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).freshness_policy
 
     def _default_freshness_policy_fn(
         self, stream_definition: Mapping[str, Any]
@@ -467,7 +467,7 @@ class DagsterSlingTranslator:
             Optional[AutoMaterializePolicy]: An eager auto-materialize policy if the configuration
             is found, otherwise None.
         """
-        return self._default_auto_materialize_policy_fn(stream_definition)
+        return self.get_asset_spec(stream_definition).auto_materialize_policy
 
     def _default_auto_materialize_policy_fn(
         self, stream_definition: Mapping[str, Any]

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -230,9 +230,29 @@ def test_base_with_custom_tags_translator() -> None:
         def get_asset_spec(self, stream_definition: Mapping[str, Any]) -> AssetSpec:
             default_spec = super().get_asset_spec(stream_definition)
             return default_spec.replace_attributes(
-                kinds=["sling", "foo"], tags={"custom_tag": "custom_value"}
+                kinds={"sling", "foo"}, tags={"custom_tag": "custom_value"}
             )
 
+    @sling_assets(
+        replication_config=replication_config_path,
+        dagster_sling_translator=CustomSlingTranslator(),
+    )
+    def my_sling_assets(): ...
+
+    for asset_key in my_sling_assets.keys:
+        assert my_sling_assets.tags_by_key[asset_key] == {
+            "custom_tag": "custom_value",
+            **build_kind_tag("sling"),
+            **build_kind_tag("foo"),
+        }
+
+
+def test_base_with_custom_tags_translator_legacy() -> None:
+    replication_config_path = file_relative_path(
+        __file__, "replication_configs/base_with_default_meta/replication.yaml"
+    )
+
+    class CustomSlingTranslator(DagsterSlingTranslator):
         def get_tags(self, stream_definition):
             return {"custom_tag": "custom_value"}
 

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -1,12 +1,15 @@
 import os
 import sqlite3
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
 from dagster import (
     AssetExecutionContext,
     AssetKey,
+    AssetSpec,
     Config,
     FreshnessPolicy,
     JsonMetadataValue,
@@ -224,6 +227,12 @@ def test_base_with_custom_tags_translator() -> None:
     )
 
     class CustomSlingTranslator(DagsterSlingTranslator):
+        def get_asset_spec(self, stream_definition: Mapping[str, Any]) -> AssetSpec:
+            default_spec = super().get_asset_spec(stream_definition)
+            return default_spec.replace_attributes(
+                kinds=["sling", "foo"], tags={"custom_tag": "custom_value"}
+            )
+
         def get_tags(self, stream_definition):
             return {"custom_tag": "custom_value"}
 

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
@@ -104,8 +104,8 @@ def test_get_metadata(stream, expected):
     [
         ({"name": "foo"}, None),
         (
-            {"name": "foo", "config": {"meta": {"dagster": {"group": "foo.bar"}}}},
-            "foo.bar",
+            {"name": "foo", "config": {"meta": {"dagster": {"group": "foo_bar"}}}},
+            "foo_bar",
         ),
     ],
 )


### PR DESCRIPTION
## Summary & Motivation

Use `get_asset_spec(...)` in other `get_*` methods to access the spec attributes. The goal is to only use `get_asset_spec`, `get_*` methods will be deprecated in a subsequent PR.

Some tests were incorrect before - updated in this PR.

## How I Tested These Changes

Updated tests with BK

