### PR TITLE
[components] Better error message for failing entry points (BUILD-647)

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -1,11 +1,13 @@
 import importlib.util
+import subprocess
 import sys
+import textwrap
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 import click
 from dagster._core.definitions.asset_key import AssetKey
@@ -17,6 +19,8 @@ from dagster._core.errors import DagsterError
 
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.objects import AssetAttributesSchema
+
+T = TypeVar("T")
 
 CLI_BUILTIN_COMPONENT_LIB_KEY = "builtin_component_lib"
 
@@ -34,6 +38,13 @@ def ensure_dagster_components_tests_import() -> None:
 def exit_with_error(error_message: str) -> None:
     click.echo(click.style(error_message, fg="red"))
     sys.exit(1)
+
+
+def format_error_message(message: str) -> str:
+    # width=10000 unwraps any hardwrapping
+    dedented = textwrap.dedent(message).strip()
+    paragraphs = [textwrap.fill(p, width=10000) for p in dedented.split("\n\n")]
+    return "\n\n".join(paragraphs)
 
 
 # Temporarily places a path at the front of sys.path, ensuring that any modules in that path are
@@ -143,3 +154,34 @@ def load_module_from_path(module_name, path) -> ModuleType:
     assert spec.loader, "Must have a loader"
     spec.loader.exec_module(module)
     return module
+
+
+# ########################
+# ##### PLATFORM
+# ########################
+
+
+def is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+# ########################
+# ##### VENV
+# ########################
+
+
+def get_venv_executable(venv_dir: Path, executable: str = "python") -> Path:
+    if is_windows():
+        return venv_dir / "Scripts" / f"{executable}.exe"
+    else:
+        return venv_dir / "bin" / executable
+
+
+def install_to_venv(venv_dir: Path, install_args: list[str]) -> None:
+    executable = get_venv_executable(venv_dir)
+    command = ["uv", "pip", "install", "--python", str(executable), *install_args]
+    subprocess.run(command, check=True)

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -48,6 +48,6 @@ setup(
     extras_require={
         "sling": ["dagster-sling"],
         "dbt": ["dagster-dbt"],
-        "test": ["dbt-duckdb", "dagster-dg"],
+        "test": ["dbt-duckdb", "dagster-dg", "tomlkit"],
     },
 )

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -334,7 +334,9 @@ def exit_with_error(error_message: str) -> Never:
 
 def _format_error_message(message: str) -> str:
     # width=10000 unwraps any hardwrapping
-    return textwrap.dedent(textwrap.fill(message, width=10000))
+    dedented = textwrap.dedent(message).strip()
+    paragraphs = [textwrap.fill(p, width=10000) for p in dedented.split("\n\n")]
+    return "\n\n".join(paragraphs)
 
 
 def generate_missing_component_type_error_message(component_key_str: str) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -130,7 +130,7 @@ def isolated_example_component_library_foo_bar(
     ) as venv_path:
         # We just use the code location generation function and then modify it to be a component library
         # only.
-        runner.invoke(
+        result = runner.invoke(
             "code-location",
             "scaffold",
             "--use-editable-dagster",
@@ -138,6 +138,7 @@ def isolated_example_component_library_foo_bar(
             "--skip-venv",
             "foo-bar",
         )
+        assert_runner_result(result)
         with clear_module_from_cache("foo_bar"), pushd("foo-bar"):
             shutil.rmtree(Path("foo_bar/components"))
 
@@ -283,6 +284,35 @@ def match_terminal_box_output(output: str, expected_output: str):
     return True
 
 
+# Windows sometimes provides short (8.3) paths in output, which can be difficult to match exactly.
+def normalize_windows_path(path: str) -> str:
+    """Convert a Windows short (8.3) path to its long form.
+    If the path does not exist or conversion fails, returns the original path.
+    """
+    import ctypes
+
+    if sys.platform != "win32":
+        raise RuntimeError("This function is only supported on Windows.")
+    # Create a buffer for the result
+    buffer_len = 260  # MAX_PATH typically 260 for Windows, though can be longer in practice
+    buffer_ = ctypes.create_unicode_buffer(buffer_len)
+
+    # Call GetLongPathNameW
+    get_len = ctypes.windll.kernel32.GetLongPathNameW(path, buffer_, buffer_len)
+
+    # If the buffer wasn't large enough, retry with bigger size
+    if get_len > buffer_len:
+        buffer_len = get_len
+        buffer_ = ctypes.create_unicode_buffer(buffer_len)
+        get_len = ctypes.windll.kernel32.GetLongPathNameW(path, buffer_, buffer_len)
+
+    # get_len == 0 indicates error (e.g. file not found, path doesn't exist)
+    if get_len == 0:
+        return path
+
+    return buffer_.value
+
+
 # ########################
 # ##### CLI RUNNER
 # ########################
@@ -338,7 +368,10 @@ class ProxyRunner:
         # For some reason the context setting `max_content_width` is not respected when using the
         # CliRunner, so we have to set it manually.
         return self.original.invoke(
-            dg_cli, all_args, terminal_width=self.console_width, **invoke_kwargs
+            dg_cli,
+            all_args,
+            terminal_width=self.console_width,
+            **invoke_kwargs,
         )
 
     @contextmanager


### PR DESCRIPTION
## Summary & Motivation

Currently if there is an error when loading a `dagster-components` entry point, the whole process terminates unceremoniously with an ugly error.

This PR changes this behavior:

Entry points are loaded in a try-catch block. We wrap any error when loading in a `ComponentsEntryPointLoadError`. This and the backtrace flow up to the output of the instigating `dg` command, which then caps it off with a clean error message about the `dagster-components` command failing.

This has the two keys properties of being debuggable and _ending_ the output with a clear error message.

## How I Tested These Changes

New unit test and manually (running `dg component-type list` in an env with a bad entry point).