### PR TITLE
[ui] Run timeline: Fix group-by persistence

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -1,45 +1,51 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 
-import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
 const GROUP_BY_KEY = 'dagster.run-timeline-group-by';
 
 export type GroupRunsBy = 'job' | 'automation';
 
+const validate = (value: string) => {
+  switch (value) {
+    case 'job':
+    case 'automation':
+      return value;
+    default:
+      return null;
+  }
+};
+
 export const useGroupTimelineRunsBy = (
   defaultValue: GroupRunsBy = 'job',
 ): [GroupRunsBy, (value: GroupRunsBy) => void] => {
-  const validate = useCallback(
-    (value: string) => {
-      switch (value) {
-        case 'job':
-        case 'automation':
-          return value;
-        default:
-          return defaultValue;
-      }
-    },
-    [defaultValue],
-  );
+  const [storedValue, setStoredValue] = useStateWithStorage(GROUP_BY_KEY, validate);
 
-  const [groupRunsBy, setGroupRunsBy] = useQueryAndLocalStoragePersistedState<GroupRunsBy>({
-    localStorageKey: GROUP_BY_KEY,
+  const [queryValue, setQueryValue] = useQueryPersistedState({
     queryKey: 'groupBy',
-    encode: (value) => {
-      return {groupBy: value};
-    },
-    decode: (pair) => {
-      return validate(pair.groupBy);
-    },
-    isEmptyState: (value) => !value,
+    decode: (pair) => validate(pair.groupBy),
+    encode: (value) => ({groupBy: value}),
   });
 
+  /**
+   * If a query value is provided, use it without writing to localStorage.
+   * Otherwise, if the user has a stored value (from previously choosing an option), use that.
+   * If neither are provided, use the default value.
+   */
+  const outputValue = queryValue || storedValue || defaultValue;
+
+  /**
+   * Set the query parameter and write the preference to localStorage. This is used when
+   * the user specifically chooses an option.
+   */
   const setGroupByWithDefault = useCallback(
     (value: GroupRunsBy) => {
-      setGroupRunsBy(value || defaultValue);
+      setStoredValue(value);
+      setQueryValue(value);
     },
-    [defaultValue, setGroupRunsBy],
+    [setStoredValue, setQueryValue],
   );
 
-  return useMemo(() => [groupRunsBy, setGroupByWithDefault], [groupRunsBy, setGroupByWithDefault]);
+  return [outputValue, setGroupByWithDefault];
 };


### PR DESCRIPTION
## Summary & Motivation

Storage persistence of the group-by option on the run timeline is currently broken. More specifically, the value may be persisted, but it's not being used -- the default value (`job`) always ends up as the initial value.

I'm not sure that the default behavior of `useQueryAndLocalStoragePersistedState` is quite right for this use case (namely, `Syncs changes back to localStorage`) so I'm trying to simplify the behavior here specifically without changing `useQueryAndLocalStoragePersistedState` itself and risking breaking other callsites.

- If the query param is present, use it.
- If not, use the stored value.
- If that's not set, use the default value.
- When changing the group-by option with the dropdown, update the query param and set the localStorage value.

Ideally this should allow sharing the URL with the query param applied without affecting the user's stored value, while also allowing the stored value to be used when the query param is absent.

## How I Tested These Changes

View run timeline with no query param.

- Verify that my stored group-by value is applied. ("automation")
- Change group-by value to "job". Verify that storage is updated and that the query param `groupBy=job` now appears in the URL.
- Reload the page with query param `groupBy=automation`. Verify that the query param is used.
- Remove the query param, load the page. Verify that the page reverts to "job", since that is my stored value.

## Changelog

[ui] FIx persistence of group-by setting in run timeline view.