### PR TITLE
[Asset graph] Fix query error notice

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -94,7 +94,7 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
       });
   }, [options.loading, queryItems]);
 
-  return {fullAssetGraphData, loading: fetchResult.loading || options.loading};
+  return {fullAssetGraphData, loading: !fetchResult.data || fetchResult.loading || options.loading};
 }
 
 export type GraphDataState = {


### PR DESCRIPTION
## Summary & Motivation
This is due to the full asset graph data not being available. Not really sure why the fetchResult.loading is false when the data is not available yet... but for now fixing it this way until I can investigate deeper.