### PR TITLE
[docs] fix education icon color

### DIFF
--- a/docs/docs-beta/static/img/getting-started/icon-education.svg
+++ b/docs/docs-beta/static/img/getting-started/icon-education.svg
@@ -1,5 +1,5 @@
 <svg width="56" height="56" viewBox="0 0 56 56" fill="none"
     xmlns="http://www.w3.org/2000/svg">
-    <path d="M28 8L7 20L28 32L45 22.5V35H49V20L28 8Z" fill="currentColor"/>
-    <path d="M14 25V37C14 37 21 44 28 44C35 44 42 37 42 37V25L28 34L14 25Z" fill="currentColor"/>
+    <path d="M28 8L7 20L28 32L45 22.5V35H49V20L28 8Z" fill="#67748A"/>
+    <path d="M14 25V37C14 37 21 44 28 44C35 44 42 37 42 37V25L28 34L14 25Z" fill="#67748A"/>
 </svg>


### PR DESCRIPTION
## Summary & Motivation

<img width="960" alt="image" src="https://github.com/user-attachments/assets/967a8cba-505c-40bc-9371-fea3a5f556ac" />

<img width="929" alt="image" src="https://github.com/user-attachments/assets/52413316-8415-4bdc-bc5d-c0921207a373" />

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
