### PR TITLE
[docs] add redirect from docs-preview to docs

### DIFF
--- a/docs/docs-beta/vercel.json
+++ b/docs/docs-beta/vercel.json
@@ -11,6 +11,16 @@
       "destination": "https://docs.dagster.io"
     },
     {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "new-docs.dagster.io"
+        }
+      ],
+      "destination": "https://docs.dagster.io"
+    },
+    {
       "source": "/dagster-cloud/:path*",
       "destination": "/dagster-plus/:path*",
       "permanent": false

--- a/docs/docs-beta/vercel.json
+++ b/docs/docs-beta/vercel.json
@@ -1,6 +1,16 @@
 {
   "redirects": [
     {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs-preview.dagster.io"
+        }
+      ],
+      "destination": "https://docs.dagster.io"
+    },
+    {
       "source": "/dagster-cloud/:path*",
       "destination": "/dagster-plus/:path*",
       "permanent": false


### PR DESCRIPTION
## Summary & Motivation

Resolves DOC-753.

There are two options suggested for this sub-domain redirect. Through the `vercel.json` or through a configuration on the DNS provider. Since I don't have access to the latter, I will move forward with doing it at the web server level for now.

https://github.com/vercel/vercel/discussions/5622#discussioncomment-4094899

## How I Tested These Changes

## Changelog

NOCHANGELOG
