### PR TITLE
[components] Add completion with auto-installation to dagster-dg (BUILD-563)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -48,16 +48,28 @@ def create_dg_cli():
         ),
         default=False,
     )
+    @click.option(
+        "--install-completion",
+        is_flag=True,
+        help="Automatically detect your shell and install a completion script for the `dg` command. This will append to your shell startup file.",
+        default=False,
+    )
     @click.version_option(__version__, "--version", "-v")
     @click.pass_context
     def group(
         context: click.Context,
+        install_completion: bool,
         clear_cache: bool,
         rebuild_component_registry: bool,
         **global_options: object,
     ):
         """CLI for working with Dagster components."""
-        if clear_cache and rebuild_component_registry:
+        if install_completion:
+            import dagster_dg.completion
+
+            dagster_dg.completion.install_completion(context)
+            context.exit(0)
+        elif clear_cache and rebuild_component_registry:
             exit_with_error("Cannot specify both --clear-cache and --rebuild-component-registry.")
         elif clear_cache:
             cli_config = normalize_cli_config(global_options, context)

--- a/python_modules/libraries/dagster-dg/dagster_dg/completion.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/completion.py
@@ -1,0 +1,45 @@
+import click
+import click.shell_completion
+import shellingham
+import typer._completion_shared
+
+from dagster_dg.utils import exit_with_error
+
+
+def install_completion(context: click.Context):
+    # Click on its own does not support automatic installation of completion scripts, but `typer`
+    # does. However, we don't use `typer` for our app, and the typer completion script is not the
+    # same as the click completion script (nor is it compatible with a pure-click app). But the
+    # typer automatic installation routine works for any completion script.
+    #
+    # Therefore, we:
+    #
+    # 1. Generate the click completion script and store it in a string.
+    # 2. Overwrite the typer completion script, stored in an internal dictionary, with the
+    #    click-generated one.
+    # 3. Call the typer installation routine, which will then install the click-generated script.
+    #
+    # This is obviously hacky and non-ideal, but it works and is probably superior to maintaining
+    # our own completion installation logic across shells.
+
+    shell, _ = shellingham.detect_shell()
+    comp_class = click.shell_completion.get_completion_class(shell)
+    if comp_class is None:
+        exit_with_error(f"Shell {shell} is not supported.")
+    else:
+        comp_inst = comp_class(
+            cli=context.command, ctx_args={}, prog_name="dg", complete_var="_DG_COMPLETE"
+        )
+        source = comp_inst.source()
+
+        # Overwrite typer's stored completion script with the click-generated one.
+        typer._completion_shared._completion_scripts[shell] = source  # noqa: SLF001
+
+        # Invoke typer's completion installation routine. It will install the click-generated
+        # script because we've injected it in the right place.
+        shell, path = typer._completion_shared.install(shell=shell, prog_name="dg")  # noqa: SLF001
+
+        # Notify the user.
+        click.secho(f"{shell} completion installed in {path}", fg="green")
+        click.echo("Completion will take effect once you restart the terminal")
+        context.exit(0)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_install_completion.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_install_completion.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+import shellingham
+from dagster_dg_tests.utils import ProxyRunner, assert_runner_result
+
+
+# It's quite difficult to have a true test of whether `install_completion` is working correctly,
+# because it modifies the home folder. Therefore we mock the actual installation routine here and
+# just ensure that the command executes and prints the correct output.
+def test_install_completion():
+    shell, _ = shellingham.detect_shell()
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        with patch("typer._completion_shared.install") as mock_install:
+            mock_install.return_value = shell, "/some/path"
+            result = runner.invoke("--install-completion")
+            assert_runner_result(result)
+            assert f"{shell} completion installed in /some/path" in result.output


### PR DESCRIPTION
## Summary & Motivation

This adds a CLI endpoint, `dg --install-completion`, to automatically install shell completion.

`click` provides functionality to generate completion scripts, but doesn't provide auto-installation functionality. `typer`, however, does provide auto-installation. But by default, it will only install it's own `typer`-compatible completion scripts, which aren't compatible with our plain-click application.

Nonetheless, there is nothing about `typer`'s shell auto-installation logic that is specific to the content of its completion scripts. Therefore, if we supply it with our own completion script (generated by click), it gets the job done. There isn't a public API to do this, so it required a little hackery, but it works well.

## How I Tested These Changes

Testing is quite challenging for this, since we are talking about functionality that is designed to permanently modify shell configuration. I did two things:

- Manually tested that it works for `bash` and `zsh` (it should also work for `fish` and powershell, but I'm not familiar with those), by running `dg --install-completion` in these respective shells and confirming that completion was working afterward.
- Wrote a basic unit test that mocks out the actual part that modifies shell config. This confirms that the command at least runs and provides the correct output, assuming the installation happened successfully.