### PR TITLE
[dg] Nicely format YAML parsing errors in dg check CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ check_prettier:
 	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
 	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' ':!:docs/*.md' \
+	':!:python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/**/*.yaml' \
 	':!:README.md'` --check
 
 prettier:

--- a/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
@@ -163,4 +163,32 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "'asdfasdf' is not of type 'object'",
         ),
     ),
+    ComponentValidationTestCase(
+        component_path="validation/invalid_yaml_missing_quote",
+        component_type_filepath=None,
+        should_error=True,
+        validate_error_msg=msg_includes_all_of(
+            "line 2",
+            "found unexpected end of stream",
+        ),
+        check_error_msg=msg_includes_all_of(
+            "component.yaml:2",
+            "Unable to parse YAML",
+            "found unexpected end of stream",
+        ),
+    ),
+    ComponentValidationTestCase(
+        component_path="validation/invalid_yaml_invalid_char",
+        component_type_filepath=None,
+        should_error=True,
+        validate_error_msg=msg_includes_all_of(
+            "line 1",
+            "found character '@' that cannot start any token",
+        ),
+        check_error_msg=msg_includes_all_of(
+            "component.yaml:1",
+            "Unable to parse YAML",
+            "found character '@' that cannot start any token",
+        ),
+    ),
 ]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_invalid_char/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_invalid_char/component.yaml
@@ -1,0 +1,3 @@
+type: @"bad char"
+
+params: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_missing_quote/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_missing_quote/component.yaml
@@ -1,0 +1,1 @@
+type: "no close quote

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -5,6 +5,7 @@ from dagster_components.test.test_cases import (
 )
 from dagster_components.utils import ensure_dagster_components_tests_import
 from pydantic import ValidationError
+from yaml.scanner import ScannerError
 
 from dagster_components_tests.integration_tests.validation_tests.utils import (
     load_test_component_defs_inject_component,
@@ -23,7 +24,7 @@ def test_validation_messages(test_case: ComponentValidationTestCase) -> None:
     errors.
     """
     if test_case.should_error:
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises((ValidationError, ScannerError)) as e:
             load_test_component_defs_inject_component(
                 str(test_case.component_path),
                 test_case.component_type_filepath,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -50,15 +50,12 @@ OFFSET_LINES_AFTER = 3
 def error_dict_to_formatted_error(
     component_name: Optional[str],
     error_details: ValidationError,
-    source_position_tree: Optional[SourcePositionTree],
+    source_position_tree: SourcePositionTree,
     prefix: Sequence[str] = (),
 ) -> str:
-    source_position = None
-    source_position_path = []
-    if source_position_tree:
-        source_position, source_position_path = source_position_tree.lookup_closest_and_path(
-            [*prefix, *error_details.absolute_path], trace=None
-        )
+    source_position, source_position_path = source_position_tree.lookup_closest_and_path(
+        [*prefix, *error_details.absolute_path], trace=None
+    )
 
     # Retrieves dotted path representation of the location of the error in the YAML file, e.g.
     # params.nested.foo.an_int
@@ -68,19 +65,15 @@ def error_dict_to_formatted_error(
 
     # Find the first source position that has a different start line than the current source position
     # This is e.g. the parent json key of the current source position
-    preceding_source_position = (
-        next(
-            iter(
-                [
-                    value
-                    for value in reversed(list(source_position_path))
-                    if value.start.line < source_position.start.line
-                ]
-            ),
-            source_position,
-        )
-        if source_position
-        else None
+    preceding_source_position = next(
+        iter(
+            [
+                value
+                for value in reversed(list(source_position_path))
+                if value.start.line < source_position.start.line
+            ]
+        ),
+        source_position,
     )
     with open(source_position.filename) as f:
         lines = f.readlines()

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -50,12 +50,15 @@ OFFSET_LINES_AFTER = 3
 def error_dict_to_formatted_error(
     component_name: Optional[str],
     error_details: ValidationError,
-    source_position_tree: SourcePositionTree,
+    source_position_tree: Optional[SourcePositionTree],
     prefix: Sequence[str] = (),
 ) -> str:
-    source_position, source_position_path = source_position_tree.lookup_closest_and_path(
-        [*prefix, *error_details.absolute_path], trace=None
-    )
+    source_position = None
+    source_position_path = []
+    if source_position_tree:
+        source_position, source_position_path = source_position_tree.lookup_closest_and_path(
+            [*prefix, *error_details.absolute_path], trace=None
+        )
 
     # Retrieves dotted path representation of the location of the error in the YAML file, e.g.
     # params.nested.foo.an_int
@@ -65,15 +68,19 @@ def error_dict_to_formatted_error(
 
     # Find the first source position that has a different start line than the current source position
     # This is e.g. the parent json key of the current source position
-    preceding_source_position = next(
-        iter(
-            [
-                value
-                for value in reversed(list(source_position_path))
-                if value.start.line < source_position.start.line
-            ]
-        ),
-        source_position,
+    preceding_source_position = (
+        next(
+            iter(
+                [
+                    value
+                    for value in reversed(list(source_position_path))
+                    if value.start.line < source_position.start.line
+                ]
+            ),
+            source_position,
+        )
+        if source_position
+        else None
     )
     with open(source_position.filename) as f:
         lines = f.readlines()


### PR DESCRIPTION
## Summary

Slurp up `yaml.scanner.ScannerErrors` and pass them into our nice error message formatter, that way `dg check` calls don't early-exit if we hit a parsing error.

<img width="993" alt="Screenshot 2025-02-03 at 3 20 58 PM" src="https://github.com/user-attachments/assets/202b316c-aa23-423e-b1bf-b4ad6afb4652" />


## Test Plan

New unit tests.
