### PR TITLE
Mirror YAML parsing utils in dagster-dg

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/yaml_utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/yaml_utils/__init__.py
@@ -1,0 +1,128 @@
+## Lifted from dagster._utils.yaml_utils
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+import yaml
+
+from dagster_dg.yaml_utils.source_position import (
+    KeyPathSegment,
+    LineCol,
+    SourcePosition,
+    SourcePositionTree,
+    ValueAndSourcePositionTree,
+)
+
+# Removing this implicit loader stops YAML-loading from returning datetime objects
+YAML_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp"
+
+
+class _CanRemoveImplicitResolver:
+    # Adds a "remove_implicit_resolver" method that can be used to selectively
+    # disable default PyYAML resolvers
+
+    @classmethod
+    def remove_implicit_resolver(cls, tag):
+        # See https://github.com/yaml/pyyaml/blob/master/lib/yaml/resolver.py#L26 for inspiration
+        if "yaml_implicit_resolvers" not in cls.__dict__:
+            implicit_resolvers = {}
+            for key in cls.yaml_implicit_resolvers:
+                implicit_resolvers[key] = cls.yaml_implicit_resolvers[key][:]
+            cls.yaml_implicit_resolvers = implicit_resolvers
+
+        for ch, mappings in cls.yaml_implicit_resolvers.items():
+            cls.yaml_implicit_resolvers[ch] = [
+                (existing_tag, regexp) for existing_tag, regexp in mappings if existing_tag != tag
+            ]
+
+
+def parse_yaml_with_source_positions(
+    src: str,
+    filename: str = "<string>",
+    implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
+) -> ValueAndSourcePositionTree:
+    """Parse YAML source with source position information.
+    This function takes a YAML source string and an optional filename, and returns a
+    `ValueAndSourcePositionTree` object. The `ValueAndSourcePositionTree` contains the
+    parsed YAML value and a `SourcePositionTree` that holds the source position information for
+    the YAML structure.
+
+    The function uses a custom YAML loader (`SourcePositionLoader`) that tracks the source position
+    information for each YAML node. It also allows for the removal of specific implicit resolvers,
+    such as the default timestamp resolver.
+
+    Args:
+        src (str): The YAML source string to be parsed.
+        filename (str): The filename associated with the YAML source, used for error reporting.
+            Defaults to "<string>" if not provided.
+        implicits_to_remove (list[str]): A list of YAML implicit resolvers to remove. Defaults to
+            removing the timestamp resolver.
+
+    Returns:
+        ValueAndSourcePositionTree: An object containing the parsed YAML value and the corresponding
+            source position information.
+    """
+
+    class SourcePositionLoader(yaml.SafeLoader, _CanRemoveImplicitResolver):
+        def construct_object(self, node: Any, deep: Any = False) -> ValueAndSourcePositionTree:
+            """Returns a ValueAndSourcePositionTree object where:
+            - Its value is what the regular yaml.SafeLoader returns
+            - Its source_position_tree is a tree where each node corresponds to a node in the YAML
+              tree.
+            """
+            source_position = SourcePosition(
+                filename=filename,
+                start=LineCol(line=node.start_mark.line + 1, col=node.start_mark.column + 1),
+                end=LineCol(line=node.end_mark.line + 1, col=node.end_mark.column + 1),
+            )
+
+            value = super().construct_object(node, True)
+            # If value is a collection, then all of its elements will be ValueAndSourcePositionTree
+            # instances. We need to do two things:
+            # - Strip out the enclosing ValueAndSourcePositionTrees, so we're just returning a
+            #   collection of the raw values
+            # - Assemble the source position subtrees into a super-tree
+
+            if isinstance(value, dict):
+                dict_with_raw_values: dict[Any, Any] = {}
+                child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
+                for k, v in cast(
+                    Mapping[ValueAndSourcePositionTree, ValueAndSourcePositionTree], value
+                ).items():
+                    dict_with_raw_values[k.value] = v.value
+                    child_trees[k.value] = SourcePositionTree(
+                        position=k.source_position_tree.position,
+                        children=v.source_position_tree.children,
+                    )
+                return ValueAndSourcePositionTree(
+                    dict_with_raw_values,
+                    SourcePositionTree(position=source_position, children=child_trees),
+                )
+            if isinstance(value, list):
+                list_with_raw_values: list[Any] = []
+                child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
+                for i, v in enumerate(cast(Sequence[ValueAndSourcePositionTree], value)):
+                    list_with_raw_values.append(v.value)
+                    child_trees[i] = v.source_position_tree
+                return ValueAndSourcePositionTree(
+                    list_with_raw_values,
+                    SourcePositionTree(position=source_position, children=child_trees),
+                )
+
+            return ValueAndSourcePositionTree(
+                value,
+                SourcePositionTree(position=source_position, children={}),
+            )
+
+    for implicit_to_remove in implicits_to_remove:
+        SourcePositionLoader.remove_implicit_resolver(implicit_to_remove)
+
+    try:
+        value_and_tree_node = yaml.load(src, Loader=SourcePositionLoader)
+    except yaml.MarkedYAMLError as e:
+        if e.context_mark is not None:
+            e.context_mark.name = filename
+        if e.problem_mark is not None:
+            e.problem_mark.name = filename
+        raise e
+
+    return value_and_tree_node

--- a/python_modules/libraries/dagster-dg/dagster_dg/yaml_utils/source_position.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/yaml_utils/source_position.py
@@ -1,0 +1,101 @@
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NamedTuple, Optional, Union
+
+KeyPathSegment = Union[str, int]
+KeyPath = Sequence[KeyPathSegment]
+
+
+class LineCol(NamedTuple):
+    line: int
+    col: int
+
+
+class SourcePosition(NamedTuple):
+    filename: str
+    start: LineCol
+    end: LineCol
+
+    def __str__(self):
+        return f"{self.filename}:{self.start.line}"
+
+
+class SourcePositionTree(NamedTuple):
+    """Represents a tree where every node has a SourcePosition."""
+
+    position: SourcePosition
+    children: Mapping[KeyPathSegment, "SourcePositionTree"]
+
+    def __hash__(self) -> int:
+        return hash((self.position, tuple(sorted(self.children.items()))))
+
+    def lookup(self, key_path: KeyPath) -> Optional[SourcePosition]:
+        """Returns the source position of the descendant at the given path."""
+        if len(key_path) == 0:
+            return self.position
+        head, *tail = key_path
+        if head not in self.children:
+            return None
+        return self.children[head].lookup(tail)
+
+    def lookup_closest_and_path(
+        self, key_path: KeyPath, trace: Optional[Sequence[SourcePosition]]
+    ) -> tuple[SourcePosition, Sequence[SourcePosition]]:
+        """Returns the source position of the descendant at the given path. If the path does not
+        exist, returns the source position of the nearest ancestor.
+        """
+        trace = [*trace, self.position] if trace else [self.position]
+        if len(key_path) == 0:
+            return self.position, trace
+        head, *tail = key_path
+        if head not in self.children:
+            return self.position, trace
+        return self.children[head].lookup_closest_and_path(tail, trace)
+
+
+class ValueAndSourcePositionTree(NamedTuple):
+    """A tree-like object (like a JSON-structured dict) and an accompanying SourcePositionTree.
+
+    Each tree node in the SourcePositionTree is expected to correspond to in value.
+    """
+
+    value: Any
+    source_position_tree: SourcePositionTree
+
+
+class SourcePositionAndKeyPath(NamedTuple):
+    """Represents a source position and key path within a file.
+
+    Attributes:
+        key_path (KeyPath): The path of keys that lead to the current object, where each element in
+            the path is either a string (for dict keys) or an integer (for list indices).
+        source_position (Optional[SourcePosition]): The source position of the object in the
+            document, if available.
+    """
+
+    key_path: KeyPath
+    source_position: Optional[SourcePosition]
+
+
+class HasSourcePositionAndKeyPath:
+    _source_position_and_key_path: Optional[SourcePositionAndKeyPath] = None
+
+    @property
+    def source_position(self) -> SourcePosition:
+        """Returns the underlying source position of the blueprint, including
+        the source file and line number.
+        """
+        assert self._source_position_and_key_path
+        assert self._source_position_and_key_path.source_position
+        return self._source_position_and_key_path.source_position
+
+    @property
+    def source_file(self) -> Path:
+        """Path to the source file where the blueprint is defined."""
+        assert self._source_position_and_key_path
+        return Path(self.source_position.filename)
+
+    @property
+    def source_file_name(self) -> str:
+        """Name of the source file where the blueprint is defined."""
+        return self.source_file.name


### PR DESCRIPTION
## Summary

Mirror the `dagster._utils` YAML parsing utils in `dagster-dg` so no dep is needed.

## Test Plan

dupe test