### PR TITLE
[components] Add help message to `dagster-components` CLI clarifying it is private (BUILD-535)

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
@@ -26,7 +26,12 @@ def create_dagster_components_cli():
     @click.version_option(__version__, "--version", "-v")
     @click.pass_context
     def group(ctx: click.Context, builtin_component_lib: str):
-        """CLI tools for working with Dagster."""
+        """Internal API for working with Dagster Components.
+
+        This CLI is private and can be considered an implementation detail for `dg`. It is called by
+        `dg` to execute commands related to Dagster Components in the context of a particular Python
+        environment. This is necessary because `dg` itself always runs in an isolated environment.
+        """
         ctx.ensure_object(dict)
         ctx.obj[CLI_BUILTIN_COMPONENT_LIB_KEY] = builtin_component_lib
 


### PR DESCRIPTION
## Summary & Motivation

Adds info to the help output of `dagster-components` (via the docstring) clarifying that it is a private API/implementation detail of `dg`.