### PR TITLE
defer merging legacy concurrency tag with pools until after snapshot

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -297,8 +297,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     @property
     def pool(self) -> Optional[str]:
         """Optional[str]: The concurrency pool for this op."""
-        # fallback to fetching from tags for backwards compatibility
-        return self._pool if self._pool else self.tags.get(GLOBAL_CONCURRENCY_TAG)
+        return self._pool
 
     @property
     def pools(self) -> Set[str]:
@@ -601,8 +600,6 @@ def _is_result_object_type(ttype):
 
 
 def _validate_pool(pool, tags):
-    from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
-
     check.opt_str_param(pool, "pool")
     tags = check.opt_mapping_param(tags, "tags")
     tag_concurrency_key = tags.get(GLOBAL_CONCURRENCY_TAG)
@@ -614,8 +611,5 @@ def _validate_pool(pool, tags):
     if pool:
         preview_warning("Pools")
         return pool
-
-    if tag_concurrency_key:
-        return tag_concurrency_key
 
     return None

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -23,13 +23,18 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode, RetryState
-from dagster._core.storage.tags import PRIORITY_TAG
+from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG, PRIORITY_TAG
 from dagster._utils.interrupts import pop_captured_interrupt
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
 
 def _default_sort_key(step: ExecutionStep) -> float:
     return int(step.tags.get(PRIORITY_TAG, 0)) * -1
+
+
+def _pool_key_for_step(step: ExecutionStep) -> Optional[str]:
+    # for backwards compatibility, we also check the tags
+    return step.pool or step.tags.get(GLOBAL_CONCURRENCY_TAG)
 
 
 CONCURRENCY_CLAIM_BLOCKED_INTERVAL = 1
@@ -339,13 +344,16 @@ class ActiveExecution:
                 run_scoped_concurrency_limits_counter.update_counters_with_launched_item(step)
 
             # fallback to fetching from tags for backwards compatibility
-            if step.pool and self._instance_concurrency_context:
+            concurrency_key = _pool_key_for_step(step)
+            if concurrency_key and self._instance_concurrency_context:
                 try:
                     step_priority = int(step.tags.get(PRIORITY_TAG, 0))
                 except ValueError:
                     step_priority = 0
 
-                if not self._instance_concurrency_context.claim(step.pool, step.key, step_priority):
+                if not self._instance_concurrency_context.claim(
+                    concurrency_key, step.key, step_priority
+                ):
                     continue
 
             batch.append(step)
@@ -642,7 +650,7 @@ class ActiveExecution:
             ):
                 step = self.get_step_by_key(step_key)
                 step_context = plan_context.for_step(step)
-                pool = check.inst(step.pool, str)
+                pool = check.inst(_pool_key_for_step(step), str)
                 self._messaged_concurrency_slots[step_key] = time.time()
                 is_initial_message = last_messaged_timestamp is None
                 yield DagsterEvent.step_concurrency_blocked(

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import dagster._check as check
 from dagster._core.instance import DagsterInstance
 from dagster._core.run_coordinator.queued_run_coordinator import PoolGranularity
-from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
+from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot, ExecutionStepSnap
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
@@ -14,10 +14,19 @@ from dagster._core.storage.dagster_run import (
     RunOpConcurrency,
     RunRecord,
 )
+from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 from dagster._time import get_current_timestamp
 
 if TYPE_CHECKING:
     from dagster._utils.concurrency import ConcurrencyKeyInfo
+
+
+def _pool_key_for_step(step: ExecutionStepSnap) -> Optional[str]:
+    if step.pool is not None:
+        return step.pool
+
+    # for backwards compatibility, we also check the tags
+    return (step.tags or {}).get(GLOBAL_CONCURRENCY_TAG)
 
 
 def compute_run_op_concurrency_info_for_snapshot(
@@ -29,26 +38,29 @@ def compute_run_op_concurrency_info_for_snapshot(
     root_step_keys = set(
         [step_key for step_key, deps in plan_snapshot.step_deps.items() if not deps]
     )
-    root_pool_counts: Mapping[str, int] = defaultdict(int)
+    root_key_counts: Mapping[str, int] = defaultdict(int)
     all_pools: set[str] = set()
     has_unconstrained_root_nodes = False
     for step in plan_snapshot.steps:
-        if step.pool is None and step.key in root_step_keys:
+        step_pool = _pool_key_for_step(step)
+        if step_pool is None and step.key in root_step_keys:
             has_unconstrained_root_nodes = True
-        elif step.pool is None:
+        elif step_pool is None:
             continue
         elif step.key in root_step_keys:
-            root_pool_counts[step.pool] += 1
-            all_pools.add(step.pool)
+            root_key_counts[step_pool] += 1
+            if step_pool is not None:
+                all_pools.add(step_pool)
         else:
-            all_pools.add(step.pool)
+            if step_pool is not None:
+                all_pools.add(step_pool)
 
     if len(all_pools) == 0:
         return None
 
     return RunOpConcurrency(
         all_pools=all_pools,
-        root_key_counts=dict(root_pool_counts),
+        root_key_counts=dict(root_key_counts),
         has_unconstrained_root_nodes=has_unconstrained_root_nodes,
     )
 


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/27250 addressed the snapshot stability issue when concurrency keys are not specified on any ops.  

This PR changes it so that the new `pool` snapshot field is not available using the legacy tag-based API (specifying `dagster/concurrency_key` either.  Previously, we coalesced both the tag and the `pool` argument into the pool property at the definition level.  Now, we keep both separate and rely on the consumer (graphql / run coordinator / executor) to be aware of the appropriate changes.

## How I Tested These Changes
BK