### PR TITLE
Use `isinstance()` over `hasattr()` for type guard

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,6 +1,8 @@
 import asyncio
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, TypeVar, Union, get_args
+
+from typing_extensions import TypeIs
 
 import dagster._check as check
 from dagster._annotations import public
@@ -21,16 +23,19 @@ if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AssetSelection
 
 
-def _has_allow_ignore(condition: AutomationCondition) -> bool:
-    return isinstance(
-        condition,
-        (
-            DepsAutomationCondition,
-            AndAutomationCondition,
-            OrAutomationCondition,
-            NotAutomationCondition,
-        ),
-    )
+T_HasAllowIgnore = TypeVar(
+    "T_HasAllowIgnore",
+    bound=Union[
+        DepsAutomationCondition,
+        "AndAutomationCondition",
+        "OrAutomationCondition",
+        "NotAutomationCondition",
+    ],
+)
+
+
+def _has_allow_ignore(condition: AutomationCondition) -> TypeIs[T_HasAllowIgnore]:
+    return isinstance(condition, get_args(T_HasAllowIgnore.__bound__))
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypeVar, Union, get_args
+from typing import TYPE_CHECKING, Union
 
 from typing_extensions import TypeIs
 
@@ -23,19 +23,31 @@ if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AssetSelection
 
 
-T_HasAllowIgnore = TypeVar(
-    "T_HasAllowIgnore",
-    bound=Union[
+def _has_allow_ignore(
+    condition: AutomationCondition,
+) -> TypeIs[
+    Union[
         DepsAutomationCondition,
         "AndAutomationCondition",
         "OrAutomationCondition",
         "NotAutomationCondition",
-    ],
-)
+    ]
+]:
+    from dagster._core.definitions.declarative_automation.operators.boolean_operators import (
+        AndAutomationCondition,
+        NotAutomationCondition,
+        OrAutomationCondition,
+    )
 
-
-def _has_allow_ignore(condition: AutomationCondition) -> TypeIs[T_HasAllowIgnore]:
-    return isinstance(condition, get_args(T_HasAllowIgnore.__bound__))
+    return isinstance(
+        condition,
+        (
+            DepsAutomationCondition,
+            AndAutomationCondition,
+            OrAutomationCondition,
+            NotAutomationCondition,
+        ),
+    )
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -11,11 +11,26 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
+from dagster._core.definitions.declarative_automation.operators.dep_operators import (
+    DepsAutomationCondition,
+)
 from dagster._record import copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AssetSelection
+
+
+def _has_allow_ignore(condition: AutomationCondition) -> bool:
+    return isinstance(
+        condition,
+        (
+            DepsAutomationCondition,
+            AndAutomationCondition,
+            OrAutomationCondition,
+            NotAutomationCondition,
+        ),
+    )
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")
@@ -98,7 +113,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.allow(selection) if hasattr(child, "allow") else child
+                child.allow(selection) if _has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -118,7 +133,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.ignore(selection) if hasattr(child, "ignore") else child
+                child.ignore(selection) if _has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -199,7 +214,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.allow(selection) if hasattr(child, "allow") else child
+                child.allow(selection) if _has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -219,7 +234,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.ignore(selection) if hasattr(child, "ignore") else child
+                child.ignore(selection) if _has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -288,7 +303,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operand=self.operand.allow(selection)
-            if hasattr(self.operand, "allow")
+            if _has_allow_ignore(self.operand)
             else self.operand,
         )
 
@@ -307,6 +322,6 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operand=self.operand.ignore(selection)
-            if hasattr(self.operand, "ignore")
+            if _has_allow_ignore(self.operand)
             else self.operand,
         )

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -95,7 +95,7 @@ setup(
         "tabulate",
         "tomli<3",
         "tqdm<5",
-        "typing_extensions>=4.4.0,<5",
+        "typing_extensions>=4.10.0,<5",
         'tzdata; platform_system=="Windows"',
         "structlog",
         "sqlalchemy>=1.0,<3",


### PR DESCRIPTION
## Summary & Motivation

Because [Pyright doesn't support type narrowing on `hasattr()`](https://github.com/microsoft/pyright/issues/6717) (and apparently can't handle the complex `isinstance()` check either without further narrowing using `TypeIs`).

## How I Tested These Changes

BK
