### PR TITLE
[fix][bk] allow make in toxfiles

### DIFF
--- a/examples/experimental/dagster-dlift/kitchen-sink/tox.ini
+++ b/examples/experimental/dagster-dlift/kitchen-sink/tox.ini
@@ -22,6 +22,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../../.. rebuild_ui

--- a/examples/experimental/dagster-dlift/tox.ini
+++ b/examples/experimental/dagster-dlift/tox.ini
@@ -18,6 +18,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../.. rebuild_ui

--- a/integration_tests/test_suites/dagster-azure-live-tests/tox.ini
+++ b/integration_tests/test_suites/dagster-azure-live-tests/tox.ini
@@ -20,6 +20,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../.. rebuild_ui

--- a/integration_tests/test_suites/dagster-gcp-live-tests/tox.ini
+++ b/integration_tests/test_suites/dagster-gcp-live-tests/tox.ini
@@ -8,7 +8,7 @@ passenv =
     COVERALLS_REPO_TOKEN
     BUILDKITE*
     TEST_GCP*
-    GCP_LIVE_TEST_CREDENTIALS 
+    GCP_LIVE_TEST_CREDENTIALS
 install_command = uv pip install {opts} {packages}
 deps =
   -e ../../../python_modules/dagster[test]
@@ -22,6 +22,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../.. rebuild_ui

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/tox.ini
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/tox.ini
@@ -21,6 +21,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../../.. rebuild_ui

--- a/python_modules/libraries/dagster-airlift/tox.ini
+++ b/python_modules/libraries/dagster-airlift/tox.ini
@@ -21,6 +21,7 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
   # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../.. rebuild_ui

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -12,7 +12,7 @@ deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e .
-whitelist_externals =
+allowlist_externals =
   /bin/bash
   uv
 commands =

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -14,6 +14,7 @@ deps =
   -e .
 whitelist_externals =
   /bin/bash
+  uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-tableau/tox.ini
+++ b/python_modules/libraries/dagster-tableau/tox.ini
@@ -3,7 +3,10 @@ skipsdist = true
 
 [testenv]
 download = True
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+passenv =
+  CI_*
+  COVERALLS_REPO_TOKEN
+  BUILDKITE*
 install_command = uv pip install {opts} {packages}
 deps =
   -e ../../dagster-pipes


### PR DESCRIPTION
## Summary

We use `make` in a bunch of toxfiles without allowlisting it. This didn't seem to be an issue until #27456 updated the buildkite runner images, potentially unintentionally bumping some other dep. Explicitly allowlists `make` to fix several tests that were broken on master: https://buildkite.com/dagster/dagster-dagster/builds/109948