### PR TITLE
[docs-beta] remove try/catch block for missing code examples

### DIFF
--- a/docs/docs-beta/src/components/CodeExample.tsx
+++ b/docs/docs-beta/src/components/CodeExample.tsx
@@ -80,16 +80,8 @@ function useLoadModule(
 ) {
   const isServer = typeof window === 'undefined';
   if (isServer) {
-    /**
-     * Note: Remove the try/catch to cause a hard error on build once all of the bad code examples are cleaned up.
-     */
-    try {
-      const module = require(`!!raw-loader!/../../examples/${path}`);
-      processModule({cacheKey, module, lineStart, lineEnd, startAfter, endBefore});
-    } catch (e) {
-      console.error(e);
-      contentCache[cacheKey] = {error: e.toString()};
-    }
+    const module = require(`!!raw-loader!/../../examples/${path}`);
+    processModule({cacheKey, module, lineStart, lineEnd, startAfter, endBefore});
   }
 
   if (!contentCache[cacheKey]) {


### PR DESCRIPTION
## Summary & Motivation

Now that code examples have been updated, we can remove the try/catch block so that the build fails when a code example is missing. This will allow us to catch broken examples at build time.

## How I Tested These Changes

## Changelog

NOCHANGELOG