### PR TITLE
[rfc] Document complex io manager use cases

### DIFF
--- a/docs/docs-beta/docs/guides/build/io-managers/index.md
+++ b/docs/docs-beta/docs/guides/build/io-managers/index.md
@@ -78,6 +78,25 @@ Dagster offers built-in library implementations for I/O managers for popular dat
 | <PyObject section="libraries" module="dagster_duckdb_pyspark" object="DuckDBPySparkIOManager" />               | Stores PySpark DataFrame outputs in DuckDB.                                   |
 | <PyObject section="libraries" module="dagster_duckdb_polars" object="DuckDBPolarsIOManager" />                 | Stores Polars DataFrame outputs in DuckDB.                                    |                                       |
 
+## IO Managers and multi-assets
+
+When your computation produces multiple assets, such as usage of the <PyObject section="dagster" module="dagster" object="multi_asset"/>, you can customize each individual asset's I/O management behavior. 
+<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/external-systems/multi-asset-io-managers.py" language="python" />
+
+# Using IO managers with multi-part or prefixed asset keys
+
+If you want to load an input from an asset key that has multiple parts or is prefixed, you'll need to explicitly map the asset key to an input name.
+
+<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/external-systems/asset-key-remap.py" language="python" />
+
+# Customizing input behavior
+
+You can use a different IO manager to _load_ the input than you used to store it. For example, let's say I have two assets, upstream and downstream. I returned a pandas dataframe from my upstream asset, and used the `SnowflakePandasIOManager` to store it in a Snowflake table, but want to load that table as a spark dataframe in my downstream asset.
+
+I can do this by overriding the `input_manager_key` argument on my downstream asset.
+<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/external-systems/swapping-input-managers.py" language="python" />
+
+
 ## Next steps
 
 - Learn to [connect databases](/guides/build/external-resources/connecting-to-databases) with resources

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/asset-key-remap.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/asset-key-remap.py
@@ -1,0 +1,11 @@
+import dagster as dg
+
+
+# Upstream asset has multiple parts in asset key
+@dg.asset(key=dg.AssetKey(["my_asset", "part1", "part2"]))
+def compute_upstream(): ...
+
+
+# When loading as an input, we map the asset key to a specific input name
+@dg.asset(deps=[compute_upstream], ins={"inpt": dg.AssetIn(key=compute_upstream.key)})
+def compute_downstream(inpt): ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/multi-asset-io-managers.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/multi-asset-io-managers.py
@@ -1,0 +1,51 @@
+from collections.abc import Iterator
+from typing import Union
+
+from dagster_aws.s3 import S3PickleIOManager, S3Resource
+from dagster_snowflake_pandas import SnowflakePandasIOManager
+
+import dagster as dg
+
+
+def clean_customer_data(): ...
+def clean_order_data(): ...
+def clean_product_data(): ...
+def clean_country_data(): ...
+
+
+@dg.multi_asset(
+    specs=[
+        # Use snowflake IO manager for cleaned customer data
+        dg.AssetSpec("cleaned_customer_data").with_io_manager_key("snowflake"),
+        # Use s3 IO manager for cleaned order data
+        dg.AssetSpec("cleaned_order_data").with_io_manager_key("s3"),
+        # Don't store cleaned product data at all
+        dg.AssetSpec("cleaned_product_data"),
+        # Use default IO manager for cleaned country data
+        dg.AssetSpec("cleaned_country_data"),
+    ]
+)
+def clean_data() -> Iterator[Union[dg.Output, dg.AssetMaterialization]]:
+    yield dg.Output(output_name="cleaned_customer_data", value=clean_customer_data())
+    yield dg.Output(output_name="cleaned_order_data", value=clean_order_data())
+    yield dg.Output(output_name="cleaned_country_data", value=clean_country_data())
+    # We're not yielding any output value for cleaned_product_data, so it will not be stored
+    yield dg.AssetMaterialization(
+        asset_key="cleaned_product_data", description="Product data cleaned"
+    )
+
+
+# Define the requisite IO managers
+defs = dg.Definitions(
+    assets=[clean_data],
+    # Define the additional IO managers
+    resources={
+        "snowflake": SnowflakePandasIOManager(
+            database=dg.EnvVar("SNOWFLAKE_DATABASE"),
+            account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
+            user=dg.EnvVar("SNOWFLAKE_USER"),
+            password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+        ),
+        "s3": S3PickleIOManager(s3_resource=S3Resource(), s3_bucket="my-bucket"),
+    },
+)

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/swapping-input-managers.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/external-systems/swapping-input-managers.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from dagster_snowflake_pandas import SnowflakePandasIOManager
+from dagster_snowflake_pyspark import SnowflakePySparkIOManager
+
+# spark dataframe
+from pyspark.sql import DataFrame as SparkDataFrame
+
+import dagster as dg
+
+
+@dg.asset
+def raw_sales_data() -> pd.DataFrame:
+    return pd.read_csv(
+        "https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/assets/raw_sales_data.csv"
+    )
+
+
+@dg.asset(
+    deps=[raw_sales_data],
+    # highlight-start
+    # Use the SnowflakePySparkIOManager when loading the input from the upstream asset.
+    ins={"raw_sales_data": dg.AssetIn(input_manager_key="snowflake_psyark")},
+    # highlight-end
+)
+def clean_sales_data(raw_sales_data: SparkDataFrame) -> SparkDataFrame:
+    return raw_sales_data.fillna({"amount": 0.0})
+
+
+defs = dg.Definitions(
+    assets=[raw_sales_data, clean_sales_data],
+    resources={
+        # highlight-start
+        # Define the SnowflakePySparkIOManager and pass it to `Definitions`
+        "snowflake_psyark": SnowflakePySparkIOManager(
+            database=dg.EnvVar("SNOWFLAKE_DATABASE"),
+            account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
+            user=dg.EnvVar("SNOWFLAKE_USER"),
+            password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+        ),
+        # highlight-end
+        "io_manager": SnowflakePandasIOManager(
+            database=dg.EnvVar("SNOWFLAKE_DATABASE"),
+            account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
+            user=dg.EnvVar("SNOWFLAKE_USER"),
+            password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+        ),
+    },
+)


### PR DESCRIPTION
## Summary & Motivation
There's a bunch of IO manager surface area that's either undocumented or documented implicitly (in the case of input managers).

I wanted to make these use cases very explicit:
- How to map an input to an asset key
- How to use different io managers for different assets within the same multi asset
- Opting into io managers for some assets and not others

## How I Tested These Changes
Eyes?

## Changelog
- [docs] added documentation for complex IO manager use cases:
  - How to map an input to an asset key
  - How to use different io managers for different assets within the same multi asset
  - Opting into io managers for some assets and not others

