### PR TITLE
[ui] Move some assets code from RepoAddress => RepositorySelector

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -46,9 +46,9 @@ import {
 } from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
+import {buildRepositorySelector} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 interface Props {
   assetKey: AssetKey;
@@ -264,10 +264,13 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
     }
   };
 
-  const repoAddress = useMemo(
+  const repositorySelector = useMemo(
     () =>
       definition
-        ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
+        ? buildRepositorySelector({
+            repositoryName: definition.repository.name,
+            repositoryLocationName: definition.repository.location.name,
+          })
         : null,
     [definition],
   );
@@ -289,7 +292,9 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   );
 
   const dynamicPartitionsDelete = useDeleteDynamicPartitionsDialog(
-    definition && repoAddress ? {assetKey: definition.assetKey, definition, repoAddress} : null,
+    definition && repositorySelector
+      ? {assetKey: definition.assetKey, definition, repositorySelector}
+      : null,
     () => {
       definitionQueryResult.refetch();
       refresh();
@@ -297,12 +302,12 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   );
 
   const reportEvents = useReportEventsDialog(
-    definition && !definition.isObservable && repoAddress
+    definition && !definition.isObservable && repositorySelector
       ? {
           assetKey: definition.assetKey,
           isPartitioned: definition.isPartitioned,
           hasReportRunlessAssetEventPermission: definition.hasReportRunlessAssetEventPermission,
-          repoAddress,
+          repositorySelector,
         }
       : null,
     refresh,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
@@ -18,13 +18,12 @@ import {usePartitionHealthData} from './usePartitionHealthData';
 import {RefetchQueriesFunction, gql, useMutation} from '../apollo-client';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
+import {AssetKeyInput, PartitionDefinitionType, RepositorySelector} from '../graphql/types';
 import {OrdinalPartitionSelector} from '../partitions/OrdinalPartitionSelector';
-import {RepoAddress} from '../workspace/types';
 
 export interface DeleteDynamicPartitionsDialogProps {
   assetKey: AssetKeyInput;
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   partitionsDefName: string;
   isOpen: boolean;
   onClose: () => void;
@@ -47,7 +46,7 @@ export const DeleteDynamicPartitionsDialog = memo((props: DeleteDynamicPartition
 
 export const DeleteDynamicPartitionsDialogInner = memo(
   ({
-    repoAddress,
+    repositorySelector,
     assetKey,
     partitionsDefName,
     onClose,
@@ -75,10 +74,7 @@ export const DeleteDynamicPartitionsDialogInner = memo(
         setDeleting(true);
         const resp = await deletePartitions({
           variables: {
-            repositorySelector: {
-              repositoryLocationName: repoAddress.location,
-              repositoryName: repoAddress.name,
-            },
+            repositorySelector,
             partitionsDefName,
             partitionKeys,
           },
@@ -87,7 +83,7 @@ export const DeleteDynamicPartitionsDialogInner = memo(
         setDeleting(false);
         onComplete?.();
       },
-      [deletePartitions, onComplete, partitionsDefName, repoAddress.location, repoAddress.name],
+      [deletePartitions, onComplete, partitionsDefName, repositorySelector],
     );
 
     const content = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
@@ -4,9 +4,9 @@ import {LaunchAssetChoosePartitionsDialogProps} from '../LaunchAssetChoosePartit
 export const ReleasesJobProps: Omit<LaunchAssetChoosePartitionsDialogProps, 'open' | 'setOpen'> = {
   assets: assetNodes,
   upstreamAssetKeys: [],
-  repoAddress: {
-    name: '__repository__',
-    location: 'assets_dynamic_partitions',
+  repositorySelector: {
+    repositoryName: '__repository__',
+    repositoryLocationName: 'assets_dynamic_partitions',
   },
   target: {
     type: 'job' as const,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/DeleteDynamicPartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/DeleteDynamicPartitionsDialog.test.tsx
@@ -54,7 +54,7 @@ describe('DeleteDynamicPartitionsDialog', () => {
       >
         <DeleteDynamicPartitionsDialog
           assetKey={{path: ['asset']}}
-          repoAddress={{location: 'location', name: 'repo.py'}}
+          repositorySelector={{repositoryLocationName: 'location', repositoryName: 'repo.py'}}
           partitionsDefName="fruits"
           isOpen
           onClose={() => {}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -13,6 +13,7 @@ import {
   buildDimensionPartitionKeys,
   buildMultiPartitionStatuses,
   buildPartitionDefinition,
+  buildRepositorySelector,
 } from '../../graphql/types';
 import {CREATE_PARTITION_MUTATION} from '../../partitions/CreatePartitionDialog';
 import {
@@ -22,7 +23,6 @@ import {
 import {buildMutationMock, buildQueryMock, getMockResultFn} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';
 import {buildWorkspaceMocks} from '../../workspace/WorkspaceContext/__fixtures__/Workspace.fixtures';
-import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {LaunchAssetChoosePartitionsDialog} from '../LaunchAssetChoosePartitionsDialog';
 import {
   PartitionHealthQuery,
@@ -100,7 +100,10 @@ describe('launchAssetChoosePartitionsDialog', () => {
             <LaunchAssetChoosePartitionsDialog
               open={true}
               setOpen={(_open: boolean) => {}}
-              repoAddress={buildRepoAddress('test', 'test')}
+              repositorySelector={buildRepositorySelector({
+                repositoryLocationName: 'test',
+                repositoryName: 'test',
+              })}
               target={{
                 jobName: '__ASSET_JOB',
                 assetKeys: [assetA.assetKey, assetB.assetKey],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
@@ -4,12 +4,11 @@ import {useContext, useState} from 'react';
 import {DeleteDynamicPartitionsDialog} from './DeleteDynamicPartitionsDialog';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {usePermissionsForLocation} from '../app/Permissions';
-import {AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
-import {RepoAddress} from '../workspace/types';
+import {AssetKeyInput, PartitionDefinitionType, RepositorySelector} from '../graphql/types';
 
 export function useDeleteDynamicPartitionsDialog(
   opts: {
-    repoAddress: RepoAddress;
+    repositorySelector: RepositorySelector;
     assetKey: AssetKeyInput;
     definition: {
       partitionDefinition: {
@@ -24,7 +23,7 @@ export function useDeleteDynamicPartitionsDialog(
   const [showing, setShowing] = useState(false);
   const {
     permissions: {canWipeAssets},
-  } = usePermissionsForLocation(opts ? opts.repoAddress.location : null);
+  } = usePermissionsForLocation(opts ? opts.repositorySelector.repositoryLocationName : null);
 
   const {
     featureContext: {canSeeWipeMaterializationAction},
@@ -48,7 +47,7 @@ export function useDeleteDynamicPartitionsDialog(
   return {
     element: (
       <DeleteDynamicPartitionsDialog
-        repoAddress={opts.repoAddress}
+        repositorySelector={opts.repositorySelector}
         assetKey={opts.assetKey}
         partitionsDefName={dynamicDimension.dynamicPartitionsDefinitionName}
         isOpen={showing}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useObserveAction.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useObserveAction.ts
@@ -10,6 +10,7 @@ import {
 import {asAssetKeyInput} from './asInput';
 import {AssetKey} from './types';
 import {useApolloClient} from '../apollo-client';
+import {buildRepositorySelector} from '../graphql/types';
 import {
   LaunchAssetExecutionAssetNodeFragment,
   LaunchAssetLoaderQuery,
@@ -17,8 +18,7 @@ import {
 } from './types/LaunchAssetExecutionButton.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {repositorySelectorAsHumanString} from '../workspace/repoAddressAsString';
 
 export type ObserveAssetsState =
   | {type: 'none'}
@@ -85,17 +85,17 @@ async function stateForObservingAssets(
       error: 'One or more of the selected assets is not an observable asset.',
     };
   }
-  const repoAddress = buildRepoAddress(
-    assets[0]?.repository.name || '',
-    assets[0]?.repository.location.name || '',
-  );
-  const repoName = repoAddressAsHumanString(repoAddress);
+  const repositorySelector = buildRepositorySelector({
+    repositoryLocationName: assets[0]?.repository.location.name || '',
+    repositoryName: assets[0]?.repository.name || '',
+  });
+  const repoName = repositorySelectorAsHumanString(repositorySelector);
 
   if (
     !assets.every(
       (a) =>
-        a.repository.name === repoAddress.name &&
-        a.repository.location.name === repoAddress.location,
+        a.repository.name === repositorySelector.repositoryName &&
+        a.repository.location.name === repositorySelector.repositoryLocationName,
     )
   ) {
     return {
@@ -114,6 +114,6 @@ async function stateForObservingAssets(
 
   return {
     type: 'single-run',
-    executionParams: executionParamsForAssetJob(repoAddress, jobName, assets, []),
+    executionParams: executionParamsForAssetJob(repositorySelector, jobName, assets, []),
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
@@ -33,15 +33,19 @@ import {showSharedToaster} from '../app/DomUtils';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {AssetEventType, AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
+import {
+  AssetEventType,
+  AssetKeyInput,
+  PartitionDefinitionType,
+  RepositorySelector,
+} from '../graphql/types';
 import {DimensionRangeWizards} from '../partitions/DimensionRangeWizards';
 import {ToggleableSection} from '../ui/ToggleableSection';
-import {RepoAddress} from '../workspace/types';
 
 type Asset = {
   isPartitioned: boolean;
   assetKey: AssetKeyInput;
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   hasReportRunlessAssetEventPermission: boolean;
 };
 
@@ -71,7 +75,7 @@ export function useReportEventsDialog(asset: Asset | null, onEventReported?: () 
       asset={asset}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
-      repoAddress={asset.repoAddress}
+      repositorySelector={asset.repositorySelector}
       onEventReported={onEventReported}
     />
   ) : undefined;
@@ -84,13 +88,13 @@ export function useReportEventsDialog(asset: Asset | null, onEventReported?: () 
 
 const ReportEventsDialog = ({
   asset,
-  repoAddress,
+  repositorySelector,
   isOpen,
   setIsOpen,
   onEventReported,
 }: {
   asset: Asset;
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   onEventReported?: () => void;
@@ -106,7 +110,7 @@ const ReportEventsDialog = ({
       <ReportEventDialogBody
         asset={asset}
         setIsOpen={setIsOpen}
-        repoAddress={repoAddress}
+        repositorySelector={repositorySelector}
         onEventReported={onEventReported}
       />
     </Dialog>
@@ -115,12 +119,12 @@ const ReportEventsDialog = ({
 
 const ReportEventDialogBody = ({
   asset,
-  repoAddress,
+  repositorySelector,
   setIsOpen,
   onEventReported,
 }: {
   asset: Asset;
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   setIsOpen: (open: boolean) => void;
   onEventReported?: () => void;
 }) => {
@@ -241,7 +245,7 @@ const ReportEventDialogBody = ({
           }
         >
           <DimensionRangeWizards
-            repoAddress={repoAddress}
+            repositorySelector={repositorySelector}
             refetch={async () => setLastRefresh(Date.now())}
             selections={selections}
             setSelections={setSelections}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -334,7 +334,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
           key={showCreatePartition ? '1' : '0'}
           isOpen={showCreatePartition}
           dynamicPartitionsDefinitionName={dynamicPartitionsDefinitionName}
-          repoAddress={repoAddress}
+          repositorySelector={repositorySelector}
           close={() => {
             setShowCreatePartition(false);
           }}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
@@ -6,21 +6,21 @@ import {LaunchpadAllowedRoot} from './LaunchpadAllowedRoot';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
+import {RepositorySelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
-import {RepoAddress} from '../workspace/types';
 
 // ########################
 // ##### LAUNCHPAD ROOTS
 // ########################
 
 export const AssetLaunchpad = ({
-  repoAddress,
+  repositorySelector,
   sessionPresets,
   assetJobName,
   open,
   setOpen,
 }: {
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   sessionPresets?: Partial<IExecutionSession>;
   assetJobName: string;
   open: boolean;
@@ -41,20 +41,20 @@ export const AssetLaunchpad = ({
       <LaunchpadAllowedRoot
         launchpadType="asset"
         pipelinePath={assetJobName}
-        repoAddress={repoAddress}
+        repositorySelector={repositorySelector}
         sessionPresets={sessionPresets}
       />
     </Dialog>
   );
 };
 
-export const JobOrAssetLaunchpad = (props: {repoAddress: RepoAddress}) => {
-  const {repoAddress} = props;
+export const JobOrAssetLaunchpad = (props: {repositorySelector: RepositorySelector}) => {
+  const {repositorySelector} = props;
   const {pipelinePath, repoPath} = useParams<{repoPath: string; pipelinePath: string}>();
   const {
     permissions: {canLaunchPipelineExecution},
     loading,
-  } = usePermissionsForLocation(repoAddress.location);
+  } = usePermissionsForLocation(repositorySelector.repositoryLocationName);
   useBlockTraceUntilTrue('Permissions', loading);
 
   if (loading) {
@@ -69,7 +69,7 @@ export const JobOrAssetLaunchpad = (props: {repoAddress: RepoAddress}) => {
     <LaunchpadAllowedRoot
       launchpadType={pipelinePath.includes(__ASSET_JOB_PREFIX) ? 'asset' : 'job'}
       pipelinePath={pipelinePath}
-      repoAddress={repoAddress}
+      repositorySelector={repositorySelector}
     />
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
@@ -22,9 +22,8 @@ import {
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {invalidatePartitions} from '../assets/PartitionSubscribers';
+import {RepositorySelector} from '../graphql/types';
 import {testId} from '../testing/testId';
-import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
-import {RepoAddress} from '../workspace/types';
 
 // Keep in sync with the backend which currently has 2 definitions:
 // INVALID_PARTITION_SUBSTRINGS and INVALID_STATIC_PARTITIONS_KEY_CHARACTERS
@@ -66,14 +65,14 @@ export const CreatePartitionDialog = ({
   isOpen,
   dynamicPartitionsDefinitionName,
   close,
-  repoAddress,
+  repositorySelector,
   refetch,
   onCreated,
 }: {
   isOpen: boolean;
   dynamicPartitionsDefinitionName?: string | null;
   close: () => void;
-  repoAddress: RepoAddress;
+  repositorySelector: RepositorySelector;
   refetch?: () => Promise<void>;
   onCreated: (partitionName: string) => void;
 }) => {
@@ -116,7 +115,7 @@ export const CreatePartitionDialog = ({
     setIsSaving(true);
     const result = await createPartition({
       variables: {
-        repositorySelector: repoAddressToSelector(repoAddress),
+        repositorySelector,
         partitionsDefName: dynamicPartitionsDefinitionName || '',
         partitionKey: partitionName,
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -6,9 +6,8 @@ import {CreatePartitionDialog} from './CreatePartitionDialog';
 import {DimensionRangeInput} from './DimensionRangeInput';
 import {OrdinalPartitionSelector} from './OrdinalPartitionSelector';
 import {PartitionStatus, PartitionStatusHealthSource} from './PartitionStatus';
-import {PartitionDefinitionType} from '../graphql/types';
+import {PartitionDefinitionType, RepositorySelector} from '../graphql/types';
 import {testId} from '../testing/testId';
-import {RepoAddress} from '../workspace/types';
 
 export const DimensionRangeWizard = ({
   selected,
@@ -17,7 +16,7 @@ export const DimensionRangeWizard = ({
   health,
   dimensionType,
   dynamicPartitionsDefinitionName,
-  repoAddress,
+  repositorySelector,
   refetch,
 }: {
   selected: string[];
@@ -26,7 +25,7 @@ export const DimensionRangeWizard = ({
   health: PartitionStatusHealthSource;
   dimensionType: PartitionDefinitionType;
   dynamicPartitionsDefinitionName?: string | null;
-  repoAddress?: RepoAddress;
+  repositorySelector?: RepositorySelector;
   refetch?: () => Promise<void>;
 }) => {
   const isTimeseries = dimensionType === PartitionDefinitionType.TIME_WINDOW;
@@ -92,12 +91,12 @@ export const DimensionRangeWizard = ({
           />
         )}
       </Box>
-      {repoAddress && (
+      {repositorySelector && (
         <CreatePartitionDialog
           key={showCreatePartition ? '1' : '0'}
           isOpen={showCreatePartition}
           dynamicPartitionsDefinitionName={dynamicPartitionsDefinitionName}
-          repoAddress={repoAddress}
+          repositorySelector={repositorySelector}
           close={() => {
             setShowCreatePartition(false);
           }}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
@@ -6,15 +6,14 @@ import {
   PartitionDimensionSelection,
   PartitionHealthDataMerged,
 } from '../assets/usePartitionHealthData';
-import {PartitionDefinitionType} from '../graphql/types';
-import {RepoAddress} from '../workspace/types';
+import {PartitionDefinitionType, RepositorySelector} from '../graphql/types';
 
 export const DimensionRangeWizards = ({
   selections,
   setSelections,
   displayedHealth,
   displayedPartitionDefinition,
-  repoAddress,
+  repositorySelector,
   refetch,
 }: {
   selections: PartitionDimensionSelection[];
@@ -27,7 +26,7 @@ export const DimensionRangeWizards = ({
       dynamicPartitionsDefinitionName: string | null;
     }[];
   } | null;
-  repoAddress?: RepoAddress;
+  repositorySelector?: RepositorySelector;
   refetch?: () => Promise<void>;
 }) => {
   return (
@@ -49,7 +48,7 @@ export const DimensionRangeWizards = ({
               : null}
           </Box>
           <DimensionRangeWizard
-            repoAddress={repoAddress}
+            repositorySelector={repositorySelector}
             refetch={refetch}
             partitionKeys={range.dimension.partitionKeys}
             health={{

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
@@ -26,9 +26,9 @@ function Test({mocks}: {mocks?: MockedResponse[]}) {
       <CreatePartitionDialog
         isOpen={true}
         close={onCloseMock}
-        repoAddress={{
-          name: 'testing',
-          location: 'testing',
+        repositorySelector={{
+          repositoryName: 'testing',
+          repositoryLocationName: 'testing',
         }}
         dynamicPartitionsDefinitionName="testPartitionDef"
         onCreated={onCreatedMock}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRoot.tsx
@@ -1,9 +1,11 @@
+import {useMemo} from 'react';
 import {Redirect, Switch} from 'react-router-dom';
 import {JobFallthroughRoot} from 'shared/pipelines/JobFallthroughRoot.oss';
 
 import {PipelineOrJobDisambiguationRoot} from './PipelineOrJobDisambiguationRoot';
 import {PipelineRunsRoot} from './PipelineRunsRoot';
 import {Route} from '../app/Route';
+import {buildRepositorySelector} from '../graphql/types';
 import {JobOrAssetLaunchpad} from '../launchpad/LaunchpadRoot';
 import {LaunchpadSetupFromRunRoot} from '../launchpad/LaunchpadSetupFromRunRoot';
 import {LaunchpadSetupRoot} from '../launchpad/LaunchpadSetupRoot';
@@ -17,6 +19,15 @@ interface Props {
 
 export const PipelineRoot = (props: Props) => {
   const {repoAddress} = props;
+
+  const repositorySelector = useMemo(
+    () =>
+      buildRepositorySelector({
+        repositoryLocationName: repoAddress.location,
+        repositoryName: repoAddress.name,
+      }),
+    [repoAddress],
+  );
 
   return (
     <div
@@ -55,7 +66,7 @@ export const PipelineRoot = (props: Props) => {
             '/locations/:repoPath/jobs/:pipelinePath/playground',
           ]}
         >
-          <JobOrAssetLaunchpad repoAddress={repoAddress} />
+          <JobOrAssetLaunchpad repositorySelector={repositorySelector} />
         </Route>
         <Route
           path={[

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -23,7 +23,7 @@ import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
 import {AssetKind} from '../graph/KindTags';
-import {AssetKeyInput} from '../graphql/types';
+import {AssetKeyInput, buildRepositorySelector} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {testId} from '../testing/testId';
@@ -89,6 +89,15 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
     }
   };
   const kinds = definition?.kinds;
+
+  const repositorySelector = React.useMemo(() => {
+    return repoAddress
+      ? buildRepositorySelector({
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+        })
+      : null;
+  }, [repoAddress]);
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-${tokenForAssetKey({path})}`)}>
@@ -213,7 +222,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
             <AssetActionMenu
               path={path}
               definition={definition}
-              repoAddress={repoAddress}
+              repositorySelector={repositorySelector}
               onRefresh={onRefresh}
             />
           ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/repoAddressAsString.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/repoAddressAsString.ts
@@ -1,5 +1,6 @@
 import {buildRepoPathForHuman, buildRepoPathForURL} from './buildRepoAddress';
 import {RepoAddress} from './types';
+import {RepositorySelector} from '../graphql/types';
 
 // Note: These are not memoized because the result is a primitive value and
 // there are scenarios where the repoAddress argument is a temporary object,
@@ -19,4 +20,17 @@ export const repoAddressAsURLString = (repoAddress: RepoAddress) => {
 // Unencoded, dunder repo visible.
 export const repoAddressAsTag = (repoAddress: RepoAddress) => {
   return `${repoAddress.name}@${repoAddress.location}`;
+};
+
+export const repositorySelectorAsHumanString = (sel: RepositorySelector) => {
+  return buildRepoPathForHuman(sel.repositoryName, sel.repositoryLocationName);
+};
+
+export const repositorySelectorAsURLString = (sel: RepositorySelector) => {
+  return buildRepoPathForURL(sel.repositoryName, sel.repositoryLocationName);
+};
+
+// Unencoded, dunder repo visible.
+export const repositorySelectorAsTag = (sel: RepositorySelector) => {
+  return `${sel.repositoryName}@${sel.repositoryLocationName}`;
 };


### PR DESCRIPTION
## Summary & Motivation

I'm curious to get thoughts on this -- when I was working on https://github.com/dagster-io/dagster/pull/27340, I was finding the mix of RepositorySelector and RepoAddress a bit annoying. It seems like if the GraphQL layer uses `RepositorySelector`,  we eventually convert to that, and we should just use it everywhere.

That said:

- We use repoAddress a lot more right now, there are 1700 occurrences in the codebase compared to 200 occurrences of repositorySelector.
- repoAddress is more concise (`repoAddress.location` vs `repositorySelector.repositoryLocationName`)
- The API gives us `repository: {name: string, location: {name: string}}` in the response shapes, so a small bit of transformation is required regardless.

I think I could plow through the remaining occurrences, but it turns out that landing in an intermediate state is undesirable because of helpers like `workspacePathFromAddress`, etc. 