### PR TITLE
[RFC] [components] Make pyproject.toml source of truth for deployment code locations (BUILD-652)

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
@@ -2,3 +2,5 @@
 directory_type = "workspace"
 
 [tool.dg.workspace]
+[[tool.dg.workspace.projects]]
+path = "projects/project-1"

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/7-scaffold-project.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/7-scaffold-project.txt
@@ -1,4 +1,4 @@
-cd ../.. && dg scaffold project project-2
+cd ../.. && dg scaffold project projects/project-2
 
 Creating a Dagster project at /.../dagster-workspace/projects/project-2.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-2.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/8-project-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/8-project-list.txt
@@ -1,4 +1,4 @@
 dg list project
 
-project-1
-project-2
+projects/project-1
+projects/project-2

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
@@ -111,7 +111,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
 
         # Scaffold new project
         run_command_and_snippet_output(
-            cmd="cd ../.. && dg scaffold project project-2 --use-editable-dagster",
+            cmd="cd ../.. && dg scaffold project projects/project-2 --use-editable-dagster",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffold-project.txt",
             update_snippets=update_snippets,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -178,8 +178,8 @@ def temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
         if dg_context.is_project:
             entries.append(_workspace_entry_for_project(dg_context))
         elif dg_context.is_workspace:
-            for project_name in dg_context.get_project_names():
-                project_root = dg_context.get_project_path(project_name)
+            for spec in dg_context.project_specs:
+                project_root = dg_context.root_path / spec.path
                 project_context: DgContext = dg_context.with_root_path(project_root)
                 entries.append(_workspace_entry_for_project(project_context))
         yaml.dump({"load_from": entries}, temp_workspace_file)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from pathlib import Path
+from typing import Final, Optional
 
 import click
 
@@ -8,6 +9,9 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.scaffold import scaffold_project, scaffold_workspace
 from dagster_dg.utils import DgClickCommand, exit_with_error
+
+# Workspace
+_DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
 
 
 @click.command(name="init", cls=DgClickCommand)
@@ -56,13 +60,12 @@ def init_command(
             "Continuing without adding a project. You can create one later by running `dg scaffold project`."
         )
     else:
+        project_path = Path(workspace_path, _DEFAULT_INIT_PROJECTS_DIR, project_name)
+        if project_path.exists():
+            exit_with_error(f"A file or directory already exists at {project_path}.")
         workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
             workspace_path, cli_config
         )
-        if workspace_dg_context.has_project(project_name):
-            exit_with_error(f"A project named {project_name} already exists.")
-
-        project_path = workspace_dg_context.get_workspace_project_path(project_name)
 
         scaffold_project(
             project_path,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -40,8 +40,8 @@ def project_list_command(**global_options: object) -> None:
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_environment(Path.cwd(), cli_config)
 
-    for project in dg_context.get_project_names():
-        click.echo(project)
+    for project in dg_context.project_specs:
+        click.echo(project.path)
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -81,7 +81,7 @@ def workspace_scaffold_command(
 
 
 @scaffold_group.command(name="project", cls=DgClickCommand)
-@click.argument("name", type=str)
+@click.argument("path", type=Path)
 @click.option(
     "--skip-venv",
     is_flag=True,
@@ -97,8 +97,8 @@ def workspace_scaffold_command(
 )
 @dg_editable_dagster_options
 @dg_global_options
-def project_scaffold_command(
-    name: str,
+def scaffold_project_command(
+    path: Path,
     skip_venv: bool,
     populate_cache: bool,
     use_editable_dagster: Optional[str],
@@ -131,15 +131,16 @@ def project_scaffold_command(
     """  # noqa: D301
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
+
+    abs_path = path.resolve()
     if dg_context.is_workspace:
-        if dg_context.has_project(name):
-            exit_with_error(f"A project named {name} already exists.")
-        project_path = dg_context.project_root_path / name
-    else:
-        project_path = Path.cwd() / name
+        if dg_context.has_project(abs_path.relative_to(dg_context.workspace_root_path)):
+            exit_with_error(f"The current workspace already specifies a project at {abs_path}.")
+        elif abs_path.exists():
+            exit_with_error(f"A file or directory already exists at {abs_path}.")
 
     scaffold_project(
-        project_path,
+        abs_path,
         dg_context,
         use_editable_dagster=use_editable_dagster,
         use_editable_components_package_only=use_editable_components_package_only,

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -114,7 +114,9 @@ class DgConfig:
         if container_workspace_file_config:
             if "cli" in container_workspace_file_config:
                 cli_partials.append(container_workspace_file_config["cli"])
-            workspace_config = DgWorkspaceConfig.from_raw(container_workspace_file_config)
+            workspace_config = DgWorkspaceConfig.from_raw(
+                container_workspace_file_config["workspace"]
+            )
 
         if root_file_config:
             if "cli" in root_file_config:
@@ -185,7 +187,7 @@ class DgCliConfig:
             verbose=merged.get("verbose", DgCliConfig.verbose),
             use_component_modules=merged.get(
                 "use_component_modules",
-                DgCliConfig.__dataclass_fields__["use_component_modules"].default_factory(),
+                cls.__dataclass_fields__["use_component_modules"].default_factory(),
             ),
             use_dg_managed_environment=merged.get(
                 "use_dg_managed_environment", DgCliConfig.use_dg_managed_environment
@@ -243,15 +245,36 @@ class DgRawProjectConfig(TypedDict):
 
 @dataclass
 class DgWorkspaceConfig:
-    pass
+    projects: list["DgWorkspaceProjectSpec"]
 
     @classmethod
     def from_raw(cls, raw: "DgRawWorkspaceConfig") -> Self:
-        return cls()
+        projects = [DgWorkspaceProjectSpec.from_raw(spec) for spec in raw.get("projects", [])]
+        return cls(projects)
 
 
-class DgRawWorkspaceConfig(TypedDict):
-    pass
+class DgRawWorkspaceConfig(TypedDict, total=False):
+    projects: list["DgRawWorkspaceProjectSpec"]
+
+
+@dataclass
+class DgWorkspaceProjectSpec:
+    path: Path
+    code_location_name: Optional[str] = None
+
+    @classmethod
+    def from_raw(cls, raw: "DgRawWorkspaceProjectSpec") -> Self:
+        return cls(
+            path=Path(raw["path"]),
+            code_location_name=raw.get(
+                "code_location_name", DgWorkspaceProjectSpec.code_location_name
+            ),
+        )
+
+
+class DgRawWorkspaceProjectSpec(TypedDict, total=False):
+    path: Required[str]
+    code_location_name: str
 
 
 # ########################
@@ -383,7 +406,7 @@ def _validate_dg_file_config(raw_dict: Mapping[str, object]) -> DgFileConfig:
 
 def _validate_dg_config_file_cli_section(section: object) -> None:
     if not isinstance(section, dict):
-        raise DgValidationError("`tool.dg.cli` must be a table.")
+        _raise_mistyped_key_error("tool.dg.cli", get_type_str(dict), section)
     for key, type_ in DgRawCliConfig.__annotations__.items():
         _validate_file_config_setting(section, key, type_, "tool.dg.cli")
     _validate_file_config_no_extraneous_keys(
@@ -393,7 +416,7 @@ def _validate_dg_config_file_cli_section(section: object) -> None:
 
 def _validate_file_config_project_section(section: object) -> None:
     if not isinstance(section, dict):
-        raise DgValidationError("`tool.dg.project` must be a table.")
+        _raise_mistyped_key_error("tool.dg.project", get_type_str(dict), section)
     for key, type_ in DgRawProjectConfig.__annotations__.items():
         _validate_file_config_setting(section, key, type_, "tool.dg.project")
     _validate_file_config_no_extraneous_keys(
@@ -403,11 +426,30 @@ def _validate_file_config_project_section(section: object) -> None:
 
 def _validate_file_config_workspace_section(section: object) -> None:
     if not isinstance(section, dict):
-        raise DgValidationError("`tool.dg.workspace` must be a table.")
+        _raise_mistyped_key_error("tool.dg.workspace", get_type_str(dict), section)
     for key, type_ in DgRawWorkspaceConfig.__annotations__.items():
-        _validate_file_config_setting(section, key, type_, "tool.dg.workspace")
+        if key == "projects":
+            _validate_file_config_setting(section, key, list, "tool.dg.workspace")
+            for i, spec in enumerate(section.get("projects") or []):
+                _validate_file_config_workspace_project_spec(spec, i)
+        else:
+            _validate_file_config_setting(section, key, type_, "tool.dg.workspace")
     _validate_file_config_no_extraneous_keys(
         set(DgRawWorkspaceConfig.__annotations__.keys()), section, "tool.dg.workspace"
+    )
+
+
+def _validate_file_config_workspace_project_spec(section: object, index: int) -> None:
+    if not isinstance(section, dict):
+        _raise_mistyped_key_error(
+            f"tool.dg.workspace.projects[{index}]", get_type_str(dict), section
+        )
+    for key, type_ in DgRawWorkspaceProjectSpec.__annotations__.items():
+        _validate_file_config_setting(section, key, type_, f"tool.dg.workspace.projects[{index}]")
+    _validate_file_config_no_extraneous_keys(
+        set(DgRawWorkspaceProjectSpec.__annotations__.keys()),
+        section,
+        f"tool.dg.workspace.projects[{index}]",
     )
 
 
@@ -467,7 +509,7 @@ def get_type_str(t: Any) -> str:
     else:
         # It's a parametric type like list[str], Union[int, str], etc.
         args = get_args(t)
-        arg_strs = [get_type_str(a) for a in args]
+        arg_strs = sorted([get_type_str(a) for a in args])
         if origin is Union:
             return " | ".join(arg_strs)
         if origin is Literal:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -164,7 +164,7 @@ def scaffold_subtree(
     normalized_path = os.path.normpath(path)
     project_name = project_name or os.path.basename(normalized_path).replace("-", "_")
     if not os.path.exists(normalized_path):
-        os.mkdir(normalized_path)
+        os.makedirs(normalized_path, exist_ok=True)
 
     project_template_path = os.path.join(os.path.dirname(__file__), "templates", templates_path)
     loader = jinja2.FileSystemLoader(searchpath=project_template_path)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -4,7 +4,7 @@ from typing import get_args
 
 import pytest
 import tomlkit
-from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import
+from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import, get_toml_node
 
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.cli_tests.test_scaffold_commands import (
@@ -29,6 +29,13 @@ def test_dg_init_command_success(monkeypatch) -> None:
         assert Path("dagster-workspace/projects/helloworld/helloworld").exists()
         assert Path("dagster-workspace/projects/helloworld/pyproject.toml").exists()
         assert Path("dagster-workspace/projects/helloworld/helloworld_tests").exists()
+
+        # Check workspace TOML content
+        toml = tomlkit.parse(Path("dagster-workspace/pyproject.toml").read_text())
+        assert (
+            get_toml_node(toml, ("tool", "dg", "workspace", "projects", 0, "path"), str)
+            == "projects/helloworld"
+        )
 
 
 def test_dg_init_command_no_project(monkeypatch) -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -27,15 +27,20 @@ from dagster_dg_tests.utils import (
 
 def test_list_project_success():
     with ProxyRunner.test() as runner, isolated_example_workspace(runner):
-        runner.invoke("scaffold", "project", "foo")
-        runner.invoke("scaffold", "project", "bar")
+        result = runner.invoke("scaffold", "project", "foo")
+        assert_runner_result(result)
+        result = runner.invoke("scaffold", "project", "projects/bar")
+        assert_runner_result(result)
+        result = runner.invoke("scaffold", "project", "more_projects/baz")
+        assert_runner_result(result)
         result = runner.invoke("list", "project")
         assert_runner_result(result)
         assert (
             result.output.strip()
             == textwrap.dedent("""
-                bar
                 foo
+                projects/bar
+                more_projects/baz
             """).strip()
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -21,7 +21,7 @@ def test_validate_command_deployment_context_success():
             "project",
             "--use-editable-components-package-only",
             dagster_git_repo_dir,
-            "project-1",
+            "projects/project-1",
         )
         assert_runner_result(result)
         result = runner.invoke(
@@ -29,7 +29,7 @@ def test_validate_command_deployment_context_success():
             "project",
             "--use-editable-components-package-only",
             dagster_git_repo_dir,
-            "project-2",
+            "projects/project-2",
         )
         assert_runner_result(result)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -118,6 +118,7 @@ def test_invalid_config_workspace():
             "tool.dg.project",
             "tool.dg.cli.invalid_key",
             "tool.dg.workspace.invalid_key",
+            "tool.dg.workspace.projects[0].invalid_key",
         ]
         for path in cases:
             with _reset_pyproject_toml():
@@ -130,10 +131,20 @@ def test_invalid_config_workspace():
             ["tool.dg.cli.use_dg_managed_environment", bool, 1],
             ["tool.dg.cli.use_component_modules", Sequence[str], 1],
             ["tool.dg.cli.require_local_venv", bool, 1],
+            ["tool.dg.workspace.projects", list, 1],
+            ["tool.dg.workspace.projects[1]", dict, 1],
+            ["tool.dg.workspace.projects[0].path", str, 1],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():
                 _set_and_detect_mistyped_value(path, expected_type, val)
+
+        cases = [
+            ["tool.dg.workspace.projects[0].path", str],
+        ]
+        for path, expected_type in cases:
+            with _reset_pyproject_toml():
+                _set_and_detect_missing_required_key(path, expected_type)
 
 
 def test_invalid_config_project():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -108,12 +108,11 @@ def isolated_example_project_foo_bar(
     """
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
+    project_path = Path("foo-bar")
     if in_workspace:
         fs_context = isolated_example_workspace(runner)
-        project_path = Path("projects/foo-bar")
     else:
         fs_context = runner.isolated_filesystem()
-        project_path = Path("foo-bar")
     with fs_context:
         result = runner.invoke(
             "scaffold",


### PR DESCRIPTION
## Summary & Motivation

- Make the `tool.dg.workspace.projects` list the source of truth for the projects in a workspace. This replaces the behavior of just relying on the content of the hardcoded "projects" folder of the workspace.
- The elements of `tool.dg.workspace.projects` are called "project specs"-- currently there is just a single key, `path`, a path relative to the workspace root.
- If you choose to have `dg init` scaffold a project, it will always do so inside a created "projects" folder.
- `dg scaffold project` now expects its argument to be a path rather than just a name. Intermediate folders will be created for you.
- The `dg list project` command now prints a list of project paths instead of names.

## How I Tested These Changes

New unit tests.