### PR TITLE
make reserved run ids and run requests tuples a tick property

### DIFF
--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import AbstractSet, Any, Generic, NamedTuple, Optional, Union  # noqa: UP035
@@ -518,12 +518,17 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         return self.tick_data.run_requests
 
     @property
+    def reserved_run_ids_with_requests(self) -> Iterable[tuple[str, RunRequest]]:
+        reserved_run_ids = self.tick_data.reserved_run_ids or []
+        return zip(reserved_run_ids, self.run_requests or [])
+
+    @property
     def unsubmitted_run_ids_with_requests(self) -> Sequence[tuple[str, RunRequest]]:
         reserved_run_ids = self.tick_data.reserved_run_ids or []
         unrequested_run_ids = set(reserved_run_ids) - set(self.tick_data.run_ids)
         return [
             (run_id, run_request)
-            for run_id, run_request in zip(reserved_run_ids, self.run_requests or [])
+            for run_id, run_request in self.reserved_run_ids_with_requests
             if run_id in unrequested_run_ids
         ]
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1132,12 +1132,12 @@ class AssetDaemon(DagsterDaemon):
         check_after_runs_num = instance.get_tick_termination_check_interval()
 
         check.invariant(len(run_requests) == len(reserved_run_ids))
-        to_submit = zip(range(len(run_requests)), reserved_run_ids, run_requests)
+        to_submit = enumerate(tick_context.tick.reserved_run_ids_with_requests)
 
         def submit_run_request(
-            run_id_with_run_request: tuple[int, str, RunRequest],
+            run_id_with_run_request: tuple[int, tuple[str, RunRequest]],
         ) -> tuple[str, AbstractSet[EntityKey]]:
-            i, run_id, run_request = run_id_with_run_request
+            i, (run_id, run_request) = run_id_with_run_request
             return self._submit_run_request(
                 i=i,
                 instance=instance,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -134,6 +134,10 @@ class SensorLaunchContext(AbstractContextManager):
         return str(self._tick.tick_id)
 
     @property
+    def tick(self) -> InstigatorTick:
+        return self._tick
+
+    @property
     def log_key(self) -> Sequence[str]:
         return [
             self._remote_sensor.handle.repository_handle.repository_name,
@@ -1055,7 +1059,7 @@ def _handle_run_requests_and_automation_condition_evaluations(
 
     check_for_debug_crash(sensor_debug_crash_flags, "RUN_IDS_RESERVED")
 
-    run_ids_with_run_requests = list(zip(reserved_run_ids, raw_run_requests))
+    run_ids_with_run_requests = list(context.tick.reserved_run_ids_with_requests)
     yield from _submit_run_requests(
         run_ids_with_run_requests,
         evaluations,


### PR DESCRIPTION
## Summary & Motivation
Small change to make the zipped list of requested run ids and their associated run requests a property on the tick, rather than something we compute each time we need it, and potentially have the implementations drift 

## How I Tested These Changes


