### PR TITLE
[dagster-dbt][dagster-sling] Remove freshness_policy methods

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -741,7 +741,6 @@ def get_asset_spec(
         group_name=translator.get_group_name(resource_props),
         code_version=translator.get_code_version(resource_props),
         automation_condition=translator.get_automation_condition(resource_props),
-        freshness_policy=translator.get_freshness_policy(resource_props),
         owners=translator.get_owners(
             {
                 **resource_props,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -6,7 +6,6 @@ from dagster import (
     AssetKey,
     AutoMaterializePolicy,
     AutomationCondition,
-    FreshnessPolicy,
     PartitionMapping,
     _check as check,
 )
@@ -19,7 +18,6 @@ from dagster_dbt.asset_utils import (
     default_auto_materialize_policy_fn,
     default_code_version_fn,
     default_description_fn,
-    default_freshness_policy_fn,
     default_group_from_dbt_resource_props,
     default_metadata_from_dbt_resource_props,
     default_owners_from_dbt_resource_props,
@@ -354,60 +352,6 @@ class DagsterDbtTranslator:
                         return ["user@owner.com", "team:team@owner.com"]
         """
         return default_owners_from_dbt_resource_props(dbt_resource_props)
-
-    @public
-    @experimental(emit_runtime_warning=False)
-    def get_freshness_policy(
-        self, dbt_resource_props: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
-        """A function that takes a dictionary representing properties of a dbt resource, and
-        returns the Dagster :py:class:`dagster.FreshnessPolicy` for that resource.
-
-        Note that a dbt resource is unrelated to Dagster's resource concept, and simply represents
-        a model, seed, snapshot or source in a given dbt project. You can learn more about dbt
-        resources and the properties available in this dictionary here:
-        https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details
-
-        This method can be overridden to provide a custom freshness policy for a dbt resource.
-
-        Args:
-            dbt_resource_props (Mapping[str, Any]): A dictionary representing the dbt resource.
-
-        Returns:
-            Optional[FreshnessPolicy]: A Dagster freshness policy.
-
-        Examples:
-            Set a custom freshness policy for all dbt resources:
-
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DagsterDbtTranslator
-
-
-                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-                    def get_freshness_policy(self, dbt_resource_props: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-                        return FreshnessPolicy(maximum_lag_minutes=60)
-
-            Set a custom freshness policy for dbt resources with a specific tag:
-
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DagsterDbtTranslator
-
-
-                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-                    def get_freshness_policy(self, dbt_resource_props: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-                        freshness_policy = None
-                        if "my_custom_tag" in dbt_resource_props.get("tags", []):
-                            freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
-
-                        return freshness_policy
-        """
-        return default_freshness_policy_fn(dbt_resource_props)
 
     @public
     @experimental(emit_runtime_warning=False)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -16,7 +16,6 @@ from dagster import (
     Definitions,
     DependencyDefinition,
     DimensionPartitionMapping,
-    FreshnessPolicy,
     Jitter,
     LastPartitionMapping,
     MultiPartitionMapping,
@@ -332,16 +331,10 @@ def test_backfill_policy(
     backfill_policy: BackfillPolicy,
     expected_backfill_policy: BackfillPolicy,
 ) -> None:
-    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-            # Disable freshness policies when using static partitions
-            return None
-
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         partitions_def=partitions_def,
         backfill_policy=backfill_policy,
-        dagster_dbt_translator=CustomDagsterDbtTranslator(),
     )
     def my_dbt_assets(): ...
 
@@ -719,31 +712,6 @@ def test_all_assets_have_a_distinct_code_version(test_jaffle_shop_manifest: dict
     assert len(code_versions) == len(set(code_versions))
 
 
-def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
-
-    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-            return expected_freshness_policy
-
-    expected_specs_by_key = {
-        spec.key: spec
-        for spec in build_dbt_asset_specs(
-            manifest=test_jaffle_shop_manifest,
-            dagster_dbt_translator=CustomDagsterDbtTranslator(),
-        )
-    }
-
-    @dbt_assets(
-        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
-    )
-    def my_dbt_assets(): ...
-
-    for asset_key, freshness_policy in my_dbt_assets.freshness_policies_by_key.items():
-        assert freshness_policy == expected_freshness_policy
-        assert expected_specs_by_key[asset_key].freshness_policy == expected_freshness_policy
-
-
 def test_with_auto_materialize_policy_replacements(
     test_jaffle_shop_manifest: dict[str, Any],
 ) -> None:
@@ -853,23 +821,6 @@ def test_dbt_meta_auto_materialize_policy(test_meta_config_manifest: dict[str, A
             expected_specs_by_key[asset_key].auto_materialize_policy
             == expected_auto_materialize_policy
         )
-
-
-def test_dbt_meta_freshness_policy(test_meta_config_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60.0, cron_schedule="* * * * *")
-    expected_specs_by_key = {
-        spec.key: spec for spec in build_dbt_asset_specs(manifest=test_meta_config_manifest)
-    }
-
-    @dbt_assets(manifest=test_meta_config_manifest)
-    def my_dbt_assets(): ...
-
-    freshness_policies = my_dbt_assets.freshness_policies_by_key.items()
-    assert freshness_policies
-
-    for asset_key, freshness_policy in freshness_policies:
-        assert freshness_policy == expected_freshness_policy
-        assert expected_specs_by_key[asset_key].freshness_policy == expected_freshness_policy
 
 
 def test_dbt_meta_asset_key(test_meta_config_manifest: dict[str, Any]) -> None:

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
-from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, FreshnessPolicy, MetadataValue
+from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, MetadataValue
 from dagster._annotations import public, superseded
 from dagster._utils.warnings import supersession_warning
 
@@ -41,9 +41,6 @@ class DagsterSlingTranslator:
             ),
             group_name=self._resolve_back_compat_method(
                 "get_group_name", self._default_group_name_fn, stream_definition
-            ),
-            freshness_policy=self._resolve_back_compat_method(
-                "get_freshness_policy", self._default_freshness_policy_fn, stream_definition
             ),
             auto_materialize_policy=self._resolve_back_compat_method(
                 "get_auto_materialize_policy",
@@ -464,58 +461,6 @@ class DagsterSlingTranslator:
         config = stream_definition.get("config", {}) or {}
         meta = config.get("meta", {})
         return meta.get("dagster", {}).get("group")
-
-    @superseded(
-        additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).freshness_policy` instead.",
-    )
-    @public
-    def get_freshness_policy(
-        self, stream_definition: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
-        """Retrieves the freshness policy for a given stream definition.
-
-        This method checks the provided stream definition for a specific configuration
-        indicating a freshness policy. If the configuration is found, it constructs and
-        returns a FreshnessPolicy object based on the provided parameters. Otherwise,
-        it returns None.
-
-        Parameters:
-            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
-            which includes configuration details.
-
-        Returns:
-            Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
-            otherwise None.
-        """
-        return self._default_freshness_policy_fn(stream_definition)
-
-    def _default_freshness_policy_fn(
-        self, stream_definition: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
-        """Retrieves the freshness policy for a given stream definition.
-
-        This method checks the provided stream definition for a specific configuration
-        indicating a freshness policy. If the configuration is found, it constructs and
-        returns a FreshnessPolicy object based on the provided parameters. Otherwise,
-        it returns None.
-
-        Parameters:
-            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
-            which includes configuration details.
-
-        Returns:
-            Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
-            otherwise None.
-        """
-        config = stream_definition.get("config", {}) or {}
-        meta = config.get("meta", {})
-        freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
-        if freshness_policy_config:
-            return FreshnessPolicy(
-                maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
-                cron_schedule=freshness_policy_config.get("cron_schedule"),
-                cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
-            )
 
     @superseded(
         additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).auto_materialize_policy` instead.",

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -276,9 +276,6 @@ def test_base_with_custom_tags_translator_legacy() -> None:
         def get_group_name(self, stream_definition):
             return super().get_group_name(stream_definition)
 
-        def get_freshness_policy(self, stream_definition):
-            return super().get_freshness_policy(stream_definition)
-
         def get_auto_materialize_policy(self, stream_definition):
             return super().get_auto_materialize_policy(stream_definition)
 


### PR DESCRIPTION
## Summary & Motivation

FreshnessPolicy has been marked as deprecated since 1.7.0.

It no longer makes sense to support methods which allow FreshnessPolicy to be set.

## How I Tested These Changes

## Changelog

Removed support for `get_freshness_policy` on the `DagsterDbtTranslator` and `DagsterSlingTranslator` classes, as well as setting a freshness policy via `build_dbt_cloud_assets`
