### PR TITLE
[ui] Fix search filter on the asset partitions page when health filters are enabled

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -157,37 +157,37 @@ export const AssetPartitions = ({
     const allKeys = dimension.partitionKeys;
     const sortType = getSort(sortTypes, idx, selections[idx]!.dimension.type);
 
-    // Apply the search filter
-    const searchLower = searchValues?.[idx]?.toLocaleLowerCase().trim() || '';
-    const filteredKeys = allKeys.filter((key) => key.toLowerCase().includes(searchLower));
+    const filterResultsBySearch = (keys: string[]) => {
+      const searchLower = searchValues?.[idx]?.toLocaleLowerCase().trim() || '';
+      return keys.filter((key) => key.toLowerCase().includes(searchLower));
+    };
 
     const getSelectionKeys = () =>
-      uniq(selectedRanges.flatMap(({start, end}) => filteredKeys.slice(start.idx, end.idx + 1)));
+      uniq(selectedRanges.flatMap(({start, end}) => allKeys.slice(start.idx, end.idx + 1)));
 
+    // Early exit #1: If you have no status filters applied, just apply the
+    // text search filter, sort and return.
     if (isEqual(DISPLAYED_STATUSES, statusFilters)) {
-      const result = getSelectionKeys();
-      return sortResults(result, sortType);
+      return sortResults(filterResultsBySearch(getSelectionKeys()), sortType);
     }
 
+    // Get the health ranges, and then explode them into a `matching` set of keys
+    // that have the requested statuses.
     const healthRangesInSelection = rangesClippedToSelection(
       rangesForEachDimension[idx]!,
       selectedRanges,
     );
-    const getKeysWithStates = (states: AssetPartitionStatus[]) => {
-      return healthRangesInSelection.flatMap((r) =>
-        states.some((s) => r.value.includes(s))
-          ? filteredKeys.slice(r.start.idx, r.end.idx + 1)
-          : [],
+    const getKeysWithStates = (states: AssetPartitionStatus[]) =>
+      healthRangesInSelection.flatMap((r) =>
+        states.some((s) => r.value.includes(s)) ? allKeys.slice(r.start.idx, r.end.idx + 1) : [],
       );
-    };
-
     const matching = uniq(
       getKeysWithStates(statusFilters.filter((f) => f !== AssetPartitionStatus.MISSING)),
     );
-    const matchingSet = new Set(matching);
 
     let result;
-    // We have to add in "missing" separately because it's the absence of a range
+
+    // We have to add in "missing" separately because it's the absence of a range.
     if (statusFilters.includes(AssetPartitionStatus.MISSING)) {
       const selectionKeys = getSelectionKeys();
       const isMissingForIndex = (idx: number) =>
@@ -197,15 +197,17 @@ export const AssetPartitions = ({
             r.end.idx >= idx &&
             !r.value.includes(AssetPartitionStatus.MISSING),
         );
+
+      const matchingSet = new Set(matching);
       const selectionKeysSet = new Set(selectionKeys);
-      result = filteredKeys.filter(
+      result = allKeys.filter(
         (a, pidx) => selectionKeysSet.has(a) && (matchingSet.has(a) || isMissingForIndex(pidx)),
       );
     } else {
       result = matching;
     }
 
-    return sortResults(result, sortType);
+    return sortResults(filterResultsBySearch(result), sortType);
   };
 
   const countsByStateInSelection = keyCountByStateInSelection(assetHealth, selections);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -146,6 +146,31 @@ describe('AssetPartitions', () => {
     expect(screen.queryByText('2022-08-31-00:00')).toBeVisible();
   });
 
+  it('should support filtering by partition status and partition text', async () => {
+    render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
+    });
+
+    const successCheck = screen.getByTestId(
+      `partition-status-${AssetPartitionStatus.MATERIALIZED}-checkbox`,
+    );
+    const missingCheck = screen.getByTestId(
+      `partition-status-${AssetPartitionStatus.MISSING}-checkbox`,
+    );
+    await userEvent.click(missingCheck);
+    await userEvent.click(successCheck);
+    expect(screen.getByTestId('router-search')).toHaveTextContent(
+      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZING}`,
+    );
+
+    const searchInput = screen.getByTestId(`search-0`);
+    await userEvent.type(searchInput, '09');
+
+    // verify that filtering by state updates the left sidebar
+    expect(screen.queryByText('2022-09-23-19:00')).toBeVisible();
+  });
+
   it('should support reverse sorting individual dimensions', async () => {
     const Component = () => {
       const [params, setParams] = useState<AssetViewParams>({});


### PR DESCRIPTION
## Summary & Motivation

We represent partition health using ranges, eg: “0->1000 are green, 1000 -> 1005 are red”, etc. We need to apply the search filtering /after/ we are finished filtering by health ranges, because the filtering changes the index of partitions in the partition space.

Fixes https://linear.app/dagster-labs/issue/FE-759/ui-bug-with-filter-and-partition-selection-on-asset-partitions-tab

## How I Tested These Changes

We actually have tests for this page (!!) and I added another test that reproduced this bug without the patch + verifies the fix. 🙌 

I tested this manually against this page: http://localhost:3001/elementl/prod/assets/poll_snowflake_query_history_hour?view=partitions&status=FAILED%2CMATERIALIZING%2CMISSING. Unchecking "Materialized" and then filtering to "2025" returned no results.


## Changelog

[ui] Fixes an issue with the search bar on the Asset partitions page incorrectly filtering partitions when combined with a status filter.