### PR TITLE
`idb-lru-cache` Change database name to avoid being blocked by old versions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/util/idb-lru-cache.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/idb-lru-cache.ts
@@ -38,16 +38,15 @@ class IDBLRUCache<T> {
   }
 
   private async initDB(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, this.dbVersion);
+    const request = indexedDB.open(this.dbName, this.dbVersion);
 
+    return new Promise((resolve, reject) => {
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
         if (!db.objectStoreNames.contains('cache')) {
           db.createObjectStore('cache');
         }
       };
-
       request.onsuccess = async (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
         this.isDbOpen = true;
@@ -71,12 +70,10 @@ class IDBLRUCache<T> {
 
         resolve(db);
       };
-
       request.onerror = (event) => {
         this.isDbOpen = false;
         reject(new IDBError('Failed to open database', (event.target as IDBOpenDBRequest).error));
       };
-
       request.onblocked = () => {
         this.isDbOpen = false;
         reject(new IDBError('Database is blocked'));

--- a/js_modules/dagster-ui/packages/ui-core/src/util/idb-lru-cache.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/idb-lru-cache.ts
@@ -4,6 +4,7 @@ import {LRUCache} from './lru-cache';
 
 interface CacheOptions {
   dbName: string;
+  dbVersion?: number;
   maxCount: number;
 }
 
@@ -26,17 +27,19 @@ class IDBLRUCache<T> {
   private dbPromise: Promise<IDBDatabase> | undefined;
   private isDbOpen = false;
   private lruCache: LRUCache<T>;
+  private dbVersion?: number;
 
-  constructor({dbName, maxCount}: CacheOptions) {
-    this.dbName = dbName;
+  constructor({dbName, dbVersion, maxCount}: CacheOptions) {
+    this.dbName = `idb-lru-cache-v1-${dbName}`;
     this.maxCount = maxCount;
     this.lruCache = new LRUCache<T>(maxCount);
     this.dbPromise = this.initDB();
+    this.dbVersion = dbVersion;
   }
 
   private async initDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, 3);
+      const request = indexedDB.open(this.dbName, this.dbVersion);
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;


### PR DESCRIPTION
## Summary & Motivation
as titled, prefixing the db name so that we don't try and re-use any existing DBs and have a fresh new one while we work out any back-compat issues.