### PR TITLE
[bk] run components/dg CLI tests when either package is updated

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -16,6 +16,7 @@ from dagster_buildkite.utils import (
     BuildkiteStep,
     connect_sibling_docker_container,
     has_dagster_airlift_changes,
+    has_dg_or_components_changes,
     has_storage_test_fixture_changes,
     network_buildkite_container,
     skip_if_not_airlift_or_dlift_commit,
@@ -317,6 +318,7 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         # snippets against all supported python versions.
         unsupported_python_versions=AvailablePythonVersion.get_all_except_default(),
         pytest_tox_factors=["all", "integrations", "docs_snapshot_test"],
+        always_run_if=has_dg_or_components_changes,
     ),
     PackageSpec(
         "examples/project_fully_featured",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -320,6 +320,14 @@ def has_dagster_airlift_changes():
 
 
 @functools.lru_cache(maxsize=None)
+def has_dg_or_components_changes():
+    return any(
+        "dagster-dg" in str(path) or "dagster-components" in str(path)
+        for path in ChangedFiles.all
+    )
+
+
+@functools.lru_cache(maxsize=None)
 def skip_if_not_airlift_or_dlift_commit() -> Optional[str]:
     """If no dlift or airlift files are touched, then do NOT run. Even if on master."""
     return (

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -33,4 +33,5 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ component        Commands for operating on components.                                 │
 │ component-type   Commands for operating on components types.                           │
 │ deployment       Commands for operating on deployment directories.                     │
+│ dev              Start a local deployment of your Dagster project.                     │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -53,6 +53,18 @@ def error_dict_to_formatted_error(
     source_position_tree: SourcePositionTree,
     prefix: Sequence[str] = (),
 ) -> str:
+    """Convert a ValidationError to a formatted error message, including
+    a code snippet of the offending YAML file.
+
+    Args:
+        component_name: The name of the component that the error occurred in, e.g. "my_component".
+        error_details: The JSON Schema ValidationError object.
+        source_position_tree: The SourcePositionTree object, which contains the source position of
+            each line in the YAML file.
+        prefix: A prefix to the JSON path of the location of the error in the YAML file. Used because
+            we validate params separately from the top-level component YAML fields, so this is often
+            set to e.g. ["params"] when validating the internal params of a component.
+    """
     source_position, source_position_path = source_position_tree.lookup_closest_and_path(
         [*prefix, *error_details.absolute_path], trace=None
     )


### PR DESCRIPTION
## Summary

#27481 introduced a (very minor) change to `dg --help` that adjusted the snapshot, but this test never ran on the branch. Updates our BK logic to always run the docs snippets tests when the dg or dagster-components packages are updated.
