### PR TITLE
disable vercel deploys for PR branches

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25
         if: |
-          github.event_name == 'pull_request' ||
           (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
         with:
           github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}


### PR DESCRIPTION
## Summary

Update the vercel publish trigger to only care about release branches and docs prod/master.
