### PR TITLE
Fix next step links in ETL pipeline documentation

### DIFF
--- a/docs/docs-beta/docs/etl-pipeline-tutorial/create-and-materialize-a-downstream-asset.md
+++ b/docs/docs-beta/docs/etl-pipeline-tutorial/create-and-materialize-a-downstream-asset.md
@@ -40,4 +40,4 @@ As you can see, the new `joined_data` asset looks a lot like our previous ones, 
 
 ## Next steps
 
-- Continue this tutorial with by [creating and materializing a partitioned asset](ensure-data-quality-with-asset-checks).
+- Continue this tutorial by [creating and materializing a partitioned asset](create-and-materialize-partitioned-asset).

--- a/docs/docs-beta/docs/etl-pipeline-tutorial/create-and-materialize-partitioned-asset.md
+++ b/docs/docs-beta/docs/etl-pipeline-tutorial/create-and-materialize-partitioned-asset.md
@@ -177,4 +177,4 @@ To materialize these assets:
 
 ## Next steps
 
-Now that we have the main assets in our ETL pipeline, its time to add [automation to our pipeline](automate-your-pipeline)
+- It is important to ensure the quality of your data. Continue this tutorial by creating a set of [asset checks](ensure-data-quality-with-asset-checks)

--- a/docs/docs-beta/docs/etl-pipeline-tutorial/ensure-data-quality-with-asset-checks.md
+++ b/docs/docs-beta/docs/etl-pipeline-tutorial/ensure-data-quality-with-asset-checks.md
@@ -15,7 +15,7 @@ In Dagster, you define [asset checks](/guides/test/asset-checks) like you define
 
 ## 1. Define an asset check
 
-In this case we want to create a check to identify if there are any rows in `joined_data` that are missing a value for `rep_name` or `product_name`. 
+In this case we want to create a check to identify if there are any rows in `joined_data` that are missing a value for `rep_name` or `product_name`.
 
 Copy the following code beneath the `joined_data` asset.
 
@@ -49,4 +49,4 @@ Asset checks will run when an asset is materialized, but asset checks can also b
 
 ## Next steps
 
-- Continue this tutorial with [Asset Checks](create-and-materialize-partitioned-asset)
+- Now that we have the main assets in our ETL pipeline, it's time to add [automation to our pipeline](automate-your-pipeline)


### PR DESCRIPTION
## Summary & Motivation
The next step links in the ETL tutorial are incorrect. This fixes the links and tweaks the wording.