### PR TITLE
Update dev python modules script to only install dagster-ge on python>=3.10

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -80,7 +80,6 @@ def main(
         "python_modules/libraries/dagster-gcp",
         "python_modules/libraries/dagster-gcp-pandas",
         "python_modules/libraries/dagster-gcp-pyspark",
-        "python_modules/libraries/dagster-ge",
         "python_modules/libraries/dagster-embedded-elt",
         "python_modules/libraries/dagster-fivetran",
         "python_modules/libraries/dagster-k8s",
@@ -109,6 +108,11 @@ def main(
         "python_modules/libraries/dagster-twilio",
         "python_modules/libraries/dagstermill",
     ]
+
+    if sys.version_info >= (3, 10):
+        editable_target_paths += [
+            "python_modules/libraries/dagster-ge",
+        ]
 
     if sys.version_info <= (3, 12):
         editable_target_paths += [


### PR DESCRIPTION
## Summary

`dagster-ge`'s setup.py specifies a 3.10 version bound - respect it in the install script.
