### PR TITLE
[components][rfc] `@component_loader` decorator

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -66,14 +66,13 @@ class PipesSubprocessScriptCollection(Component):
 
         return Definitions(
             assets=[self._create_asset_def(path, specs) for path, specs in self.path_specs.items()],
-            resources={"pipes_client": PipesSubprocessClient()},
         )
 
     def _create_asset_def(self, path: Path, specs: Sequence[AssetSpec]) -> AssetsDefinition:
         # TODO: allow name paraeterization
         @multi_asset(specs=specs, name=f"script_{path.stem}")
-        def _asset(context: AssetExecutionContext, pipes_client: PipesSubprocessClient):
+        def _asset(context: AssetExecutionContext):
             cmd = [shutil.which("python"), path]
-            return pipes_client.run(command=cmd, context=context).get_results()
+            return PipesSubprocessClient().run(command=cmd, context=context).get_results()
 
         return _asset

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
@@ -1,0 +1,25 @@
+from dagster_components import AssetAttributesModel, ComponentLoadContext
+from dagster_components.core.component import component_loader
+from dagster_components.lib import PipesSubprocessScriptCollection
+from dagster_components.lib.pipes_subprocess_script_collection import (
+    PipesSubprocessScriptCollectionParams,
+    PipesSubprocessScriptParams,
+)
+
+
+@component_loader
+def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
+    params = PipesSubprocessScriptCollectionParams(
+        scripts=[
+            PipesSubprocessScriptParams(
+                path="cool_script.py",
+                assets=[
+                    AssetAttributesModel(
+                        key="cool_script",
+                        automation_condition="{{ automation_condition.eager() }}",
+                    ),
+                ],
+            ),
+        ]
+    )
+    return PipesSubprocessScriptCollection.load(params=params, context=context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/cool_script.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/cool_script.py
@@ -1,0 +1,6 @@
+def do_thing() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    do_thing()


### PR DESCRIPTION
## Summary & Motivation

Adds an `@component_loader` decorator and the corresponding infrastructure to allow users to write arbitrary python code to load their Components.

Note that the convention I've gone with here has the user manually call `XComponent.load()`, rather than going through the `__init__`. My thought here was basically just that this feels like better practice as it provides a common shared format between the python and yaml interfaces.

In short, the way to use this is to have a `component.py` file instead of a `component.yaml` file, which will look something like:

```python
from dagster_components import ComponentLoadContext, component_loader
from ... import MyComponentClass

@component_loader
def load(context: ComponentLoadContext) -> MyComponentClass:
    return MyComponentClass.load(
        params=...,
        context=context,
    )
```

And again, there's nothing stopping you from using the regular constructor, I just think that might be harder to use.

## How I Tested These Changes

## Changelog

NOCHANGELOG
