### PR TITLE
[components] Rework resolvable model

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/basic-subclass.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/basic-subclass.py
@@ -1,6 +1,6 @@
 from dagster_components import component_type
-from dagster_components.lib import SlingReplicationCollectionComponent
+from dagster_components.lib import SlingReplicationCollection
 
 
 @component_type(name="custom_subclass")
-class CustomSubclass(SlingReplicationCollectionComponent): ...
+class CustomSubclass(SlingReplicationCollection): ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
@@ -2,13 +2,13 @@ from collections.abc import Mapping
 from typing import Any
 
 from dagster_components import component_type
-from dagster_components.lib import SlingReplicationCollectionComponent
+from dagster_components.lib import SlingReplicationCollection
 
 import dagster as dg
 
 
 @component_type(name="custom_subclass")
-class SubclassWithScope(SlingReplicationCollectionComponent):
+class SubclassWithScope(SlingReplicationCollection):
     def get_additional_scope(self) -> Mapping[str, Any]:
         def _custom_cron(cron_schedule: str) -> dg.AutomationCondition:
             return (

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/debug-mode.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/debug-mode.py
@@ -1,14 +1,14 @@
 from collections.abc import Iterator
 
 from dagster_components import component_type
-from dagster_components.lib import SlingReplicationCollectionComponent
+from dagster_components.lib import SlingReplicationCollection
 from dagster_sling import SlingResource
 
 import dagster as dg
 
 
 @component_type(name="debug_sling_replication")
-class DebugSlingReplicationComponent(SlingReplicationCollectionComponent):
+class DebugSlingReplicationComponent(SlingReplicationCollection):
     def execute(
         self, context: dg.AssetExecutionContext, sling: SlingResource
     ) -> Iterator:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolvable-field.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolvable-field.py
@@ -1,13 +1,14 @@
 from typing import Annotated, Optional
 
-from dagster_components import ComponentSchemaBaseModel, ResolvableFieldInfo
-from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecBaseModel
+from dagster_components import ResolvableFieldInfo
+from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecModel
+from pydantic import BaseModel
 
 
 class ScriptRunner: ...
 
 
-class ShellScriptSchema(ComponentSchemaBaseModel):
+class ShellScriptSchema(BaseModel):
     script_path: str
     asset_attributes: AssetAttributesModel
     # highlight-start
@@ -18,4 +19,4 @@ class ShellScriptSchema(ComponentSchemaBaseModel):
         ),
     ]
     # highlight-end
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
@@ -1,9 +1,5 @@
-from dagster_components import (
-    Component,
-    ComponentLoadContext,
-    ComponentSchemaBaseModel,
-    component_type,
-)
+from dagster_components import Component, ComponentLoadContext, component_type
+from pydantic import BaseModel
 
 from dagster import Definitions
 
@@ -11,6 +7,6 @@ from dagster import Definitions
 @component_type(name="shell_command")
 class ShellCommand(Component):
     @classmethod
-    def get_schema(cls) -> type[ComponentSchemaBaseModel]: ...
+    def get_schema(cls) -> type[BaseModel]: ...
 
     def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -1,22 +1,18 @@
 import subprocess
 from typing import Optional
 
-from dagster_components import (
-    Component,
-    ComponentLoadContext,
-    ComponentSchemaBaseModel,
-    component_type,
-)
-from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecBaseModel
+from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecModel
+from pydantic import BaseModel
 
 import dagster as dg
 
 
 # highlight-start
-class ShellScriptSchema(ComponentSchemaBaseModel):
+class ShellScriptSchema(BaseModel):
     script_path: str
     asset_attributes: AssetAttributesModel
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None
     # highlight-end
 
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
@@ -1,28 +1,24 @@
 from typing import Optional
 
-from dagster_components import (
-    Component,
-    ComponentLoadContext,
-    ComponentSchemaBaseModel,
-    component_type,
-)
-from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecBaseModel
+from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecModel
+from pydantic import BaseModel
 
 from dagster import Definitions
 
 
 # highlight-start
-class ShellScriptSchema(ComponentSchemaBaseModel):
+class ShellScriptSchema(BaseModel):
     script_path: str
     asset_attributes: AssetAttributesModel
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None
     # highlight-end
 
 
 @component_type(name="shell_command")
 class ShellCommand(Component):
     @classmethod
-    def get_schema(cls) -> type[ComponentSchemaBaseModel]:
+    def get_schema(cls) -> type[ShellScriptSchema]:
         # higlight-start
         return ShellScriptSchema
         # highlight-end

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -13,12 +13,12 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffoldRequest as ComponentScaffoldRequest,
     DefaultComponentScaffolder as DefaultComponentScaffolder,
 )
-from dagster_components.core.schema.base import ComponentSchemaBaseModel as ComponentSchemaBaseModel
+from dagster_components.core.schema.base import ResolvableModel as ResolvableModel
 from dagster_components.core.schema.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesModel as AssetAttributesModel,
     AssetSpecTransformModel as AssetSpecTransformModel,
-    OpSpecBaseModel as OpSpecBaseModel,
+    OpSpecModel as OpSpecModel,
 )
 from dagster_components.core.schema.resolver import TemplatedValueResolver as TemplatedValueResolver
 from dagster_components.version import __version__ as __version__

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -130,19 +130,16 @@ class YamlComponentDecl(ComponentDeclNode):
 
     def get_params(self, context: ComponentLoadContext, params_schema: type[T]) -> T:
         with pushd(str(self.path)):
-            raw_params = self.component_file_model.params
-            preprocessed_params = context.templated_value_resolver.resolve_params(
-                raw_params, params_schema
-            )
-
             if self.source_position_tree:
                 source_position_tree_of_params = self.source_position_tree.children["params"]
                 with enrich_validation_errors_with_source_position(
                     source_position_tree_of_params, ["params"]
                 ):
-                    return TypeAdapter(params_schema).validate_python(preprocessed_params)
+                    return TypeAdapter(params_schema).validate_python(
+                        self.component_file_model.params
+                    )
             else:
-                return TypeAdapter(params_schema).validate_python(preprocessed_params)
+                return TypeAdapter(params_schema).validate_python(self.component_file_model.params)
 
     def load(self, context: ComponentLoadContext) -> Sequence[Component]:
         component_type = self.get_component_type(context.registry)

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -1,18 +1,21 @@
+from abc import abstractmethod
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from dagster_components.core.schema.metadata import get_resolution_metadata
 from dagster_components.core.schema.resolver import TemplatedValueResolver
 
+T = TypeVar("T")
 
-class ComponentSchemaBaseModel(BaseModel):
+
+class ResolvableModel(BaseModel, Generic[T]):
     """Base class for models that are part of a component schema."""
 
     model_config = ConfigDict(extra="forbid")
 
-    def resolve_properties(self, value_resolver: TemplatedValueResolver) -> Mapping[str, Any]:
+    def _resolved_properties(self, value_resolver: TemplatedValueResolver) -> Mapping[str, Any]:
         """Returns a dictionary of resolved properties for this class."""
         raw_properties = self.model_dump(exclude_unset=True)
 
@@ -34,3 +37,6 @@ class ComponentSchemaBaseModel(BaseModel):
             resolved_properties[k] = resolved
 
         return resolved_properties
+
+    @abstractmethod
+    def resolve(self, value_resolver: TemplatedValueResolver) -> T: ...

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolver.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolver.py
@@ -1,4 +1,3 @@
-import functools
 import os
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable, Optional, TypeVar, Union
@@ -8,9 +7,6 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._record import record
 from jinja2.nativetypes import NativeTemplate
-from pydantic import BaseModel
-
-from dagster_components.core.schema.metadata import allow_resolve
 
 T = TypeVar("T")
 
@@ -72,13 +68,3 @@ class TemplatedValueResolver:
     def resolve_obj(self, val: Any) -> Any:
         """Recursively resolves templated values in a nested object."""
         return self._resolve_obj(val, None, lambda _: True)
-
-    def resolve_params(self, val: T, target_type: type[BaseModel]) -> T:
-        """Given a raw params value, preprocesses it by resolving any templated values that are not marked
-        as deferred in the target_type's json schema.
-        """
-        json_schema = target_type.model_json_schema()
-        should_resolve = functools.partial(
-            allow_resolve, json_schema=json_schema, subschema=json_schema
-        )
-        return self._resolve_obj(val, [], should_resolve=should_resolve)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/__init__.py
@@ -10,7 +10,7 @@ if _has_dagster_dbt:
 
 if _has_dagster_sling:
     from dagster_components.lib.sling_replication_collection.component import (
-        SlingReplicationCollectionComponent as SlingReplicationCollectionComponent,
+        SlingReplicationCollection as SlingReplicationCollection,
     )
 
 from dagster_components.lib.definitions_component.component import (

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Sequence
-from typing import Annotated, Optional
+from typing import Annotated, Callable, Optional
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
@@ -10,29 +10,40 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from pydantic import BaseModel
-from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.component import component_type
+from dagster_components.core.schema.base import ResolvableModel
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesModel,
     AssetSpecTransformModel,
-    OpSpecBaseModel,
+    OpSpecModel,
     TemplatedValueResolver,
 )
 from dagster_components.lib.dbt_project.scaffolder import DbtProjectComponentScaffolder
 from dagster_components.utils import ResolvingInfo, get_wrapped_translator_class
 
 
-class DbtProjectParams(BaseModel):
+class DbtProjectParams(ResolvableModel["DbtProjectComponent"]):
     dbt: DbtCliResource
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None
     asset_attributes: Annotated[
         Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"node"})
     ] = None
     transforms: Optional[Sequence[AssetSpecTransformModel]] = None
+
+    def resolve(self, resolver: TemplatedValueResolver) -> "DbtProjectComponent":
+        return DbtProjectComponent(
+            resource=self.dbt,
+            op_spec=self.op.resolve(resolver) if self.op else None,
+            translator=get_wrapped_translator_class(DagsterDbtTranslator)(
+                resolving_info=ResolvingInfo(
+                    "node", self.asset_attributes or AssetAttributesModel(), resolver
+                )
+            ),
+            transforms=[transform.resolve(resolver) for transform in (self.transforms or [])],
+        )
 
 
 @component_type(name="dbt_project")
@@ -41,19 +52,16 @@ class DbtProjectComponent(Component):
 
     def __init__(
         self,
-        dbt_resource: DbtCliResource,
-        op_spec: Optional[OpSpecBaseModel],
-        asset_attributes: Optional[AssetAttributesModel],
-        transforms: Sequence[AssetSpecTransformModel],
-        value_resolver: TemplatedValueResolver,
+        resource: DbtCliResource,
+        op_spec: Optional[OpSpecModel],
+        translator: DagsterDbtTranslator,
+        transforms: Sequence[Callable[[Definitions], Definitions]],
     ):
-        self.dbt_resource = dbt_resource
-        self.project = DbtProject(self.dbt_resource.project_dir)
+        self.resource = resource
+        self.project = DbtProject(resource.project_dir)
         self.op_spec = op_spec
-        self.asset_attributes = asset_attributes
         self.transforms = transforms
-        self.value_resolver = value_resolver
-        self.translator = self._get_wrapped_translator()
+        self.translator = translator
 
     @classmethod
     def get_scaffolder(cls) -> "DbtProjectComponentScaffolder":
@@ -64,28 +72,8 @@ class DbtProjectComponent(Component):
         return DbtProjectParams
 
     @classmethod
-    def load(cls, params: DbtProjectParams, context: ComponentLoadContext) -> Self:
-        return cls(
-            dbt_resource=params.dbt,
-            op_spec=params.op,
-            asset_attributes=params.asset_attributes,
-            transforms=params.transforms or [],
-            value_resolver=context.templated_value_resolver,
-        )
-
-    def get_translator(self) -> DagsterDbtTranslator:
-        return DagsterDbtTranslator()
-
-    def _get_wrapped_translator(self) -> DagsterDbtTranslator:
-        translator_cls = get_wrapped_translator_class(DagsterDbtTranslator)
-        return translator_cls(
-            base_translator=self.get_translator(),
-            resolving_info=ResolvingInfo(
-                obj_name="node",
-                asset_attributes=self.asset_attributes or AssetAttributesModel(),
-                value_resolver=self.value_resolver,
-            ),
-        )
+    def load(cls, params: DbtProjectParams, context: ComponentLoadContext) -> "DbtProjectComponent":
+        return params.resolve(context.templated_value_resolver)
 
     def get_asset_selection(
         self, select: str, exclude: Optional[str] = None
@@ -108,11 +96,11 @@ class DbtProjectComponent(Component):
             dagster_dbt_translator=self.translator,
         )
         def _fn(context: AssetExecutionContext):
-            yield from self.execute(context=context, dbt=self.dbt_resource)
+            yield from self.execute(context=context, dbt=self.resource)
 
         defs = Definitions(assets=[_fn])
         for transform in self.transforms:
-            defs = transform.apply(defs, context.templated_value_resolver)
+            defs = transform(defs)
         return defs
 
     def execute(self, context: AssetExecutionContext, dbt: DbtCliResource) -> Iterator:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -11,7 +11,9 @@ from dagster._core.pipes.subprocess import PipesSubprocessClient
 from pydantic import BaseModel
 
 from dagster_components.core.component import Component, ComponentLoadContext, component_type
-from dagster_components.core.schema.objects import AssetAttributesModel
+from dagster_components.core.schema.base import ResolvableModel
+from dagster_components.core.schema.objects import AssetSpecModel
+from dagster_components.core.schema.resolver import TemplatedValueResolver
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -19,27 +21,35 @@ if TYPE_CHECKING:
 
 class PipesSubprocessScriptParams(BaseModel):
     path: str
-    assets: Sequence[AssetAttributesModel]
+    assets: Sequence[AssetSpecModel]
 
 
-class PipesSubprocessScriptCollectionParams(BaseModel):
+class PipesSubprocessScriptCollectionParams(ResolvableModel[Mapping[Path, Sequence[AssetSpec]]]):
     scripts: Sequence[PipesSubprocessScriptParams]
+
+    def resolve(self, resolver: TemplatedValueResolver) -> Mapping[str, Sequence[AssetSpec]]:
+        return {
+            resolver.resolve_obj(script.path): [
+                asset_model.resolve(resolver) for asset_model in script.assets
+            ]
+            for script in self.scripts
+        }
 
 
 @component_type(name="pipes_subprocess_script_collection")
 class PipesSubprocessScriptCollection(Component):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
 
-    def __init__(self, dirpath: Path, path_specs: Mapping[Path, Sequence[AssetSpec]]):
+    def __init__(self, dirpath: Path, specs_by_path: Mapping[str, Sequence[AssetSpec]]):
         self.dirpath = dirpath
         # mapping from the script name (e.g. /path/to/script_abc.py -> script_abc)
         # to the specs it produces
-        self.path_specs = path_specs
+        self.specs_by_path = specs_by_path
 
     @staticmethod
     def introspect_from_path(path: Path) -> "PipesSubprocessScriptCollection":
-        path_specs = {path: [AssetSpec(path.stem)] for path in list(path.rglob("*.py"))}
-        return PipesSubprocessScriptCollection(dirpath=path, path_specs=path_specs)
+        path_specs = {str(path): [AssetSpec(path.stem)] for path in list(path.rglob("*.py"))}
+        return PipesSubprocessScriptCollection(dirpath=path, specs_by_path=path_specs)
 
     @classmethod
     def get_schema(cls) -> type[PipesSubprocessScriptCollectionParams]:
@@ -49,23 +59,18 @@ class PipesSubprocessScriptCollection(Component):
     def load(
         cls, params: PipesSubprocessScriptCollectionParams, context: ComponentLoadContext
     ) -> "PipesSubprocessScriptCollection":
-        path_specs = {}
-        for script in params.scripts:
-            script_path = context.path / script.path
-            if not script_path.exists():
-                raise FileNotFoundError(f"Script {script_path} does not exist")
-            path_specs[script_path] = [
-                AssetSpec(**asset.resolve_properties(context.templated_value_resolver))
-                for asset in script.assets
-            ]
-
-        return cls(dirpath=context.path, path_specs=path_specs)
+        return cls(
+            dirpath=context.path, specs_by_path=params.resolve(context.templated_value_resolver)
+        )
 
     def build_defs(self, context: "ComponentLoadContext") -> "Definitions":
         from dagster._core.definitions.definitions_class import Definitions
 
         return Definitions(
-            assets=[self._create_asset_def(path, specs) for path, specs in self.path_specs.items()],
+            assets=[
+                self._create_asset_def(self.dirpath / path, specs)
+                for path, specs in self.specs_by_path.items()
+            ],
         )
 
     def _create_asset_def(self, path: Path, specs: Sequence[AssetSpec]) -> AssetsDefinition:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -1,14 +1,14 @@
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Annotated, Optional, Union
+from typing import Annotated, Callable, Optional, Union
 
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.result import MaterializeResult
+from dagster._record import record
 from dagster_sling import DagsterSlingTranslator, SlingResource, sling_assets
 from dagster_sling.resources import AssetExecutionContext
-from pydantic import BaseModel
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
@@ -18,39 +18,75 @@ from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesModel,
     AssetSpecTransformModel,
-    OpSpecBaseModel,
+    OpSpecModel,
+    ResolvableModel,
 )
+from dagster_components.core.schema.resolver import TemplatedValueResolver
 from dagster_components.utils import ResolvingInfo, get_wrapped_translator_class
 
 
-class SlingReplicationParams(BaseModel):
+@record
+class SlingReplicationSpec:
+    relative_path: str
+    op_spec: OpSpecModel
+    translator: DagsterSlingTranslator
+
+
+class SlingReplicationParams(ResolvableModel[SlingReplicationSpec]):
     path: str
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None
     asset_attributes: Annotated[
         Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"stream_definition"})
     ] = None
 
+    def resolve(self, resolver: TemplatedValueResolver) -> SlingReplicationSpec:
+        return SlingReplicationSpec(
+            relative_path=resolver.resolve_obj(self.path),
+            op_spec=self.op.resolve(resolver) if self.op else OpSpecModel(),
+            translator=get_wrapped_translator_class(DagsterSlingTranslator)(
+                resolving_info=ResolvingInfo(
+                    "stream_definition", self.asset_attributes or AssetAttributesModel(), resolver
+                ),
+            ),
+        )
 
-class SlingReplicationCollectionParams(BaseModel):
+
+ResolvedSlingReplicationCollectionParams = tuple[
+    SlingResource,
+    Sequence[SlingReplicationSpec],
+    Sequence[Callable[[Definitions], Definitions]],
+]
+
+
+class SlingReplicationCollectionParams(ResolvableModel[ResolvedSlingReplicationCollectionParams]):
     sling: Optional[SlingResource] = None
     replications: Sequence[SlingReplicationParams]
     transforms: Optional[Sequence[AssetSpecTransformModel]] = None
 
+    def resolve(self, resolver: TemplatedValueResolver) -> ResolvedSlingReplicationCollectionParams:
+        return (
+            self.sling if self.sling else SlingResource(),
+            [replication.resolve(resolver) for replication in self.replications],
+            [transform.resolve(resolver) for transform in self.transforms]
+            if self.transforms
+            else [],
+        )
 
-@component_type(name="sling_replication_collection")
-class SlingReplicationCollectionComponent(Component):
+
+@component_type
+class SlingReplicationCollection(Component):
     """Expose one or more Sling replications to Dagster as assets."""
 
     def __init__(
         self,
         dirpath: Path,
         resource: SlingResource,
-        sling_replications: Sequence[SlingReplicationParams],
-        transforms: Sequence[AssetSpecTransformModel],
+        replication_specs: Sequence[SlingReplicationSpec],
+        transforms: Sequence[Callable[[Definitions], Definitions]],
     ):
         self.dirpath = dirpath
         self.resource = resource
-        self.sling_replications = sling_replications
+        self.replication_specs = replication_specs
         self.transforms = transforms
 
     @classmethod
@@ -67,30 +103,22 @@ class SlingReplicationCollectionComponent(Component):
 
     @classmethod
     def load(cls, params: SlingReplicationCollectionParams, context: ComponentLoadContext) -> Self:
+        resource, replication_specs, transforms = params.resolve(context.templated_value_resolver)
         return cls(
             dirpath=context.path,
-            resource=params.sling or SlingResource(),
-            sling_replications=params.replications,
-            transforms=params.transforms or [],
+            resource=resource,
+            replication_specs=replication_specs,
+            transforms=transforms,
         )
 
-    def build_replication_asset(
-        self, context: ComponentLoadContext, replication: SlingReplicationParams
+    def build_asset(
+        self, context: ComponentLoadContext, replication_spec: SlingReplicationSpec
     ) -> AssetsDefinition:
-        translator_cls = get_wrapped_translator_class(DagsterSlingTranslator)
-
         @sling_assets(
-            name=replication.op.name if replication.op else Path(replication.path).stem,
-            op_tags=replication.op.tags if replication.op else {},
-            replication_config=self.dirpath / replication.path,
-            dagster_sling_translator=translator_cls(
-                base_translator=DagsterSlingTranslator(),
-                resolving_info=ResolvingInfo(
-                    obj_name="stream_definition",
-                    asset_attributes=replication.asset_attributes or AssetAttributesModel(),
-                    value_resolver=context.templated_value_resolver,
-                ),
-            ),
+            name=replication_spec.op_spec.name or Path(replication_spec.relative_path).stem,
+            op_tags=replication_spec.op_spec.tags,
+            replication_config=self.dirpath / replication_spec.relative_path,
+            dagster_sling_translator=replication_spec.translator,
         )
         def _asset(context: AssetExecutionContext):
             yield from self.execute(context=context, sling=self.resource)
@@ -105,10 +133,9 @@ class SlingReplicationCollectionComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         defs = Definitions(
             assets=[
-                self.build_replication_asset(context, replication)
-                for replication in self.sling_replications
+                self.build_asset(context, replication) for replication in self.replication_specs
             ],
         )
         for transform in self.transforms:
-            defs = transform.apply(defs, context.templated_value_resolver)
+            defs = transform(defs)
         return defs

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -13,13 +13,13 @@ from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesModel,
     AssetSpecTransformModel,
-    OpSpecBaseModel,
+    OpSpecModel,
 )
 
 
 class ComplexAssetParams(BaseModel):
     value: str
-    op: Optional[OpSpecBaseModel] = None
+    op: Optional[OpSpecModel] = None
     asset_attributes: Annotated[
         Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"node"})
     ] = None
@@ -50,7 +50,7 @@ class ComplexSchemaAsset(Component):
     def __init__(
         self,
         value: str,
-        op_spec: Optional[OpSpecBaseModel],
+        op_spec: Optional[OpSpecModel],
         asset_attributes: Optional[AssetAttributesModel],
         asset_transforms: Sequence[AssetSpecTransformModel],
     ):

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -3,16 +3,18 @@ in integration_tests/components/validation.
 """
 
 from dagster._core.definitions.definitions_class import Definitions
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Self
 
 from dagster_components import Component, component_type
 from dagster_components.core.component import ComponentLoadContext
-from dagster_components.core.schema.base import ComponentSchemaBaseModel
 
 
-class MyComponentSchema(ComponentSchemaBaseModel):
+class MyComponentSchema(BaseModel):
     a_string: str
     an_int: int
+
+    model_config = ConfigDict(extra="forbid")
 
 
 @component_type
@@ -31,13 +33,17 @@ class MyComponent(Component):
         return Definitions()
 
 
-class MyNestedModel(ComponentSchemaBaseModel):
+class MyNestedModel(BaseModel):
     a_string: str
     an_int: int
 
+    model_config = ConfigDict(extra="forbid")
 
-class MyNestedComponentSchema(ComponentSchemaBaseModel):
+
+class MyNestedComponentSchema(BaseModel):
     nested: dict[str, MyNestedModel]
+
+    model_config = ConfigDict(extra="forbid")
 
 
 @component_type

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -67,7 +67,7 @@ class ResolvingInfo:
 
     def get_resolved_attribute(self, attribute: str, obj: Any, default_method) -> Any:
         renderer = self.value_resolver.with_scope(**{self.obj_name: obj})
-        rendered_attributes = self.asset_attributes.resolve_properties(renderer)
+        rendered_attributes = self.asset_attributes.resolve(renderer)
         return (
             rendered_attributes[attribute]
             if attribute in rendered_attributes
@@ -93,7 +93,7 @@ class ResolvingInfo:
         ```
         """
         resolver = self.value_resolver.with_scope(**context)
-        resolved_attributes = self.asset_attributes.resolve_properties(resolver)
+        resolved_attributes = self.asset_attributes.resolve(resolver)
         return base_spec.replace_attributes(**resolved_attributes)
 
 
@@ -103,8 +103,8 @@ def get_wrapped_translator_class(translator_type: type):
     """
 
     class WrappedTranslator(translator_type):
-        def __init__(self, *, base_translator, resolving_info: ResolvingInfo):
-            self.base_translator = base_translator
+        def __init__(self, *, resolving_info: ResolvingInfo):
+            self.base_translator = translator_type()
             self.resolving_info = resolving_info
 
         def get_asset_key(self, obj: Any) -> AssetKey:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
@@ -2,13 +2,11 @@ from collections.abc import Iterator
 
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import component_type
-from dagster_components.lib.sling_replication_collection.component import (
-    SlingReplicationCollectionComponent,
-)
+from dagster_components.lib.sling_replication_collection.component import SlingReplicationCollection
 from dagster_sling import SlingResource
 
 
 @component_type(name="debug_sling_replication")
-class DebugSlingReplicationComponent(SlingReplicationCollectionComponent):
+class DebugSlingReplicationComponent(SlingReplicationCollection):
     def execute(self, context: AssetExecutionContext, sling: SlingResource) -> Iterator:
         return sling.replicate(context=context, debug=True)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
@@ -1,5 +1,6 @@
-from dagster_components import AssetAttributesModel, ComponentLoadContext
+from dagster_components import ComponentLoadContext
 from dagster_components.core.component import component_loader
+from dagster_components.core.schema.objects import AssetSpecModel
 from dagster_components.lib import PipesSubprocessScriptCollection
 from dagster_components.lib.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionParams,
@@ -14,7 +15,7 @@ def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
             PipesSubprocessScriptParams(
                 path="cool_script.py",
                 assets=[
-                    AssetAttributesModel(
+                    AssetSpecModel(
                         key="cool_script",
                         automation_condition="{{ automation_condition.eager() }}",
                     ),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -1,11 +1,11 @@
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component, component_type
 from dagster_components.core.component import ComponentLoadContext
-from dagster_components.core.schema.base import ComponentSchemaBaseModel
+from dagster_components.core.schema.base import BaseModel
 from typing_extensions import Self
 
 
-class MyComponentSchema(ComponentSchemaBaseModel):
+class MyComponentSchema(BaseModel):
     a_string: str
     an_int: int
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/__init__.py
@@ -1,11 +1,11 @@
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component, component_type
 from dagster_components.core.component import ComponentLoadContext
-from dagster_components.core.schema.base import ComponentSchemaBaseModel
+from pydantic import BaseModel
 from typing_extensions import Self
 
 
-class MyNewComponentSchema(ComponentSchemaBaseModel):
+class MyNewComponentSchema(BaseModel):
     a_string: str
     an_int: int
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -18,9 +18,8 @@ from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
     build_components_from_component_folder,
 )
-from dagster_components.lib.sling_replication_collection.component import (
-    SlingReplicationCollectionComponent,
-)
+from dagster_components.core.schema.objects import OpSpecModel
+from dagster_components.lib.sling_replication_collection.component import SlingReplicationCollection
 from dagster_sling import SlingResource
 
 from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
@@ -78,13 +77,13 @@ def test_python_params(sling_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(context, SlingReplicationCollectionComponent.get_schema())
-    component = SlingReplicationCollectionComponent.load(params, context)
+    params = decl_node.get_params(context, SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(params, context)
 
-    replications = component.sling_replications
+    replications = component.replication_specs
     assert len(replications) == 1
-    op_spec = replications[0].op
-    assert op_spec is None
+    op_spec = replications[0].op_spec
+    assert op_spec == OpSpecModel()
     assert get_asset_keys(component) == {
         AssetKey("input_csv"),
         AssetKey("input_duckdb"),
@@ -109,12 +108,12 @@ def test_python_params_op_name(sling_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(context, SlingReplicationCollectionComponent.get_schema())
-    component = SlingReplicationCollectionComponent.load(params, context=context)
+    params = decl_node.get_params(context, SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(params, context=context)
 
-    replications = component.sling_replications
+    replications = component.replication_specs
     assert len(replications) == 1
-    op_spec = replications[0].op
+    op_spec = replications[0].op_spec
     assert op_spec
     assert op_spec.name == "my_op"
     defs = component.build_defs(context)
@@ -139,11 +138,11 @@ def test_python_params_op_tags(sling_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(context, SlingReplicationCollectionComponent.get_schema())
-    component = SlingReplicationCollectionComponent.load(params=params, context=context)
-    replications = component.sling_replications
+    params = decl_node.get_params(context, SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(params=params, context=context)
+    replications = component.replication_specs
     assert len(replications) == 1
-    op_spec = replications[0].op
+    op_spec = replications[0].op_spec
     assert op_spec
     assert op_spec.tags == {"tag1": "value1"}
     defs = component.build_defs(context)
@@ -165,7 +164,7 @@ def test_load_from_path(sling_path: Path) -> None:
 
 def test_sling_subclass() -> None:
     @component_type(name="debug_sling_replication")
-    class DebugSlingReplicationComponent(SlingReplicationCollectionComponent):
+    class DebugSlingReplicationComponent(SlingReplicationCollection):
         def execute(
             self, context: AssetExecutionContext, sling: SlingResource
         ) -> Iterator[Union[AssetMaterialization, MaterializeResult]]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
@@ -1,9 +1,8 @@
 type: .custom_scope_component
 
 params:
-  attributes:
-    group_name: "{{ custom_str }}"
-    tags: "{{ custom_dict }}"
-    metadata:
-      prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
-    automation_condition: "{{ custom_automation_condition('@daily') }}"
+  group_name: "{{ custom_str }}"
+  tags: "{{ custom_dict }}"
+  metadata:
+    prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
+  automation_condition: "{{ custom_automation_condition('@daily') }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/test_schema_resolution.py
@@ -1,152 +1,75 @@
-from collections.abc import Sequence, Set
-from typing import Annotated, Optional
+from collections.abc import Sequence
+from typing import Annotated, Optional, Union
 
 import pytest
-from dagster_components import ComponentSchemaBaseModel, ResolvableFieldInfo, TemplatedValueResolver
-from dagster_components.core.schema.metadata import allow_resolve, get_required_scope
-from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from dagster._record import record
+from dagster_components import ResolvableFieldInfo, ResolvableModel, TemplatedValueResolver
+from pydantic import ValidationError
 
 
-class InnerRendered(ComponentSchemaBaseModel):
-    a: Annotated[Optional[str], ResolvableFieldInfo(required_scope={"deferred"})] = None
+@record
+class InnerObject:
+    val1: int
+    val2: Optional[str]
 
 
-class Container(BaseModel):
-    a: str
-    inner: InnerRendered
-    inner_scoped: Annotated[InnerRendered, ResolvableFieldInfo(required_scope={"c", "d"})] = Field(
-        default_factory=InnerRendered
-    )
+@record
+class TargetObject:
+    int_val: int
+    str_val: str
+    inners: Optional[Sequence[InnerObject]]
 
 
-class Outer(BaseModel):
-    a: str
-    inner: InnerRendered
-    container: Container
-    container_optional: Optional[Container] = None
-    container_optional_scoped: Annotated[
-        Optional[Container], ResolvableFieldInfo(required_scope={"a", "b"})
+class InnerParams(ResolvableModel[InnerObject]):
+    val1: Annotated[Union[int, str], ResolvableFieldInfo(output_type=int)]
+    val2: Optional[str]
+
+    def resolve(self, resolver: TemplatedValueResolver) -> InnerObject:
+        resolved_properties = self._resolved_properties(resolver)
+        return InnerObject(val1=resolved_properties["val1"], val2=resolved_properties["val2"])
+
+
+class TargetParams(ResolvableModel[TargetObject]):
+    int_val: Annotated[str, ResolvableFieldInfo(output_type=int)]
+    str_val: str
+    inners: Annotated[
+        Optional[Sequence[InnerParams]],
+        ResolvableFieldInfo(output_type=Optional[Sequence[InnerObject]]),
     ] = None
-    inner_seq: Sequence[InnerRendered]
-    inner_optional: Optional[InnerRendered] = None
-    inner_optional_seq: Optional[Sequence[InnerRendered]] = None
-    transformed: Annotated[Optional[str], ResolvableFieldInfo(output_type=Optional[int])] = None
+
+    def resolve(self, resolver: TemplatedValueResolver) -> TargetObject:
+        resolved_properties = self._resolved_properties(resolver)
+        return TargetObject(
+            int_val=resolved_properties["int_val"],
+            str_val=resolved_properties["str_val"],
+            inners=[inner.resolve(resolver) for inner in self.inners] if self.inners else None,
+        )
 
 
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        (["a"], True),
-        (["inner"], True),
-        (["inner", "a"], False),
-        (["container", "a"], True),
-        (["container", "inner"], True),
-        (["container", "inner", "a"], False),
-        (["container_optional", "a"], True),
-        (["container_optional", "inner"], True),
-        (["container_optional", "inner", "a"], False),
-        (["container_optional_scoped"], False),
-        (["container_optional_scoped", "inner", "a"], False),
-        (["container_optional_scoped", "inner_scoped", "a"], False),
-        (["inner_seq"], True),
-        (["inner_seq", 0], True),
-        (["inner_seq", 0, "a"], False),
-        (["inner_optional"], True),
-        (["inner_optional", "a"], False),
-        (["inner_optional_seq"], True),
-        (["inner_optional_seq", 0], True),
-        (["inner_optional_seq", 0, "a"], False),
-        (["transformed"], False),
-    ],
-)
-def test_allow_render(path, expected: bool) -> None:
-    assert allow_resolve(path, Outer.model_json_schema(), Outer.model_json_schema()) == expected
-
-
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        (["a"], set()),
-        (["inner", "a"], {"deferred"}),
-        (["container_optional", "inner", "a"], {"deferred"}),
-        (["inner_seq"], set()),
-        (["container_optional_scoped"], {"a", "b"}),
-        (["container_optional_scoped", "inner"], {"a", "b"}),
-        (["container_optional_scoped", "inner_scoped"], {"a", "b", "c", "d"}),
-        (["container_optional_scoped", "inner_scoped", "a"], {"a", "b", "c", "d", "deferred"}),
-    ],
-)
-def test_get_required_scope(path, expected: Set[str]) -> None:
-    assert get_required_scope(path, Outer.model_json_schema()) == expected
-
-
-def test_render() -> None:
-    data = {
-        "a": "{{ foo_val }}",
-        "inner": {"a": "{{ deferred }}"},
-        "inner_seq": [
-            {"a": "{{ deferred }}"},
-        ],
-        "container": {
-            "a": "{{ bar_val }}",
-            "inner": {"a": "{{ deferred }}"},
-        },
-    }
-
-    renderer = TemplatedValueResolver(scope={"foo_val": "foo", "bar_val": "bar"})
-    rendered_data = renderer.resolve_params(data, Outer)
-
-    assert rendered_data == {
-        "a": "foo",
-        "inner": {"a": "{{ deferred }}"},
-        "inner_seq": [
-            {"a": "{{ deferred }}"},
-        ],
-        "container": {
-            "a": "bar",
-            "inner": {"a": "{{ deferred }}"},
-        },
-    }
-
-    TypeAdapter(Outer).validate_python(rendered_data)
-
-
-class RM(ComponentSchemaBaseModel):
-    the_renderable_int: Annotated[str, ResolvableFieldInfo(output_type=int)]
-    the_unrenderable_int: int
-
-    the_str: str
-    the_opt_int: Annotated[Optional[str], ResolvableFieldInfo(output_type=Optional[int])] = None
-
-
-def test_valid_rendering() -> None:
-    rm = RM(
-        the_renderable_int="{{ some_int }}",
-        the_unrenderable_int=1,
-        the_str="{{ some_str }}",
-        the_opt_int="{{ some_int }}",
-    )
-    renderer = TemplatedValueResolver(scope={"some_int": 1, "some_str": "aaa"})
-    resolved_properties = rm.resolve_properties(renderer)
-
-    assert resolved_properties == {
-        "the_renderable_int": 1,
-        "the_unrenderable_int": 1,
-        "the_str": "aaa",
-        "the_opt_int": 1,
-    }
-
-
-def test_invalid_rendering() -> None:
-    rm = RM(
-        the_renderable_int="{{ some_int }}",
-        the_unrenderable_int=1,
-        the_str="{{ some_str }}",
-        the_opt_int="{{ some_str }}",
+def test_valid_resolution_simple() -> None:
+    resolved = InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_b").resolve(
+        TemplatedValueResolver(scope={"some_int": 1, "some_str": "a"})
     )
 
-    renderer = TemplatedValueResolver(scope={"some_int": 1, "some_str": "aaa"})
+    assert resolved == InnerObject(val1=1, val2="a_b")
 
+
+def test_valid_resolution_nested() -> None:
+    resolved = TargetParams(
+        int_val="{{ some_int }}",
+        str_val="{{ some_str }}_x",
+        inners=[InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_y")],
+    ).resolve(TemplatedValueResolver(scope={"some_int": 1, "some_str": "a"}))
+
+    assert resolved == TargetObject(
+        int_val=1,
+        str_val="a_x",
+        inners=[InnerObject(val1=1, val2="a_y")],
+    )
+
+
+def test_invalid_resolution_simple() -> None:
     with pytest.raises(ValidationError):
-        # string is not a valid output type for the_opt_int
-        rm.resolve_properties(renderer)
+        InnerParams(val1="{{ some_int }}", val2="abc").resolve(
+            TemplatedValueResolver(scope={"some_int": "NOT_AN_INT"})
+        )

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -2,7 +2,6 @@ from dagster import Definitions
 from dagster_components import (
     Component,
     ComponentLoadContext,
-    ComponentSchemaBaseModel,
     DefaultComponentScaffolder,
     component_type,
 )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -1,16 +1,17 @@
 from collections.abc import Sequence
 from typing import Annotated
 
-from dagster_components import ComponentSchemaBaseModel, ResolvableFieldInfo
+from dagster_components import ResolvableFieldInfo, ResolvableModel
 from dagster_dg.docs import generate_sample_yaml
+from pydantic import BaseModel
 
 
-class SampleSubSchema(ComponentSchemaBaseModel):
+class SampleSubSchema(BaseModel):
     str_field: str
     int_field: int
 
 
-class SampleSchema(ComponentSchemaBaseModel):
+class SampleSchema(ResolvableModel):
     sub_scoped: Annotated[SampleSubSchema, ResolvableFieldInfo(required_scope={"outer_scope"})]
     sub_optional: SampleSubSchema
     sub_list: Sequence[SampleSubSchema]


### PR DESCRIPTION
## Summary & Motivation

This is a larger rework of how the yaml resolution logic works in service of creating a clear separation between the `__init__` args and the params schema.

Each params schema is now a `ResolvableModel`, which defines an explicit function to turn the blob of configuration into an explicit object type.

This also removes the "first pass" of the resolution logic, which was way too confusing.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
