### PR TITLE
[dg docs test] Use solely editable packages in components docs test, re-enable

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/11-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/11-component-type-list.txt
@@ -3,9 +3,9 @@ cd code_locations/code-location-2 && dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/12-workspace.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/12-workspace.yaml
@@ -1,9 +1,9 @@
 load_from:
-  - python_file:	
-      relative_path: code_locations/code-location-1/code_location_1/definitions.py	
-      location_name: code_location_1	
-      executable_path: code_locations/code-location-1/.venv/bin/python	
-  - python_file:	
-      relative_path: code_locations/code-location-2/code_location_2/definitions.py	
-      location_name: code_location_2	
-      executable_path: code_locations/code-location-2/.venv/bin/python	
+  - python_file:
+      relative_path: code_locations/code-location-1/code_location_1/definitions.py
+      location_name: code_location_1
+      executable_path: code_locations/code-location-1/.venv/bin/python
+  - python_file:
+      relative_path: code_locations/code-location-2/code_location_2/definitions.py
+      location_name: code_location_2
+      executable_path: code_locations/code-location-2/.venv/bin/python

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/7-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/7-component-type-list.txt
@@ -3,9 +3,9 @@ cd code_locations/code-location-1 && dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/8-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/8-component-type-list.txt
@@ -3,13 +3,13 @@ dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │
-│ dagster_components.sling_replication_collection       │ Expose one or more Sling       │
+│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
 │                                                       │ replications to Dagster as     │
 │                                                       │ assets.                        │
 └───────────────────────────────────────────────────────┴────────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.sling_replication_collection
+type: sling_replication_collection@dagster_components
 
 params:
   replications:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
@@ -3,15 +3,15 @@ dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.dbt_project                        │ Expose a DBT project to        │
+│ dbt_project@dagster_components                        │ Expose a DBT project to        │
 │                                                       │ Dagster as a set of assets.    │
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │
-│ dagster_components.sling_replication_collection       │ Expose one or more Sling       │
+│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
 │                                                       │ replications to Dagster as     │
 │                                                       │ assets.                        │
 └───────────────────────────────────────────────────────┴────────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-component-type-info.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-component-type-info.txt
@@ -1,6 +1,6 @@
-dg component-type info dagster_components.dbt_project
+dg component-type info 'dbt_project@dagster_components'
 
-dagster_components.dbt_project
+dbt_project@dagster_components
 
 Description:
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/20-dg-scaffold-jdbt.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/20-dg-scaffold-jdbt.txt
@@ -1,3 +1,3 @@
-dg component scaffold dagster_components.dbt_project jdbt --project-path dbt/jdbt
+dg component scaffold dbt_project@dagster_components jdbt --project-path dbt/jdbt
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/components/jdbt.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/21-component-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/21-component-jdbt.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dbt_project
+type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/22-project-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/22-project-jdbt.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dbt_project
+type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
@@ -3,9 +3,9 @@ dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
@@ -3,13 +3,13 @@ dg component-type list
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster_components.definitions                        │ Wraps an arbitrary set of      │
+│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
 │                                                       │ Dagster definitions.           │
-│ dagster_components.pipes_subprocess_script_collection │ Assets that wrap Python        │
+│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
 │                                                       │ scripts executed with          │
 │                                                       │ Dagster's                      │
 │                                                       │ PipesSubprocessClient.         │
-│ dagster_components.sling_replication_collection       │ Expose one or more Sling       │
+│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
 │                                                       │ replications to Dagster as     │
 │                                                       │ assets.                        │
 └───────────────────────────────────────────────────────┴────────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
@@ -1,3 +1,3 @@
-dg component scaffold dagster_components.sling_replication_collection ingest_files
+dg component scaffold 'sling_replication_collection@dagster_components' ingest_files
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/components/ingest_files.

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -53,6 +53,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
                 "COLUMNS": "90",
                 "NO_COLOR": "1",
                 "HOME": "/tmp",
+                "DAGSTER_GIT_REPO_DIR": str(DAGSTER_ROOT),
             }
         ),
     ):

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -9,6 +9,8 @@ import pytest
 from dagster._utils.env import environ
 from docs_beta_snippets_tests.snippet_checks.guides.components.utils import (
     DAGSTER_ROOT,
+    EDITABLE_DIR,
+    MASK_EDITABLE_DAGSTER,
     MASK_JAFFLE_PLATFORM,
     MASK_SLING_DOWNLOAD_DUCKDB,
     MASK_SLING_PROMO,
@@ -36,7 +38,6 @@ COMPONENTS_SNIPPETS_DIR = (
 )
 
 
-@pytest.mark.skip
 def test_components_docs_index(update_snippets: bool) -> None:
     snip_no = 0
 
@@ -66,10 +67,11 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
         # Scaffold code location
         run_command_and_snippet_output(
-            cmd="dg code-location scaffold jaffle-platform",
+            cmd="dg code-location scaffold jaffle-platform --use-editable-dagster",
             snippet_path=COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-scaffold.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[
+                MASK_EDITABLE_DAGSTER,
                 MASK_JAFFLE_PLATFORM,
                 (r"\nUsing[\s\S]*", "\n..."),
             ],
@@ -115,12 +117,11 @@ def test_components_docs_index(update_snippets: bool) -> None:
             / f"{next_snip_no()}-dg-list-component-types.txt",
             update_snippets=update_snippets,
         )
-        components_dir = str(
-            DAGSTER_ROOT / "python_modules" / "libraries" / "dagster-components"
-        )
+
         _run_command(
-            f"uv add sling_mac_arm64 && uv add --editable '{components_dir}[sling]'"
+            f"uv add sling_mac_arm64 && uv add --editable '{EDITABLE_DIR / 'dagster-sling'!s}' && uv add --editable '{EDITABLE_DIR / 'dagster-components'!s}[sling]'"
         )
+        _run_command("uv tree")
         run_command_and_snippet_output(
             cmd="dg component-type list",
             snippet_path=COMPONENTS_SNIPPETS_DIR
@@ -130,7 +131,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
         # Scaffold new ingestion, validate new files
         run_command_and_snippet_output(
-            cmd="dg component scaffold dagster_components.sling_replication_collection ingest_files",
+            cmd="dg component scaffold 'sling_replication_collection@dagster_components' ingest_files",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-dg-scaffold-sling-replication.txt",
             update_snippets=update_snippets,
@@ -240,7 +241,7 @@ streams:
                 ignore_output=True,
             )
             _run_command(
-                f"uv add --editable '{components_dir}[dbt]'; uv add dbt-duckdb"
+                f"uv add --editable '{EDITABLE_DIR / 'dagster-dbt'!s}' && uv add --editable '{EDITABLE_DIR / 'dagster-components'!s}[dbt]'; uv add dbt-duckdb"
             )
             run_command_and_snippet_output(
                 cmd="dg component-type list",
@@ -249,7 +250,7 @@ streams:
                 update_snippets=update_snippets,
             )
             run_command_and_snippet_output(
-                cmd="dg component-type info dagster_components.dbt_project",
+                cmd="dg component-type info 'dbt_project@dagster_components'",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-type-info.txt",
                 update_snippets=update_snippets,
@@ -258,7 +259,7 @@ streams:
 
             # Scaffold dbt project components
             run_command_and_snippet_output(
-                cmd="dg component scaffold dagster_components.dbt_project jdbt --project-path dbt/jdbt",
+                cmd="dg component scaffold dbt_project@dagster_components jdbt --project-path dbt/jdbt",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-scaffold-jdbt.txt",
                 update_snippets=update_snippets,
@@ -273,7 +274,7 @@ streams:
                 Path("jaffle_platform") / "components" / "jdbt" / "component.yaml",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-project-jdbt.yaml",
-                contents="""type: dagster_components.dbt_project
+                contents="""type: dbt_project@dagster_components
 
 params:
   dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
@@ -48,6 +48,7 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
                 "COLUMNS": "90",
                 "NO_COLOR": "1",
                 "HOME": "/tmp",
+                "DAGSTER_GIT_REPO_DIR": str(DAGSTER_ROOT),
             }
         ),
     ):

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_deployments.py
@@ -6,7 +6,11 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from dagster._utils.env import environ
-from docs_beta_snippets_tests.snippet_checks.guides.components.utils import DAGSTER_ROOT
+from docs_beta_snippets_tests.snippet_checks.guides.components.utils import (
+    DAGSTER_ROOT,
+    EDITABLE_DIR,
+    MASK_EDITABLE_DAGSTER,
+)
 from docs_beta_snippets_tests.snippet_checks.utils import (
     _run_command,
     check_file,
@@ -29,7 +33,6 @@ COMPONENTS_SNIPPETS_DIR = (
 MASK_MY_DEPLOYMENT = (r" \/.*?\/my-deployment", " /.../my-deployment")
 
 
-@pytest.mark.skip
 def test_components_docs_deployments(update_snippets: bool) -> None:
     snip_no = 0
 
@@ -80,11 +83,12 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
 
         # Scaffold code location
         run_command_and_snippet_output(
-            cmd="dg code-location scaffold code-location-1",
+            cmd="dg code-location scaffold code-location-1 --use-editable-dagster",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-code-location-scaffold.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[
+                MASK_EDITABLE_DAGSTER,
                 MASK_MY_DEPLOYMENT,
                 (r"\nUsing[\s\S]*", "\n..."),
             ],
@@ -123,11 +127,8 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
             / f"{next_snip_no()}-component-type-list.txt",
             update_snippets=update_snippets,
         )
-        components_dir = str(
-            DAGSTER_ROOT / "python_modules" / "libraries" / "dagster-components"
-        )
         _run_command(
-            f"uv add sling_mac_arm64 && uv add --editable '{components_dir}[sling]'"
+            f"uv add sling_mac_arm64 && uv add --editable '{EDITABLE_DIR / 'dagster-sling'!s}' && uv add --editable '{EDITABLE_DIR / 'dagster-components'!s}[sling]'"
         )
         run_command_and_snippet_output(
             cmd="dg component-type list",
@@ -138,11 +139,12 @@ def test_components_docs_deployments(update_snippets: bool) -> None:
 
         # Scaffold new code location
         run_command_and_snippet_output(
-            cmd="cd ../.. && dg code-location scaffold code-location-2",
+            cmd="cd ../.. && dg code-location scaffold code-location-2 --use-editable-dagster",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-code-location-scaffold.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[
+                MASK_EDITABLE_DAGSTER,
                 MASK_MY_DEPLOYMENT,
                 (r"\nUsing[\s\S]*", "\n..."),
             ],

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
@@ -4,6 +4,7 @@ MASK_TIME = (r"\d+:\d+(:?AM|PM)", "9:00AM")
 MASK_SLING_WARNING = (r"warning.*\n", "")
 MASK_SLING_PROMO = (r"Follow Sling.*\n", "")
 MASK_SLING_DOWNLOAD_DUCKDB = (r".*downloading duckdb.*\n", "")
+MASK_EDITABLE_DAGSTER = (r" --use-editable-dagster", "")
 MASK_JAFFLE_PLATFORM = (r" \/.*?\/jaffle-platform", " /.../jaffle-platform")
 
 DAGSTER_ROOT = Path(__file__).parent.parent.parent.parent.parent.parent.parent
@@ -16,3 +17,5 @@ COMPONENTS_SNIPPETS_DIR = (
     / "components"
     / "index"
 )
+
+EDITABLE_DIR = DAGSTER_ROOT / "python_modules" / "libraries"

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/utils.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/utils.py
@@ -208,7 +208,7 @@ def check_file(
             Useful to remove dynamic content, e.g. the temporary directory path or timestamps.
     """
     file_path = Path(file_path)
-    assert file_path.exists()
+    assert file_path.exists(), f"Expected file {file_path} to exist"
     contents = file_path.read_text()
 
     if snippet_path:

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -8,7 +8,6 @@ passenv =
     COVERALLS_REPO_TOKEN
     POSTGRES_TEST_DB_HOST
     BUILDKITE*
-    DAGSTER_GIT_REPO_DIR
 install_command = uv pip install {opts} {packages}
 deps =
   duckdb

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -8,6 +8,7 @@ passenv =
     COVERALLS_REPO_TOKEN
     POSTGRES_TEST_DB_HOST
     BUILDKITE*
+    DAGSTER_GIT_REPO_DIR
 install_command = uv pip install {opts} {packages}
 deps =
   duckdb
@@ -75,12 +76,18 @@ allowlist_externals =
   sh
 commands =
   # install cloud packages out of band due to version conflicts between pypi and source
-  uv pip install dagster-cloud-cli --no-deps
-  uv pip install dagster-cloud --no-deps
-  uv pip install path
-  /bin/bash -c '! pip list --exclude-editable | grep -e dagster | grep -v dagster-cloud'
+  all: uv pip install dagster-cloud-cli --no-deps
+  all: uv pip install dagster-cloud --no-deps
+  all: uv pip install path
+  all: /bin/bash -c '! pip list --exclude-editable | grep -e dagster | grep -v dagster-cloud'
   all: pytest -c ../../pyproject.toml -vv {posargs} --ignore=docs_beta_snippets_tests/test_integration_files_load.py --ignore=docs_beta_snippets_tests/snippet_checks
+
+  integrations: uv pip install dagster-cloud-cli --no-deps
+  integrations: uv pip install dagster-cloud --no-deps
+  integrations: uv pip install path
+  integrations: /bin/bash -c '! pip list --exclude-editable | grep -e dagster | grep -v dagster-cloud'
   integrations: pytest -c ../../pyproject.toml -vv {posargs} docs_beta_snippets_tests/test_integration_files_load.py
+
   docs_snapshot_test: sh ./docs_beta_snippets_tests/ensure_snapshot_deps.sh
   docs_snapshot_test: pytest -c ../../pyproject.toml -vv {posargs} docs_beta_snippets_tests/snippet_checks
   docs_snapshot_update: sh ./docs_beta_snippets_tests/ensure_snapshot_deps.sh


### PR DESCRIPTION
## Summary

Previously, scaffolding code locations in the docs snippet dg CLI tests would install production copies of the components library. This PR ensures in every place we use solely editable packages, to prevent any cross-version incompatibility issues.


