### PR TITLE
[1/n][dagster-looker] Move asset spec creation to DagsterLookerLkmlTranslator.get_asset_spec

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_utils.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_utils.py
@@ -131,15 +131,7 @@ def build_looker_dashboard_specs(
             )
 
             looker_dashboard_specs.append(
-                AssetSpec(
-                    key=dagster_looker_translator.get_asset_key(lookml_dashboard),
-                    deps=dagster_looker_translator.get_deps(lookml_dashboard),
-                    description=dagster_looker_translator.get_description(lookml_dashboard),
-                    metadata=dagster_looker_translator.get_metadata(lookml_dashboard),
-                    group_name=dagster_looker_translator.get_group_name(lookml_dashboard),
-                    owners=dagster_looker_translator.get_owners(lookml_dashboard),
-                    tags=dagster_looker_translator.get_tags(lookml_dashboard),
-                )
+                dagster_looker_translator.get_asset_spec(lookml_dashboard)
             )
 
     return looker_dashboard_specs
@@ -162,17 +154,7 @@ def build_looker_explore_specs(
 
     explores_postprocessed = postprocess_loaded_structures(explores)
     for lookml_explore in explores_postprocessed:
-        looker_explore_specs.append(
-            AssetSpec(
-                key=dagster_looker_translator.get_asset_key(lookml_explore),
-                deps=dagster_looker_translator.get_deps(lookml_explore),
-                description=dagster_looker_translator.get_description(lookml_explore),
-                metadata=dagster_looker_translator.get_metadata(lookml_explore),
-                group_name=dagster_looker_translator.get_group_name(lookml_explore),
-                owners=dagster_looker_translator.get_owners(lookml_explore),
-                tags=dagster_looker_translator.get_tags(lookml_explore),
-            )
-        )
+        looker_explore_specs.append(dagster_looker_translator.get_asset_spec(lookml_explore))
 
     return looker_explore_specs
 
@@ -192,16 +174,6 @@ def build_looker_view_specs(
     views_postprocessed = postprocess_loaded_structures(views)
 
     for lookml_view in views_postprocessed:
-        looker_view_specs.append(
-            AssetSpec(
-                key=dagster_looker_translator.get_asset_key(lookml_view),
-                deps=dagster_looker_translator.get_deps(lookml_view),
-                description=dagster_looker_translator.get_description(lookml_view),
-                metadata=dagster_looker_translator.get_metadata(lookml_view),
-                group_name=dagster_looker_translator.get_group_name(lookml_view),
-                owners=dagster_looker_translator.get_owners(lookml_view),
-                tags=dagster_looker_translator.get_tags(lookml_view),
-            )
-        )
+        looker_view_specs.append(dagster_looker_translator.get_asset_spec(lookml_view))
 
     return looker_view_specs

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal, Optional, cast
 
-from dagster import AssetKey
+from dagster import AssetKey, AssetSpec
 from dagster._annotations import experimental, public
 from sqlglot import ParseError, exp, parse_one, to_table
 from sqlglot.optimizer import Scope, build_scope, optimize
@@ -167,9 +167,45 @@ class DagsterLookerLkmlTranslator:
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
     of a LookML structure (dashboards, explores, views).
 
-    This class is exposed so that methods can be overriden to customize how Dagster asset metadata
+    This class is exposed so that methods can be overridden to customize how Dagster asset metadata
     is derived.
     """
+
+    @public
+    def get_asset_spec(
+        self, lookml_structure: tuple[Path, LookMLStructureType, Mapping[str, Any]]
+    ) -> AssetSpec:
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster asset spec that represents the structure.
+
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
+        https://lkml.readthedocs.io/en/latest/simple.html.
+
+        You can learn more about LookML dashboards and the properties available in this
+        dictionary here: https://cloud.google.com/looker/docs/reference/param-lookml-dashboard.
+
+        You can learn more about LookML explores and views and the properties available in this
+        dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
+
+        This method can be overridden to provide a custom asset spec for a LookML structure.
+
+        Args:
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
+
+        Returns:
+            AssetSpec: The Dagster asset spec that represents the LookML structure.
+        """
+        return AssetSpec(
+            key=self.get_asset_key(lookml_structure),
+            deps=self.get_deps(lookml_structure),
+            description=self.get_description(lookml_structure),
+            metadata=self.get_metadata(lookml_structure),
+            group_name=self.get_group_name(lookml_structure),
+            owners=self.get_owners(lookml_structure),
+            tags=self.get_tags(lookml_structure),
+        )
 
     @public
     def get_asset_key(
@@ -187,7 +223,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom asset key for a LookML structure.
+        This method can be overridden to provide a custom asset key for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -243,7 +279,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom dependencies for a LookML structure.
+        This method can be overridden to provide custom dependencies for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -290,7 +326,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom description for a LookML structure.
+        This method can be overridden to provide a custom description for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -320,7 +356,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom metadata for a LookML structure.
+        This method can be overridden to provide custom metadata for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -349,7 +385,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom group name for a LookML structure.
+        This method can be overridden to provide a custom group name for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -377,7 +413,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom owners for a LookML structure.
+        This method can be overridden to provide custom owners for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
@@ -405,7 +441,7 @@ class DagsterLookerLkmlTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom tags for a LookML structure.
+        This method can be overridden to provide custom tags for a LookML structure.
 
         Args:
             lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
@@ -366,7 +366,6 @@ def test_with_asset_key_replacements() -> None:
             default_spec = super().get_asset_spec(lookml_structure)
             return default_spec.replace_attributes(
                 key=default_spec.key.with_prefix("prefix"),
-                deps=[dep.asset_key.with_prefix("prefix") for dep in default_spec.deps],
             )
 
     my_looker_assets = build_looker_asset_specs(

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
@@ -479,7 +479,7 @@ def test_with_metadata_replacements() -> None:
     )
 
     for spec in my_looker_assets:
-        assert "customized" in spec.metadata == expected_metadata
+        assert "customized" in spec.metadata
         assert spec.metadata["customized"] == expected_metadata["customized"]
 
 


### PR DESCRIPTION
## Summary & Motivation

Move the asset spec creation from the asset decorator to a `get_asset_spec` method in the translator.

Also updates adds tests. No additional test was added for group names, owners and tags. It is not recommended to update these values by overriding `get_asset_spec` because they are not related to Looker specifically.

## How I Tested These Changes

Updated and new tests with BK
