### PR TITLE
[components] Add `dg dev` command (BUILD-578)

### DIFF
--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -184,7 +184,7 @@ def ipc_read_event_stream(
             message = _process_line(file_pointer)
 
 
-# Windows subprocess termination utilities
+# Windows subprocess termination utilities. See here for why we send CTRL_BREAK_EVENT on Windows:
 # https://stefan.sofa-rockers.org/2013/08/15/handling-sub-process-hierarchies-python-linux-os-x/
 
 
@@ -212,7 +212,7 @@ def interrupt_ipc_subprocess(proc: "Popen[Any]") -> None:
 
 
 def interrupt_ipc_subprocess_pid(pid: int) -> None:
-    """Send CTRL_BREAK on Windows, SIGINT on other platforms."""
+    """Send CTRL_BREAK_EVENT on Windows, SIGINT on other platforms."""
     check.int_param(pid, "pid")
 
     if sys.platform == "win32":

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -6,6 +6,7 @@ from dagster_dg.cli.code_location import code_location_group
 from dagster_dg.cli.component import component_group
 from dagster_dg.cli.component_type import component_type_group
 from dagster_dg.cli.deployment import deployment_group
+from dagster_dg.cli.dev import dev_command
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
@@ -21,9 +22,10 @@ def create_dg_cli():
         name="dg",
         commands={
             "code-location": code_location_group,
-            "deployment": deployment_group,
             "component": component_group,
             "component-type": component_type_group,
+            "deployment": deployment_group,
+            "dev": dev_command,
         },
         context_settings={
             "max_content_width": DG_CLI_MAX_OUTPUT_WIDTH,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -1,0 +1,215 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Optional, TypeVar
+
+import click
+import psutil
+import yaml
+
+from dagster_dg.cli.global_options import dg_global_options
+from dagster_dg.config import normalize_cli_config
+from dagster_dg.context import DgContext
+from dagster_dg.error import DgError
+from dagster_dg.utils import DgClickCommand, exit_with_error, pushd
+
+T = TypeVar("T")
+
+_CHECK_SUBPROCESS_INTERVAL = 5
+
+
+@click.command(name="dev", cls=DgClickCommand)
+@click.option(
+    "--code-server-log-level",
+    help="Set the log level for code servers spun up by dagster services.",
+    show_default=True,
+    default="warning",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+)
+@click.option(
+    "--log-level",
+    help="Set the log level for dagster services.",
+    show_default=True,
+    default="info",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+)
+@click.option(
+    "--log-format",
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="colored",
+    help="Format of the logs for dagster services",
+)
+@click.option(
+    "--port",
+    "-p",
+    type=int,
+    help="Port to use for the Dagster webserver.",
+    required=False,
+)
+@click.option(
+    "--host",
+    "-h",
+    type=str,
+    help="Host to use for the Dagster webserver.",
+    required=False,
+)
+@click.option(
+    "--live-data-poll-rate",
+    help="Rate at which the dagster UI polls for updated asset data (in milliseconds)",
+    type=int,
+    default=2000,
+    show_default=True,
+    required=False,
+)
+@dg_global_options
+@click.pass_context
+def dev_command(
+    context: click.Context,
+    code_server_log_level: str,
+    log_level: str,
+    log_format: str,
+    port: Optional[int],
+    host: Optional[str],
+    live_data_poll_rate: int,
+    **global_options: Mapping[str, object],
+) -> None:
+    """Start a local deployment of your Dagster project.
+
+    If run inside a deployment directory, this command will launch all code locations in the
+    deployment. If launched inside a code location directory, it will launch only that code
+    location.
+    """
+    cli_config = normalize_cli_config(global_options, context)
+    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+
+    forward_options = [
+        *_format_forwarded_option("--code-server-log-level", code_server_log_level),
+        *_format_forwarded_option("--log-level", log_level),
+        *_format_forwarded_option("--log-format", log_format),
+        *_format_forwarded_option("--port", port),
+        *_format_forwarded_option("--host", host),
+        *_format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
+    ]
+
+    # In a code location context, we can just run `dagster dev` directly, using `dagster` from the
+    # code location's environment.
+    if dg_context.is_code_location:
+        cmd = ["uv", "run", "dagster", "dev", *forward_options]
+        temp_workspace_file_cm = nullcontext()
+
+    # In a deployment context, dg dev will construct a temporary
+    # workspace file that points at all defined code locations and invoke:
+    #
+    #     uv tool run --with dagster-webserver dagster dev
+    #
+    # The `--with dagster-webserver` is necessary here to ensure that dagster-webserver is
+    # installed in the isolated environment that `uv` will install `dagster` in.
+    # `dagster-webserver` is not a dependency of `dagster` but is required to run the `dev`
+    # command.
+    elif dg_context.is_deployment:
+        cmd = [
+            "uv",
+            "tool",
+            "run",
+            "--with",
+            "dagster-webserver",
+            "dagster",
+            "dev",
+            *forward_options,
+        ]
+        temp_workspace_file_cm = _temp_workspace_file(dg_context)
+    else:
+        exit_with_error("This command must be run inside a code location or deployment directory.")
+
+    with pushd(dg_context.root_path), temp_workspace_file_cm as workspace_file:
+        if workspace_file:  # only non-None deployment context
+            cmd.extend(["--workspace", workspace_file])
+        uv_run_dagster_dev_process = _open_subprocess(cmd)
+        try:
+            while True:
+                time.sleep(_CHECK_SUBPROCESS_INTERVAL)
+                if uv_run_dagster_dev_process.poll() is not None:
+                    raise DgError(
+                        f"dagster-dev process shut down unexpectedly with return code {uv_run_dagster_dev_process.returncode}."
+                    )
+        except KeyboardInterrupt:
+            click.secho(
+                "Received keyboard interrupt. Shutting down dagster-dev process.", fg="yellow"
+            )
+        finally:
+            # For reasons not fully understood, directly interrupting the `uv run` process does not
+            # work as intended. The interrupt signal is not correctly propagated to the `dagster
+            # dev` process, and so that process never shuts down. Therefore, we send the signal
+            # directly to the `dagster dev` process (the only child of the `uv run` process). This
+            # will cause `dagster dev` to terminate which in turn will cause `uv run` to terminate.
+            dagster_dev_pid = _get_child_process_pid(uv_run_dagster_dev_process)
+            _interrupt_subprocess(dagster_dev_pid)
+
+            try:
+                uv_run_dagster_dev_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                click.secho("`dagster dev` did not terminate in time. Killing it.")
+                uv_run_dagster_dev_process.kill()
+
+
+@contextmanager
+def _temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
+    with NamedTemporaryFile(mode="w+", delete=True) as temp_workspace_file:
+        entries = []
+        for location in dg_context.get_code_location_names():
+            code_location_root = dg_context.get_code_location_path(location)
+            loc_context = dg_context.with_root_path(code_location_root)
+            entry = {
+                "working_directory": str(dg_context.deployment_root_path),
+                "relative_path": str(loc_context.definitions_path),
+                "location_name": loc_context.code_location_name,
+            }
+            if loc_context.use_dg_managed_environment:
+                entry["executable_path"] = str(loc_context.code_location_python_executable)
+            entries.append({"python_file": entry})
+        yaml.dump({"load_from": entries}, temp_workspace_file)
+        temp_workspace_file.flush()
+        yield temp_workspace_file.name
+
+
+def _format_forwarded_option(option: str, value: object) -> list[str]:
+    return [] if value is None else [option, str(value)]
+
+
+def _get_child_process_pid(proc: "subprocess.Popen") -> int:
+    children = psutil.Process(proc.pid).children(recursive=False)
+    if len(children) != 1:
+        raise ValueError(f"Expected exactly one child process, but found {len(children)}")
+    return children[0].pid
+
+
+# Windows subprocess termination utilities. See here for why we send CTRL_BREAK_EVENT on Windows:
+# https://stefan.sofa-rockers.org/2013/08/15/handling-sub-process-hierarchies-python-linux-os-x/
+
+
+def _interrupt_subprocess(pid: int) -> None:
+    """Send CTRL_BREAK_EVENT on Windows, SIGINT on other platforms."""
+    if sys.platform == "win32":
+        os.kill(pid, signal.CTRL_BREAK_EVENT)
+    else:
+        os.kill(pid, signal.SIGINT)
+
+
+def _open_subprocess(command: Sequence[str]) -> "subprocess.Popen":
+    """Sets the correct flags to support graceful termination."""
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    return subprocess.Popen(
+        command,
+        creationflags=creationflags,
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -1,0 +1,204 @@
+import contextlib
+import signal
+import socket
+import subprocess
+import time
+
+import psutil
+import requests
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+from dagster_graphql.client import DagsterGraphQLClient
+
+ensure_dagster_dg_tests_import()
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    isolated_example_code_location_foo_bar,
+    isolated_example_deployment_foo,
+)
+
+
+def test_dev_command_deployment_context_success():
+    with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
+        runner.invoke("code-location", "scaffold", "code-location-1")
+        runner.invoke("code-location", "scaffold", "code-location-2")
+
+        port = _find_free_port()
+        dev_process = _launch_dev_command(["--port", str(port)])
+        code_locations = {"code-location-1", "code-location-2"}
+        _assert_code_locations_loaded_and_exit(code_locations, port, dev_process)
+
+
+def test_dev_command_code_location_context_success():
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        port = _find_free_port()
+        dev_process = _launch_dev_command(["--port", str(port)])
+        _assert_code_locations_loaded_and_exit({"foo-bar"}, port, dev_process)
+
+
+def test_dev_command_outside_project_context_fails():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        port = _find_free_port()
+        dev_process = _launch_dev_command(["--port", str(port)], capture_output=True)
+        assert dev_process.wait() != 0
+        assert dev_process.stdout
+        assert (
+            "This command must be run inside a code location or deployment directory."
+            in dev_process.stdout.read().decode()
+        )
+
+
+def test_dev_command_has_options_of_dagster_dev():
+    from dagster._cli.dev import dev_command as dagster_dev_command
+    from dagster_dg.cli import dev_command as dev_command
+
+    exclude_dagster_dev_params = {
+        # Exclude options that are used to set the target. `dg dev` does not use.
+        "empty_workspace",
+        "workspace",
+        "python_file",
+        "module_name",
+        "package_name",
+        "attribute",
+        "working_directory",
+        "grpc_port",
+        "grpc_socket",
+        "grpc_host",
+        "use_ssl",
+        # Misc others to exclude
+        "use_legacy_code_server_behavior",
+    }
+
+    dg_dev_param_names = {param.name for param in dev_command.params}
+    dagster_dev_param_names = {param.name for param in dagster_dev_command.params}
+    dagster_dev_params_to_check = dagster_dev_param_names - exclude_dagster_dev_params
+
+    unmatched_params = dagster_dev_params_to_check - dg_dev_param_names
+    assert not unmatched_params, f"dg dev missing params: {unmatched_params}"
+
+
+# Modify this test with a new option whenever a new forwarded option is added to `dagster-dev`.
+def test_dev_command_forwards_options_to_dagster_dev():
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        port = _find_free_port()
+        options = [
+            "--code-server-log-level",
+            "debug",
+            "--log-level",
+            "debug",
+            "--log-format",
+            "json",
+            "--port",
+            str(port),
+            "--host",
+            "localhost",
+            "--live-data-poll-rate",
+            "3000",
+        ]
+        try:
+            dev_process = _launch_dev_command(options)
+            time.sleep(0.5)
+            child_process = _get_child_processes(dev_process.pid)[0]
+            expected_cmdline = [
+                "uv",
+                "run",
+                "dagster",
+                "dev",
+                *options,
+            ]
+            assert child_process.cmdline() == expected_cmdline
+        finally:
+            dev_process.terminate()
+            dev_process.communicate()
+
+
+# ########################
+# ##### HELPERS
+# ########################
+
+
+def _launch_dev_command(options: list[str], capture_output: bool = False) -> subprocess.Popen:
+    # We start a new process instead of using the runner to avoid blocking the test. We need to
+    # poll the webserver to know when it is ready.
+    return subprocess.Popen(
+        [
+            "dg",
+            "dev",
+            *options,
+        ],
+        stdout=subprocess.PIPE if capture_output else None,
+    )
+
+
+def _assert_code_locations_loaded_and_exit(
+    code_locations: set[str], port: int, proc: subprocess.Popen
+) -> None:
+    child_processes = []
+    try:
+        _ping_webserver(port)
+        child_processes = _get_child_processes(proc.pid)
+        assert _query_code_locations(port) == code_locations
+    finally:
+        proc.send_signal(signal.SIGINT)
+        proc.communicate()
+        time.sleep(3)
+        _assert_no_child_processes_running(child_processes)
+
+
+def _assert_no_child_processes_running(child_procs: list[psutil.Process]) -> None:
+    for proc in child_procs:
+        assert not proc.is_running(), f"Process {proc.pid} ({proc.cmdline()}) is still running"
+
+
+def _get_child_processes(pid) -> list[psutil.Process]:
+    parent = psutil.Process(pid)
+    return parent.children(recursive=True)
+
+
+def _find_free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+def _ping_webserver(port: int) -> None:
+    start_time = time.time()
+    while True:
+        try:
+            server_info = requests.get(f"http://localhost:{port}/server_info").json()
+            if server_info:
+                return
+        except:
+            print("Waiting for dagster-webserver to be ready..")  # noqa: T201
+
+        if time.time() - start_time > 30:
+            raise Exception("Timed out waiting for dagster-webserver to serve requests")
+
+        time.sleep(1)
+
+
+_GET_CODE_LOCATION_NAMES_QUERY = """
+query GetCodeLocationNames {
+  repositoriesOrError {
+    __typename
+    ... on RepositoryConnection {
+      nodes {
+        name
+        location {
+          name
+        }
+      }
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}
+"""
+
+
+def _query_code_locations(port: int) -> set[str]:
+    gql_client = DagsterGraphQLClient(hostname="localhost", port_number=port)
+    result = gql_client._execute(_GET_CODE_LOCATION_NAMES_QUERY)  # noqa: SLF001
+    assert result["repositoriesOrError"]["__typename"] == "RepositoryConnection"
+    return {node["location"]["name"] for node in result["repositoriesOrError"]["nodes"]}

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -38,6 +38,7 @@ setup(
         "typing_extensions>=4.4.0,<5",
         "markdown",
         "jsonschema",
+        "psutil",
         "PyYAML>=5.1",
         "rich",
         # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
@@ -52,6 +53,13 @@ setup(
         ]
     },
     extras_require={
-        "test": ["click", "dagster-components", "pydantic", "pytest", "tomli-w"],
+        "test": [
+            "click",
+            "dagster-components",
+            "dagster-graphql",
+            "pydantic",
+            "pytest",
+            "tomli-w",
+        ],
     },
 )

--- a/python_modules/libraries/dagster-dg/tox.ini
+++ b/python_modules/libraries/dagster-dg/tox.ini
@@ -13,6 +13,7 @@ deps =
   -e .[test]
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-test
+  -e ../../../python_modules/dagster-graphql
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-components
 allowlist_externals =


### PR DESCRIPTION
## Summary & Motivation

Add the `dg dev` command.

- Unlike `dagster dev`, you cannot pass a target (like `--python-file ...`) to `dg dev`. Instead, `dg dev` works by inferring the target from the context:
    - In a code location context, `dg dev` will run `uv run dagster dev ...` against the code location environment.
    - In a deployment context, `dg dev` will construct a temporary workspace file that points at all defined code locations and `uv tool run --with dagster-webserver dagster dev`
- `dg dev` accepts almost all the arguments of `dagster dev` that make sense, and forwards them.

There is a discussion here about how to support venvs in the deployment root-- this PR takes the position that regardless of what we decide to do there, we should just use `uv tool run` if no venv is present.

## How I Tested These Changes

New unit tests. I encountered some difficulties around process shutdown, where `uv run` was not properly forwarding signals to the underlying `dagster dev` process. I've worked around this and the tests ensure that no orphaned processes are left behind from the four-layer process hierarchy: `dg` -> `uv run` -> `dagster dev` -> code servers, daemon, webserver.