### PR TITLE
[1/n][dagster-dlt] Move asset spec creation to DagsterDltTranslator.get_asset_spec

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
@@ -12,7 +12,7 @@ from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
 from dagster_dlt.constants import META_KEY_PIPELINE, META_KEY_SOURCE, META_KEY_TRANSLATOR
-from dagster_dlt.translator import DagsterDltTranslator
+from dagster_dlt.translator import DagsterDltTranslator, DltResourceTranslatorData
 
 
 def build_dlt_asset_specs(
@@ -34,23 +34,14 @@ def build_dlt_asset_specs(
     """
     dagster_dlt_translator = dagster_dlt_translator or DagsterDltTranslator()
     return [
-        AssetSpec(
-            key=dagster_dlt_translator.get_asset_key(dlt_source_resource),
-            automation_condition=dagster_dlt_translator.get_automation_condition(
-                dlt_source_resource
-            ),
-            deps=dagster_dlt_translator.get_deps_asset_keys(dlt_source_resource),
-            description=dagster_dlt_translator.get_description(dlt_source_resource),
-            group_name=dagster_dlt_translator.get_group_name(dlt_source_resource),
+        dagster_dlt_translator.get_asset_spec(
+            DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline.destination)
+        ).merge_attributes(
             metadata={
-                **dagster_dlt_translator.get_metadata(dlt_source_resource),
                 META_KEY_SOURCE: dlt_source,
                 META_KEY_PIPELINE: dlt_pipeline,
                 META_KEY_TRANSLATOR: dagster_dlt_translator,
-            },
-            owners=dagster_dlt_translator.get_owners(dlt_source_resource),
-            tags=dagster_dlt_translator.get_tags(dlt_source_resource),
-            kinds=dagster_dlt_translator.get_kinds(dlt_source_resource, dlt_pipeline.destination),
+            }
         )
         for dlt_source_resource in dlt_source.selected_resources.values()
     ]

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
@@ -35,7 +35,9 @@ def build_dlt_asset_specs(
     dagster_dlt_translator = dagster_dlt_translator or DagsterDltTranslator()
     return [
         dagster_dlt_translator.get_asset_spec(
-            DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline.destination)
+            DltResourceTranslatorData(
+                resource=dlt_source_resource, destination=dlt_pipeline.destination
+            )
         ).merge_attributes(
             metadata={
                 META_KEY_SOURCE: dlt_source,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -258,7 +258,11 @@ class DagsterDltResource(ConfigurableResource):
 
         """
         asset_key_dlt_source_resource_mapping = {
-            dagster_dlt_translator.get_asset_spec(DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline.destination)).key: dlt_source_resource
+            dagster_dlt_translator.get_asset_spec(
+                DltResourceTranslatorData(
+                    resource=dlt_source_resource, destination=dlt_pipeline.destination
+                )
+            ).key: dlt_source_resource
             for dlt_source_resource in dlt_source.selected_resources.values()
         }
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -23,7 +23,7 @@ from dlt.pipeline.pipeline import Pipeline
 
 from dagster_dlt.constants import META_KEY_PIPELINE, META_KEY_SOURCE, META_KEY_TRANSLATOR
 from dagster_dlt.dlt_event_iterator import DltEventIterator, DltEventType
-from dagster_dlt.translator import DagsterDltTranslator
+from dagster_dlt.translator import DagsterDltTranslator, DltResourceTranslatorData
 
 
 @experimental
@@ -258,7 +258,7 @@ class DagsterDltResource(ConfigurableResource):
 
         """
         asset_key_dlt_source_resource_mapping = {
-            dagster_dlt_translator.get_asset_key(dlt_source_resource): dlt_source_resource
+            dagster_dlt_translator.get_asset_spec(DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline.destination)).key: dlt_source_resource
             for dlt_source_resource in dlt_source.selected_resources.values()
         }
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
@@ -61,7 +61,7 @@ class DagsterDltTranslator:
     def get_auto_materialize_policy(self, resource: DltResource) -> Optional[AutoMaterializePolicy]:
         """Defines resource specific auto materialize policy.
 
-        This method can be overrdidden to provide custom auto materialize policy for a dlt resource.
+        This method can be overridden to provide custom auto materialize policy for a dlt resource.
 
         Args:
             resource (DltResource): dlt resource

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -699,6 +699,7 @@ def test_with_group_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     for group in my_dlt_assets.group_names_by_key.values():
         assert group == expected_group
 
+
 def test_with_owner_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     expected_owners = ["custom@custom.com"]
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -7,6 +7,7 @@ import duckdb
 from dagster import (
     AssetExecutionContext,
     AssetKey,
+    AssetSpec,
     AutoMaterializePolicy,
     AutoMaterializeRule,
     AutomationCondition,
@@ -23,6 +24,7 @@ from dagster._core.definitions.metadata.metadata_value import (
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
+from dagster_dlt.translator import DltResourceTranslatorData
 from dlt import Pipeline
 from dlt.common.destination import Destination
 from dlt.extract.resource import DltResource
@@ -192,6 +194,28 @@ def test_example_pipeline(dlt_pipeline: Pipeline) -> None:
 
 def test_multi_asset_names_do_not_conflict(dlt_pipeline: Pipeline) -> None:
     class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(key=AssetKey("custom_" + data.resource.name))
+
+    @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline, name="multi_asset_name1")
+    def assets1():
+        pass
+
+    @dlt_assets(
+        dlt_source=pipeline(),
+        dlt_pipeline=dlt_pipeline,
+        name="multi_asset_name2",
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def assets2():
+        pass
+
+    assert Definitions(assets=[assets1, assets2])
+
+
+def test_multi_asset_names_do_not_conflict_legacy(dlt_pipeline: Pipeline) -> None:
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_asset_key(self, resource: DltResource) -> AssetKey:
             return AssetKey("custom_" + resource.name)
 
@@ -211,7 +235,7 @@ def test_multi_asset_names_do_not_conflict(dlt_pipeline: Pipeline) -> None:
     assert Definitions(assets=[assets1, assets2])
 
 
-def test_get_materialize_policy(dlt_pipeline: Pipeline):
+def test_get_materialize_policy_legacy(dlt_pipeline: Pipeline):
     class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_auto_materialize_policy(
             self, resource: DltResource
@@ -232,7 +256,7 @@ def test_get_materialize_policy(dlt_pipeline: Pipeline):
         assert "0 1 * * *" in str(item)
 
 
-def test_get_automation_condition(dlt_pipeline: Pipeline):
+def test_get_automation_condition_legacy(dlt_pipeline: Pipeline):
     class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_automation_condition(self, resource: DltResource) -> Optional[AutomationCondition]:
             return AutomationCondition.eager() | AutomationCondition.on_cron("0 1 * * *")
@@ -249,7 +273,7 @@ def test_get_automation_condition(dlt_pipeline: Pipeline):
         assert "0 1 * * *" in str(item)
 
 
-def test_get_automation_condition_converts_auto_materialize_policy(
+def test_get_automation_condition_converts_auto_materialize_policy_legacy(
     dlt_pipeline: Pipeline,
 ):
     class CustomDagsterDltTranslator(DagsterDltTranslator):
@@ -407,6 +431,52 @@ def test_asset_metadata(dlt_pipeline: Pipeline) -> None:
             "repo_issues": {"mode": "upsert", "primary_key": ["repo_id", "issue_id"]},
         }
 
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.merge_attributes(
+                metadata=self.metadata_by_resource_name.get(data.resource.name, {})
+            )
+
+    @dlt_assets(
+        dlt_source=pipeline(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    first_asset_metadata = next(iter(example_pipeline_assets.metadata_by_key.values()))
+    dagster_dlt_source = first_asset_metadata.get("dagster_dlt/source")
+    dagster_dlt_pipeline = first_asset_metadata.get("dagster_dlt/pipeline")
+    dagster_dlt_translator = first_asset_metadata.get("dagster_dlt/translator")
+
+    assert example_pipeline_assets.metadata_by_key == {
+        AssetKey("dlt_pipeline_repos"): {
+            "dagster_dlt/source": dagster_dlt_source,
+            "dagster_dlt/pipeline": dagster_dlt_pipeline,
+            "dagster_dlt/translator": dagster_dlt_translator,
+            "mode": "upsert",
+            "primary_key": "id",
+        },
+        AssetKey("dlt_pipeline_repo_issues"): {
+            "dagster_dlt/source": dagster_dlt_source,
+            "dagster_dlt/pipeline": dagster_dlt_pipeline,
+            "dagster_dlt/translator": dagster_dlt_translator,
+            "mode": "upsert",
+            "primary_key": ["repo_id", "issue_id"],
+        },
+    }
+
+
+def test_asset_metadata_legacy(dlt_pipeline: Pipeline) -> None:
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
+        metadata_by_resource_name = {
+            "repos": {"mode": "upsert", "primary_key": "id"},
+            "repo_issues": {"mode": "upsert", "primary_key": ["repo_id", "issue_id"]},
+        }
+
         def get_metadata(self, resource: DltResource) -> Mapping[str, Any]:
             return self.metadata_by_resource_name.get(resource.name, {})
 
@@ -474,6 +544,23 @@ def test_partitioned_materialization(dlt_pipeline: Pipeline) -> None:
 
 def test_with_asset_key_replacements(dlt_pipeline: Pipeline) -> None:
     class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(key=default_spec.key.with_prefix("prefix"))
+
+    @dlt_assets(
+        dlt_source=dlt_source(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+    assert my_dlt_assets.asset_deps.keys()
+    assert all(key.has_prefix(["prefix"]) for key in my_dlt_assets.asset_deps.keys())
+
+
+def test_with_asset_key_replacements_legacy(dlt_pipeline: Pipeline) -> None:
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_asset_key(self, resource: DltResource) -> AssetKey:
             return super().get_asset_key(resource).with_prefix("prefix")
 
@@ -490,6 +577,23 @@ def test_with_asset_key_replacements(dlt_pipeline: Pipeline) -> None:
 
 def test_with_deps_replacements(dlt_pipeline: Pipeline) -> None:
     class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(deps=[])
+
+    @dlt_assets(
+        dlt_source=dlt_source(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+    assert my_dlt_assets.asset_deps.keys()
+    assert all(not deps for deps in my_dlt_assets.asset_deps.values())
+
+
+def test_with_deps_replacements_legacy(dlt_pipeline: Pipeline) -> None:
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_deps_asset_keys(self, _) -> Sequence[AssetKey]:
             return []
 
@@ -505,6 +609,25 @@ def test_with_deps_replacements(dlt_pipeline: Pipeline) -> None:
 
 
 def test_with_description_replacements(dlt_pipeline: Pipeline) -> None:
+    expected_description = "customized description"
+
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(description=expected_description)
+
+    @dlt_assets(
+        dlt_source=dlt_source(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+    for description in my_dlt_assets.descriptions_by_key.values():
+        assert description == expected_description
+
+
+def test_with_description_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     expected_description = "customized description"
 
     class CustomDagsterDltTranslator(DagsterDltTranslator):
@@ -526,6 +649,25 @@ def test_with_metadata_replacements(dlt_pipeline: Pipeline) -> None:
     expected_metadata = {"customized": "metadata"}
 
     class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.merge_attributes(metadata=expected_metadata)
+
+    @dlt_assets(
+        dlt_source=dlt_source(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+    for metadata in my_dlt_assets.metadata_by_key.values():
+        assert metadata["customized"] == "metadata"
+
+
+def test_with_metadata_replacements_legacy(dlt_pipeline: Pipeline) -> None:
+    expected_metadata = {"customized": "metadata"}
+
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_metadata(self, _) -> Optional[Mapping[str, Any]]:
             return expected_metadata
 
@@ -540,7 +682,7 @@ def test_with_metadata_replacements(dlt_pipeline: Pipeline) -> None:
         assert metadata["customized"] == "metadata"
 
 
-def test_with_group_replacements(dlt_pipeline: Pipeline) -> None:
+def test_with_group_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     expected_group = "customized_group"
 
     class CustomDagsterDltTranslator(DagsterDltTranslator):
@@ -557,8 +699,7 @@ def test_with_group_replacements(dlt_pipeline: Pipeline) -> None:
     for group in my_dlt_assets.group_names_by_key.values():
         assert group == expected_group
 
-
-def test_with_owner_replacements(dlt_pipeline: Pipeline) -> None:
+def test_with_owner_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     expected_owners = ["custom@custom.com"]
 
     class CustomDagsterDltTranslator(DagsterDltTranslator):
@@ -577,6 +718,33 @@ def test_with_owner_replacements(dlt_pipeline: Pipeline) -> None:
 
 
 def test_with_tag_replacements(dlt_pipeline: Pipeline) -> None:
+    custom_tags = {
+        "customized": "tag",
+    }
+
+    expected_tags = {
+        **custom_tags,
+        **build_kind_tag("dlt"),
+        **build_kind_tag("test"),
+    }
+
+    class CustomDagsterDltTranslator(DagsterDltTranslator):
+        def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(tags=expected_tags, kinds={"dlt", "test"})
+
+    @dlt_assets(
+        dlt_source=dlt_source(),
+        dlt_pipeline=dlt_pipeline,
+        dagster_dlt_translator=CustomDagsterDltTranslator(),
+    )
+    def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+    for tags in my_dlt_assets.tags_by_key.values():
+        assert tags == expected_tags
+
+
+def test_with_tag_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     custom_tags = {
         "customized": "tag",
     }


### PR DESCRIPTION
## Summary & Motivation

Move the asset spec creation from the asset decorator to a `get_asset_spec` method in the translator.

Also updates adds tests. No additional test was added for group names, owners, automation condition and auto-materialize policies. It is not recommended to update these values by overriding `get_asset_spec` because they are not related to dlt specifically.

## How I Tested These Changes

Updated and new tests with BK
