### PR TITLE
[components] project_name -> code_location_name in scaffolded pyproject.toml

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.dagster]
 module_name = "{{ project_name }}.definitions"
-project_name = "{{ project_name }}"
+code_location_name = "{{ project_name }}"
 
 [tool.setuptools.packages.find]
 exclude=["{{ project_name }}_tests"]

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -51,6 +51,7 @@ def test_project_scaffold_command_succeeds():
         origins = get_origins_from_toml("my_dagster_project/pyproject.toml")
         assert len(origins) == 1
         assert origins[0].loadable_target_origin.module_name == "my_dagster_project.definitions"
+        assert origins[0].location_name == "my_dagster_project"
 
 
 def test_project_scaffold_command_excludes_succeeds():

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -117,6 +117,7 @@ def scaffold_code_location(
         ),
         dependencies=dependencies,
         dev_dependencies=dev_dependencies,
+        code_location_name=path.name,
         uv_sources=uv_sources,
     )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.dagster]
 module_name = "{{ project_name }}.definitions"
-project_name = "{{ project_name }}"
+code_location_name = "{{ code_location_name }}"
 
 [tool.dg]
 is_code_location = true

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils.py
@@ -200,7 +200,6 @@ def scaffold_subtree(
                 f.write(
                     template.render(
                         repo_name=project_name,  # deprecated
-                        code_location_name=project_name,
                         dagster_version=dagster_version,
                         project_name=project_name,
                         **other_template_vars,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -43,6 +43,11 @@ def test_code_location_scaffold_inside_deployment_success(monkeypatch) -> None:
         assert Path("code_locations/foo-bar/foo_bar_tests").exists()
         assert Path("code_locations/foo-bar/pyproject.toml").exists()
 
+        # Check TOML content
+        toml = tomli.loads(Path("code_locations/foo-bar/pyproject.toml").read_text())
+        assert toml["tool"]["dagster"]["module_name"] == "foo_bar.definitions"
+        assert toml["tool"]["dagster"]["code_location_name"] == "foo-bar"
+
         # Check venv created
         assert Path("code_locations/foo-bar/.venv").exists()
         assert Path("code_locations/foo-bar/uv.lock").exists()


### PR DESCRIPTION
## Summary & Motivation

The `tool.dagster` section in our scaffolded `pyproject.toml` contained a `project_name` field. However, this isn't actually read by our tooling. What _is_ read is a `code_location_name` field. This renames the `project_name` field to `code_location_name`. It affects both `dagster` and `dagster-dg` (which had started by copying the `pyproject.toml` scaffolding from dagster core).

## How I Tested These Changes

Tweaked unit tests.