### PR TITLE
data migration for backfill end timestamp

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -426,7 +426,7 @@ def migrate_backfill_end_timestamp(storage: RunStorage, print_fn: Optional[Print
             # we don't want to mutate a backfill that is still in progress. Additionally, it won't
             # have an end timestamp until it moves to a terminal state
             continue
-        if backfill.backfill_end_timestamp is not None:
+        if backfill.backfill_end_timestamp is None:
             end_time = get_end_timestamp_for_backfill(storage, backfill)
             updated_backfill = backfill.with_end_timestamp(end_time)
             storage.update_backfill(updated_backfill)

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -9,7 +9,11 @@ from tqdm import tqdm
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._core.execution.job_backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import (
+    BULK_ACTION_TERMINAL_STATUSES,
+    BulkActionStatus,
+    PartitionBackfill,
+)
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunRecord, RunsFilter
 from dagster._core.storage.runs.base import RunStorage
 from dagster._core.storage.runs.schema import (
@@ -433,6 +437,7 @@ def migrate_backfill_end_timestamp(storage: RunStorage, print_fn: Optional[Print
 
 
 def get_end_timestamp_for_backfill(run_storage: RunStorage, backfill: PartitionBackfill) -> float:
+    assert backfill.status in BULK_ACTION_TERMINAL_STATUSES
     filters = RunsFilter.for_backfill(backfill.backfill_id)
     run_records = run_storage.get_run_records(filters=filters)
     if len(run_records) == 0:
@@ -440,7 +445,4 @@ def get_end_timestamp_for_backfill(run_storage: RunStorage, backfill: PartitionB
         # reconstruct the time the backfill actually moved to a terminal state, so use the start
         # time as an estimation
         return backfill.backfill_timestamp
-    max_end_time = 0
-    for rr in run_records:
-        max_end_time = max(rr.end_time or 0, max_end_time)
-    return max_end_time
+    return max([record.end_time or 0 for record in run_records])

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1700,6 +1700,15 @@ def test_add_backfill_end_timestamp():
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(in_progress_backfill)
+            no_runs_backfill = PartitionBackfill(
+                "no_runs_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.CANCELED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(no_runs_backfill)
             # before migration, backfill end timestamps will be None
             completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
             assert completed_backfill
@@ -1707,6 +1716,9 @@ def test_add_backfill_end_timestamp():
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp is None
 
             for _ in range(3):
                 instance.run_storage.add_run(
@@ -1765,3 +1777,7 @@ def test_add_backfill_end_timestamp():
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp == no_runs_backfill.backfill_timestamp

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -28,7 +28,7 @@ from dagster._core.definitions.events import UNDEFINED_ASSET_KEY_PATH, AssetLine
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidInvocationError
-from dagster._core.events import DagsterEvent, StepMaterializationData
+from dagster._core.events import DagsterEvent, DagsterEventType, StepMaterializationData
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.plan.outputs import StepOutputHandle
@@ -1676,3 +1676,92 @@ def test_known_execution_state_step_output_version_serialization() -> None:
     ]
 
     assert deserialize_value(serialized, KnownExecutionState) == known_state
+
+
+def test_add_backfill_end_timestamp():
+    src_dir = file_relative_path(__file__, "snapshot_1_9_3_add_run_tags_run_id_idx/sqlite")
+    with copy_directory(src_dir) as test_dir:
+        with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
+            completed_backfill = PartitionBackfill(
+                "before_end_timestamp_migration",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.COMPLETED_SUCCESS,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(completed_backfill)
+            in_progress_backfill = PartitionBackfill(
+                "in_progress_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(in_progress_backfill)
+            # before migration, backfill end timestamps will be None
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert completed_backfill.backfill_end_timestamp is None
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None
+
+            for _ in range(3):
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: completed_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: in_progress_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+            completed_backfill_run_end_times = []
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+                updated_run = instance.get_run_record_by_id(run.run_id)
+                completed_backfill_run_end_times.append(
+                    updated_run.end_time if updated_run else None
+                )
+
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+
+            instance.upgrade()
+
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert (
+                completed_backfill.backfill_end_timestamp is not None
+                and completed_backfill.backfill_end_timestamp
+                == max(completed_backfill_run_end_times)
+            )
+
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -825,6 +825,15 @@ def test_add_backfill_end_timestamp(conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(in_progress_backfill)
+            no_runs_backfill = PartitionBackfill(
+                "no_runs_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.CANCELED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(no_runs_backfill)
             # before migration, backfill end timestamps will be None
             completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
             assert completed_backfill
@@ -832,6 +841,9 @@ def test_add_backfill_end_timestamp(conn_string):
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp is None
 
             for _ in range(3):
                 instance.run_storage.add_run(
@@ -890,3 +902,7 @@ def test_add_backfill_end_timestamp(conn_string):
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp == no_runs_backfill.backfill_timestamp

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -10,6 +10,7 @@ import sqlalchemy as db
 from dagster import AssetKey, AssetMaterialization, AssetObservation, Output, job, op
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
@@ -790,3 +791,102 @@ def test_add_run_tags_run_id_idx(conn_string):
             assert "run_tags" in get_tables(instance)
             assert "idx_run_tags" not in get_indexes(instance, "run_tags")
             assert "idx_run_tags_run_id" in get_indexes(instance, "run_tags")
+
+
+def test_add_backfill_end_timestamp(conn_string):
+    hostname, port = _reconstruct_from_file(
+        conn_string,
+        # use an old snapshot, it has the bulk actions table but not the new columns
+        file_relative_path(__file__, "snapshot_1_9_3_add_run_tags_run_id_idx.sql"),
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(file_relative_path(__file__, "dagster.yaml"), encoding="utf8") as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname, port=port)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            completed_backfill = PartitionBackfill(
+                "before_end_timestamp_migration",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.COMPLETED_SUCCESS,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(completed_backfill)
+            in_progress_backfill = PartitionBackfill(
+                "in_progress_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(in_progress_backfill)
+            # before migration, backfill end timestamps will be None
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert completed_backfill.backfill_end_timestamp is None
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None
+
+            for _ in range(3):
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: completed_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: in_progress_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+            completed_backfill_run_end_times = []
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+                updated_run = instance.get_run_record_by_id(run.run_id)
+                completed_backfill_run_end_times.append(
+                    updated_run.end_time if updated_run else None
+                )
+
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+
+            instance.upgrade()
+
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert (
+                completed_backfill.backfill_end_timestamp is not None
+                and completed_backfill.backfill_end_timestamp
+                == max(completed_backfill_run_end_times)
+            )
+
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1233,6 +1233,15 @@ def test_add_backfill_end_timestamp(hostname, conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(in_progress_backfill)
+            no_runs_backfill = PartitionBackfill(
+                "no_runs_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.CANCELED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(no_runs_backfill)
             # before migration, backfill end timestamps will be None
             completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
             assert completed_backfill
@@ -1240,6 +1249,9 @@ def test_add_backfill_end_timestamp(hostname, conn_string):
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp is None
 
             for _ in range(3):
                 instance.run_storage.add_run(
@@ -1298,3 +1310,7 @@ def test_add_backfill_end_timestamp(hostname, conn_string):
             in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
             assert in_progress_backfill
             assert in_progress_backfill.backfill_end_timestamp is None
+
+            no_runs_backfill = instance.get_backfill(no_runs_backfill.backfill_id)
+            assert no_runs_backfill
+            assert no_runs_backfill.backfill_end_timestamp == no_runs_backfill.backfill_timestamp

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -18,6 +18,7 @@ from dagster import (
 )
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.execution.api import execute_job
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
@@ -1195,3 +1196,105 @@ def test_add_run_tags_run_id_idx(hostname, conn_string):
             assert "run_tags" in get_tables(instance)
             assert "idx_run_tags" not in get_indexes(instance, "run_tags")
             assert "idx_run_tags_run_id" in get_indexes(instance, "run_tags")
+
+
+def test_add_backfill_end_timestamp(hostname, conn_string):
+    _reconstruct_from_file(
+        hostname,
+        conn_string,
+        file_relative_path(
+            __file__,
+            "snapshot_1_9_3_add_run_tags_run_id_idx/postgres/pg_dump.txt",
+        ),
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(file_relative_path(__file__, "dagster.yaml"), encoding="utf8") as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            completed_backfill = PartitionBackfill(
+                "before_end_timestamp_migration",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.COMPLETED_SUCCESS,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(completed_backfill)
+            in_progress_backfill = PartitionBackfill(
+                "in_progress_backfill",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(in_progress_backfill)
+            # before migration, backfill end timestamps will be None
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert completed_backfill.backfill_end_timestamp is None
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None
+
+            for _ in range(3):
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: completed_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+                instance.run_storage.add_run(
+                    DagsterRun(
+                        job_name="foo",
+                        run_id=make_new_run_id(),
+                        tags={BACKFILL_ID_TAG: in_progress_backfill.backfill_id},
+                        status=DagsterRunStatus.NOT_STARTED,
+                    )
+                )
+            completed_backfill_run_end_times = []
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+                updated_run = instance.get_run_record_by_id(run.run_id)
+                completed_backfill_run_end_times.append(
+                    updated_run.end_time if updated_run else None
+                )
+
+            for run in instance.get_runs(
+                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+            ):
+                dagster_event = DagsterEvent(
+                    event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                    job_name=run.job_name,
+                    message="yay run success",
+                    step_key="bar",
+                )
+                instance.report_dagster_event(dagster_event, run_id=run.run_id)
+
+            instance.upgrade()
+
+            completed_backfill = instance.get_backfill(completed_backfill.backfill_id)
+            assert completed_backfill
+            assert (
+                completed_backfill.backfill_end_timestamp is not None
+                and completed_backfill.backfill_end_timestamp
+                == max(completed_backfill_run_end_times)
+            )
+
+            in_progress_backfill = instance.get_backfill(in_progress_backfill.backfill_id)
+            assert in_progress_backfill
+            assert in_progress_backfill.backfill_end_timestamp is None


### PR DESCRIPTION
## Summary & Motivation
Data migration for adding an end timestamp for backfills. 

## How I Tested These Changes
backcompat unit tests. Also ran the migration on my local db, and 1. visually confirmed that the end timestamp was added for backfills; 2. loaded the ui page that accesses the end timestamp and confirmed it did not call the path that queries all runs for a backfil.

## Changelog

Optional data migration to improve performance of the Runs page. Run `dagster instance migrate` to run the date migration. The migration will update serialized backfill objects in the database with an end timestamp attribute computed by querying the runs launched by that backfill to determine the when the last run completed.
