### PR TITLE
[chore] use uv to install pyright deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install_prettier:
 	npm install -g prettier
 
 install_pyright:
-	pip install -e 'python_modules/dagster[pyright]' -e 'python_modules/dagster-pipes'
+	uv pip install -e 'python_modules/dagster[pyright]' -e 'python_modules/dagster-pipes'
 
 rebuild_pyright:
 	python scripts/run-pyright.py --all --rebuild


### PR DESCRIPTION
## Summary & Motivation

I noticed we are not using `uv` when running `make install_pyright`. Fixing it. 
