### PR TITLE
[components] Typer help output

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 import click
 
 from dagster_dg.config import DgConfig
+from dagster_dg.utils import set_option_help_output_group
 
 T_Command = TypeVar("T_Command", bound=Union[Callable[..., Any], click.Command])
 
@@ -44,6 +45,10 @@ GLOBAL_OPTIONS = {
         ),
     ]
 }
+
+# Ensure that these options show up in the help output under the "Global options" group.
+for option in GLOBAL_OPTIONS.values():
+    set_option_help_output_group(option, "Global options")
 
 
 def dg_global_options(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_commands.py
@@ -25,16 +25,16 @@ def test_component_scaffold_dynamic_subcommand_generation() -> None:
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         result = runner.invoke("component", "scaffold", "--help")
         assert_runner_result(result)
-        assert (
-            textwrap.dedent("""
-            Commands:
-              dagster_components.test.all_metadata_empty_asset
-              dagster_components.test.complex_schema_asset
-              dagster_components.test.simple_asset
-              dagster_components.test.simple_pipes_script_asset
-        """).strip()
-            in result.output
-        )
+
+        # These are wrapped in a table so it's hard to check exact output.
+        for line in [
+            "╭─ Commands",
+            "│ dagster_components.test.all_metadata_empty_asset",
+            "│ dagster_components.test.complex_schema_asset",
+            "│ dagster_components.test.simple_asset",
+            "│ dagster_components.test.simple_pipes_script_asset",
+        ]:
+            assert line in result.output
 
 
 @pytest.mark.parametrize("in_deployment", [True, False])

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -2,7 +2,12 @@ import textwrap
 
 import click
 from click.testing import CliRunner
-from dagster_dg.utils import DgClickCommand, DgClickGroup, ensure_dagster_dg_tests_import
+from dagster_dg.utils import (
+    DgClickCommand,
+    DgClickGroup,
+    ensure_dagster_dg_tests_import,
+    set_option_help_output_group,
+)
 
 ensure_dagster_dg_tests_import()
 
@@ -57,33 +62,51 @@ def sub_command(sub_command_opt, disable_cache):
     pass
 
 
+for cmd in [root, sub_group, sub_group_command, sub_command]:
+    # Make this a global option
+    disable_cache_opt = next(p for p in cmd.params if p.name == "disable_cache")
+    set_option_help_output_group(disable_cache_opt, "Global options")
+
+
 # ########################
 # ##### TESTS
 # ########################
+
+
+# Typer's rich help output is difficult to match exactly, as it contains blank lines with extraneous
+# whitespace. So we use this helper function to compare the output of the help message with the
+# expected output. Comparing line-by-line also helps debugging.
+def _match_output(output: str, expected_output: str):
+    output_lines = output.split("\n")
+    expected_output_lines = expected_output.split("\n")
+    for i in range(len(output_lines)):
+        assert output_lines[i].strip() == expected_output_lines[i].strip()
+    return True
 
 
 def test_root_help_message():
     runner = CliRunner()
     result = runner.invoke(root, ["--help"])
     assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: root [OPTIONS] COMMAND [ARGS]...
+    assert _match_output(
+        result.output.strip(),
+        textwrap.dedent("""
+             Usage: root [OPTIONS] COMMAND [ARGS]...                                        
 
-          Root group.
+             Root group.                                                                    
 
-        Commands:
-          sub-command  Sub-command.
-          sub-group    Sub-group.
-
-        Options:
-          --root-opt TEXT  Root option.
-          --help           Show this message and exit.
-
-        Global options:
-          --disable-cache TEXT  Disable cache.
-    """).strip()
+            ╭─ Options ────────────────────────────────────────────────────────────────────╮
+            │ --root-opt        TEXT  Root option.                                         │
+            │ --help                  Show this message and exit.                          │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Global options ─────────────────────────────────────────────────────────────╮
+            │ --disable-cache        TEXT  Disable cache.                                  │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Commands ───────────────────────────────────────────────────────────────────╮
+            │ sub-command   Sub-command.                                                   │
+            │ sub-group     Sub-group.                                                     │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+    """).strip(),
     )
 
 
@@ -91,23 +114,24 @@ def test_sub_group_with_option_help_message():
     runner = CliRunner()
     result = runner.invoke(root, ["sub-group", "--help"])
     assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: root sub-group [OPTIONS] COMMAND [ARGS]...
-
-          Sub-group.
-
-        Commands:
-          sub-group-command  Sub-group-command.
-
-        Options:
-          --sub-group-opt TEXT  Sub-group option.
-          --help                Show this message and exit.
-
-        Global options:
-          --disable-cache TEXT  Disable cache.
-    """).strip()
+    assert _match_output(
+        result.output.strip(),
+        textwrap.dedent("""
+             Usage: root sub-group [OPTIONS] COMMAND [ARGS]...                              
+                                                                                    
+             Sub-group.                                                                     
+                                                                                    
+            ╭─ Options ────────────────────────────────────────────────────────────────────╮
+            │ --sub-group-opt        TEXT  Sub-group option.                               │
+            │ --help                       Show this message and exit.                     │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Global options ─────────────────────────────────────────────────────────────╮
+            │ --disable-cache        TEXT  Disable cache.                                  │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Commands ───────────────────────────────────────────────────────────────────╮
+            │ sub-group-command   Sub-group-command.                                       │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+        """).strip(),
     )
 
 
@@ -115,20 +139,21 @@ def test_sub_group_command_with_option_help_message():
     runner = CliRunner()
     result = runner.invoke(root, ["sub-group", "sub-group-command", "--help"])
     assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: root sub-group sub-group-command [OPTIONS]
-
-          Sub-group-command.
-
-        Options:
-          --sub-group-command-opt TEXT  Sub-group-command option.
-          --help                        Show this message and exit.
-
-        Global options:
-          --disable-cache TEXT  Disable cache.
-    """).strip()
+    assert _match_output(
+        result.output.strip(),
+        textwrap.dedent("""
+             Usage: root sub-group sub-group-command [OPTIONS]                              
+                                                                                            
+             Sub-group-command.                                                             
+                                                                                            
+            ╭─ Options ────────────────────────────────────────────────────────────────────╮
+            │ --sub-group-command-opt        TEXT  Sub-group-command option.               │
+            │ --help                               Show this message and exit.             │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Global options ─────────────────────────────────────────────────────────────╮
+            │ --disable-cache        TEXT  Disable cache.                                  │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+    """).strip(),
     )
 
 
@@ -136,20 +161,21 @@ def test_sub_command_with_option_help_message():
     runner = CliRunner()
     result = runner.invoke(root, ["sub-command", "--help"])
     assert_runner_result(result)
-    assert (
-        result.output.strip()
-        == textwrap.dedent("""
-        Usage: root sub-command [OPTIONS] COMMAND [ARGS]...
-
-          Sub-command.
-
-        Options:
-          --sub-command-opt TEXT  Sub-command option.
-          --help                  Show this message and exit.
-
-        Global options:
-          --disable-cache TEXT  Disable cache.
-    """).strip()
+    assert _match_output(
+        result.output.strip(),
+        textwrap.dedent("""
+             Usage: root sub-command [OPTIONS] COMMAND [ARGS]...                            
+                                                                                            
+             Sub-command.                                                                   
+                                                                                            
+            ╭─ Options ────────────────────────────────────────────────────────────────────╮
+            │ --sub-command-opt        TEXT  Sub-command option.                           │
+            │ --help                         Show this message and exit.                   │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+            ╭─ Global options ─────────────────────────────────────────────────────────────╮
+            │ --disable-cache        TEXT  Disable cache.                                  │
+            ╰──────────────────────────────────────────────────────────────────────────────╯
+    """).strip(),
     )
 
 
@@ -158,23 +184,33 @@ def test_dynamic_subcommand_help_message():
         result = runner.invoke(
             "component", "scaffold", "dagster_components.test.simple_pipes_script_asset", "--help"
         )
-        assert (
-            result.output.strip()
-            == textwrap.dedent("""
-            Usage: dg component scaffold [GLOBAL OPTIONS] dagster_components.test.simple_pipes_script_asset [OPTIONS] COMPONENT_NAME
-
-            Options:
-              --json-params TEXT  JSON string of component parameters.
-              --asset-key TEXT    asset_key
-              --filename TEXT     filename
-              -h, --help          Show this message and exit.
-
-            Global options:
-              --use-dg-managed-environment / --no-use-dg-managed-environment
-                                              Enable management of the virtual environment with uv.
-              --builtin-component-lib TEXT    Specify a builitin component library to use.
-              --verbose                       Enable verbose output for debugging.
-              --disable-cache                 Disable the cache..
-              --cache-dir PATH                Specify a directory to use for the cache.
-        """).strip()
+        assert _match_output(
+            result.output.strip(),
+            textwrap.dedent("""
+                 Usage: dg component scaffold [GLOBAL OPTIONS]                                  
+                 dagster_components.test.simple_pipes_script_asset [OPTIONS] COMPONENT_NAME     
+                                                                                                
+                ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+                │ *    component_name      TEXT  [required]                                    │
+                ╰──────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Options ────────────────────────────────────────────────────────────────────╮
+                │ --json-params          TEXT  JSON string of component parameters.            │
+                │ --asset-key            TEXT  asset_key                                       │
+                │ --filename             TEXT  filename                                        │
+                │ --help         -h            Show this message and exit.                     │
+                ╰──────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Global options ─────────────────────────────────────────────────────────────╮
+                │ --cache-dir                                      PATH  Specify a directory   │
+                │                                                        to use for the cache. │
+                │ --disable-cache                                        Disable the cache..   │
+                │ --verbose                                              Enable verbose output │
+                │                                                        for debugging.        │
+                │ --builtin-component-…                            TEXT  Specify a builitin    │
+                │                                                        component library to  │
+                │                                                        use.                  │
+                │ --use-dg-managed-env…    --no-use-dg-managed…          Enable management of  │
+                │                                                        the virtual           │
+                │                                                        environment with uv.  │
+                ╰──────────────────────────────────────────────────────────────────────────────╯
+        """).strip(),
         )

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -39,6 +39,7 @@ setup(
         "markdown",
         "jsonschema",
         "PyYAML>=5.1",
+        "typer",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

This updates `dagster-dg` to use the rich/colored help style borrowed from [typer](https://github.com/fastapi/typer) (which in turn borrowed it from an older package called `rich-cli`).

This began as an effort to convert the entire app over to `typer`, which would have granted us this kind of output by default. However, it turns out that typer isn't sufficiently flexible for our needs. Among the difficulties I ran into trying to port to typer:

- dynamic subcommand generation-- we do this for `dagster-dg`, and it is "last minute" generation that is dependent on callbacks for the groups in `dg component scaffold <component>` executing before the subcommands are generated. Couldn't figure out how to do this in `typer`.
- The `--use-editable-dagster` command can optionally take an argument (or be used as a flag). Couldn't figure out how to implement this in `typer`.
- Sharing a single set of global options across many different commands without undue repetition surprisingly does not have a typer-native solution. Instead I had to use subsidiary lib [typer-di](https://github.com/greendwin/typer_di).

Here is an example of the old vs new help output:

```
dg component scaffold dagster_components.dbt_project --help
```

Old:

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/4adcfe64-846a-43dd-8c43-2a7c919c3bd9" />

New:

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/333266f4-33ad-4800-8fcf-111d774a29d0" />

## How I Tested These Changes

Adjusted unit tests.