### PR TITLE
[dagster-dbt] Drop --numprocesses in dagster-dbt tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -32,8 +32,8 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --numprocesses 6 --durations 10  --reruns 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core-main: pytest --numprocesses 6 --durations 10  --reruns 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --numprocesses 6 --durations 10 --reruns 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  cloud: pytest --durations 10  --reruns 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core-main: pytest --durations 10  --reruns 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --durations 10 --reruns 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
## Summary & Motivation

dbt tests are incredibly flaky lately.

We get one error and one warning in each failed test:

`Fatal Python error: PyEval_SaveThread: the function must be called with the GIL held, but the GIL is released (the current Python thread state is NULL)`

and

`/usr/local/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdo`wn

Posts found online suggest that this is related to the number of thread/memory. 

We are unable to repro locally - dropping `--numprocesses 6` to see if it helps.

See this thread https://dagsterlabs.slack.com/archives/C03A0D72A6T/p1738592567816529

## How I Tested These Changes

BK
