### PR TITLE
[graphql] request context scoped caching resolvers

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -7,7 +7,6 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetDefinitionChangeType, AssetGraphDiffer
-from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import (
     NULL_DATA_VERSION,
     StaleCauseCategory,
@@ -39,7 +38,6 @@ from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.utils import is_valid_email
 from dagster._core.workspace.permissions import Permissions
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from packaging import version
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -548,15 +546,8 @@ class GrapheneAssetNode(graphene.ObjectType):
             return []
 
         instance = graphene_info.context.instance
-        asset_graph = graphene_info.context.get_repository(self._repository_selector).asset_graph
+        asset_graph = graphene_info.context.asset_graph
         asset_key = self._asset_node_snap.asset_key
-
-        instance_queryer = CachingInstanceQueryer(
-            instance=graphene_info.context.instance,
-            asset_graph=asset_graph,
-            loading_context=graphene_info.context,
-        )
-        data_time_resolver = CachingDataTimeResolver(instance_queryer=instance_queryer)
         event_records = instance.fetch_materializations(
             AssetRecordsFilter(
                 asset_key=asset_key,
@@ -572,7 +563,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         if not asset_graph.has_materializable_parents(asset_key):
             return []
 
-        used_data_times = data_time_resolver.get_data_time_by_key_for_record(
+        used_data_times = graphene_info.context.data_time_resolver.get_data_time_by_key_for_record(
             record=next(iter(event_records)),
         )
 
@@ -817,20 +808,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetFreshnessInfo]:
         if self._asset_node_snap.freshness_policy:
-            asset_graph = graphene_info.context.get_repository(
-                self._repository_selector
-            ).asset_graph
             return get_freshness_info(
                 asset_key=self._asset_node_snap.asset_key,
-                # in the future, we can share this same CachingInstanceQueryer across all
-                # GrapheneAssetNodes which share an external repository for improved performance
-                data_time_resolver=CachingDataTimeResolver(
-                    instance_queryer=CachingInstanceQueryer(
-                        instance=graphene_info.context.instance,
-                        asset_graph=asset_graph,
-                        loading_context=graphene_info.context,
-                    ),
-                ),
+                data_time_resolver=graphene_info.context.data_time_resolver,
             )
         return None
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
@@ -54,7 +54,7 @@ def test_source_asset_freshness_info():
     with instance_for_test() as instance:
         with define_out_of_process_context(__file__, "get_repo", instance) as graphql_context:
             result = execute_dagster_graphql(
-                graphql_context,
+                graphql_context.reset_for_test(),
                 GET_FRESHNESS_INFO,
                 variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
             )
@@ -68,7 +68,7 @@ def test_source_asset_freshness_info():
             )
 
             result = execute_dagster_graphql(
-                graphql_context,
+                graphql_context.reset_for_test(),
                 GET_FRESHNESS_INFO,
                 variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
             )
@@ -82,7 +82,7 @@ def test_source_asset_freshness_info():
             )
 
             result = execute_dagster_graphql(
-                graphql_context,
+                graphql_context.reset_for_test(),
                 GET_FRESHNESS_INFO,
                 variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
             )

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/conftest.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/conftest.py
@@ -2,12 +2,29 @@ import pytest
 from dagster import DagsterInstance, __version__
 from dagster._cli.workspace.cli_target import get_workspace_process_context_from_kwargs
 from dagster_webserver.webserver import DagsterWebserver
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
 from starlette.testclient import TestClient
 
 
 @pytest.fixture(scope="session")
 def instance():
     return DagsterInstance.local_temp()
+
+
+class TestDagsterWebserver(DagsterWebserver):
+    def test_req_ctx_endpoint(self, request: Request):
+        ctx = self.make_request_context(request)
+        # instantiate cached property with backref
+        _ = ctx.instance_queryer
+        return JSONResponse({"name": ctx.__class__.__name__})
+
+    def build_routes(self):
+        return [
+            Route("/test_request_context", self.test_req_ctx_endpoint),
+            *super().build_routes(),
+        ]
 
 
 @pytest.fixture(scope="session")
@@ -18,5 +35,6 @@ def test_client(instance):
         read_only=False,
         kwargs={"empty_workspace": True},  # pyright: ignore[reportArgumentType]
     )
-    app = DagsterWebserver(process_context).create_asgi_app(debug=True)
+
+    app = TestDagsterWebserver(process_context).create_asgi_app(debug=True)
     return TestClient(app)

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -299,3 +299,12 @@ def test_download_captured_logs_not_found(test_client: TestClient):
 def test_download_captured_logs_invalid_path(test_client: TestClient):
     with pytest.raises(ValueError, match="Invalid path"):
         test_client.get("/logs/%2e%2e/secret/txt")
+
+
+def test_no_leak(test_client: TestClient):
+    res = test_client.get("/test_request_context")
+    assert res.status_code == 200
+    data = res.json()
+    assert data
+    gc.collect()
+    assert len(objgraph.by_type(data["name"])) == 0


### PR DESCRIPTION
instead of creating new ones of these for each asset node, share them for the scope of a request

this also switches over to using the workspace scoped asset graph which I am not cetain of

## How I Tested These Changes

existing coverage
