### PR TITLE
[1/3][Selection Input] Add double quotes only if necessary

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
@@ -362,7 +362,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     const value = _value.trim();
     if (value) {
       const substringMatchDisplayText = `${this.nameBase}_substring:${removeQuotesFromString(value)}`;
-      const substringMatchText = `${this.nameBase}_substring:"${removeQuotesFromString(value)}"`;
+      const substringMatchText = `${this.nameBase}_substring:${addQuotesIfNecessary(removeQuotesFromString(value))}`;
       this.list.push({
         text: textCallback(substringMatchText),
         displayText: substringMatchDisplayText,
@@ -377,7 +377,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
       this.allAttributes.forEach((attribute) => {
         if (attribute.value.includes(value.toLowerCase())) {
           this.list.push({
-            text: textCallback(`${attribute.key}:"${attribute.value}"`),
+            text: textCallback(`${attribute.key}:${addQuotesIfNecessary(attribute.value)}`),
             displayText: `${attribute.key}:${attribute.value}`,
             type: 'attribute' as const,
             attributeName: attribute.key,
@@ -422,7 +422,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     possibleValues.forEach((attributeValue) => {
       if (attributeValue.includes(unquotedValue)) {
         this.list.push({
-          text: textCallback(`"${attributeValue}"`),
+          text: textCallback(addQuotesIfNecessary(attributeValue)),
           displayText: attributeValue,
           type: 'attribute' as const,
           attributeName: attributeKey,
@@ -450,4 +450,9 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
       this.list.push({text: ')', displayText: ')', type: 'parenthesis' as const});
     }
   }
+}
+
+function addQuotesIfNecessary(value: string) {
+  const doesContainSpecialCharacters = /[^\w]/.test(value);
+  return doesContainSpecialCharacters ? `"${value}"` : value;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
@@ -362,7 +362,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     const value = _value.trim();
     if (value) {
       const substringMatchDisplayText = `${this.nameBase}_substring:${removeQuotesFromString(value)}`;
-      const substringMatchText = `${this.nameBase}_substring:${addQuotesIfNecessary(removeQuotesFromString(value))}`;
+      const substringMatchText = `${this.nameBase}_substring:${addQuotesIfNecessary(removeQuotesFromString(value))} `;
       this.list.push({
         text: textCallback(substringMatchText),
         displayText: substringMatchDisplayText,
@@ -377,7 +377,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
       this.allAttributes.forEach((attribute) => {
         if (attribute.value.includes(value.toLowerCase())) {
           this.list.push({
-            text: textCallback(`${attribute.key}:${addQuotesIfNecessary(attribute.value)}`),
+            text: textCallback(`${attribute.key}:${addQuotesIfNecessary(attribute.value)} `),
             displayText: `${attribute.key}:${attribute.value}`,
             type: 'attribute' as const,
             attributeName: attribute.key,
@@ -422,7 +422,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     possibleValues.forEach((attributeValue) => {
       if (attributeValue.includes(unquotedValue)) {
         this.list.push({
-          text: textCallback(addQuotesIfNecessary(attributeValue)),
+          text: `${textCallback(addQuotesIfNecessary(attributeValue))} `,
           displayText: attributeValue,
           type: 'attribute' as const,
           attributeName: attributeKey,

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -125,13 +125,24 @@ export const SelectionAutoCompleteInput = ({
 
       // Enforce single line by preventing newlines
       cmInstance.current.on('beforeChange', (_instance: Editor, change) => {
-        if (change.text.length !== 1 || change.text[0]?.includes('\n')) {
+        if (
+          change.text.length !== 1 ||
+          change.text[0]?.includes('\n') ||
+          change.text[0]?.includes('  ')
+        ) {
           change.cancel();
         }
       });
 
       cmInstance.current.on('change', (instance: Editor) => {
         const newValue = instance.getValue().replace(/\s+/g, ' ');
+        const cursor = instance.getCursor();
+        if (instance.getValue() !== newValue) {
+          // In this case they added a space, we removed it,
+          // so we need to move the cursor back one character
+          instance.setValue(newValue);
+          instance.setCursor({...cursor, ch: cursor.ch - 1});
+        }
         setInnerValue(newValue);
         setShowResults({current: true});
         adjustHeight();

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -138,10 +138,11 @@ export const SelectionAutoCompleteInput = ({
         const newValue = instance.getValue().replace(/\s+/g, ' ');
         const cursor = instance.getCursor();
         if (instance.getValue() !== newValue) {
+          const difference = newValue.length - instance.getValue().length;
           // In this case they added a space, we removed it,
           // so we need to move the cursor back one character
           instance.setValue(newValue);
-          instance.setCursor({...cursor, ch: cursor.ch - 1});
+          instance.setCursor({...cursor, ch: cursor.ch - difference});
         }
         setInnerValue(newValue);
         setShowResults({current: true});

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -253,6 +253,7 @@ export const SelectionAutoCompleteInput = ({
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Enter') {
         onSelectionChange(innerValueRef.current);
+        setShowResults({current: false});
       }
       if (!showResults.current) {
         return;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
@@ -36,19 +36,19 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('key_substring:|')).toEqual({
       list: [
         {
-          text: 'asset1',
+          text: 'asset1 ',
           displayText: 'asset1',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: 'asset2',
+          text: 'asset2 ',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: 'asset3',
+          text: 'asset3 ',
           displayText: 'asset3',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -63,13 +63,13 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('owner:|')).toEqual({
       list: [
         {
-          text: '"marco@dagsterlabs.com"',
+          text: '"marco@dagsterlabs.com" ',
           displayText: 'marco@dagsterlabs.com',
           type: 'attribute',
           attributeName: 'owner',
         },
         {
-          text: '"team:frontend"',
+          text: '"team:frontend" ',
           displayText: 'team:frontend',
           type: 'attribute',
           attributeName: 'owner',
@@ -83,9 +83,9 @@ describe('createAssetSelectionHint', () => {
   it('should suggest tag names after typing tag:', () => {
     expect(testAutocomplete('tag:|')).toEqual({
       list: [
-        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1 ', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2 ', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3 ', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       from: 4, // cursor location
       to: 4, // cursor location
@@ -93,9 +93,9 @@ describe('createAssetSelectionHint', () => {
 
     expect(testAutocomplete('tag:"|"')).toEqual({
       list: [
-        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1 ', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2 ', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3 ', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       from: 4, // cursor location
       to: 6, // cursor location
@@ -128,7 +128,7 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('owner:marco|')).toEqual({
       list: [
         {
-          text: '"marco@dagsterlabs.com"',
+          text: '"marco@dagsterlabs.com" ',
           displayText: 'marco@dagsterlabs.com',
           type: 'attribute',
           attributeName: 'owner',
@@ -200,44 +200,44 @@ describe('createAssetSelectionHint', () => {
       list: [
         {
           displayText: 'key_substring:o',
-          text: 'key_substring:o',
+          text: 'key_substring:o ',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {displayText: 'owner:', text: 'owner:', type: 'attribute', attributeName: 'owner'},
         {
           displayText: 'owner:marco@dagsterlabs.com',
-          text: 'owner:"marco@dagsterlabs.com"',
+          text: 'owner:"marco@dagsterlabs.com" ',
           type: 'attribute',
           attributeName: 'owner',
         },
         {
           displayText: 'owner:team:frontend',
-          text: 'owner:"team:frontend"',
+          text: 'owner:"team:frontend" ',
           type: 'attribute',
           attributeName: 'owner',
         },
         {
           displayText: 'group:group1',
-          text: 'group:group1',
+          text: 'group:group1 ',
           type: 'attribute',
           attributeName: 'group',
         },
         {
           displayText: 'group:group2',
-          text: 'group:group2',
+          text: 'group:group2 ',
           type: 'attribute',
           attributeName: 'group',
         },
         {
           displayText: 'code_location:repo1@location1',
-          text: 'code_location:"repo1@location1"',
+          text: 'code_location:"repo1@location1" ',
           type: 'attribute',
           attributeName: 'code_location',
         },
         {
           displayText: 'code_location:repo2@location2',
-          text: 'code_location:"repo2@location2"',
+          text: 'code_location:"repo2@location2" ',
           type: 'attribute',
           attributeName: 'code_location',
         },
@@ -345,13 +345,13 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('code_location:|')).toEqual({
       list: [
         {
-          text: '"repo1@location1"',
+          text: '"repo1@location1" ',
           displayText: 'repo1@location1',
           type: 'attribute',
           attributeName: 'code_location',
         },
         {
-          text: '"repo2@location2"',
+          text: '"repo2@location2" ',
           displayText: 'repo2@location2',
           type: 'attribute',
           attributeName: 'code_location',
@@ -487,19 +487,19 @@ describe('createAssetSelectionHint', () => {
       list: [
         {
           displayText: 'asset1',
-          text: 'asset1',
+          text: 'asset1 ',
           type: 'attribute',
           attributeName: 'key',
         },
         {
           displayText: 'asset2',
-          text: 'asset2',
+          text: 'asset2 ',
           type: 'attribute',
           attributeName: 'key',
         },
         {
           displayText: 'asset3',
-          text: 'asset3',
+          text: 'asset3 ',
           type: 'attribute',
           attributeName: 'key',
         },
@@ -584,19 +584,19 @@ describe('createAssetSelectionHint', () => {
     ).toEqual({
       list: [
         {
-          text: 'asset1',
+          text: 'asset1 ',
           displayText: 'asset1',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: 'asset2',
+          text: 'asset2 ',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: 'asset3',
+          text: 'asset3 ',
           displayText: 'asset3',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -774,7 +774,7 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('sinks(key_substring:"asset" or key_substring:"s|et2")')).toEqual({
       list: [
         {
-          text: 'asset2',
+          text: 'asset2 ',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -1024,9 +1024,9 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('tag:"tag|"')).toEqual({
       from: 4,
       list: [
-        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1 ', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2 ', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3 ', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       to: 9,
     });
@@ -1061,9 +1061,9 @@ describe('createAssetSelectionHint', () => {
     ).toEqual({
       from: 58,
       list: [
-        {text: 'asset1', displayText: 'asset1', type: 'attribute', attributeName: 'key'},
-        {text: 'asset2', displayText: 'asset2', type: 'attribute', attributeName: 'key'},
-        {text: 'asset3', displayText: 'asset3', type: 'attribute', attributeName: 'key'},
+        {text: 'asset1 ', displayText: 'asset1', type: 'attribute', attributeName: 'key'},
+        {text: 'asset2 ', displayText: 'asset2', type: 'attribute', attributeName: 'key'},
+        {text: 'asset3 ', displayText: 'asset3', type: 'attribute', attributeName: 'key'},
       ],
       to: 60,
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
@@ -36,19 +36,19 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('key_substring:|')).toEqual({
       list: [
         {
-          text: '"asset1"',
+          text: 'asset1',
           displayText: 'asset1',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: '"asset2"',
+          text: 'asset2',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: '"asset3"',
+          text: 'asset3',
           displayText: 'asset3',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -83,9 +83,9 @@ describe('createAssetSelectionHint', () => {
   it('should suggest tag names after typing tag:', () => {
     expect(testAutocomplete('tag:|')).toEqual({
       list: [
-        {text: '"tag1"', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag2"', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag3"', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       from: 4, // cursor location
       to: 4, // cursor location
@@ -93,9 +93,9 @@ describe('createAssetSelectionHint', () => {
 
     expect(testAutocomplete('tag:"|"')).toEqual({
       list: [
-        {text: '"tag1"', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag2"', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag3"', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       from: 4, // cursor location
       to: 6, // cursor location
@@ -200,7 +200,7 @@ describe('createAssetSelectionHint', () => {
       list: [
         {
           displayText: 'key_substring:o',
-          text: 'key_substring:"o"',
+          text: 'key_substring:o',
           type: 'attribute',
           attributeName: 'key_substring',
         },
@@ -219,13 +219,13 @@ describe('createAssetSelectionHint', () => {
         },
         {
           displayText: 'group:group1',
-          text: 'group:"group1"',
+          text: 'group:group1',
           type: 'attribute',
           attributeName: 'group',
         },
         {
           displayText: 'group:group2',
-          text: 'group:"group2"',
+          text: 'group:group2',
           type: 'attribute',
           attributeName: 'group',
         },
@@ -487,19 +487,19 @@ describe('createAssetSelectionHint', () => {
       list: [
         {
           displayText: 'asset1',
-          text: '"asset1"',
+          text: 'asset1',
           type: 'attribute',
           attributeName: 'key',
         },
         {
           displayText: 'asset2',
-          text: '"asset2"',
+          text: 'asset2',
           type: 'attribute',
           attributeName: 'key',
         },
         {
           displayText: 'asset3',
-          text: '"asset3"',
+          text: 'asset3',
           type: 'attribute',
           attributeName: 'key',
         },
@@ -584,19 +584,19 @@ describe('createAssetSelectionHint', () => {
     ).toEqual({
       list: [
         {
-          text: '"asset1"',
+          text: 'asset1',
           displayText: 'asset1',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: '"asset2"',
+          text: 'asset2',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
         },
         {
-          text: '"asset3"',
+          text: 'asset3',
           displayText: 'asset3',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -774,7 +774,7 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('sinks(key_substring:"asset" or key_substring:"s|et2")')).toEqual({
       list: [
         {
-          text: '"asset2"',
+          text: 'asset2',
           displayText: 'asset2',
           type: 'attribute',
           attributeName: 'key_substring',
@@ -1024,9 +1024,9 @@ describe('createAssetSelectionHint', () => {
     expect(testAutocomplete('tag:"tag|"')).toEqual({
       from: 4,
       list: [
-        {text: '"tag1"', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag2"', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
-        {text: '"tag3"', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag1', displayText: 'tag1', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag2', displayText: 'tag2', type: 'attribute', attributeName: 'tag'},
+        {text: 'tag3', displayText: 'tag3', type: 'attribute', attributeName: 'tag'},
       ],
       to: 9,
     });
@@ -1061,9 +1061,9 @@ describe('createAssetSelectionHint', () => {
     ).toEqual({
       from: 58,
       list: [
-        {text: '"asset1"', displayText: 'asset1', type: 'attribute', attributeName: 'key'},
-        {text: '"asset2"', displayText: 'asset2', type: 'attribute', attributeName: 'key'},
-        {text: '"asset3"', displayText: 'asset3', type: 'attribute', attributeName: 'key'},
+        {text: 'asset1', displayText: 'asset1', type: 'attribute', attributeName: 'key'},
+        {text: 'asset2', displayText: 'asset2', type: 'attribute', attributeName: 'key'},
+        {text: 'asset3', displayText: 'asset3', type: 'attribute', attributeName: 'key'},
       ],
       to: 60,
     });


### PR DESCRIPTION
## Summary & Motivation

We only want to surround values with double quotes if they contain special characters. 

Also add a space after each attribute value so that to auto-complete suggests `and`/`or`. Otherwise, since we removed the double quotes, it would keep suggesting other attribute values since without the quotes its not clear that the value is complete

## How I Tested These Changes

jest tests