### PR TITLE
[dagster-airlift] properly handle dag run batching

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -11,6 +11,7 @@ from dagster import (
 from dagster._annotations import beta
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._core.definitions.external_asset import external_asset_from_spec
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 
 from dagster_airlift.core.airflow_defs_data import MappedAsset
 from dagster_airlift.core.airflow_instance import AirflowInstance
@@ -76,6 +77,7 @@ def build_defs_from_airflow_instance(
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     dag_selector_fn: Optional[DagSelectorFn] = None,
     source_code_retrieval_enabled: Optional[bool] = None,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> Definitions:
     """Builds a :py:class:`dagster.Definitions` object from an Airflow instance.
 
@@ -104,6 +106,7 @@ def build_defs_from_airflow_instance(
             produced by the sensor.
         dag_selector_fn (Optional[DagSelectorFn]): A function that allows for filtering which DAGs assets are created for.
         source_code_retrieval_enabled (Optional[bool]): Whether to retrieve source code for the Airflow dags. By default, source code is retrieved when the number of dags is under 50 for performance reasons. This setting overrides the default behavior.
+        default_sensor_status (Optional[DefaultSensorStatus]): The default status for the sensor. By default, the sensor will be enabled.
 
     Returns:
         Definitions: A :py:class:`dagster.Definitions` object containing the assets and sensor.
@@ -237,6 +240,7 @@ def build_defs_from_airflow_instance(
                     airflow_instance=airflow_instance,
                     minimum_interval_seconds=sensor_minimum_interval_seconds,
                     event_transformer_fn=event_transformer_fn,
+                    default_sensor_status=default_sensor_status,
                 )
             ]
         ),

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -87,6 +87,7 @@ def build_airflow_polling_sensor(
     airflow_instance: AirflowInstance,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
 ) -> SensorDefinition:
     """The constructed sensor polls the Airflow instance for activity, and inserts asset events into Dagster's event log.
 
@@ -114,7 +115,7 @@ def build_airflow_polling_sensor(
     @sensor(
         name=f"{airflow_data.airflow_instance.name}__airflow_dag_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,
-        default_status=DefaultSensorStatus.RUNNING,
+        default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
         # This sensor will only ever execute asset checks and not asset materializations.
         asset_selection=AssetSelection.all_asset_checks(),
     )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -154,6 +154,7 @@ def build_airflow_polling_sensor(
         while get_current_datetime() - current_date < timedelta(seconds=MAIN_LOOP_TIMEOUT_SECONDS):
             batch_result = next(sensor_iter, None)
             if batch_result is None:
+                context.log.info("Received no batch result. Breaking.")
                 break
             all_asset_events.extend(batch_result.asset_events)
 
@@ -257,30 +258,50 @@ def materializations_and_requests_from_batch_iter(
     offset: int,
     airflow_data: AirflowDefinitionsData,
 ) -> Iterator[Optional[BatchResult]]:
-    runs = airflow_data.airflow_instance.get_dag_runs_batch(
-        dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
-        end_date_gte=datetime_from_timestamp(end_date_gte),
-        end_date_lte=datetime_from_timestamp(end_date_lte),
-        offset=offset,
-    )
-    context.log.info(f"Found {len(runs)} dag runs for {airflow_data.airflow_instance.name}")
-    context.log.info(f"All runs {runs}")
-    for i, dag_run in enumerate(runs):
-        mats = build_synthetic_asset_materializations(
-            context, airflow_data.airflow_instance, dag_run, airflow_data
+    total_processed_runs = 0
+    total_entries = 0
+    while True:
+        latest_offset = total_processed_runs + offset
+        runs, total_entries = airflow_data.airflow_instance.get_dag_runs_batch(
+            dag_ids=list(airflow_data.dag_ids_with_mapped_asset_keys),
+            end_date_gte=datetime_from_timestamp(end_date_gte),
+            end_date_lte=datetime_from_timestamp(end_date_lte),
+            offset=latest_offset,
         )
-        context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
-
-        all_asset_keys_materialized = {mat.asset_key for mat in mats}
-        yield (
-            BatchResult(
-                idx=i + offset,
-                asset_events=mats,
-                all_asset_keys_materialized=all_asset_keys_materialized,
+        if len(runs) == 0:
+            yield None
+            context.log.info("Received no runs. Breaking.")
+            break
+        context.log.info(
+            f"Processing {len(runs)}/{total_entries} dag runs for {airflow_data.airflow_instance.name}..."
+        )
+        for i, dag_run in enumerate(runs):
+            context.log.info(
+                f"dag ids: {[dag_id for dag_id in airflow_data.dag_ids_with_mapped_asset_keys]}"
             )
-            if mats
-            else None
+            mats = build_synthetic_asset_materializations(
+                context, airflow_data.airflow_instance, dag_run, airflow_data
+            )
+            context.log.info(f"Found {len(mats)} materializations for {dag_run.run_id}")
+
+            all_asset_keys_materialized = {mat.asset_key for mat in mats}
+            yield (
+                BatchResult(
+                    idx=i + latest_offset,
+                    asset_events=mats,
+                    all_asset_keys_materialized=all_asset_keys_materialized,
+                )
+                if mats
+                else None
+            )
+        total_processed_runs += len(runs)
+        context.log.info(
+            f"Processed {total_processed_runs}/{total_entries} dag runs for {airflow_data.airflow_instance.name}."
         )
+        if total_processed_runs == total_entries:
+            yield None
+            context.log.info("Processed all runs. Breaking.")
+            break
 
 
 def build_synthetic_asset_materializations(

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -2,6 +2,9 @@ from typing import cast
 
 import requests
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.definitions.sensor_definition import build_sensor_context
+from dagster._core.test_utils import instance_for_test
 from dagster_airlift.constants import SOURCE_CODE_METADATA_KEY
 from dagster_airlift.core import build_defs_from_airflow_instance
 from dagster_airlift.core.airflow_instance import AirflowInstance
@@ -56,3 +59,30 @@ def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
     for assets_def in defs.assets:
         metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
         assert SOURCE_CODE_METADATA_KEY in metadata
+
+
+def test_sensor_iteration_multiple_batches(airflow_instance: None, mocker: MockFixture) -> None:
+    """Test that sensor iteration correctly retrieves all sensors when over batch limit."""
+    spy = mocker.spy(AirflowInstance, "get_dag_runs_batch")
+    af_instance = AirflowInstance(
+        auth_backend=AirflowBasicAuthBackend(
+            webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+        ),
+        name=AIRFLOW_INSTANCE_NAME,
+        # Set low list limit, force batched retrieval.
+        batch_dag_runs_limit=1,
+    )
+    defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
+    # create a bunch of runs
+    for i in range(2):
+        run_id = af_instance.trigger_dag("simple_unproxied_dag")
+        af_instance.wait_for_run_completion(dag_id="simple_unproxied_dag", run_id=run_id)
+
+    assert defs.sensors
+    sensor_def = next(iter(defs.sensors))
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(instance=instance, definitions=defs)
+        result = sensor_def(ctx)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert spy.call_count == 2


### PR DESCRIPTION
## Summary & Motivation
Properly handle batched runs in the airlift sensor.

Previously, we were always stopping after the first batch. Now, we re-run the request until we're out of runs.

## How I Tested These Changes
Tested on mwaa instance with 500 runs + new unit tests.

## Changelog
- [dagster-airlift] fixed a bug when handling large batches of dag runs at once.
