### PR TITLE
[dagster-sling] Add explicit sling-mac-arm64 dependency for uv compatibility

### DIFF
--- a/python_modules/libraries/dagster-sling/setup.py
+++ b/python_modules/libraries/dagster-sling/setup.py
@@ -33,7 +33,13 @@ setup(
     packages=find_packages(exclude=["dagster_sling_tests*"]),
     include_package_data=True,
     python_requires=">=3.9,<3.13",
-    install_requires=[f"dagster{pin}", "sling>=1.1.5"],
+    install_requires=[
+        f"dagster{pin}",
+        "sling>=1.1.5",
+        # Required due to a bug in uv that can cause sling-linux-amd64 to be installed instead.
+        # See: https://github.com/astral-sh/uv/issues/10945
+        "sling-mac-arm64; platform_system=='Darwin' and platform_machine=='arm64'",
+    ],
     zip_safe=False,
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary & Motivation

Problem: currently, installing `sling` using `uv` in a fresh virtual environment on macOS with the cache disabled will incorrectly install `sling-linux-amd64` instead of the correct `sling-mac-arm64`. This causes the package to be unimportable.

```
mkdir test-sling && cd test-sling
uv venv
uv pip install --no-cache sling
uv run python -c 'import sling'

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/smackesey/stm/code/elementl/tmp/testsling-editable-2/.venv/lib/python3.12/site-packages/sling/__init__.py", line 39, in <module>
    exec('from sling_mac_arm64 import SLING_BIN')
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'sling_mac_arm64'
```

This bites us when installing `dagster-sling` (a dependency of `dagster-components[sling]`).

This PR adds `sling_mac_arm64` as a platform-dependent dependency of `dagster-sling`, thereby averting this problem.

Note: according to `uv` maintainer, the problem originates from incorrect metadata published in `sling`. We should be able to remove this in the future when that metadata is fixed. `uv` issue here: https://github.com/astral-sh/uv/issues/10945

## How I Tested These Changes

Tried above flow with an editable install of `dagster-sling`, observed correctly installed package and ability to import `sling`.