### PR TITLE
speed up dagster dev shutdown

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1599,7 +1599,7 @@ class GrpcServerProcess:
 
     def auto_restart_thread(self):
         while True:
-            time.sleep(get_auto_restart_code_server_interval())
+            self.__shutdown_event.wait(get_auto_restart_code_server_interval())
             if self.__shutdown_event.is_set():
                 break
             if self._server_process and self._server_process.poll() is not None:


### PR DESCRIPTION
Summary:
This makes things shut down faster once the shutdown event is set.

Run dagster dev, press CTRL-C, see it shut down right away instead of waiting on average 15 seconds

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
