### PR TITLE
[components] Fix SlingResource resolution

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -65,7 +65,9 @@ class SlingReplicationCollectionParams(ResolvableModel[ResolvedSlingReplicationC
 
     def resolve(self, resolver: TemplatedValueResolver) -> ResolvedSlingReplicationCollectionParams:
         return (
-            self.sling if self.sling else SlingResource(),
+            SlingResource(**resolver.resolve_obj(self.sling.model_dump()))
+            if self.sling
+            else SlingResource(),
             [replication.resolve(resolver) for replication in self.replications],
             [transform.resolve(resolver) for transform in self.transforms]
             if self.transforms

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
@@ -10,3 +10,4 @@ params:
       - name: DUCKDB
         type: duckdb
         instance: <PLACEHOLDER>
+        password: "{{ env('SOME_PASSWORD') }}"


### PR DESCRIPTION
## Summary & Motivation

After recent changes, we no longer do a pre-resolution step for the params schema, which means we need to explicitly resolve parameters passed to resources.

This should probably be done using a separate wrapper class but for now we can just do the simple fix that restores previous behavior.

A similar thing should be done for dbt

## How I Tested These Changes

## Changelog

NOCHANGELOG
