### PR TITLE
fix asset materialization events getting the wrong partition because of dictionary overloading

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1147,10 +1147,7 @@ class DefaultPartitionsSubset(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[PartitionKeyRange]:
-        from dagster._core.definitions.multi_dimensional_partitions import (
-            MultiPartitionKey,
-            MultiPartitionsDefinition,
-        )
+        from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 
         if isinstance(partitions_def, MultiPartitionsDefinition):
             # For multi-partitions, we construct the ranges by holding one dimension constant
@@ -1162,10 +1159,12 @@ class DefaultPartitionsSubset(
             secondary_keys_in_subset = set()
             for partition_key in self.subset:
                 primary_keys_in_subset.add(
-                    cast(MultiPartitionKey, partition_key).keys_by_dimension[primary_dimension.name]
+                    partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
+                        primary_dimension.name
+                    ]
                 )
                 secondary_keys_in_subset.add(
-                    cast(MultiPartitionKey, partition_key).keys_by_dimension[
+                    partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
                         secondary_dimension.name
                     ]
                 )

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -638,9 +638,9 @@ def _get_output_asset_events(
                     **all_unpartitioned_asset_metadata,
                     **(partition_scoped_metadata or {}),
                 }
-                # copy the tags dictionary before setting the partition key tags. Otherwize
+                # copy the tags dictionary before setting the partition key tags. Otherwise
                 # all asset materialization events will point to the same dictionary with the
-                # parititon key tags of the last partition processed.
+                # partition key tags of the last partition processed.
                 tags_for_event = {**all_tags}
                 tags_for_event.update(
                     get_tags_from_multi_partition_key(partition)

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -638,7 +638,8 @@ def _get_output_asset_events(
                     **all_unpartitioned_asset_metadata,
                     **(partition_scoped_metadata or {}),
                 }
-                all_tags.update(
+                tags_for_event = {**all_tags}
+                tags_for_event.update(
                     get_tags_from_multi_partition_key(partition)
                     if isinstance(partition, MultiPartitionKey)
                     else {}
@@ -648,7 +649,7 @@ def _get_output_asset_events(
                     asset_key=asset_key,
                     partition=partition,
                     metadata=all_metadata_for_partitioned_event,
-                    tags=all_tags,
+                    tags=tags_for_event,
                 )
     else:
         with disable_dagster_warnings():

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -638,6 +638,9 @@ def _get_output_asset_events(
                     **all_unpartitioned_asset_metadata,
                     **(partition_scoped_metadata or {}),
                 }
+                # copy the tags dictionary before setting the partition key tags. Otherwize
+                # all asset materialization events will point to the same dictionary with the
+                # parititon key tags of the last partition processed.
                 tags_for_event = {**all_tags}
                 tags_for_event.update(
                     get_tags_from_multi_partition_key(partition)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -25,6 +25,7 @@ from dagster import (
     DailyPartitionsDefinition,
     Field,
     In,
+    MultiPartitionsDefinition,
     Nothing,
     Out,
     Output,
@@ -408,6 +409,26 @@ def daily_1():
 @asset(partitions_def=daily_partitions_def)
 def daily_2(daily_1):
     return 1
+
+
+multi_partitions_def = MultiPartitionsDefinition(
+    {"day": daily_partitions_def, "name": static_partitions}
+)
+
+
+@asset(
+    partitions_def=multi_partitions_def,
+    backfill_policy=BackfillPolicy.single_run(),
+)
+def multi_partitioned_asset_with_single_run_bp() -> None:
+    return
+
+
+@asset(
+    partitions_def=multi_partitions_def,
+)
+def multi_partitioned_asset() -> None:
+    return
 
 
 @asset(


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue where `ASSET_MATERIALIZATION` events emitted for each partition in a multi-partition run were getting the same partition key tags because each event was using the same tags dictionary. The impact of this is that when we fetch these events from the event log, the reconstructed event has the wrong partition key, because we source the key from the tags

## How I Tested These Changes
unit tests

## Changelog

[bug fix] Fixed an issue where querying for Asset Materialization events from multi-partition runs would assign incorrect partition keys to the events
