### PR TITLE
Update _process_stdout within SlingResource to handle Emojis

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -238,9 +238,26 @@ class SlingResource(ConfigurableResource):
 
     def _process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
         """Process stdout from the Sling CLI."""
+        emoji_pattern = re.compile(
+            "["
+            "\U0001F600-\U0001F64F"  # emoticons
+            "\U0001F300-\U0001F5FF"  # symbols & pictographs
+            "\U0001F680-\U0001F6FF"  # transport & map symbols
+            "\U0001F700-\U0001F77F"  # alchemical symbols
+            "\U0001F780-\U0001F7FF"  # Geometric Shapes Extended
+            "\U0001F800-\U0001F8FF"  # Supplemental Arrows-C
+            "\U0001F900-\U0001F9FF"  # Supplemental Symbols and Pictographs
+            "\U0001FA00-\U0001FA6F"  # Chess Symbols
+            "\U0001FA70-\U0001FAFF"  # Symbols and Pictographs Extended-A
+            "\U00002702-\U000027B0"  # Dingbats
+            "\U000024C2-\U0001F251" 
+            "]+", flags=re.UNICODE
+        )
+        
         for line in stdout:
             assert isinstance(line, bytes)
             fmt_line = bytes.decode(line, encoding=encoding, errors="replace")
+            fmt_line = emoji_pattern.sub(r'', fmt_line)
             yield self._clean_line(fmt_line)
 
     def _exec_sling_cmd(


### PR DESCRIPTION
Added specific error handling for a range of emoji symbols. Relates to issues #27239 

## Summary & Motivation
When sling stdout sees an emoji, it causes an error as described in issue 27239 . Occasionally sling returns a plug to checkout their side which includes a 👉. 

https://github.com/slingdata-io/sling-cli/blob/main/cmd/sling/sling_media.go

## How I Tested These Changes
I've not been able to replicate the issue as it seems almost random when it appears....but maybe someone can debug when sling pushes that specific alert...

## Changelog

> Insert changelog entry or delete this section.
