### PR TITLE
[dagster-polars] Pin `pyarrow<19.0.0` during tests

### DIFF
--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -49,6 +49,7 @@ setup(
             "hypothesis[zoneinfo]>=6.89.0",
             "deepdiff>=6.3.0",
             "pytest-cases>=3.6.14",
+            "pyarrow<19.0.0",  # temporary until polars supports pyarrow 19
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

BK started failing upon PyArrow 19 release (and I can replicate it on my machine); it's probably an issue with Polars not supporting it properly.

I don't see any issues on the Polars repo yet, so will see if something pops up tomorrow before trying to debug anything Dagster-specific—would expect that to be quite unlikely.

## How I Tested These Changes

BK
