### PR TITLE
[da] Fix initial_evaluation condition handling of missing automation conditions (BUILD-684)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -147,6 +147,7 @@ class AutomationTickEvaluationContext:
                 )
             ],
             evaluation_timestamp=self._evaluator.evaluation_time.timestamp(),
+            asset_graph=self.asset_graph,
         )
 
     def _get_updated_evaluations(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -120,6 +120,13 @@ def evaluate_automation_conditions(
         )
 
     asset_graph = defs.get_asset_graph()
+
+    # round-trip the provided cursor to simulate actual usage
+    cursor = (
+        deserialize_value(serialize_value(cursor), AssetDaemonCursor)
+        if cursor
+        else AssetDaemonCursor.empty()
+    )
     evaluator = AutomationConditionEvaluator(
         asset_graph=asset_graph,
         instance=instance,
@@ -132,19 +139,17 @@ def evaluate_automation_conditions(
         evaluation_time=evaluation_time,
         emit_backfills=False,
         logger=logging.getLogger("dagster.automation_condition_tester"),
-        # round-trip the provided cursor to simulate actual usage
-        cursor=deserialize_value(serialize_value(cursor), AssetDaemonCursor)
-        if cursor
-        else AssetDaemonCursor.empty(),
+        cursor=cursor,
     )
     results, requested_subsets = evaluator.evaluate()
-    cursor = AssetDaemonCursor(
-        evaluation_id=1 if cursor is None else cursor.evaluation_id + 1,
-        last_observe_request_timestamp_by_asset_key={},
-        previous_evaluation_state=None,
-        previous_condition_cursors=[result.get_new_cursor() for result in results],
+    new_cursor = cursor.with_updates(
+        evaluation_timestamp=(evaluation_time or datetime.datetime.now()).timestamp(),
+        newly_observe_requested_asset_keys=[],
+        evaluation_id=cursor.evaluation_id + 1,
+        condition_cursors=[result.get_new_cursor() for result in results],
+        asset_graph=asset_graph,
     )
 
     return EvaluateAutomationConditionsResult(
-        cursor=cursor, requested_subsets=requested_subsets, results=results
+        cursor=new_cursor, requested_subsets=requested_subsets, results=results
     )

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_initial_evaluation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_initial_evaluation_condition.py
@@ -121,6 +121,42 @@ def test_update_on_condition_change(pd_change: bool) -> None:
         assert _get_initial_evaluation_count(result) == 0
 
 
+def test_initial_evaluation_condition_toggle() -> None:
+    def _get_defs(has_condition: bool = True) -> dg.Definitions:
+        @dg.asset(
+            automation_condition=dg.AutomationCondition.initial_evaluation()
+            if has_condition
+            else None
+        )
+        def a() -> None: ...
+
+        return dg.Definitions(assets=[a])
+
+    instance = dg.DagsterInstance.ephemeral()
+
+    # initial evaluation, should be true
+    result = dg.evaluate_automation_conditions(defs=_get_defs(), instance=instance)
+    assert result.total_requested == 1
+
+    # no longer initial evaluation
+    result = dg.evaluate_automation_conditions(
+        defs=_get_defs(), instance=instance, cursor=result.cursor
+    )
+    assert result.total_requested == 0
+
+    # remove condition, nothing to evaluate
+    result = dg.evaluate_automation_conditions(
+        defs=_get_defs(has_condition=False), instance=instance, cursor=result.cursor
+    )
+    assert result.total_requested == 0
+
+    # add condition back, now it's initial evaluation again
+    result = dg.evaluate_automation_conditions(
+        defs=_get_defs(), instance=instance, cursor=result.cursor
+    )
+    assert result.total_requested == 1
+
+
 def test_no_update_on_new_deps() -> None:
     def _get_defs(deps: Sequence[str]) -> dg.Definitions:
         @dg.multi_asset(specs=[dg.AssetSpec(d) for d in deps])

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_cursor.py
@@ -34,7 +34,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat() -> None:
 
     assert c == AssetDaemonCursor.empty(20)
 
-    c2 = c.with_updates(21, datetime.datetime.now().timestamp(), [], [])
+    c2 = c.with_updates(21, datetime.datetime.now().timestamp(), [], [], asset_graph)
 
     serdes_c2 = deserialize_value(serialize_value(c2), as_type=AssetDaemonCursor)
     assert serdes_c2 == c2

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -89,7 +89,7 @@ class AutomationConditionScenarioState(ScenarioState):
                 instance=self.instance,
                 entity_keys=asset_graph.get_all_asset_keys(),
                 cursor=AssetDaemonCursor.empty().with_updates(
-                    0, 0, [], [self.condition_cursor] if self.condition_cursor else []
+                    0, 0, [], [self.condition_cursor] if self.condition_cursor else [], asset_graph
                 ),
                 logger=self.logger,
                 emit_backfills=False,


### PR DESCRIPTION
## Summary & Motivation

This fixes a bug as described in the changelog entry.

The existing logic for updating the AssetDaemonCursor ensured that we would never "forget" about the cursor of any asset that was ever evaluated by a given process.

This is a bit of a holdover from the world of AMP + global AMP evaluation in which:

1. it was possible for a single code-location to be unavailable while the rest of the evaluation was proceeding normally
2. it was very bad (perf-wise) if an AMP cursor was lost to the void

So the existing code was the safest possible measure -- we just literally always propagate old cursors forward. This means that over time, if you change asset names or change how things are automated, your cursor just hold on to a lot of baggage.

This PR makes a small step in the direction of clearing out this baggage, but deeming it safe to remove the cursor of an asset that is still in the asset graph (so we know about it), but did not have any cursoring information (meaning it was explicitly not being automated by DA)

So we still keep around some amount of baggage (to continue to support the scary situation from AMP-times), but get to remove some subset of it.

My belief is that once we remove the "global" mode of the daemon, we should be able to remove all of the propagation logic, but I haven't thought about that too hard.

## How I Tested These Changes

## Changelog

Fixed a bug with `AutomationCondition.initial_evaluation` which could cause it to return `False` for an asset that went from having a condition, to having no condition at all, back to having the original condition again.
