### PR TITLE
update great_expectations pin

### DIFF
--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -34,7 +34,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pandas{pin}",
         "pandas",
-        "great_expectations >=0.17.15",
+        "great_expectations>=0.17.15,<1.0.0",  # need to migrate from DataContext
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
we were previosuly resolving to sub 1.0.0 in tests so we didn't catch this but our integration is built around `DataContext` which was removed in `1.0.0` so set the pin correctly

## How I Tested These Changes

bk