### PR TITLE
[partition-status-cache][repro] Bug when using old AssetRecord in get_and_update_asset_status_cache_value

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1975,7 +1975,10 @@ class SqlEventLogStorage(EventLogStorage):
         return dict(latest_tags_by_partition)
 
     def get_latest_asset_partition_materialization_attempts_without_materializations(
-        self, asset_key: AssetKey, after_storage_id: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        after_storage_id: Optional[int] = None,
+        before_storage_id: Optional[int] = None,
     ) -> Mapping[str, tuple[str, int]]:
         """Fetch the latest materialzation and materialization planned events for each partition of the given asset.
         Return the partitions that have a materialization planned event but no matching (same run) materialization event.
@@ -1993,6 +1996,7 @@ class SqlEventLogStorage(EventLogStorage):
                 DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
             ],
             after_cursor=after_storage_id,
+            before_cursor=before_storage_id,
         )
 
         latest_events_subquery = db_subquery(

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -418,6 +418,7 @@ def build_failed_and_in_progress_partition_subset(
         incomplete_materializations = instance.event_log_storage.get_latest_asset_partition_materialization_attempts_without_materializations(
             asset_key, after_storage_id=after_storage_id
         )
+        print(incomplete_materializations)
 
     failed_partitions: set[str] = set()
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/observable_to_eager.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/observable_to_eager.py
@@ -1,0 +1,12 @@
+import dagster as dg
+
+
+@dg.observable_source_asset(automation_condition=dg.AutomationCondition.on_cron("@hourly"))
+def obs() -> None: ...
+
+
+@dg.asset(deps=[obs], automation_condition=dg.AutomationCondition.eager())
+def mat() -> None: ...
+
+
+defs = dg.Definitions(assets=[obs, mat])


### PR DESCRIPTION
## Summary & Motivation

This just reproduces the issue in a unit test, it does not fix it.

The core issue is that we get an invalid state where the partition goes from in_progress to not in_progress without getting set to materialized.

## How I Tested These Changes

## Changelog

NOCHANGELOG
