### PR TITLE
Allow assets with output_required=False and embedded checks to forego AssetCheckResults (#27399)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -521,7 +521,8 @@ def create_assets_def_from_fn_and_decorator_args(
             specs=[],
             # no internal asset deps
             asset_deps={},
-            can_subset=False,
+            # Allow AssetCheckResults to be optional when asset materializations are optional
+            can_subset=not args.output_required,
             decorator_name="@asset",
             execution_type=AssetExecutionType.MATERIALIZATION,
             pool=args.pool,


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/issues/27399

For non-multi assets with embedded asset checks, AssetCheckResults must always be generated, even when a MaterializeResult is not required. Asset checks acquire their `is_required` value from their respective asset's `can_subset` value, negated. Previously `can_subset` was always being set to False for non-multi assets. Now `can_subset=not args.output_required` which allows for the optional generation of AssetCheckResults if `output_required` is False.

## How I tested these changes

pytest python_modules/dagster/dagster_tests