### PR TITLE
feat: Added value "revisionHistoryLimit"

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -14,6 +14,7 @@ metadata:
   annotations: {{ $deployment.annotations | toYaml | nindent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ $deployment.revisionHistoryLimit }}
   {{- if $deployment.deploymentStrategy }}
   strategy:
     {{- toYaml $deployment.deploymentStrategy | nindent 4 }}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -31,6 +31,9 @@ deployments:
       # image pull policy to anything other than "Always" will use a cached/stale image, which is
       # almost certainly not what you want.
       pullPolicy: Always
+
+    revisionHistoryLimit: 10
+
     # Arguments to `dagster api grpc`.
     # Ex: "dagster api grpc -m dagster_test.test_project.test_jobs.repo -a define_demo_execution_repo"
     # would translate to:

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ $queue.replicaCount }}
+  revisionHistoryLimit: {{ $queue.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" $ | nindent 6 }}

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.dagsterDaemon.revisionHistoryLimit }}
   strategy:
     type: Recreate
   selector:

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.flower.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" . | nindent 6 }}

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -17,6 +17,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ $_.Values.dagsterWebserver.replicaCount }}
+  revisionHistoryLimit: {{ $_.Values.dagsterWebserver.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" . | nindent 6 }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -30,6 +30,8 @@ imagePullSecrets: []
 ####################################################################################################
 dagsterWebserver:
   replicaCount: 1
+  revisionHistoryLimit: 10
+
   image:
     # When a tag is not supplied for a Dagster provided image,
     # it will default as the Helm chart version.
@@ -331,6 +333,8 @@ dagster-user-deployments:
         # image pull policy to anything other than "Always" will use a cached/stale image, which is
         # almost certainly not what you want.
         pullPolicy: Always
+
+      revisionHistoryLimit: 10
 
       # Arguments to `dagster api grpc`.
       # Ex: "dagster api grpc -m dagster_test.test_project.test_jobs.repo -a define_demo_execution_repo"
@@ -664,6 +668,7 @@ runLauncher:
       workerQueues:
         - name: "dagster"
           replicaCount: 2
+          revisionHistoryLimit: 10
           labels: {}
           nodeSelector: {}
           configSource: {}
@@ -909,6 +914,8 @@ flower:
     tag: "0.9.5"
     pullPolicy: Always
 
+  revisionHistoryLimit: 10
+
   service:
     type: ClusterIP
     annotations: {}
@@ -1096,6 +1103,8 @@ dagsterDaemon:
     repository: "docker.io/dagster/dagster-celery-k8s"
     tag: ~
     pullPolicy: Always
+
+  revisionHistoryLimit: 10
 
   heartbeatTolerance: 1800
 


### PR DESCRIPTION
Refs: #17433

## Summary & Motivation
As requested in #17433, the (user) deployments should have the possibilities to set revisionHistoryLimits.

## How I Tested These Changes
I deployed the adapted helm-chart in my local kubernetes cluster and everything worked well. Only the defined amount of replicaSets were persisted.
