### PR TITLE
[Runs feed] Fix status filtering logic on tabs with hardcoded filters

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -331,6 +331,8 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     },
   });
 
+  console.log({tokens, StatusFilterValues});
+
   const statusFilter = useStaticSetFilter({
     name: 'Status',
     icon: 'status',


### PR DESCRIPTION
## Summary & Motivation

On certain tabs (eg. Failed) we hardcode in a status filter. On these pages we're *supposed* to also disable the status filter option (This should have been the behavior to mirror the original runs page, but its missing, an oversight).  On the "Failed" tab this makes sense since "Failed" corresponds to exactly 1 status, but on the in-progress page there are actually 3 statuses and being able to further filter down to a particular status can be useful as shown by the user report prompting this. So to allow for that I'm allowing status filters on all tabs. If you're on the "Failed" tab and change the status filter we automatically change you to the "All" tab, this behavior comes from [this utility](https://github.com/dagster-io/dagster/blob/7875b8c60223227a373f9304ac09c0e0e12f0560/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx#L116-L140). 

I think this is a better UX for the user because it removes the arbitrary filtering limitations on different tabs.


## How I Tested These Changes

locally went to the "Failed" tab and added more filters and saw the tab changed.