### PR TITLE
[components] Improve error message for `dg component scaffold <uninstalled-component>` (BUILD-666)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -25,6 +25,7 @@ from dagster_dg.utils import (
     DgClickCommand,
     DgClickGroup,
     exit_with_error,
+    generate_missing_component_type_error_message,
     json_schema_property_to_click_option,
     not_none,
     parse_json_option,
@@ -64,7 +65,10 @@ class ComponentScaffoldGroup(DgClickGroup):
     def get_command(self, cli_context: click.Context, cmd_name: str) -> Optional[click.Command]:
         if not self._commands_defined:
             self._define_commands(cli_context)
-        return super().get_command(cli_context, cmd_name)
+        cmd = super().get_command(cli_context, cmd_name)
+        if cmd is None:
+            exit_with_error(generate_missing_component_type_error_message(cmd_name))
+        return cmd
 
     def list_commands(self, cli_context: click.Context) -> list[str]:
         if not self._commands_defined:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -14,7 +14,12 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.docs import markdown_for_component_type, render_markdown_in_browser
 from dagster_dg.scaffold import scaffold_component_type
-from dagster_dg.utils import DgClickCommand, DgClickGroup, exit_with_error
+from dagster_dg.utils import (
+    DgClickCommand,
+    DgClickGroup,
+    exit_with_error,
+    generate_missing_component_type_error_message,
+)
 
 
 @click.group(name="component-type", cls=DgClickGroup)
@@ -100,7 +105,7 @@ def component_type_info_command(
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     component_key = GlobalComponentKey.from_typename(component_type)
     if not registry.has_global(component_key):
-        exit_with_error(f"Component type `{component_type}` not found.")
+        exit_with_error(generate_missing_component_type_error_message(component_type))
     elif sum([description, scaffold_params_schema, component_params_schema]) > 1:
         exit_with_error(
             "Only one of --description, --scaffold-params-schema, and --component-params-schema can be specified."

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -279,33 +279,42 @@ def not_none(value: Optional[T]) -> T:
 
 
 def exit_with_error(error_message: str) -> Never:
-    click.echo(click.style(error_message, fg="red"))
+    formatted_error_message = _format_error_message(error_message)
+    click.echo(click.style(formatted_error_message, fg="red"))
     sys.exit(1)
 
 
 def _format_error_message(message: str) -> str:
     # width=10000 unwraps any hardwrapping
-    return textwrap.fill(message, width=10000)
+    return textwrap.dedent(textwrap.fill(message, width=10000))
 
 
-NOT_DEPLOYMENT_ERROR_MESSAGE = _format_error_message("""
+def generate_missing_component_type_error_message(component_key_str: str) -> str:
+    return f"""
+        No component type `{component_key_str}` is registered. Use 'dg component-type list'
+        to see the registered component types in your environment. You may need to install a package
+        that provides `{component_key_str}` into your environment.
+    """
+
+
+NOT_DEPLOYMENT_ERROR_MESSAGE = """
 This command must be run inside a Dagster deployment directory. Ensure that there is a
 `pyproject.toml` file with `tool.dg.is_deployment = true` set in the root deployment directory.
-""")
+"""
 
 
-NOT_CODE_LOCATION_ERROR_MESSAGE = _format_error_message("""
+NOT_CODE_LOCATION_ERROR_MESSAGE = """
 This command must be run inside a Dagster code location directory. Ensure that the nearest
 pyproject.toml has `tool.dg.is_code_location = true` set.
-""")
+"""
 
-NOT_COMPONENT_LIBRARY_ERROR_MESSAGE = _format_error_message("""
+NOT_COMPONENT_LIBRARY_ERROR_MESSAGE = """
 This command must be run inside a Dagster component library directory. Ensure that the nearest
 pyproject.toml has `tool.dg.is_component_lib = true` set.
-""")
+"""
 
 
-MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE = _format_error_message("""
+MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE = """
 Could not find the `dagster-components` executable on the system path.
 
 The `dagster-components` executable is installed with the `dagster-components` PyPI package and is
@@ -314,7 +323,7 @@ necessary for `dg` to interface with Python environments containing Dagster defi
 you are using `dg` in a non-managed environment (either outside of a code location or using the
 `--no-use-dg-managed-environment` flag), you need to independently ensure `dagster-components` is
 installed.
-""")
+"""
 
 # ########################
 # ##### CUSTOM CLICK SUBCLASSES

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
@@ -126,6 +126,13 @@ def test_component_scaffold_json_params_and_key_value_params_fails() -> None:
         )
 
 
+def test_component_scaffold_undefined_component_type_fails() -> None:
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        result = runner.invoke("component", "scaffold", "fake@fake", "qux")
+        assert_runner_result(result, exit_0=False)
+        assert "No component type `fake@fake` is registered" in result.output
+
+
 def test_component_scaffold_outside_code_location_fails() -> None:
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
         result = runner.invoke("component", "scaffold", "bar.baz", "qux")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -323,6 +323,20 @@ def test_component_type_info_with_no_dagster_components_fails() -> None:
         assert "Could not find the `dagster-components` executable" in result.output
 
 
+def test_component_type_info_undefined_component_type_fails() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_components_venv(runner),
+    ):
+        result = runner.invoke(
+            "component-type",
+            "info",
+            "fake@fake",
+        )
+        assert_runner_result(result, exit_0=False)
+        assert "No component type `fake@fake` is registered" in result.output
+
+
 # ########################
 # ##### LIST
 # ########################


### PR DESCRIPTION
## Summary & Motivation

Previously, running `dg component scaffold some.component` would fail with a missing subcommand error (from `click`) if the component wasn't installed. This customizes the error message to be about the component being unregistered.

## How I Tested These Changes

New unit test