### PR TITLE
[run storage] remove snapshot_id override

### DIFF
--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -77,12 +77,10 @@ def import_command(input_files: tuple[str, ...]):
             if not instance.has_snapshot(run.execution_plan_snapshot_id):  # type: ignore  # (possible none)
                 instance.add_snapshot(
                     debug_payload.execution_plan_snapshot,
-                    run.execution_plan_snapshot_id,
                 )
             if not instance.has_snapshot(run.job_snapshot_id):  # type: ignore  # (possible none)
                 instance.add_snapshot(
                     debug_payload.job_snapshot,
-                    run.job_snapshot_id,
                 )
 
             if not instance.has_run(run.run_id):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1315,9 +1315,7 @@ class DagsterInstance(DynamicPartitionsStore):
                 )
 
             if not self._run_storage.has_job_snapshot(parent_snapshot_id):
-                self._run_storage.add_job_snapshot(
-                    check.not_none(parent_job_snapshot), parent_snapshot_id
-                )
+                self._run_storage.add_job_snapshot(check.not_none(parent_job_snapshot))
 
         job_snapshot_id = job_snapshot.snapshot_id
         if not self._run_storage.has_job_snapshot(job_snapshot_id):
@@ -1804,9 +1802,8 @@ class DagsterInstance(DynamicPartitionsStore):
     def add_snapshot(
         self,
         snapshot: Union["JobSnap", "ExecutionPlanSnapshot"],
-        snapshot_id: Optional[str] = None,
     ) -> None:
-        return self._run_storage.add_snapshot(snapshot, snapshot_id)
+        return self._run_storage.add_snapshot(snapshot)
 
     @traced
     def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -257,9 +257,8 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def add_snapshot(
         self,
         snapshot: Union["JobSnap", "ExecutionPlanSnapshot"],
-        snapshot_id: Optional[str] = None,
     ) -> None:
-        return self._storage.run_storage.add_snapshot(snapshot, snapshot_id)
+        return self._storage.run_storage.add_snapshot(snapshot)
 
     def has_snapshot(self, snapshot_id: str) -> bool:
         return self._storage.run_storage.has_snapshot(snapshot_id)
@@ -267,8 +266,8 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def has_job_snapshot(self, job_snapshot_id: str) -> bool:
         return self._storage.run_storage.has_job_snapshot(job_snapshot_id)
 
-    def add_job_snapshot(self, job_snapshot: "JobSnap", snapshot_id: Optional[str] = None) -> str:
-        return self._storage.run_storage.add_job_snapshot(job_snapshot, snapshot_id)
+    def add_job_snapshot(self, job_snapshot: "JobSnap") -> str:
+        return self._storage.run_storage.add_job_snapshot(job_snapshot)
 
     def get_job_snapshot(self, job_snapshot_id: str) -> "JobSnap":
         return self._storage.run_storage.get_job_snapshot(job_snapshot_id)
@@ -276,12 +275,8 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def has_execution_plan_snapshot(self, execution_plan_snapshot_id: str) -> bool:
         return self._storage.run_storage.has_execution_plan_snapshot(execution_plan_snapshot_id)
 
-    def add_execution_plan_snapshot(
-        self, execution_plan_snapshot: "ExecutionPlanSnapshot", snapshot_id: Optional[str] = None
-    ) -> str:
-        return self._storage.run_storage.add_execution_plan_snapshot(
-            execution_plan_snapshot, snapshot_id
-        )
+    def add_execution_plan_snapshot(self, execution_plan_snapshot: "ExecutionPlanSnapshot") -> str:
+        return self._storage.run_storage.add_execution_plan_snapshot(execution_plan_snapshot)
 
     def get_execution_plan_snapshot(
         self, execution_plan_snapshot_id: str

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -203,24 +203,16 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
             bool
         """
 
-    def add_snapshot(
-        self,
-        snapshot: Union[JobSnap, ExecutionPlanSnapshot],
-        snapshot_id: Optional[str] = None,
-    ) -> None:
+    def add_snapshot(self, snapshot: Union[JobSnap, ExecutionPlanSnapshot]) -> None:
         """Add a snapshot to the storage.
 
         Args:
             snapshot (Union[PipelineSnapshot, ExecutionPlanSnapshot])
-            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
-                snapshot id will be generated from a hash of the snapshot. This should only be used
-                in debugging, where we might want to import a historical run whose snapshots were
-                calculated using a different hash function than the current code.
         """
         if isinstance(snapshot, JobSnap):
-            self.add_job_snapshot(snapshot, snapshot_id)
+            self.add_job_snapshot(snapshot)
         else:
-            self.add_execution_plan_snapshot(snapshot, snapshot_id)
+            self.add_execution_plan_snapshot(snapshot)
 
     def has_snapshot(self, snapshot_id: str):
         return self.has_job_snapshot(snapshot_id) or self.has_execution_plan_snapshot(snapshot_id)
@@ -237,7 +229,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def add_job_snapshot(self, job_snapshot: JobSnap, snapshot_id: Optional[str] = None) -> str:
+    def add_job_snapshot(self, job_snapshot: JobSnap) -> str:
         """Add a pipeline snapshot to the run store.
 
         Pipeline snapshots are content-addressable, meaning
@@ -247,10 +239,6 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
 
         Args:
             job_snapshot (PipelineSnapshot)
-            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
-                snapshot id will be generated from a hash of the snapshot. This should only be used
-                in debugging, where we might want to import a historical run whose snapshots were
-                calculated using a different hash function than the current code.
 
         Return:
             str: The job_snapshot_id
@@ -279,9 +267,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def add_execution_plan_snapshot(
-        self, execution_plan_snapshot: ExecutionPlanSnapshot, snapshot_id: Optional[str] = None
-    ) -> str:
+    def add_execution_plan_snapshot(self, execution_plan_snapshot: ExecutionPlanSnapshot) -> str:
         """Add an execution plan snapshot to the run store.
 
         Execution plan snapshots are content-addressable, meaning
@@ -291,10 +277,6 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
 
         Args:
             execution_plan_snapshot (ExecutionPlanSnapshot)
-            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
-                snapshot id will be generated from a hash of the snapshot. This should only be used
-                in debugging, where we might want to import a historical run whose snapshots were
-                calculated using a different hash function than the current code.
 
         Return:
             str: The execution_plan_snapshot_id

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -41,11 +41,18 @@ class InMemoryRunStorage(SqlRunStorage):
 
         if preload:
             for payload in preload:
-                self.add_job_snapshot(payload.job_snapshot, payload.dagster_run.job_snapshot_id)
-                self.add_execution_plan_snapshot(
-                    payload.execution_plan_snapshot, payload.dagster_run.execution_plan_snapshot_id
-                )
-                self.add_run(payload.dagster_run)
+                run = payload.dagster_run
+                job_snap_id = self.add_job_snapshot(payload.job_snapshot)
+                plan_snap_id = self.add_execution_plan_snapshot(payload.execution_plan_snapshot)
+
+                # if the snapshot id has shifted due to changes in json structure
+                # update the runs pointers
+                if job_snap_id != run.job_snapshot_id:
+                    run = run._replace(job_snapshot_id=job_snap_id)
+                if plan_snap_id != run.execution_plan_snapshot_id:
+                    run = run._replace(execution_plan_snapshot_id=plan_snap_id)
+
+                self.add_run(run)
 
     def has_secondary_index(self, name: str) -> bool:
         return True

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -557,12 +557,10 @@ class SqlRunStorage(RunStorage):
         check.str_param(job_snapshot_id, "job_snapshot_id")
         return self._has_snapshot_id(job_snapshot_id)
 
-    def add_job_snapshot(self, job_snapshot: JobSnap, snapshot_id: Optional[str] = None) -> str:
+    def add_job_snapshot(self, job_snapshot: JobSnap) -> str:
         check.inst_param(job_snapshot, "job_snapshot", JobSnap)
-        check.opt_str_param(snapshot_id, "snapshot_id")
 
-        if not snapshot_id:
-            snapshot_id = job_snapshot.snapshot_id
+        snapshot_id = job_snapshot.snapshot_id
 
         return self._add_snapshot(
             snapshot_id=snapshot_id,
@@ -579,13 +577,12 @@ class SqlRunStorage(RunStorage):
         return bool(self.get_execution_plan_snapshot(execution_plan_snapshot_id))
 
     def add_execution_plan_snapshot(
-        self, execution_plan_snapshot: ExecutionPlanSnapshot, snapshot_id: Optional[str] = None
+        self,
+        execution_plan_snapshot: ExecutionPlanSnapshot,
     ) -> str:
         check.inst_param(execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot)
-        check.opt_str_param(snapshot_id, "snapshot_id")
 
-        if not snapshot_id:
-            snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
+        snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
 
         return self._add_snapshot(
             snapshot_id=snapshot_id,


### PR DESCRIPTION
This was added in https://github.com/dagster-io/dagster/pull/5728

The value of this capability isn't as high as it was then, and the complexity of having snapshot mismatch is greater so lets remove it.

## How I Tested These Changes

bk
