### PR TITLE
[dagster-components cli] List command now returns local components

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -121,6 +121,7 @@ class ComponentTypeInternalMetadata(TypedDict):
 class ComponentTypeMetadata(ComponentTypeInternalMetadata):
     name: str
     package: str
+    component_directory: Optional[str]
 
 
 def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.metadata.EntryPoint]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -1,0 +1,24 @@
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component, component_type
+from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.schema.base import ComponentSchemaBaseModel
+from typing_extensions import Self
+
+
+class MyComponentSchema(ComponentSchemaBaseModel):
+    a_string: str
+    an_int: int
+
+
+@component_type
+class MyComponent(Component):
+    name = "my_component"
+    params_schema = MyComponentSchema
+
+    @classmethod
+    def load(cls, context: ComponentLoadContext) -> Self:
+        context.load_params(cls.params_schema)
+        return cls()
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
@@ -1,0 +1,5 @@
+type: .my_component
+
+params:
+  a_string: "a string"
+  an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -14,9 +14,9 @@ from dagster_components_tests.integration_tests.validation_tests.test_cases impo
     ComponentValidationTestCase,
 )
 from dagster_components_tests.integration_tests.validation_tests.utils import (
-    create_code_location_from_components,
     load_test_component_defs_inject_component,
 )
+from dagster_components_tests.utils import create_code_location_from_components
 
 ensure_dagster_components_tests_import()
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/utils.py
@@ -1,7 +1,3 @@
-import contextlib
-import shutil
-import tempfile
-from collections.abc import Iterator
 from pathlib import Path
 
 from dagster._core.definitions.definitions_class import Definitions
@@ -10,51 +6,7 @@ from dagster_components_tests.integration_tests.component_loader import (
     build_defs_from_component_path,
     load_test_component_project_context,
 )
-from dagster_components_tests.utils import generate_component_lib_pyproject_toml
-
-
-def _setup_component_in_folder(
-    src_path: str, dst_path: str, local_component_defn_to_inject: Path
-) -> None:
-    origin_path = Path(__file__).parent.parent / "components" / src_path
-
-    shutil.copytree(origin_path, dst_path, dirs_exist_ok=True)
-    shutil.copy(local_component_defn_to_inject, Path(dst_path) / "__init__.py")
-
-
-@contextlib.contextmanager
-def inject_component(src_path: str, local_component_defn_to_inject: Path) -> Iterator[str]:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _setup_component_in_folder(src_path, tmpdir, local_component_defn_to_inject)
-        yield tmpdir
-
-
-@contextlib.contextmanager
-def create_code_location_from_components(
-    *src_paths: str, local_component_defn_to_inject: Path
-) -> Iterator[Path]:
-    """Scaffolds a code location with the given components in a temporary directory,
-    injecting the provided local component defn into each component's __init__.py.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        code_location_dir = Path(tmpdir) / "my_location"
-        code_location_dir.mkdir()
-        with open(code_location_dir / "pyproject.toml", "w") as f:
-            f.write(generate_component_lib_pyproject_toml("my_location", is_code_location=True))
-
-        for src_path in src_paths:
-            component_name = src_path.split("/")[-1]
-
-            components_dir = code_location_dir / "my_location" / "components" / component_name
-            components_dir.mkdir(parents=True, exist_ok=True)
-
-            _setup_component_in_folder(
-                src_path=src_path,
-                dst_path=str(components_dir),
-                local_component_defn_to_inject=local_component_defn_to_inject,
-            )
-
-        yield code_location_dir
+from dagster_components_tests.utils import inject_component
 
 
 def load_test_component_defs_inject_component(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -1,3 +1,6 @@
+import contextlib
+import shutil
+import tempfile
 import textwrap
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -81,3 +84,50 @@ def temp_code_location_bar() -> Iterator[None]:
 
         with pushd("bar"):
             yield
+
+
+def _setup_component_in_folder(
+    src_path: str, dst_path: str, local_component_defn_to_inject: Optional[Path]
+) -> None:
+    origin_path = Path(__file__).parent / "integration_tests" / "components" / src_path
+
+    shutil.copytree(origin_path, dst_path, dirs_exist_ok=True)
+    if local_component_defn_to_inject:
+        shutil.copy(local_component_defn_to_inject, Path(dst_path) / "__init__.py")
+
+
+@contextlib.contextmanager
+def inject_component(
+    src_path: str, local_component_defn_to_inject: Optional[Path]
+) -> Iterator[str]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_component_in_folder(src_path, tmpdir, local_component_defn_to_inject)
+        yield tmpdir
+
+
+@contextlib.contextmanager
+def create_code_location_from_components(
+    *src_paths: str, local_component_defn_to_inject: Optional[Path] = None
+) -> Iterator[Path]:
+    """Scaffolds a code location with the given components in a temporary directory,
+    injecting the provided local component defn into each component's __init__.py.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code_location_dir = Path(tmpdir) / "my_location"
+        code_location_dir.mkdir()
+        with open(code_location_dir / "pyproject.toml", "w") as f:
+            f.write(generate_component_lib_pyproject_toml("my_location", is_code_location=True))
+
+        for src_path in src_paths:
+            component_name = src_path.split("/")[-1]
+
+            components_dir = code_location_dir / "my_location" / "components" / component_name
+            components_dir.mkdir(parents=True, exist_ok=True)
+
+            _setup_component_in_folder(
+                src_path=src_path,
+                dst_path=str(components_dir),
+                local_component_defn_to_inject=local_component_defn_to_inject,
+            )
+
+        yield code_location_dir

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class RemoteComponentType:
     name: str
     package: str
+    component_directory: Optional[str]
     summary: Optional[str]
     description: Optional[str]
     scaffold_params_schema: Optional[Mapping[str, Any]]  # json schema
@@ -46,9 +47,9 @@ class RemoteComponentRegistry:
         return cls.from_dict(registry_data)
 
     @classmethod
-    def from_dict(cls, components: dict[str, Mapping[str, Any]]) -> "RemoteComponentRegistry":
+    def from_dict(cls, components: list[Mapping[str, Any]]) -> "RemoteComponentRegistry":
         return RemoteComponentRegistry(
-            {key: RemoteComponentType(**value) for key, value in components.items()}
+            {item["key"]: RemoteComponentType(**item["value"]) for item in components}
         )
 
     def __init__(self, components: dict[str, RemoteComponentType]):


### PR DESCRIPTION
## Summary

Updates the `dagster-components list component-types` command to return info on local component types (e.g. component types defined in the same directory as the component yaml file).

Also includes the optional `component_directory` field in all results, which specifies the directory that component type is scoped to, if any.

## Test Plan

New unit test.
