### PR TITLE
[ui] Repair asset check asOf param from run logs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -463,9 +463,12 @@ const AssetCheckEvaluationContent = ({
   const {checkName, success, metadataEntries, targetMaterialization, assetKey} = node.evaluation;
 
   const checkLink = assetDetailsPathForAssetCheck({assetKey, name: checkName});
+
+  // Target materialization timestamp is in seconds, and must be converted to msec for the query param.
+  const asOf = targetMaterialization?.timestamp ?? null;
   const matLink = assetDetailsPathForKey(assetKey, {
     view: 'events',
-    asOf: targetMaterialization ? `${targetMaterialization.timestamp}` : undefined,
+    asOf: asOf ? `${Math.floor(asOf * 1000)}` : undefined,
   });
 
   return (


### PR DESCRIPTION
## Summary & Motivation

Asset check events in the run logs link to a seconds-based timestamp on the corresponding asset permalink, since the value coming from GraphQL is seconds-based. The value on the permalink query param needs to be msec-based.

I think it would be better if all of our timestamp fields consistently provided msec-based timestamps, but even within the relevant GraphQL types involved in this narrow use case (asset evaluation and materialization timestamps), I see a mix of seconds-based and msec-based...so this is potentially a gnarly change to take on here. cc @OwenKephart 

## How I Tested These Changes

View run logs where the issue repros. Filter to `type:ASSET_CHECK_EVALUATION`, verify that permalinks to assets have correct `asOf` values, and that navigation to those pages results in appropriate timestamps in the UI.

## Changelog

[ui] Fix timestamped links to asset pages from asset check evaluations in run logs.
