### PR TITLE
[dagster-aws] fix QUEUED state in PipesEMRServerlessClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_serverless.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_serverless.py
@@ -219,7 +219,7 @@ class PipesEMRServerlessClient(PipesClient, TreatAsResourceParam):
                     f"[pipes] {self.AWS_SERVICE_NAME} job {job_run_id} completed with state: {state}"
                 )
                 return response
-            elif state in ["PENDING", "SUBMITTED", "SCHEDULED", "RUNNING"]:
+            elif state in ["PENDING", "SUBMITTED", "SCHEDULED", "RUNNING", "QUEUED"]:
                 time.sleep(self.poll_interval)
                 continue
             else:


### PR DESCRIPTION
## Summary & Motivation

Resolve #27217

## How I Tested These Changes

Checked https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/job-states.html again

## Changelog

[dagster-aws] fix PipesEMRServerlessClient failing with QUEUED job state
