### PR TITLE
[perf] Fetch freshnessInfo separately from other asset data

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -1,7 +1,8 @@
 {
   "PermissionsQuery": "505a351d43369bd83e7d4ff2d974368d2a754a85661dfb077a26d1a11ff2f714",
   "LogTelemetryMutation": "b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3",
-  "AssetGraphLiveQuery": "cf42c8b34b97b7bb696ba56e0b363eaa15b58df4bbb384e58ca49811da7ccc01",
+  "AssetGraphLiveQuery": "d65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497",
+  "AssetsFreshnessInfoQuery": "5ced7579607f729f8423937a9baba83b0e5080574d8d3a7611e1f7dc6c931d60",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "dec086c5cc4b9fb1ab796679125eb4b628b8f60510e23293a401e70d4b69cca2",
   "AssetLiveRunLogsSubscription": "4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -2,7 +2,7 @@
   "PermissionsQuery": "505a351d43369bd83e7d4ff2d974368d2a754a85661dfb077a26d1a11ff2f714",
   "LogTelemetryMutation": "b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3",
   "AssetGraphLiveQuery": "d65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497",
-  "AssetsFreshnessInfoQuery": "5ced7579607f729f8423937a9baba83b0e5080574d8d3a7611e1f7dc6c931d60",
+  "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "dec086c5cc4b9fb1ab796679125eb4b628b8f60510e23293a401e70d4b69cca2",
   "AssetLiveRunLogsSubscription": "4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -24,19 +24,20 @@ function init() {
       return useApolloClient();
     },
     async (keys, client: ApolloClient<any>) => {
+      const assetKeys = keys.map(tokenToAssetKey);
       const [graphResponse, freshnessResponse] = await Promise.all([
         client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
           query: ASSETS_GRAPH_LIVE_QUERY,
           fetchPolicy: 'no-cache',
           variables: {
-            assetKeys: keys.map(tokenToAssetKey),
+            assetKeys,
           },
         }),
         client.query<AssetsFreshnessInfoQuery, AssetsFreshnessInfoQueryVariables>({
           query: ASSETS_FRESHNESS_INFO_QUERY,
           fetchPolicy: 'no-cache',
           variables: {
-            assetKeys: keys.map(tokenToAssetKey),
+            assetKeys,
           },
         }),
       ]);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -208,12 +208,12 @@ export const ASSETS_FRESHNESS_INFO_QUERY = gql`
         path
       }
       freshnessInfo {
-        ...AssetFreshnessInfoFragment
+        ...AssetNodeLiveFreshnessInfoFragment
       }
     }
   }
 
-  fragment AssetFreshnessInfoFragment on AssetFreshnessInfo {
+  fragment AssetNodeLiveFreshnessInfoFragment on AssetFreshnessInfo {
     currentMinutesLate
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -4,6 +4,8 @@ import {ApolloClient, gql, useApolloClient} from '../apollo-client';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
+  AssetsFreshnessInfoQuery,
+  AssetsFreshnessInfoQueryVariables,
 } from './types/AssetBaseDataProvider.types';
 import {
   LiveDataForNode,
@@ -22,16 +24,32 @@ function init() {
       return useApolloClient();
     },
     async (keys, client: ApolloClient<any>) => {
-      const {data} = await client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
-        query: ASSETS_GRAPH_LIVE_QUERY,
-        fetchPolicy: 'no-cache',
-        variables: {
-          assetKeys: keys.map(tokenToAssetKey),
-        },
-      });
+      const [graphResponse, freshnessResponse] = await Promise.all([
+        client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
+          query: ASSETS_GRAPH_LIVE_QUERY,
+          fetchPolicy: 'no-cache',
+          variables: {
+            assetKeys: keys.map(tokenToAssetKey),
+          },
+        }),
+        client.query<AssetsFreshnessInfoQuery, AssetsFreshnessInfoQueryVariables>({
+          query: ASSETS_FRESHNESS_INFO_QUERY,
+          fetchPolicy: 'no-cache',
+          variables: {
+            assetKeys: keys.map(tokenToAssetKey),
+          },
+        }),
+      ]);
+
+      const {data} = graphResponse;
+      const {data: freshnessData} = freshnessResponse;
 
       const nodesByKey = Object.fromEntries(
         data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
+      );
+
+      const freshnessInfoByKey = Object.fromEntries(
+        freshnessData.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
       );
 
       return Object.fromEntries(
@@ -39,7 +57,21 @@ function init() {
           .map((assetLatestInfo) => {
             const id = tokenForAssetKey(assetLatestInfo.assetKey);
             const node = nodesByKey[id];
-            return node ? [id, buildLiveDataForNode(node, assetLatestInfo)] : null;
+            const freshnessInfo = freshnessInfoByKey[id];
+            return node
+              ? [
+                  id,
+                  buildLiveDataForNode(
+                    {
+                      ...node,
+                      ...(freshnessInfo ?? {
+                        freshnessInfo: null,
+                      }),
+                    },
+                    assetLatestInfo,
+                  ),
+                ]
+              : null;
           })
           .filter((entry): entry is [string, LiveDataForNode] => !!entry),
       );
@@ -117,19 +149,12 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
         }
       }
     }
-    freshnessInfo {
-      ...AssetNodeLiveFreshnessInfo
-    }
     partitionStats {
       numMaterialized
       numMaterializing
       numPartitions
       numFailed
     }
-  }
-
-  fragment AssetNodeLiveFreshnessInfo on AssetFreshnessInfo {
-    currentMinutesLate
   }
 
   fragment AssetNodeLiveMaterialization on MaterializationEvent {
@@ -172,6 +197,24 @@ export const ASSETS_GRAPH_LIVE_QUERY = gql`
 
   ${ASSET_NODE_LIVE_FRAGMENT}
   ${ASSET_LATEST_INFO_FRAGMENT}
+`;
+
+export const ASSETS_FRESHNESS_INFO_QUERY = gql`
+  query AssetsFreshnessInfoQuery($assetKeys: [AssetKeyInput!]!) {
+    assetNodes(assetKeys: $assetKeys) {
+      id
+      assetKey {
+        path
+      }
+      freshnessInfo {
+        ...AssetFreshnessInfoFragment
+      }
+    }
+  }
+
+  fragment AssetFreshnessInfoFragment on AssetFreshnessInfo {
+    currentMinutesLate
+  }
 `;
 
 // For tests

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -80,8 +80,8 @@ function Test({
 describe('AssetLiveDataProvider', () => {
   it('provides asset data and uses cache if recently fetched', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
-    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(assetKeys);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(assetKeys);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -90,7 +90,10 @@ describe('AssetLiveDataProvider', () => {
     const hookResult2 = jest.fn();
 
     const {rerender} = render(
-      <Test mocks={[mockedQuery, mockedQuery2]} hooks={[{keys: assetKeys, hookResult}]} />,
+      <Test
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
+        hooks={[{keys: assetKeys, hookResult}]}
+      />,
     );
 
     // Initially an empty object
@@ -142,8 +145,8 @@ describe('AssetLiveDataProvider', () => {
 
   it('obeys document visibility', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
-    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(assetKeys);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(assetKeys);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -152,7 +155,10 @@ describe('AssetLiveDataProvider', () => {
     const hookResult2 = jest.fn();
 
     const {rerender} = render(
-      <Test mocks={[mockedQuery, mockedQuery2]} hooks={[{keys: assetKeys, hookResult}]} />,
+      <Test
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
+        hooks={[{keys: assetKeys, hookResult}]}
+      />,
     );
 
     // Initially an empty object
@@ -170,7 +176,7 @@ describe('AssetLiveDataProvider', () => {
 
     rerender(
       <Test
-        mocks={[mockedQuery, mockedQuery2]}
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
         hooks={[{keys: assetKeys, hookResult: hookResult2}]}
       />,
     );
@@ -220,15 +226,20 @@ describe('AssetLiveDataProvider', () => {
     const chunk1 = assetKeys.slice(0, BATCH_SIZE);
     const chunk2 = assetKeys.slice(BATCH_SIZE, 2 * BATCH_SIZE);
 
-    const mockedQuery = buildMockedAssetGraphLiveQuery(chunk1);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(chunk2);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(chunk1);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(chunk2);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
 
     const hookResult = jest.fn();
 
-    render(<Test mocks={[mockedQuery, mockedQuery2]} hooks={[{keys: assetKeys, hookResult}]} />);
+    render(
+      <Test
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
+        hooks={[{keys: assetKeys, hookResult}]}
+      />,
+    );
 
     // Initially an empty object
     expect(resultFn).not.toHaveBeenCalled();
@@ -269,15 +280,15 @@ describe('AssetLiveDataProvider', () => {
     );
     const hook3Keys = assetKeys.slice(Math.floor((4 / 3) * BATCH_SIZE), 2 * BATCH_SIZE);
 
-    const mockedQuery = buildMockedAssetGraphLiveQuery(chunk1);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(chunk2);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(chunk1);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(chunk2);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
 
     render(
       <Test
-        mocks={[mockedQuery, mockedQuery2]}
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
         hooks={[
           {keys: hook1Keys, hookResult},
           {keys: hook2Keys, hookResult},
@@ -322,9 +333,12 @@ describe('AssetLiveDataProvider', () => {
 
     secondPrioritizedFetchKeys.push(...fetch1Keys);
 
-    const mockedQuery = buildMockedAssetGraphLiveQuery(fetch1Keys);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(firstPrioritizedFetchKeys);
-    const mockedQuery3 = buildMockedAssetGraphLiveQuery(secondPrioritizedFetchKeys);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(fetch1Keys);
+    const [mockedQuery2, mockedFreshnessQuery2] =
+      buildMockedAssetGraphLiveQuery(firstPrioritizedFetchKeys);
+    const [mockedQuery3, mockedFreshnessQuery3] = buildMockedAssetGraphLiveQuery(
+      secondPrioritizedFetchKeys,
+    );
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -333,7 +347,14 @@ describe('AssetLiveDataProvider', () => {
     // First we fetch the keys from fetch1
     const {unmount} = render(
       <Test
-        mocks={[mockedQuery, mockedQuery2, mockedQuery3]}
+        mocks={[
+          mockedQuery,
+          mockedFreshnessQuery,
+          mockedQuery2,
+          mockedFreshnessQuery2,
+          mockedQuery3,
+          mockedFreshnessQuery3,
+        ]}
         hooks={[{keys: fetch1Keys, hookResult}]}
       />,
     );
@@ -360,7 +381,14 @@ describe('AssetLiveDataProvider', () => {
     // were previously fetched.
     render(
       <Test
-        mocks={[mockedQuery, mockedQuery2, mockedQuery3]}
+        mocks={[
+          mockedQuery,
+          mockedFreshnessQuery,
+          mockedQuery2,
+          mockedFreshnessQuery2,
+          mockedQuery3,
+          mockedFreshnessQuery3,
+        ]}
         hooks={[{keys: assetKeys, hookResult}]}
       />,
     );
@@ -377,12 +405,16 @@ describe('AssetLiveDataProvider', () => {
 
   it('Skips over asset keys that fail to fetch', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
-    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
-      new GraphQLError('500'),
-    ]);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
-      new GraphQLError('500'),
-    ]);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(
+      assetKeys,
+      undefined,
+      [new GraphQLError('500')],
+    );
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(
+      assetKeys,
+      undefined,
+      [new GraphQLError('500')],
+    );
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -391,7 +423,10 @@ describe('AssetLiveDataProvider', () => {
     const hookResult2 = jest.fn();
 
     const {rerender} = render(
-      <Test mocks={[mockedQuery, mockedQuery2]} hooks={[{keys: assetKeys, hookResult}]} />,
+      <Test
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
+        hooks={[{keys: assetKeys, hookResult}]}
+      />,
     );
 
     // Initially an empty object
@@ -440,8 +475,8 @@ describe('AssetLiveDataProvider', () => {
   it('Has multiple threads', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
     const assetKeys2 = [buildAssetKey({path: ['key2']})];
-    const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(assetKeys2);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(assetKeys);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(assetKeys2);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -451,7 +486,7 @@ describe('AssetLiveDataProvider', () => {
 
     render(
       <Test
-        mocks={[mockedQuery, mockedQuery2]}
+        mocks={[mockedQuery, mockedFreshnessQuery, mockedQuery2, mockedFreshnessQuery2]}
         hooks={[
           {keys: assetKeys, thread: 'default', hookResult},
           {keys: assetKeys2, thread: 'context-menu', hookResult: hookResult2},
@@ -490,10 +525,10 @@ describe('AssetLiveDataProvider', () => {
     const chunk3 = assetKeys.slice(2 * BATCH_SIZE, 3 * BATCH_SIZE);
     const chunk4 = assetKeys.slice(3 * BATCH_SIZE, 4 * BATCH_SIZE);
 
-    const mockedQuery = buildMockedAssetGraphLiveQuery(chunk1);
-    const mockedQuery2 = buildMockedAssetGraphLiveQuery(chunk2);
-    const mockedQuery3 = buildMockedAssetGraphLiveQuery(chunk3);
-    const mockedQuery4 = buildMockedAssetGraphLiveQuery(chunk4);
+    const [mockedQuery, mockedFreshnessQuery] = buildMockedAssetGraphLiveQuery(chunk1);
+    const [mockedQuery2, mockedFreshnessQuery2] = buildMockedAssetGraphLiveQuery(chunk2);
+    const [mockedQuery3, mockedFreshnessQuery3] = buildMockedAssetGraphLiveQuery(chunk3);
+    const [mockedQuery4, mockedFreshnessQuery4] = buildMockedAssetGraphLiveQuery(chunk4);
 
     const resultFn = getMockResultFn(mockedQuery);
     const resultFn2 = getMockResultFn(mockedQuery2);
@@ -504,7 +539,16 @@ describe('AssetLiveDataProvider', () => {
 
     render(
       <Test
-        mocks={[mockedQuery, mockedQuery2, mockedQuery3, mockedQuery4]}
+        mocks={[
+          mockedQuery,
+          mockedFreshnessQuery,
+          mockedQuery2,
+          mockedFreshnessQuery2,
+          mockedQuery3,
+          mockedFreshnessQuery3,
+          mockedQuery4,
+          mockedFreshnessQuery4,
+        ]}
         hooks={[{keys: assetKeys, hookResult}]}
       />,
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
@@ -7,10 +7,12 @@ import {
   buildAssetNode,
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
-import {ASSETS_GRAPH_LIVE_QUERY} from '../AssetBaseDataProvider';
+import {ASSETS_FRESHNESS_INFO_QUERY, ASSETS_GRAPH_LIVE_QUERY} from '../AssetBaseDataProvider';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
+  AssetsFreshnessInfoQuery,
+  AssetsFreshnessInfoQueryVariables,
 } from '../types/AssetBaseDataProvider.types';
 
 export function buildMockedAssetGraphLiveQuery(
@@ -22,8 +24,7 @@ export function buildMockedAssetGraphLiveQuery(
     | undefined = undefined,
   errors: readonly GraphQLError[] | undefined = undefined,
 ) {
-  return buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
-    query: ASSETS_GRAPH_LIVE_QUERY,
+  const opts = {
     variables: {
       // strip __typename
       assetKeys: assetKeys.map((assetKey) => ({path: assetKey.path})),
@@ -43,5 +44,23 @@ export function buildMockedAssetGraphLiveQuery(
           }
         : data,
     errors,
-  });
+  };
+  return [
+    buildQueryMock<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
+      query: ASSETS_GRAPH_LIVE_QUERY,
+      ...opts,
+    }),
+    buildQueryMock<AssetsFreshnessInfoQuery, AssetsFreshnessInfoQueryVariables>({
+      query: ASSETS_FRESHNESS_INFO_QUERY,
+      ...opts,
+      data:
+        data === undefined && errors === undefined
+          ? {
+              assetNodes: assetKeys.map((assetKey) =>
+                buildAssetNode({assetKey: buildAssetKey(assetKey), id: JSON.stringify(assetKey)}),
+              ),
+            }
+          : undefined,
+    }),
+  ] as const;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
@@ -174,11 +174,11 @@ export type AssetsFreshnessInfoQuery = {
   }>;
 };
 
-export type AssetFreshnessInfoFragment = {
+export type AssetNodeLiveFreshnessInfoFragment = {
   __typename: 'AssetFreshnessInfo';
   currentMinutesLate: number | null;
 };
 
 export const AssetGraphLiveQueryVersion = 'd65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497';
 
-export const AssetsFreshnessInfoQueryVersion = '5ced7579607f729f8423937a9baba83b0e5080574d8d3a7611e1f7dc6c931d60';
+export const AssetsFreshnessInfoQueryVersion = '1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
@@ -59,7 +59,6 @@ export type AssetNodeLiveFragment = {
           } | null;
         }>;
       };
-  freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
   partitionStats: {
     __typename: 'PartitionStats';
     numMaterialized: number;
@@ -67,11 +66,6 @@ export type AssetNodeLiveFragment = {
     numPartitions: number;
     numFailed: number;
   } | null;
-};
-
-export type AssetNodeLiveFreshnessInfoFragment = {
-  __typename: 'AssetFreshnessInfo';
-  currentMinutesLate: number | null;
 };
 
 export type AssetNodeLiveMaterializationFragment = {
@@ -143,7 +137,6 @@ export type AssetGraphLiveQuery = {
             } | null;
           }>;
         };
-    freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
     partitionStats: {
       __typename: 'PartitionStats';
       numMaterialized: number;
@@ -167,4 +160,25 @@ export type AssetGraphLiveQuery = {
   }>;
 };
 
-export const AssetGraphLiveQueryVersion = 'cf42c8b34b97b7bb696ba56e0b363eaa15b58df4bbb384e58ca49811da7ccc01';
+export type AssetsFreshnessInfoQueryVariables = Types.Exact<{
+  assetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
+}>;
+
+export type AssetsFreshnessInfoQuery = {
+  __typename: 'Query';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
+  }>;
+};
+
+export type AssetFreshnessInfoFragment = {
+  __typename: 'AssetFreshnessInfo';
+  currentMinutesLate: number | null;
+};
+
+export const AssetGraphLiveQueryVersion = 'd65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497';
+
+export const AssetsFreshnessInfoQueryVersion = '5ced7579607f729f8423937a9baba83b0e5080574d8d3a7611e1f7dc6c931d60';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -6,7 +6,6 @@ import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {COMMON_COLLATOR} from '../app/Util';
 import {
   AssetCheckLiveFragment,
-  AssetGraphLiveQuery,
   AssetLatestInfoFragment,
   AssetLatestInfoRunFragment,
   AssetNodeLiveFragment,
@@ -33,7 +32,9 @@ export enum AssetGraphViewType {
 
 type AssetNode = AssetNodeForGraphQueryFragment;
 type AssetKey = AssetNodeKeyFragment;
-type AssetLiveNode = AssetNodeLiveFragment;
+type AssetLiveNode = AssetNodeLiveFragment & {
+  freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null | undefined;
+};
 type AssetLatestInfo = AssetLatestInfoFragment;
 
 export const __ASSET_JOB_PREFIX = '__ASSET_JOB';
@@ -157,7 +158,7 @@ export interface LiveDataForNode {
   runWhichFailedToMaterialize: AssetLatestInfoRunFragment | null;
   lastMaterialization: AssetNodeLiveMaterializationFragment | null;
   lastMaterializationRunStatus: RunStatus | null; // only available if runWhichFailedToMaterialize is null
-  freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null;
+  freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null | undefined;
   lastObservation: AssetNodeLiveObservationFragment | null;
   assetChecks: AssetCheckLiveFragment[];
   partitionStats: {
@@ -193,24 +194,6 @@ export const MISSING_LIVE_DATA: LiveDataForNodeWithStaleData = {
 export interface LiveData {
   [assetId: GraphId]: LiveDataForNode;
 }
-
-export const buildLiveData = ({
-  assetNodes,
-  assetsLatestInfo,
-}: Pick<AssetGraphLiveQuery, 'assetNodes' | 'assetsLatestInfo'>) => {
-  const data: LiveData = {};
-
-  for (const liveNode of assetNodes) {
-    const graphId = toGraphId(liveNode.assetKey);
-    const assetLatestInfo = assetsLatestInfo.find(
-      (r) => JSON.stringify(r.assetKey) === JSON.stringify(liveNode.assetKey),
-    );
-
-    data[graphId] = buildLiveDataForNode(liveNode, assetLatestInfo);
-  }
-
-  return data;
-};
 
 export const buildLiveDataForNode = (
   assetNode: AssetLiveNode,


### PR DESCRIPTION
## Summary & Motivation

freshnessInfo is expensive to fetch, and our graphene layer can't parallelize fetching it with other data it fetches... so fetch it separately.

## How I Tested These Changes

host cloud, 

You can see the AssetFreshness queries at the top of the network tab here:
<img width="1463" alt="Screenshot 2025-01-22 at 4 18 28 PM" src="https://github.com/user-attachments/assets/dfa2f06e-42dc-460d-9cbe-049d148f9aa7" />
