### PR TITLE
[easy][Asset Graph] useLayoutEffect + wait for supplementary data 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -1,7 +1,7 @@
 import keyBy from 'lodash/keyBy';
 import memoize from 'lodash/memoize';
 import reject from 'lodash/reject';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {useAssetGraphSupplementaryData} from 'shared/asset-graph/useAssetGraphSupplementaryData.oss';
 
@@ -164,7 +164,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
   const {loading: supplementaryDataLoading, data: supplementaryData} =
     useAssetGraphSupplementaryData(opsQuery);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (options.loading || supplementaryDataLoading) {
       return;
     }
@@ -206,7 +206,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     supplementaryDataLoading,
   ]);
 
-  const loading = fetchResult.loading || graphDataLoading;
+  const loading = fetchResult.loading || graphDataLoading || supplementaryDataLoading;
   useBlockTraceUntilTrue('useAssetGraphData', !loading);
   return {
     loading,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
@@ -10,7 +10,7 @@ import {SelectionAutoCompleteProvider} from '../../selection/SelectionAutoComple
 import {SelectionAutoCompleteInput} from '../../selection/SelectionInput';
 import {createSelectionLinter} from '../../selection/createSelectionLinter';
 
-interface AssetSelectionInputProps {
+export interface AssetSelectionInputProps {
   assets: AssetGraphQueryItem[];
   value: string;
   onChange: (value: string) => void;


### PR DESCRIPTION
## Summary & Motivation

as titled. 

Switching to useLayoutEffect to avoid a render where the loading spinner disappears. 