### PR TITLE
[components] Refactor RemoteComponentRegistry

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from dagster_dg.cli.global_options import dg_global_options
-from dagster_dg.component import RemoteComponentKey, RemoteComponentRegistry
+from dagster_dg.component import GlobalRemoteComponentKey, RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.docs import markdown_for_component_type, render_markdown_in_browser
@@ -41,7 +41,7 @@ def component_type_scaffold_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = RemoteComponentKey(name=name, package=dg_context.root_package_name)
+    component_key = GlobalRemoteComponentKey(name=name, package=dg_context.root_package_name)
     if registry.has_global(component_key):
         exit_with_error(f"A component type named `{name}` already exists.")
 
@@ -66,7 +66,7 @@ def component_type_docs_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = RemoteComponentKey.from_string(component_type)
+    component_key = GlobalRemoteComponentKey.from_identifier(component_type)
     if not registry.has_global(component_key):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
 
@@ -97,7 +97,7 @@ def component_type_info_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = RemoteComponentKey.from_string(component_type)
+    component_key = GlobalRemoteComponentKey.from_identifier(component_type)
     if not registry.has_global(component_key):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
     elif sum([description, scaffold_params_schema, component_params_schema]) > 1:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -1,7 +1,7 @@
 import textwrap
 from pathlib import Path
 
-from dagster_dg.component import RemoteComponentKey, RemoteComponentRegistry
+from dagster_dg.component import GlobalRemoteComponentKey, RemoteComponentRegistry
 from dagster_dg.context import DgContext
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
@@ -31,7 +31,7 @@ def test_component_type_scaffold_success() -> None:
         assert Path("foo_bar/lib/baz.py").exists()
         dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        assert registry.has_global(RemoteComponentKey(name="baz", package="foo_bar"))
+        assert registry.has_global(GlobalRemoteComponentKey(name="baz", package="foo_bar"))
 
 
 def test_component_type_scaffold_outside_component_library_fails() -> None:
@@ -77,7 +77,7 @@ def test_component_type_scaffold_succeeds_non_default_component_lib_package() ->
         assert Path("foo_bar/_lib/baz.py").exists()
         dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        assert registry.has_global(RemoteComponentKey(name="baz", package="foo_bar"))
+        assert registry.has_global(GlobalRemoteComponentKey(name="baz", package="foo_bar"))
 
 
 def test_component_type_scaffold_fails_components_lib_package_does_not_exist() -> None:


### PR DESCRIPTION
## Summary & Motivation

Refactors the RemoteComponentRegistry to use separate types for the different types of keys rather than separate dictionaries.

## How I Tested These Changes

## Changelog

NOCHANGELOG
