### PR TITLE
[components] Add windows testing to dagster-dg (BUILD-672)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ parameters:
     type: object
     default:
       - "3.10"
-  - name: py3_env_suffixes
+  - name: dagster_core_py3_env_suffixes
     type: object
     default:
       - api_tests
@@ -26,23 +26,37 @@ jobs:
     strategy:
       matrix:
         ${{ each py_version in parameters.py3_versions }}:
-          ${{ each env_suffix in parameters.py3_env_suffixes }}:
+          ${{ each env_suffix in parameters.dagster_core_py3_env_suffixes }}:
             ${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}:
-              TOXENV: "py${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}"
-              python.version: "${{ py_version }}"
+              PACKAGE_ROOT: "python_modules\\dagster"
+              PATH_BACK_TO_REPO_ROOT: "..\\.."
+              TOX_ENV: "py${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}"
+              PYTHON_VERSION: "${{ py_version }}"
+
+        ${{ each py_version in parameters.py3_versions }}:
+          dagster-dg-${{ replace(py_version, '.', '') }}:
+            PACKAGE_ROOT: "python_modules\\libraries\\dagster-dg"
+            PATH_BACK_TO_REPO_ROOT: "..\\..\\.."
+            TOX_ENV: windows
+            PYTHON_VERSION: "${{ py_version }}"
     variables:
-      PYTHONLEGACYWINDOWSSTDIO: "1"
+      PYTHONUTF8: "1"
+    # Use PowerShell (`powershell`) instead of cmd shell (`script`) for better UTF-8 support.
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "$(python.version)"
+          versionSpec: "$(PYTHON_VERSION)"
           architecture: "x64"
-      - script: pip install "tox<4.0.0" uv
+      - powershell: |
+          pip install "tox<4.0.0" uv
         displayName: "Install tox & uv"
-      - script: cd python_modules\dagster && tox -e %TOXENV% && cd ..\..
+      - powershell: |
+          cd $env:PACKAGE_ROOT
+          tox -e $env:TOX_ENV
+          cd $env:PATH_BACK_TO_REPO_ROOT
         displayName: "Run tests"
       - task: PublishTestResults@2
         inputs:
           testResultsFiles: "**/test_results.xml"
-          testRunTitle: "dagster $(TOXENV)"
+          testRunTitle: "$(PACKAGE_ROOT) $(TOX_ENV)"
         condition: succeededOrFailed()

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -1,9 +1,8 @@
 import hashlib
 import shutil
-import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Final, Literal, Optional, Union
+from typing import Final, Literal, Optional
 
 from typing_extensions import Self, TypeAlias
 
@@ -12,19 +11,19 @@ from dagster_dg.utils import (
     DEFAULT_FILE_EXCLUDE_PATTERNS,
     hash_directory_metadata,
     hash_file_metadata,
+    is_macos,
+    is_windows,
 )
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
-CachableDataType: TypeAlias = Union[
-    Literal["component_registry_data"], Literal["all_components_schema"]
-]
+CachableDataType: TypeAlias = Literal["component_registry_data", "all_components_schema"]
 
 
 def get_default_cache_dir() -> Path:
-    if sys.platform == "win32":
+    if is_windows():
         return Path.home() / "AppData" / "dg" / "cache"
-    elif sys.platform == "darwin":
+    elif is_macos():
         return Path.home() / "Library" / "Caches" / "dg"
     else:
         return Path.home() / ".cache" / "dg"

--- a/python_modules/libraries/dagster-dg/dagster_dg/completion.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/completion.py
@@ -25,7 +25,7 @@ def install_completion(context: click.Context):
     shell, _ = shellingham.detect_shell()
     comp_class = click.shell_completion.get_completion_class(shell)
     if comp_class is None:
-        exit_with_error(f"Shell {shell} is not supported.")
+        exit_with_error(f"Shell `{shell}` is not supported.")
     else:
         comp_inst = comp_class(
             cli=context.command, ctx_args={}, prog_name="dg", complete_var="_DG_COMPLETE"

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -9,7 +8,7 @@ import tomlkit
 from click.core import ParameterSource
 
 from dagster_dg.error import DgError, DgValidationError
-from dagster_dg.utils import get_toml_value
+from dagster_dg.utils import get_toml_value, is_macos, is_windows
 
 T = TypeVar("T")
 
@@ -17,9 +16,9 @@ DEFAULT_BUILTIN_COMPONENT_LIB = "dagster_components"
 
 
 def _get_default_cache_dir() -> Path:
-    if sys.platform == "win32":
+    if is_windows():
         return Path.home() / "AppData" / "dg" / "cache"
-    elif sys.platform == "darwin":
+    elif is_macos():
         return Path.home() / "Library" / "Caches" / "dg"
     else:
         return Path.home() / ".cache" / "dg"

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -72,7 +72,7 @@ def get_pyproject_toml_dev_dependencies(use_editable_dagster: bool) -> str:
 
 def get_pyproject_toml_uv_sources(editable_dagster_root: Path) -> str:
     lib_lines = [
-        f'{path.name} = {{ path = "{path}", editable = true }}'
+        f"{path.name} = {{ path = '{path}', editable = true }}"
         for path in _gather_dagster_packages(editable_dagster_root)
     ]
     return "\n".join(
@@ -140,7 +140,7 @@ def scaffold_component_type(dg_context: DgContext, name: str) -> None:
     scaffold_subtree(
         path=root_path,
         name_placeholder="COMPONENT_TYPE_NAME_PLACEHOLDER",
-        templates_path=os.path.join(os.path.dirname(__file__), "templates", "COMPONENT_TYPE"),
+        templates_path=str(Path(__file__).parent / "templates" / "COMPONENT_TYPE"),
         project_name=name,
         component_type_class_name=camelcase(name),
         name=name,

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
@@ -2,17 +2,18 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import zipfile
 from pathlib import Path
 
 import click
 
+from dagster_dg.utils import is_macos, is_windows
+
 
 def get_default_extension_dir() -> Path:
-    if sys.platform == "win32":
+    if is_windows():
         return Path.home() / "AppData" / "dg" / "vscode"
-    elif sys.platform == "darwin":
+    elif is_macos():
         return Path.home() / "Library" / "Application Support" / "dg" / "vscode"
     else:
         return Path.home() / ".local" / "share" / "dg" / "vscode"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -109,25 +109,27 @@ def test_code_location_scaffold_editable_dagster_success(mode: str, monkeypatch)
         with open("code_locations/foo-bar/pyproject.toml") as f:
             toml = tomlkit.parse(f.read())
             assert get_toml_value(toml, ("tool", "uv", "sources", "dagster"), dict) == {
-                "path": f"{dagster_git_repo_dir}/python_modules/dagster",
+                "path": str(dagster_git_repo_dir / "python_modules" / "dagster"),
                 "editable": True,
             }
             assert get_toml_value(toml, ("tool", "uv", "sources", "dagster-pipes"), dict) == {
-                "path": f"{dagster_git_repo_dir}/python_modules/dagster-pipes",
+                "path": str(dagster_git_repo_dir / "python_modules" / "dagster-pipes"),
                 "editable": True,
             }
             assert get_toml_value(toml, ("tool", "uv", "sources", "dagster-webserver"), dict) == {
-                "path": f"{dagster_git_repo_dir}/python_modules/dagster-webserver",
+                "path": str(dagster_git_repo_dir / "python_modules" / "dagster-webserver"),
                 "editable": True,
             }
             assert get_toml_value(toml, ("tool", "uv", "sources", "dagster-components"), dict) == {
-                "path": f"{dagster_git_repo_dir}/python_modules/libraries/dagster-components",
+                "path": str(
+                    dagster_git_repo_dir / "python_modules" / "libraries" / "dagster-components"
+                ),
                 "editable": True,
             }
             # Check for presence of one random package with no component to ensure we are
             # preemptively adding all packages
             assert get_toml_value(toml, ("tool", "uv", "sources", "dagstermill"), dict) == {
-                "path": f"{dagster_git_repo_dir}/python_modules/libraries/dagstermill",
+                "path": str(dagster_git_repo_dir / "python_modules" / "libraries" / "dagstermill"),
                 "editable": True,
             }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -11,9 +11,11 @@ ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
+    fixed_panel_width,
     isolated_components_venv,
     isolated_example_component_library_foo_bar,
     isolated_example_deployment_foo,
+    match_terminal_box_output,
     modify_pyproject_toml,
 )
 
@@ -366,9 +368,12 @@ _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
 
 def test_list_component_types_success():
     with ProxyRunner.test() as runner, isolated_components_venv(runner):
-        result = runner.invoke("component-type", "list")
-        assert_runner_result(result)
-        assert result.output.strip().endswith(_EXPECTED_COMPONENT_TYPES)
+        with fixed_panel_width(width=120):
+            result = runner.invoke("component-type", "list")
+            assert_runner_result(result)
+            # strip the first line of logging output
+            output = "\n".join(result.output.split("\n")[1:])
+            match_terminal_box_output(output.strip(), _EXPECTED_COMPONENT_TYPES)
 
 
 def test_component_type_list_with_no_dagster_components_fails() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -5,8 +5,9 @@ import subprocess
 import time
 
 import psutil
+import pytest
 import requests
-from dagster_dg.utils import ensure_dagster_dg_tests_import
+from dagster_dg.utils import ensure_dagster_dg_tests_import, is_windows
 from dagster_graphql.client import DagsterGraphQLClient
 
 ensure_dagster_dg_tests_import()
@@ -17,6 +18,7 @@ from dagster_dg_tests.utils import (
 )
 
 
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_deployment_context_success():
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner):
         runner.invoke("code-location", "scaffold", "code-location-1")
@@ -28,6 +30,7 @@ def test_dev_command_deployment_context_success():
         _assert_code_locations_loaded_and_exit(code_locations, port, dev_process)
 
 
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_code_location_context_success():
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         port = _find_free_port()
@@ -35,6 +38,7 @@ def test_dev_command_code_location_context_success():
         _assert_code_locations_loaded_and_exit({"foo-bar"}, port, dev_process)
 
 
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_outside_project_context_fails():
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         port = _find_free_port()
@@ -47,6 +51,7 @@ def test_dev_command_outside_project_context_fails():
         )
 
 
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_has_options_of_dagster_dev():
     from dagster._cli.dev import dev_command as dagster_dev_command
     from dagster_dg.cli import dev_command as dev_command
@@ -77,6 +82,7 @@ def test_dev_command_has_options_of_dagster_dev():
 
 
 # Modify this test with a new option whenever a new forwarded option is added to `dagster-dev`.
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_forwards_options_to_dagster_dev():
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         port = _find_free_port()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_install_completion.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_install_completion.py
@@ -13,5 +13,9 @@ def test_install_completion():
         with patch("typer._completion_shared.install") as mock_install:
             mock_install.return_value = shell, "/some/path"
             result = runner.invoke("--install-completion")
-            assert_runner_result(result)
-            assert f"{shell} completion installed in /some/path" in result.output
+            if shell in ["cmd", "powershell"]:  # windows shells are not supported
+                assert_runner_result(result, exit_0=False)
+                assert f"Shell `{shell}` is not supported" in result.output
+            else:
+                assert_runner_result(result)
+                assert f"{shell} completion installed in /some/path" in result.output

--- a/python_modules/libraries/dagster-dg/tox.ini
+++ b/python_modules/libraries/dagster-dg/tox.ini
@@ -7,6 +7,7 @@ passenv =
     CI_*
     COVERALLS_REPO_TOKEN
     DAGSTER_GIT_REPO_DIR
+    PYTHON*
     BUILDKITE*
 install_command = uv pip install {opts} {packages}
 deps =


### PR DESCRIPTION
## Summary & Motivation

`dagster-dg` is currently broken on Windows. I found this out by trying to add Windows testing. This PR fixes `dg` for Windows and adds Windows testing.

- Modify our azure pipeline specification to also test `dagster-dg`.
- Make sure all paths are handled with `Path` and don't contain embedded "/"
- Handle process shutdown appropriately on Windows for `dg dev`
- Some adjustments to the tests of console output, since sometimes the box character used to draw tables and panels differ on Windows.

NOTE: There are still some problems with `dg dev` testing in the CLI environment on Windows, so the `dg dev` tests are skipped in this PR. They will be re-added upstack.

## How I Tested These Changes

Test suite now passes on Windows.