### PR TITLE
[docs] Fix font-face

### DIFF
--- a/docs/docs-beta/src/styles/theme-globals.scss
+++ b/docs/docs-beta/src/styles/theme-globals.scss
@@ -1,10 +1,14 @@
 @font-face {
   font-family: 'Geist';
+  font-style: normal;
+  font-weight: 100 900;
   src: url('/fonts/GeistVF.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Geist-Mono';
+  font-style: normal;
+  font-weight: 100 900;
   src: url('/fonts/GeistMonoVF.woff') format('woff');
 }
 


### PR DESCRIPTION
## Summary & Motivation

Specify the font style and font weight range for Geist, in particular to avoid weird incorrect weights in Safari.

Before:

<img width="411" alt="Screenshot 2025-01-24 at 10 44 37" src="https://github.com/user-attachments/assets/8b07aef8-bdc7-43da-9f7d-ef7b98316c02" />

After:

<img width="402" alt="Screenshot 2025-01-24 at 10 44 46" src="https://github.com/user-attachments/assets/7e4be8e8-4dec-4f65-8d56-0752fc81b2d2" />


## How I Tested These Changes

Run docs-beta app, open in Safari. Verify that bold text looks correct.
