### PR TITLE
fix redacted errors outputting the message twice

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/objects.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/objects.py
@@ -114,7 +114,7 @@ class StepFailureData(
             # For a redacted error, just return the redacted message without any
             # internal user code error.
             if self.error.cls_name == DagsterRedactedUserCodeError.__name__:
-                return self.error.message.strip() + ":\n\n" + self.error.to_string()
+                return self.error.to_string()
 
             user_code_error = self.error.cause
             check.invariant(


### PR DESCRIPTION
Summary:
Noticed this while testing user code masking. The error emits the message, then to_string(), which contains the message.

Test Plan:
Launch a run with the redaction env var on, raise an Exception from the asset, view output

Changelog:
Fixed an issue where runs with the `DAGSTER_REDACT_USER_CODE_ERRORS` environment variable enable emitted the same log message twice.
