### PR TITLE
[components] Update naming conventions and error messages

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -29,10 +29,10 @@ def list_component_types_command(ctx: click.Context) -> None:
     registry = ComponentTypeRegistry.from_entry_point_discovery(
         builtin_component_lib=builtin_component_lib
     )
-    for key in sorted(registry.keys(), key=lambda k: k.to_string()):
-        output[key.to_string()] = ComponentTypeMetadata(
+    for key in sorted(registry.keys(), key=lambda k: k.to_typename()):
+        output[key.to_typename()] = ComponentTypeMetadata(
             name=key.name,
-            package=key.package,
+            package=key.namespace,
             **registry.get(key).get_metadata(),
         )
     click.echo(json.dumps(output))
@@ -46,7 +46,7 @@ def list_local_component_types_command(component_directories: Sequence[str]) -> 
     for component_directory in component_directories:
         output_for_directory = {}
         for key, component_type in find_local_component_types(Path(component_directory)).items():
-            output_for_directory[key.to_string()] = ComponentTypeMetadata(
+            output_for_directory[key.to_typename()] = ComponentTypeMetadata(
                 name=get_component_type_name(component_type),
                 package=component_directory,
                 **component_type.get_metadata(),
@@ -71,7 +71,7 @@ def list_all_components_schema_command(ctx: click.Context) -> None:
     for key, component_type in sorted(registry.items()):
         # Create ComponentFileModel schema for each type
         schema_type = component_type.get_schema()
-        key_string = key.to_string()
+        key_string = key.to_typename()
         if schema_type:
             schemas.append(
                 create_model(

--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -5,7 +5,7 @@ import click
 from pydantic import TypeAdapter
 
 from dagster_components import ComponentTypeRegistry
-from dagster_components.core.component import ComponentTypeKey
+from dagster_components.core.component import ComponentKey
 from dagster_components.scaffold import (
     ComponentScaffolderUnavailableReason,
     scaffold_component_instance,
@@ -33,7 +33,7 @@ def scaffold_component_command(
     registry = ComponentTypeRegistry.from_entry_point_discovery(
         builtin_component_lib=builtin_component_lib
     )
-    component_key = ComponentTypeKey.from_string(component_type)
+    component_key = ComponentKey.from_typename(component_type)
     if not registry.has(component_key):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -3,6 +3,7 @@ import dataclasses
 import importlib
 import importlib.metadata
 import inspect
+import re
 import sys
 import textwrap
 from abc import ABC, abstractmethod
@@ -111,21 +112,27 @@ class ComponentTypeInternalMetadata(TypedDict):
 
 class ComponentTypeMetadata(ComponentTypeInternalMetadata):
     name: str
-    package: str
+    namespace: str
+
+
+COMPONENT_TYPE_REGEX = re.compile(r"^([a-zA-Z0-9_]+)@([a-zA-Z0-9_]+)$")
 
 
 @record
-class ComponentTypeKey:
+class ComponentKey:
     name: str
-    package: str
+    namespace: str
 
-    def to_string(self) -> str:
-        return f"{self.name}@{self.package}"
+    def to_typename(self) -> str:
+        return f"{self.name}@{self.namespace}"
 
     @staticmethod
-    def from_string(s: str) -> "ComponentTypeKey":
-        name, package = s.split("@")
-        return ComponentTypeKey(name=name, package=package)
+    def from_typename(typename: str) -> "ComponentKey":
+        match = COMPONENT_TYPE_REGEX.match(typename)
+        if not match:
+            raise ValueError(f"Invalid component type name: {typename}")
+        name, package = match.groups()
+        return ComponentKey(name=name, namespace=package)
 
 
 def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.metadata.EntryPoint]:
@@ -160,7 +167,7 @@ class ComponentTypeRegistry:
             `dagster_components*`. Only one built-in  component library can be loaded at a time.
             Defaults to `dagster_components`, the standard set of published component types.
         """
-        component_types: dict[ComponentTypeKey, type[Component]] = {}
+        component_types: dict[ComponentKey, type[Component]] = {}
         for entry_point in get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP):
             # Skip built-in entry points that are not the specified builtin component library.
             if (
@@ -176,35 +183,35 @@ class ComponentTypeRegistry:
                     f"Value expected to be a module, got {root_module}."
                 )
             for component_type in get_registered_component_types_in_module(root_module):
-                key = ComponentTypeKey(
-                    name=get_component_type_name(component_type), package=entry_point.name
+                key = ComponentKey(
+                    name=get_component_type_name(component_type), namespace=entry_point.name
                 )
                 component_types[key] = component_type
 
         return cls(component_types)
 
-    def __init__(self, component_types: dict[ComponentTypeKey, type[Component]]):
-        self._component_types: dict[ComponentTypeKey, type[Component]] = copy.copy(component_types)
+    def __init__(self, component_types: dict[ComponentKey, type[Component]]):
+        self._component_types: dict[ComponentKey, type[Component]] = copy.copy(component_types)
 
     @staticmethod
     def empty() -> "ComponentTypeRegistry":
         return ComponentTypeRegistry({})
 
-    def register(self, key: ComponentTypeKey, component_type: type[Component]) -> None:
+    def register(self, key: ComponentKey, component_type: type[Component]) -> None:
         if key in self._component_types:
             raise DagsterError(f"There is an existing component registered under {key}")
         self._component_types[key] = component_type
 
-    def has(self, key: ComponentTypeKey) -> bool:
+    def has(self, key: ComponentKey) -> bool:
         return key in self._component_types
 
-    def get(self, key: ComponentTypeKey) -> type[Component]:
+    def get(self, key: ComponentKey) -> type[Component]:
         return self._component_types[key]
 
-    def keys(self) -> Iterable[ComponentTypeKey]:
+    def keys(self) -> Iterable[ComponentKey]:
         return self._component_types.keys()
 
-    def items(self) -> Iterable[tuple[ComponentTypeKey, type[Component]]]:
+    def items(self) -> Iterable[tuple[ComponentKey, type[Component]]]:
         return self._component_types.items()
 
     def __repr__(self) -> str:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components.core.component import (
-    ComponentTypeKey,
+    ComponentKey,
     ComponentTypeRegistry,
     get_component_type_name,
     get_registered_component_types_in_module,
@@ -31,9 +31,9 @@ def load_test_component_project_registry(include_test: bool = False) -> Componen
         dc_module = importlib.import_module(package_name)
 
         for component in get_registered_component_types_in_module(dc_module):
-            key = ComponentTypeKey(
+            key = ComponentKey(
                 name=get_component_type_name(component),
-                package=f"dagster_components{'.test' if package_name.endswith('test') else ''}",
+                namespace=f"dagster_components{'.test' if package_name.endswith('test') else ''}",
             )
             components[key] = component
     return ComponentTypeRegistry(components)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
-from dagster_components.core.component import ComponentTypeKey
+from dagster_components.core.component import ComponentKey
 
 
 @contextmanager
@@ -181,10 +181,10 @@ def test_components_from_third_party_lib(tmpdir):
         with _temp_venv(deps) as python_executable:
             component_types = _get_component_types_in_python_environment(python_executable)
             assert (
-                ComponentTypeKey(name="test_component_1", package="dagster_foo").to_string()
+                ComponentKey(name="test_component_1", namespace="dagster_foo").to_typename()
                 in component_types
             )
             assert (
-                ComponentTypeKey(name="test_component_2", package="dagster_foo").to_string()
+                ComponentKey(name="test_component_2", namespace="dagster_foo").to_typename()
                 in component_types
             )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -5,6 +5,7 @@ import click
 import typer
 from jsonschema import ValidationError
 
+from dagster_dg.component import ComponentKey
 from dagster_dg.yaml_utils.source_position import SourcePositionTree
 
 
@@ -48,7 +49,7 @@ OFFSET_LINES_AFTER = 3
 
 
 def error_dict_to_formatted_error(
-    component_name: Optional[str],
+    component_key: Optional[ComponentKey],
     error_details: ValidationError,
     source_position_tree: SourcePositionTree,
     prefix: Sequence[str] = (),
@@ -121,5 +122,7 @@ def error_dict_to_formatted_error(
         f":{typer.style(source_position.start.line, fg=typer.colors.GREEN)}"
     )
     fmt_location = typer.style(location, fg=typer.colors.BRIGHT_WHITE)
-    fmt_name = typer.style(f"{component_name} " if component_name else "", fg=typer.colors.RED)
+    fmt_name = typer.style(
+        f"{component_key.to_typename()} " if component_key else "", fg=typer.colors.RED
+    )
     return f"{fmt_filename} - {fmt_name}{fmt_location} {error_details.message}\n{code_snippet}\n"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from dagster_dg.cli.global_options import dg_global_options
-from dagster_dg.component import GlobalRemoteComponentKey, RemoteComponentRegistry
+from dagster_dg.component import GlobalComponentKey, RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.docs import markdown_for_component_type, render_markdown_in_browser
@@ -41,9 +41,9 @@ def component_type_scaffold_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalRemoteComponentKey(name=name, package=dg_context.root_package_name)
+    component_key = GlobalComponentKey(name=name, namespace=dg_context.root_package_name)
     if registry.has_global(component_key):
-        exit_with_error(f"A component type named `{name}` already exists.")
+        exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
     scaffold_component_type(dg_context, name)
 
@@ -66,9 +66,9 @@ def component_type_docs_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalRemoteComponentKey.from_identifier(component_type)
+    component_key = GlobalComponentKey.from_typename(component_type)
     if not registry.has_global(component_key):
-        exit_with_error(f"No component type `{component_type}` could be resolved.")
+        exit_with_error(f"Component type`{component_type}` not found.")
 
     render_markdown_in_browser(markdown_for_component_type(registry.get_global(component_key)))
 
@@ -97,9 +97,9 @@ def component_type_info_command(
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalRemoteComponentKey.from_identifier(component_type)
+    component_key = GlobalComponentKey.from_typename(component_type)
     if not registry.has_global(component_key):
-        exit_with_error(f"No component type `{component_type}` could be resolved.")
+        exit_with_error(f"Component type `{component_type}` not found.")
     elif sum([description, scaffold_params_schema, component_params_schema]) > 1:
         exit_with_error(
             "Only one of --description, --scaffold-params-schema, and --component-params-schema can be specified."
@@ -158,7 +158,7 @@ def component_type_list(context: click.Context, **global_options: object) -> Non
     table = Table(border_style="dim")
     table.add_column("Component Type", style="bold cyan", no_wrap=True)
     table.add_column("Summary")
-    for key in sorted(registry.global_keys(), key=lambda k: k.to_string()):
-        table.add_row(key.to_string(), registry.get_global(key).summary)
+    for key in sorted(registry.global_keys(), key=lambda k: k.to_typename()):
+        table.add_row(key.to_typename(), registry.get_global(key).summary)
     console = Console()
     console.print(table)

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -234,10 +234,10 @@ class DgContext:
                 )
             return Path(get_path_for_package(self.components_package_name))
 
-    def get_component_names(self) -> Iterable[str]:
+    def get_component_instance_names(self) -> Iterable[str]:
         return [str(instance_path.name) for instance_path in self.components_path.iterdir()]
 
-    def has_component(self, name: str) -> bool:
+    def has_component_instance(self, name: str) -> bool:
         return (self.components_path / name).is_dir()
 
     @property

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -1,7 +1,7 @@
 import textwrap
 from pathlib import Path
 
-from dagster_dg.component import GlobalRemoteComponentKey, RemoteComponentRegistry
+from dagster_dg.component import GlobalComponentKey, RemoteComponentRegistry
 from dagster_dg.context import DgContext
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
@@ -31,7 +31,7 @@ def test_component_type_scaffold_success() -> None:
         assert Path("foo_bar/lib/baz.py").exists()
         dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        assert registry.has_global(GlobalRemoteComponentKey(name="baz", package="foo_bar"))
+        assert registry.has_global(GlobalComponentKey(name="baz", namespace="foo_bar"))
 
 
 def test_component_type_scaffold_outside_component_library_fails() -> None:
@@ -77,7 +77,7 @@ def test_component_type_scaffold_succeeds_non_default_component_lib_package() ->
         assert Path("foo_bar/_lib/baz.py").exists()
         dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
         registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        assert registry.has_global(GlobalRemoteComponentKey(name="baz", package="foo_bar"))
+        assert registry.has_global(GlobalComponentKey(name="baz", namespace="foo_bar"))
 
 
 def test_component_type_scaffold_fails_components_lib_package_does_not_exist() -> None:


### PR DESCRIPTION
## Summary & Motivation

Makes the following changes to our ontology:

- The `ComponentKey` refers to an in-memory object that bundles together all information necessary to locate a ComponentType (name and namespace). This term is not intended to be user-visible.
- The "typename" of a component refers to the fully-disambiguated string that the user will use to refer to a component type, e.g. `dbt_project@dagster_dbt`. Users will see this as an argument to CLI commands (component-type = ...), and in error messages ("component type xyz@abc not found"). 
- The "name" of a component type is the name of the component type within a particular namespace. This is what gets passed into the `@register_component_type` decorator as the "name" argument.
- The "namespace" of a component type is the container that this component type lives in. This could be a component library (e.g. dagster_dbt), or a local python file (e.g. component.py)

Also changes `component_name` to `component_instance_name` where appropriate

## How I Tested These Changes

## Changelog

NOCHANGELOG
