### PR TITLE
[prettier] Fix `make prettier`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# These files have broken syntax purpose for error testing purposes
+python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_invalid_char/component.yaml
+python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_missing_quote/component.yaml


### PR DESCRIPTION
## Summary & Motivation

`make prettier` is broken due to some files added for testing broken components yaml, this fixes it by adding a `.prettierignore` file.

## How I Tested These Changes

`make prettier`