### PR TITLE
Allow rendering asset graph without full asset graph data

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -157,7 +157,7 @@ export const AssetGraphExplorer = (props: Props) => {
         if (graphDataLoading || filteredAssetsLoading || fullAssetGraphDataLoading) {
           return <LoadingSpinner purpose="page" />;
         }
-        if (!assetGraphData || !allAssetKeys || !fullAssetGraphData) {
+        if (!assetGraphData || !allAssetKeys) {
           return <NonIdealState icon="error" title="Query Error" />;
         }
 
@@ -176,7 +176,7 @@ export const AssetGraphExplorer = (props: Props) => {
           <AssetGraphExplorerWithData
             key={props.explorerPath.pipelineName}
             assetGraphData={assetGraphData}
-            fullAssetGraphData={fullAssetGraphData}
+            fullAssetGraphData={fullAssetGraphData ?? assetGraphData}
             allAssetKeys={allAssetKeys}
             graphQueryItems={graphQueryItems}
             filterBar={filterBar}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -154,7 +154,7 @@ export const AssetGraphExplorer = (props: Props) => {
   return (
     <Loading allowStaleData queryResult={fetchResult}>
       {() => {
-        if (graphDataLoading || filteredAssetsLoading || fullAssetGraphDataLoading) {
+        if (graphDataLoading || filteredAssetsLoading) {
           return <LoadingSpinner purpose="page" />;
         }
         if (!assetGraphData || !allAssetKeys) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -101,9 +101,7 @@ export const GROUPS_ONLY_SCALE = 0.15;
 const DEFAULT_SET_HIDE_NODES_MATCH = (_node: AssetNodeForGraphQueryFragment) => true;
 
 export const AssetGraphExplorer = (props: Props) => {
-  const {fullAssetGraphData, loading: fullAssetGraphDataLoading} = useFullAssetGraphData(
-    props.fetchOptions,
-  );
+  const {fullAssetGraphData} = useFullAssetGraphData(props.fetchOptions);
   const [hideNodesMatching, setHideNodesMatching] = useState(() => DEFAULT_SET_HIDE_NODES_MATCH);
 
   const {


### PR DESCRIPTION
## Summary & Motivation

**Problem:** The full asset graph data (used only for sidebar/context menu lineage dialogs) was causing delays in rendering asset job lineage graphs while waiting for complete data loading.

**Solution:** Pass partial asset graph data to lineage components during initial load while full data loads in the background. This optimizes rendering performance and resolves query errors encountered during initial loading.

## How I Tested These Changes

- Verified query error issue goes away using local testing with app proxy
- Confirmed lineage dialogs remain functional with partial data
- 
<img width="826" alt="Screenshot 2025-02-04 at 12 38 25 PM" src="https://github.com/user-attachments/assets/736c7be5-ef14-41a9-a30d-dd985c5f52c2" />
