### PR TITLE
[components] Add note to Components README telling how to use local dg

### DIFF
--- a/docs/docs-beta/docs/guides/build/components/index.md
+++ b/docs/docs-beta/docs/guides/build/components/index.md
@@ -32,6 +32,10 @@ $ uv tool install dagster-dg
 
 `uv tool install` installs python packages from PyPI into isolated environments and exposes their executables on your shell path. This means the `dg` command should now be available. It will always execute in an isolated environment separate from any project environment.
 
+:::note
+If you have a local clone of the `dagster` repo, you can install a local version of `dg` with `uv tool install -e $DAGSTER_GIT_REPO_DIR/python_modules/libraries/dagster-dg`. This will create an isolated environment for `dg` just like the standard `uv tool install`, but the environment will contain an editable install of `dagster-dg`.
+:::
+
 Let's take a look at the help message for `dg`:
 
 ```bash


### PR DESCRIPTION
## Summary & Motivation

Adds a brief note to the tutorial explaining how to use local `dg` in development instead of PyPI `dg`.

## How I Tested These Changes

Installed this way myself.