### PR TITLE
[dagster-dbt] Skip failing test with lock issue for Duckdb

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -603,8 +603,8 @@ def test_custom_subclass():
 
 
 @pytest.mark.skipif(
-    version.parse(dbt_version) < version.parse("1.7.9"),
-    reason="Lock issue with Duckdb in test suite for `dbt-core>=1.7.9`",
+    version.parse(dbt_version) < version.parse("1.8"),
+    reason="Lock issue with Duckdb in test suite for `dbt-core==1.7",
 )
 def test_metadata(test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource) -> None:
     def assert_on_expected_metadata(metadata):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -602,6 +602,10 @@ def test_custom_subclass():
     assert isinstance(custom, DbtCliResource)
 
 
+@pytest.mark.skipif(
+    version.parse(dbt_version) < version.parse("1.7.9"),
+    reason="Lock issue with Duckdb in test suite for `dbt-core>=1.7.9`",
+)
 def test_metadata(test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource) -> None:
     def assert_on_expected_metadata(metadata):
         assert isinstance(metadata["Execution Duration"], FloatMetadataValue)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -604,7 +604,7 @@ def test_custom_subclass():
 
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.8"),
-    reason="Lock issue with Duckdb in test suite for `dbt-core==1.7",
+    reason="Lock issue with Duckdb in test suite for `dbt-core==1.7`",
 )
 def test_metadata(test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource) -> None:
     def assert_on_expected_metadata(metadata):


### PR DESCRIPTION
## Summary & Motivation

Follow up for PR https://github.com/dagster-io/dagster/pull/27562

Duckdb 1.2.0 was released earlier this afternoon - only one test failing in BK since the new version instead of random flaky tests. It's always the same tests, for dbt core 1.7: https://buildkite.com/dagster/dagster-dagster/builds/111070#0194d668-40aa-440e-a2e4-a039389e8967

Skipping this test until we resolve the lock issue.

## How I Tested These Changes

BK
