### PR TITLE
Embed old code in /integrations/libraries/shell.md to fix build

### DIFF
--- a/docs/docs-beta/versioned_docs/version-1.9.10/integrations/libraries/shell.md
+++ b/docs/docs-beta/versioned_docs/version-1.9.10/integrations/libraries/shell.md
@@ -28,7 +28,30 @@ pip install dagster
 
 ### Example
 
-<CodeExample path="docs_beta_snippets/docs_beta_snippets/integrations/shell.py" language="python" />
+```python
+
+import shutil
+
+import dagster as dg
+
+
+@dg.asset
+def shell_asset(
+    context: dg.AssetExecutionContext, pipes_subprocess_client: dg.PipesSubprocessClient
+):
+    shell_script_path = "/path/to/your/script.sh"
+    return pipes_subprocess_client.run(
+        command=["bash", shell_script_path],
+        context=context,
+    ).get_results()
+
+
+defs = dg.Definitions(
+    assets=[shell_asset],
+    resources={"pipes_subprocess_client": dg.PipesSubprocessClient()},
+)
+
+```
 
 ### About shell
 


### PR DESCRIPTION
## Summary & Motivation

Versioned /integrations/libraries/shell.md doc points to example code that no longer exists. This PR embeds that old example code in the doc to fix the failing build.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
