### PR TITLE
[dg docs] Improve frustrating tree comparison in CLI output

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,4 +44,4 @@ regenerate_cli_snippets_and_test:
 	cd ../examples/docs_beta_snippets && tox -e docs_snapshot_update && tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!"
 
 test_cli_snippets_simulate_bk:
-	docker run --platform linux/amd64 --rm -it  -v "$(DAGSTER_GIT_REPO_DIR):/dagster" --entrypoint /bin/sh dagster/buildkite-test:py3.9-2025-01-31T181043 -c 'cd /dagster/examples/docs_beta_snippets && tox -e docs_snapshot_test'
+	docker run --platform linux/amd64 --rm -it  -v "$(DAGSTER_GIT_REPO_DIR):/dagster" --entrypoint /bin/sh dagster/buildkite-test:py3.9-2025-01-31T181043 -c 'cd /dagster/examples/docs_beta_snippets && tox -e docs_snapshot_test -- --pdb'

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/5-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/5-tree.txt
@@ -1,18 +1,18 @@
-tree 
+tree
 
 .
 ├── code_locations
 │   └── code-location-1
 │       ├── code_location_1
-│       │   ├── lib
-│       │   │   └── __init__.py
+│       │   ├── __init__.py
 │       │   ├── components
 │       │   ├── definitions.py
-│       │   └── __init__.py
+│       │   └── lib
+│       │       └── __init__.py
 │       ├── code_location_1_tests
 │       │   └── __init__.py
-│       ├── uv.lock
-│       └── pyproject.toml
+│       ├── pyproject.toml
+│       └── uv.lock
 └── pyproject.toml
 
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
@@ -1,12 +1,12 @@
 tree jaffle_platform
 
 jaffle_platform
-├── definitions.py
+├── __init__.py
 ├── components
 │   └── ingest_files
 │       └── component.yaml
-├── lib
-│   └── __init__.py
-└── __init__.py
+├── definitions.py
+└── lib
+    └── __init__.py
 
 4 directories, 4 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
@@ -1,22 +1,22 @@
 cd jaffle-platform && tree
 
 .
-├── uv.lock
-├── pyproject.toml
+├── jaffle_platform
+│   ├── __init__.py
+│   ├── components
+│   ├── definitions.py
+│   └── lib
+│       └── __init__.py
 ├── jaffle_platform.egg-info
-│   ├── SOURCES.txt
 │   ├── PKG-INFO
+│   ├── SOURCES.txt
+│   ├── dependency_links.txt
 │   ├── entry_points.txt
 │   ├── requires.txt
-│   ├── top_level.txt
-│   └── dependency_links.txt
-├── jaffle_platform
-│   ├── definitions.py
-│   ├── lib
-│   │   └── __init__.py
-│   ├── components
+│   └── top_level.txt
+├── jaffle_platform_tests
 │   └── __init__.py
-└── jaffle_platform_tests
-    └── __init__.py
+├── pyproject.toml
+└── uv.lock
 
 6 directories, 12 files

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -16,6 +16,7 @@ from docs_beta_snippets_tests.snippet_checks.guides.components.utils import (
 from docs_beta_snippets_tests.snippet_checks.utils import (
     _run_command,
     check_file,
+    compare_tree_output,
     create_file,
     re_ignore_after,
     re_ignore_before,
@@ -74,12 +75,10 @@ def test_components_docs_index(update_snippets: bool) -> None:
         # Validate scaffolded files
         _run_command(r"find . -type d -name __pycache__ -exec rm -r {} \+")
         run_command_and_snippet_output(
-            cmd="cd jaffle-platform && tree --sort size",
+            cmd="cd jaffle-platform && tree",
             snippet_path=COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-tree.txt",
             update_snippets=update_snippets,
-            # Remove --sort size from tree output, sadly OSX and Linux tree
-            # sort differently when using alpha sort
-            snippet_replace_regex=[(" --sort size", "")],
+            custom_comparison_fn=compare_tree_output,
         )
         check_file(
             "pyproject.toml",
@@ -137,13 +136,11 @@ def test_components_docs_index(update_snippets: bool) -> None:
         # Cleanup __pycache__ directories
         _run_command(r"find . -type d -name __pycache__ -exec rm -r {} \+")
         run_command_and_snippet_output(
-            cmd="tree jaffle_platform --sort size",
+            cmd="tree jaffle_platform",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-tree-jaffle-platform.txt",
             update_snippets=update_snippets,
-            # Remove --sort size from tree output, sadly OSX and Linux tree
-            # sort differently when using alpha sort
-            snippet_replace_regex=[(" --sort size", "")],
+            custom_comparison_fn=compare_tree_output,
         )
         check_file(
             Path("jaffle_platform") / "components" / "ingest_files" / "component.yaml",

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
@@ -8,6 +8,7 @@ from docs_beta_snippets_tests.snippet_checks.guides.components.utils import DAGS
 from docs_beta_snippets_tests.snippet_checks.utils import (
     _run_command,
     check_file,
+    compare_tree_output,
     create_file,
     re_ignore_after,
     re_ignore_before,
@@ -62,6 +63,7 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
             cmd="cd my-deployment && tree",
             snippet_path=COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-tree.txt",
             update_snippets=update_snippets,
+            custom_comparison_fn=compare_tree_output,
         )
         check_file(
             "pyproject.toml",
@@ -89,15 +91,15 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
         _run_command(r"find . -type d -name __pycache__ -exec rm -r {} \+")
         _run_command(r"find . -type d -name code_location_1.egg-info -exec rm -r {} \+")
         run_command_and_snippet_output(
-            cmd="tree --sort size --dirsfirst",
+            cmd="tree",
             snippet_path=COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-tree.txt",
             update_snippets=update_snippets,
             # Remove --sort size from tree output, sadly OSX and Linux tree
             # sort differently when using alpha sort
             snippet_replace_regex=[
-                ("--sort size --dirsfirst", ""),
                 (r"\d+ directories, \d+ files", "..."),
             ],
+            custom_comparison_fn=compare_tree_output,
         )
 
         # Validate code location toml


### PR DESCRIPTION
## Summary

Comparing `tree` output cross platform sucks. Adds custom comparison logic to ignore the ordering.

This also means that `make test_cli_snippets_simulate_bk` works locally, good for local debugging. This cmd now opens pdb too if it fails.
