### PR TITLE
[docs] Fixed the markdown link towards assets metadata from assets

### DIFF
--- a/docs/docs-beta/versioned_docs/version-1.9.10/guides/build/assets/defining-assets.md
+++ b/docs/docs-beta/versioned_docs/version-1.9.10/guides/build/assets/defining-assets.md
@@ -106,6 +106,6 @@ When an asset with a code version is materialized, the generated `AssetMateriali
 
 ## Next steps
 
-- Enrich Dagster's built-in data catalog with [asset metadata]/guides/build/assets/metadata-and-tags/)
+- Enrich Dagster's built-in data catalog with [asset metadata](/guides/build/assets/metadata-and-tags/)
 - Learn to [pass data between assets](/guides/build/assets/passing-data-between-assets)
 - Learn to use a [factory pattern](/guides/build/assets/creating-asset-factories) to create multiple, similar assets


### PR DESCRIPTION
## Summary & Motivation

The link wasn't clickable and i wanted to click it. 

## How I Tested These Changes
Used the Github rich markdown preview to test that it works as expected. 

## Changelog

> Insert changelog entry or delete this section.
