### PR TITLE
Add basic utility/class for WebWorkers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/jest/mocks/ComputeGraphData.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/jest/mocks/ComputeGraphData.worker.ts
@@ -1,5 +1,3 @@
-import {setFeatureFlagsInternal} from '../../src/app/Flags';
-import {assertUnreachable} from '../../src/app/Util';
 import {computeGraphData} from '../../src/asset-graph/ComputeGraphData';
 import {ComputeGraphDataWorkerMessageType} from '../../src/asset-graph/ComputeGraphData.types';
 import {buildGraphData} from '../../src/asset-graph/Utils';
@@ -22,17 +20,12 @@ export default class MockWorker {
   // mock expects data: { } instead of e: { data: { } }
   async postMessage(data: ComputeGraphDataWorkerMessageType) {
     if (data.type === 'computeGraphData') {
-      if (data.flagSelectionSyntax) {
-        setFeatureFlagsInternal({flagSelectionSyntax: true});
-      }
       const state = await computeGraphData(data);
       this.onmessage.forEach((onmessage) => onmessage({data: {...state, id: data.id}}));
     } else if (data.type === 'buildGraphData') {
       this.onmessage.forEach((onmessage) =>
         onmessage({data: {...buildGraphData(data.nodes), id: data.id}}),
       );
-    } else {
-      assertUnreachable(data);
     }
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -6,6 +6,8 @@ import {getJSONForKey} from '../hooks/useStateWithStorage';
 
 export const DAGSTER_FLAGS_KEY = 'DAGSTER_FLAGS';
 
+export const WEB_WORKER_FEATURE_FLAGS_KEY = '__featureFlags';
+
 /**
  * Type representing the mapping of feature flags to their boolean states.
  */
@@ -61,6 +63,10 @@ export const getFeatureFlagsWithoutDefaultValues = (): FeatureFlagMap => {
 
 export const getFeatureFlagDefaults = (): FeatureFlagMap => {
   return DEFAULT_FEATURE_FLAG_VALUES;
+};
+
+export const getFeatureFlagsWithDefaults = (): FeatureFlagMap => {
+  return {...DEFAULT_FEATURE_FLAG_VALUES, ...currentFeatureFlags};
 };
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.types.ts
@@ -4,7 +4,6 @@ import {AssetGraphFetchScope, AssetGraphQueryItem} from './useAssetGraphData';
 
 type BaseType = {
   id: number;
-  flagSelectionSyntax?: boolean;
 };
 
 export type ComputeGraphDataMessageType = BaseType & {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
@@ -8,7 +8,6 @@ type WorkerMessageData = ComputeGraphDataMessageType | BuildGraphDataMessageType
 
 createWorkerThread(
   async (postMessage: (message: any) => void, data: WorkerMessageData) => {
-    console.log({data});
     if (data.type === 'computeGraphData') {
       const state = await computeGraphData(data);
       postMessage({...state, id: data.id});

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
@@ -3,6 +3,7 @@ import {createWorkerThread} from 'shared/workers/WorkerThread.oss';
 import {computeGraphData} from './ComputeGraphData';
 import {BuildGraphDataMessageType, ComputeGraphDataMessageType} from './ComputeGraphData.types';
 import {buildGraphData} from './Utils';
+import {assertUnreachable} from '../app/Util';
 
 type WorkerMessageData = ComputeGraphDataMessageType | BuildGraphDataMessageType;
 
@@ -13,6 +14,8 @@ createWorkerThread(
       postMessage({...state, id: data.id});
     } else if (data.type === 'buildGraphData') {
       postMessage({...buildGraphData(data.nodes), id: data.id});
+    } else {
+      assertUnreachable(data);
     }
   },
   (_postMessage: (message: any) => void, error: Error) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.worker.ts
@@ -1,32 +1,22 @@
-import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
+import {createWorkerThread} from 'shared/workers/WorkerThread.oss';
 
 import {computeGraphData} from './ComputeGraphData';
 import {BuildGraphDataMessageType, ComputeGraphDataMessageType} from './ComputeGraphData.types';
 import {buildGraphData} from './Utils';
-import {setFeatureFlags} from '../app/Flags';
-import {assertUnreachable} from '../app/Util';
 
 type WorkerMessageData = ComputeGraphDataMessageType | BuildGraphDataMessageType;
 
-self.addEventListener('message', async (event: MessageEvent & {data: WorkerMessageData}) => {
-  const data: WorkerMessageData = event.data;
-
-  if (data.flagSelectionSyntax) {
-    setFeatureFlags({[FeatureFlag.flagSelectionSyntax]: true});
-  }
-
-  if (data.type === 'computeGraphData') {
-    const state = await computeGraphData(data);
-    self.postMessage({...state, id: data.id});
-  } else if (data.type === 'buildGraphData') {
-    self.postMessage({...buildGraphData(data.nodes), id: data.id});
-  } else {
-    assertUnreachable(data);
-  }
-});
-
-self.onmessage = function (event) {
-  if (event.data === 'close') {
-    self.close(); // Terminates the worker
-  }
-};
+createWorkerThread(
+  async (postMessage: (message: any) => void, data: WorkerMessageData) => {
+    console.log({data});
+    if (data.type === 'computeGraphData') {
+      const state = await computeGraphData(data);
+      postMessage({...state, id: data.id});
+    } else if (data.type === 'buildGraphData') {
+      postMessage({...buildGraphData(data.nodes), id: data.id});
+    }
+  },
+  (_postMessage: (message: any) => void, error: Error) => {
+    console.error(error);
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -351,8 +351,13 @@ const computeGraphData = throttleLatest(
 );
 
 const getWorker = memoize(
-  (_key: string = '') => new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
+  (_key: 'computeGraphWorker' | 'buildGraphWorker') =>
+    new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
 );
+
+// Pre-warm workers
+getWorker('computeGraphWorker');
+getWorker('buildGraphWorker');
 
 let _id = 0;
 async function computeGraphDataWrapper(

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -355,9 +355,11 @@ const getWorker = memoize(
     new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
 );
 
-// Pre-warm workers
-getWorker('computeGraphWorker');
-getWorker('buildGraphWorker');
+if (typeof jest === 'undefined') {
+  // Pre-warm workers
+  getWorker('computeGraphWorker');
+  getWorker('buildGraphWorker');
+}
 
 let _id = 0;
 async function computeGraphDataWrapper(

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -1,5 +1,6 @@
 import memoize from 'lodash/memoize';
 import {useEffect, useLayoutEffect, useMemo, useReducer, useRef} from 'react';
+import {Worker} from 'shared/workers/Worker.oss';
 
 import {ILayoutOp, LayoutOpGraphOptions, OpGraphLayout, layoutOpGraph} from './layout';
 import {useFeatureFlags} from '../app/Flags';
@@ -27,7 +28,7 @@ export const getFullOpLayout = memoize(layoutOpGraph, _opLayoutCacheKey);
 const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraphOptions) => {
   return new Promise<OpGraphLayout>((resolve) => {
     const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-    worker.addEventListener('message', (event) => {
+    worker.onMessage((event) => {
       resolve(event.data);
       worker.terminate();
     });
@@ -77,7 +78,7 @@ export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-      worker.addEventListener('message', (event) => {
+      worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
       });
@@ -91,7 +92,7 @@ const asyncGetFullAssetLayout = asyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
       const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-      worker.addEventListener('message', (event) => {
+      worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/createSearchWorker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/createSearchWorker.tsx
@@ -1,5 +1,6 @@
 import Fuse from 'fuse.js';
 import memoize from 'lodash/memoize';
+import {Worker} from 'shared/workers/Worker.oss';
 
 import {ResultResponse, SearchResult} from './types';
 
@@ -33,7 +34,7 @@ export const createSearchWorker = (
   const searchWorker = spawnSearchWorker(key);
   const listeners: Set<QueryListener> = new Set();
 
-  searchWorker.addEventListener('message', (event) => {
+  searchWorker.onMessage((event) => {
     const {data} = event;
     if (data.type === 'results') {
       const {queryString, results} = data as ResultResponse;

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/Worker.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/Worker.oss.ts
@@ -27,7 +27,7 @@ export class Worker {
     });
   }
 
-  onError(handler: (error: ErrorEvent) => void) {
+  public onError(handler: (error: ErrorEvent) => void) {
     this.errorHandlers.push(handler);
     this.worker.addEventListener('error', handler);
     return () => {
@@ -36,16 +36,16 @@ export class Worker {
     };
   }
 
-  onMessage(handler: (event: MessageEvent) => void) {
+  public onMessage(handler: (event: MessageEvent) => void) {
     this.worker.addEventListener('message', handler);
     return () => this.worker.removeEventListener('message', handler);
   }
 
-  postMessage(message: any) {
+  public postMessage(message: any) {
     this.worker.postMessage(message);
   }
 
-  terminate() {
+  public terminate() {
     this.worker.terminate();
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/Worker.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/Worker.oss.ts
@@ -1,0 +1,51 @@
+import {WEB_WORKER_FEATURE_FLAGS_KEY, getFeatureFlagsWithDefaults} from '../app/Flags';
+
+/**
+ * Wrapper for worker on the main thread.
+ */
+export class Worker {
+  private worker: globalThis.Worker;
+
+  private errorHandlers = Array<(error: ErrorEvent) => void>();
+
+  constructor(url: string | URL, options?: WorkerOptions) {
+    this.worker = new globalThis.Worker(url, options);
+    this.onMessage((event) => {
+      if (event.data.type === 'error') {
+        const error = new Error(event.data.error);
+        error.stack = event.data.stack;
+        if (this.errorHandlers.length > 0) {
+          const errorEvent = new ErrorEvent('error', {error});
+          this.errorHandlers.forEach((handler) => handler(errorEvent));
+        } else {
+          throw error;
+        }
+      }
+    });
+    this.worker.postMessage({
+      [WEB_WORKER_FEATURE_FLAGS_KEY]: getFeatureFlagsWithDefaults(),
+    });
+  }
+
+  onError(handler: (error: ErrorEvent) => void) {
+    this.errorHandlers.push(handler);
+    this.worker.addEventListener('error', handler);
+    return () => {
+      this.errorHandlers = this.errorHandlers.filter((h) => h !== handler);
+      this.worker.removeEventListener('error', handler);
+    };
+  }
+
+  onMessage(handler: (event: MessageEvent) => void) {
+    this.worker.addEventListener('message', handler);
+    return () => this.worker.removeEventListener('message', handler);
+  }
+
+  postMessage(message: any) {
+    this.worker.postMessage(message);
+  }
+
+  terminate() {
+    this.worker.terminate();
+  }
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/WorkerThread.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/WorkerThread.oss.ts
@@ -1,0 +1,23 @@
+import {WEB_WORKER_FEATURE_FLAGS_KEY, setFeatureFlags} from '../app/Flags';
+
+export const createWorkerThread = (
+  onMessage: (postMessage: (message: any) => void, data: any) => Promise<void>,
+  onError: (postMessage: (message: any) => void, error: Error) => void,
+) => {
+  self.addEventListener('message', async (event) => {
+    try {
+      if (event.data[WEB_WORKER_FEATURE_FLAGS_KEY]) {
+        setFeatureFlags(event.data[WEB_WORKER_FEATURE_FLAGS_KEY]);
+      } else {
+        await onMessage(self.postMessage, event.data);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        self.postMessage({type: 'error', error: error.message, stack: error.stack});
+      } else {
+        self.postMessage({type: 'error', error: String(error), stack: undefined});
+      }
+      onError(self.postMessage, error as Error);
+    }
+  });
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/dagre_layout.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/dagre_layout.worker.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-restricted-globals */
 
+import {createWorkerThread} from 'shared/workers/WorkerThread.oss';
+
 import {layoutAssetGraph} from '../asset-graph/layout';
 import {layoutOpGraph} from '../graph/layout';
-
 /**
  * NOTE: Please avoid adding React as a transitive dependency to this file, as it can break
  * the development workflow. https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/24
@@ -12,18 +13,21 @@ import {layoutOpGraph} from '../graph/layout';
  * try to remove it.
  */
 
-self.addEventListener('message', (event) => {
-  const {data} = event;
-
-  switch (data.type) {
-    case 'layoutOpGraph': {
-      const {ops, opts} = data;
-      self.postMessage(layoutOpGraph(ops, opts));
-      break;
+createWorkerThread(
+  async (postMessage: (message: any) => void, data: any) => {
+    switch (data.type) {
+      case 'layoutOpGraph': {
+        const {ops, opts} = data;
+        postMessage(layoutOpGraph(ops, opts));
+        break;
+      }
+      case 'layoutAssetGraph': {
+        const {graphData, opts} = data;
+        postMessage(layoutAssetGraph(graphData, opts));
+      }
     }
-    case 'layoutAssetGraph': {
-      const {graphData, opts} = data;
-      self.postMessage(layoutAssetGraph(graphData, opts));
-    }
-  }
-});
+  },
+  (_postMessage: (message: any) => void, error: Error) => {
+    console.error(error);
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/fuseSearch.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/fuseSearch.worker.ts
@@ -2,34 +2,40 @@
  * A Web Worker that creates and queries a Fuse object.
  */
 
+import {createWorkerThread} from 'shared/workers/WorkerThread.oss';
+
 import {Fuse} from '../search/fuse';
 
 let fuseObject: null | Fuse<any> = null;
 let allResults: any = null;
 
-self.addEventListener('message', (event) => {
-  const {data} = event;
-
-  switch (data.type) {
-    case 'set-results': {
-      if (!fuseObject) {
-        fuseObject = new Fuse(data.results, data.fuseOptions);
-      } else {
-        fuseObject.setCollection(data.results);
+createWorkerThread(
+  async (postMessage: (message: any) => void, data: any) => {
+    switch (data.type) {
+      case 'set-results': {
+        if (!fuseObject) {
+          fuseObject = new Fuse(data.results, data.fuseOptions);
+        } else {
+          fuseObject.setCollection(data.results);
+        }
+        allResults = data.results.map(fakeFuseItem);
+        postMessage({type: 'ready'});
+        break;
       }
-      allResults = data.results.map(fakeFuseItem);
-      self.postMessage({type: 'ready'});
-      break;
-    }
-    case 'query': {
-      if (fuseObject) {
-        const {queryString} = data;
-        const results = queryString ? fuseObject.search(queryString) : allResults;
-        self.postMessage({type: 'results', queryString, results});
+      case 'query': {
+        if (fuseObject) {
+          const {queryString} = data;
+          const results = queryString ? fuseObject.search(queryString) : allResults;
+          postMessage({type: 'results', queryString, results});
+        }
+        break;
       }
     }
-  }
-});
+  },
+  (_postMessage: (message: any) => void, error: Error) => {
+    console.error(error);
+  },
+);
 
 function fakeFuseItem<T>(item: T, refIndex: number = 0): Fuse.FuseResult<T> {
   return {


### PR DESCRIPTION
## Summary & Motivation

1. Added a `createWorkerThread` utility to be used inside of web-worker threads. This utility handles setting up feature flags and forwarding errors back to the main thread. In cloud it will also receive cloud specific flags.
2. Added a `Worker` class to be used in place of the global Worker class.  This class forwards feature flags and receives errors. It's a shared component so that cloud can inject custom behavior.


In a follow-up PR I will figure out mocking with these utilities and add lint rules to make us go through our custom Worker abstraction once we feel its ready for prime time. 

## How I Tested These Changes

I stopped forwarding the `flagSelectionSyntax` flag manually for `ComputeGraphData.worker` and saw that it was correctly handling the selection syntax when the flag was on and not when it was off.