### PR TITLE
[ui] Replace all newlines in SelectionInput

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -192,7 +192,7 @@ export const SelectionAutoCompleteInput = ({
 
   // Update CodeMirror when value prop changes
   useLayoutEffect(() => {
-    const noNewLineValue = value.replace('\n', ' ');
+    const noNewLineValue = value.replace(/\n/g, ' ');
     if (cmInstance.current && cmInstance.current.getValue() !== noNewLineValue) {
       const instance = cmInstance.current;
       const cursor = instance.getCursor();


### PR DESCRIPTION
## Summary & Motivation

Resolve https://github.com/dagster-io/dagster/security/code-scanning/63.

## How I Tested These Changes

Not sure of the right way to test this. I tried forcing the `value` prop with strings containing newlines, and the code correctly replaces the `\n`'s, but I'm not sure how this is supposed to appear in the UI.