### PR TITLE
Keep the passed in working directory in sys.path after the initial import of user code

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Sequence
 from types import ModuleType
-from typing import Callable, NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, Union
 
 from dagster import DagsterInvariantViolationError, GraphDefinition, RepositoryDefinition
 from dagster._core.code_pointer import load_python_file, load_python_module
@@ -28,12 +28,10 @@ def loadable_targets_from_python_file(
 def loadable_targets_from_python_module(
     module_name: str,
     working_directory: Optional[str],
-    remove_from_path_fn: Optional[Callable[[], Sequence[str]]] = None,
 ) -> Sequence[LoadableTarget]:
     module = load_python_module(
         module_name,
         working_directory=working_directory,
-        remove_from_path_fn=remove_from_path_fn,
     )
     return loadable_targets_from_loaded_module(module)
 
@@ -41,11 +39,8 @@ def loadable_targets_from_python_module(
 def loadable_targets_from_python_package(
     package_name: str,
     working_directory: Optional[str],
-    remove_from_path_fn: Optional[Callable[[], Sequence[str]]] = None,
 ) -> Sequence[LoadableTarget]:
-    module = load_python_module(
-        package_name, working_directory, remove_from_path_fn=remove_from_path_fn
-    )
+    module = load_python_module(package_name, working_directory)
     return loadable_targets_from_loaded_module(module)
 
 

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -582,10 +582,7 @@ def is_port_in_use(host, port) -> bool:
         sock.close()
 
 
-@contextlib.contextmanager
 def alter_sys_path(to_add: Sequence[str], to_remove: Sequence[str]) -> Iterator[None]:
-    to_restore = [path for path in sys.path]
-
     # remove paths
     for path in to_remove:
         if path in sys.path:
@@ -594,11 +591,6 @@ def alter_sys_path(to_add: Sequence[str], to_remove: Sequence[str]) -> Iterator[
     # add paths
     for path in to_add:
         sys.path.insert(0, path)
-
-    try:
-        yield
-    finally:
-        sys.path = to_restore
 
 
 @contextlib.contextmanager

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -582,7 +582,10 @@ def is_port_in_use(host, port) -> bool:
         sock.close()
 
 
+@contextlib.contextmanager
 def alter_sys_path(to_add: Sequence[str], to_remove: Sequence[str]) -> Iterator[None]:
+    to_restore = [path for path in sys.path]
+
     # remove paths
     for path in to_remove:
         if path in sys.path:
@@ -591,6 +594,11 @@ def alter_sys_path(to_add: Sequence[str], to_remove: Sequence[str]) -> Iterator[
     # add paths
     for path in to_add:
         sys.path.insert(0, path)
+
+    try:
+        yield
+    finally:
+        sys.path = to_restore
 
 
 @contextlib.contextmanager

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/asset_with_process_pool_executor.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/asset_with_process_pool_executor.py
@@ -1,0 +1,19 @@
+from concurrent.futures import ProcessPoolExecutor
+
+import dagster
+import tqdm
+
+
+def f(x: int) -> int:
+    return x * 2
+
+
+@dagster.asset()
+def multiprocess_asset() -> None:
+    with ProcessPoolExecutor(max_workers=1) as pool:
+        list(
+            tqdm.tqdm(
+                pool.map(f, range(1)),
+                total=1,
+            )
+        )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 from typing import Optional
 
 from click.testing import CliRunner
@@ -177,6 +179,23 @@ def test_partition_range_multi_run_backfill_policy():
 def test_failure():
     result = invoke_materialize("fail_asset")
     assert result.exit_code == 1
+
+
+def test_asset_with_multiprocessing():
+    with instance_for_test():
+        subprocess.check_call(
+            [
+                "dagster",
+                "asset",
+                "materialize",
+                "-f",
+                file_relative_path(__file__, "asset_with_process_pool_executor.py"),
+                "--select",
+                "multiprocess_asset",
+                "--working-directory",
+                os.path.dirname(__file__),
+            ]
+        )
 
 
 def test_run_cli_config_json():

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -282,8 +282,12 @@ def test_local_directory_file() -> None:
 
         assert "No module named 'autodiscover_src'" in str(exc_info.value)
 
-    with alter_sys_path(to_add=[os.path.dirname(path)], to_remove=[]):
+    to_restore = [path for path in sys.path]
+    try:
+        alter_sys_path(to_add=[os.path.dirname(path)], to_remove=[])
         loadable_targets_from_python_file(path, working_directory=os.path.dirname(path))
+    finally:
+        sys.path = to_restore
 
 
 def test_lazy_definitions() -> None:

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -223,11 +223,11 @@ def test_local_directory_module_multiple_defs() -> None:
         DagsterInvariantViolationError,
         match="Cannot have more than one Definitions object defined at module scope. Found Definitions objects: autodiscover_in_module_multiple.defs, autodiscover_in_module_multiple.defs1, autodiscover_in_module_multiple.defs2",
     ):
-        loadable_targets_from_python_module(
-            "autodiscover_in_module_multiple",
-            working_directory=os.path.dirname(__file__),
-            remove_from_path_fn=_current_test_directory_paths,
-        )
+        with alter_sys_path(to_add=[], to_remove=_current_test_directory_paths()):
+            loadable_targets_from_python_module(
+                "autodiscover_in_module_multiple",
+                working_directory=os.path.dirname(__file__),
+            )
 
 
 def _current_test_directory_paths():
@@ -251,25 +251,25 @@ def test_local_directory_module() -> None:
     if "autodiscover_in_module" in sys.modules:
         del sys.modules["autodiscover_in_module"]
 
-    with pytest.raises(DagsterImportError):
-        loadable_targets_from_python_module(
-            "complete_bogus_module",
-            working_directory=os.path.dirname(__file__),
-            remove_from_path_fn=_current_test_directory_paths,
-        )
+    with alter_sys_path(to_add=[], to_remove=_current_test_directory_paths()):
+        with pytest.raises(DagsterImportError):
+            loadable_targets_from_python_module(
+                "complete_bogus_module",
+                working_directory=os.path.dirname(__file__),
+            )
 
-    with pytest.raises(DagsterImportError):
-        loadable_targets_from_python_module(
+    with alter_sys_path(to_add=[], to_remove=_current_test_directory_paths()):
+        with pytest.raises(DagsterImportError):
+            loadable_targets_from_python_module(
+                "autodiscover_in_module",
+                working_directory=None,
+            )
+
+    with alter_sys_path(to_add=[], to_remove=_current_test_directory_paths()):
+        loadable_targets = loadable_targets_from_python_module(
             "autodiscover_in_module",
-            working_directory=None,
-            remove_from_path_fn=_current_test_directory_paths,
+            working_directory=os.path.dirname(__file__),
         )
-
-    loadable_targets = loadable_targets_from_python_module(
-        "autodiscover_in_module",
-        working_directory=os.path.dirname(__file__),
-        remove_from_path_fn=_current_test_directory_paths,
-    )
     assert len(loadable_targets) == 1
 
 


### PR DESCRIPTION

## Summary & Motivation
The goal of cleaning after ourselves here is understandable, but prevents user code that depends on being able to re-import the same module implicitly (like ProcessPoolExecutor) from working correctly.

## How I Tested These Changes

## Changelog
Fixed an issue where assets using ProcessPoolExecutor or multiprocessing with a spawn context sometimes failed to work with a ModuleNotFoundError.

