### PR TITLE
[integrations-api][beta_param] use beta_param for dbt Cloud

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_containers.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 import boto3
 import dagster._check as check
 from dagster import PipesClient
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError
@@ -33,7 +33,7 @@ AWS_SERVICE_NAME = "EMR Containers"
 
 
 @public
-@experimental
+@preview
 class PipesEMRContainersClient(PipesClient, TreatAsResourceParam):
     """A pipes client for running workloads on AWS EMR Containers.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -18,7 +18,7 @@ from dagster import (
     multi_asset,
     with_resources,
 )
-from dagster._annotations import beta, experimental_param
+from dagster._annotations import beta, beta_param
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -531,8 +531,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
 
 
 @beta
-@experimental_param(param="partitions_def")
-@experimental_param(param="partition_key_to_vars_fn")
+@beta_param(param="partitions_def")
+@beta_param(param="partition_key_to_vars_fn")
 def load_assets_from_dbt_cloud_job(
     dbt_cloud: Union[DbtCloudClientResource, ResourceDefinition],
     job_id: int,


### PR DESCRIPTION
## Summary & Motivation

decision: experimental_param -> beta_param

reason: experimental_param will be removed and the alternative is the beta_param

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
