### PR TITLE
[components] Change code_locations directory to code-locations

### DIFF
--- a/docs/docs-beta/docs/guides/build/components/setting-up-a-deployment.md
+++ b/docs/docs-beta/docs/guides/build/components/setting-up-a-deployment.md
@@ -29,7 +29,7 @@ This will create a new directory `my-deployment`. Let's look at the structure:
 $ cd my-deployment && tree
 
 .
-├── code_locations
+├── code-locations
 └── pyproject.toml
 ```
 
@@ -48,18 +48,18 @@ To add a code location to the deployment, run:
 ```bash
 $ dg code-location scaffold code-location-1
 
-Creating a Dagster code location at .../my-deployment/code_locations/code-location-1.
-Scaffolded files for Dagster project in .../my-deployment/code_locations/code-location-1.
+Creating a Dagster code location at .../my-deployment/code-locations/code-location-1.
+Scaffolded files for Dagster project in .../my-deployment/code-locations/code-location-1.
 ...
 ```
 
-This will create a new directory `code-location-1` within the `code_locations`.
+This will create a new directory `code-location-1` within the `code-locations`.
 It will also setup a new uv-managed Python environment for the code location. Let's have a look:
 
 ```bash
 $ tree
 
-├── code_locations
+├── code-locations
 │   └── code-location-1
 │       ├── code_location_1
 │       │   ├── __init__.py
@@ -124,8 +124,8 @@ Let's create another code location to demonstrate this:
 ```bash
 $ cd ../.. && dg code-location scaffold code-location-2
 
-Creating a Dagster code location at .../my-deployment/code_locations/code-location-2.
-Scaffolded files for Dagster project in .../my-deployment/code_locations/code-location-2.
+Creating a Dagster code location at .../my-deployment/code-locations/code-location-2.
+Scaffolded files for Dagster project in .../my-deployment/code-locations/code-location-2.
 ```
 
 Now we have two code locations. We can list them with:
@@ -140,7 +140,7 @@ code-location-2
 And finally, let's check the available component types in `code-location-2`:
 
 ```bash
-$ cd code_locations/code-location-2 && dg component-type list
+$ cd code-locations/code-location-2 && dg component-type list
 
 dagster_components.definitions
 dagster_components.pipes_subprocess_script_collection

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -20,7 +20,7 @@ from dagster_dg.utils import (
 )
 
 # Deployment
-_DEPLOYMENT_CODE_LOCATIONS_DIR: Final = "code_locations"
+_DEPLOYMENT_CODE_LOCATIONS_DIR: Final = "code-locations"
 
 # Code location
 _DEFAULT_CODE_LOCATION_COMPONENTS_LIB_SUBMODULE: Final = "lib"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -36,26 +36,26 @@ def test_code_location_scaffold_inside_deployment_success(monkeypatch) -> None:
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
         result = runner.invoke("code-location", "scaffold", "foo-bar", "--use-editable-dagster")
         assert_runner_result(result)
-        assert Path("code_locations/foo-bar").exists()
-        assert Path("code_locations/foo-bar/foo_bar").exists()
-        assert Path("code_locations/foo-bar/foo_bar/lib").exists()
-        assert Path("code_locations/foo-bar/foo_bar/components").exists()
-        assert Path("code_locations/foo-bar/foo_bar_tests").exists()
-        assert Path("code_locations/foo-bar/pyproject.toml").exists()
+        assert Path("code-locations/foo-bar").exists()
+        assert Path("code-locations/foo-bar/foo_bar").exists()
+        assert Path("code-locations/foo-bar/foo_bar/lib").exists()
+        assert Path("code-locations/foo-bar/foo_bar/components").exists()
+        assert Path("code-locations/foo-bar/foo_bar_tests").exists()
+        assert Path("code-locations/foo-bar/pyproject.toml").exists()
 
         # Check venv created
-        assert Path("code_locations/foo-bar/.venv").exists()
-        assert Path("code_locations/foo-bar/uv.lock").exists()
+        assert Path("code-locations/foo-bar/.venv").exists()
+        assert Path("code-locations/foo-bar/uv.lock").exists()
 
         # Restore when we are able to test without editable install
-        # with open("code_locations/bar/pyproject.toml") as f:
+        # with open("code-locations/bar/pyproject.toml") as f:
         #     toml = tomli.loads(f.read())
         #
         #     # No tool.uv.sources added without --use-editable-dagster
         #     assert "uv" not in toml["tool"]
 
         # Check cache was populated
-        with pushd("code_locations/foo-bar"):
+        with pushd("code-locations/foo-bar"):
             result = runner.invoke("component-type", "list", "--verbose")
             assert_runner_result(result)
             assert "CACHE [hit]" in result.output
@@ -92,9 +92,9 @@ def test_code_location_scaffold_editable_dagster_success(mode: str, monkeypatch)
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
         result = runner.invoke("code-location", "scaffold", *editable_args, "foo-bar")
         assert_runner_result(result)
-        assert Path("code_locations/foo-bar").exists()
-        assert Path("code_locations/foo-bar/pyproject.toml").exists()
-        with open("code_locations/foo-bar/pyproject.toml") as f:
+        assert Path("code-locations/foo-bar").exists()
+        assert Path("code-locations/foo-bar/pyproject.toml").exists()
+        with open("code-locations/foo-bar/pyproject.toml") as f:
             toml = tomli.loads(f.read())
             assert toml["tool"]["uv"]["sources"]["dagster"] == {
                 "path": f"{dagster_git_repo_dir}/python_modules/dagster",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_deployment_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_deployment_commands.py
@@ -17,7 +17,7 @@ def test_scaffold_deployment_command_success() -> None:
         result = runner.invoke("deployment", "scaffold", "foo")
         assert_runner_result(result)
         assert Path("foo").exists()
-        assert Path("foo/code_locations").exists()
+        assert Path("foo/code-locations").exists()
 
 
 def test_scaffold_deployment_command_already_exists_fails() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -46,7 +46,7 @@ def isolated_example_code_location_foo_bar(
                 *(["--no-use-dg-managed-environment"] if skip_venv else []),
                 "foo-bar",
             )
-            with clear_module_from_cache("foo_bar"), pushd("code_locations/foo-bar"):
+            with clear_module_from_cache("foo_bar"), pushd("code-locations/foo-bar"):
                 yield
     else:
         with runner.isolated_filesystem():


### PR DESCRIPTION
## Summary & Motivation

This is a minor thing but I think it is better to default to hyphens for directories that contain python but aren't python packages.

## How I Tested These Changes

Modified existing tests.