### PR TITLE
store end timestamp on PartitionBackfill

### DIFF
--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -669,7 +669,9 @@ def _execute_backfill_command_at_location(
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
             instance.add_backfill(
-                backfill_job.with_status(BulkActionStatus.FAILED).with_error(error_info)
+                backfill_job.with_status(BulkActionStatus.FAILED)
+                .with_error(error_info)
+                .with_end_timestamp(get_current_timestamp())
             )
             raise DagsterBackfillFailedError(f"Backfill failed: {error_info}")
 
@@ -689,8 +691,11 @@ def _execute_backfill_command_at_location(
             if dagster_run:
                 instance.submit_run(dagster_run.run_id, workspace)
 
-        # TODO - figure out what to do here
-        instance.add_backfill(backfill_job.with_status(BulkActionStatus.COMPLETED))
+        instance.add_backfill(
+            backfill_job.with_status(BulkActionStatus.COMPLETED).with_end_timestamp(
+                get_current_timestamp()
+            )
+        )
 
         print_fn(f"Launched backfill job `{backfill_id}`")
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1110,6 +1110,8 @@ def execute_asset_backfill_iteration(
                 updated_backfill: PartitionBackfill = updated_backfill.with_status(
                     BulkActionStatus.COMPLETED_SUCCESS
                 )
+
+            updated_backfill = updated_backfill.with_end_timestamp(get_current_timestamp())
             instance.update_backfill(updated_backfill)
 
         new_materialized_partitions = (
@@ -1191,7 +1193,9 @@ def execute_asset_backfill_iteration(
             updated_asset_backfill_data.all_requested_partitions_marked_as_materialized_or_failed()
         )
         if all_partitions_marked_completed:
-            updated_backfill = updated_backfill.with_status(BulkActionStatus.CANCELED)
+            updated_backfill = updated_backfill.with_status(
+                BulkActionStatus.CANCELED
+            ).with_end_timestamp(get_current_timestamp())
 
         instance.update_backfill(updated_backfill)
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -117,6 +117,7 @@ class PartitionBackfill(
             ("failure_count", int),
             ("submitting_run_requests", Sequence[RunRequest]),
             ("reserved_run_ids", Sequence[str]),
+            ("backfill_end_timestamp", Optional[float]),
         ],
     ),
 ):
@@ -140,6 +141,7 @@ class PartitionBackfill(
         failure_count: Optional[int] = None,
         submitting_run_requests: Optional[Sequence[RunRequest]] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
+        backfill_end_timestamp: Optional[float] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
@@ -189,6 +191,9 @@ class PartitionBackfill(
             ),
             reserved_run_ids=check.opt_sequence_param(
                 reserved_run_ids, "reserved_run_ids", of_type=str
+            ),
+            backfill_end_timestamp=check.opt_float_param(
+                backfill_end_timestamp, "backfill_end_timestamp"
             ),
         )
 
@@ -398,6 +403,10 @@ class PartitionBackfill(
     def with_error(self, error):
         check.opt_inst_param(error, "error", SerializableErrorInfo)
         return self._replace(error=error)
+
+    def with_end_timestamp(self, end_timestamp: float) -> "PartitionBackfill":
+        check.float_param(end_timestamp, "end_timestamp")
+        return self._replace(backfill_end_timestamp=end_timestamp)
 
     def with_asset_backfill_data(
         self,

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -36,6 +36,7 @@ from dagster._core.storage.tags import (
 from dagster._core.telemetry import BACKFILL_RUN_CREATED, hash_name, log_action
 from dagster._core.utils import make_new_run_id
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
+from dagster._time import get_current_timestamp
 from dagster._utils import check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
@@ -77,7 +78,11 @@ def execute_job_backfill_iteration(
             )
 
         if all_runs_canceled:
-            instance.update_backfill(backfill.with_status(BulkActionStatus.CANCELED))
+            instance.update_backfill(
+                backfill.with_status(BulkActionStatus.CANCELED).with_end_timestamp(
+                    get_current_timestamp()
+                )
+            )
         return
 
     has_more = True
@@ -145,9 +150,17 @@ def execute_job_backfill_iteration(
                 )
                 > 0
             ):
-                instance.update_backfill(backfill.with_status(BulkActionStatus.COMPLETED_FAILED))
+                instance.update_backfill(
+                    backfill.with_status(BulkActionStatus.COMPLETED_FAILED).with_end_timestamp(
+                        get_current_timestamp()
+                    )
+                )
             else:
-                instance.update_backfill(backfill.with_status(BulkActionStatus.COMPLETED_SUCCESS))
+                instance.update_backfill(
+                    backfill.with_status(BulkActionStatus.COMPLETED_SUCCESS).with_end_timestamp(
+                        get_current_timestamp()
+                    )
+                )
             yield None
 
 

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -249,5 +249,6 @@ def execute_backfill_jobs(
                         backfill.with_status(BulkActionStatus.FAILED)
                         .with_error(error_info)
                         .with_failure_count(backfill.failure_count + 1)
+                        .with_end_timestamp(get_current_timestamp())
                     )
                 yield error_info

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1187,7 +1187,6 @@ def test_unloadable_backfill(instance, workspace_context):
     backfill = instance.get_backfill("simple")
     assert backfill.status == BulkActionStatus.FAILED
     assert isinstance(backfill.error, SerializableErrorInfo)
-    assert backfill.backfill_end_timestamp is not None
 
 
 def test_unloadable_asset_backfill(instance, workspace_context):

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1323,7 +1323,7 @@ def test_asset_backfill_retryable_error(instance, workspace_context):
             updated_backfill = instance.get_backfill(backfill_id)
             assert updated_backfill.status == BulkActionStatus.FAILED
             assert updated_backfill.failure_count == 3
-            assert backfill.backfill_end_timestamp is not None
+            assert updated_backfill.backfill_end_timestamp is not None
 
 
 def test_unloadable_backfill_retry(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -989,6 +989,7 @@ def test_job_backfill_status(
     backfill = instance.get_backfill("simple")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
@@ -1186,6 +1187,7 @@ def test_unloadable_backfill(instance, workspace_context):
     backfill = instance.get_backfill("simple")
     assert backfill.status == BulkActionStatus.FAILED
     assert isinstance(backfill.error, SerializableErrorInfo)
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_unloadable_asset_backfill(instance, workspace_context):
@@ -1228,6 +1230,7 @@ def test_unloadable_asset_backfill(instance, workspace_context):
     assert backfill.status == BulkActionStatus.FAILED
     assert backfill.failure_count == 1
     assert isinstance(backfill.error, SerializableErrorInfo)
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_retryable_error(instance, workspace_context):
@@ -1321,6 +1324,7 @@ def test_asset_backfill_retryable_error(instance, workspace_context):
             updated_backfill = instance.get_backfill(backfill_id)
             assert updated_backfill.status == BulkActionStatus.FAILED
             assert updated_backfill.failure_count == 3
+            assert backfill.backfill_end_timestamp is not None
 
 
 def test_unloadable_backfill_retry(
@@ -1564,6 +1568,7 @@ def test_pure_asset_backfill(
     backfill = instance.get_backfill("backfill_with_asset_selection")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_backfill_from_failure_for_subselection(
@@ -1663,6 +1668,7 @@ def test_asset_backfill_cancellation(
     assert backfill
     assert backfill.status == BulkActionStatus.CANCELED
     assert instance.get_runs_count() == 1  # Assert that additional runs are not created
+    assert backfill.backfill_end_timestamp is not None
 
 
 # Check run submission at chunk boundary and off of chunk boundary
@@ -2356,6 +2362,7 @@ def test_asset_job_backfill_single_run_multiple_iterations(
     backfill = instance.get_backfill("simple")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_job_backfill_multi_run(
@@ -2608,6 +2615,7 @@ def test_complex_asset_with_backfill_policy(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_error_code_location(
@@ -3048,6 +3056,7 @@ def test_asset_backfill_logs(
     backfill = instance.get_backfill("backfill_with_asset_selection")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
     # set num_lines high so we know we get all of the remaining logs
     os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "100"
@@ -3154,6 +3163,7 @@ def test_asset_backfill_from_asset_graph_subset(
     backfill = instance.get_backfill("backfill_from_asset_graph_subset")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_from_asset_graph_subset_with_static_and_time_partitions(
@@ -3220,6 +3230,7 @@ def test_asset_backfill_from_asset_graph_subset_with_static_and_time_partitions(
     )
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_not_complete_until_retries_complete(
@@ -3307,6 +3318,7 @@ def test_asset_backfill_not_complete_until_retries_complete(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_not_complete_if_automatic_retry_could_happen(
@@ -3376,6 +3388,7 @@ def test_asset_backfill_not_complete_if_automatic_retry_could_happen(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_fails_if_retries_fail(
@@ -3461,6 +3474,7 @@ def test_asset_backfill_fails_if_retries_fail(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_FAILED
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_asset_backfill_retries_make_downstreams_runnable(
@@ -3550,6 +3564,7 @@ def test_asset_backfill_retries_make_downstreams_runnable(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
     assert backfill.asset_backfill_data
     assert (
         backfill.asset_backfill_data.failed_and_downstream_subset.num_partitions_and_non_partitioned_assets
@@ -3604,6 +3619,7 @@ def test_run_retry_not_part_of_completed_backfill(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
     # simulate a retry of a run
     run_to_retry = instance.get_runs()[0]
@@ -3633,6 +3649,7 @@ def test_run_retry_not_part_of_completed_backfill(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
 
     assert retried_run.run_id not in [
         r.run_id for r in instance.get_runs(filters=RunsFilter.for_backfill(backfill_id))


### PR DESCRIPTION
## Summary & Motivation
We don't store the time a backfill ends on the `PartitionBackfill` object. Instead we query for all of the runs in the backfill and find the one with the most recent end time. This results in noticeably slow load times (~10seconds on our deployment) on the Backfills tab of the Runs page because we have to fetch every run for every backfill on the page. 

The PR stores the current time when a backfill is moved into a terminal state. Then we can access this value in the GQL resolver. If the end timestamp doesn't exist on the backfill object we fall back to calculating based on run end times. Maybe we could also write this value to the db after we've computed it?

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
