### PR TITLE
Consolidate codepath for passing params into open_server_process

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -197,7 +197,9 @@ def test_get_server_id():
 def create_server_process():
     port = find_free_port()
     with instance_for_test() as instance:
-        server_process = open_server_process(instance.get_ref(), port=port, socket=None)
+        server_process = open_server_process(
+            instance.get_ref(), port=port, socket=None, server_command=GrpcServerCommand.API_GRPC
+        )
         assert server_process is not None
         return port, server_process
 
@@ -206,7 +208,11 @@ def test_fixed_server_id():
     port = find_free_port()
     with instance_for_test() as instance:
         server_process = open_server_process(
-            instance.get_ref(), port=port, socket=None, fixed_server_id="fixed_id"
+            instance.get_ref(),
+            port=port,
+            socket=None,
+            fixed_server_id="fixed_id",
+            server_command=GrpcServerCommand.API_GRPC,
         )
         assert server_process is not None
 
@@ -247,7 +253,11 @@ def test_ping_metrics_retrieval():
     with instance_for_test() as instance:
         port = find_free_port()
         server_process = open_server_process(
-            instance.get_ref(), port=port, socket=None, enable_metrics=True
+            instance.get_ref(),
+            port=port,
+            socket=None,
+            enable_metrics=True,
+            server_command=GrpcServerCommand.API_GRPC,
         )
         assert server_process is not None
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_watch_server.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_watch_server.py
@@ -3,7 +3,7 @@ import time
 import pytest
 from dagster._core.test_utils import instance_for_test
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import open_server_process
+from dagster._grpc.server import GrpcServerCommand, open_server_process
 from dagster._grpc.server_watcher import create_grpc_watch_thread
 from dagster._serdes.ipc import interrupt_ipc_subprocess_pid
 from dagster._utils import find_free_port
@@ -56,7 +56,12 @@ def test_grpc_watch_thread_server_update(instance, process_cleanup):
         called["yup"] = True
 
     # Create initial server
-    server_process = open_server_process(instance.get_ref(), port=port, socket=None)
+    server_process = open_server_process(
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        server_command=GrpcServerCommand.API_GRPC,
+    )
     process_cleanup.append(server_process)
 
     try:
@@ -77,7 +82,12 @@ def test_grpc_watch_thread_server_update(instance, process_cleanup):
     assert not called
 
     # Create updated server
-    server_process = open_server_process(instance.get_ref(), port=port, socket=None)
+    server_process = open_server_process(
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        server_command=GrpcServerCommand.API_GRPC,
+    )
     process_cleanup.append(server_process)
 
     try:
@@ -109,7 +119,11 @@ def test_grpc_watch_thread_server_reconnect(process_cleanup, instance):
 
     # Create initial server
     server_process = open_server_process(
-        instance.get_ref(), port=port, socket=None, fixed_server_id=fixed_server_id
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        fixed_server_id=fixed_server_id,
+        server_command=GrpcServerCommand.API_GRPC,
     )
     process_cleanup.append(server_process)
 
@@ -133,7 +147,11 @@ def test_grpc_watch_thread_server_reconnect(process_cleanup, instance):
     wait_for_condition(lambda: called.get("on_disconnect"), watch_interval)
 
     server_process = open_server_process(
-        instance.get_ref(), port=port, socket=None, fixed_server_id=fixed_server_id
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        fixed_server_id=fixed_server_id,
+        server_command=GrpcServerCommand.API_GRPC,
     )
     process_cleanup.append(server_process)
     wait_for_condition(lambda: called.get("on_reconnected"), watch_interval)
@@ -166,7 +184,11 @@ def test_grpc_watch_thread_server_error(process_cleanup, instance):
 
     # Create initial server
     server_process = open_server_process(
-        instance.get_ref(), port=port, socket=None, fixed_server_id=fixed_server_id
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        fixed_server_id=fixed_server_id,
+        server_command=GrpcServerCommand.API_GRPC,
     )
     process_cleanup.append(server_process)
 
@@ -198,7 +220,11 @@ def test_grpc_watch_thread_server_error(process_cleanup, instance):
 
     new_server_id = "new_server_id"
     server_process = open_server_process(
-        instance.get_ref(), port=port, socket=None, fixed_server_id=new_server_id
+        instance.get_ref(),
+        port=port,
+        socket=None,
+        fixed_server_id=new_server_id,
+        server_command=GrpcServerCommand.API_GRPC,
     )
     process_cleanup.append(server_process)
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -63,7 +63,7 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import EmptyWorkspaceTarget, ModuleTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import open_server_process
+from dagster._grpc.server import GrpcServerCommand, open_server_process
 from dagster._record import copy
 from dagster._scheduler.scheduler import (
     RETAIN_ORPHANED_STATE_INTERVAL_SECONDS,
@@ -764,6 +764,7 @@ def _grpc_server_remote_repo(port: int, scheduler_instance: DagsterInstance):
         port=port,
         socket=None,
         loadable_target_origin=loadable_target_origin(),
+        server_command=GrpcServerCommand.API_GRPC,
     )
     try:
         location_origin: GrpcServerCodeLocationOrigin = GrpcServerCodeLocationOrigin(


### PR DESCRIPTION
## Summary & Motivation
The previous logic made it very easy to accidentally miss a parameter. Instead, construct as dict of kwargs and pass them through.

## How I Tested These Changes
Existing dagster dev commands, launch dagster dev with force_port set to true or false

## Changelog
Fixed an issue where the "Reload definitions" button didn't work when using `dagster dev` on Windows, starting in the 1.9.10 release.
