### PR TITLE
[components] add cli command to generate schema for code location component types

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -1,9 +1,10 @@
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, Union
 
 import click
+from pydantic import TypeAdapter, create_model
 
 from dagster_components.core.component import (
     Component,
@@ -79,3 +80,36 @@ def list_local_component_types_command(component_directories: Sequence[str]) -> 
         if len(output_for_directory) > 0:
             output[component_directory] = output_for_directory
     click.echo(json.dumps(output))
+
+
+@list_cli.command(name="all-components-schema")
+@click.pass_context
+def generate_code_location_components_schema(ctx: click.Context) -> None:
+    """Builds a JSON schema which ORs the schema for a component
+    file for all component types available in the current code location.
+    """
+    assert is_inside_code_location_project(Path.cwd())
+
+    builtin_component_lib = ctx.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
+
+    context = CodeLocationProjectContext.from_code_location_path(
+        find_enclosing_code_location_root_path(Path.cwd()),
+        ComponentTypeRegistry.from_entry_point_discovery(
+            builtin_component_lib=builtin_component_lib
+        ),
+    )
+
+    schemas = []
+    for key, component_type in context.list_component_types():
+        # Create ComponentFileModel schema for each type
+        schema_type = component_type.get_schema()
+        if schema_type:
+            schemas.append(
+                create_model(
+                    key,
+                    type=(Literal[key], key),
+                    params=(schema_type, None),
+                )
+            )
+    union_type = Union[tuple(schemas)]  # type: ignore
+    click.echo(json.dumps(TypeAdapter(union_type).json_schema()))

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -155,6 +155,40 @@ def test_list_local_components_types() -> None:
             assert len(result) == 2
 
 
+def test_all_components_schema_command():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["--builtin-component-lib", "dagster_components.test", "list", "all-components-schema"]
+    )
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+
+    component_type_keys = [
+        "complex_schema_asset",
+        "simple_asset",
+        "simple_pipes_script_asset",
+    ]
+
+    assert result["anyOf"] == [
+        {"$ref": f"#/$defs/{component_type_key}"} for component_type_key in component_type_keys
+    ]
+
+    # Sanity check each of the component type schemas has a constant type property matching the
+    # fully scoped component type key
+    for component_type_key in component_type_keys:
+        component_type_schema_def = result["$defs"][component_type_key]
+        assert "type" in component_type_schema_def["properties"]
+        assert (
+            component_type_schema_def["properties"]["type"]["default"]
+            == f"dagster_components.test.{component_type_key}"
+        )
+        assert (
+            component_type_schema_def["properties"]["type"]["const"]
+            == f"dagster_components.test.{component_type_key}"
+        )
+
+
 def test_scaffold_component_command():
     runner = CliRunner()
 


### PR DESCRIPTION
## Summary

Adds a `dagster-components` CLI command used to generate a schema for component files, which ORs all component types available in a given code location.

This schema can be used to type check all component files for a code location.

## How I Tested These Changes

New unit test.
