### PR TITLE
[dagster-dbt] Support profiles_dir and profile in DbtProject

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -217,6 +217,12 @@ class DbtCliResource(ConfigurableResource):
             if not state_path and project_dir.state_path:
                 state_path = project_dir.state_path
 
+            if not profiles_dir and project_dir.profiles_dir:
+                profiles_dir = project_dir.profiles_dir
+
+            if not profile and project_dir.profile:
+                profile = project_dir.profile
+
             if not target and project_dir.target:
                 target = project_dir.target
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -11,6 +11,7 @@ from dagster._utils import run_with_concurrent_update_guard
 
 from dagster_dbt.errors import (
     DagsterDbtManifestNotFoundError,
+    DagsterDbtProfilesDirectoryNotFoundError,
     DagsterDbtProjectNotFoundError,
     DagsterDbtProjectYmlFileNotFoundError,
 )
@@ -153,6 +154,11 @@ class DbtProject(IHaveNew):
             The path, relative to the project directory, to output artifacts.
             It corresponds to the target path in dbt.
             Default: "target"
+        profiles_dir (Union[str, Path]):
+            The path to the directory containing your dbt `profiles.yml`.
+            By default, the current working directory is used, which is the dbt project directory.
+        profile (Optional[str]):
+            The profile from your dbt `profiles.yml` to use for execution, if it should be explicitly set.
         target (Optional[str]):
             The target from your dbt `profiles.yml` to use for execution, if it should be explicitly set.
         packaged_project_dir (Optional[Union[str, Path]]):
@@ -203,6 +209,8 @@ class DbtProject(IHaveNew):
     name: str
     project_dir: Path
     target_path: Path
+    profiles_dir: Path
+    profile: Optional[str]
     target: Optional[str]
     manifest_path: Path
     packaged_project_dir: Optional[Path]
@@ -215,6 +223,8 @@ class DbtProject(IHaveNew):
         project_dir: Union[Path, str],
         *,
         target_path: Union[Path, str] = Path("target"),
+        profiles_dir: Optional[Union[Path, str]] = None,
+        profile: Optional[str] = None,
         target: Optional[str] = None,
         packaged_project_dir: Optional[Union[Path, str]] = None,
         state_path: Optional[Union[Path, str]] = None,
@@ -222,6 +232,12 @@ class DbtProject(IHaveNew):
         project_dir = Path(project_dir)
         if not project_dir.exists():
             raise DagsterDbtProjectNotFoundError(f"project_dir {project_dir} does not exist.")
+
+        profiles_dir = Path(profiles_dir) if profiles_dir else project_dir
+        if not profiles_dir.exists():
+            raise DagsterDbtProfilesDirectoryNotFoundError(
+                f"profiles {profiles_dir} does not exist."
+            )
 
         packaged_project_dir = Path(packaged_project_dir) if packaged_project_dir else None
         if not using_dagster_dev() and packaged_project_dir and packaged_project_dir.exists():
@@ -255,6 +271,8 @@ class DbtProject(IHaveNew):
             name=dbt_project_yml["name"],
             project_dir=project_dir,
             target_path=target_path,
+            profiles_dir=profiles_dir,
+            profile=profile,
             target=target,
             manifest_path=manifest_path,
             state_path=project_dir.joinpath(state_path) if state_path else None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -19,6 +19,10 @@ class DagsterDbtProjectNotFoundError(DagsterDbtError):
     """Error when the specified project directory can not be found."""
 
 
+class DagsterDbtProfilesDirectoryNotFoundError(DagsterDbtError):
+    """Error when the specified profiles directory can not be found."""
+
+
 class DagsterDbtManifestNotFoundError(DagsterDbtError):
     """Error when we expect manifest.json to generated already but it is absent."""
 


### PR DESCRIPTION
## Summary & Motivation

Same as #21108 but for `profiles_dir` and `profile`.

In response to PR #26928, fixes issue #26504

## How I Tested These Changes

Additional tests with BK

## Changelog

[dagster-dbt] Specifying a dbt profiles directory and profile is now supported in `DbtProject`.
