### PR TITLE
Fix pip install command for zsh

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-2/2-set-up-the-dagster-project.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-2/2-set-up-the-dagster-project.md
@@ -51,7 +51,7 @@ Then, run the following in the command line to rename the `.env.example`  file a
 ```bash
 cd dagster-and-dbt
 cp .env.example .env
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 The `e` flag installs the project in editable mode so you can modify existing Dagster assets without having to reload the code location. This allows you to shorten the time it takes to test a change. However, you’ll need to reload the code location in the Dagster UI when adding new assets or installing additional dependencies.

--- a/docs/dagster-university/pages/dagster-essentials/lesson-2/create-dagster-project.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-2/create-dagster-project.md
@@ -23,7 +23,7 @@ Next, set up the default environment variables and install the project’s Pytho
 ```shell
 cd dagster_university
 cp .env.example .env
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 The `-e` flag installs the project in editable mode, which will improve your development experience by shortening how long it takes to test a change. The main exceptions are when you're adding new assets or installing additional dependencies.


### PR DESCRIPTION
Added double quotation marks around pip install command, so this works in zsh

## Summary & Motivation
[This PR](https://github.com/dagster-io/dagster/pull/27127) changed not only the quotes around `pip install 'dagster~=1.9'` as [recommended](https://github.com/dagster-io/project-dagster-university/issues/42), but also removed the double quotes from around the environment name to install packages listed in setup.py

For zsh users, this throws the error `zsh: no matches found: .[dev]`

When changed to running in bash, the unquoted command works as expected
