### PR TITLE
only retrieve task-level info for mapped dags

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/constants.py
@@ -12,3 +12,5 @@ AIRFLOW_RUN_ID_METADATA_KEY = "dagster-airlift/airflow-run-id"
 DAG_RUN_ID_TAG_KEY = "dagster-airlift/airflow-dag-run-id"
 DAG_ID_TAG_KEY = "dagster-airlift/airflow-dag-id"
 TASK_ID_TAG_KEY = "dagster-airlift/airflow-task-id"
+
+SOURCE_CODE_METADATA_KEY = "Source Code"

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
 from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 
-from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY
+from dagster_airlift.constants import PEERED_DAG_MAPPING_METADATA_KEY, SOURCE_CODE_METADATA_KEY
 from dagster_airlift.core.airflow_instance import DagInfo
 
 
@@ -22,17 +22,17 @@ def dag_asset_metadata(dag_info: DagInfo) -> dict[str, Any]:
     }
 
 
-def peered_dag_asset_metadata(dag_info: DagInfo, source_code: str) -> Mapping[str, Any]:
+def peered_dag_asset_metadata(dag_info: DagInfo, source_code: Optional[str]) -> Mapping[str, Any]:
     metadata = dag_asset_metadata(dag_info)
     metadata[PEERED_DAG_MAPPING_METADATA_KEY] = [{"dag_id": dag_info.dag_id}]
-    # Attempt to retrieve source code from the DAG.
-    metadata["Source Code"] = MarkdownMetadataValue(
-        f"""
+    if source_code:
+        metadata[SOURCE_CODE_METADATA_KEY] = MarkdownMetadataValue(
+            f"""
 ```python
 {source_code}
 ```
-            """
-    )
+"""
+        )
     return metadata
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -51,6 +51,7 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=self.dag_selector_fn,
+            automapping_enabled=False,
         )
 
     def defs_from_state(
@@ -252,6 +253,7 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
             airflow_instance=self.airflow_instance,
             mapped_assets=self.mapped_assets,
             dag_selector_fn=None,
+            automapping_enabled=True,
         )
 
     def defs_from_state(

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -87,6 +87,7 @@ def build_airflow_polling_sensor(
     airflow_instance: AirflowInstance,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> SensorDefinition:
     """The constructed sensor polls the Airflow instance for activity, and inserts asset events into Dagster's event log.
 
@@ -114,7 +115,7 @@ def build_airflow_polling_sensor(
     @sensor(
         name=f"{airflow_data.airflow_instance.name}__airflow_dag_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,
-        default_status=DefaultSensorStatus.RUNNING,
+        default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
         # This sensor will only ever execute asset checks and not asset materializations.
         asset_selection=AssetSelection.all_asset_checks(),
     )
@@ -153,6 +154,7 @@ def build_airflow_polling_sensor(
         while get_current_datetime() - current_date < timedelta(seconds=MAIN_LOOP_TIMEOUT_SECONDS):
             batch_result = next(sensor_iter, None)
             if batch_result is None:
+                context.log.info("Received no batch result. Breaking.")
                 break
             all_asset_events.extend(batch_result.asset_events)
 
@@ -256,30 +258,50 @@ def materializations_and_requests_from_batch_iter(
     offset: int,
     airflow_data: AirflowDefinitionsData,
 ) -> Iterator[Optional[BatchResult]]:
-    runs = airflow_data.airflow_instance.get_dag_runs_batch(
-        dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
-        end_date_gte=datetime_from_timestamp(end_date_gte),
-        end_date_lte=datetime_from_timestamp(end_date_lte),
-        offset=offset,
-    )
-    context.log.info(f"Found {len(runs)} dag runs for {airflow_data.airflow_instance.name}")
-    context.log.info(f"All runs {runs}")
-    for i, dag_run in enumerate(runs):
-        mats = build_synthetic_asset_materializations(
-            context, airflow_data.airflow_instance, dag_run, airflow_data
+    total_processed_runs = 0
+    total_entries = 0
+    while True:
+        latest_offset = total_processed_runs + offset
+        runs, total_entries = airflow_data.airflow_instance.get_dag_runs_batch(
+            dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
+            end_date_gte=datetime_from_timestamp(end_date_gte),
+            end_date_lte=datetime_from_timestamp(end_date_lte),
+            offset=latest_offset,
         )
-        context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
-
-        all_asset_keys_materialized = {mat.asset_key for mat in mats}
-        yield (
-            BatchResult(
-                idx=i + offset,
-                asset_events=mats,
-                all_asset_keys_materialized=all_asset_keys_materialized,
+        if len(runs) == 0:
+            yield None
+            context.log.info("Received no runs. Breaking.")
+            break
+        context.log.info(
+            f"Processing {len(runs)}/{total_entries} dag runs for {airflow_data.airflow_instance.name}..."
+        )
+        for i, dag_run in enumerate(runs):
+            context.log.info(
+                f"dag ids: {[dag_id for dag_id in airflow_data.dag_ids_with_mapped_asset_keys]}"
             )
-            if mats
-            else None
+            mats = build_synthetic_asset_materializations(
+                context, airflow_data.airflow_instance, dag_run, airflow_data
+            )
+            context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
+
+            all_asset_keys_materialized = {mat.asset_key for mat in mats}
+            yield (
+                BatchResult(
+                    idx=i + latest_offset,
+                    asset_events=mats,
+                    all_asset_keys_materialized=all_asset_keys_materialized,
+                )
+                if mats
+                else None
+            )
+        total_processed_runs += len(runs)
+        context.log.info(
+            f"Processed {total_processed_runs}/{total_entries} dag runs for {airflow_data.airflow_instance.name}."
         )
+        if total_processed_runs == total_entries:
+            yield None
+            context.log.info("Processed all runs. Breaking.")
+            break
 
 
 def build_synthetic_asset_materializations(

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -141,14 +141,22 @@ def fetch_all_airflow_data(
     airflow_instance: AirflowInstance,
     mapping_info: AirliftMetadataMappingInfo,
     dag_selector_fn: Optional[DagSelectorFn],
+    automapping_enabled: bool,
 ) -> FetchedAirflowData:
     dag_infos = {
         dag.dag_id: dag
         for dag in airflow_instance.list_dags()
         if dag_selector_fn is None or dag_selector_fn(dag)
     }
+    # To limit the number of API calls, only fetch task infos for the dags that we absolutely have to.
+    # Airflow has no batch API for fetching task infos, so we have to fetch them one dag
+    # at a time.
     task_info_map = defaultdict(dict)
-    for dag_id in dag_infos:
+    for dag_id in dag_infos.keys():
+        # Explicitly don't fetch task information for dags that have no mapped tasks,
+        # unless automapping is enabled.
+        if len(mapping_info.task_id_map[dag_id]) == 0 and not automapping_enabled:
+            continue
         task_info_map[dag_id] = {
             task_info.task_id: task_info
             for task_info in airflow_instance.get_task_infos(dag_id=dag_id)
@@ -165,9 +173,12 @@ def compute_serialized_data(
     airflow_instance: AirflowInstance,
     mapped_assets: Iterable["MappedAsset"],
     dag_selector_fn: Optional[DagSelectorFn],
+    automapping_enabled: bool,
 ) -> "SerializedAirflowDefinitionsData":
     mapping_info = build_airlift_metadata_mapping_info(mapped_assets)
-    fetched_airflow_data = fetch_all_airflow_data(airflow_instance, mapping_info, dag_selector_fn)
+    fetched_airflow_data = fetch_all_airflow_data(
+        airflow_instance, mapping_info, dag_selector_fn, automapping_enabled=automapping_enabled
+    )
     return SerializedAirflowDefinitionsData(
         instance_name=airflow_instance.name,
         key_scoped_task_handles=[

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -28,6 +28,8 @@ from dagster_airlift.core.utils import (
 if TYPE_CHECKING:
     from dagster_airlift.core.airflow_defs_data import MappedAsset
 
+
+DEFAULT_MAX_NUM_DAGS_SOURCE_CODE_RETRIEVAL = 50
 DagSelectorFn = Callable[[DagInfo], bool]
 
 
@@ -169,15 +171,27 @@ def fetch_all_airflow_data(
     )
 
 
+def infer_code_retrieval_enabled(
+    source_code_retrieval_enabled: Optional[bool], fetched_airflow_data: FetchedAirflowData
+) -> bool:
+    if source_code_retrieval_enabled is None:
+        return len(fetched_airflow_data.dag_infos) < DEFAULT_MAX_NUM_DAGS_SOURCE_CODE_RETRIEVAL
+    return source_code_retrieval_enabled
+
+
 def compute_serialized_data(
     airflow_instance: AirflowInstance,
     mapped_assets: Iterable["MappedAsset"],
     dag_selector_fn: Optional[DagSelectorFn],
     automapping_enabled: bool,
+    source_code_retrieval_enabled: Optional[bool],
 ) -> "SerializedAirflowDefinitionsData":
     mapping_info = build_airlift_metadata_mapping_info(mapped_assets)
     fetched_airflow_data = fetch_all_airflow_data(
         airflow_instance, mapping_info, dag_selector_fn, automapping_enabled=automapping_enabled
+    )
+    source_code_retrieval_enabled = infer_code_retrieval_enabled(
+        source_code_retrieval_enabled, fetched_airflow_data
     )
     return SerializedAirflowDefinitionsData(
         instance_name=airflow_instance.name,
@@ -193,7 +207,9 @@ def compute_serialized_data(
             dag_id: SerializedDagData(
                 dag_id=dag_id,
                 dag_info=dag_info,
-                source_code=airflow_instance.get_dag_source_code(dag_info.metadata["file_token"]),
+                source_code=airflow_instance.get_dag_source_code(dag_info.metadata["file_token"])
+                if source_code_retrieval_enabled
+                else None,
                 leaf_asset_keys=get_leaf_assets_for_dag(
                     asset_keys_in_dag=mapping_info.all_mapped_asset_keys_by_dag_id[dag_id],
                     downstreams_asset_dependency_graph=mapping_info.downstream_deps,

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from functools import cached_property
-from typing import AbstractSet, Any, NamedTuple  # noqa: UP035
+from typing import AbstractSet, Any, NamedTuple, Optional  # noqa: UP035
 
 from dagster import (
     AssetKey,
@@ -78,7 +78,7 @@ class SerializedDagData:
 
     dag_id: str
     dag_info: DagInfo
-    source_code: str
+    source_code: Optional[str]
     leaf_asset_keys: set[AssetKey]
     task_infos: Mapping[str, TaskInfo]
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -183,6 +183,7 @@ def test_produce_fetched_airflow_data() -> None:
         airflow_instance=instance,
         mapping_info=mapping_info,
         dag_selector_fn=None,
+        automapping_enabled=True,
     )
 
     assert len(fetched_airflow_data.mapping_info.mapped_task_asset_specs) == 1

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -773,6 +773,7 @@ def test_enrich() -> None:
     airflow_assets = enrich_airflow_mapped_assets(
         airflow_instance=make_instance({"dag": ["task"]}),
         mapped_assets=[spec],
+        source_code_retrieval_enabled=None,
     )
     assert len(airflow_assets) == 1
     assets_def = next(iter(airflow_assets))

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_instance.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 from dagster_airlift.core import AirflowBasicAuthBackend, AirflowInstance
 
 from kitchen_sink.constants import AIRFLOW_BASE_URL, AIRFLOW_INSTANCE_NAME, PASSWORD, USERNAME
 
 
-def local_airflow_instance() -> AirflowInstance:
+def local_airflow_instance(name: Optional[str] = None) -> AirflowInstance:
     return AirflowInstance(
         auth_backend=AirflowBasicAuthBackend(
             webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
         ),
-        name=AIRFLOW_INSTANCE_NAME,
+        name=name or AIRFLOW_INSTANCE_NAME,
     )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,4 +1,12 @@
+from typing import cast
+
 import requests
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.definitions.sensor_definition import build_sensor_context
+from dagster._core.test_utils import instance_for_test
+from dagster_airlift.constants import SOURCE_CODE_METADATA_KEY
+from dagster_airlift.core import build_defs_from_airflow_instance
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
 from kitchen_sink.airflow_instance import (
@@ -6,6 +14,7 @@ from kitchen_sink.airflow_instance import (
     AIRFLOW_INSTANCE_NAME,
     PASSWORD,
     USERNAME,
+    local_airflow_instance,
 )
 from pytest_mock import MockFixture
 
@@ -24,3 +33,67 @@ def test_configure_dag_list_limit(airflow_instance: None, mocker: MockFixture) -
     assert len(af_instance.list_dags()) == 16
     # 16 with actual results, 1 with no results
     assert spy.call_count == 17
+
+
+def change_dag_limit_source_code(limit: int) -> None:
+    import dagster_airlift.core.serialization.compute
+
+    dagster_airlift.core.serialization.compute.DEFAULT_MAX_NUM_DAGS_SOURCE_CODE_RETRIEVAL = limit
+
+
+def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
+    """Test that source code retrieval is disabled at scale."""
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance()
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY not in metadata
+
+    change_dag_limit_source_code(200)
+    # Also force re-retrieval of state by giving the airflow instance a different name.
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+    # If source code retrieval is explicitly enabled, we don't use the limit.
+    change_dag_limit_source_code(1)
+    af_instance = local_airflow_instance(name="different_name")
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=af_instance, source_code_retrieval_enabled=True
+    )
+    assert defs.assets
+    for assets_def in defs.assets:
+        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        assert SOURCE_CODE_METADATA_KEY in metadata
+
+
+def test_sensor_iteration_multiple_batches(airflow_instance: None, mocker: MockFixture) -> None:
+    """Test that sensor iteration correctly retrieves all sensors when over batch limit."""
+    spy = mocker.spy(AirflowInstance, "get_dag_runs_batch")
+    af_instance = AirflowInstance(
+        auth_backend=AirflowBasicAuthBackend(
+            webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+        ),
+        name=AIRFLOW_INSTANCE_NAME,
+        # Set low list limit, force batched retrieval.
+        batch_dag_runs_limit=1,
+    )
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    # create a bunch of runs
+    for i in range(2):
+        run_id = af_instance.trigger_dag("simple_unproxied_dag")
+        af_instance.wait_for_run_completion(dag_id="simple_unproxied_dag", run_id=run_id)
+
+    assert defs.sensors
+    sensor_def = next(iter(defs.sensors))
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(instance=instance, definitions=defs)
+        result = sensor_def(ctx)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert spy.call_count == 2


### PR DESCRIPTION
## Summary & Motivation
Changes airlift internals to only make expensive dag-level calls for task info when absolutely necessary. 

This speeds up initial load significantly. For 200 dags, 90s -> 50s.
## How I Tested These Changes

## Changelog
- [dagster-airlift] fixed some scaling issues which were causing slow initial load times for code locations including dagster-airlift code.
