### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs-beta/docs/integrations/libraries/duckdb/using-duckdb-with-dagster.md
+++ b/docs/docs-beta/docs/integrations/libraries/duckdb/using-duckdb-with-dagster.md
@@ -1,5 +1,5 @@
 ---
-title: "Using DucDB with Dagster"
+title: "Using DuckDB with Dagster"
 description: Store your Dagster assets in DuckDB
 sidebar_position: 100
 ---


### PR DESCRIPTION
## Summary & Motivation

`DucDB` -> `DuckDB`