### PR TITLE
Make list dags batchable

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
@@ -12,3 +12,5 @@ AIRFLOW_RUN_ID_METADATA_KEY = "dagster-airlift/airflow-run-id"
 DAG_RUN_ID_TAG_KEY = "dagster-airlift/airflow-dag-run-id"
 DAG_ID_TAG_KEY = "dagster-airlift/airflow-dag-id"
 TASK_ID_TAG_KEY = "dagster-airlift/airflow-task-id"
+
+SOURCE_CODE_METADATA_KEY = "Source Code"

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -23,6 +23,7 @@ DEFAULT_BATCH_TASK_RETRIEVAL_LIMIT = 100
 # This corresponds directly to the page_limit parameter on airflow's batch dag runs rest API.
 # Airflow dag run batch API: https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/get_dag_runs_batch
 DEFAULT_BATCH_DAG_RUNS_LIMIT = 100
+DEFAULT_DAG_LIST_LIMIT = 100
 SLEEP_SECONDS = 1
 
 
@@ -63,11 +64,13 @@ class AirflowInstance:
         name: str,
         batch_task_instance_limit: int = DEFAULT_BATCH_TASK_RETRIEVAL_LIMIT,
         batch_dag_runs_limit: int = DEFAULT_BATCH_DAG_RUNS_LIMIT,
+        dag_list_limit: int = DEFAULT_DAG_LIST_LIMIT,
     ) -> None:
         self.auth_backend = auth_backend
         self.name = check_valid_name(name)
         self.batch_task_instance_limit = batch_task_instance_limit
         self.batch_dag_runs_limit = batch_dag_runs_limit
+        self.dag_list_limit = dag_list_limit
 
     @property
     def normalized_name(self) -> str:
@@ -77,24 +80,30 @@ class AirflowInstance:
         return f"{self.auth_backend.get_webserver_url()}/api/v1"
 
     def list_dags(self) -> list["DagInfo"]:
-        response = self.auth_backend.get_session().get(
-            f"{self.get_api_url()}/dags", params={"limit": 1000}
-        )
-        if response.status_code == 200:
-            dags = response.json()
-            webserver_url = self.auth_backend.get_webserver_url()
-            return [
-                DagInfo(
-                    webserver_url=webserver_url,
-                    dag_id=dag["dag_id"],
-                    metadata=dag,
-                )
-                for dag in dags["dags"]
-            ]
-        else:
-            raise DagsterError(
-                f"Failed to fetch DAGs. Status code: {response.status_code}, Message: {response.text}"
+        dag_responses = []
+        webserver_url = self.auth_backend.get_webserver_url()
+        while True:
+            response = self.auth_backend.get_session().get(
+                f"{self.get_api_url()}/dags",
+                params={"limit": self.dag_list_limit, "offset": len(dag_responses)},
             )
+            if response.status_code == 200:
+                dags = response.json()
+                dag_responses.extend(
+                    DagInfo(
+                        webserver_url=webserver_url,
+                        dag_id=dag["dag_id"],
+                        metadata=dag,
+                    )
+                    for dag in dags["dags"]
+                )
+                if len(dags["dags"]) < self.dag_list_limit:
+                    break
+            else:
+                raise DagsterError(
+                    f"Failed to fetch DAGs. Status code: {response.status_code}, Message: {response.text}"
+                )
+        return dag_responses
 
     def list_variables(self) -> list[dict[str, Any]]:
         response = self.auth_backend.get_session().get(f"{self.get_api_url()}/variables")

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
 from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 
-from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY
+from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY, SOURCE_CODE_METADATA_KEY
 from dagster_airlift.core.airflow_instance import DagInfo
 
 
@@ -22,17 +22,17 @@ def dag_asset_metadata(dag_info: DagInfo) -> dict[str, Any]:
     }
 
 
-def peered_dag_asset_metadata(dag_info: DagInfo, source_code: str) -> Mapping[str, Any]:
+def peered_dag_asset_metadata(dag_info: DagInfo, source_code: Optional[str]) -> Mapping[str, Any]:
     metadata = dag_asset_metadata(dag_info)
     metadata[PEERED_DAG_MAPPING_METADATA_KEY] = [{"dag_id": dag_info.dag_id}]
-    # Attempt to retrieve source code from the DAG.
-    metadata["Source Code"] = MarkdownMetadataValue(
-        f"""
+    if source_code:
+        metadata[SOURCE_CODE_METADATA_KEY] = MarkdownMetadataValue(
+            f"""
 ```python
 {source_code}
 ```
-            """
-    )
+"""
+        )
     return metadata
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -11,6 +11,7 @@ from dagster import (
 from dagster._annotations import beta
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._core.definitions.external_asset import external_asset_from_spec
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 
 from dagster_airlift.core.airflow_defs_data import MappedAsset
 from dagster_airlift.core.airflow_instance import AirflowInstance
@@ -39,6 +40,7 @@ from dagster_airlift.core.utils import get_metadata_key, spec_iterator
 class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDefinitionsData]):
     airflow_instance: AirflowInstance
     mapped_assets: Sequence[MappedAsset]
+    source_code_retrieval_enabled: Optional[bool]
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS
     dag_selector_fn: Optional[Callable[[DagInfo], bool]] = None
 
@@ -51,6 +53,8 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=self.dag_selector_fn,
+            automapping_enabled=False,
+            source_code_retrieval_enabled=self.source_code_retrieval_enabled,
         )
 
     def defs_from_state(
@@ -72,6 +76,8 @@ def build_defs_from_airflow_instance(
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     dag_selector_fn: Optional[DagSelectorFn] = None,
+    source_code_retrieval_enabled: Optional[bool] = None,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> Definitions:
     """Builds a :py:class:`dagster.Definitions` object from an Airflow instance.
 
@@ -99,6 +105,8 @@ def build_defs_from_airflow_instance(
         event_transformer_fn (DagsterEventTransformerFn): A function that allows for modifying the Dagster events
             produced by the sensor.
         dag_selector_fn (Optional[DagSelectorFn]): A function that allows for filtering which DAGs assets are created for.
+        source_code_retrieval_enabled (Optional[bool]): Whether to retrieve source code for the Airflow DAGs. By default, source code is retrieved when the number of DAGs is under 50 for performance reasons. This setting overrides the default behavior.
+        default_sensor_status (Optional[DefaultSensorStatus]): The default status for the sensor. By default, the sensor will be enabled.
 
     Returns:
         Definitions: A :py:class:`dagster.Definitions` object containing the assets and sensor.
@@ -213,6 +221,7 @@ def build_defs_from_airflow_instance(
         airflow_instance=airflow_instance,
         mapped_assets=mapped_assets,
         dag_selector_fn=dag_selector_fn,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     mapped_and_constructed_assets = [
         *_apply_airflow_data_to_specs(mapped_assets, serialized_airflow_data),
@@ -231,6 +240,7 @@ def build_defs_from_airflow_instance(
                     airflow_instance=airflow_instance,
                     minimum_interval_seconds=sensor_minimum_interval_seconds,
                     event_transformer_fn=event_transformer_fn,
+                    default_sensor_status=default_sensor_status,
                 )
             ]
         ),
@@ -252,6 +262,8 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=None,
+            automapping_enabled=True,
+            source_code_retrieval_enabled=True,
         )
 
     def defs_from_state(
@@ -342,10 +354,13 @@ def replace_assets_in_defs(
 def enrich_airflow_mapped_assets(
     mapped_assets: Sequence[MappedAsset],
     airflow_instance: AirflowInstance,
+    source_code_retrieval_enabled: Optional[bool],
 ) -> Sequence[AssetsDefinition]:
     """Enrich Airflow-mapped assets with metadata from the provided :py:class:`AirflowInstance`."""
     serialized_data = AirflowInstanceDefsLoader(
-        airflow_instance=airflow_instance, mapped_assets=mapped_assets
+        airflow_instance=airflow_instance,
+        mapped_assets=mapped_assets,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     return list(_apply_airflow_data_to_specs(mapped_assets, serialized_data))
 
@@ -355,11 +370,13 @@ def load_airflow_dag_asset_specs(
     airflow_instance: AirflowInstance,
     mapped_assets: Optional[Sequence[MappedAsset]] = None,
     dag_selector_fn: Optional[DagSelectorFn] = None,
+    source_code_retrieval_enabled: Optional[bool] = None,
 ) -> Sequence[AssetSpec]:
     """Load asset specs for Airflow DAGs from the provided :py:class:`AirflowInstance`, and link upstreams from mapped assets."""
     serialized_data = AirflowInstanceDefsLoader(
         airflow_instance=airflow_instance,
         mapped_assets=mapped_assets or [],
         dag_selector_fn=dag_selector_fn,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     return list(spec_iterator(construct_dag_assets_defs(serialized_data)))

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from functools import cached_property
-from typing import AbstractSet, Any, NamedTuple  # noqa: UP035
+from typing import AbstractSet, Any, NamedTuple, Optional  # noqa: UP035
 
 from dagster import (
     AssetKey,
@@ -78,7 +78,7 @@ class SerializedDagData:
 
     dag_id: str
     dag_info: DagInfo
-    source_code: str
+    source_code: Optional[str]
     leaf_asset_keys: set[AssetKey]
     task_infos: Mapping[str, TaskInfo]
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -183,6 +183,7 @@ def test_produce_fetched_airflow_data() -> None:
         airflow_instance=instance,
         mapping_info=mapping_info,
         dag_selector_fn=None,
+        automapping_enabled=True,
     )
 
     assert len(fetched_airflow_data.mapping_info.mapped_task_asset_specs) == 1

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -773,6 +773,7 @@ def test_enrich() -> None:
     airflow_assets = enrich_airflow_mapped_assets(
         airflow_instance=make_instance({"dag": ["task"]}),
         mapped_assets=[spec],
+        source_code_retrieval_enabled=None,
     )
     assert len(airflow_assets) == 1
     assets_def = next(iter(airflow_assets))

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 from dagster_airlift.core import AirflowBasicAuthBackend, AirflowInstance
 
 from kitchen_sink.constants import AIRFLOW_BASE_URL, AIRFLOW_INSTANCE_NAME, PASSWORD, USERNAME
 
 
-def local_airflow_instance() -> AirflowInstance:
+def local_airflow_instance(name: Optional[str] = None) -> AirflowInstance:
     return AirflowInstance(
         auth_backend=AirflowBasicAuthBackend(
             webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
         ),
-        name=AIRFLOW_INSTANCE_NAME,
+        name=name or AIRFLOW_INSTANCE_NAME,
     )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
@@ -25,6 +25,7 @@ def build_full_automapped_defs() -> Definitions:
             task_defs("print_task", Definitions(assets=[the_print_asset])),
             task_defs("downstream_print_task", Definitions(assets=[the_downstream_print_asset])),
         ),
+        sensor_minimum_interval_seconds=1,
     )
 
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -79,6 +79,7 @@ def build_mapped_defs() -> Definitions:
     return build_defs_from_airflow_instance(
         airflow_instance=local_airflow_instance(),
         dag_selector_fn=lambda dag: not dag.dag_id.startswith("unmapped"),
+        sensor_minimum_interval_seconds=1,
         defs=Definitions.merge(
             dag_defs(
                 "print_dag",

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/observation_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/observation_defs.py
@@ -47,6 +47,7 @@ def build_mapped_defs() -> Definitions:
             ),
         ),
         event_transformer_fn=observations_from_materializations,
+        sensor_minimum_interval_seconds=1,
     )
 
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
@@ -14,4 +14,5 @@ defs = build_defs_from_airflow_instance(
         ),
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_first_code_location",
+    sensor_minimum_interval_seconds=1,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
@@ -14,4 +14,5 @@ defs = build_defs_from_airflow_instance(
         ),
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_second_code_location",
+    sensor_minimum_interval_seconds=1,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,4 +1,12 @@
+from typing import cast
+
 import requests
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.definitions.sensor_definition import build_sensor_context
+from dagster._core.test_utils import instance_for_test
+from dagster_airlift.constants import SOURCE_CODE_METADATA_KEY
+from dagster_airlift.core import build_defs_from_airflow_instance
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
 from kitchen_sink.airflow_instance import (
@@ -6,6 +14,7 @@ from kitchen_sink.airflow_instance import (
     AIRFLOW_INSTANCE_NAME,
     PASSWORD,
     USERNAME,
+    local_airflow_instance,
 )
 from pytest_mock import MockFixture
 
@@ -24,3 +33,67 @@ def test_configure_dag_list_limit(airflow_instance: None, mocker: MockFixture) -
     assert len(af_instance.list_dags()) == 16
     # 16 with actual results, 1 with no results
     assert spy.call_count == 17
+
+
+def change_dag_limit_source_code(limit: int) -> None:
+    import dagster_airlift.core.serialization.compute
+
+    dagster_airlift.core.serialization.compute.DEFAULT_MAX_NUM_DAGS_SOURCE_CODE_RETRIEVAL = limit
+
+
+def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
+    """Test that source code retrieval is disabled at scale."""
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance()
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY not in metadata
+
+    change_dag_limit_source_code(200)
+    # Also force re-retrieval of state by giving the airflow instance a different name.
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+    # If source code retrieval is explicitly enabled, we don't use the limit.
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=af_instance, source_code_retrieval_enabled=True
+    )
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+
+def test_sensor_iteration_multiple_batches(airflow_instance: None, mocker: MockFixture) -> None:
+    """Test that sensor iteration correctly retrieves all sensors when over batch limit."""
+    spy = mocker.spy(AirflowInstance, "get_dag_runs_batch")
+    af_instance = AirflowInstance(
+        auth_backend=AirflowBasicAuthBackend(
+            webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+        ),
+        name=AIRFLOW_INSTANCE_NAME,
+        # Set low list limit, force batched retrieval.
+        batch_dag_runs_limit=1,
+    )
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    # create a bunch of runs
+    for i in range(2):
+        run_id = af_instance.trigger_dag("simple_unproxied_dag")
+        af_instance.wait_for_run_completion(dag_id="simple_unproxied_dag", run_id=run_id)
+
+    assert defs.sensors
+    sensor_def = next(iter(defs.sensors))
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(instance=instance, definitions=defs)
+        result = sensor_def(ctx)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert spy.call_count == 2

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,0 +1,26 @@
+import requests
+from dagster_airlift.core.airflow_instance import AirflowInstance
+from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
+from kitchen_sink.airflow_instance import (
+    AIRFLOW_BASE_URL,
+    AIRFLOW_INSTANCE_NAME,
+    PASSWORD,
+    USERNAME,
+)
+from pytest_mock import MockFixture
+
+
+def test_configure_dag_list_limit(airflow_instance: None, mocker: MockFixture) -> None:
+    """Test that batch instance logic correctly retrieves all dags when over batch limit."""
+    spy = mocker.spy(requests.Session, "get")
+    af_instance = AirflowInstance(
+        auth_backend=AirflowBasicAuthBackend(
+            webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+        ),
+        name=AIRFLOW_INSTANCE_NAME,
+        # Set low list limit, force batched retrieval.
+        dag_list_limit=1,
+    )
+    assert len(af_instance.list_dags()) == 16
+    # 16 with actual results, 1 with no results
+    assert spy.call_count == 17


### PR DESCRIPTION
## Summary & Motivation
List dags API on `AirflowInstance` currently only retrieves the first batch of results. Change to receive all batches.

## How I Tested These Changes
New API test, ensured that live load works across multiple batches.

## Changelog
- [dagster-airlift] previously, if there were over the limit of dags retrieved in a single batch within the Airflow instance, we would not retrieve them all. This has been fixed.
