### PR TITLE
Change default sensor interval

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
@@ -12,3 +12,5 @@ AIRFLOW_RUN_ID_METADATA_KEY = "dagster-airlift/airflow-run-id"
 DAG_RUN_ID_TAG_KEY = "dagster-airlift/airflow-dag-run-id"
 DAG_ID_TAG_KEY = "dagster-airlift/airflow-dag-id"
 TASK_ID_TAG_KEY = "dagster-airlift/airflow-task-id"
+
+SOURCE_CODE_METADATA_KEY = "Source Code"

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
 from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 
-from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY
+from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY, SOURCE_CODE_METADATA_KEY
 from dagster_airlift.core.airflow_instance import DagInfo
 
 
@@ -22,17 +22,17 @@ def dag_asset_metadata(dag_info: DagInfo) -> dict[str, Any]:
     }
 
 
-def peered_dag_asset_metadata(dag_info: DagInfo, source_code: str) -> Mapping[str, Any]:
+def peered_dag_asset_metadata(dag_info: DagInfo, source_code: Optional[str]) -> Mapping[str, Any]:
     metadata = dag_asset_metadata(dag_info)
     metadata[PEERED_DAG_MAPPING_METADATA_KEY] = [{"dag_id": dag_info.dag_id}]
-    # Attempt to retrieve source code from the DAG.
-    metadata["Source Code"] = MarkdownMetadataValue(
-        f"""
+    if source_code:
+        metadata[SOURCE_CODE_METADATA_KEY] = MarkdownMetadataValue(
+            f"""
 ```python
 {source_code}
 ```
-            """
-    )
+"""
+        )
     return metadata
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -11,6 +11,7 @@ from dagster import (
 from dagster._annotations import beta
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._core.definitions.external_asset import external_asset_from_spec
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 
 from dagster_airlift.core.airflow_defs_data import MappedAsset
 from dagster_airlift.core.airflow_instance import AirflowInstance
@@ -39,6 +40,7 @@ from dagster_airlift.core.utils import get_metadata_key, spec_iterator
 class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDefinitionsData]):
     airflow_instance: AirflowInstance
     mapped_assets: Sequence[MappedAsset]
+    source_code_retrieval_enabled: Optional[bool]
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS
     dag_selector_fn: Optional[Callable[[DagInfo], bool]] = None
 
@@ -51,6 +53,8 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=self.dag_selector_fn,
+            automapping_enabled=False,
+            source_code_retrieval_enabled=self.source_code_retrieval_enabled,
         )
 
     def defs_from_state(
@@ -72,6 +76,8 @@ def build_defs_from_airflow_instance(
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     dag_selector_fn: Optional[DagSelectorFn] = None,
+    source_code_retrieval_enabled: Optional[bool] = None,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> Definitions:
     """Builds a :py:class:`dagster.Definitions` object from an Airflow instance.
 
@@ -99,6 +105,8 @@ def build_defs_from_airflow_instance(
         event_transformer_fn (DagsterEventTransformerFn): A function that allows for modifying the Dagster events
             produced by the sensor.
         dag_selector_fn (Optional[DagSelectorFn]): A function that allows for filtering which DAGs assets are created for.
+        source_code_retrieval_enabled (Optional[bool]): Whether to retrieve source code for the Airflow DAGs. By default, source code is retrieved when the number of DAGs is under 50 for performance reasons. This setting overrides the default behavior.
+        default_sensor_status (Optional[DefaultSensorStatus]): The default status for the sensor. By default, the sensor will be enabled.
 
     Returns:
         Definitions: A :py:class:`dagster.Definitions` object containing the assets and sensor.
@@ -213,6 +221,7 @@ def build_defs_from_airflow_instance(
         airflow_instance=airflow_instance,
         mapped_assets=mapped_assets,
         dag_selector_fn=dag_selector_fn,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     mapped_and_constructed_assets = [
         *_apply_airflow_data_to_specs(mapped_assets, serialized_airflow_data),
@@ -231,6 +240,7 @@ def build_defs_from_airflow_instance(
                     airflow_instance=airflow_instance,
                     minimum_interval_seconds=sensor_minimum_interval_seconds,
                     event_transformer_fn=event_transformer_fn,
+                    default_sensor_status=default_sensor_status,
                 )
             ]
         ),
@@ -252,6 +262,8 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=None,
+            automapping_enabled=True,
+            source_code_retrieval_enabled=True,
         )
 
     def defs_from_state(
@@ -342,10 +354,13 @@ def replace_assets_in_defs(
 def enrich_airflow_mapped_assets(
     mapped_assets: Sequence[MappedAsset],
     airflow_instance: AirflowInstance,
+    source_code_retrieval_enabled: Optional[bool],
 ) -> Sequence[AssetsDefinition]:
     """Enrich Airflow-mapped assets with metadata from the provided :py:class:`AirflowInstance`."""
     serialized_data = AirflowInstanceDefsLoader(
-        airflow_instance=airflow_instance, mapped_assets=mapped_assets
+        airflow_instance=airflow_instance,
+        mapped_assets=mapped_assets,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     return list(_apply_airflow_data_to_specs(mapped_assets, serialized_data))
 
@@ -355,11 +370,13 @@ def load_airflow_dag_asset_specs(
     airflow_instance: AirflowInstance,
     mapped_assets: Optional[Sequence[MappedAsset]] = None,
     dag_selector_fn: Optional[DagSelectorFn] = None,
+    source_code_retrieval_enabled: Optional[bool] = None,
 ) -> Sequence[AssetSpec]:
     """Load asset specs for Airflow DAGs from the provided :py:class:`AirflowInstance`, and link upstreams from mapped assets."""
     serialized_data = AirflowInstanceDefsLoader(
         airflow_instance=airflow_instance,
         mapped_assets=mapped_assets or [],
         dag_selector_fn=dag_selector_fn,
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
     ).get_or_fetch_state()
     return list(spec_iterator(construct_dag_assets_defs(serialized_data)))

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -53,7 +53,7 @@ from dagster_airlift.core.sensor.event_translation import (
 )
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
-DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 1
+DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 30
 START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -87,6 +87,7 @@ def build_airflow_polling_sensor(
     airflow_instance: AirflowInstance,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> SensorDefinition:
     """The constructed sensor polls the Airflow instance for activity, and inserts asset events into Dagster's event log.
 
@@ -114,7 +115,7 @@ def build_airflow_polling_sensor(
     @sensor(
         name=f"{airflow_data.airflow_instance.name}__airflow_dag_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,
-        default_status=DefaultSensorStatus.RUNNING,
+        default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
         # This sensor will only ever execute asset checks and not asset materializations.
         asset_selection=AssetSelection.all_asset_checks(),
     )
@@ -153,6 +154,7 @@ def build_airflow_polling_sensor(
         while get_current_datetime() - current_date < timedelta(seconds=MAIN_LOOP_TIMEOUT_SECONDS):
             batch_result = next(sensor_iter, None)
             if batch_result is None:
+                context.log.info("Received no batch result. Breaking.")
                 break
             all_asset_events.extend(batch_result.asset_events)
 
@@ -256,30 +258,50 @@ def materializations_and_requests_from_batch_iter(
     offset: int,
     airflow_data: AirflowDefinitionsData,
 ) -> Iterator[Optional[BatchResult]]:
-    runs = airflow_data.airflow_instance.get_dag_runs_batch(
-        dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
-        end_date_gte=datetime_from_timestamp(end_date_gte),
-        end_date_lte=datetime_from_timestamp(end_date_lte),
-        offset=offset,
-    )
-    context.log.info(f"Found {len(runs)} dag runs for {airflow_data.airflow_instance.name}")
-    context.log.info(f"All runs {runs}")
-    for i, dag_run in enumerate(runs):
-        mats = build_synthetic_asset_materializations(
-            context, airflow_data.airflow_instance, dag_run, airflow_data
+    total_processed_runs = 0
+    total_entries = 0
+    while True:
+        latest_offset = total_processed_runs + offset
+        runs, total_entries = airflow_data.airflow_instance.get_dag_runs_batch(
+            dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
+            end_date_gte=datetime_from_timestamp(end_date_gte),
+            end_date_lte=datetime_from_timestamp(end_date_lte),
+            offset=latest_offset,
         )
-        context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
-
-        all_asset_keys_materialized = {mat.asset_key for mat in mats}
-        yield (
-            BatchResult(
-                idx=i + offset,
-                asset_events=mats,
-                all_asset_keys_materialized=all_asset_keys_materialized,
+        if len(runs) == 0:
+            yield None
+            context.log.info("Received no runs. Breaking.")
+            break
+        context.log.info(
+            f"Processing {len(runs)}/{total_entries} dag runs for {airflow_data.airflow_instance.name}..."
+        )
+        for i, dag_run in enumerate(runs):
+            context.log.info(
+                f"dag ids: {[dag_id for dag_id in airflow_data.dag_ids_with_mapped_asset_keys]}"
             )
-            if mats
-            else None
+            mats = build_synthetic_asset_materializations(
+                context, airflow_data.airflow_instance, dag_run, airflow_data
+            )
+            context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
+
+            all_asset_keys_materialized = {mat.asset_key for mat in mats}
+            yield (
+                BatchResult(
+                    idx=i + latest_offset,
+                    asset_events=mats,
+                    all_asset_keys_materialized=all_asset_keys_materialized,
+                )
+                if mats
+                else None
+            )
+        total_processed_runs += len(runs)
+        context.log.info(
+            f"Processed {total_processed_runs}/{total_entries} dag runs for {airflow_data.airflow_instance.name}."
         )
+        if total_processed_runs == total_entries:
+            yield None
+            context.log.info("Processed all runs. Breaking.")
+            break
 
 
 def build_synthetic_asset_materializations(

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from functools import cached_property
-from typing import AbstractSet, Any, NamedTuple  # noqa: UP035
+from typing import AbstractSet, Any, NamedTuple, Optional  # noqa: UP035
 
 from dagster import (
     AssetKey,
@@ -78,7 +78,7 @@ class SerializedDagData:
 
     dag_id: str
     dag_info: DagInfo
-    source_code: str
+    source_code: Optional[str]
     leaf_asset_keys: set[AssetKey]
     task_infos: Mapping[str, TaskInfo]
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -183,6 +183,7 @@ def test_produce_fetched_airflow_data() -> None:
         airflow_instance=instance,
         mapping_info=mapping_info,
         dag_selector_fn=None,
+        automapping_enabled=True,
     )
 
     assert len(fetched_airflow_data.mapping_info.mapped_task_asset_specs) == 1

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -773,6 +773,7 @@ def test_enrich() -> None:
     airflow_assets = enrich_airflow_mapped_assets(
         airflow_instance=make_instance({"dag": ["task"]}),
         mapped_assets=[spec],
+        source_code_retrieval_enabled=None,
     )
     assert len(airflow_assets) == 1
     assets_def = next(iter(airflow_assets))

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 from dagster_airlift.core import AirflowBasicAuthBackend, AirflowInstance
 
 from kitchen_sink.constants import AIRFLOW_BASE_URL, AIRFLOW_INSTANCE_NAME, PASSWORD, USERNAME
 
 
-def local_airflow_instance() -> AirflowInstance:
+def local_airflow_instance(name: Optional[str] = None) -> AirflowInstance:
     return AirflowInstance(
         auth_backend=AirflowBasicAuthBackend(
             webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
         ),
-        name=AIRFLOW_INSTANCE_NAME,
+        name=name or AIRFLOW_INSTANCE_NAME,
     )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
@@ -25,6 +25,7 @@ def build_full_automapped_defs() -> Definitions:
             task_defs("print_task", Definitions(assets=[the_print_asset])),
             task_defs("downstream_print_task", Definitions(assets=[the_downstream_print_asset])),
         ),
+        sensor_minimum_interval_seconds=1,
     )
 
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -79,6 +79,7 @@ def build_mapped_defs() -> Definitions:
     return build_defs_from_airflow_instance(
         airflow_instance=local_airflow_instance(),
         dag_selector_fn=lambda dag: not dag.dag_id.startswith("unmapped"),
+        sensor_minimum_interval_seconds=1,
         defs=Definitions.merge(
             dag_defs(
                 "print_dag",

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/observation_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/observation_defs.py
@@ -47,6 +47,7 @@ def build_mapped_defs() -> Definitions:
             ),
         ),
         event_transformer_fn=observations_from_materializations,
+        sensor_minimum_interval_seconds=1,
     )
 
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/first_dag_defs.py
@@ -14,4 +14,5 @@ defs = build_defs_from_airflow_instance(
         ),
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_first_code_location",
+    sensor_minimum_interval_seconds=1,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_multi_code_locations/second_dag_defs.py
@@ -14,4 +14,5 @@ defs = build_defs_from_airflow_instance(
         ),
     ),
     dag_selector_fn=lambda dag_info: dag_info.dag_id == "dag_second_code_location",
+    sensor_minimum_interval_seconds=1,
 )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,4 +1,12 @@
+from typing import cast
+
 import requests
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.definitions.sensor_definition import build_sensor_context
+from dagster._core.test_utils import instance_for_test
+from dagster_airlift.constants import SOURCE_CODE_METADATA_KEY
+from dagster_airlift.core import build_defs_from_airflow_instance
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
 from kitchen_sink.airflow_instance import (
@@ -6,6 +14,7 @@ from kitchen_sink.airflow_instance import (
     AIRFLOW_INSTANCE_NAME,
     PASSWORD,
     USERNAME,
+    local_airflow_instance,
 )
 from pytest_mock import MockFixture
 
@@ -24,3 +33,67 @@ def test_configure_dag_list_limit(airflow_instance: None, mocker: MockFixture) -
     assert len(af_instance.list_dags()) == 16
     # 16 with actual results, 1 with no results
     assert spy.call_count == 17
+
+
+def change_dag_limit_source_code(limit: int) -> None:
+    import dagster_airlift.core.serialization.compute
+
+    dagster_airlift.core.serialization.compute.DEFAULT_MAX_NUM_DAGS_SOURCE_CODE_RETRIEVAL = limit
+
+
+def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
+    """Test that source code retrieval is disabled at scale."""
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance()
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY not in metadata
+
+    change_dag_limit_source_code(200)
+    # Also force re-retrieval of state by giving the airflow instance a different name.
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+    # If source code retrieval is explicitly enabled, we don't use the limit.
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=af_instance, source_code_retrieval_enabled=True
+    )
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+
+def test_sensor_iteration_multiple_batches(airflow_instance: None, mocker: MockFixture) -> None:
+    """Test that sensor iteration correctly retrieves all sensors when over batch limit."""
+    spy = mocker.spy(AirflowInstance, "get_dag_runs_batch")
+    af_instance = AirflowInstance(
+        auth_backend=AirflowBasicAuthBackend(
+            webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+        ),
+        name=AIRFLOW_INSTANCE_NAME,
+        # Set low list limit, force batched retrieval.
+        batch_dag_runs_limit=1,
+    )
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    # create a bunch of runs
+    for i in range(2):
+        run_id = af_instance.trigger_dag("simple_unproxied_dag")
+        af_instance.wait_for_run_completion(dag_id="simple_unproxied_dag", run_id=run_id)
+
+    assert defs.sensors
+    sensor_def = next(iter(defs.sensors))
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(instance=instance, definitions=defs)
+        result = sensor_def(ctx)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert spy.call_count == 2


### PR DESCRIPTION
## Summary & Motivation
Make the default sensor interval way slower. 1 second is incredibly aggressive for real life use cases.

## How I Tested These Changes
Existing tests
## Changelog
- [dagster-airlift] The default sensor interval on the airflow polling sensor has been brought down to 30 seconds.
