### PR TITLE
extract instance concurrency config

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -287,9 +287,9 @@ class GrapheneInstance(graphene.ObjectType):
         return isinstance(self._instance.run_coordinator, QueuedRunCoordinator)
 
     def resolve_runQueueConfig(self, _graphene_info: ResolveInfo):
-        run_queue_config = self._instance.get_run_queue_config()
-        if run_queue_config:
-            return GrapheneRunQueueConfig(run_queue_config)
+        concurrency_config = self._instance.get_concurrency_config()
+        if concurrency_config.run_queue_config:
+            return GrapheneRunQueueConfig(concurrency_config.run_queue_config)
         else:
             return None
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -971,12 +971,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def global_op_concurrency_default_limit(self) -> Optional[int]:
-        default_limit = self.get_settings("concurrency").get("pools", {}).get("default_limit")
-        if default_limit is not None:
-            return default_limit
-
-        # fallback to the old settings
-        return self.get_settings("concurrency").get("default_op_concurrency_limit")
+        return self.get_concurrency_config().pool_config.default_pool_limit
 
     # python logs
 

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional
 
 import dagster._check as check
 from dagster._core.instance import DagsterInstance
-from dagster._core.run_coordinator.queued_run_coordinator import PoolGranularity
+from dagster._core.instance.config import PoolGranularity
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot, ExecutionStepSnap
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -15,7 +15,6 @@ from dagster._builtins import Bool
 from dagster._config import Array, Field, Noneable, ScalarUnion, Shape
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.instance import T_DagsterInstance
-from dagster._core.instance.config import PoolGranularity
 from dagster._core.run_coordinator.base import RunCoordinator, SubmitRunContext
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
@@ -136,12 +135,6 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
                 "op_concurrency_slot_buffer can only be set if block_op_concurrency_limited_runs "
                 "is enabled",
             )
-        self._pool_granularity: Optional[PoolGranularity] = (
-            PoolGranularity.OP
-            if block_op_concurrency_limited_runs
-            and bool(block_op_concurrency_limited_runs.get("enabled"))
-            else None
-        )
         self._logger = logging.getLogger("dagster.run_coordinator.queued_run_coordinator")
         super().__init__()
 
@@ -157,7 +150,6 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             user_code_failure_retry_delay=self._user_code_failure_retry_delay,
             should_block_op_concurrency_limited_runs=self._should_block_op_concurrency_limited_runs,
             op_concurrency_slot_buffer=self._op_concurrency_slot_buffer,
-            pool_granularity=self._pool_granularity,
         )
 
     @property

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -83,10 +83,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         run_coordinator = check.inst(
             workspace_process_context.instance.run_coordinator, QueuedRunCoordinator
         )
-        concurrency_config = (
-            workspace_process_context.instance.get_concurrency_config()
-            or run_coordinator.get_concurrency_config()
-        )
+        concurrency_config = workspace_process_context.instance.get_concurrency_config()
         if not concurrency_config.run_queue_config:
             check.failed("Got invalid run queue config")
 
@@ -278,7 +275,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                         batch,
                         in_progress_run_records,
                         run_queue_config.op_concurrency_slot_buffer,
-                        concurrency_config.pool_granularity,
+                        concurrency_config.pool_config.pool_granularity,
                     )
                 except:
                     self._logger.exception("Failed to initialize op concurrency counter")

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_default_run_blocking.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_default_run_blocking.yaml
@@ -1,0 +1,9 @@
+run_queue:
+  max_concurrent_runs: 5
+  tag_concurrency_limits:
+    - key: "dagster/solid_selection"
+      limit: 2
+  max_user_code_failure_retries: 3
+  user_code_failure_retry_delay: 10
+  block_op_concurrency_limited_runs:
+    enabled: false

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_disabled_run_blocking.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_disabled_run_blocking.yaml
@@ -1,0 +1,9 @@
+run_queue:
+  max_concurrent_runs: 5
+  tag_concurrency_limits:
+    - key: "dagster/solid_selection"
+      limit: 2
+  max_user_code_failure_retries: 3
+  user_code_failure_retry_delay: 10
+  block_op_concurrency_limited_runs:
+    enabled: false

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_enabled_run_blocking.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_config/legacy_run_queue_enabled_run_blocking.yaml
@@ -1,0 +1,10 @@
+run_queue:
+  max_concurrent_runs: 5
+  tag_concurrency_limits:
+    - key: "dagster/solid_selection"
+      limit: 2
+  max_user_code_failure_retries: 3
+  user_code_failure_retry_delay: 10
+  block_op_concurrency_limited_runs:
+    enabled: true
+    op_concurrency_slot_buffer: 1

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -175,7 +175,7 @@ def test_run_queue_key():
 
     with instance_for_test(overrides={"run_queue": config}) as instance:
         assert isinstance(instance.run_coordinator, QueuedRunCoordinator)
-        run_queue_config = instance.get_run_queue_config()
+        run_queue_config = instance.get_concurrency_config().run_queue_config
         assert run_queue_config
         assert run_queue_config.max_concurrent_runs == 50
         assert run_queue_config.tag_concurrency_limits == tag_rules
@@ -190,7 +190,7 @@ def test_run_queue_key():
         }
     ) as instance:
         assert isinstance(instance.run_coordinator, QueuedRunCoordinator)
-        run_queue_config = instance.get_run_queue_config()
+        run_queue_config = instance.get_concurrency_config().run_queue_config
         assert run_queue_config
         assert run_queue_config.max_concurrent_runs == 50
         assert run_queue_config.tag_concurrency_limits == tag_rules
@@ -229,7 +229,7 @@ def test_run_coordinator_key():
         overrides={"run_queue": {"max_concurrent_runs": 50, "tag_concurrency_limits": tag_rules}}
     ) as instance:
         assert isinstance(instance.run_coordinator, QueuedRunCoordinator)
-        run_queue_config = instance.get_run_queue_config()
+        run_queue_config = instance.get_concurrency_config().run_queue_config
         assert run_queue_config
         assert run_queue_config.max_concurrent_runs == 50
         assert run_queue_config.tag_concurrency_limits == tag_rules

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_config.py
@@ -1,8 +1,7 @@
 import pytest
 from dagster import file_relative_path
 from dagster._core.errors import DagsterInvalidConfigError
-from dagster._core.instance.config import dagster_instance_config
-from dagster._core.run_coordinator.queued_run_coordinator import PoolGranularity
+from dagster._core.instance.config import PoolGranularity, dagster_instance_config
 from dagster._core.test_utils import environ, instance_for_test
 
 
@@ -21,12 +20,13 @@ def test_instance_yaml_config_not_set(config_filename, caplog):
         "merged_run_queue_concurrency.yaml",
     ),
 )
-def test_concurrency_config(config_filename, caplog):
+def test_concurrency_config(config_filename):
     base_dir = file_relative_path(__file__, "./test_config")
     with environ({"DAGSTER_HOME": base_dir}):
         instance_config, _ = dagster_instance_config(base_dir, config_filename)
         with instance_for_test(overrides=instance_config) as instance:
-            run_queue_config = instance.get_run_queue_config()
+            concurrency_config = instance.get_concurrency_config()
+            run_queue_config = concurrency_config.run_queue_config
             assert run_queue_config
             assert run_queue_config.max_concurrent_runs == 5
             assert run_queue_config.tag_concurrency_limits == [
@@ -38,7 +38,8 @@ def test_concurrency_config(config_filename, caplog):
             assert run_queue_config.max_user_code_failure_retries == 3
             assert run_queue_config.user_code_failure_retry_delay == 10
             assert run_queue_config.op_concurrency_slot_buffer == 1
-            assert run_queue_config.pool_granularity == PoolGranularity.RUN
+            assert run_queue_config.should_block_op_concurrency_limited_runs
+            assert concurrency_config.pool_config.pool_granularity == PoolGranularity.RUN
 
 
 @pytest.mark.parametrize(
@@ -48,8 +49,81 @@ def test_concurrency_config(config_filename, caplog):
         "error_run_queue_concurrency_mismatch.yaml",
     ),
 )
-def test_concurrency_config_mismatch(config_filename, caplog):
+def test_concurrency_config_mismatch(config_filename):
     base_dir = file_relative_path(__file__, "./test_config")
     with environ({"DAGSTER_HOME": base_dir}):
         with pytest.raises(DagsterInvalidConfigError, match="the `concurrency > "):
             dagster_instance_config(base_dir, config_filename)
+
+
+def test_legacy_concurrency_enabled_run_blocking():
+    base_dir = file_relative_path(__file__, "./test_config")
+    with environ({"DAGSTER_HOME": base_dir}):
+        instance_config, _ = dagster_instance_config(
+            base_dir, "legacy_run_queue_enabled_run_blocking.yaml"
+        )
+        with instance_for_test(overrides=instance_config) as instance:
+            concurrency_config = instance.get_concurrency_config()
+            run_queue_config = concurrency_config.run_queue_config
+            assert run_queue_config
+            assert run_queue_config.max_concurrent_runs == 5
+            assert run_queue_config.tag_concurrency_limits == [
+                {
+                    "key": "dagster/solid_selection",
+                    "limit": 2,
+                }
+            ]
+            assert run_queue_config.max_user_code_failure_retries == 3
+            assert run_queue_config.user_code_failure_retry_delay == 10
+            assert run_queue_config.op_concurrency_slot_buffer == 1
+            assert run_queue_config.should_block_op_concurrency_limited_runs
+            assert concurrency_config.pool_config.pool_granularity == PoolGranularity.OP
+
+
+def test_legacy_run_queue_disabled_run_blocking():
+    base_dir = file_relative_path(__file__, "./test_config")
+    with environ({"DAGSTER_HOME": base_dir}):
+        instance_config, _ = dagster_instance_config(
+            base_dir, "legacy_run_queue_disabled_run_blocking.yaml"
+        )
+        with instance_for_test(overrides=instance_config) as instance:
+            concurrency_config = instance.get_concurrency_config()
+            run_queue_config = concurrency_config.run_queue_config
+            assert run_queue_config
+            assert run_queue_config.max_concurrent_runs == 5
+            assert run_queue_config.tag_concurrency_limits == [
+                {
+                    "key": "dagster/solid_selection",
+                    "limit": 2,
+                }
+            ]
+            assert run_queue_config.max_user_code_failure_retries == 3
+            assert run_queue_config.user_code_failure_retry_delay == 10
+            assert run_queue_config.op_concurrency_slot_buffer == 0
+            assert not run_queue_config.should_block_op_concurrency_limited_runs
+            assert concurrency_config.pool_config.pool_granularity is None
+
+
+def test_legacy_run_queue_default_run_blocking():
+    base_dir = file_relative_path(__file__, "./test_config")
+    with environ({"DAGSTER_HOME": base_dir}):
+        instance_config, _ = dagster_instance_config(
+            base_dir, "legacy_run_queue_default_run_blocking.yaml"
+        )
+        with instance_for_test(overrides=instance_config) as instance:
+            concurrency_config = instance.get_concurrency_config()
+            run_queue_config = concurrency_config.run_queue_config
+            assert run_queue_config
+            assert run_queue_config.max_concurrent_runs == 5
+            assert run_queue_config.tag_concurrency_limits == [
+                {
+                    "key": "dagster/solid_selection",
+                    "limit": 2,
+                }
+            ]
+            assert run_queue_config.max_user_code_failure_retries == 3
+            assert run_queue_config.user_code_failure_retry_delay == 10
+            assert run_queue_config.op_concurrency_slot_buffer == 0
+            # should change this with the 1.10.0 major release
+            assert not run_queue_config.should_block_op_concurrency_limited_runs
+            assert concurrency_config.pool_config.pool_granularity is None


### PR DESCRIPTION
## Summary & Motivation
Creates a new concurrency config typed object, to carry config from settings into the queued run coordinator, and into the graphql layer.

Separates it out from the existing `RunQueueConfig` since it can now carry settings that control concurrency at the op level, not just the run level.

## How I Tested These Changes
BK

