### PR TITLE
sensors stopped while submitting runs stop submitting runs

### DIFF
--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import AbstractSet, Any, Generic, NamedTuple, Optional, Union  # noqa: UP035
+from typing import AbstractSet, Any, Generic, Iterable, NamedTuple, Optional, Union  # noqa: UP035
 
 from typing_extensions import TypeAlias
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import AbstractSet, Any, Generic, Iterable, NamedTuple, Optional, Union  # noqa: UP035
+from typing import AbstractSet, Any, Generic, NamedTuple, Optional, Union  # noqa: UP035
 
 from typing_extensions import TypeAlias
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import AbstractSet, Any, Generic, NamedTuple, Optional, Union  # noqa: UP035
@@ -518,12 +518,17 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         return self.tick_data.run_requests
 
     @property
+    def reserved_run_ids_with_requests(self) -> Iterable[tuple[str, RunRequest]]:
+        reserved_run_ids = self.tick_data.reserved_run_ids or []
+        return zip(reserved_run_ids, self.run_requests or [])
+
+    @property
     def unsubmitted_run_ids_with_requests(self) -> Sequence[tuple[str, RunRequest]]:
         reserved_run_ids = self.tick_data.reserved_run_ids or []
         unrequested_run_ids = set(reserved_run_ids) - set(self.tick_data.run_ids)
         return [
             (run_id, run_request)
-            for run_id, run_request in zip(reserved_run_ids, self.run_requests or [])
+            for run_id, run_request in self.reserved_run_ids_with_requests
             if run_id in unrequested_run_ids
         ]
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1132,12 +1132,12 @@ class AssetDaemon(DagsterDaemon):
         check_after_runs_num = instance.get_tick_termination_check_interval()
 
         check.invariant(len(run_requests) == len(reserved_run_ids))
-        to_submit = zip(range(len(run_requests)), reserved_run_ids, run_requests)
+        to_submit = enumerate(tick_context.tick.reserved_run_ids_with_requests)
 
         def submit_run_request(
-            run_id_with_run_request: tuple[int, str, RunRequest],
+            run_id_with_run_request: tuple[int, tuple[str, RunRequest]],
         ) -> tuple[str, AbstractSet[EntityKey]]:
-            i, run_id, run_request = run_id_with_run_request
+            i, (run_id, run_request) = run_id_with_run_request
             return self._submit_run_request(
                 i=i,
                 instance=instance,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -134,6 +134,10 @@ class SensorLaunchContext(AbstractContextManager):
         return str(self._tick.tick_id)
 
     @property
+    def tick(self) -> InstigatorTick:
+        return self._tick
+
+    @property
     def log_key(self) -> Sequence[str]:
         return [
             self._remote_sensor.handle.repository_handle.repository_name,
@@ -1055,7 +1059,7 @@ def _handle_run_requests_and_automation_condition_evaluations(
 
     check_for_debug_crash(sensor_debug_crash_flags, "RUN_IDS_RESERVED")
 
-    run_ids_with_run_requests = list(zip(reserved_run_ids, raw_run_requests))
+    run_ids_with_run_requests = list(context.tick.reserved_run_ids_with_requests)
     yield from _submit_run_requests(
         run_ids_with_run_requests,
         evaluations,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -118,10 +118,6 @@ class SensorLaunchContext(AbstractContextManager):
             self._purge_settings[day_offset].add(status)
 
     @property
-    def tick(self) -> InstigatorTick:
-        return self._tick
-
-    @property
     def status(self) -> TickStatus:
         return self._tick.status
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -786,7 +786,7 @@ def _resume_tick(
             skip_reason="Sensor manually stopped mid-iteration.",
         )
 
-    context.update_state(TickStatus.SUCCESS, cursor=context._tick.cursor)  # noqa # TODO
+    context.update_state(TickStatus.SUCCESS, cursor=context.tick.cursor)  # TODO
 
 
 def _get_code_location_for_sensor(
@@ -891,7 +891,7 @@ def _evaluate_sensor(
         if context.tick.tick_data.user_interrupted:
             context.update_state(
                 TickStatus.SKIPPED,
-                cursor=context.tick.cursor,
+                cursor=sensor_runtime_data.cursor,
                 skip_reason="Sensor manually stopped mid-iteration.",
             )
         elif context.run_count:
@@ -1190,6 +1190,7 @@ def _submit_run_requests(
                     "Sensor has been manually stopped while submitted runs. No more runs will be submitted."
                 )
                 context.update_state(context.status, user_interrupted=True)
+                break
 
     if (
         updated_evaluation_keys

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -118,6 +118,10 @@ class SensorLaunchContext(AbstractContextManager):
             self._purge_settings[day_offset].add(status)
 
     @property
+    def tick(self) -> InstigatorTick:
+        return self._tick
+
+    @property
     def status(self) -> TickStatus:
         return self._tick.status
 
@@ -153,6 +157,7 @@ class SensorLaunchContext(AbstractContextManager):
         skip_reason = cast(Optional[str], kwargs.get("skip_reason"))
         cursor = cast(Optional[str], kwargs.get("cursor"))
         origin_run_id = cast(Optional[str], kwargs.get("origin_run_id"))
+        user_interrupted = cast(Optional[bool], kwargs.get("user_interrupted"))
         if "skip_reason" in kwargs:
             del kwargs["skip_reason"]
 
@@ -161,6 +166,10 @@ class SensorLaunchContext(AbstractContextManager):
 
         if "origin_run_id" in kwargs:
             del kwargs["origin_run_id"]
+
+        if "user_interrupted" in kwargs:
+            del kwargs["user_interrupted"]
+
         if kwargs:
             check.inst_param(status, "status", TickStatus)
 
@@ -175,6 +184,9 @@ class SensorLaunchContext(AbstractContextManager):
 
         if origin_run_id:
             self._tick = self._tick.with_origin_run(origin_run_id)
+
+        if user_interrupted:
+            self._tick = self._tick.with_user_interrupted(user_interrupted)
 
     def add_run_info(self, run_id: Optional[str] = None, run_key: Optional[str] = None) -> None:
         self._tick = self._tick.with_run_info(run_id, run_key)
@@ -204,6 +216,15 @@ class SensorLaunchContext(AbstractContextManager):
             cursor=cursor,
         )
         self._write()
+
+    def sensor_is_enabled(self):
+        instigator_state = self._instance.get_instigator_state(
+            self._remote_sensor.get_remote_origin_id(), self._remote_sensor.selector_id
+        )
+        if instigator_state and not instigator_state.is_running:
+            return False
+
+        return True
 
     def _write(self) -> None:
         self._instance.update_tick(self._tick)
@@ -758,6 +779,13 @@ def _resume_tick(
         submit_threadpool_executor=submit_threadpool_executor,
         sensor_debug_crash_flags=sensor_debug_crash_flags,
     )
+    if context.tick.tick_data.user_interrupted:
+        context.update_state(
+            TickStatus.SKIPPED,
+            cursor=context.tick.cursor,
+            skip_reason="Sensor manually stopped mid-iteration.",
+        )
+
     context.update_state(TickStatus.SUCCESS, cursor=context._tick.cursor)  # noqa # TODO
 
 
@@ -860,7 +888,13 @@ def _evaluate_sensor(
             sensor_debug_crash_flags=sensor_debug_crash_flags,
         )
 
-        if context.run_count:
+        if context.tick.tick_data.user_interrupted:
+            context.update_state(
+                TickStatus.SKIPPED,
+                cursor=context.tick.cursor,
+                skip_reason="Sensor manually stopped mid-iteration.",
+            )
+        elif context.run_count:
             context.update_state(TickStatus.SUCCESS, cursor=sensor_runtime_data.cursor)
         else:
             context.update_state(TickStatus.SKIPPED, cursor=sensor_runtime_data.cursor)
@@ -1092,6 +1126,7 @@ def _submit_run_requests(
     existing_runs_by_key = _fetch_existing_runs(
         instance, remote_sensor, [request for _, request in resolved_run_ids_with_requests]
     )
+    check_after_runs_num = instance.get_tick_termination_check_interval()
 
     def submit_run_request(
         run_id_with_run_request: tuple[str, RunRequest],
@@ -1122,7 +1157,7 @@ def _submit_run_requests(
         evaluation.key: evaluation for evaluation in automation_condition_evaluations
     }
     updated_evaluation_keys = set()
-    for run_request_result in gen_run_request_results:
+    for i, run_request_result in enumerate(gen_run_request_results):
         yield run_request_result.error_info
 
         run = run_request_result.run
@@ -1142,6 +1177,19 @@ def _submit_run_requests(
                         evaluation, run_ids=evaluation.run_ids | {run.run_id}
                     )
                     updated_evaluation_keys.add(key)
+
+        # check if the sensor is still enabled:
+        if check_after_runs_num is not None and i % check_after_runs_num == 0:
+            if not context.sensor_is_enabled():
+                # The user has manually stopped the sensor mid-iteration. In this case we assume
+                # the user has a good reason for stopping the sensor (e.g. the sensor is submitting
+                # many unintentional runs) so we stop submitting runs and will mark the tick as
+                # skipped so that when the sensor is turned back on we don't detect this tick as incomplete
+                # and try to submit the same runs again.
+                context.logger.info(
+                    "Sensor has been manually stopped while submitted runs. No more runs will be submitted."
+                )
+                context.update_state(context.status, user_interrupted=True)
 
     if (
         updated_evaluation_keys

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -781,8 +781,8 @@ def _resume_tick(
             cursor=context.tick.cursor,
             skip_reason="Sensor manually stopped mid-iteration.",
         )
-
-    context.update_state(TickStatus.SUCCESS, cursor=context.tick.cursor)  # TODO
+    else:
+        context.update_state(TickStatus.SUCCESS, cursor=context.tick.cursor)  # TODO
 
 
 def _get_code_location_for_sensor(
@@ -1183,7 +1183,7 @@ def _submit_run_requests(
                 # skipped so that when the sensor is turned back on we don't detect this tick as incomplete
                 # and try to submit the same runs again.
                 context.logger.info(
-                    "Sensor has been manually stopped while submitted runs. No more runs will be submitted."
+                    "Sensor has been manually stopped while submitting runs. No more runs will be submitted."
                 )
                 context.update_state(context.status, user_interrupted=True)
                 break

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -782,7 +782,7 @@ def _resume_tick(
             skip_reason="Sensor manually stopped mid-iteration.",
         )
     else:
-        context.update_state(TickStatus.SUCCESS, cursor=context.tick.cursor)  # TODO
+        context.update_state(TickStatus.SUCCESS, cursor=context.tick.cursor)
 
 
 def _get_code_location_for_sensor(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 from collections.abc import Iterator
 from typing import Optional
+from unittest import mock
 
 import pytest
 from dagster._core.instance import DagsterInstance
@@ -37,12 +38,16 @@ def submit_executor(request):
 
 @pytest.fixture(name="instance_module_scoped", scope="module")
 def instance_module_scoped_fixture() -> Iterator[DagsterInstance]:
-    with instance_for_test(
-        overrides={
-            "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"}
-        }
-    ) as instance:
-        yield instance
+    with mock.patch(
+        "dagster._core.instance.DagsterInstance.get_tick_termination_check_interval",
+        return_value=1,  # check that the sensor is enabled after every run submission
+    ):
+        with instance_for_test(
+            overrides={
+                "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"}
+            }
+        ) as instance:
+            yield instance
 
 
 @pytest.fixture(name="instance", scope="function")

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -300,12 +300,6 @@ def start_skip_sensor(context: SensorEvaluationContext):
     return RunRequest()
 
 
-@sensor(job_name="the_job")
-def sensor_turns_off_while_submitting_runs(context):
-    yield RunRequest(run_key="1")
-    yield RunRequest(run_key="2")
-
-
 @asset
 def asset_a():
     return 1
@@ -1265,6 +1259,7 @@ def test_sensor_stopped_while_submitting_runs(
 
             evaluate_sensors(workspace_context, executor)
 
+        # sensor is stopped after the first run is submitted, so only one run should exist
         assert instance.get_runs_count() == 1
         first_run = instance.get_runs()[0]
         ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
@@ -1279,6 +1274,9 @@ def test_sensor_stopped_while_submitting_runs(
 
         assert ticks[0].run_requests and len(ticks[0].run_requests) == 5
         assert len(ticks[0].unsubmitted_run_ids_with_requests) == 4
+        assert first_run.run_id not in [
+            run_id for run_id, _ in ticks[0].unsubmitted_run_ids_with_requests
+        ]
         # if a tick is stopped mid-iteration we don't reset the cursor
         assert ticks[0].cursor == "1"
 


### PR DESCRIPTION
## Summary & Motivation
Version of https://github.com/dagster-io/dagster/pull/26958 for vanilla sensors.

While submitting runs, polls the status of the sensor after every N runs are submitted. If the sensor gets turned off, we stop submitting runs and mark the tick as SKIPPED so that we don't try to resubmit the remaining runs in the future.

The motivation for this is to allow users to stop sensors if they are submitting a large number of unexpected runs (usually due to a configuration error or some other error in the sensor logic). They'll want to 1. prevent the remaining runs from getting submitted, and 2. fix the sensor before starting it back up. When they do start it back up, we want to make sure we don't continue submitting the runs from the old/bad tick, which is why we mark the tick as skipped.

## How I Tested These Changes

nochangelog
