### PR TITLE
[integrations-api][preview] PipesEMRContainersClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 import boto3
 import dagster._check as check
 from dagster import PipesClient
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError
@@ -33,7 +33,7 @@ AWS_SERVICE_NAME = "EMR Containers"
 
 
 @public
-@experimental
+@preview
 class PipesEMRContainersClient(PipesClient, TreatAsResourceParam):
     """A pipes client for running workloads on AWS EMR Containers.
 


### PR DESCRIPTION
## Summary & Motivation

decision: experimental -> preview

reason: PipesEMRContainersClient is pretty new, so using the preview decorator. We can use the beta decorator if @danielgafni thinks the feature is a beta stage.

docs exist: yes https://docs.dagster.io/guides/build/external-pipelines/aws-emr-containers-pipeline

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
