### PR TITLE
[docs] Explain TTL defaults, scope TTL example to branch & full

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/management/settings/customizing-agent-settings.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/management/settings/customizing-agent-settings.md
@@ -19,6 +19,8 @@ For [Kubernetes agents](/dagster-plus/deployment/deployment-types/hybrid/kuberne
 
 User code servers support a configurable time-to-live (TTL). The agent will spin down any user code servers that haven't served requests recently and will spin them back up the next time they're needed. Configuring TTL can save compute cost because user code servers will spend less time sitting idle.
 
+TTL is disabled by default for full deployments, and can be configured separately for full and [branch deployments](/dagster-plus/managing-deployments/branch-deployments). TTL defaults to 24 hours for both full and branch deployments.
+
 To configure TTL:
 ```yaml
 # dagster.yaml
@@ -36,8 +38,11 @@ user_code_launcher:
   class: DockerUserCodeLauncher
   config:
     server_ttl:
-      enabled: true
-      ttl_seconds: 7200 #2 hours
+      full_deployments:
+        enabled: true # Disabled by default for full deployments
+        ttl_seconds: 7200 # 2 hours
+      branch_deployments:
+        ttl_seconds: 3600 # 1 hour
 ```
 
 ## Streaming compute logs


### PR DESCRIPTION
## Summary

Updates our docs to match the most current TTL configuration format, and explain default TTL values.
