### PR TITLE
[docs] fix warnings for svg images being parsed by Docusaurus

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/management/settings/customizing-agent-settings.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/management/settings/customizing-agent-settings.md
@@ -19,7 +19,7 @@ For [Kubernetes agents](/dagster-plus/deployment/deployment-types/hybrid/kuberne
 
 User code servers support a configurable time-to-live (TTL). The agent will spin down any user code servers that haven't served requests recently and will spin them back up the next time they're needed. Configuring TTL can save compute cost because user code servers will spend less time sitting idle.
 
-TTL is disabled by default for full deployments, and can be configured separately for full and [branch deployments](/dagster-plus/managing-deployments/branch-deployments). TTL defaults to 24 hours for both full and branch deployments.
+TTL is disabled by default for full deployments, and can be configured separately for full and [branch deployments](/dagster-plus/features/ci-cd/branch-deployments/setting-up-branch-deployments). TTL defaults to 24 hours for both full and branch deployments.
 
 To configure TTL:
 ```yaml

--- a/docs/docs-beta/docs/guides/build/assets/metadata-and-tags/kind-tags.md
+++ b/docs/docs-beta/docs/guides/build/assets/metadata-and-tags/kind-tags.md
@@ -40,7 +40,10 @@ On the backend, these kind inputs are stored as tags on the asset. For more info
 
 When viewing the asset in the lineage view, the attached kinds will be visible at the bottom the asset.
 
-![Asset in lineage view with attached kind tags](/images/guides/build/assets/metadata-tags/kinds/kinds.svg)
+<img
+  src="/images/guides/build/assets/metadata-tags/kinds/kinds.svg"
+  alt="Asset in lineage view with attached kind tags"
+/>
 
 ## Adding compute kinds to assets
 

--- a/docs/docs-beta/docs/integrations/libraries/airlift/airflow-to-dagster/observe.md
+++ b/docs/docs-beta/docs/integrations/libraries/airlift/airflow-to-dagster/observe.md
@@ -35,7 +35,10 @@ Then, we will construct our assets:
 
 Once your assets are set up, you should be able to reload your Dagster definitions and see a full representation of the dbt project and other data assets in your code.
 
-![Observed asset graph in Dagster](/images/integrations/airlift/observe.svg)
+<img
+  src="/images/integrations/airlift/observe.svg"
+  alt="Observed asset graph in Dagster"
+/>
 
 Kicking off a run of the DAG in Airflow, you should see the newly created assets materialize in Dagster as each task completes.
 

--- a/docs/docs-beta/docs/integrations/libraries/airlift/airflow-to-dagster/peer.md
+++ b/docs/docs-beta/docs/integrations/libraries/airlift/airflow-to-dagster/peer.md
@@ -32,7 +32,11 @@ export TUTORIAL_DBT_PROJECT_DIR="$TUTORIAL_EXAMPLE_DIR/tutorial_example/shared/d
 export AIRFLOW_HOME="$TUTORIAL_EXAMPLE_DIR/.airflow_home"
 dagster dev -f tutorial_example/dagster_defs/definitions.py
 ```
-![Peered asset in Dagster UI](/images/integrations/airlift/peer.svg)
+
+<img
+  src="/images/integrations/airlift/peer.svg"
+  alt="Peered asset in Dagster UI"
+/>
 
 Let's kick off a run of the `reubild_customers_list` DAG in Airflow.
 
@@ -42,7 +46,10 @@ airflow dags backfill rebuild_customers_list --start-date $(shell date +"%Y-%m-%
 
 When this run has completed in Airflow, we should be able to navigate to the Dagster UI, and see that the Dagster has registered a materialization corresponding to that successful run.
 
-![Materialized peer asset in Dagster UI](/images/integrations/airlift/peer_materialize.svg)
+<img
+  src="/images/integrations/airlift/peer_materialize.svg"
+  alt="Materialized peer asset in Dagster UI"
+/>
 
 Run the following command to clean the Airflow and Dagster run history (we just do this so we can run the same example backfill in the future). Under the hood, this just deletes runs from Airflow and asset materializations from Dagster.
 


### PR DESCRIPTION
## Summary & Motivation

Using `<img>` tags prevents the warning displayed by Docusaurus:

```
[WARNING] The image at "/Users/<>/src/dagster/docs/docs-beta/static/images/integrations/airlift/peer_materialize.svg" can't be read correctly. Please ensure it's a valid image.
unsupported file type: undefined (file: /Users/<>/src/dagster/docs/docs-beta/static/images/integrations/airlift/peer_materialize.svg)
```

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
