### PR TITLE
[pythonic config] properly propagate default values set at the top level for nested config classes

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -403,6 +403,7 @@ def infer_schema_from_config_class(
     model_cls: type["Config"],
     description: Optional[str] = None,
     fields_to_omit: Optional[set[str]] = None,
+    default: Optional[Any] = None,
 ) -> DagsterField:
     from dagster._config.pythonic_config.config import Config
     from dagster._config.pythonic_config.resource import (
@@ -433,9 +434,11 @@ def infer_schema_from_config_class(
                     " definition. 'dagster.Field' should only be used in legacy Dagster config"
                     " schemas. Did you mean to use 'pydantic.Field' instead?"
                 )
-
+            field_default = default.get(resolved_field_name) if isinstance(default, dict) else None
             try:
-                fields[resolved_field_name] = _convert_pydantic_field(pydantic_field_info)
+                fields[resolved_field_name] = _convert_pydantic_field(
+                    pydantic_field_info, default=field_default
+                )
             except DagsterInvalidConfigDefinitionError as e:
                 raise DagsterInvalidPythonicConfigDefinitionError(
                     config_class=model_cls,


### PR DESCRIPTION
## Summary

Ensures that default values on Pythonic Config get properly propagated to inner Config classes, e.g.

```python
class ANestedOpConfig(Config):
    an_int: int = 1
    a_bool: bool = True

class AnOpConfig(Config):
    a_string: str = "foo"
    a_nested: ANestedOpConfig = ANestedOpConfig(an_int=5)
```

An alternative impl which uses some utils in a stacked PR can be found at #27209.

## Test Plan

New unit test; todo add a few more