### PR TITLE
[3/n][dagster-dlt] Resolve back compat in DagsterDltTranslator.get_asset_spec

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
@@ -88,9 +88,7 @@ class DagsterDltTranslator:
             AssetKey of Dagster asset derived from dlt resource
 
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).key
+        return self._default_asset_key_fn(resource)
 
     def _default_asset_key_fn(self, resource: DltResource) -> AssetKey:
         """Defines asset key for a given dlt resource key and dataset name.
@@ -117,9 +115,7 @@ class DagsterDltTranslator:
             Optional[AutoMaterializePolicy]: The auto-materialize policy for a resource
 
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).auto_materialize_policy
+        return self._default_auto_materialize_policy_fn(resource)
 
     def _default_auto_materialize_policy_fn(
         self, resource: DltResource
@@ -148,9 +144,7 @@ class DagsterDltTranslator:
             Optional[AutomationCondition]: The automation condition for a resource
 
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).automation_condition
+        return self._default_automation_condition_fn(resource)
 
     def _default_automation_condition_fn(
         self, resource: DltResource
@@ -182,12 +176,7 @@ class DagsterDltTranslator:
             Iterable[AssetKey]: The Dagster asset keys upstream of `dlt_resource_key`.
 
         """
-        return [
-            dep.asset_key
-            for dep in self.get_asset_spec(
-                DltResourceTranslatorData(resource=resource, destination=None)
-            ).deps
-        ]
+        return self._default_deps_fn(resource)
 
     def _default_deps_fn(self, resource: DltResource) -> Iterable[AssetKey]:
         """Defines upstream asset dependencies given a dlt resource.
@@ -218,9 +207,7 @@ class DagsterDltTranslator:
         Returns:
             Optional[str]: The Dagster description for the dlt resource.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).description
+        return self._default_description_fn(resource)
 
     def _default_description_fn(self, resource: DltResource) -> Optional[str]:
         """A method that takes in a dlt resource returns the Dagster description of the resource.
@@ -250,9 +237,7 @@ class DagsterDltTranslator:
         Returns:
             Optional[str]: A Dagster group name for the dlt resource.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).group_name
+        return self._default_group_name_fn(resource)
 
     def _default_group_name_fn(self, resource: DltResource) -> Optional[str]:
         """A method that takes in a dlt resource and returns the Dagster group name of the resource.
@@ -275,9 +260,7 @@ class DagsterDltTranslator:
         Returns:
             Mapping[str, Any]: The custom metadata entries for this resource.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).metadata
+        return self._default_metadata_fn(resource)
 
     def _default_metadata_fn(self, resource: DltResource) -> Mapping[str, Any]:
         """Defines resource specific metadata.
@@ -302,9 +285,7 @@ class DagsterDltTranslator:
         Returns:
             Optional[Sequence[str]]: A sequence of Dagster owners for the dlt resource.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).owners
+        return self._default_owners_fn(resource)
 
     def _default_owners_fn(self, resource: DltResource) -> Optional[Sequence[str]]:
         """A method that takes in a dlt resource and returns the Dagster owners of the resource.
@@ -330,9 +311,7 @@ class DagsterDltTranslator:
             Optional[Mapping[str, str]]: A dictionary representing the Dagster tags for the
                 dlt resource.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=None)
-        ).tags
+        return self._default_tags_fn(resource)
 
     def _default_tags_fn(self, resource: DltResource) -> Mapping[str, str]:
         """A method that takes in a dlt resource and returns the Dagster tags of the structure.
@@ -360,9 +339,7 @@ class DagsterDltTranslator:
         Returns:
             Set[str]: The kinds of the asset.
         """
-        return self.get_asset_spec(
-            DltResourceTranslatorData(resource=resource, destination=destination)
-        ).kinds
+        return self._default_kinds_fn(resource, destination)
 
     def _default_kinds_fn(
         self, resource: DltResource, destination: Optional[Destination]

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -562,7 +562,7 @@ def test_with_asset_key_replacements(dlt_pipeline: Pipeline) -> None:
 def test_with_asset_key_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_asset_key(self, resource: DltResource) -> AssetKey:
-            return super().get_asset_key(resource).with_prefix("prefix")
+            return super()._default_asset_key_fn(resource).with_prefix("prefix")
 
     @dlt_assets(
         dlt_source=dlt_source(),

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -562,7 +562,7 @@ def test_with_asset_key_replacements(dlt_pipeline: Pipeline) -> None:
 def test_with_asset_key_replacements_legacy(dlt_pipeline: Pipeline) -> None:
     class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_asset_key(self, resource: DltResource) -> AssetKey:
-            return super()._default_asset_key_fn(resource).with_prefix("prefix")
+            return super().get_asset_key(resource).with_prefix("prefix")
 
     @dlt_assets(
         dlt_source=dlt_source(),


### PR DESCRIPTION
## Summary & Motivation

Use `DagsterDltTranslator._default_*` fns in `get_asset_spec`. To make sure custom translators are not breaking, we also use the resolve back compat fn.

## How I Tested These Changes

Existing tests with BK
