### PR TITLE
[ui] Tweak markdown syntax highlighting colors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -64,33 +64,59 @@ const sanitizeConfig = {
 };
 
 const GlobalStyle = createGlobalStyle`
-.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_ {
-    color: ${Colors.accentRed()}
-}
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    color: ${Colors.textBlue()}
+  }
 
-.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_ {
-    color: ${Colors.dataVizBlurple()}
-}
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    color: ${Colors.textBlue()};
+  }
 
-.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable {
-    color: ${Colors.dataVizBlue()}
-}
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id,
+  .hljs-variable {
+    color: ${Colors.textLight()};
+  }
 
-.hljs-meta .hljs-string,.hljs-regexp,.hljs-string {
-    color: ${Colors.accentBlue()}
-}
+  .hljs-meta .hljs-string,
+  .hljs-regexp,
+  .hljs-string {
+    color: ${Colors.textCyan()};
+  }
 
-.hljs-built_in,.hljs-symbol {
-    color: ${Colors.dataVizOrange()}
-}
+  .hljs-built_in,
+  .hljs-symbol {
+    color: ${Colors.textYellow()};
+  }
 
-.hljs-code,.hljs-comment,.hljs-formula {
-    color: ${Colors.dataVizGray()}
-}
+  .hljs-code,
+  .hljs-comment,
+  .hljs-formula {
+    color: ${Colors.textLight()};
+  }
 
-.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag {
-    color: ${Colors.dataVizGreen()}
-}
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-pseudo,
+  .hljs-selector-tag {
+    color: ${Colors.textGreen()};
+  }
 `;
 
 interface Props {


### PR DESCRIPTION
## Summary & Motivation

Modify the syntax highlighting in markdown rendering to be a little closer to the launchpad styles.

#### Now:

<img width="544" alt="Screenshot 2025-02-03 at 10 37 23" src="https://github.com/user-attachments/assets/d1aa9aaa-1a21-4cc2-82cf-0eb5feb601f7" />

<img width="543" alt="Screenshot 2025-02-03 at 10 37 49" src="https://github.com/user-attachments/assets/1fc1b75a-9999-4654-a99e-83df491a251c" />

#### Before (current prod):

<img width="551" alt="Screenshot 2025-02-03 at 10 41 00" src="https://github.com/user-attachments/assets/995a9237-b0f8-4732-9a7a-2865341b1316" />

<img width="553" alt="Screenshot 2025-02-03 at 10 42 05" src="https://github.com/user-attachments/assets/a2a3fb3c-05d3-47ad-973b-6d7f6b5f1064" />


## How I Tested These Changes

View an asset with raw SQL values rendered via markdown, verify colors.
