### PR TITLE
[components] Don't use uv-managed environment by default when outside code location

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -27,7 +27,7 @@ class RemoteComponentType:
 class RemoteComponentRegistry:
     @classmethod
     def from_dg_context(cls, dg_context: "DgContext") -> "RemoteComponentRegistry":
-        if dg_context.config.use_dg_managed_environment:
+        if dg_context.use_dg_managed_environment:
             dg_context.ensure_uv_lock()
 
         if dg_context.has_cache:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -35,7 +35,8 @@ class DgContext:
     def __init__(self, config: DgConfig, root_path: Path):
         self.config = config
         self.root_path = root_path
-        if config.disable_cache or not config.use_dg_managed_environment:
+        # self.use_dg_managed_environment is a property derived from self.config
+        if config.disable_cache or not self.use_dg_managed_environment:
             self._cache = None
         else:
             self._cache = DgCache.from_config(config)
@@ -200,7 +201,7 @@ class DgContext:
     # ########################
 
     def external_components_command(self, command: list[str]) -> str:
-        if self.config.use_dg_managed_environment:
+        if self.use_dg_managed_environment:
             code_location_command_prefix = ["uv", "run", "dagster-components"]
             env = get_uv_command_env()
         else:
@@ -224,3 +225,7 @@ class DgContext:
         with pushd(path):
             if not (path / "uv.lock").exists():
                 subprocess.run(["uv", "sync"], check=True, env=get_uv_command_env())
+
+    @property
+    def use_dg_managed_environment(self) -> bool:
+        return self.config.use_dg_managed_environment and self.is_code_location

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -122,7 +122,7 @@ def scaffold_code_location(
 
     # Build the venv
     cl_dg_context = dg_context.with_root_path(path)
-    if cl_dg_context.config.use_dg_managed_environment and not skip_venv:
+    if cl_dg_context.use_dg_managed_environment and not skip_venv:
         cl_dg_context.ensure_uv_lock()
         RemoteComponentRegistry.from_dg_context(cl_dg_context)  # Populate the cache
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -30,7 +30,7 @@ def test_component_type_scaffold_success(in_deployment: bool) -> None:
         result = runner.invoke("component-type", "scaffold", "baz")
         assert_runner_result(result)
         assert Path("foo_bar/lib/baz.py").exists()
-        dg_context = DgContext.default()
+        dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
         assert registry.has("foo_bar.baz")
 
@@ -69,7 +69,7 @@ def test_component_type_scaffold_succeeds_non_default_component_lib_package() ->
         )
         assert_runner_result(result)
         assert Path("foo_bar/_lib/baz.py").exists()
-        dg_context = DgContext.default()
+        dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
         assert registry.has("bar.baz")
 
@@ -331,5 +331,5 @@ def test_list_component_types_success_with_unmanaged_environment():
 
 def test_component_type_list_success_outside_code_location():
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("component-type", "list", "--no-use-dg-managed-environment")
+        result = runner.invoke("component-type", "list")
         assert_runner_result(result)


### PR DESCRIPTION
## Summary & Motivation

Tweak the behavior of `dg` so that it will _not_ assume a uv-managed virtual environment if we are outside of a declared dg code location. This makes it much easier to use in a regular python env.

## How I Tested These Changes

Modified existing unit tests.