### PR TITLE
[chore] Add GitHub issue to comment on PyArrow pin

### DIFF
--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -49,7 +49,7 @@ setup(
             "hypothesis[zoneinfo]>=6.89.0",
             "deepdiff>=6.3.0",
             "pytest-cases>=3.6.14",
-            "pyarrow<19.0.0",  # temporary until polars supports pyarrow 19
+            "pyarrow<19.0.0",  # temporary pin until https://github.com/apache/arrow/issues/45283 is fixed
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

Probably was partially premature in blaming Polars; they are probably just using the Rust crate under the hood to write Parquet, but the issue actually needs to be fixed on Arrow side. Linking the [issue](https://github.com/apache/arrow/issues/45283) so have something to track.