### PR TITLE
[cli-refactor] Centralize utilities in dagster._cli.utils

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/cli.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/cli.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 import click
 from dagster import _check as check
-from dagster._cli.workspace.cli_target import has_pyproject_dagster_block
+from dagster._cli.utils import has_pyproject_dagster_block
 from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.workspace.load_target import PyProjectFileTarget
 from dagster._utils.warnings import disable_dagster_warnings

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -11,12 +11,12 @@ import click
 import dagster._check as check
 import uvicorn
 from dagster._annotations import deprecated
-from dagster._cli.utils import get_possibly_temporary_instance_for_cli
+from dagster._cli.utils import ClickArgValue, get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace import (
     get_workspace_process_context_from_kwargs,
     workspace_target_options,
 )
-from dagster._cli.workspace.cli_target import WORKSPACE_TARGET_WARNING, ClickArgValue
+from dagster._cli.workspace.cli_target import WORKSPACE_TARGET_WARNING
 from dagster._core.instance import InstanceRef
 from dagster._core.telemetry import START_DAGSTER_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -5,10 +5,12 @@ import sys
 import click
 
 from dagster import __version__ as dagster_version
-from dagster._cli.job import apply_click_params
-from dagster._cli.utils import get_possibly_temporary_instance_for_cli
-from dagster._cli.workspace.cli_target import (
+from dagster._cli.utils import (
     ClickArgValue,
+    apply_click_params,
+    get_possibly_temporary_instance_for_cli,
+)
+from dagster._cli.workspace.cli_target import (
     generate_module_name_option,
     generate_python_file_option,
     generate_workspace_option,

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -14,10 +14,12 @@ import yaml
 
 from dagster import _check as check
 from dagster._annotations import deprecated
-from dagster._cli.job import apply_click_params
-from dagster._cli.utils import get_possibly_temporary_instance_for_cli
-from dagster._cli.workspace.cli_target import (
+from dagster._cli.utils import (
     ClickArgValue,
+    apply_click_params,
+    get_possibly_temporary_instance_for_cli,
+)
+from dagster._cli.workspace.cli_target import (
     generate_grpc_server_target_options,
     generate_module_name_option,
     generate_python_file_option,

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -10,12 +10,14 @@ import click
 import dagster._check as check
 from dagster import __version__ as dagster_version
 from dagster._cli.config_scaffolder import scaffold_job_config
-from dagster._cli.utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
-from dagster._cli.workspace.cli_target import (
-    WORKSPACE_TARGET_WARNING,
+from dagster._cli.utils import (
     ClickArgMapping,
     ClickArgValue,
-    ClickOption,
+    get_instance_for_cli,
+    get_possibly_temporary_instance_for_cli,
+)
+from dagster._cli.workspace.cli_target import (
+    WORKSPACE_TARGET_WARNING,
     get_code_location_from_workspace,
     get_config_from_args,
     get_job_python_origin_from_kwargs,
@@ -66,18 +68,11 @@ from dagster._utils.tags import normalize_tags
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
 T = TypeVar("T")
-T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
 
 
 @click.group(name="job")
 def job_cli():
     """Commands for working with Dagster jobs."""
-
-
-def apply_click_params(command: T_Callable, *click_params: ClickOption) -> T_Callable:
-    for click_param in click_params:
-        command = click_param(command)
-    return command
 
 
 @job_cli.command(

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -1,14 +1,40 @@
 import logging
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Callable, Optional, TypeVar, Union
+
+import tomli
+from typing_extensions import TypeAlias
 
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import is_dagster_home_set
 from dagster._core.secrets.env_file import get_env_var_dict
 from dagster._utils.env import environ
+
+T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
+
+ClickArgValue: TypeAlias = Union[str, tuple[str]]
+ClickArgMapping: TypeAlias = Mapping[str, ClickArgValue]
+ClickOption: TypeAlias = Callable[[T_Callable], T_Callable]
+
+
+def apply_click_params(command: T_Callable, *click_params: ClickOption) -> T_Callable:
+    for click_param in click_params:
+        command = click_param(command)
+    return command
+
+
+def has_pyproject_dagster_block(path: str) -> bool:
+    if not os.path.exists(path):
+        return False
+    with open(path, "rb") as f:
+        data = tomli.load(f)
+        if not isinstance(data, dict):
+            return False
+
+        return "dagster" in data.get("tool", {})
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -5,13 +5,8 @@ from typing import Optional
 import click
 
 from dagster import __version__ as dagster_version
-from dagster._cli.utils import get_instance_for_cli
-from dagster._cli.workspace.cli_target import (
-    ClickArgMapping,
-    ClickArgValue,
-    get_workspace_load_target,
-    workspace_target_options,
-)
+from dagster._cli.utils import ClickArgMapping, ClickArgValue, get_instance_for_cli
+from dagster._cli.workspace.cli_target import get_workspace_load_target, workspace_target_options
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.telemetry import telemetry_wrapper
 from dagster._daemon.controller import (


### PR DESCRIPTION
## Summary & Motivation

Some widely used CLI utilities were defined in random modules instead of the dedicated `dagster._cli.utils` module. Move to utils.

## How I Tested These Changes

Existing test suite.