### PR TITLE
[ui] Remove status dot from Asset events left pane

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -9,7 +9,6 @@ import {isRunlessEvent} from './isRunlessEvent';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {AssetKeyInput} from '../graphql/types';
-import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun} from '../runs/RunUtils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';
 
@@ -207,7 +206,7 @@ const AssetEventListEventRow = ({
               event={{stepKey: latest.stepKey, timestamp: latest.timestamp}}
             >
               <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
-                <RunStatusWithStats runId={run.id} status={run.status} size={8} />
+                <Icon name="run" />
                 {titleForRun(run)}
               </Box>
             </AssetRunLink>


### PR DESCRIPTION
## Summary & Motivation

The run status dot in the left pane of Asset events is misleading, since the materialization may have occurred even when the run is marked as failed -- a red dot makes it look as though the materialization also failed, even when it didn't.

Replace the dot with a `run` icon. For more details on the run itself, the user can click to view the materialization event.

![Screenshot 2025-01-22 at 13.37.28.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04l624FRNbtX4kJhQyXR/5312109d-94e5-4eb0-9782-5cb52529c358.png)

## How I Tested These Changes

View asset events, verify that the icon appears in the tag instead of the status dot.

## Changelog

[ui] Remove misleading run status dot from the asset events list.
