### PR TITLE
[dagster-gcp] PipesDataprocJobClient tutorial

### DIFF
--- a/docs/docs-beta/docs/guides/build/external-pipelines/gcp-dataproc-pipeline.md
+++ b/docs/docs-beta/docs/guides/build/external-pipelines/gcp-dataproc-pipeline.md
@@ -1,0 +1,75 @@
+---
+title: Build pipelines with GCP Dataproc
+description: "Learn to integrate Dagster Pipes with GCP Dataproc to launch external code from Dagster assets."
+sidebar_position: 300
+---
+
+This article covers how to use [Dagster Pipes](/guides/build/external-pipelines/) to [submit jobs](https://cloud.google.com/dataproc/docs/guides/submit-job) to [GCP Dataproc](https://cloud.google.com/dataproc).
+
+The [dagster-gcp](/api/python-api/libraries/dagster-gcp) integration library provides the <PyObject section="libraries" object="pipes.PipesDataprocJobClient" module="dagster_gcp" /> resource, which can be used to launch GCP Dataproc jobs from Dagster assets and ops. Dagster can receive events such as logs, asset checks, or asset materializations from jobs launched with this client. The client requires minimal code changes to your Dataproc jobs.
+
+
+<details>
+  <summary>Prerequisites</summary>
+
+    - **In the Dagster environment**, you'll need to:
+
+      - Install the following packages:
+
+          ```shell
+          pip install dagster dagster-webserver 'dagster-gcp[dataproc]'
+          ```
+
+          Refer to the [Dagster installation guide](/getting-started/installation) for more info.
+
+      - **Configure GCP authentication for applications**. If you don't have this set up already, refer to the [GCP authentication guide](https://cloud.google.com/docs/authentication/gcloud).
+
+    - **In GCP**, you'll need:
+
+      - An existing project with a Dataproc cluster.
+      - Prepared infrastructure such as GCS buckets, IAM roles, and other resources required for your Dataproc job.
+
+</details>
+
+## Step 1: Install the dagster-pipes module in your Dataproc environment
+
+Choose one of the [options](https://cloud.google.com/dataproc/docs/tutorials/python-configuration) to install `dagster-pipes` in the Dataproc environment.
+
+For example, use the following property in your configuration:
+
+```yaml
+dataproc:pip.packages: "dagster-pipes,google-cloud-storage"
+```
+
+`google-cloud-storage` is an optional dependency required for passing Pipes messages from the Dataproc job to Dagster.
+
+
+## Step 2: Add dagster-pipes to the Dataproc job script
+
+Call `open_dagster_pipes` in the Dataproc script to create a context that can be used to send messages to Dagster:
+
+<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/script.py" />
+
+:::tip
+
+The metadata format shown above (`{"raw_value": value, "type": type}`) is part of Dagster Pipes' special syntax for specifying rich Dagster metadata. For a complete reference of all supported metadata types and their formats, see the [Dagster Pipes metadata reference](using-dagster-pipes/reference#passing-rich-metadata-to-dagster).
+
+:::
+
+## Step 3: Create an asset using the PipesDataprocJobClient to launch the job
+
+In the Dagster asset/op code, use the `PipesDataprocJobClient` resource to launch the job:
+
+<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py" startAfter="start_asset_marker" endBefore="end_asset_marker" />
+
+This will launch the Dataproc job and wait for it to complete. If the job fails, the Dagster process will raise an exception. If the Dagster process is interrupted while the job is still running, the job will be terminated.
+
+Setting `include_stdtio_in_messages=True` in the `PipesDataprocJobClient` constructor enables forwarding `stdout` and `stderr` from the job driver to Dagster.
+
+## Step 4: Create Dagster definitions
+
+Next, add the `PipesDataprocJobClient` resource to your project's <PyObject section="definitions" module="dagster" object="Definitions" /> object:
+
+<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py" startAfter="start_definitions_marker" endBefore="end_definitions_marker" />
+
+Dagster will now be able to launch the GCP Dataproc job from the `dataproc_asset` asset, and receive logs and events from the job.

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/Dockerfile
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/Dockerfile
@@ -1,0 +1,26 @@
+FROM bitnami/minideb AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+WORKDIR /build
+
+ENV VIRTUAL_ENV=/build/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+ARG PYTHON_TAG=3.9.16-slim
+RUN uv python install --python-preference only-managed 3.9.16 && uv python pin 3.9.16
+RUN uv venv .venv
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install pex google-cloud-storage pyspark dagster-pipes
+
+RUN uv pip install --no-cache /build/dagster-pipes
+
+RUN pex --include-tools dagster-pipes google-cloud-storage pyspark -o /output/venv.pex && chmod +x /output/venv.pex
+
+# test imports
+RUN /output/venv.pex -c "import dagster_pipes, pyspark, google.cloud.storage;"
+
+FROM scratch AS export
+
+COPY --from=builder /output/venv.pex /venv.pex

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py
@@ -1,0 +1,87 @@
+# example Dataproc creation CLI:
+# gcloud dataproc clusters create dagster --enable-component-gateway --bucket dagster-pipes --region us-central1 --subnet default --single-node --master-machine-type n2-standard-4 --master-boot-disk-type pd-balanced --master-boot-disk-size 100 --public-ip-address --image-version 2.2-debian12 --optional-components DOCKER --initialization-actions 'gs://dagster-pipes/init.sh' --metadata PEX_ENV_FILE_URI=gs://dagster-pipes/venv.pex --project dagster-infra
+
+# start_asset_marker
+import os
+
+import boto3
+from dagster_gcp.pipes import (
+    PipesDataprocJobClient,
+    PipesGCSContextInjector,
+    PipesGCSMessageReader,
+)
+from google.cloud.dataproc_v1 import (
+    Job,
+    JobControllerClient,
+    JobPlacement,
+    PySparkJob,
+    SubmitJobRequest,
+)
+from google.cloud.storage import Client as GCSClient
+
+import dagster as dg
+
+
+@dg.asset
+def dataproc_job_asset(
+    context: dg.AssetExecutionContext,
+    dataproc_job_client: PipesDataprocJobClient,
+):
+    return dataproc_job_client.run(
+        context=context,
+        submit_job_params={
+            "request": SubmitJobRequest(
+                region="us-central1",
+                project_id="dagster-infra",
+                job=Job(
+                    placement=JobPlacement(cluster_name="dagster"),
+                    pyspark_job=PySparkJob(
+                        main_python_file_uri="gs://dagster-pipes/script.py",
+                        # args=["./venv.pex", "./script.py"],
+                        file_uris=[
+                            # "gs://dagster-pipes/venv.pex",
+                            # "gs://dagster-pipes/script.py",
+                        ],
+                        properties={
+                            "spark.pyspark.python": "/pexenvs/venv.pex/bin/python",
+                            # "spark.pyspark.driver.python": "/pexenvs/venv.pex",
+                            # "dataproc:pip.packages": "google-cloud-storage,git+https://github.com/dagster-io/dagster.git@main",
+                            # load gs://dagster-pipes/venv.pex  as venv.pex file
+                        },
+                    ),
+                ),
+            )
+        },
+    ).get_results()
+
+
+# end_asset_marker
+
+# start_definitions_marker
+
+from dagster import Definitions  # noqa
+
+
+defs = Definitions(
+    assets=[dataproc_job_asset],
+    resources={
+        "dataproc_job_client": PipesDataprocJobClient(
+            client=JobControllerClient(
+                client_options={
+                    "api_endpoint": "us-central1-dataproc.googleapis.com:443"
+                },
+            ),
+            message_reader=PipesGCSMessageReader(
+                bucket="dagster-pipes",
+                client=GCSClient(project="dagster-infra"),
+                include_stdio_in_messages=True,
+            ),
+            context_injector=PipesGCSContextInjector(
+                bucket="dagster-pipes",
+                client=GCSClient(project="dagster-infra"),
+            ),
+        )
+    },
+)
+
+# end_definitions_marker

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dev.Dockerfile
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dev.Dockerfile
@@ -1,0 +1,31 @@
+# this Dockerfile can be used to create a PEX executable for PySpark on GCP Dataproc
+# it will install dagster-pipes from the current dev Dagster project
+
+FROM bitnami/minideb AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+WORKDIR /build
+
+ENV VIRTUAL_ENV=/build/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+ARG PYTHON_TAG=3.9.16-slim
+RUN uv python install --python-preference only-managed 3.9.16 && uv python pin 3.9.16
+RUN uv venv .venv
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install pex boto3 pyspark
+
+COPY python_modules/dagster-pipes /build/dagster-pipes
+
+RUN uv pip install --no-cache /build/dagster-pipes
+
+RUN pex --include-tools /build/dagster-pipes google-cloud-storage pyspark -o /output/venv.pex && chmod +x /output/venv.pex
+
+# test imports
+RUN /output/venv.pex -c "import dagster_pipes, pyspark, google.cloud.storage;"
+
+FROM scratch AS export
+
+COPY --from=builder /output/venv.pex /venv.pex

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/init.sh
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/init.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# this is an init action for a Dataproc cluster that installs a PEX file into the cluster's environment
+# requires setting the PEX_ENV_FILE_URI cluster metadata key to the URI of the PEX file to install
+
+set -exo pipefail
+
+readonly PEX_ENV_FILE_URI=$(/usr/share/google/get_metadata_value attributes/PEX_ENV_FILE_URI || true)
+readonly PEX_FILES_DIR="/pexfiles"
+readonly PEX_ENV_DIR="/pexenvs"
+
+function err() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+    exit 1
+}
+
+function install_pex_into_venv() {
+    local -r pex_name=${PEX_ENV_FILE_URI##*/}
+    local -r pex_file="${PEX_FILES_DIR}/${pex_name}"
+    local -r pex_venv="${PEX_ENV_DIR}/${pex_name}"
+
+    echo "Installing pex from ${pex_file} into venv ${pex_venv}..."
+    gsutil cp "${PEX_ENV_FILE_URI}" "${pex_file}"
+    PEX_TOOLS=1 python "${pex_file}" venv --compile "${pex_venv}"
+}
+
+function main() {
+    if [[ -z "${PEX_ENV_FILE_URI}" ]]; then
+        err "ERROR: Must specify PEX_ENV_FILE_URI metadata key"
+    fi
+
+    install_pex_into_venv
+}
+
+main

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/script.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/script.py
@@ -1,0 +1,42 @@
+from dagster_pipes import (
+    PipesCliArgsParamsLoader,
+    PipesGCSContextLoader,
+    PipesGCSMessageWriter,
+    open_dagster_pipes,
+)
+from google.cloud.storage import Client as GCSClient
+from pyspark.sql import SparkSession
+
+
+def main():
+    gcs_client = GCSClient()
+    with open_dagster_pipes(
+        context_loader=PipesGCSContextLoader(client=gcs_client),
+        message_writer=PipesGCSMessageWriter(client=gcs_client),
+        params_loader=PipesCliArgsParamsLoader(),
+    ) as pipes:
+        pipes.log.info("Hello from GCP Dataproc!")
+
+        print("Hello from GCP Dataproc Spark driver stdout!")  # noqa: T201
+
+        spark = SparkSession.builder.appName("HelloWorld").getOrCreate()
+
+        df = spark.createDataFrame(
+            [(1, "Alice", 34), (2, "Bob", 45), (3, "Charlie", 56)],
+            ["id", "name", "age"],
+        )
+
+        # calculate a really important statistic
+        avg_age = float(df.agg({"age": "avg"}).collect()[0][0])
+
+        # attach it to the asset materialization in Dagster
+        pipes.report_asset_materialization(
+            metadata={"average_age": {"raw_value": avg_age, "type": "float"}},
+            data_version="alpha",
+        )
+
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/upload_artifacts.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/upload_artifacts.py
@@ -1,0 +1,45 @@
+# this script can be used to pack and upload a python .pex file to an gcs bucket
+# requires docker and gsutil
+
+import argparse
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+REQUIREMENTS_TXT = SCRIPT_DIR / "requirements.txt"
+DAGSTER_DIR = (
+    Path(*SCRIPT_DIR.parts[: SCRIPT_DIR.parts.index("dagster-io")])
+    / "dagster-io/dagster"
+)
+
+parser = argparse.ArgumentParser(description="Build & upload a PEX executable to GCS")
+parser.add_argument(
+    "--gcs-dir",
+    type=str,
+    help="gcs directory to copy files into",
+)
+
+
+def main():
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        subprocess.run(
+            " && \\\n".join(
+                [
+                    f"DOCKER_BUILDKIT=1 docker build --output type=local,dest=./output -f {SCRIPT_DIR}/dev.Dockerfile {DAGSTER_DIR}",
+                    f"gsutil cp ./output/venv.pex {os.path.join(args.gcs_dir, 'venv.pex')}",
+                    f"gsutil cp {SCRIPT_DIR / 'script.py'} {os.path.join(args.gcs_dir, 'script.py')}",
+                ]
+            ),
+            shell=True,
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/pipes/clients/dataproc_job.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/pipes/clients/dataproc_job.py
@@ -125,7 +125,7 @@ class PipesDataprocJobClient(PipesClient, TreatAsResourceParam):
 
         Args:
             context (Union[OpExecutionContext, AssetExecutionContext]): The context of the currently executing Dagster op or asset.
-            submit_job_params (dict): Parameters for the ``JobControllerClient.submit_job`` call.
+            submit_job_params (SubmitJobParams): Parameters for the ``JobControllerClient.submit_job`` call.
                 See `Google Cloud SDK Documentation <https://cloud.google.com/python/docs/reference/dataproc/latest/google.cloud.dataproc_v1.services.job_controller.JobControllerClient#google_cloud_dataproc_v1_services_job_controller_JobControllerClient_submit_job>`_
             extras (Optional[Dict[str, Any]]): Additional information to pass to the Pipes session in the external process.
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a tutorial for `PipesDataprocJobClient`. 

## How I Tested These Changes

## Changelog

[docs] added a tutorial for using GCP Dataproc with Dagster Pipes
