### PR TITLE
[dagster-snowflake] fix bug where private key was required to be base64 encoded

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -398,7 +398,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             with open(config.get("private_key_path"), "rb") as key:
                 private_key = key.read()
         else:
-            private_key = config.get("private_key", None)
+            private_key = config.get("private_key", None).encode()
 
         kwargs = {}
         if config.get("private_key_password", None) is not None:
@@ -410,7 +410,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             p_key = serialization.load_pem_private_key(
                 private_key, backend=default_backend(), **kwargs
             )
-        except TypeError:
+        except (ValueError, TypeError):
             try:
                 private_key = base64.b64decode(private_key)
                 p_key = serialization.load_pem_private_key(

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -132,8 +132,8 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             "Raw private key to use. See the `Snowflake documentation"
             " <https://docs.snowflake.com/en/user-guide/key-pair-auth.html>`__ for details."
             " Alternately, set private_key_path and private_key_password. To avoid issues with"
-            " newlines in the keys, you can base64 encode the key. You can retrieve the base64"
-            " encoded key with this shell command: ``cat rsa_key.p8 | base64``"
+            " newlines in the keys, you can optionally base64 encode the key. You can retrieve"
+            " the base64 encoded key with this shell command: ``cat rsa_key.p8 | base64``"
         ),
     )
 
@@ -410,7 +410,9 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             p_key = serialization.load_pem_private_key(
                 private_key, backend=default_backend(), **kwargs
             )
-        except (ValueError, TypeError):
+
+        # key fails to load, possibly indicating key is base64 encoded
+        except ValueError:
             try:
                 private_key = base64.b64decode(private_key)
                 p_key = serialization.load_pem_private_key(


### PR DESCRIPTION
## Summary & Motivation

Previously, it was not possible to pass a non-base64 encoded private key to the SnowflakeResource, as the `TypeError` would be thrown, as `private_key` was a string, and not bytes when read directly as a parameter and not a file.

This encodes the private key, which allows it to be loaded via `load_pem_private_key`. Now, when the parameter is base64 encoded, and `load_pem_private_key` will throw a `ValueError` and the key will be decoded as a fallback.

## How I Tested These Changes

Functionality was confirmed working by running the two files below locally, one with the key base64 encoded, and the other with plaintext.

---

Confirmed functionality with plaintext private key.

```
import dagster as dg

from dagster_snowflake import SnowflakeResource


@dg.asset(kinds={"snowflake"})
def example_snowflake_asset(
    context: dg.AssetExecutionContext, snowflake: SnowflakeResource
):
    with snowflake.get_connection() as conn:
        result = conn.cursor().execute(
            """
            select current_timestamp()
            """
        )
    return dg.MaterializeResult(metadata={"num_rows": len(result.fetchall())})


private_key_plaintext = """
-----BEGIN PRIVATE KEY-----
<REDACTED>
-----END PRIVATE KEY-----
"""

defs = dg.Definitions(
    assets=[example_snowflake_asset],
    resources={
        "snowflake": SnowflakeResource(
            user="REDACTED@REDACTED.com",
            account="REDACTED.us-east-1",
            database="REDACTED",
            private_key=private_key_plaintext,  # <-- plaintext key
        )
    },
)
```

Confirmed functionality with base64 encoded private key.

```
import dagster as dg

from dagster_snowflake import SnowflakeResource


@dg.asset(kinds={"snowflake"})
def example_snowflake_asset(
    context: dg.AssetExecutionContext, snowflake: SnowflakeResource
):
    with snowflake.get_connection() as conn:
        result = conn.cursor().execute(
            """
            select current_timestamp()
            """
        )
    return dg.MaterializeResult(metadata={"num_rows": len(result.fetchall())})


defs = dg.Definitions(
    assets=[example_snowflake_asset],
    resources={
        "snowflake": SnowflakeResource(
            user="REDACTED@REDACTED.com",
            account="REDACTED.us-east-1",
            database="REDACTED",
            private_key="BASE64_KEY_REDACTED==",  # <-- base64 encoded key
        )
    },
)
```

## Changelog

- [dagster-snowflake] fixed bug where plaintext private key via `private_key` parameter failed to load, and required base64 encoding
