### PR TITLE
[ui] Restrict CodeLocationSource hostnames

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationSource.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationSource.tsx
@@ -47,6 +47,9 @@ type RepoURLType =
   | {type: 'gitlab-url'; url: URL}
   | {type: 'unknown-url'; url: URL};
 
+const GITHUB_HOSTNAMES = new Set(['github.com', 'www.github.com']);
+const GITLAB_HOSTNAMES = new Set(['gitlab.com', 'www.gitlab.com']);
+
 export const extractRepoURL = (metadata: Metadata[]): RepoURLType => {
   const metadataWithURL = metadata.find(({key}) => key === 'url');
   if (!metadataWithURL) {
@@ -65,13 +68,12 @@ export const extractRepoURL = (metadata: Metadata[]): RepoURLType => {
     return {type: 'non-url', value};
   }
 
-  const isGithub = url.hostname.includes('github.com');
-  const isGitlab = url.hostname.includes('gitlab.com');
-
+  const isGithub = GITHUB_HOSTNAMES.has(url.hostname);
   if (isGithub) {
     return {type: 'github-url', url};
   }
 
+  const isGitlab = GITLAB_HOSTNAMES.has(url.hostname);
   if (isGitlab) {
     return {type: 'gitlab-url', url};
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
@@ -52,4 +52,15 @@ describe('CodeLocationSource', () => {
     expect(link.getAttribute('href')).toBe(cleanedUrl);
     expect(link.textContent).toBe(cleanedUrl);
   });
+
+  it('is treated as a plain link if a sneaky GitHub-like hostname is provided', () => {
+    const url = 'https://not-really-github.com/gh-namespace/foo-project/abcd1234';
+    const metadata = [{key: 'url', value: url}];
+
+    render(<CodeLocationSource metadata={metadata} />);
+
+    const link = screen.getByRole('link', {name: /not-really-github/});
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', url);
+  });
 });


### PR DESCRIPTION
## Summary & Motivation

Try to resolve:

- https://github.com/dagster-io/dagster/security/code-scanning/18
- https://github.com/dagster-io/dagster/security/code-scanning/19

Within `CodeLocationSource`, we currently check whether `github.com` or `gitlab.com` are included in the hostname at all. This only affects how we render the outbound link or button, but even so, we should be more restrictive about this.

## How I Tested These Changes

`yarn jest CodeLocationSource`
