### PR TITLE
[da] Create `data_version_changed` AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -674,10 +674,12 @@ class AssetGraphView(LoadingContext):
         )
 
     async def _compute_updated_since_cursor_subset(
-        self, key: AssetKey, cursor: Optional[int]
+        self, key: AssetKey, cursor: Optional[int], require_data_version_update: bool = False
     ) -> EntitySubset[AssetKey]:
         value = self._queryer.get_asset_subset_updated_after_cursor(
-            asset_key=key, after_cursor=cursor
+            asset_key=key,
+            after_cursor=cursor,
+            require_data_version_update=require_data_version_update,
         ).value
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
@@ -712,6 +714,14 @@ class AssetGraphView(LoadingContext):
             asset_method=functools.partial(
                 self._compute_updated_since_cursor_subset, cursor=temporal_context.last_event_id
             ),
+        )
+
+    @cached_method
+    async def compute_data_version_changed_since_temporal_context_subset(
+        self, *, key: AssetKey, temporal_context: TemporalContext
+    ) -> EntitySubset[AssetKey]:
+        return await self._compute_updated_since_cursor_subset(
+            key, cursor=temporal_context.last_event_id, require_data_version_update=True
         )
 
     class MultiDimInfo(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -847,6 +847,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
                 context.legacy_context.instance_queryer.get_asset_subset_updated_after_cursor(
                     asset_key=parent_asset_key,
                     after_cursor=context.legacy_context.previous_max_storage_id,
+                    require_data_version_update=False,
                 ),
                 parent_partitions_def,
             )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -498,6 +498,18 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
 
     @public
     @staticmethod
+    def data_version_changed() -> "BuiltinAutomationCondition[AssetKey]":
+        """Returns an AutomationCondition that is true if the target's data version has been changed
+        since the previous tick.
+        """
+        from dagster._core.definitions.declarative_automation.operands.operands import (
+            DataVersionChangedCondition,
+        )
+
+        return DataVersionChangedCondition()
+
+    @public
+    @staticmethod
     def cron_tick_passed(
         cron_schedule: str, cron_timezone: str = "UTC"
     ) -> "BuiltinAutomationCondition":

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -171,6 +171,22 @@ class NewlyUpdatedCondition(SubsetAutomationCondition):
 
 @whitelist_for_serdes
 @record
+class DataVersionChangedCondition(SubsetAutomationCondition):
+    @property
+    def name(self) -> str:
+        return "data_version_changed"
+
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        # if it's the first time evaluating, just return the empty subset
+        if context.previous_temporal_context is None:
+            return context.get_empty_subset()
+        return await context.asset_graph_view.compute_data_version_changed_since_temporal_context_subset(
+            key=context.key, temporal_context=context.previous_temporal_context
+        )
+
+
+@whitelist_for_serdes
+@record
 class CronTickPassedCondition(SubsetAutomationCondition):
     cron_schedule: str
     cron_timezone: str

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -737,7 +737,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
                 # the set of asset partitions which have been updated since the latest storage id
                 parent_partitions_subset = self.get_asset_subset_updated_after_cursor(
-                    asset_key=parent_asset_key, after_cursor=latest_storage_id
+                    asset_key=parent_asset_key,
+                    after_cursor=latest_storage_id,
+                    require_data_version_update=False,
                 ).subset_value
 
                 # we are mapping from the partitions of the parent asset to the partitions of
@@ -930,7 +932,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
     @cached_method
     def get_asset_subset_updated_after_cursor(
-        self, *, asset_key: AssetKey, after_cursor: Optional[int]
+        self, *, asset_key: AssetKey, after_cursor: Optional[int], require_data_version_update: bool
     ) -> SerializableEntitySubset[AssetKey]:
         """Returns the AssetSubset of the given asset that has been updated after the given cursor."""
         partitions_def = self.asset_graph.get(asset_key).partitions_def
@@ -938,7 +940,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             asset_key,
             asset_partitions=None,
             after_cursor=after_cursor,
-            respect_materialization_data_versions=False,
+            respect_materialization_data_versions=require_data_version_update,
         )
         if partitions_def is None:
             validated_asset_partitions = {
@@ -988,7 +990,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             return ValidAssetSubset.empty(asset_key, partitions_def=partitions_def)
         else:
             return self.get_asset_subset_updated_after_cursor(
-                asset_key=asset_key, after_cursor=first_event_after_time.storage_id - 1
+                asset_key=asset_key,
+                after_cursor=first_event_after_time.storage_id - 1,
+                require_data_version_update=False,
             )
 
     def get_parent_asset_partitions_updated_after_child(

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_data_version_changed.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_data_version_changed.py
@@ -1,0 +1,78 @@
+from typing import Optional
+
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetMaterialization,
+    AutomationCondition,
+    DagsterInstance,
+    DailyPartitionsDefinition,
+    Definitions,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
+    asset,
+    evaluate_automation_conditions,
+)
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+
+
+@pytest.mark.parametrize(
+    "partitions_def",
+    [None, DailyPartitionsDefinition("2025-01-01"), StaticPartitionsDefinition(["0", "1", "2"])],
+)
+def test_data_version_changed_condition(partitions_def: Optional[PartitionsDefinition]) -> None:
+    partition_key = partitions_def.get_last_partition_key() if partitions_def else None
+
+    @asset(automation_condition=AutomationCondition.data_version_changed())
+    def foo() -> AssetCheckResult:
+        return AssetCheckResult(passed=True)
+
+    defs = Definitions(assets=[foo])
+    instance = DagsterInstance.ephemeral()
+
+    # hasn't newly updated
+    result = evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.total_requested == 0
+
+    # now updates
+    instance.report_runless_asset_event(
+        AssetMaterialization(foo.key, tags={DATA_VERSION_TAG: "a"}, partition=partition_key)
+    )
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # no longer "newly updated"
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # now updates with the same data version
+    instance.report_runless_asset_event(
+        AssetMaterialization(foo.key, tags={DATA_VERSION_TAG: "a"}, partition=partition_key)
+    )
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # again
+    instance.report_runless_asset_event(
+        AssetMaterialization(foo.key, tags={DATA_VERSION_TAG: "a"}, partition=partition_key)
+    )
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # new data version
+    instance.report_runless_asset_event(
+        AssetMaterialization(foo.key, tags={DATA_VERSION_TAG: "b"}, partition=partition_key)
+    )
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # new data version
+    instance.report_runless_asset_event(
+        AssetMaterialization(foo.key, tags={DATA_VERSION_TAG: "c"}, partition=partition_key)
+    )
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # no longer "newly updated"
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0


### PR DESCRIPTION
## Summary & Motivation

This closes a gap we've had for awhile -- we have a `code_version_changed` condition but not a `data_version_changed` one. This is useful for users who make heavy use of data versions to avoid triggering materializations in response to upstream updats that don't change the data version

## How I Tested These Changes

## Changelog

Added a new `AutomationCondition.data_version_changed()` condition.
