### PR TITLE
Unlist components docs

### DIFF
--- a/docs/docs-beta/docs/guides/build/project-structure/components.md
+++ b/docs/docs-beta/docs/guides/build/project-structure/components.md
@@ -1,6 +1,7 @@
 ---
 title: "Components"
 sidebar_position: 100
+unlisted: true
 ---
 
 Welcome to Dagster Components.

--- a/docs/docs-beta/docs/guides/build/project-structure/creating-a-component.md
+++ b/docs/docs-beta/docs/guides/build/project-structure/creating-a-component.md
@@ -1,6 +1,7 @@
 ---
 title: 'Creating a New Component Type'
 sidebar_position: 100
+unlisted: true
 ---
 
 :::note

--- a/docs/docs-beta/docs/guides/build/project-structure/existing-code-location.md
+++ b/docs/docs-beta/docs/guides/build/project-structure/existing-code-location.md
@@ -1,6 +1,7 @@
 ---
 title: 'Making an existing code location components-compatible'
 sidebar_position: 100
+unlisted: true
 ---
 
 :::note

--- a/docs/docs-beta/docs/guides/build/project-structure/using-a-component.md
+++ b/docs/docs-beta/docs/guides/build/project-structure/using-a-component.md
@@ -1,6 +1,7 @@
 ---
 title: "Adding a component to a project"
 sidebar_position: 100
+unlisted: true
 ---
 
 


### PR DESCRIPTION
## Summary & Motivation

Unlist components docs -- they can still be accessed via direct URL, but will not appear in the sidebar.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
