### PR TITLE
[ui] Bump specificity of markdown syntax highlighting CSS

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -64,58 +64,60 @@ const sanitizeConfig = {
 };
 
 const GlobalStyle = createGlobalStyle`
-  .hljs-doctag,
-  .hljs-keyword,
-  .hljs-meta .hljs-keyword,
-  .hljs-template-tag,
-  .hljs-template-variable,
-  .hljs-type,
-  .hljs-variable.language_ {
-    color: ${Colors.textBlue()}
-  }
+  .dagster-markdown {
+    .hljs-doctag,
+    .hljs-keyword,
+    .hljs-meta .hljs-keyword,
+    .hljs-template-tag,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable.language_ {
+      color: ${Colors.textBlue()}
+    }
 
-  .hljs-title,
-  .hljs-title.class_,
-  .hljs-title.class_.inherited__,
-  .hljs-title.function_ {
-    color: ${Colors.textBlue()};
-  }
+    .hljs-title,
+    .hljs-title.class_,
+    .hljs-title.class_.inherited__,
+    .hljs-title.function_ {
+      color: ${Colors.textBlue()};
+    }
 
-  .hljs-attr,
-  .hljs-attribute,
-  .hljs-literal,
-  .hljs-meta,
-  .hljs-number,
-  .hljs-operator,
-  .hljs-selector-attr,
-  .hljs-selector-class,
-  .hljs-selector-id,
-  .hljs-variable {
-    color: ${Colors.textLight()};
-  }
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-literal,
+    .hljs-meta,
+    .hljs-number,
+    .hljs-operator,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id,
+    .hljs-variable {
+      color: ${Colors.textLight()};
+    }
 
-  .hljs-meta .hljs-string,
-  .hljs-regexp,
-  .hljs-string {
-    color: ${Colors.textCyan()};
-  }
+    .hljs-meta .hljs-string,
+    .hljs-regexp,
+    .hljs-string {
+      color: ${Colors.textCyan()};
+    }
 
-  .hljs-built_in,
-  .hljs-symbol {
-    color: ${Colors.textYellow()};
-  }
+    .hljs-built_in,
+    .hljs-symbol {
+      color: ${Colors.textYellow()};
+    }
 
-  .hljs-code,
-  .hljs-comment,
-  .hljs-formula {
-    color: ${Colors.textLight()};
-  }
+    .hljs-code,
+    .hljs-comment,
+    .hljs-formula {
+      color: ${Colors.textLight()};
+    }
 
-  .hljs-name,
-  .hljs-quote,
-  .hljs-selector-pseudo,
-  .hljs-selector-tag {
-    color: ${Colors.textGreen()};
+    .hljs-name,
+    .hljs-quote,
+    .hljs-selector-pseudo,
+    .hljs-selector-tag {
+      color: ${Colors.textGreen()};
+    }
   }
 `;
 
@@ -129,6 +131,7 @@ export const MarkdownWithPlugins = (props: Props) => {
       <GlobalStyle />
       <ReactMarkdown
         {...props}
+        className="dagster-markdown"
         remarkPlugins={[gfm]}
         rehypePlugins={[rehypeHighlight, [rehypeSanitize, sanitizeConfig]]}
       />


### PR DESCRIPTION
## Summary & Motivation

Apply an additional (wrapper) classname to `ReactMarkdown` to ensure that our custom hljs styles can take precedence over GitHub styles.

Leaving the GitHub styles in place for now since we may be relying on some classnames that aren't being overridden here, and I don't want to hunt for those right now.

## How I Tested These Changes

View Storybook examples, verify that colors are correct, double check Chrome devtools to verify CSS precedence.