### PR TITLE
[docs-beta][tool] Fix links to /index pages from docs beta deploy GH Action

### DIFF
--- a/.github/workflows/build-docs-revamp.yml
+++ b/.github/workflows/build-docs-revamp.yml
@@ -36,7 +36,7 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
         if: |
-          github.event_name == 'pull_request' || 
+          github.event_name == 'pull_request' ||
           (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
         run: |
           BRANCH_PREVIEW_SUBDOMAIN=$(echo "${HEAD_REF:-$REF_NAME}" | sed -e 's/[^a-zA-Z0-9-]/-/g; s/^-*//; s/-*$//' | cut -c1-63)
@@ -76,7 +76,7 @@ jobs:
           git fetch origin $GITHUB_HEAD_SHA
           # Compare the commit the branch is based on to its head to list changed files
           CHANGED_MD_FILES=$(git diff --name-only HEAD~${{ github.event.pull_request.commits }} "$GITHUB_HEAD_SHA" -- '*.md' '*.mdx')
-          CHANGES_ENTRY=$(echo "$CHANGED_MD_FILES" | sed 's/\.mdx*$//' | sed 's/^docs\/docs-beta\/docs/- {{deploymentUrl}}/')
+          CHANGES_ENTRY=$(echo "$CHANGED_MD_FILES" | sed 's/\(index\)*\.mdx*$//' | sed 's/^docs\/docs-beta\/docs/- {{deploymentUrl}}/')
           CHANGES_ENTRY=$(echo -e "Preview available at {{deploymentUrl}}\n\nDirect link to changed pages:\n$CHANGES_ENTRY")
           echo "$CHANGES_ENTRY"
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -90,7 +90,7 @@ jobs:
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25
         if: |
-          github.event_name == 'pull_request' || 
+          github.event_name == 'pull_request' ||
           (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
         with:
           github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}

--- a/docs/docs-beta/docs/guides/build/components/index.md
+++ b/docs/docs-beta/docs/guides/build/components/index.md
@@ -145,7 +145,7 @@ But first, let's set up DuckDB:
 <CliInvocationExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/13-sling-test-duckdb.txt" />
 
 
-Now let's download some files locally to use our Sling source (Sling doesn't support reading from the public internet):
+Now, let's download some files locally to use our Sling source (Sling doesn't support reading from the public internet):
 
 <CliInvocationExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/14-curl.txt" />
 


### PR DESCRIPTION
## Summary

The docs beta deploy GitHub Action constructs links to changed pages based on the filepath, stripping `.mdx`. This doesn't work for index pages, which do not include `index` in the URL.

Strips out a trailing `index` before the `.md(x)` suffix on a file, when turning it into a URL for the GitHub Action comment.

## Test Plan

See below.