### PR TITLE
[components] Add dagster-components to install_dev_python_modules script

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -67,6 +67,7 @@ def main(
         "python_modules/libraries/dagster-azure",
         "python_modules/libraries/dagster-celery",
         "python_modules/libraries/dagster-celery-docker",
+        "python_modules/libraries/dagster-components",
         "python_modules/libraries/dagster-dask[yarn,pbs,kube]",
         "python_modules/libraries/dagster-databricks",
         "python_modules/libraries/dagster-datadog",


### PR DESCRIPTION
## Summary & Motivation

Make sure `dagster-components` gets installed when rebuild dev env.