### PR TITLE
[dagster-dbt] Fix error when using dbt_assets decorator with io_manager_key

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -58,6 +58,11 @@ SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 # keys are otherwise encoded inside OutputDefinitions within NodeDefinitions.
 SYSTEM_METADATA_KEY_IO_MANAGER_KEY = "dagster/io_manager_key"
 
+# SYSTEM_METADATA_KEY_DAGSTER_TYPE lives on the metadata of an asset without a node def and
+# determines the dagster_type that it is expected to output as. This is necessary because
+# dagster types are otherwise encoded inside OutputDefinitions within NodeDefinitions.
+SYSTEM_METADATA_KEY_DAGSTER_TYPE = "dagster/dagster_type"
+
 # SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES lives on the metadata of
 # external assets resulting from a source asset conversion. It contains the
 # `auto_observe_interval_minutes` value from the source asset and is consulted

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -26,12 +26,14 @@ from dagster import (
     _check as check,
     define_asset_job,
 )
+from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._core.definitions.metadata.source_code import (
     CodeReferencesMetadataSet,
     CodeReferencesMetadataValue,
     LocalFileCodeReference,
 )
+from dagster._core.types.dagster_type import Nothing
 
 from dagster_dbt.metadata_set import DbtMetadataSet
 from dagster_dbt.utils import (
@@ -812,9 +814,10 @@ def build_dbt_specs(
         spec = get_asset_spec(translator, manifest, dbt_nodes, group_props, project, resource_props)
         key_by_unique_id[unique_id] = spec.key
 
-        # add the io manager key
+        # add the io manager key and set the dagster type to Nothing
         if io_manager_key is not None:
             spec = spec.with_io_manager_key(io_manager_key)
+            spec = spec.merge_attributes(metadata={SYSTEM_METADATA_KEY_DAGSTER_TYPE: Nothing})
 
         specs.append(spec)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -34,7 +34,7 @@ from dagster import (
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
-from dagster._core.types.dagster_type import DagsterType
+from dagster._core.types.dagster_type import DagsterType, Nothing
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_specs import build_dbt_asset_specs
 from dagster_dbt.asset_utils import DUPLICATE_ASSET_KEY_ERROR_MESSAGE
@@ -290,6 +290,7 @@ def test_io_manager_key(
     for output_def in my_dbt_assets.node_def.output_defs:
         if output_def.name in my_dbt_assets.keys_by_output_name:
             assert output_def.io_manager_key == expected_io_manager_key
+            assert output_def.dagster_type == Nothing
         else:  # asset checks don't use io managers
             assert output_def.name in my_dbt_assets.check_specs_by_output_name
             assert output_def.io_manager_key == DEFAULT_IO_MANAGER_KEY


### PR DESCRIPTION
## Summary & Motivation

Fixes a regression in dagster-dbt after converting it to use spec-based creation. The core thing here is that we need a way to pass a DagsterType into the system when using specs.

Before, it was assumed that if you were passing an io_manager_key, this meant that you definitely wanted that IOManager to handle all of the outputs, hence the DagsterType was set to DagsterAny instead of the default Nothing.

However, this is not actually a safe assumption in all cases, as with the dagster-dbt integration it's useful to set the io_manager_key so that downstream assets can know how to consume these outputs.

This PR follows patterns we've used in the past of adding another bit of named metadata to the spec that allows us to wire this sort of information into the op construction logic.

Because this is a fairly niche usecase, I did not add a `with_dagster_type` method to the AssetSpec (which would further copy the io_manager_key solution), but that's something we could consider in the future.

## How I Tested These Changes

Unit tests

## Changelog

Fixed a bug introduced in dagster-dbt 0.25.7 which would cause execution to fail when using the `@dbt_assets` decorator with an `io_manager_key` specified.
