### PR TITLE
[docs] use dash in dagster-pagerduty package name

### DIFF
--- a/docs/docs-beta/docs/integrations/libraries/pagerduty.md
+++ b/docs/docs-beta/docs/integrations/libraries/pagerduty.md
@@ -23,7 +23,7 @@ This library provides an integration between Dagster and PagerDuty to support cr
 ### Installation
 
 ```bash
-pip install dagster_pagerduty
+pip install dagster-pagerduty
 ```
 
 ### Example

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-pagerduty.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-pagerduty.rst
@@ -14,7 +14,7 @@ You can install this library with:
 
 .. code-block::
 
-   pip install dagster_pagerduty
+   pip install dagster-pagerduty
 
 To use this integration, you'll first need to create an Events API V2 PagerDuty integration on a PagerDuty service. There are instructions
 `here <https://support.pagerduty.com/docs/services-and-integrations#section-events-api-v2>`_ for


### PR DESCRIPTION
## Summary & Motivation

Package name should use dashes (`dagster_pagerduty` -> `dagster-pagerduty`)

## How I Tested These Changes

## Changelog

NOCHANGELOG
