### PR TITLE
Allow get_entity_subset_from_asset_graph_subset to stil return EntitySubsets for serialized AssetGraphSubsets when the underlying partitions definition has gotten larger

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -68,6 +68,19 @@ class AssetGraphSubset(NamedTuple):
         AssetGraphSubset contains.
         """
         partitions_def = asset_graph.get(asset_key).partitions_def
+        if asset_key in self.non_partitioned_asset_keys:
+            return SerializableEntitySubset(key=asset_key, value=True)
+        elif asset_key in self.partitions_subsets_by_asset_key:
+            return SerializableEntitySubset(
+                key=asset_key, value=self.partitions_subsets_by_asset_key[asset_key]
+            )
+        else:
+            return SerializableEntitySubset(
+                key=asset_key,
+                value=partitions_def.empty_subset() if partitions_def else False,
+            )
+
+        partitions_def = asset_graph.get(asset_key).partitions_def
         if partitions_def is None:
             return SerializableEntitySubset(
                 key=asset_key, value=asset_key in self.non_partitioned_asset_keys


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue where a relatively benign change to a partitions definition like extending the range of the partition keys could cause a backfill to fail due to the partitions not exactly matching. Instead of rejecting the subset as invalid, it returns a corrected subset object with the latest partitions definition in it, as long as it is valid.

## How I Tested These Changes
New test case

## Changelog
NOCHANGELOG

