### PR TITLE
Add AWS RDS Resource

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
@@ -53,6 +53,12 @@ ECS
   :annotation: ExecutorDefinition
 
 
+RDS
+---
+.. autoconfigurable:: dagster_aws.rds.RDSResource
+  :annotation: ResourceDefinition
+
+
 Redshift
 --------
 .. autoconfigurable:: dagster_aws.redshift.RedshiftClientResource

--- a/python_modules/libraries/dagster-aws/dagster_aws/rds/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/rds/__init__.py
@@ -1,0 +1,1 @@
+from dagster_aws.rds.resources import RDSResource as RDSResource

--- a/python_modules/libraries/dagster-aws/dagster_aws/rds/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/rds/resources.py
@@ -1,0 +1,78 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+import boto3.session
+import botocore.client
+
+from dagster_aws.utils import ResourceWithBoto3Configuration, construct_boto_client_retry_config
+
+if TYPE_CHECKING:
+    import botocore
+
+
+class RDSResource(ResourceWithBoto3Configuration):
+    """A resource for interacting with the AWS RDS service.
+
+    It wraps both the AWS RDS client (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html),
+    and the AWS RDS Data client (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds-data.html).
+
+    The AWS-RDS client (``RDSResource.get_rds_client()``) allows access to the management layer of RDS (creating, starting, configuring databases).
+    The AWS RDS Data (``RDSResource.get_data_client``) allows executing queries on the SQL databases themselves.
+    Note that AWS RDS Data service is only available for Aurora database. For accessing data from other types of RDS databases,
+    you should directly use the corresponding SQL client instead (e.g. Postgres/MySQL).
+
+
+    Example:
+        .. code-block:: python
+
+            from dagster import Definitions, asset
+            from dagster_aws.rds import RDSResource
+
+            @asset
+            def my_table(rds_resource: RDSResource):
+                with rds_resource.get_rds_client() as rds_client:
+                    rds_client.describe_db_instances()['DBInstances']
+                with rds_resource.get_data_client() as data_client:
+                    data_client.execute_statement(
+                        resourceArn="RESOURCE_ARN",
+                        secretArn="SECRET_ARN",
+                        sql="SELECT * from mytable",
+                    )
+
+            defs = Definitions(
+                assets=[my_table],
+                resources={
+                    "rds_resource": RDSResource(
+                        region_name="us-west-1"
+                    )
+                }
+            )
+
+    """
+
+    @classmethod
+    def _is_dagster_maintained(cls) -> bool:
+        return True
+
+    def _create_rds_client(self, client_type: str) -> Any:
+        session = boto3.session.Session(profile_name=self.profile_name)
+        return session.client(
+            client_type,
+            region_name=self.region_name,
+            use_ssl=self.use_ssl,
+            verify=self.verify,
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
+            config=construct_boto_client_retry_config(self.max_attempts),
+        )
+
+    @contextmanager
+    def get_rds_client(self) -> Generator["botocore.client.rds", None, None]:  # pyright: ignore (reportAttributeAccessIssue)
+        yield self._create_rds_client("rds")
+
+    @contextmanager
+    def get_data_client(self) -> Generator["botocore.client.rds_data", None, None]:  # pyright: ignore (reportAttributeAccessIssue)
+        yield self._create_rds_client("rds-data")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
@@ -1,6 +1,6 @@
 import boto3
 import pytest
-from moto import mock_s3, mock_secretsmanager, mock_ssm
+from moto import mock_rds, mock_rdsdata, mock_s3, mock_secretsmanager, mock_ssm
 
 
 # Make sure unit tests never connect to real AWS
@@ -32,3 +32,15 @@ def mock_secretsmanager_resource():
 def mock_ssm_client():
     with mock_ssm():
         yield boto3.client("ssm")
+
+
+@pytest.fixture
+def mock_rds_client():
+    with mock_rds():
+        yield boto3.client("rds")
+
+
+@pytest.fixture
+def mock_rds_data_client():
+    with mock_rdsdata():
+        yield boto3.client("rds-data")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/rds_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/rds_tests/test_resources.py
@@ -1,0 +1,60 @@
+import requests
+from dagster import asset, materialize_to_memory
+
+from dagster_aws.rds import RDSResource
+
+
+def configure_moto_mock_response():
+    mock_response = {
+        "results": [
+            {
+                "records": [
+                    [{"stringValue": "title1"}, {"longValue": 2001}],
+                    [{"stringValue": "title2"}, {"longValue": 2010}],
+                ],
+                "numberOfRecordsUpdated": 0,
+            }
+        ]
+    }
+
+    # moto is configured through HTTP: https://docs.getmoto.org/en/stable/docs/services/rds-data.html
+    resp = requests.post(
+        "http://motoapi.amazonaws.com/moto-api/static/rds-data/statement-results",
+        json=mock_response,
+    )
+    assert resp.status_code == 201
+
+
+def test_rds_resource(mock_rds_client, mock_rds_data_client):
+    @asset
+    def rds_asset(rds_resource: RDSResource):
+        with rds_resource.get_rds_client() as rds_client:
+            rds_client.create_db_instance(
+                DBInstanceIdentifier="test-instance",
+                MasterUsername="admin",
+                MasterUserPassword="password",
+                DBInstanceClass="db.t2.micro",
+                Engine="postgres",
+            )
+            db_instances = rds_client.describe_db_instances()["DBInstances"]
+            assert len(db_instances) == 1
+
+    @asset
+    def rds_data_asset(rds_resource: RDSResource):
+        configure_moto_mock_response()
+
+        with rds_resource.get_data_client() as rds_data_client:
+            response = rds_data_client.execute_statement(
+                resourceArn="arn:aws:rds:us-east-1:123456789012:cluster:database-1",
+                secretArn="arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-1",
+                sql="SELECT * from films;",
+            )
+
+            assert len(response["records"]) == 2
+
+    result = materialize_to_memory(
+        [rds_asset, rds_data_asset],
+        resources={"rds_resource": RDSResource(region_name="us-east-1")},
+    )
+
+    assert result.success


### PR DESCRIPTION
## Summary & Motivation

Added dagster resource to wrap  [AWS-RDS](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html), and [AWS-RDS-DATA](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds-data.html), under dagster_aws.rds.

## How I Tested These Changes

- Tested locally with a real AWS RDS Instance (both the management, and data APIs).
- Wrote unit-tests with moto (mock boto) library.

## Changelog

Added AWS RDSResource
