### PR TITLE
[cli-refactor] Type and validate python_pointer_opts at entry point

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -12,11 +12,8 @@ import click
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._cli.utils import get_instance_for_cli
-from dagster._cli.workspace.cli_target import (
-    get_working_directory_from_kwargs,
-    python_pointer_options,
-)
+from dagster._cli.utils import assert_no_remaining_opts, get_instance_for_cli
+from dagster._cli.workspace.cli_target import PythonPointerOpts, python_pointer_options
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
@@ -577,6 +574,7 @@ def _execute_step_command_body(
 @click.option(
     "--heartbeat",
     is_flag=True,
+    default=False,
     help=(
         "If set, the GRPC server will shut itself down when it fails to receive a heartbeat "
         "after a timeout configurable with --heartbeat-timeout."
@@ -601,7 +599,6 @@ def _execute_step_command_body(
     ),
     envvar="DAGSTER_LAZY_LOAD_USER_CODE",
 )
-@python_pointer_options
 @click.option(
     "--use-python-environment-entry-point",
     is_flag=True,
@@ -699,26 +696,31 @@ def _execute_step_command_body(
     help="[INTERNAL] Retrieves current utilization metrics from GRPC server.",
     envvar="DAGSTER_ENABLE_SERVER_METRICS",
 )
+@python_pointer_options
 def grpc_command(
     port: Optional[int],
     socket: Optional[str],
     host: str,
     max_workers: Optional[int],
-    heartbeat: bool = False,
-    heartbeat_timeout: int = 30,
-    lazy_load_user_code: bool = False,
-    fixed_server_id: Optional[str] = None,
-    log_level: str = "INFO",
-    log_format: str = "colored",
-    use_python_environment_entry_point: Optional[bool] = False,
-    container_image: Optional[str] = None,
-    container_context: Optional[str] = None,
-    location_name: Optional[str] = None,
-    instance_ref=None,
-    inject_env_vars_from_instance: bool = False,
+    heartbeat: bool,
+    heartbeat_timeout: int,
+    lazy_load_user_code: bool,
+    use_python_environment_entry_point: bool,
+    empty_working_directory: bool,
+    fixed_server_id: Optional[str],
+    log_level: str,
+    log_format: str,
+    container_image: Optional[str],
+    container_context: Optional[str],
+    inject_env_vars_from_instance: bool,
+    location_name: Optional[str],
+    instance_ref: Optional[str],
     enable_metrics: bool = False,
-    **kwargs: Any,
+    **other_opts: Any,
 ) -> None:
+    python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
+    assert_no_remaining_opts(other_opts)
+
     check.invariant(heartbeat_timeout > 0, "heartbeat_timeout must be greater than 0")
 
     check.invariant(
@@ -743,31 +745,28 @@ def grpc_command(
 
     loadable_target_origin = None
     if any(
-        kwargs[key]
-        for key in [
-            "attribute",
-            "working_directory",
-            "module_name",
-            "package_name",
-            "python_file",
-            "empty_working_directory",
+        [
+            python_pointer_opts.attribute,
+            python_pointer_opts.working_directory,
+            python_pointer_opts.module_name,
+            python_pointer_opts.package_name,
+            python_pointer_opts.python_file,
+            empty_working_directory,
         ]
     ):
         # in the gRPC api CLI we never load more than one module or python file at a time
-        module_name = check.opt_str_elem(kwargs, "module_name")
-        python_file = check.opt_str_elem(kwargs, "python_file")
 
         loadable_target_origin = LoadableTargetOrigin(
             executable_path=sys.executable,
-            attribute=kwargs["attribute"],
+            attribute=python_pointer_opts.attribute,
             working_directory=(
                 None
-                if kwargs.get("empty_working_directory")
-                else get_working_directory_from_kwargs(kwargs)
+                if empty_working_directory
+                else (python_pointer_opts.working_directory or os.getcwd())
             ),
-            module_name=module_name,
-            python_file=python_file,
-            package_name=kwargs["package_name"],
+            module_name=python_pointer_opts.module_name,
+            python_file=python_pointer_opts.python_file,
+            package_name=python_pointer_opts.package_name,
         )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -1,12 +1,17 @@
-from collections.abc import Mapping
+from typing import Optional
 
 import click
 
 import dagster._check as check
-from dagster._cli.job import get_config_from_args
-from dagster._cli.utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
+from dagster._cli.job import get_run_config_from_cli_opts
+from dagster._cli.utils import (
+    assert_no_remaining_opts,
+    get_instance_for_cli,
+    get_possibly_temporary_instance_for_cli,
+)
 from dagster._cli.workspace.cli_target import (
-    get_repository_python_origin_from_kwargs,
+    PythonPointerOpts,
+    get_repository_python_origin_from_cli_opts,
     python_pointer_options,
     run_config_option,
 )
@@ -32,7 +37,6 @@ def asset_cli():
 
 
 @asset_cli.command(name="materialize", help="Execute a run to materialize a selection of assets")
-@python_pointer_options
 @click.option("--select", help="Comma-separated Asset selection to target", required=True)
 @click.option("--partition", help="Asset partition to target", required=False)
 @click.option(
@@ -40,29 +44,57 @@ def asset_cli():
     help="Asset partition range to target i.e. <start>...<end>",
     required=False,
 )
-@run_config_option(name="config", command_name="materialize")
 @click.option(
     "--config-json",
     type=click.STRING,
     help="JSON string of run config to use for this job run. Cannot be used with -c / --config.",
 )
-def asset_materialize_command(**kwargs):
+@run_config_option(name="config", command_name="materialize")
+@python_pointer_options
+def asset_materialize_command(
+    select: str,
+    partition: Optional[str],
+    partition_range: Optional[str],
+    config: tuple[str, ...],
+    config_json: Optional[str],
+    **other_opts: object,
+) -> None:
+    python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
+    assert_no_remaining_opts(other_opts)
+
     with capture_interrupts():
         with get_possibly_temporary_instance_for_cli(
             "``dagster asset materialize``",
         ) as instance:
-            execute_materialize_command(instance, kwargs)
+            execute_materialize_command(
+                instance=instance,
+                select=select,
+                partition=partition,
+                partition_range=partition_range,
+                config=config,
+                config_json=config_json,
+                python_pointer_opts=python_pointer_opts,
+            )
 
 
 @telemetry_wrapper
-def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, str]) -> None:
-    config = get_config_from_args(kwargs)
-    repository_origin = get_repository_python_origin_from_kwargs(kwargs)
+def execute_materialize_command(
+    *,
+    instance: DagsterInstance,
+    select: str,
+    partition: Optional[str],
+    partition_range: Optional[str],
+    config: tuple[str, ...],
+    config_json: Optional[str],
+    python_pointer_opts: PythonPointerOpts,
+) -> None:
+    run_config = get_run_config_from_cli_opts(config, config_json)
+    repository_origin = get_repository_python_origin_from_cli_opts(python_pointer_opts)
 
     recon_repo = recon_repository_from_origin(repository_origin)
     repo_def = recon_repo.get_definition()
 
-    asset_selection = AssetSelection.from_coercible(kwargs["select"].split(","))
+    asset_selection = AssetSelection.from_coercible(select.split(","))
     asset_keys = asset_selection.resolve(repo_def.asset_graph)
 
     implicit_job_def = repo_def.get_implicit_job_def_for_assets(asset_keys)
@@ -77,8 +109,6 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     reconstructable_job = recon_job_from_origin(
         JobPythonOrigin(implicit_job_def.name, repository_origin=repository_origin)
     )
-    partition = kwargs.get("partition")
-    partition_range = kwargs.get("partition_range")
 
     if partition and partition_range:
         check.failed("Cannot specify both --partition and --partition-range options. Use only one.")
@@ -150,23 +180,25 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
         asset_selection=list(asset_keys),
         instance=instance,
         tags=tags,
-        run_config=config,
+        run_config=run_config,
     )
     if not result.success:
         raise click.ClickException("Materialization failed.")
 
 
 @asset_cli.command(name="list", help="List assets")
-@python_pointer_options
 @click.option("--select", help="Asset selection to target", required=False)
-def asset_list_command(**kwargs):
-    repository_origin = get_repository_python_origin_from_kwargs(kwargs)
+@python_pointer_options
+def asset_list_command(select: Optional[str], **other_opts):
+    python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
+    assert_no_remaining_opts(other_opts)
+
+    repository_origin = get_repository_python_origin_from_cli_opts(python_pointer_opts)
     recon_repo = recon_repository_from_origin(repository_origin)
     repo_def = recon_repo.get_definition()
 
-    select = kwargs.get("select")
     if select is not None:
-        asset_selection = AssetSelection.from_coercible(kwargs["select"].split(","))
+        asset_selection = AssetSelection.from_coercible(select.split(","))
     else:
         asset_selection = AssetSelection.all()
 

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -7,12 +7,9 @@ from typing import Optional
 
 import click
 
-import dagster._check as check
 import dagster._seven as seven
-from dagster._cli.workspace.cli_target import (
-    get_working_directory_from_kwargs,
-    python_pointer_options,
-)
+from dagster._cli.utils import assert_no_remaining_opts
+from dagster._cli.workspace.cli_target import PythonPointerOpts, python_pointer_options
 from dagster._core.instance import InstanceRef
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import FuturesAwareThreadPoolExecutor
@@ -62,11 +59,9 @@ def code_server_cli():
     "-n",
     type=click.INT,
     required=False,
-    default=None,
     help="Maximum number of (threaded) workers to use in the code server",
     envvar="DAGSTER_CODE_SERVER_MAX_WORKERS",
 )
-@python_pointer_options
 @click.option(
     "--use-python-environment-entry-point",
     is_flag=True,
@@ -149,6 +144,7 @@ def code_server_cli():
 @click.option(
     "--heartbeat",
     is_flag=True,
+    default=False,
     help=(
         "If set, the GRPC server will shut itself down when it fails to receive a heartbeat "
         "after a timeout configurable with --heartbeat-timeout."
@@ -168,27 +164,31 @@ def code_server_cli():
     help="[INTERNAL] Serialized InstanceRef to use for accessing the instance",
     envvar="DAGSTER_INSTANCE_REF",
 )
+@python_pointer_options
 def start_command(
-    port: Optional[int] = None,
-    socket: Optional[str] = None,
-    host: str = "localhost",
-    max_workers: Optional[int] = None,
-    fixed_server_id: Optional[str] = None,
-    log_level: str = "INFO",
-    log_format: str = "colored",
-    use_python_environment_entry_point: bool = False,
-    container_image: Optional[str] = None,
-    container_context: Optional[str] = None,
-    location_name: Optional[str] = None,
-    inject_env_vars_from_instance: bool = False,
-    startup_timeout: int = 0,
-    heartbeat: bool = False,
-    heartbeat_timeout: int = DEFAULT_HEARTBEAT_TIMEOUT,
-    instance_ref=None,
-    **kwargs,
+    port: Optional[int],
+    socket: Optional[str],
+    host: str,
+    max_workers: Optional[int],
+    use_python_environment_entry_point: bool,
+    fixed_server_id: Optional[str],
+    log_level: str,
+    log_format: str,
+    container_image: Optional[str],
+    container_context: Optional[str],
+    inject_env_vars_from_instance: bool,
+    location_name: Optional[str],
+    startup_timeout: int,
+    heartbeat: bool,
+    heartbeat_timeout,
+    instance_ref: Optional[str],
+    **other_opts,
 ):
     from dagster._grpc import DagsterGrpcServer
     from dagster._grpc.proxy_server import DagsterProxyApiServicer
+
+    python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
+    assert_no_remaining_opts(other_opts)
 
     if seven.IS_WINDOWS and port is None:
         raise click.UsageError(
@@ -205,16 +205,13 @@ def start_command(
     container_image = container_image or os.getenv("DAGSTER_CURRENT_IMAGE")
 
     # in the gRPC api CLI we never load more than one module or python file at a time
-    module_name = check.opt_str_elem(kwargs, "module_name")
-    python_file = check.opt_str_elem(kwargs, "python_file")
-
     loadable_target_origin = LoadableTargetOrigin(
         executable_path=sys.executable if use_python_environment_entry_point else None,
-        attribute=kwargs["attribute"],
-        working_directory=get_working_directory_from_kwargs(kwargs),
-        module_name=module_name,
-        python_file=python_file,
-        package_name=kwargs["package_name"],
+        attribute=python_pointer_opts.attribute,
+        working_directory=python_pointer_opts.working_directory or os.getcwd(),
+        module_name=python_pointer_opts.module_name,
+        python_file=python_pointer_opts.python_file,
+        package_name=python_pointer_opts.package_name,
     )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -1,13 +1,14 @@
 import logging
 import os
 import tempfile
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any, Callable, Optional, TypeVar, Union
 
 import tomli
 from typing_extensions import TypeAlias
 
+import dagster._check as check
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import is_dagster_home_set
 from dagster._core.secrets.env_file import get_env_var_dict
@@ -133,3 +134,14 @@ def get_instance_for_cli(
         else:
             with DagsterInstance.get() as instance:
                 yield instance
+
+
+def assert_no_remaining_opts(opts: Mapping[str, object]) -> None:
+    if opts:
+        check.failed(
+            f"Unexpected options remaining: {list(opts.keys())}. Ensure that all options are extracted."
+        )
+
+
+def serialize_sorted_quoted(strings: Iterable[str]) -> str:
+    return "[" + ", ".join([f"'{s}'" for s in sorted(list(strings))]) + "]"

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
@@ -18,7 +18,7 @@ def test_empty():
 
     result = runner.invoke(asset_list_command, [])
     assert result.exit_code == 2
-    assert "Must specify a python file or module name" in result.output
+    assert "Invalid set of CLI arguments for loading repository/job" in result.output
 
 
 def test_no_selection():

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -3,7 +3,7 @@ import string
 import sys
 import tempfile
 from contextlib import contextmanager
-from typing import ContextManager, NoReturn, Optional  # noqa: UP035
+from typing import Any, ContextManager, NoReturn, Optional  # noqa: UP035
 from unittest import mock
 
 import pytest
@@ -27,7 +27,7 @@ from dagster._cli.run import (
     run_migrate_command,
     run_wipe_command,
 )
-from dagster._cli.workspace.cli_target import ClickArgMapping
+from dagster._cli.workspace.cli_target import ClickArgMapping, PythonPointerOpts
 from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
@@ -445,13 +445,13 @@ def grpc_server_backfill_args():
             yield merge_dicts(args, {"noprompt": True}), instance
 
 
-def non_existant_python_origin_target_args():
+def non_existant_python_origin_target_args() -> dict[str, Any]:
     return {
-        "workspace": None,
-        "job_name": "foo",
-        "python_file": file_relative_path(__file__, "made_up_file.py"),
-        "module_name": None,
-        "attribute": "bar",
+        "python_pointer_opts": PythonPointerOpts(
+            python_file=file_relative_path(__file__, "made_up_file.py"),
+            module_name=None,
+            attribute="bar",
+        ),
     }
 
 
@@ -471,102 +471,122 @@ def valid_job_python_origin_target_args():
     job_def_name = "define_qux_job"
     return [
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "module_name": None,
-            "attribute": "bar",
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=file_relative_path(__file__, "test_cli_commands.py"),
+                module_name=None,
+                attribute="bar",
+            ),
         },
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "module_name": None,
-            "attribute": "bar",
-            "working_directory": os.path.dirname(__file__),
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=file_relative_path(__file__, "test_cli_commands.py"),
+                module_name=None,
+                attribute="bar",
+                working_directory=os.path.dirname(__file__),
+            ),
         },
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": None,
-            "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "bar",
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                module_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute="bar",
+            ),
         },
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": None,
-            "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "bar",
-            "working_directory": os.path.dirname(__file__),
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                module_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute="bar",
+                working_directory=os.path.dirname(__file__),
+            ),
         },
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": None,
-            "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "bar",
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                package_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute="bar",
+            ),
         },
         {
-            "workspace": None,
             "job_name": job_name,
-            "python_file": None,
-            "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "bar",
-            "working_directory": os.path.dirname(__file__),
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                package_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute="bar",
+                working_directory=os.path.dirname(__file__),
+            ),
         },
         {
-            "workspace": None,
             "job_name": None,
-            "python_file": None,
-            "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": job_fn_name,
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                module_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute=job_fn_name,
+            ),
         },
         {
-            "workspace": None,
             "job_name": None,
-            "python_file": None,
-            "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": job_fn_name,
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=None,
+                package_name="dagster_tests.cli_tests.command_tests.test_cli_commands",
+                attribute=job_fn_name,
+            ),
         },
         {
-            "workspace": None,
             "job_name": None,
-            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "module_name": None,
-            "attribute": job_def_name,
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=file_relative_path(__file__, "test_cli_commands.py"),
+                module_name=None,
+                attribute=job_def_name,
+            ),
         },
         {
-            "workspace": None,
             "job_name": None,
-            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "module_name": None,
-            "attribute": job_def_name,
-            "working_directory": os.path.dirname(__file__),
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=file_relative_path(__file__, "test_cli_commands.py"),
+                module_name=None,
+                attribute=job_def_name,
+                working_directory=os.path.dirname(__file__),
+            ),
         },
         {
-            "workspace": None,
             "job_name": None,
-            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "module_name": None,
-            "attribute": job_fn_name,
+            "python_pointer_opts": PythonPointerOpts(
+                python_file=file_relative_path(__file__, "test_cli_commands.py"),
+                module_name=None,
+                attribute=job_fn_name,
+            ),
         },
     ]
 
 
-def job_python_args_to_workspace_args(args):
+def job_python_args_to_workspace_args(job_python_arg_sets: list[dict[str, Any]]):
     # Turn args expecting non-multiple files/modules into args allowing multiple
-    return [
-        {
-            "workspace": a.get("workspace"),
-            "job_name": a.get("job_name"),
-            "python_file": (a["python_file"],) if a.get("python_file") else None,
-            "module_name": (a["module_name"],) if a.get("module_name") else None,
-            "attribute": a["attribute"],
-            "package_name": a.get("package_name"),
-        }
-        for a in args
-    ]
+    workspace_arg_sets: list[dict[str, Any]] = []
+    for arg_set in job_python_arg_sets:
+        python_pointer_opts = arg_set["python_pointer_opts"]
+        job_name = arg_set.get("job_name")
+        workspace_arg_sets.append(
+            {
+                "job_name": job_name,
+                "python_file": (python_pointer_opts.python_file,)
+                if python_pointer_opts.python_file
+                else None,
+                "module_name": (python_pointer_opts.module_name,)
+                if python_pointer_opts.module_name
+                else None,
+                "attribute": python_pointer_opts.attribute,
+                "package_name": python_pointer_opts.package_name
+                if python_pointer_opts.package_name
+                else None,
+            }
+        )
+    return workspace_arg_sets
 
 
 def valid_external_pipeline_target_args():

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -38,7 +38,7 @@ def test_missing_origin():
 
         result = runner.invoke(asset_materialize_command, ["--select", "asset1"])
         assert result.exit_code == 2
-        assert "Must specify a python file or module name" in result.output
+        assert "Invalid set of CLI arguments for loading repository/job" in result.output
 
 
 def test_single_asset():

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from click.testing import CliRunner
 from dagster._cli.job import execute_scaffold_command, job_scaffold_command
@@ -13,12 +15,12 @@ def no_print(_):
 
 
 @pytest.mark.parametrize("cli_args", valid_job_python_origin_target_args())
-def test_scaffold_command(cli_args):
+def test_scaffold_command(cli_args: dict[str, Any]):
     cli_args["print_only_required"] = True
-    execute_scaffold_command(cli_args=cli_args, print_fn=no_print)
+    execute_scaffold_command(**cli_args, print_fn=no_print)
 
     cli_args["print_only_required"] = False
-    execute_scaffold_command(cli_args=cli_args, print_fn=no_print)
+    execute_scaffold_command(**cli_args, print_fn=no_print)
 
 
 @pytest.mark.parametrize("cli_args", valid_job_python_origin_target_cli_args())


### PR DESCRIPTION
## Summary & Motivation

First PR in the stack that replaces passing around "kwargs" with entry point validation and typing.

- Add a `PythonPointerOpts` value object corresponding to the `@python_pointer_opts` decorator.
- Wherever `@python_pointer_opts` is used:
     - Immediately parse the untyped bag of cli_opts into a `PythonPointerOpts` object.
     - Generally clean up the signatures of the targeted click commands, ensuring all other opts are passed as arguments instead of inside the generic bag of CLI opts.

## How I Tested These Changes

Existing test suite.