### PR TITLE
[components] hard-pin typer==0.15.1

### DIFF
--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -40,7 +40,9 @@ setup(
         "jsonschema",
         "PyYAML>=5.1",
         "rich",
-        "typer",
+        # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
+        # frequently updated since is designed to be used from an isolated environment.
+        "typer==0.15.1",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

Hard-pin `typer` in `dagster-dg`. We do this because we use some internal APIs which might suddenly be changed. We can get away with this because `dg` is designed to be used from an isolated environment, so we are not going to hit dependency conflicts.

## How I Tested These Changes

Existing test suite.