### PR TITLE
[components] Implement @local namespace for local components (BUILD-654)

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/basic-subclass.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/basic-subclass.py
@@ -1,6 +1,6 @@
-from dagster_components import component_type
+from dagster_components import registered_component_type
 from dagster_components.lib import SlingReplicationCollection
 
 
-@component_type(name="custom_subclass")
+@registered_component_type(name="custom_subclass")
 class CustomSubclass(SlingReplicationCollection): ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
@@ -1,13 +1,13 @@
 from collections.abc import Mapping
 from typing import Any
 
-from dagster_components import component_type
+from dagster_components import registered_component_type
 from dagster_components.lib import SlingReplicationCollection
 
 import dagster as dg
 
 
-@component_type(name="custom_subclass")
+@registered_component_type(name="custom_subclass")
 class SubclassWithScope(SlingReplicationCollection):
     def get_additional_scope(self) -> Mapping[str, Any]:
         def _custom_cron(cron_schedule: str) -> dg.AutomationCondition:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/debug-mode.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/debug-mode.py
@@ -1,13 +1,13 @@
 from collections.abc import Iterator
 
-from dagster_components import component_type
+from dagster_components import registered_component_type
 from dagster_components.lib import SlingReplicationCollection
 from dagster_sling import SlingResource
 
 import dagster as dg
 
 
-@component_type(name="debug_sling_replication")
+@registered_component_type(name="debug_sling_replication")
 class DebugSlingReplicationComponent(SlingReplicationCollection):
     def execute(
         self, context: dg.AssetExecutionContext, sling: SlingResource

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
@@ -1,10 +1,14 @@
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import (
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 from pydantic import BaseModel
 
 from dagster import Definitions
 
 
-@component_type(name="shell_command")
+@registered_component_type(name="shell_command")
 class ShellCommand(Component):
     @classmethod
     def get_schema(cls) -> type[BaseModel]: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
@@ -1,4 +1,8 @@
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import (
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 
 import dagster as dg
 
@@ -10,7 +14,7 @@ def _get_script_runner(val: str) -> ScriptRunner:
     return ScriptRunner()
 
 
-@component_type(name="shell_command")
+@registered_component_type(name="shell_command")
 class ShellCommand(Component):
     def __init__(self, params):
         self.params = params

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -1,7 +1,11 @@
 import subprocess
 from typing import Optional
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import (
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecModel
 from pydantic import BaseModel
 
@@ -16,7 +20,7 @@ class ShellScriptSchema(BaseModel):
     # highlight-end
 
 
-@component_type(name="shell_command")
+@registered_component_type(name="shell_command")
 class ShellCommand(Component):
     def __init__(self, params: ShellScriptSchema):
         self.params = params

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
@@ -1,6 +1,10 @@
 from typing import Optional
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import (
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 from dagster_components.core.schema.objects import AssetAttributesModel, OpSpecModel
 from pydantic import BaseModel
 
@@ -15,7 +19,7 @@ class ShellScriptSchema(BaseModel):
     # highlight-end
 
 
-@component_type(name="shell_command")
+@registered_component_type(name="shell_command")
 class ShellCommand(Component):
     @classmethod
     def get_schema(cls) -> type[ShellScriptSchema]:

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -2,7 +2,7 @@ from dagster_components.core.component import (
     Component as Component,
     ComponentLoadContext as ComponentLoadContext,
     ComponentTypeRegistry as ComponentTypeRegistry,
-    component_type as component_type,
+    registered_component_type as registered_component_type,
 )
 from dagster_components.core.component_defs_builder import (
     build_component_defs as build_component_defs,

--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -11,7 +11,10 @@ from dagster_components.core.component import (
     ComponentTypeRegistry,
     get_component_type_name,
 )
-from dagster_components.core.component_decl_builder import find_local_component_types
+from dagster_components.core.component_decl_builder import (
+    LOCAL_COMPONENT_NAMESPACE,
+    find_local_component_types,
+)
 from dagster_components.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
 
 
@@ -47,12 +50,12 @@ def list_local_component_types_command(component_directories: Sequence[str]) -> 
     for component_directory in component_directories:
         output_for_directory = {}
         for component_type in find_local_component_types(Path(component_directory)):
-            output_for_directory[f".{get_component_type_name(component_type)}"] = (
-                ComponentTypeMetadata(
-                    name=get_component_type_name(component_type),
-                    package=component_directory,
-                    **component_type.get_metadata(),
-                )
+            output_for_directory[
+                f"{LOCAL_COMPONENT_NAMESPACE}.{get_component_type_name(component_type)}"
+            ] = ComponentTypeMetadata(
+                name=get_component_type_name(component_type),
+                package=component_directory,
+                **component_type.get_metadata(),
             )
         if len(output_for_directory) > 0:
             output[component_directory] = output_for_directory

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -254,7 +254,9 @@ COMPONENT_REGISTRY_KEY_ATTR = "__dagster_component_registry_key"
 COMPONENT_LOADER_FN_ATTR = "__dagster_component_loader_fn"
 
 
-def component_type(cls: Optional[type[Component]] = None, *, name: Optional[str] = None) -> Any:
+def registered_component_type(
+    cls: Optional[type[Component]] = None, *, name: Optional[str] = None
+) -> Any:
     """Decorator for registering a component type. You must annotate a component
     type with this decorator in order for it to be inspectable and loaded by tools.
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -33,6 +33,8 @@ class ComponentFileModel(BaseModel):
 
 T = TypeVar("T", bound=BaseModel)
 
+LOCAL_COMPONENT_NAMESPACE = "@local"
+
 
 def find_local_component_types(component_path: Path) -> list[type[Component]]:
     """Find all component types defined in a component directory."""
@@ -115,8 +117,8 @@ class YamlComponentDecl(ComponentDeclNode):
 
     def get_component_type(self, registry: ComponentTypeRegistry) -> type[Component]:
         parsed_defs = self.component_file_model
-        if parsed_defs.type.startswith("."):
-            component_registry_key = parsed_defs.type[1:]
+        if parsed_defs.type.startswith(LOCAL_COMPONENT_NAMESPACE):
+            component_registry_key = parsed_defs.type.split(".", maxsplit=1)[1]
 
             for component_type in find_local_component_types(self.path):
                 if get_component_type_name(component_type) == component_registry_key:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -12,7 +12,7 @@ from dagster_dbt import (
 )
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component import component_type
+from dagster_components.core.component import registered_component_type
 from dagster_components.core.schema.base import ResolvableModel
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
@@ -46,7 +46,7 @@ class DbtProjectParams(ResolvableModel["DbtProjectComponent"]):
         )
 
 
-@component_type(name="dbt_project")
+@registered_component_type(name="dbt_project")
 class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
@@ -10,7 +10,7 @@ from dagster._utils import pushd
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.lib.definitions_component.scaffolder import DefinitionsComponentScaffolder
 
 
@@ -18,7 +18,7 @@ class DefinitionsParamSchema(BaseModel):
     definitions_path: Optional[str] = None
 
 
-@component_type(name="definitions")
+@registered_component_type(name="definitions")
 class DefinitionsComponent(Component):
     """Wraps an arbitrary set of Dagster definitions."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -10,7 +10,11 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 from pydantic import BaseModel
 
-from dagster_components.core.component import Component, ComponentLoadContext, component_type
+from dagster_components.core.component import (
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 from dagster_components.core.schema.base import ResolvableModel
 from dagster_components.core.schema.objects import AssetSpecModel
 from dagster_components.core.schema.resolver import TemplatedValueResolver
@@ -36,7 +40,7 @@ class PipesSubprocessScriptCollectionParams(ResolvableModel[Mapping[Path, Sequen
         }
 
 
-@component_type(name="pipes_subprocess_script_collection")
+@registered_component_type(name="pipes_subprocess_script_collection")
 class PipesSubprocessScriptCollection(Component):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -12,7 +12,7 @@ from dagster_sling.resources import AssetExecutionContext
 from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component import component_type
+from dagster_components.core.component import registered_component_type
 from dagster_components.core.component_scaffolder import ComponentScaffolder
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
@@ -73,7 +73,7 @@ class SlingReplicationCollectionParams(ResolvableModel[ResolvedSlingReplicationC
         )
 
 
-@component_type
+@registered_component_type
 class SlingReplicationCollection(Component):
     """Expose one or more Sling replications to Dagster as assets."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/all_metadata_empty_asset.py
@@ -3,11 +3,11 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from typing_extensions import Self
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
 
 
-@component_type(name="all_metadata_empty_asset")
+@registered_component_type(name="all_metadata_empty_asset")
 class AllMetadataEmptyAsset(Component):
     @classmethod
     def load(cls, context: "ComponentLoadContext") -> Self:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -7,7 +7,7 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
@@ -26,7 +26,7 @@ class ComplexAssetParams(BaseModel):
     asset_transforms: Optional[Sequence[AssetSpecTransformModel]] = None
 
 
-@component_type(name="complex_schema_asset")
+@registered_component_type(name="complex_schema_asset")
 class ComplexSchemaAsset(Component):
     """An asset that has a complex params schema."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_asset.py
@@ -5,7 +5,7 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.core.component_scaffolder import (
     ComponentScaffolder,
     DefaultComponentScaffolder,
@@ -17,7 +17,7 @@ class SimpleAssetParams(BaseModel):
     value: str
 
 
-@component_type(name="simple_asset")
+@registered_component_type(name="simple_asset")
 class SimpleAsset(Component):
     """A simple asset that returns a constant string value."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_pipes_script_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/simple_pipes_script_asset.py
@@ -9,7 +9,7 @@ from dagster._core.pipes.subprocess import PipesSubprocessClient
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from dagster_components import Component, ComponentLoadContext, component_type
+from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.core.component_scaffolder import (
     ComponentScaffolder,
     ComponentScaffoldRequest,
@@ -47,7 +47,7 @@ context.report_asset_materialization(asset_key="{asset_key}")
 """
 
 
-@component_type(name="simple_pipes_script_asset")
+@registered_component_type(name="simple_pipes_script_asset")
 class SimplePipesScriptAsset(Component):
     """A simple asset that runs a Python script with the Pipes subprocess client.
 

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import Self
 
-from dagster_components import Component, component_type
+from dagster_components import Component, registered_component_type
 from dagster_components.core.component import ComponentLoadContext
 
 
@@ -17,7 +17,7 @@ class MyComponentSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-@component_type
+@registered_component_type
 class MyComponent(Component):
     name = "my_component"
 
@@ -46,7 +46,7 @@ class MyNestedComponentSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-@component_type
+@registered_component_type
 class MyNestedComponent(Component):
     name = "my_nested_component"
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -114,7 +114,7 @@ def test_list_local_components_types() -> None:
             assert len(result) == 1
             assert set(result.keys()) == {"my_location/components/local_component_sample"}
             assert set(result["my_location/components/local_component_sample"].keys()) == {
-                ".my_component"
+                "@local.my_component"
             }
 
             # Add a second directory and local component

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.py
@@ -1,12 +1,12 @@
 from collections.abc import Iterator
 
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster_components import component_type
+from dagster_components import registered_component_type
 from dagster_components.lib.sling_replication_collection.component import SlingReplicationCollection
 from dagster_sling import SlingResource
 
 
-@component_type(name="debug_sling_replication")
+@registered_component_type(name="debug_sling_replication")
 class DebugSlingReplicationComponent(SlingReplicationCollection):
     def execute(self, context: AssetExecutionContext, sling: SlingResource) -> Iterator:
         return sling.replicate(context=context, debug=True)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.yaml
@@ -1,4 +1,4 @@
-type: .debug_sling_replication
+type: "@local.debug_sling_replication"
 
 params:
   sling:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -1,5 +1,5 @@
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, component_type
+from dagster_components import Component, registered_component_type
 from dagster_components.core.component import ComponentLoadContext
 from dagster_components.core.schema.base import BaseModel
 from typing_extensions import Self
@@ -10,7 +10,7 @@ class MyComponentSchema(BaseModel):
     an_int: int
 
 
-@component_type
+@registered_component_type
 class MyComponent(Component):
     name = "my_component"
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: "@local.my_component"
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/__init__.py
@@ -1,5 +1,5 @@
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, component_type
+from dagster_components import Component, registered_component_type
 from dagster_components.core.component import ComponentLoadContext
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -10,7 +10,7 @@ class MyNewComponentSchema(BaseModel):
     an_int: int
 
 
-@component_type
+@registered_component_type
 class MyNewComponent(Component):
     name = "my_new_component"
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
@@ -1,4 +1,4 @@
-type: .my_new_component
+type: "@local.my_new_component"
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: "@local.my_component"
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: "@local.my_component"
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component_does_not_exist
+type: "@local.my_component_does_not_exist"
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: "@local.my_component"
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: "@local.my_component"
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: "@local.my_nested_component"
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: "@local.my_nested_component"
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: "@local.my_nested_component"
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.env import environ
-from dagster_components import component_type
+from dagster_components import registered_component_type
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -163,7 +163,7 @@ def test_load_from_path(sling_path: Path) -> None:
 
 
 def test_sling_subclass() -> None:
-    @component_type(name="debug_sling_replication")
+    @registered_component_type(name="debug_sling_replication")
     class DebugSlingReplicationComponent(SlingReplicationCollection):
         def execute(
             self, context: AssetExecutionContext, sling: SlingResource

--- a/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
@@ -55,8 +55,8 @@ def _find_repo_root():
 
 def _generate_test_component_source(number: int) -> str:
     return textwrap.dedent(f"""
-    from dagster_components import Component, component_type
-    @component_type(name="test_component_{number}")
+    from dagster_components import Component, registered_component_type
+    @registered_component_type(name="test_component_{number}")
     class TestComponent{number}(Component):
         pass
     """)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.py
@@ -2,7 +2,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from dagster import AssetSpec, AutomationCondition, Definitions
-from dagster_components import AssetAttributesModel, Component, ComponentLoadContext, component_type
+from dagster_components import (
+    AssetAttributesModel,
+    Component,
+    ComponentLoadContext,
+    registered_component_type,
+)
 
 
 def my_custom_fn(a: str, b: str) -> str:
@@ -13,7 +18,7 @@ def my_custom_automation_condition(cron_schedule: str) -> AutomationCondition:
     return AutomationCondition.cron_tick_passed(cron_schedule) & ~AutomationCondition.in_progress()
 
 
-@component_type(name="custom_scope_component")
+@registered_component_type(name="custom_scope_component")
 class HasCustomScope(Component):
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
@@ -1,4 +1,4 @@
-type: .custom_scope_component
+type: "@local.custom_scope_component"
 
 params:
   group_name: "{{ custom_str }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_registered_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_registered_component.py
@@ -1,9 +1,9 @@
-from dagster_components import Component, component_type
+from dagster_components import Component, registered_component_type
 from dagster_components.core.component import get_component_type_name, is_registered_component_type
 
 
 def test_registered_component_with_default_name() -> None:
-    @component_type
+    @registered_component_type
     class RegisteredComponent(Component): ...
 
     assert is_registered_component_type(RegisteredComponent)
@@ -11,7 +11,7 @@ def test_registered_component_with_default_name() -> None:
 
 
 def test_registered_component_with_default_name_and_parens() -> None:
-    @component_type()
+    @registered_component_type()
     class RegisteredComponent(Component): ...
 
     assert is_registered_component_type(RegisteredComponent)
@@ -19,7 +19,7 @@ def test_registered_component_with_default_name_and_parens() -> None:
 
 
 def test_registered_component_with_explicit_kwarg_name() -> None:
-    @component_type(name="explicit_name")
+    @registered_component_type(name="explicit_name")
     class RegisteredComponent(Component): ...
 
     assert is_registered_component_type(RegisteredComponent)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -260,9 +260,11 @@ COMPONENT_FILE_SCHEMA = {
     },
 }
 
+LOCAL_COMPONENT_NAMESPACE = "@local"
+
 
 def _is_local_component(component_name: str) -> bool:
-    return component_name.startswith(".")
+    return component_name.split(".", maxsplit=1)[0] == LOCAL_COMPONENT_NAMESPACE
 
 
 @component_group.command(name="check", cls=DgClickCommand)

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -3,14 +3,14 @@ from dagster_components import (
     Component,
     ComponentLoadContext,
     DefaultComponentScaffolder,
-    component_type,
+    registered_component_type,
 )
 from pydantic import BaseModel
 
 class {{ component_type_class_name }}Params(BaseModel):
     ...
 
-@component_type(name="{{ name }}")
+@registered_component_type(name="{{ name }}")
 class {{ component_type_class_name }}(Component):
     """COMPONENT SUMMARY HERE.
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -41,7 +41,7 @@ CLI_TEST_CASES = [
         should_error=True,
         check_error_msg=msg_includes_all_of(
             "component.yaml:1",
-            "Unable to locate local component type '.my_component_does_not_exist'",
+            "Unable to locate local component type '@local.my_component_does_not_exist'",
         ),
     ),
 ]
@@ -122,13 +122,13 @@ def test_validation_cli(test_case: ComponentValidationTestCase) -> None:
         with pushd(tmpdir):
             result = runner.invoke("component", "check")
             if test_case.should_error:
-                assert result.exit_code != 0, str(result.stdout)
+                assert_runner_result(result, exit_0=False)
 
                 assert test_case.check_error_msg
                 test_case.check_error_msg(str(result.stdout))
 
             else:
-                assert result.exit_code == 0
+                assert_runner_result(result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

Change local component naming scheme. This:

```
type: .my_component
```

Is now this:

```
type: "@local.my_component"
```

Unfortunately the quotes are required with `@`, which might be a reason to change it.

## How I Tested These Changes

Modified existing tests.