### PR TITLE
Add support for optional location names in modules list in `pyproject…

### DIFF
--- a/docs/docs-beta/docs/guides/deploy/code-locations/managing-code-locations-with-definitions.md
+++ b/docs/docs-beta/docs/guides/deploy/code-locations/managing-code-locations-with-definitions.md
@@ -121,7 +121,10 @@ You can also include multiple modules at a time using the `pyproject.toml` file,
 
 ```toml
 [tool.dagster]
-modules = [{ type = "module", name = "foo" }, { type = "module", name = "bar" }]
+modules = [
+    { type = "module", name = "foo.definitions", location_name = "Foo" },
+    { type = "module", name = "bar.definitions", location_name = "Bar" },
+]
 ```
 
 </TabItem>

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -77,6 +77,9 @@ def is_valid_modules_list(modules: list[dict[str, str]]) -> bool:
             raise ValueError(f"Dictionary at index {index} does not contain the key 'name'.")
         if not isinstance(item["name"], str):
             raise ValueError(f"The 'name' value in dictionary at index {index} is not a string.")
+        # location_name is optional key
+        if "location_name" in item and not isinstance(item["location_name"], str):
+            raise ValueError(f"The 'location_name' value in dictionary at index {index} is not a string.")
 
     return True
 
@@ -102,7 +105,7 @@ def get_origins_from_toml(
                 location_name=dagster_block.get("code_location_name"),
             ).create_origins()
         elif "modules" in dagster_block and is_valid_modules_list(dagster_block.get("modules")):
-            origins = []
+            origins: list[ManagedGrpcPythonEnvCodeLocationOrigin] = []
             for module in dagster_block.get("modules"):
                 if module.get("type") == "module":
                     origins.extend(
@@ -110,7 +113,7 @@ def get_origins_from_toml(
                             module_name=module.get("name"),
                             attribute=None,
                             working_directory=os.getcwd(),
-                            location_name=dagster_block.get("code_location_name"),
+                            location_name=module.get("location_name"),
                         ).create_origins()
                     )
             return origins

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/multiple_modules.toml
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/multiple_modules.toml
@@ -1,5 +1,5 @@
 [tool.dagster]
 modules = [
     { type = "module", name = "foo" },
-    { type = "module", name = "bar" }
+    { type = "module", name = "bar", location_name = "optional display name" }
 ]  ## names of project's Python modules

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -29,12 +29,15 @@ def test_load_multiple_modules_from_toml():
     origins = get_origins_from_toml(file_relative_path(__file__, "multiple_modules.toml"))
     assert len(origins) == 2
 
-    module_names = {origin.loadable_target_origin.module_name for origin in origins}
-    expected_module_names = {"foo", "bar"}
+    expected_modules = {
+        "foo": {"location_name": "foo"},
+        "bar": {"location_name": "optional display name"},
+    }
 
-    assert module_names == expected_module_names
     for origin in origins:
-        assert origin.location_name in expected_module_names
+        module_name = origin.loadable_target_origin.module_name
+        assert module_name in expected_modules
+        assert origin.location_name == expected_modules[module_name]["location_name"]
 
 
 def test_load_mixed_modules_and_module_name_from_toml():


### PR DESCRIPTION
## Summary & Motivation

PR #22327 introduced the option to define multiple code locations for local development directly in the `pyproject.toml` file.

I would like to have the ability to add a code location name for each module as well, e.g. like this:
```toml
[tool.dagster]
modules = [
    { type = "module", name = "module_a.definitions", location_name = "Module A" },
    { type = "module", name = "module_b.definitions", location_name = "Module B" },
]
```
The key `location_name` is added as new optional parameter.

## How I Tested These Changes

Added test case, which covers `location_name` as optional parameter in `dagster_tests/cli_tests/test_toml_loading.py`.

## Changelog

* Modified `is_valid_modules_list` to check that optional key location_name is a string (`load_target.py`)
* Modified `get_origins_from_toml` to read optional key location_name (`load_target.py`)
* Modified `multiple_modules.toml` and `test_load_multiple_modules_from_toml` to verify reading the optional location name as expected (`test_toml_loading.py`)
* Updated example of loading multiple modules with location name in documentation (`managing-code-locations-with-definitions.md`)
