### PR TITLE
[dg] Cache local component type schemas to speed up repeated dg check calls

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -65,18 +65,17 @@ def _add_component_type_to_output(
 @click.argument("component_directories", nargs=-1, type=click.Path(exists=True))
 def list_local_component_types_command(component_directories: Sequence[str]) -> None:
     """List local Dagster components found in the specified directories."""
-    output: list = []
+    output: dict = {}
     for component_directory in component_directories:
+        output_for_directory = {}
         for component_type in find_local_component_types(Path(component_directory)):
-            output.append(
-                {
-                    "directory": component_directory,
-                    "key": f".{get_component_type_name(component_type)}",
-                    "metadata": ComponentTypeMetadata(
-                        name=get_component_type_name(component_type),
-                        package=component_directory,
-                        **component_type.get_metadata(),
-                    ),
-                }
+            output_for_directory[f".{get_component_type_name(component_type)}"] = (
+                ComponentTypeMetadata(
+                    name=get_component_type_name(component_type),
+                    package=component_directory,
+                    **component_type.get_metadata(),
+                )
             )
+        if len(output_for_directory) > 0:
+            output[component_directory] = output_for_directory
     click.echo(json.dumps(output))

--- a/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
@@ -50,12 +50,14 @@ BASIC_MISSING_VALUE = ComponentValidationTestCase(
     ),
 )
 
+BASIC_VALID_VALUE = ComponentValidationTestCase(
+    component_path="validation/basic_component_success",
+    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    should_error=False,
+)
+
 COMPONENT_VALIDATION_TEST_CASES = [
-    ComponentValidationTestCase(
-        component_path="validation/basic_component_success",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
-        should_error=False,
-    ),
+    BASIC_VALID_VALUE,
     BASIC_INVALID_VALUE,
     BASIC_MISSING_VALUE,
     ComponentValidationTestCase(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -112,8 +112,10 @@ def test_list_local_components_types() -> None:
 
             result = json.loads(result.output)
             assert len(result) == 1
-            assert result[0]["directory"] == "my_location/components/local_component_sample"
-            assert result[0]["key"] == ".my_component"
+            assert set(result.keys()) == {"my_location/components/local_component_sample"}
+            assert set(result["my_location/components/local_component_sample"].keys()) == {
+                ".my_component"
+            }
 
             # Add a second directory and local component
             result = runner.invoke(

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -8,7 +8,11 @@ from typing import Final, Literal, Optional
 from typing_extensions import Self, TypeAlias
 
 from dagster_dg.config import DgConfig
-from dagster_dg.utils import _DEFAULT_EXCLUDES, hash_directory_metadata, hash_file_metadata
+from dagster_dg.utils import (
+    DEFAULT_FILE_EXCLUDE_PATTERNS,
+    hash_directory_metadata,
+    hash_file_metadata,
+)
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
@@ -27,7 +31,7 @@ def get_default_cache_dir() -> Path:
 def hash_paths(
     paths: Sequence[Path],
     includes: Optional[Sequence[str]] = None,
-    excludes: Sequence[str] = _DEFAULT_EXCLUDES,
+    excludes: Sequence[str] = DEFAULT_FILE_EXCLUDE_PATTERNS,
 ) -> str:
     hasher = hashlib.md5()
     for path in paths:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -8,7 +8,7 @@ from typing import Final, Literal, Optional
 from typing_extensions import Self, TypeAlias
 
 from dagster_dg.config import DgConfig
-from dagster_dg.utils import hash_directory_metadata, hash_file_metadata
+from dagster_dg.utils import _DEFAULT_EXCLUDES, hash_directory_metadata, hash_file_metadata
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
@@ -24,11 +24,15 @@ def get_default_cache_dir() -> Path:
         return Path.home() / ".cache" / "dg"
 
 
-def hash_paths(paths: Sequence[Path]) -> str:
+def hash_paths(
+    paths: Sequence[Path],
+    includes: Optional[Sequence[str]] = None,
+    excludes: Sequence[str] = _DEFAULT_EXCLUDES,
+) -> str:
     hasher = hashlib.md5()
     for path in paths:
         if path.is_dir():
-            hash_directory_metadata(hasher, path)
+            hash_directory_metadata(hasher, path, includes=includes, excludes=excludes)
         else:
             hash_file_metadata(hasher, path)
     return hasher.hexdigest()

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -26,6 +26,40 @@ class RemoteComponentType:
         return self.name
 
 
+def _retrieve_local_component_types(
+    dg_context: "DgContext", paths: Sequence[Path]
+) -> dict[str, dict[str, Mapping[str, Any]]]:
+    paths_to_fetch = set(paths)
+    data_for_path: dict[str, dict[str, Mapping[str, Any]]] = {}
+    if dg_context.has_cache:
+        for path in paths:
+            cache_key = dg_context.get_cache_key_for_local_components(path)
+            raw_data = dg_context.cache.get(cache_key)
+            if raw_data:
+                data_for_path[str(path)] = json.loads(raw_data)
+                paths_to_fetch.remove(path)
+
+    if paths_to_fetch:
+        raw_local_component_data = dg_context.external_components_command(
+            [
+                "list",
+                "local-component-types",
+                *[str(path) for path in paths_to_fetch],
+            ]
+        )
+        local_component_data = json.loads(raw_local_component_data)
+        for path in paths_to_fetch:
+            data_for_path[str(path)] = local_component_data.get(str(path), {})
+
+        for path in paths_to_fetch:
+            cache_key = dg_context.get_cache_key_for_local_components(path)
+            data_for_path_json = json.dumps(local_component_data.get(str(path), {}))
+            if dg_context.has_cache and cache_key and is_valid_json(data_for_path_json):
+                dg_context.cache.set(cache_key, data_for_path_json)
+
+    return data_for_path
+
+
 class RemoteComponentRegistry:
     @classmethod
     def from_dg_context(
@@ -51,19 +85,11 @@ class RemoteComponentRegistry:
 
         registry_data = json.loads(raw_registry_data)
 
-        local_component_data = []
+        local_component_data: dict[str, dict[str, Mapping[str, Any]]] = {}
         if local_component_type_dirs:
-            # TODO: cache
-
-            raw_local_component_data = dg_context.external_components_command(
-                [
-                    "list",
-                    "local-component-types",
-                    *[str(path) for path in local_component_type_dirs],
-                ]
+            local_component_data = _retrieve_local_component_types(
+                dg_context, local_component_type_dirs
             )
-            local_component_data = json.loads(raw_local_component_data)
-
         return cls.from_dict(
             global_component_types=registry_data, local_component_types=local_component_data
         )
@@ -72,13 +98,12 @@ class RemoteComponentRegistry:
     def from_dict(
         cls,
         global_component_types: dict[str, Mapping[str, Any]],
-        local_component_types: list[dict[str, Any]],
+        local_component_types: dict[str, dict[str, Mapping[str, Any]]],
     ) -> "RemoteComponentRegistry":
         components_by_path = defaultdict(dict)
-        for entry in local_component_types:
-            components_by_path[entry["directory"]][entry["key"]] = RemoteComponentType(
-                **entry["metadata"]
-            )
+        for directory in local_component_types:
+            for key, metadata in local_component_types[directory].items():
+                components_by_path[directory][key] = RemoteComponentType(**metadata)
 
         return RemoteComponentRegistry(
             {key: RemoteComponentType(**value) for key, value in global_component_types.items()},

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -28,7 +28,7 @@ class RemoteComponentType:
 
 def _retrieve_local_component_types(
     dg_context: "DgContext", paths: Sequence[Path]
-) -> dict[str, dict[str, Mapping[str, Any]]]:
+) -> Mapping[str, Mapping[str, Mapping[str, Any]]]:
     paths_to_fetch = set(paths)
     data_for_path: dict[str, dict[str, Mapping[str, Any]]] = {}
     if dg_context.has_cache:
@@ -51,11 +51,12 @@ def _retrieve_local_component_types(
         for path in paths_to_fetch:
             data_for_path[str(path)] = local_component_data.get(str(path), {})
 
-        for path in paths_to_fetch:
-            cache_key = dg_context.get_cache_key_for_local_components(path)
-            data_for_path_json = json.dumps(local_component_data.get(str(path), {}))
-            if dg_context.has_cache and cache_key and is_valid_json(data_for_path_json):
-                dg_context.cache.set(cache_key, data_for_path_json)
+        if dg_context.has_cache:
+            for path in paths_to_fetch:
+                cache_key = dg_context.get_cache_key_for_local_components(path)
+                data_for_path_json = json.dumps(local_component_data.get(str(path), {}))
+                if cache_key and is_valid_json(data_for_path_json):
+                    dg_context.cache.set(cache_key, data_for_path_json)
 
     return data_for_path
 
@@ -85,7 +86,7 @@ class RemoteComponentRegistry:
 
         registry_data = json.loads(raw_registry_data)
 
-        local_component_data: dict[str, dict[str, Mapping[str, Any]]] = {}
+        local_component_data: Mapping[str, Mapping[str, Mapping[str, Any]]] = {}
         if local_component_type_dirs:
             local_component_data = _retrieve_local_component_types(
                 dg_context, local_component_type_dirs
@@ -97,8 +98,8 @@ class RemoteComponentRegistry:
     @classmethod
     def from_dict(
         cls,
-        global_component_types: dict[str, Mapping[str, Any]],
-        local_component_types: dict[str, dict[str, Mapping[str, Any]]],
+        global_component_types: Mapping[str, Mapping[str, Any]],
+        local_component_types: Mapping[str, Mapping[str, Mapping[str, Any]]],
     ) -> "RemoteComponentRegistry":
         components_by_path = defaultdict(dict)
         for directory in local_component_types:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -35,7 +35,6 @@ class DgContext:
     def __init__(self, config: DgConfig, root_path: Path):
         self.config = config
         self.root_path = root_path
-        # self.use_dg_managed_environment is a property derived from self.config
         if config.disable_cache or not self.use_dg_managed_environment:
             self._cache = None
         else:
@@ -86,6 +85,11 @@ class DgContext:
         ]
         env_hash = hash_paths(paths_to_hash)
         return ("_".join(path_parts), env_hash, data_type)
+
+    def get_cache_key_for_local_components(self, path: Path) -> tuple[str, str, str]:
+        env_hash = hash_paths([path], includes=["*.py"])
+        path_parts = [str(part) for part in path.parts if part != "/"]
+        return ("_".join(path_parts), env_hash, "local_component_registry")
 
     # ########################
     # ##### DEPLOYMENT METHODS

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -214,10 +214,17 @@ def ensure_dagster_dg_tests_import() -> None:
     sys.path.append(dagster_dg_package_root.as_posix())
 
 
-def hash_directory_metadata(hasher: Hash, path: Union[str, Path]) -> None:
+def hash_directory_metadata(
+    hasher: Hash,
+    path: Union[str, Path],
+    includes: Optional[Sequence[str]],
+    excludes: Sequence[str],
+) -> None:
     for root, dirs, files in os.walk(path):
         for name in dirs + files:
-            if any(fnmatch(name, pattern) for pattern in _DEFAULT_EXCLUDES):
+            if any(fnmatch(name, pattern) for pattern in excludes):
+                continue
+            if includes and not any(fnmatch(name, pattern) for pattern in includes):
                 continue
             filepath = os.path.join(root, name)
             hash_file_metadata(hasher, filepath)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -103,7 +103,7 @@ def snakecase(string: str) -> str:
     return string
 
 
-_DEFAULT_EXCLUDES: list[str] = [
+DEFAULT_FILE_EXCLUDE_PATTERNS: list[str] = [
     "__pycache__",
     ".pytest_cache",
     "*.egg-info",
@@ -127,7 +127,9 @@ def scaffold_subtree(
     **other_template_vars: Any,
 ):
     """Renders templates for Dagster project."""
-    excludes = _DEFAULT_EXCLUDES if not excludes else _DEFAULT_EXCLUDES + excludes
+    excludes = (
+        DEFAULT_FILE_EXCLUDE_PATTERNS if not excludes else DEFAULT_FILE_EXCLUDE_PATTERNS + excludes
+    )
 
     normalized_path = os.path.normpath(path)
     project_name = project_name or os.path.basename(normalized_path).replace("-", "_")
@@ -191,7 +193,7 @@ def scaffold_subtree(
     click.echo(f"Scaffolded files for Dagster project in {path}.")
 
 
-def _should_skip_file(path: str, excludes: list[str] = _DEFAULT_EXCLUDES):
+def _should_skip_file(path: str, excludes: list[str] = DEFAULT_FILE_EXCLUDE_PATTERNS):
     """Given a file path `path` in a source template, returns whether or not the file should be skipped
     when generating destination files.
 


### PR DESCRIPTION
## Summary

Begins to cache local component type info in dg CLI cache, so that the schema can be re-used easily. These are cached separately
so that only the updated local component types are re-fetched when they do change.

## Test Plan

New unit test to test caching behavior.
