### PR TITLE
[docs] remove 404 links

### DIFF
--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -409,23 +409,6 @@ table {
   }
 }
 
-.not-found-links {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  border: 1px solid var(--theme-color-keyline);
-  padding: 1rem;
-
-  a {
-    text-align: center;
-    font-weight: var(--ifm-font-weight-normal);
-
-    &:hover {
-      color: var(--theme-color-accent-blue);
-    }
-  }
-}
-
 .footer__title {
   display: none;
 }

--- a/docs/docs-beta/src/theme/NotFound/Content/index.tsx
+++ b/docs/docs-beta/src/theme/NotFound/Content/index.tsx
@@ -22,11 +22,6 @@ export default function NotFoundContent({className}: Props): JSX.Element {
               .
             </p>
           </div>
-          <div className="not-found-links card">
-            <Link href="/">Welcome to Dagster</Link>
-            <Link href="/getting-started/quickstart">Build your first Dagster project</Link>
-            <Link href="/etl-pipeline-tutorial">Build your first ETL pipeline</Link>
-          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary & Motivation

Links were not formatted well, and I don't think they are necessary for now.

We can revisit a fun Daggy-themed 404 in the future.

**before**
![image](https://github.com/user-attachments/assets/44cb9257-476d-4a58-8fb9-b26b37aa276d)

**after**
![image](https://github.com/user-attachments/assets/a0e6440f-b3ef-4195-8c49-b25594a937e2)


## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
