### PR TITLE
More aggressively mask user code errors when masking enabled

### DIFF
--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -282,7 +282,6 @@ def user_code_error_boundary(
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
     from dagster._utils.error import log_and_redact_stacktrace_if_enabled
 
-    print("enter user")
     with log_and_redact_stacktrace_if_enabled(), raise_execution_interrupts():
         if log_manager:
             log_manager.begin_python_log_capture()

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -280,8 +280,10 @@ def user_code_error_boundary(
     """
     check.callable_param(msg_fn, "msg_fn")
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
+    from dagster._utils.error import log_and_redact_stacktrace_if_enabled
 
-    with raise_execution_interrupts():
+    print("enter user")
+    with log_and_redact_stacktrace_if_enabled(), raise_execution_interrupts():
         if log_manager:
             log_manager.begin_python_log_capture()
         try:

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -280,9 +280,9 @@ def user_code_error_boundary(
     """
     check.callable_param(msg_fn, "msg_fn")
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
-    from dagster._utils.error import log_and_redact_stacktrace_if_enabled
+    from dagster._utils.error import redact_user_stacktrace_if_enabled
 
-    with log_and_redact_stacktrace_if_enabled(), raise_execution_interrupts():
+    with redact_user_stacktrace_if_enabled(), raise_execution_interrupts():
         if log_manager:
             log_manager.begin_python_log_capture()
         try:

--- a/python_modules/dagster/dagster/_core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/utils.py
@@ -44,8 +44,6 @@ def op_execution_error_boundary(
     from dagster._core.execution.context.system import StepExecutionContext
     from dagster._utils.error import log_and_redact_stacktrace_if_enabled
 
-    print("enter op")
-
     check.callable_param(msg_fn, "msg_fn")
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
     check.inst_param(step_context, "step_context", StepExecutionContext)

--- a/python_modules/dagster/dagster/_core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/utils.py
@@ -42,13 +42,13 @@ def op_execution_error_boundary(
     as respecting the RetryPolicy if present.
     """
     from dagster._core.execution.context.system import StepExecutionContext
-    from dagster._utils.error import log_and_redact_stacktrace_if_enabled
+    from dagster._utils.error import redact_user_stacktrace_if_enabled
 
     check.callable_param(msg_fn, "msg_fn")
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
-    with log_and_redact_stacktrace_if_enabled(), raise_execution_interrupts():
+    with redact_user_stacktrace_if_enabled(), raise_execution_interrupts():
         step_context.log.begin_python_log_capture()
         retry_policy = step_context.op_retry_policy
 

--- a/python_modules/dagster/dagster/_core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/utils.py
@@ -42,12 +42,15 @@ def op_execution_error_boundary(
     as respecting the RetryPolicy if present.
     """
     from dagster._core.execution.context.system import StepExecutionContext
+    from dagster._utils.error import log_and_redact_stacktrace_if_enabled
+
+    print("enter op")
 
     check.callable_param(msg_fn, "msg_fn")
     check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
-    with raise_execution_interrupts():
+    with log_and_redact_stacktrace_if_enabled(), raise_execution_interrupts():
         step_context.log.begin_python_log_capture()
         retry_policy = step_context.op_retry_policy
 

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -98,7 +98,7 @@ _REDACTED_ERROR_LOGGER_NAME = os.getenv(
 )
 
 
-exception_id_to_masked_error_id: Dict[int, str] = {}
+redacted_exception_id_to_user_facing_identifier: Dict[int, str] = {}
 
 
 @contextlib.contextmanager
@@ -118,13 +118,13 @@ def redact_user_stacktrace_if_enabled():
 
             # Generate a unique error ID for this error, or re-use an existing one
             # if this error has already been seen
-            existing_error_id = exception_id_to_masked_error_id.get(id(e))
+            existing_error_id = redacted_exception_id_to_user_facing_identifier.get(id(e))
 
             if not existing_error_id:
                 error_id = str(uuid.uuid4())
 
                 # Track the error ID for this exception so we can redact it later
-                exception_id_to_masked_error_id[id(e)]= error_id
+                redacted_exception_id_to_user_facing_identifier[id(e)]= error_id
                 masked_logger = logging.getLogger(_REDACTED_ERROR_LOGGER_NAME)
 
                 masked_logger.error(
@@ -195,7 +195,7 @@ def serializable_error_info_from_exc_info(
 
     from dagster._core.errors import DagsterUserCodeProcessError
 
-    err_id = exception_id_to_masked_error_id.get(id(e))
+    err_id = redacted_exception_id_to_user_facing_identifier.get(id(e))
     if err_id:
         if isinstance(e, DagsterUserCodeExecutionError):
             # For user code, we want to completely mask the error message, since

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -173,7 +173,7 @@ def serializable_error_info_from_exc_info(
             return SerializableErrorInfo(
                 message=error_info.message
                 + (
-                    "Error ID {err_id}. "
+                    f"Error ID {err_id}. "
                     "The error has been masked to prevent leaking sensitive information. "
                     "Search in logs for this error ID for more details."
                 ),

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -152,6 +152,9 @@ def test_masking_op_execution(
 
     step_error = next(event for event in result.all_events if event.is_step_failure)
 
+    # Certain exceptions will not be fully redacted, just the stack trace
+    # For example, system errors and interrupts may contain useful information
+    # or information that the framework itself relies on
     if expect_exc_name_in_error:
         assert (
             step_error.step_failure_data.error

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -99,6 +99,8 @@ def test_masking_nested_user_code_err_boundaries_reraise(enable_masking_user_cod
 
                 hunter2()
         except Exception as e:
+            # Mimics behavior of resource teardown, which runs in a
+            # user_code_error_boundary after the user code raises an error
             with user_code_error_boundary(
                 error_cls=DagsterUserCodeExecutionError,
                 msg_fn=lambda: "teardown after we raised hunter2 error",

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -95,7 +95,7 @@ def test_masking_nested_user_code_err_reraise(enable_masking_user_code_errors):
         try:
             with user_code_error_boundary(
                 error_cls=DagsterUserCodeExecutionError,
-                msg_fn=lambda: "hunter2",
+                msg_fn=lambda: "test",
             ):
 
                 def hunter2():


### PR DESCRIPTION
## Summary

Follow-on to the functionality introduced in #18688. The original PR ensures that if the `DAGSTER_REDACT_USER_CODE_ERRORS` env var is set to `1`, instances of `DagsterUserCodeExecutionError` which are serialized are masked so that their potentially sensitive contents are not leaked. However, there is a class of errors that can still expose elements of user code: system/framework errors or interrupts, for example, will include their stack trace and snippets of user code.

This PR attempts to handle this second class of errors, in a few ways:
- Any error which is raised in a user code context has its stacktrace logged and then cleared, so if the error makes it to serialization, it will only include the error message.
- User code exceptions have their `original_exc_info` purged.
- A global mapping stores the error, so that a unique error ID can be raised in the UI, which can be used to locate the original error in logs.

## Test Plan

New unit tests which specifically handle the intterrupt/system error cases.