### PR TITLE
Add `.allow()` and `.ignore()` for bool conditions

### DIFF
--- a/docs/content/concepts/automation/declarative-automation/customizing-automation-conditions.mdx
+++ b/docs/content/concepts/automation/declarative-automation/customizing-automation-conditions.mdx
@@ -73,15 +73,9 @@ By default, `AutomationCondition.on_cron()` will wait for all upstream dependenc
 ```python file=concepts/declarative_automation/ignore_dependencies_cron.py
 import dagster as dg
 
-all_deps_except_foo_updated = dg.AutomationCondition.all_deps_updated_since_cron(
-    "@hourly"
-).ignore(dg.AssetSelection.assets("foo"))
-
-condition = (
-    dg.AutomationCondition.on_cron("@hourly").without(
-        dg.AutomationCondition.all_deps_updated_since_cron("@hourly")
-    )
-) & all_deps_except_foo_updated
+condition = dg.AutomationCondition.on_cron("@hourly").ignore(
+    dg.AssetSelection.assets("foo")
+)
 ```
 
 Alternatively, you can pass in an <PyObject object="AssetSelection" /> to be allowed:
@@ -89,15 +83,9 @@ Alternatively, you can pass in an <PyObject object="AssetSelection" /> to be all
 ```python file=concepts/declarative_automation/allow_dependencies_cron.py
 import dagster as dg
 
-group_abc_updated = dg.AutomationCondition.all_deps_updated_since_cron("@hourly").allow(
+condition = dg.AutomationCondition.on_cron("@hourly").allow(
     dg.AssetSelection.groups("abc")
 )
-
-condition = (
-    dg.AutomationCondition.on_cron("@hourly").without(
-        dg.AutomationCondition.all_deps_updated_since_cron("@hourly")
-    )
-) & group_abc_updated
 ```
 
 ### Wait for all blocking asset checks to complete before executing

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_automation/allow_dependencies_cron.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_automation/allow_dependencies_cron.py
@@ -1,11 +1,5 @@
 import dagster as dg
 
-group_abc_updated = dg.AutomationCondition.all_deps_updated_since_cron("@hourly").allow(
+condition = dg.AutomationCondition.on_cron("@hourly").allow(
     dg.AssetSelection.groups("abc")
 )
-
-condition = (
-    dg.AutomationCondition.on_cron("@hourly").without(
-        dg.AutomationCondition.all_deps_updated_since_cron("@hourly")
-    )
-) & group_abc_updated

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_automation/ignore_dependencies_cron.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_automation/ignore_dependencies_cron.py
@@ -1,11 +1,5 @@
 import dagster as dg
 
-all_deps_except_foo_updated = dg.AutomationCondition.all_deps_updated_since_cron(
-    "@hourly"
-).ignore(dg.AssetSelection.assets("foo"))
-
-condition = (
-    dg.AutomationCondition.on_cron("@hourly").without(
-        dg.AutomationCondition.all_deps_updated_since_cron("@hourly")
-    )
-) & all_deps_except_foo_updated
+condition = dg.AutomationCondition.on_cron("@hourly").ignore(
+    dg.AssetSelection.assets("foo")
+)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Sequence
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import dagster._check as check
 from dagster._annotations import public
@@ -13,6 +13,9 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._record import copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_selection import AssetSelection
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")
@@ -82,6 +85,46 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
             else copy(self, operands=[child.replace(old, new) for child in self.operands])
         )
 
+    @public
+    def allow(self, selection: "AssetSelection") -> "AndAutomationCondition":
+        """Applies the ``.allow()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to allow.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operands=[
+                child.allow(selection) if hasattr(child, "allow") else child
+                for child in self.operands
+            ],
+        )
+
+    @public
+    def ignore(self, selection: "AssetSelection") -> "AndAutomationCondition":
+        """Applies the ``.ignore()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to ignore.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operands=[
+                child.ignore(selection) if hasattr(child, "ignore") else child
+                for child in self.operands
+            ],
+        )
+
 
 @whitelist_for_serdes(storage_name="OrAssetCondition")
 @record
@@ -143,6 +186,46 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
             else copy(self, operands=[child.replace(old, new) for child in self.operands])
         )
 
+    @public
+    def allow(self, selection: "AssetSelection") -> "OrAutomationCondition":
+        """Applies the ``.allow()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to allow.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operands=[
+                child.allow(selection) if hasattr(child, "allow") else child
+                for child in self.operands
+            ],
+        )
+
+    @public
+    def ignore(self, selection: "AssetSelection") -> "OrAutomationCondition":
+        """Applies the ``.ignore()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to ignore.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operands=[
+                child.ignore(selection) if hasattr(child, "ignore") else child
+                for child in self.operands
+            ],
+        )
+
 
 @whitelist_for_serdes(storage_name="NotAssetCondition")
 @record
@@ -190,4 +273,42 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
             new
             if old in [self, self.get_label()]
             else copy(self, operand=self.operand.replace(old, new))
+        )
+
+    @public
+    def allow(self, selection: "AssetSelection") -> "NotAutomationCondition":
+        """Applies the ``.allow()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to allow.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operand=self.operand.allow(selection)
+            if hasattr(self.operand, "allow")
+            else self.operand,
+        )
+
+    @public
+    def ignore(self, selection: "AssetSelection") -> "NotAutomationCondition":
+        """Applies the ``.ignore()`` method across all sub-conditions.
+
+        This impacts any dep-related sub-conditions.
+
+        Args:
+            selection (AssetSelection): The selection to ignore.
+        """
+        from dagster._core.definitions.asset_selection import AssetSelection
+
+        check.inst_param(selection, "selection", AssetSelection)
+        return copy(
+            self,
+            operand=self.operand.ignore(selection)
+            if hasattr(self.operand, "ignore")
+            else self.operand,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -107,6 +107,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
+    @public
     def allow(self, selection: "AssetSelection") -> "DepsAutomationCondition":
         """Returns a copy of this condition that will only consider dependencies within the provided
         AssetSelection.
@@ -119,6 +120,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
         return copy(self, allow_selection=allow_selection)
 
+    @public
     def ignore(self, selection: "AssetSelection") -> "DepsAutomationCondition":
         """Returns a copy of this condition that will ignore dependencies within the provided
         AssetSelection.


### PR DESCRIPTION
## Summary & Motivation

Users often want to make small changes to the existing built-in policies. However, these utilities aren't always the most ergonomic for certain use cases. For example, dep conditions support allowing or ignoring an asset selection, but this has to be done individually for each sub-condition of a complex condition.

## How I Tested These Changes

Added unit tests.

## Changelog

Implement the `.allow()` and `.ignore()` methods on boolean conditions, which will propagate the asset selection down to any contained dep sub-conditions.