### PR TITLE
[ui] Fix long asset key display in header

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import {BreadcrumbProps, Breadcrumbs2 as Breadcrumbs} from '@blueprintjs/popover2';
+import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
 import {
   Box,
   Colors,
@@ -77,20 +77,16 @@ export const AssetPageHeader = ({
             <BreadcrumbsWithSlashes
               items={breadcrumbs}
               currentBreadcrumbRenderer={({text, href}) => (
-                <span key={href}>
-                  <TruncatedHeading>
-                    {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
-                  </TruncatedHeading>
-                </span>
+                <TruncatedHeading key={href}>
+                  {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
+                </TruncatedHeading>
               )}
               breadcrumbRenderer={({text, href}) => (
-                <span key={href}>
-                  <TruncatedHeading>
-                    <BreadcrumbLink to={href || '#'}>
-                      {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
-                    </BreadcrumbLink>
-                  </TruncatedHeading>
-                </span>
+                <TruncatedHeading key={href}>
+                  <BreadcrumbLink to={href || '#'}>
+                    {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
+                  </BreadcrumbLink>
+                </TruncatedHeading>
               )}
               $numHeaderBreadcrumbs={headerBreadcrumbs.length}
               popoverProps={{


### PR DESCRIPTION
## Summary & Motivation

We received a report that long asset key path values are broken in the Asset page header breadcrumbs. We had fixed this before, but a recent change to fix some incorrect React node re-use looks like it also inadvertently affected measurement for truncation.

To fix this, remove wrapper spans and put the key on the `TruncatedHeading` elements themselves.

I'm not sure if this will reintroduce the flashing issue noted in https://github.com/dagster-io/dagster/pull/25188, but I don't see any flashing when I test this with very long keys.

## How I Tested These Changes

View an asset with long keys, verify truncation.

## Changelog

[ui] Fix Asset page header display of long key values.
