### PR TITLE
Change step execution to be aware of pool granularity

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -352,7 +352,7 @@ class ActiveExecution:
                     step_priority = 0
 
                 if not self._instance_concurrency_context.claim(
-                    concurrency_key, step.key, step_priority
+                    concurrency_key, step.key, step_priority, is_legacy_tag=not step.pool
                 ):
                     continue
 

--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional
 from typing_extensions import Self
 
 from dagster._core.instance import DagsterInstance
+from dagster._core.instance.config import PoolGranularity
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.storage.tags import PRIORITY_TAG
 
@@ -40,7 +41,7 @@ class InstanceConcurrencyContext:
         self._pending_timeouts = defaultdict(float)
         self._pending_claim_counts = defaultdict(int)
         self._pending_claims = set()
-        self._default_limit = instance.global_op_concurrency_default_limit
+        self._pool_config = instance.event_log_storage.get_pool_config()
         self._claims = set()
         try:
             self._run_priority = int(dagster_run.tags.get(PRIORITY_TAG, "0"))
@@ -86,8 +87,22 @@ class InstanceConcurrencyContext:
         pool_limits = self._instance.event_log_storage.get_pool_limits()
         self._pools = {pool.name: pool for pool in pool_limits}
 
-    def claim(self, concurrency_key: str, step_key: str, step_priority: int = 0):
+    def claim(
+        self,
+        concurrency_key: str,
+        step_key: str,
+        step_priority: int = 0,
+        is_legacy_tag: bool = False,
+    ) -> bool:
         if not self._instance.event_log_storage.supports_global_concurrency_limits:
+            return True
+
+        if self._pool_config.pool_granularity == PoolGranularity.RUN or (
+            self._pool_config.pool_granularity is None and not is_legacy_tag
+        ):
+            # short-circuit the claiming of the global op concurrency slot
+            # no need to reset pending claims here since the pool config doesn't change over the
+            # lifetime of the context
             return True
 
         if step_key in self._pending_claims:
@@ -99,11 +114,10 @@ class InstanceConcurrencyContext:
         else:
             self._pending_claims.add(step_key)
 
+        default_limit = self._pool_config.default_pool_limit
         pool_info = self.get_pool_info(concurrency_key)
-        if (pool_info is None and self._default_limit is not None) or (
-            pool_info is not None
-            and pool_info.from_default
-            and pool_info.limit != self._default_limit
+        if (pool_info is None and default_limit is not None) or (
+            pool_info is not None and pool_info.from_default and pool_info.limit != default_limit
         ):
             self._instance.event_log_storage.initialize_concurrency_limit_to_default(
                 concurrency_key
@@ -113,6 +127,8 @@ class InstanceConcurrencyContext:
             pool_info = self.get_pool_info(concurrency_key)
 
         if pool_info is None:
+            # make sure we remove claims here, since we could have previously blocked on a pool,
+            # which then had its limit removed
             if step_key in self._pending_claims:
                 self._pending_claims.remove(step_key)
             return True

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/conftest.py
@@ -7,7 +7,7 @@ CUSTOM_SLEEP_INTERVAL = 3
 
 
 @pytest.fixture()
-def concurrency_instance():
+def concurrency_instance_default_granularity():
     with tempfile.TemporaryDirectory() as temp_dir:
         with instance_for_test(
             overrides={
@@ -15,6 +15,42 @@ def concurrency_instance():
                     "module": "dagster.utils.test",
                     "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
                     "config": {"base_dir": temp_dir},
+                },
+            }
+        ) as instance:
+            yield instance
+
+
+@pytest.fixture()
+def concurrency_instance_run_granularity():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            overrides={
+                "event_log_storage": {
+                    "module": "dagster.utils.test",
+                    "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
+                    "config": {"base_dir": temp_dir},
+                },
+                "concurrency": {
+                    "pools": {"granularity": "run"},
+                },
+            }
+        ) as instance:
+            yield instance
+
+
+@pytest.fixture()
+def concurrency_instance_op_granularity():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            overrides={
+                "event_log_storage": {
+                    "module": "dagster.utils.test",
+                    "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
+                    "config": {"base_dir": temp_dir},
+                },
+                "concurrency": {
+                    "pools": {"granularity": "op"},
                 },
             }
         ) as instance:
@@ -31,7 +67,9 @@ def concurrency_instance_with_default_one():
                     "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
                     "config": {"base_dir": temp_dir},
                 },
-                "concurrency": {"default_op_concurrency_limit": 1},
+                "concurrency": {
+                    "pools": {"granularity": "op", "default_limit": 1},
+                },
             }
         ) as instance:
             yield instance
@@ -46,6 +84,9 @@ def concurrency_custom_sleep_instance():
                     "module": "dagster.utils.test",
                     "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
                     "config": {"base_dir": temp_dir, "sleep_interval": CUSTOM_SLEEP_INTERVAL},
+                },
+                "concurrency": {
+                    "pools": {"granularity": "op"},
                 },
             }
         ) as instance:

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -198,6 +198,9 @@ def test_active_concurrency(use_tags):
                     "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
                     "config": {"base_dir": temp_dir},
                 },
+                "concurrency": {
+                    "pools": {"granularity": "op"},
+                },
             }
         ) as instance:
             assert instance.event_log_storage.supports_global_concurrency_limits
@@ -249,7 +252,9 @@ class MockInstanceConcurrencyContext(InstanceConcurrencyContext):
     def global_concurrency_keys(self) -> set[str]:
         return {"foo"}
 
-    def claim(self, concurrency_key: str, step_key: str, priority: int = 0):
+    def claim(
+        self, concurrency_key: str, step_key: str, priority: int = 0, is_legacy_tag: bool = False
+    ):
         self._pending_claims.add(step_key)
         return False
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/conftest.py
@@ -31,6 +31,9 @@ def instance():
                     "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
                     "config": {"base_dir": temp_dir, "sleep_interval": 0.01},
                 },
+                "concurrency": {
+                    "pools": {"granularity": "op"},
+                },
             }
         ) as _instance:
             yield _instance


### PR DESCRIPTION
## Summary & Motivation
Previously, op concurrency tags were only used to enforce limits for global op concurrency.

Now, with the introduction of pools, we support an API where pool limits are only enforced at the run level.  This means that we are unnecessarily constraining ops at the op level.

This PR changes the behavior of op execution to no longer require the acquisition of a pool slot if the pool granularity is set for runs.

## How I Tested These Changes
BK