### PR TITLE
[components] Provide good error message if dagster-components is not available (BUILD-633)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
@@ -110,9 +110,7 @@ def code_location_scaffold_command(
 def code_location_list_command(context: click.Context, **global_options: object) -> None:
     """List code locations in the current deployment."""
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
-    if not dg_context.is_deployment:
-        exit_with_error("This command must be run inside a Dagster deployment directory.")
+    dg_context = DgContext.for_deployment_environment(Path.cwd(), cli_config)
 
     for code_location in dg_context.get_code_location_names():
         click.echo(code_location)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -184,9 +184,7 @@ def _create_component_scaffold_subcommand(
         It is an error to pass both --json-params and key-value pairs as options.
         """
         cli_config = get_config_from_cli_context(cli_context)
-        dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
-        if not dg_context.is_code_location:
-            exit_with_error("This command must be run inside a Dagster code location directory.")
+        dg_context = DgContext.for_code_location_environment(Path.cwd(), cli_config)
 
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
         if not registry.has_global(component_key):
@@ -245,9 +243,7 @@ def _create_component_scaffold_subcommand(
 def component_list_command(context: click.Context, **global_options: object) -> None:
     """List Dagster component instances defined in the current code location."""
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
-    if not dg_context.is_code_location:
-        exit_with_error("This command must be run inside a Dagster code location directory.")
+    dg_context = DgContext.for_code_location_environment(Path.cwd(), cli_config)
 
     for component_name in dg_context.get_component_names():
         click.echo(component_name)
@@ -284,9 +280,7 @@ def component_check_command(
     top_level_component_validator = Draft202012Validator(schema=COMPONENT_FILE_SCHEMA)
 
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
-    if not dg_context.is_code_location:
-        exit_with_error("This command must be run inside a Dagster code location directory.")
+    dg_context = DgContext.for_code_location_environment(Path.cwd(), cli_config)
 
     validation_errors: list[tuple[Optional[str], ValidationError, ValueAndSourcePositionTree]] = []
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -39,9 +39,7 @@ def component_type_scaffold_command(
     will be placed in submodule `<code_location_name>.lib.<name>`.
     """
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
-    if not dg_context.is_code_location:
-        exit_with_error("This command must be run inside a Dagster code location directory.")
+    dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     full_component_name = f"{dg_context.root_package_name}.{name}"
     if registry.has_global(full_component_name):
@@ -66,7 +64,7 @@ def component_type_docs_command(
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     if not registry.has_global(component_type):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
@@ -96,7 +94,7 @@ def component_type_info_command(
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     if not registry.has_global(component_type):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
@@ -152,7 +150,7 @@ def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
 def component_type_list(context: click.Context, **global_options: object) -> None:
     """List registered Dagster components in the current code location environment."""
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 
     table = Table(border_style="dim")

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -12,9 +12,15 @@ from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import DgConfig, DgPartialConfig, load_dg_config_file
 from dagster_dg.error import DgError
 from dagster_dg.utils import (
+    MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE,
+    NOT_CODE_LOCATION_ERROR_MESSAGE,
+    NOT_COMPONENT_LIBRARY_ERROR_MESSAGE,
+    NOT_DEPLOYMENT_ERROR_MESSAGE,
     ensure_loadable_path,
+    exit_with_error,
     get_path_for_package,
     get_uv_command_env,
+    is_executable_available,
     is_package_installed,
     pushd,
 )
@@ -40,6 +46,49 @@ class DgContext:
         else:
             self._cache = DgCache.from_config(config)
         self.component_registry = RemoteComponentRegistry.empty()
+
+    @classmethod
+    def for_deployment_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
+        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+
+        # Commands that operate on a deployment need to be run inside a deployment context.
+        if not context.is_deployment:
+            exit_with_error(NOT_DEPLOYMENT_ERROR_MESSAGE)
+        return context
+
+    @classmethod
+    def for_code_location_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
+        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+
+        # Commands that operate on a code location need to be run (a) inside a code location
+        # context; and (b) with dagster-components available on $PATH.
+        if not context.is_code_location:
+            exit_with_error(NOT_CODE_LOCATION_ERROR_MESSAGE)
+        elif not is_executable_available("dagster-components"):
+            exit_with_error(MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE)
+        return context
+
+    @classmethod
+    def for_component_library_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
+        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+
+        # Commands that operate on a component library need to be run (a) inside a component
+        # library context; and (b) with dagster-components available on $PATH.
+        if not context.is_component_library:
+            exit_with_error(NOT_COMPONENT_LIBRARY_ERROR_MESSAGE)
+        elif not is_executable_available("dagster-components"):
+            exit_with_error(MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE)
+        return context
+
+    @classmethod
+    def for_defined_registry_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
+        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+
+        # Commands that access the component registry need to be run with dagster-components
+        # available on $PATH.
+        if not is_executable_available("dagster-components"):
+            exit_with_error(MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE)
+        return context
 
     @classmethod
     def from_config_file_discovery_and_cli_config(
@@ -233,3 +282,15 @@ class DgContext:
     @property
     def use_dg_managed_environment(self) -> bool:
         return self.config.use_dg_managed_environment and self.is_code_location
+
+    def validate_deployment_command_environment(self) -> None:
+        """Commands that operate on a deployment need to be run inside a deployment context."""
+        if not self.is_deployment:
+            exit_with_error(NOT_DEPLOYMENT_ERROR_MESSAGE)
+
+    def validate_registry_command_environment(self) -> None:
+        """Commands that access the component registry need to be run with dagster-components
+        available on $PATH.
+        """
+        if not is_executable_available("dagster-components"):
+            exit_with_error(MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -71,6 +71,13 @@ def test_component_check_outside_code_location_fails() -> None:
         assert "must be run inside a Dagster code location directory" in result.output
 
 
+def test_list_components_with_no_dagster_components_fails() -> None:
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        result = runner.invoke("component", "check", env={"PATH": "/dev/null"})
+        assert_runner_result(result, exit_0=False)
+        assert "Could not find the `dagster-components` executable" in result.output
+
+
 def test_component_check_succeeds_non_default_component_package() -> None:
     with (
         ProxyRunner.test() as runner,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
@@ -133,6 +133,19 @@ def test_component_scaffold_outside_code_location_fails() -> None:
         assert "must be run inside a Dagster code location directory" in result.output
 
 
+def test_component_scaffold_with_no_dagster_components_fails() -> None:
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        result = runner.invoke(
+            "component",
+            "scaffold",
+            "dagster_components.test.simple_pipes_script_asset",
+            "qux",
+            env={"PATH": "/dev/null"},
+        )
+        assert_runner_result(result, exit_0=False)
+        assert "Could not find the `dagster-components` executable" in result.output
+
+
 @pytest.mark.parametrize("in_deployment", [True, False])
 def test_component_scaffold_already_exists_fails(in_deployment: bool) -> None:
     with (
@@ -275,3 +288,10 @@ def test_list_components_command_outside_code_location_fails() -> None:
         result = runner.invoke("component", "list")
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster code location directory" in result.output
+
+
+def test_list_components_with_no_dagster_components_fails() -> None:
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        result = runner.invoke("component", "list", env={"PATH": "/dev/null"})
+        assert_runner_result(result, exit_0=False)
+        assert "Could not find the `dagster-components` executable" in result.output


### PR DESCRIPTION
## Summary & Motivation

Currently some `dagster-dg` commands fail with an ugly error message if `dagster-components` is not found on the path. This can happen if you are not using a dg-managed environment.

This PR runs a check for `dagster-components` on the path (when it is needed) and also does some refactoring of our validation code more generally.

Prior error message was an uncaught subprocess error (`dagster-components` not found) with a backtrace.

New error message:

```
Could not find the `dagster-components` executable on the system path.

The `dagster-components` executable is installed with the `dagster-components` PyPI package and is necessary for `dg` to interface with Python environments containing Dagster definitions. `dagster-components` is installed by default when a code location is scaffolded by `dg`. However, if you are using `dg` in a non-managed environment (either outside of a code location or using the `--no-use-dg-managed-environment` flag), you need to independently ensure `dagster-components` is installed.
```

## How I Tested These Changes

New unit tests.