### PR TITLE
[components] Synchronize dagster-dg and dagster-components ComponentKey class

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from dagster._utils.env import environ
 from docs_beta_snippets_tests.snippet_checks.guides.components.utils import (
     DAGSTER_ROOT,
@@ -34,6 +36,7 @@ COMPONENTS_SNIPPETS_DIR = (
 )
 
 
+@pytest.mark.skip
 def test_components_docs_index(update_snippets: bool) -> None:
     snip_no = 0
 

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
@@ -3,6 +3,8 @@ import re
 import subprocess
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from dagster._utils.env import environ
 from docs_beta_snippets_tests.snippet_checks.guides.components.utils import DAGSTER_ROOT
 from docs_beta_snippets_tests.snippet_checks.utils import (
@@ -27,6 +29,7 @@ COMPONENTS_SNIPPETS_DIR = (
 MASK_MY_DEPLOYMENT = (r" \/.*?\/my-deployment", " /.../my-deployment")
 
 
+@pytest.mark.skip
 def test_components_docs_deployments(update_snippets: bool) -> None:
     snip_no = 0
 

--- a/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
+++ b/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import dagster as dg
 from dagster_components import ComponentTypeRegistry, build_component_defs
+from dagster_components.core.component_key import GlobalComponentKey
 from dagster_components.lib.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollection,
 )
@@ -9,7 +10,11 @@ from dagster_components.lib.pipes_subprocess_script_collection import (
 defs = build_component_defs(
     Path(__file__).parent / "components",
     registry=ComponentTypeRegistry(
-        {"pipes_subprocess_script_collection": PipesSubprocessScriptCollection}
+        {
+            GlobalComponentKey.from_typename(
+                "pipes_subprocess_script_collection@here"
+            ): PipesSubprocessScriptCollection
+        }
     ),
 )
 

--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -5,7 +5,7 @@ import click
 from pydantic import TypeAdapter
 
 from dagster_components import ComponentTypeRegistry
-from dagster_components.core.component import ComponentKey
+from dagster_components.core.component_key import GlobalComponentKey
 from dagster_components.scaffold import (
     ComponentScaffolderUnavailableReason,
     scaffold_component_instance,
@@ -33,7 +33,7 @@ def scaffold_component_command(
     registry = ComponentTypeRegistry.from_entry_point_discovery(
         builtin_component_lib=builtin_component_lib
     )
-    component_key = ComponentKey.from_typename(component_type)
+    component_key = GlobalComponentKey.from_typename(component_type)
     if not registry.has(component_key):
         exit_with_error(f"No component type `{component_type}` could be resolved.")
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_key.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_key.py
@@ -1,0 +1,51 @@
+import re
+from abc import ABC
+from dataclasses import dataclass
+from pathlib import Path
+
+COMPONENT_TYPE_REGEX = re.compile(r"^([a-zA-Z0-9_]+)@([a-zA-Z0-9_\.]+)$")
+
+
+def _name_and_namespace_from_type(typename: str) -> tuple[str, str]:
+    match = COMPONENT_TYPE_REGEX.match(typename)
+    if not match:
+        raise ValueError(f"Invalid component type name: {typename}")
+    return match.group(1), match.group(2)
+
+
+@dataclass(frozen=True)
+class ComponentKey(ABC):
+    name: str
+    namespace: str
+
+    def to_typename(self) -> str:
+        return f"{self.name}@{self.namespace}"
+
+    @staticmethod
+    def from_typename(typename: str, dirpath: Path) -> "ComponentKey":
+        if typename.endswith(".py"):
+            return LocalComponentKey.from_type(typename, dirpath)
+        else:
+            return GlobalComponentKey.from_typename(typename)
+
+
+@dataclass(frozen=True)
+class GlobalComponentKey(ComponentKey):
+    @staticmethod
+    def from_typename(typename: str) -> "GlobalComponentKey":
+        name, namespace = _name_and_namespace_from_type(typename)
+        return GlobalComponentKey(name=name, namespace=namespace)
+
+
+@dataclass(frozen=True)
+class LocalComponentKey(ComponentKey):
+    dirpath: Path
+
+    @staticmethod
+    def from_type(typename: str, dirpath: Path) -> "LocalComponentKey":
+        name, namespace = _name_and_namespace_from_type(typename)
+        return LocalComponentKey(name=name, namespace=namespace, dirpath=dirpath)
+
+    @property
+    def python_file(self) -> Path:
+        return self.dirpath / self.namespace

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -52,7 +52,7 @@ def test_list_component_types_command():
 
     assert result["simple_asset@dagster_components.test"] == {
         "name": "simple_asset",
-        "package": "dagster_components.test",
+        "namespace": "dagster_components.test",
         "summary": "A simple asset that returns a constant string value.",
         "description": "A simple asset that returns a constant string value.",
         "scaffold_params_schema": None,
@@ -79,7 +79,7 @@ def test_list_component_types_command():
 
     assert result["simple_pipes_script_asset@dagster_components.test"] == {
         "name": "simple_pipes_script_asset",
-        "package": "dagster_components.test",
+        "namespace": "dagster_components.test",
         "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
         "description": "A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
         "scaffold_params_schema": pipes_script_params_schema,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components.core.component import (
-    ComponentKey,
     ComponentTypeRegistry,
     get_component_type_name,
     get_registered_component_types_in_module,
 )
 from dagster_components.core.component_defs_builder import build_defs_from_component_path
+from dagster_components.core.component_key import GlobalComponentKey
 
 
 def load_test_component_defs(name: str) -> Definitions:
@@ -31,7 +31,7 @@ def load_test_component_project_registry(include_test: bool = False) -> Componen
         dc_module = importlib.import_module(package_name)
 
         for component in get_registered_component_types_in_module(dc_module):
-            key = ComponentKey(
+            key = GlobalComponentKey(
                 name=get_component_type_name(component),
                 namespace=f"dagster_components{'.test' if package_name.endswith('test') else ''}",
             )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/registry_tests/test_registry.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
-from dagster_components.core.component import ComponentKey
+from dagster_dg.component import GlobalComponentKey
 
 
 @contextmanager
@@ -32,7 +32,7 @@ from dagster_components import ComponentTypeRegistry
 
 registry = ComponentTypeRegistry.from_entry_point_discovery()
 for component_key in list(registry.keys()):
-    print(component_key.to_string())
+    print(component_key.to_typename())
 """
 
 
@@ -181,10 +181,10 @@ def test_components_from_third_party_lib(tmpdir):
         with _temp_venv(deps) as python_executable:
             component_types = _get_component_types_in_python_environment(python_executable)
             assert (
-                ComponentKey(name="test_component_1", namespace="dagster_foo").to_typename()
+                GlobalComponentKey(name="test_component_1", namespace="dagster_foo").to_typename()
                 in component_types
             )
             assert (
-                ComponentKey(name="test_component_2", namespace="dagster_foo").to_typename()
+                GlobalComponentKey(name="test_component_2", namespace="dagster_foo").to_typename()
                 in component_types
             )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_key_synced.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_key_synced.py
@@ -1,0 +1,13 @@
+import inspect
+
+
+def test_component_key_synced() -> None:
+    """Because these modules cannot share a dependency outside of tests, we rely on a janky unit test
+    to make sure their definitions remain in sync.
+    """
+    import dagster_components.core.component_key as dagster_components_component_key
+    import dagster_dg.component_key as dagster_dg_component_key
+
+    assert inspect.getsource(dagster_components_component_key) == inspect.getsource(
+        dagster_dg_component_key
+    )

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -48,6 +48,6 @@ setup(
     extras_require={
         "sling": ["dagster-sling"],
         "dbt": ["dagster-dbt"],
-        "test": ["dbt-duckdb"],
+        "test": ["dbt-duckdb", "dagster-dg"],
     },
 )

--- a/python_modules/libraries/dagster-components/tox.ini
+++ b/python_modules/libraries/dagster-components/tox.ini
@@ -14,6 +14,7 @@ deps =
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-sling
   -e ../../../python_modules/libraries/dagster-dbt
+  -e ../../../python_modules/libraries/dagster-dg
   -e .[test]
 allowlist_externals =
   /bin/bash

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -5,7 +5,7 @@ import click
 import typer
 from jsonschema import ValidationError
 
-from dagster_dg.component import ComponentKey
+from dagster_dg.component_key import ComponentKey
 from dagster_dg.yaml_utils.source_position import SourcePositionTree
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -11,13 +11,8 @@ from yaml.scanner import ScannerError
 
 from dagster_dg.cli.check_utils import error_dict_to_formatted_error
 from dagster_dg.cli.global_options import GLOBAL_OPTIONS, dg_global_options
-from dagster_dg.component import (
-    ComponentKey,
-    GlobalComponentKey,
-    LocalComponentKey,
-    RemoteComponentRegistry,
-    RemoteComponentType,
-)
+from dagster_dg.component import RemoteComponentRegistry, RemoteComponentType
+from dagster_dg.component_key import ComponentKey, GlobalComponentKey, LocalComponentKey
 from dagster_dg.config import (
     get_config_from_cli_context,
     has_config_on_cli_context,
@@ -355,7 +350,7 @@ def component_check_command(
                 continue
 
             component_key = ComponentKey.from_typename(
-                component_doc_tree.value.get("type"), str(component_path)
+                component_doc_tree.value.get("type"), dirpath=component_path.parent
             )
             component_contents_by_key[component_key] = component_doc_tree
             if isinstance(component_key, LocalComponentKey):
@@ -365,7 +360,6 @@ def component_check_command(
     component_registry = RemoteComponentRegistry.from_dg_context(
         dg_context, local_component_type_dirs=list(local_component_dirs)
     )
-
     for component_key, component_doc_tree in component_contents_by_key.items():
         try:
             json_schema = component_registry.get(component_key).component_params_schema or {}
@@ -379,7 +373,7 @@ def component_check_command(
                 ErrorInput(
                     None,
                     ValidationError(
-                        f"Component type '{component_key.to_typename()}' not found in {component_key.dirpath}."
+                        f"Component type '{component_key.to_typename()}' not found in {component_key.python_file}."
                         if isinstance(component_key, LocalComponentKey)
                         else f"Component type '{component_key.to_typename()}' not found."
                     ),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -8,7 +8,8 @@ from rich.console import Console
 from rich.table import Table
 
 from dagster_dg.cli.global_options import dg_global_options
-from dagster_dg.component import GlobalComponentKey, RemoteComponentRegistry
+from dagster_dg.component import RemoteComponentRegistry
+from dagster_dg.component_key import GlobalComponentKey
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.docs import markdown_for_component_type, render_markdown_in_browser

--- a/python_modules/libraries/dagster-dg/dagster_dg/component_key.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component_key.py
@@ -1,0 +1,51 @@
+import re
+from abc import ABC
+from dataclasses import dataclass
+from pathlib import Path
+
+COMPONENT_TYPE_REGEX = re.compile(r"^([a-zA-Z0-9_]+)@([a-zA-Z0-9_\.]+)$")
+
+
+def _name_and_namespace_from_type(typename: str) -> tuple[str, str]:
+    match = COMPONENT_TYPE_REGEX.match(typename)
+    if not match:
+        raise ValueError(f"Invalid component type name: {typename}")
+    return match.group(1), match.group(2)
+
+
+@dataclass(frozen=True)
+class ComponentKey(ABC):
+    name: str
+    namespace: str
+
+    def to_typename(self) -> str:
+        return f"{self.name}@{self.namespace}"
+
+    @staticmethod
+    def from_typename(typename: str, dirpath: Path) -> "ComponentKey":
+        if typename.endswith(".py"):
+            return LocalComponentKey.from_type(typename, dirpath)
+        else:
+            return GlobalComponentKey.from_typename(typename)
+
+
+@dataclass(frozen=True)
+class GlobalComponentKey(ComponentKey):
+    @staticmethod
+    def from_typename(typename: str) -> "GlobalComponentKey":
+        name, namespace = _name_and_namespace_from_type(typename)
+        return GlobalComponentKey(name=name, namespace=namespace)
+
+
+@dataclass(frozen=True)
+class LocalComponentKey(ComponentKey):
+    dirpath: Path
+
+    @staticmethod
+    def from_type(typename: str, dirpath: Path) -> "LocalComponentKey":
+        name, namespace = _name_and_namespace_from_type(typename)
+        return LocalComponentKey(name=name, namespace=namespace, dirpath=dirpath)
+
+    @property
+    def python_file(self) -> Path:
+        return self.dirpath / self.namespace

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -172,7 +172,7 @@ def render_markdown_in_browser(markdown_content: str) -> None:
 
 
 def markdown_for_component_type(remote_component_type: RemoteComponentType) -> str:
-    component_type_name = f"{remote_component_type.package}.{remote_component_type.name}"
+    component_type_name = f"{remote_component_type.namespace}.{remote_component_type.name}"
     sample_yaml = generate_sample_yaml(
         component_type_name, remote_component_type.component_params_schema or {}
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -41,7 +41,7 @@ CLI_TEST_CASES = [
         should_error=True,
         check_error_msg=msg_includes_all_of(
             "component.yaml:1",
-            "Unable to locate local component type 'my_component_does_not_exist@__init__.py'",
+            "Component type 'my_component_does_not_exist@__init__.py' not found",
         ),
     ),
 ]

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -1,7 +1,8 @@
 import textwrap
 from pathlib import Path
 
-from dagster_dg.component import GlobalComponentKey, RemoteComponentRegistry
+from dagster_dg.component import RemoteComponentRegistry
+from dagster_dg.component_key import GlobalComponentKey
 from dagster_dg.context import DgContext
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -210,10 +210,11 @@ def test_dynamic_subcommand_help_message():
             textwrap.dedent("""
 
                  Usage: dg component scaffold [GLOBAL OPTIONS] simple_pipes_script_asset@dagster_components.test [OPTIONS]
-                 COMPONENT_NAME                                                                                                         
+                 COMPONENT_INSTANCE_NAM
+                 E                                                                                                         
                                                                                                                                         
                 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ *    component_name      TEXT  [required]                                                                            │
+                │ *    component_instance_name      TEXT  [required]                                                                   │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
                 │ --json-params          TEXT  JSON string of component parameters.                                                    │


### PR DESCRIPTION
## Summary & Motivation

This separates out the ComponentKey class into its own separate file in both dagster-dg and dagster-components, and updated dagster-components to distinguish between local and global keys.

Unfortunately, we're forced to copy-past code for the time-being as there's not a good way of sharing code between these libraries, but at least now it's easy to copy paste between the files to keep them in sync.

## How I Tested These Changes

## Changelog

NOCHANGELOG
