### PR TITLE
[components] Update component naming scheme

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -5,6 +5,7 @@ import click
 from pydantic import TypeAdapter
 
 from dagster_components import ComponentTypeRegistry
+from dagster_components.core.component import ComponentTypeKey
 from dagster_components.scaffold import (
     ComponentScaffolderUnavailableReason,
     scaffold_component_instance,
@@ -32,10 +33,11 @@ def scaffold_component_command(
     registry = ComponentTypeRegistry.from_entry_point_discovery(
         builtin_component_lib=builtin_component_lib
     )
-    if not registry.has(component_type):
+    component_key = ComponentTypeKey.from_string(component_type)
+    if not registry.has(component_key):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
 
-    component_type_cls = registry.get(component_type)
+    component_type_cls = registry.get(component_key)
     if json_params:
         scaffolder = component_type_cls.get_scaffolder()
         if isinstance(scaffolder, ComponentScaffolderUnavailableReason):

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, ClassVar, Optional, TypedDict, TypeVar, Union
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterError
+from dagster._record import record
 from dagster._utils import snakecase
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -113,6 +114,20 @@ class ComponentTypeMetadata(ComponentTypeInternalMetadata):
     package: str
 
 
+@record
+class ComponentTypeKey:
+    name: str
+    package: str
+
+    def to_string(self) -> str:
+        return f"{self.name}@{self.package}"
+
+    @staticmethod
+    def from_string(s: str) -> "ComponentTypeKey":
+        name, package = s.split("@")
+        return ComponentTypeKey(name=name, package=package)
+
+
 def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.metadata.EntryPoint]:
     if sys.version_info >= (3, 10):
         return importlib.metadata.entry_points(group=group)
@@ -145,7 +160,7 @@ class ComponentTypeRegistry:
             `dagster_components*`. Only one built-in  component library can be loaded at a time.
             Defaults to `dagster_components`, the standard set of published component types.
         """
-        component_types: dict[str, type[Component]] = {}
+        component_types: dict[ComponentTypeKey, type[Component]] = {}
         for entry_point in get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP):
             # Skip built-in entry points that are not the specified builtin component library.
             if (
@@ -161,33 +176,35 @@ class ComponentTypeRegistry:
                     f"Value expected to be a module, got {root_module}."
                 )
             for component_type in get_registered_component_types_in_module(root_module):
-                key = f"{entry_point.name}.{get_component_type_name(component_type)}"
+                key = ComponentTypeKey(
+                    name=get_component_type_name(component_type), package=entry_point.name
+                )
                 component_types[key] = component_type
 
         return cls(component_types)
 
-    def __init__(self, component_types: dict[str, type[Component]]):
-        self._component_types: dict[str, type[Component]] = copy.copy(component_types)
+    def __init__(self, component_types: dict[ComponentTypeKey, type[Component]]):
+        self._component_types: dict[ComponentTypeKey, type[Component]] = copy.copy(component_types)
 
     @staticmethod
     def empty() -> "ComponentTypeRegistry":
         return ComponentTypeRegistry({})
 
-    def register(self, name: str, component_type: type[Component]) -> None:
-        if name in self._component_types:
-            raise DagsterError(f"There is an existing component registered under {name}")
-        self._component_types[name] = component_type
+    def register(self, key: ComponentTypeKey, component_type: type[Component]) -> None:
+        if key in self._component_types:
+            raise DagsterError(f"There is an existing component registered under {key}")
+        self._component_types[key] = component_type
 
-    def has(self, name: str) -> bool:
-        return name in self._component_types
+    def has(self, key: ComponentTypeKey) -> bool:
+        return key in self._component_types
 
-    def get(self, name: str) -> type[Component]:
-        return self._component_types[name]
+    def get(self, key: ComponentTypeKey) -> type[Component]:
+        return self._component_types[key]
 
-    def keys(self) -> Iterable[str]:
+    def keys(self) -> Iterable[ComponentTypeKey]:
         return self._component_types.keys()
 
-    def items(self) -> Iterable[tuple[str, type[Component]]]:
+    def items(self) -> Iterable[tuple[ComponentTypeKey, type[Component]]]:
         return self._component_types.items()
 
     def __repr__(self) -> str:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -44,13 +44,13 @@ def test_list_component_types_command():
     result = json.loads(result.output)
 
     assert list(result.keys()) == [
-        "dagster_components.test.all_metadata_empty_asset",
-        "dagster_components.test.complex_schema_asset",
-        "dagster_components.test.simple_asset",
-        "dagster_components.test.simple_pipes_script_asset",
+        "all_metadata_empty_asset@dagster_components.test",
+        "complex_schema_asset@dagster_components.test",
+        "simple_asset@dagster_components.test",
+        "simple_pipes_script_asset@dagster_components.test",
     ]
 
-    assert result["dagster_components.test.simple_asset"] == {
+    assert result["simple_asset@dagster_components.test"] == {
         "name": "simple_asset",
         "package": "dagster_components.test",
         "summary": "A simple asset that returns a constant string value.",
@@ -77,7 +77,7 @@ def test_list_component_types_command():
         "type": "object",
     }
 
-    assert result["dagster_components.test.simple_pipes_script_asset"] == {
+    assert result["simple_pipes_script_asset@dagster_components.test"] == {
         "name": "simple_pipes_script_asset",
         "package": "dagster_components.test",
         "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
@@ -114,7 +114,7 @@ def test_list_local_components_types() -> None:
             assert len(result) == 1
             assert set(result.keys()) == {"my_location/components/local_component_sample"}
             assert set(result["my_location/components/local_component_sample"].keys()) == {
-                ".my_component"
+                "my_component@__init__.py"
             }
 
             # Add a second directory and local component
@@ -181,11 +181,11 @@ def test_all_components_schema_command():
         assert "type" in component_type_schema_def["properties"]
         assert (
             component_type_schema_def["properties"]["type"]["default"]
-            == f"dagster_components.test.{component_type_key}"
+            == f"{component_type_key}@dagster_components.test"
         )
         assert (
             component_type_schema_def["properties"]["type"]["const"]
-            == f"dagster_components.test.{component_type_key}"
+            == f"{component_type_key}@dagster_components.test"
         )
 
 
@@ -200,7 +200,7 @@ def test_scaffold_component_command():
                 "dagster_components.test",
                 "scaffold",
                 "component",
-                "dagster_components.test.simple_pipes_script_asset",
+                "simple_pipes_script_asset@dagster_components.test",
                 "bar/components/qux",
                 "--json-params",
                 '{"asset_key": "my_asset", "filename": "my_asset.py"}',

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dbt_project
+type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dbt_project
+type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.pipes_subprocess_script_collection
+type: pipes_subprocess_script_collection@dagster_components
 
 params:
   scripts:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.sling_replication_collection
+type: sling_replication_collection@dagster_components
 
 params:
   replications:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dbt_project
+type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components.core.component import (
+    ComponentTypeKey,
     ComponentTypeRegistry,
     get_component_type_name,
     get_registered_component_types_in_module,
@@ -30,6 +31,9 @@ def load_test_component_project_registry(include_test: bool = False) -> Componen
         dc_module = importlib.import_module(package_name)
 
         for component in get_registered_component_types_in_module(dc_module):
-            key = f"dagster_components.{'test.' if package_name.endswith('test') else ''}{get_component_type_name(component)}"
+            key = ComponentTypeKey(
+                name=get_component_type_name(component),
+                package=f"dagster_components{'.test' if package_name.endswith('test') else ''}",
+            )
             components[key] = component
     return ComponentTypeRegistry(components)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
@@ -1,3 +1,3 @@
-type: dagster_components.definitions
+type: definitions@dagster_components
 
 params: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.definitions
+type: definitions@dagster_components
 
 params:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: my_component@__init__.py
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.definitions
+type: definitions@dagster_components
 
 params:
   definitions_path: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: my_component@__init__.py
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: my_component@__init__.py
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component_does_not_exist
+type: my_component_does_not_exist@__init__.py
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: my_component@__init__.py
 
 params:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
@@ -1,4 +1,4 @@
-type: .my_component
+type: my_component@__init__.py
 
 params:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: my_nested_component@__init__.py
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: my_nested_component@__init__.py
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
@@ -1,4 +1,4 @@
-type: .my_nested_component
+type: my_nested_component@__init__.py
 
 params:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.test.simple_asset
+type: simple_asset@dagster_components.test
 
 params:
   asset_key: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/rendering_tests/custom_scope_component/component.yaml
@@ -1,4 +1,4 @@
-type: .custom_scope_component
+type: custom_scope_component@component.py
 
 params:
   group_name: "{{ custom_str }}"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -41,7 +41,7 @@ CLI_TEST_CASES = [
         should_error=True,
         check_error_msg=msg_includes_all_of(
             "component.yaml:1",
-            "Unable to locate local component type '.my_component_does_not_exist'",
+            "Unable to locate local component type 'my_component_does_not_exist@__init__.py'",
         ),
     ),
 ]

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
@@ -29,10 +29,10 @@ def test_component_scaffold_dynamic_subcommand_generation() -> None:
         # These are wrapped in a table so it's hard to check exact output.
         for line in [
             "╭─ Commands",
-            "│ dagster_components.test.all_metadata_empty_asset",
-            "│ dagster_components.test.complex_schema_asset",
-            "│ dagster_components.test.simple_asset",
-            "│ dagster_components.test.simple_pipes_script_asset",
+            "│ all_metadata_empty_asset@dagster_components.test",
+            "│ complex_schema_asset@dagster_components.test",
+            "│ simple_asset@dagster_components.test",
+            "│ simple_pipes_script_asset@dagster_components.test",
         ]:
             assert line in result.output
 
@@ -46,7 +46,7 @@ def test_component_scaffold_no_params_success(in_deployment: bool) -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result)
@@ -54,7 +54,7 @@ def test_component_scaffold_no_params_success(in_deployment: bool) -> None:
         component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
-            "type: dagster_components.test.all_metadata_empty_asset"
+            "type: all_metadata_empty_asset@dagster_components.test"
             in component_yaml_path.read_text()
         )
 
@@ -68,7 +68,7 @@ def test_component_scaffold_json_params_success(in_deployment: bool) -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.simple_pipes_script_asset",
+            "simple_pipes_script_asset@dagster_components.test",
             "qux",
             "--json-params",
             '{"asset_key": "foo", "filename": "hello.py"}',
@@ -79,7 +79,7 @@ def test_component_scaffold_json_params_success(in_deployment: bool) -> None:
         component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
-            "type: dagster_components.test.simple_pipes_script_asset"
+            "type: simple_pipes_script_asset@dagster_components.test"
             in component_yaml_path.read_text()
         )
 
@@ -93,7 +93,7 @@ def test_component_scaffold_key_value_params_success(in_deployment: bool) -> Non
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.simple_pipes_script_asset",
+            "simple_pipes_script_asset@dagster_components.test",
             "qux",
             "--asset-key=foo",
             "--filename=hello.py",
@@ -104,7 +104,7 @@ def test_component_scaffold_key_value_params_success(in_deployment: bool) -> Non
         component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
-            "type: dagster_components.test.simple_pipes_script_asset"
+            "type: simple_pipes_script_asset@dagster_components.test"
             in component_yaml_path.read_text()
         )
 
@@ -114,7 +114,7 @@ def test_component_scaffold_json_params_and_key_value_params_fails() -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.simple_pipes_script_asset",
+            "simple_pipes_script_asset@dagster_components.test",
             "qux",
             "--json-params",
             '{"filename": "hello.py"}',
@@ -138,7 +138,7 @@ def test_component_scaffold_with_no_dagster_components_fails() -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.simple_pipes_script_asset",
+            "simple_pipes_script_asset@dagster_components.test",
             "qux",
             env={"PATH": "/dev/null"},
         )
@@ -155,14 +155,14 @@ def test_component_scaffold_already_exists_fails(in_deployment: bool) -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result)
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result, exit_0=False)
@@ -178,7 +178,7 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result)
@@ -186,7 +186,7 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
         component_yaml_path = Path("foo_bar/_components/qux/component.yaml")
         assert component_yaml_path.exists()
         assert (
-            "type: dagster_components.test.all_metadata_empty_asset"
+            "type: all_metadata_empty_asset@dagster_components.test"
             in component_yaml_path.read_text()
         )
 
@@ -198,7 +198,7 @@ def test_component_scaffold_fails_components_package_does_not_exist() -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result, exit_0=False)
@@ -211,12 +211,12 @@ def test_component_scaffold_succeeds_scaffolded_component_type() -> None:
         assert_runner_result(result)
         assert Path("foo_bar/lib/baz.py").exists()
 
-        result = runner.invoke("component", "scaffold", "foo_bar.baz", "qux")
+        result = runner.invoke("component", "scaffold", "baz@foo_bar", "qux")
         assert_runner_result(result)
         assert Path("foo_bar/components/qux").exists()
         component_yaml_path = Path("foo_bar/components/qux/component.yaml")
         assert component_yaml_path.exists()
-        assert "type: foo_bar.baz" in component_yaml_path.read_text()
+        assert "type: baz@foo_bar" in component_yaml_path.read_text()
 
 
 # ##### REAL COMPONENTS
@@ -243,7 +243,7 @@ def test_scaffold_dbt_project_instance(params) -> None:
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.dbt_project",
+            "dbt_project@dagster_components",
             "my_project",
             *params,
         )
@@ -252,7 +252,7 @@ def test_scaffold_dbt_project_instance(params) -> None:
 
         component_yaml_path = Path("foo_bar/components/my_project/component.yaml")
         assert component_yaml_path.exists()
-        assert "type: dagster_components.dbt_project" in component_yaml_path.read_text()
+        assert "type: dbt_project@dagster_components" in component_yaml_path.read_text()
         assert (
             "stub_code_locations/dbt_project_location/components/jaffle_shop"
             in component_yaml_path.read_text()
@@ -269,7 +269,7 @@ def test_list_components_succeeds():
         result = runner.invoke(
             "component",
             "scaffold",
-            "dagster_components.test.all_metadata_empty_asset",
+            "all_metadata_empty_asset@dagster_components.test",
             "qux",
         )
         assert_runner_result(result)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -202,14 +202,14 @@ def test_dynamic_subcommand_help_message():
             result = runner.invoke(
                 "component",
                 "scaffold",
-                "dagster_components.test.simple_pipes_script_asset",
+                "simple_pipes_script_asset@dagster_components.test",
                 "--help",
             )
         assert _match_output(
             result.output.strip(),
             textwrap.dedent("""
 
-                 Usage: dg component scaffold [GLOBAL OPTIONS] dagster_components.test.simple_pipes_script_asset [OPTIONS]
+                 Usage: dg component scaffold [GLOBAL OPTIONS] simple_pipes_script_asset@dagster_components.test [OPTIONS]
                  COMPONENT_NAME                                                                                                         
                                                                                                                                         
                 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮


### PR DESCRIPTION
## Summary & Motivation

This updates the naming scheme of our components to be `<name>@<namespace>` instead of `<namespace>.<name>`.

This also updates some terminology throughout the codepaths to distinguish between the name of a component (which does not include the namespace), and the registry key (which is the unique identifier). Previously, we used the term "name" for both of these cases, which was confusing.

## How I Tested These Changes

## Changelog

NOCHANGELOG
