### PR TITLE
[DOC-723][docs-beta] add startAfter and endBefore props to CodeExample

### DIFF
--- a/docs/docs-beta/src/components/CodeExample.tsx
+++ b/docs/docs-beta/src/components/CodeExample.tsx
@@ -7,6 +7,8 @@ interface CodeExampleProps {
   title?: string;
   lineStart?: number;
   lineEnd?: number;
+  startAfter?: string; // marker that indicates beginning of code snippet
+  endBefore?: string; // marker that indicates ending of code snippet
 }
 
 /**
@@ -33,24 +35,49 @@ function processModule({
   module,
   lineStart,
   lineEnd,
+  startAfter,
+  endBefore,
 }: {
   cacheKey: string;
   module: any;
   lineStart?: number;
   lineEnd?: number;
+  startAfter?: string;
+  endBefore?: string;
 }) {
   var lines = module.default.split('\n');
 
-  const sliceStart = lineStart && lineStart > 0 ? lineStart : 0;
-  const sliceEnd = lineEnd && lineEnd <= lines.length ? lineEnd : lines.length;
-  lines = lines.slice(sliceStart, sliceEnd);
+  // limit to range of `lineStart` and `lineEnd`
+  const lineStartIndex = lineStart && lineStart > 0 ? lineStart : 0;
+  const lineEndIndex = lineEnd && lineEnd <= lines.length ? lineEnd : lines.length;
+
+  // limit to range of `startAfter` and `endBefore`
+  let startAfterIndex = startAfter
+    ? lines.findIndex((line: string) => line.includes(startAfter)) + 1
+    : 0;
+
+  const endAfterIndex = endBefore
+    ? lines.findIndex((line: string) => line.includes(endBefore))
+    : lines.length;
+
+  const ix1 = Math.max(lineStartIndex, startAfterIndex);
+  const ix2 = Math.min(lineEndIndex, endAfterIndex);
+
+  lines = lines.slice(ix1, ix2);
 
   lines = filterNoqaComments(lines);
   lines = trimMainBlock(lines);
   contentCache[cacheKey] = {content: lines.join('\n')};
 }
 
-function useLoadModule(cacheKey: string, path: string, lineStart: number, lineEnd: number) {
+function useLoadModule(
+  cacheKey: string,
+  path: string,
+  lineStart: number,
+  lineEnd: number,
+  startAfter: string,
+  endBefore: string,
+) {
   const isServer = typeof window === 'undefined';
   if (isServer) {
     /**
@@ -58,7 +85,7 @@ function useLoadModule(cacheKey: string, path: string, lineStart: number, lineEn
      */
     try {
       const module = require(`!!raw-loader!/../../examples/${path}`);
-      processModule({cacheKey, module, lineStart, lineEnd});
+      processModule({cacheKey, module, lineStart, lineEnd, startAfter, endBefore});
     } catch (e) {
       console.error(e);
       contentCache[cacheKey] = {error: e.toString()};
@@ -72,7 +99,7 @@ function useLoadModule(cacheKey: string, path: string, lineStart: number, lineEn
      */
     throw import(`!!raw-loader!/../../examples/${path}`)
       .then((module) => {
-        processModule({cacheKey, module, lineStart, lineEnd});
+        processModule({cacheKey, module, lineStart, lineEnd, startAfter, endBefore});
       })
       .catch((e) => {
         contentCache[cacheKey] = {error: e.toString()};
@@ -91,11 +118,20 @@ const CodeExample: React.FC<CodeExampleProps> = ({...props}) => {
 };
 
 const CodeExampleInner: React.FC<CodeExampleProps> = (props) => {
-  const {filePath, title, lineStart, lineEnd, language = 'python', ...extraProps} = props;
+  const {
+    filePath,
+    title,
+    lineStart,
+    lineEnd,
+    startAfter,
+    endBefore,
+    language = 'python',
+    ...extraProps
+  } = props;
 
   const path = 'docs_beta_snippets/docs_beta_snippets/' + filePath;
   const cacheKey = JSON.stringify(props);
-  const {content, error} = useLoadModule(cacheKey, path, lineStart, lineEnd);
+  const {content, error} = useLoadModule(cacheKey, path, lineStart, lineEnd, startAfter, endBefore);
 
   if (error) {
     return <div style={{color: 'red', padding: '1rem', border: '1px solid red'}}>{error}</div>;


### PR DESCRIPTION
## Summary & Motivation

- Adds ability to specify strings, `startAfter` and `endBefore` for filtering `CodeExample` lines

Example usage:
```
<CodeExample
  filePath="getting-started/hello-world.py"
  language="python"
  startAfter="start_after_marker"
  endBefore="end_before_marker"
/>
```

```
import dagster as dg


@dg.asset
def hello(context: dg.AssetExecutionContext):
    context.log.info("Hello!")

# start_after_marker
@dg.asset(deps=[hello])
def world(context: dg.AssetExecutionContext):
    context.log.info("World!")
# end_before_marker


defs = dg.Definitions(assets=[hello, world])

if __name__ == "__main__":
    dg.materialize(hello)
    dg.materialize(world)
```

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/6c72b02b-ef2a-4b78-b3b1-650a13b22201" />

## How I Tested These Changes

## Changelog

NOCHANGELOG
