### PR TITLE
[components] Add a summary to all published components (BUILD-634)

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -187,6 +187,9 @@ class ComponentTypeRegistry:
     def keys(self) -> Iterable[str]:
         return self._component_types.keys()
 
+    def items(self) -> Iterable[tuple[str, type[Component]]]:
+        return self._component_types.items()
+
     def __repr__(self) -> str:
         return f"<ComponentRegistry {list(self._component_types.keys())}>"
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -37,6 +37,8 @@ class DbtProjectParams(BaseModel):
 
 @component_type(name="dbt_project")
 class DbtProjectComponent(Component):
+    """Expose a DBT project to Dagster as a set of assets."""
+
     def __init__(
         self,
         dbt_resource: DbtCliResource,

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
@@ -20,6 +20,8 @@ class DefinitionsParamSchema(BaseModel):
 
 @component_type(name="definitions")
 class DefinitionsComponent(Component):
+    """Wraps an arbitrary set of Dagster definitions."""
+
     def __init__(self, definitions_path: Path):
         self.definitions_path = definitions_path
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -39,6 +39,8 @@ class SlingReplicationCollectionParams(BaseModel):
 
 @component_type(name="sling_replication_collection")
 class SlingReplicationCollectionComponent(Component):
+    """Expose one or more Sling replications to Dagster as assets."""
+
     def __init__(
         self,
         dirpath: Path,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
@@ -111,6 +111,16 @@ def test_components_from_dagster():
         assert "dagster_components.sling_replication_collection" in component_types
 
 
+def test_all_dagster_components_have_defined_summary():
+    from dagster_components import ComponentTypeRegistry
+
+    registry = ComponentTypeRegistry.from_entry_point_discovery()
+    for component_name, component_type in registry.items():
+        assert component_type.get_metadata()[
+            "summary"
+        ], f"Component {component_name} has no summary defined"
+
+
 # Our pyproject.toml installs local dagster components
 DAGSTER_FOO_PYPROJECT_TOML = """
 [build-system]


### PR DESCRIPTION
## Summary & Motivation
Introduced docstring summaries for published component types. This change ensures all components have proper documentation and enables better component type inspection.

## How I Tested These Changes

- Added a new test `test_all_dagster_components_have_defined_summary` to verify all components have defined summaries