### PR TITLE
[config] clean-up and perf pass

### DIFF
--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -1,6 +1,7 @@
 import typing
 from collections.abc import Iterator, Sequence
 from enum import Enum as PythonEnum
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, cast
 
 import dagster._check as check
@@ -77,9 +78,6 @@ class ConfigType:
             else None
         )
 
-        # memoized snap representation
-        self._snap: Optional[ConfigTypeSnap] = None
-
     @property
     def description(self) -> Optional[str]:
         return self._description
@@ -98,22 +96,21 @@ class ConfigType:
         """
         return value
 
-    def get_snapshot(self) -> "ConfigTypeSnap":
+    @cached_property
+    def snapshot(self) -> "ConfigTypeSnap":
         from dagster._config.snap import snap_from_config_type
 
-        if self._snap is None:
-            self._snap = snap_from_config_type(self)
-
-        return self._snap
+        return snap_from_config_type(self)
 
     def type_iterator(self) -> Iterator["ConfigType"]:
         yield self
 
-    def get_schema_snapshot(self) -> "ConfigSchemaSnapshot":
+    @cached_property
+    def schema_snapshot(self) -> "ConfigSchemaSnapshot":
         from dagster._config.snap import ConfigSchemaSnapshot
 
         return ConfigSchemaSnapshot(
-            all_config_snaps_by_key={ct.key: ct.get_snapshot() for ct in self.type_iterator()}
+            all_config_snaps_by_key={ct.key: ct.snapshot for ct in self.type_iterator()}
         )
 
 

--- a/python_modules/dagster/dagster/_config/errors.py
+++ b/python_modules/dagster/dagster/_config/errors.py
@@ -6,7 +6,11 @@ import dagster._check as check
 from dagster._config.config_type import ConfigTypeKind
 from dagster._config.field_utils import EnvVar, IntEnvVar
 from dagster._config.snap import ConfigFieldSnap, ConfigTypeSnap, minimal_config_for_type_snap
-from dagster._config.stack import EvaluationStack, get_friendly_path_info, get_friendly_path_msg
+from dagster._config.stack import (
+    EvaluationStackEntry,
+    get_friendly_path_info,
+    get_friendly_path_msg,
+)
 from dagster._config.traversal_context import ContextData
 from dagster._config.type_printer import print_config_type_key_to_string
 from dagster._record import IHaveNew, record, record_custom
@@ -94,7 +98,7 @@ ERROR_DATA_TYPES = ERROR_DATA_UNION.__args__  # type: ignore
 
 @record
 class EvaluationError:
-    stack: EvaluationStack
+    stack: EvaluationStackEntry
     reason: DagsterEvaluationErrorReason
     message: str
     error_data: ERROR_DATA_UNION

--- a/python_modules/dagster/dagster/_config/evaluate_value_result.py
+++ b/python_modules/dagster/dagster/_config/evaluate_value_result.py
@@ -4,36 +4,28 @@ from typing import Any, Generic, Optional, TypeVar
 
 import dagster._check as check
 from dagster._config.errors import EvaluationError
+from dagster._record import record
 
 T = TypeVar("T")
 
 
-# Python 3.6 doesn't simultaneously support NamedTuple and Generic, so we omit
-# the usual NamedTuple pattern here. See:
-# https://stackoverflow.com/questions/50530959/generic-namedtuple-in-python-3-6
+@record
 class EvaluateValueResult(Generic[T]):
-    success: Optional[bool]
+    success: bool
     value: Optional[T]
     errors: Optional[Sequence[EvaluationError]]
 
-    def __init__(
-        self, success: Optional[bool], value: T, errors: Optional[Sequence[EvaluationError]]
-    ):
-        self.success = check.opt_bool_param(success, "success")
-        self.value = value
-        self.errors = check.opt_sequence_param(errors, "errors", of_type=EvaluationError)
-
     @staticmethod
     def for_error(error: EvaluationError) -> "EvaluateValueResult[Any]":
-        return EvaluateValueResult(False, None, [error])
+        return EvaluateValueResult(success=False, value=None, errors=[error])
 
     @staticmethod
     def for_errors(errors: Sequence[EvaluationError]) -> "EvaluateValueResult[Any]":
-        return EvaluateValueResult(False, None, errors)
+        return EvaluateValueResult(success=False, value=None, errors=errors)
 
     @staticmethod
     def for_value(value: T) -> "EvaluateValueResult[T]":
-        return EvaluateValueResult(True, value, None)
+        return EvaluateValueResult(success=True, value=value, errors=None)
 
     def errors_at_level(self, *levels: str) -> Sequence[EvaluationError]:
         return list(self._iterate_errors_at_level(list(levels)))

--- a/python_modules/dagster/dagster/_config/stack.py
+++ b/python_modules/dagster/dagster/_config/stack.py
@@ -1,17 +1,24 @@
-from collections.abc import Sequence
-from typing import NamedTuple
+from collections.abc import Iterator, Sequence
+from typing import Optional
 
 import dagster._check as check
+from dagster._record import record
 
 
-class EvaluationStack(
-    NamedTuple("_EvaluationStack", [("entries", Sequence["EvaluationStackEntry"])])
-):
-    def __new__(cls, entries):
-        return super().__new__(
-            cls,
-            check.list_param(entries, "entries", of_type=EvaluationStackEntry),
-        )
+@record
+class EvaluationStackEntry:
+    parent: Optional["EvaluationStackEntry"]
+
+    @property
+    def entries(self) -> Sequence["EvaluationStackEntry"]:
+        return list(self.iter_entries())
+
+    def iter_entries(self) -> Iterator["EvaluationStackEntry"]:
+        if self.parent:
+            yield from self.parent.iter_entries()
+
+        if self:
+            yield self
 
     @property
     def levels(self) -> Sequence[str]:
@@ -21,64 +28,65 @@ class EvaluationStack(
             if isinstance(entry, EvaluationStackPathEntry)
         ]
 
-    def for_field(self, field_name: str) -> "EvaluationStack":
-        return EvaluationStack(entries=[*self.entries, EvaluationStackPathEntry(field_name)])
+    def for_field(self, field_name: str) -> "EvaluationStackEntry":
+        return EvaluationStackPathEntry(
+            field_name=field_name,
+            parent=self,
+        )
 
-    def for_array_index(self, list_index: int) -> "EvaluationStack":
-        return EvaluationStack(entries=[*self.entries, EvaluationStackListItemEntry(list_index)])
+    def for_array_index(self, list_index: int) -> "EvaluationStackEntry":
+        return EvaluationStackListItemEntry(
+            list_index=list_index,
+            parent=self,
+        )
 
-    def for_map_key(self, map_key: object) -> "EvaluationStack":
-        return EvaluationStack(entries=[*self.entries, EvaluationStackMapKeyEntry(map_key)])
+    def for_map_key(self, map_key: object) -> "EvaluationStackEntry":
+        return EvaluationStackMapKeyEntry(
+            map_key=map_key,
+            parent=self,
+        )
 
-    def for_map_value(self, map_key: object) -> "EvaluationStack":
-        return EvaluationStack(entries=[*self.entries, EvaluationStackMapValueEntry(map_key)])
-
-
-class EvaluationStackEntry:  # marker interface
-    pass
-
-
-class EvaluationStackPathEntry(
-    NamedTuple("_EvaluationStackEntry", [("field_name", str)]), EvaluationStackEntry
-):
-    def __new__(cls, field_name: str):
-        return super().__new__(
-            cls,
-            check.str_param(field_name, "field_name"),
+    def for_map_value(self, map_key: object) -> "EvaluationStackEntry":
+        return EvaluationStackMapValueEntry(
+            map_key=map_key,
+            parent=self,
         )
 
 
-class EvaluationStackListItemEntry(
-    NamedTuple("_EvaluationStackListItemEntry", [("list_index", int)]), EvaluationStackEntry
-):
-    def __new__(cls, list_index: int):
-        check.int_param(list_index, "list_index")
-        check.param_invariant(list_index >= 0, "list_index")
-        return super().__new__(cls, list_index)
+@record
+class EvaluationStackPathEntry(EvaluationStackEntry):
+    field_name: str
 
 
-class EvaluationStackMapKeyEntry(
-    NamedTuple("EvaluationStackMapKeyEntry", [("map_key", object)]),
-    EvaluationStackEntry,
-):
-    def __new__(cls, map_key: object):
-        return super().__new__(cls, map_key)
+@record
+class EvaluationStackListItemEntry(EvaluationStackEntry):
+    list_index: int
 
 
-class EvaluationStackMapValueEntry(
-    NamedTuple("_EvaluationStackMapItemEntry", [("map_key", object)]),
-    EvaluationStackEntry,
-):
-    def __new__(cls, map_key: object):
-        return super().__new__(cls, map_key)
+@record
+class EvaluationStackMapKeyEntry(EvaluationStackEntry):
+    map_key: object
 
 
-def get_friendly_path_msg(stack: EvaluationStack) -> str:
+@record
+class EvaluationStackMapValueEntry(EvaluationStackEntry):
+    map_key: object
+
+
+@record
+class EvaluationStackRoot(EvaluationStackEntry):
+    parent: Optional["EvaluationStackEntry"] = None
+
+    def iter_entries(self):
+        yield from []
+
+
+def get_friendly_path_msg(stack: EvaluationStackEntry) -> str:
     return get_friendly_path_info(stack)[0]
 
 
-def get_friendly_path_info(stack: EvaluationStack) -> tuple[str, str]:
-    if not stack.entries:
+def get_friendly_path_info(stack: EvaluationStackEntry) -> tuple[str, str]:
+    if isinstance(stack, EvaluationStackRoot):
         path = ""
         path_msg = "at the root"
     else:

--- a/python_modules/dagster/dagster/_config/traversal_context.py
+++ b/python_modules/dagster/dagster/_config/traversal_context.py
@@ -1,58 +1,23 @@
-from enum import Enum
-
 import dagster._check as check
 from dagster._config.config_type import ConfigType
 from dagster._config.field import Field
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot, ConfigTypeSnap
-from dagster._config.stack import EvaluationStack
+from dagster._config.stack import EvaluationStackEntry
+from dagster._record import record
 
 
-class TraversalType(Enum):
-    VALIDATE = "VALIDATE"
-    RESOLVE_DEFAULTS = "RESOLVE_DEFAULTS"
-    RESOLVE_DEFAULTS_AND_POSTPROCESS = "RESOLVE_DEFAULTS_AND_POSTPROCESS"
-
-
+@record
 class ContextData:
-    __slots__ = ["_config_schema_snapshot", "_config_type_snap", "_stack"]
-
-    _config_schema_snapshot: ConfigSchemaSnapshot
-    _config_type_snap: ConfigTypeSnap
-    _stack: EvaluationStack
-
-    def __init__(
-        self,
-        config_schema_snapshot: ConfigSchemaSnapshot,
-        config_type_snap: ConfigTypeSnap,
-        stack: EvaluationStack,
-    ):
-        self._config_schema_snapshot = check.inst_param(
-            config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot
-        )
-
-        self._config_type_snap = check.inst_param(
-            config_type_snap, "config_type_snap", ConfigTypeSnap
-        )
-
-        self._stack = check.inst_param(stack, "stack", EvaluationStack)
-
-    @property
-    def config_schema_snapshot(self) -> ConfigSchemaSnapshot:
-        return self._config_schema_snapshot
-
-    @property
-    def config_type_snap(self) -> ConfigTypeSnap:
-        return self._config_type_snap
+    config_schema_snapshot: ConfigSchemaSnapshot
+    config_type_snap: ConfigTypeSnap
+    stack: EvaluationStackEntry
 
     @property
     def config_type_key(self) -> str:
-        return self._config_type_snap.key
-
-    @property
-    def stack(self) -> EvaluationStack:
-        return self._stack
+        return self.config_type_snap.key
 
 
+@record
 class ValidationContext(ContextData):
     def for_field_snap(self, field_snap: ConfigFieldSnap) -> "ValidationContext":
         check.inst_param(field_snap, "field_snap", ConfigFieldSnap)
@@ -109,50 +74,24 @@ class ValidationContext(ContextData):
         )
 
 
+@record
 class TraversalContext(ContextData):
-    __slots__ = ["_all_config_types", "_config_type", "_traversal_type"]
-
-    def __init__(
-        self,
-        config_schema_snapshot: ConfigSchemaSnapshot,
-        config_type_snap: ConfigTypeSnap,
-        config_type: ConfigType,
-        stack: EvaluationStack,
-        traversal_type: TraversalType,
-    ):
-        super().__init__(
-            config_schema_snapshot=config_schema_snapshot,
-            config_type_snap=config_type_snap,
-            stack=stack,
-        )
-        self._config_type = check.inst_param(config_type, "config_type", ConfigType)
-        self._traversal_type = check.inst_param(traversal_type, "traversal_type", TraversalType)
+    config_type: ConfigType
+    do_post_process: bool
 
     @staticmethod
     def from_config_type(
         config_type: ConfigType,
-        stack: EvaluationStack,
-        traversal_type: TraversalType,
+        stack: EvaluationStackEntry,
+        do_post_process: bool,
     ) -> "TraversalContext":
         return TraversalContext(
-            config_schema_snapshot=config_type.get_schema_snapshot(),
-            config_type_snap=config_type.get_snapshot(),
+            config_schema_snapshot=config_type.schema_snapshot,
+            config_type_snap=config_type.snapshot,
             config_type=config_type,
             stack=stack,
-            traversal_type=traversal_type,
+            do_post_process=do_post_process,
         )
-
-    @property
-    def config_type(self) -> ConfigType:
-        return self._config_type
-
-    @property
-    def traversal_type(self) -> TraversalType:
-        return self._traversal_type
-
-    @property
-    def do_post_process(self) -> bool:
-        return self.traversal_type == TraversalType.RESOLVE_DEFAULTS_AND_POSTPROCESS
 
     def for_array(self, index: int) -> "TraversalContext":
         check.int_param(index, "index")
@@ -163,7 +102,7 @@ class TraversalContext(ContextData):
             ),
             config_type=self.config_type.inner_type,  # type: ignore
             stack=self.stack.for_array_index(index),
-            traversal_type=self.traversal_type,
+            do_post_process=self.do_post_process,
         )
 
     def for_map(self, key: object) -> "TraversalContext":
@@ -174,18 +113,16 @@ class TraversalContext(ContextData):
             ),
             config_type=self.config_type.inner_type,  # type: ignore
             stack=self.stack.for_map_value(key),
-            traversal_type=self.traversal_type,
+            do_post_process=self.do_post_process,
         )
 
     def for_field(self, field_def: Field, field_name: str) -> "TraversalContext":
-        check.inst_param(field_def, "field_def", Field)
-        check.str_param(field_name, "field_name")
         return TraversalContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(field_def.config_type.key),
             config_type=field_def.config_type,
             stack=self.stack.for_field(field_name),
-            traversal_type=self.traversal_type,
+            do_post_process=self.do_post_process,
         )
 
     def for_nullable_inner_type(self) -> "TraversalContext":
@@ -196,7 +133,7 @@ class TraversalContext(ContextData):
             ),
             config_type=self.config_type.inner_type,  # type: ignore
             stack=self.stack,
-            traversal_type=self.traversal_type,
+            do_post_process=self.do_post_process,
         )
 
     def for_new_config_type(self, config_type: ConfigType) -> "TraversalContext":
@@ -205,5 +142,5 @@ class TraversalContext(ContextData):
             config_type_snap=self.config_schema_snapshot.get_config_snap(config_type.key),
             config_type=config_type,
             stack=self.stack,
-            traversal_type=self.traversal_type,
+            do_post_process=self.do_post_process,
         )

--- a/python_modules/dagster/dagster/_config/type_printer.py
+++ b/python_modules/dagster/dagster/_config/type_printer.py
@@ -7,7 +7,7 @@ from dagster._utils.indenting_printer import IndentingPrinter
 
 def _print_type_from_config_type(config_type, print_fn=print, with_lines=True):
     check.inst_param(config_type, "config_type", ConfigType)
-    return _print_type(config_type.get_schema_snapshot(), config_type.key, print_fn, with_lines)
+    return _print_type(config_type.schema_snapshot, config_type.key, print_fn, with_lines)
 
 
 def _print_type(config_schema_snapshot, config_type_key, print_fn, with_lines):

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1289,7 +1289,7 @@ class ResourceSnap(IHaveNew):
             resource_snapshot=build_resource_def_snap(name, resource_def),
             configured_values=configured_values,
             config_field_snaps=unconfigured_config_type_snap.fields or [],
-            config_schema_snap=config_type.get_schema_snapshot(),
+            config_schema_snap=config_type.schema_snapshot,
             nested_resources=nested_resources,
             parent_resources=parent_resources,
             is_top_level=True,

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -9,7 +9,7 @@ from dagster._config import (
 
 def assert_inner_types(parent_type, *dagster_types):
     config_type = resolve_to_config_type(parent_type)
-    config_schema_snapshot = config_type.get_schema_snapshot()  # pyright: ignore[reportAttributeAccessIssue]
+    config_schema_snapshot = config_type.schema_snapshot  # pyright: ignore[reportAttributeAccessIssue]
 
     all_type_keys = get_recursive_type_keys(
         snap_from_config_type(config_type),  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Cut repeat config processing time roughly in half by
* updating some namedtuples to `@record` 
* refining some memoization
* making various small tweaks informed by profiler output


## How I Tested These Changes

bk

![Screenshot 2025-02-03 at 5 18 16 PM](https://github.com/user-attachments/assets/fb1de732-2069-43db-9779-1d879e733cad)
