### PR TITLE
[components] Make dg component-type list output a table with colors (BUILD-637)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Any
 
 import click
+from rich.console import Console
+from rich.table import Table
 
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
@@ -152,8 +154,11 @@ def component_type_list(context: click.Context, **global_options: object) -> Non
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
+
+    table = Table(border_style="dim")
+    table.add_column("Component Type", style="bold cyan", no_wrap=True)
+    table.add_column("Summary")
     for key in sorted(registry.global_keys()):
-        click.echo(key)
-        component_type = registry.get_global(key)
-        if component_type.summary:
-            click.echo(f"    {component_type.summary}")
+        table.add_row(key, registry.get_global(key).summary)
+    console = Console()
+    console.print(table)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -301,13 +301,15 @@ def test_component_type_info_multiple_flags_fails() -> None:
 # ########################
 
 _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
-    dagster_components.test.all_metadata_empty_asset
-    dagster_components.test.complex_schema_asset
-        An asset that has a complex params schema.
-    dagster_components.test.simple_asset
-        A simple asset that returns a constant string value.
-    dagster_components.test.simple_pipes_script_asset
-        A simple asset that runs a Python script with the Pipes subprocess client.
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ Component Type                                    ┃ Summary                                                          ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ dagster_components.test.all_metadata_empty_asset  │                                                                  │
+    │ dagster_components.test.complex_schema_asset      │ An asset that has a complex params schema.                       │
+    │ dagster_components.test.simple_asset              │ A simple asset that returns a constant string value.             │
+    │ dagster_components.test.simple_pipes_script_asset │ A simple asset that runs a Python script with the Pipes          │
+    │                                                   │ subprocess client.                                               │
+    └───────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┘
 """).strip()
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -187,30 +187,27 @@ def test_dynamic_subcommand_help_message():
         assert _match_output(
             result.output.strip(),
             textwrap.dedent("""
-                 Usage: dg component scaffold [GLOBAL OPTIONS]                                  
-                 dagster_components.test.simple_pipes_script_asset [OPTIONS] COMPONENT_NAME     
-                                                                                                
-                ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-                │ *    component_name      TEXT  [required]                                    │
-                ╰──────────────────────────────────────────────────────────────────────────────╯
-                ╭─ Options ────────────────────────────────────────────────────────────────────╮
-                │ --json-params          TEXT  JSON string of component parameters.            │
-                │ --asset-key            TEXT  asset_key                                       │
-                │ --filename             TEXT  filename                                        │
-                │ --help         -h            Show this message and exit.                     │
-                ╰──────────────────────────────────────────────────────────────────────────────╯
-                ╭─ Global options ─────────────────────────────────────────────────────────────╮
-                │ --cache-dir                                      PATH  Specify a directory   │
-                │                                                        to use for the cache. │
-                │ --disable-cache                                        Disable the cache..   │
-                │ --verbose                                              Enable verbose output │
-                │                                                        for debugging.        │
-                │ --builtin-component-…                            TEXT  Specify a builitin    │
-                │                                                        component library to  │
-                │                                                        use.                  │
-                │ --use-dg-managed-env…    --no-use-dg-managed…          Enable management of  │
-                │                                                        the virtual           │
-                │                                                        environment with uv.  │
-                ╰──────────────────────────────────────────────────────────────────────────────╯
+
+                 Usage: dg component scaffold [GLOBAL OPTIONS] dagster_components.test.simple_pipes_script_asset [OPTIONS]              
+                 COMPONENT_NAME                                                                                                         
+                                                                                                                                        
+                ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ *    component_name      TEXT  [required]                                                                            │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ --json-params          TEXT  JSON string of component parameters.                                                    │
+                │ --asset-key            TEXT  asset_key                                                                               │
+                │ --filename             TEXT  filename                                                                                │
+                │ --help         -h            Show this message and exit.                                                             │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ --cache-dir                                                        PATH  Specify a directory to use for the cache.   │
+                │ --disable-cache                                                          Disable the cache..                         │
+                │ --verbose                                                                Enable verbose output for debugging.        │
+                │ --builtin-component-lib                                            TEXT  Specify a builitin component library to     │
+                │                                                                          use.                                        │
+                │ --use-dg-managed-environment    --no-use-dg-managed-environment          Enable management of the virtual            │
+                │                                                                          environment with uv.                        │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
         """).strip(),
         )

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -39,6 +39,7 @@ setup(
         "markdown",
         "jsonschema",
         "PyYAML>=5.1",
+        "rich",
         "typer",
     ],
     include_package_data=True,


### PR DESCRIPTION
## Summary & Motivation

Linear: https://linear.app/dagster-labs/issue/BUILD-637/generate-a-table-output-for-dg-component-type-list

Changes the output of `dg component-type list` to be a table. Uses the `rich` library (which is already a dependency of `typer`). Probably we will eventually completely remove the `typer` dependency and just use `rich` directly to style all output.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/1c257d58-48ff-4a40-b3e7-72c825663a49.png)

## How I Tested These Changes

Adjusted existing tests.