### PR TITLE
use prefix for DAGSTER_HOME temp directory

### DIFF
--- a/docs/docs/guides/deploy/deployment-options/running-dagster-locally.md
+++ b/docs/docs/guides/deploy/deployment-options/running-dagster-locally.md
@@ -52,7 +52,7 @@ For a refresher on how to set up a Dagster project, follow our [Recommended Dags
 
 Running `dagster dev` without any additional configuration starts an ephemeral instance in a temporary directory.  You may see log output indicating as such:
 ```shell
-Using temporary directory /Users/rhendricks/tmpqs_fk8_5 for storage.
+Using temporary directory /Users/rhendricks/.dagster_home_tmp_qs_fk8_5 for storage.
 ```
 This indicates that any runs or materialized assets created during your session won't be persisted once the session ends.
 

--- a/docs/docs/guides/deploy/deployment-options/running-dagster-locally.md
+++ b/docs/docs/guides/deploy/deployment-options/running-dagster-locally.md
@@ -52,7 +52,7 @@ For a refresher on how to set up a Dagster project, follow our [Recommended Dags
 
 Running `dagster dev` without any additional configuration starts an ephemeral instance in a temporary directory.  You may see log output indicating as such:
 ```shell
-Using temporary directory /Users/rhendricks/.dagster_home_tmp_qs_fk8_5 for storage.
+Using temporary directory /Users/rhendricks/.tmp_dagster_home_qs_fk8_5 for storage.
 ```
 This indicates that any runs or materialized assets created during your session won't be persisted once the session ends.
 

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -59,7 +59,7 @@ def _get_temporary_instance(cli_command: str, logger: logging.Logger) -> Iterato
     # have issues with FS notify-based event log watching
     # use a fixed prefix so that consumer projects can reliably manage,
     # e.g., add to .gitignore
-    with tempfile.TemporaryDirectory(prefix='.tmp_dagster_home_', dir=os.getcwd()) as tempdir:
+    with tempfile.TemporaryDirectory(prefix=".tmp_dagster_home_", dir=os.getcwd()) as tempdir:
         logger.info(
             f"Using temporary directory {tempdir} for storage. This will be removed when"
             f" {cli_command} exits."

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -59,7 +59,7 @@ def _get_temporary_instance(cli_command: str, logger: logging.Logger) -> Iterato
     # have issues with FS notify-based event log watching
     # use a fixed prefix so that consumer projects can reliably manage,
     # e.g., add to .gitignore
-    with tempfile.TemporaryDirectory(prefix='.dagster_home_tmp_', dir=os.getcwd()) as tempdir:
+    with tempfile.TemporaryDirectory(prefix='.tmp_dagster_home_', dir=os.getcwd()) as tempdir:
         logger.info(
             f"Using temporary directory {tempdir} for storage. This will be removed when"
             f" {cli_command} exits."

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -57,7 +57,9 @@ def _inject_local_env_file(logger: logging.Logger) -> Iterator[None]:
 def _get_temporary_instance(cli_command: str, logger: logging.Logger) -> Iterator[DagsterInstance]:
     # make the temp dir in the cwd since default temp dir roots
     # have issues with FS notify-based event log watching
-    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tempdir:
+    # use a fixed prefix so that consumer projects can reliably manage,
+    # e.g., add to .gitignore
+    with tempfile.TemporaryDirectory(prefix='.dagster_home_tmp_', dir=os.getcwd()) as tempdir:
         logger.info(
             f"Using temporary directory {tempdir} for storage. This will be removed when"
             f" {cli_command} exits."


### PR DESCRIPTION
## Summary & Motivation

This will make it easier for consumer projects to manage these directories, e.g., add them to `.gitignore` files, with less risk of picking up unintended files.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
