### PR TITLE
[dagster-aws] get_objects fix return all objects in case of equivalent timestamps

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -65,6 +65,9 @@ def get_objects(
         for idx, obj in enumerate(sorted_objects):
             if obj.get("LastModified") > since_last_modified:
                 return sorted_objects[idx:]
+            else:
+                # if TS are same then no results are reported, otherwise we fall into the trap of returning all objects
+                return []
 
     return sorted_objects
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -60,13 +60,14 @@ def get_objects(
         for idx, obj in enumerate(sorted_objects):
             if obj.get("Key") == since_key:
                 return sorted_objects[idx + 1 :]
+            else:
+                return []
 
     if since_last_modified:
         for idx, obj in enumerate(sorted_objects):
             if obj.get("LastModified") > since_last_modified:
                 return sorted_objects[idx:]
             else:
-                # if TS are same then no results are reported, otherwise we fall into the trap of returning all objects
                 return []
 
     return sorted_objects

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -60,15 +60,13 @@ def get_objects(
         for idx, obj in enumerate(sorted_objects):
             if obj.get("Key") == since_key:
                 return sorted_objects[idx + 1 :]
-            else:
-                return []
+        return []
 
     if since_last_modified:
         for idx, obj in enumerate(sorted_objects):
             if obj.get("LastModified") > since_last_modified:
                 return sorted_objects[idx:]
-            else:
-                return []
+        return []
 
     return sorted_objects
 


### PR DESCRIPTION
## Summary & Motivation

currently, ALL values are returned if the timestamp is the same but  if both TS are same then no results are reported, otherwise, we fall into the trap of returning all objects


## How I Tested These Changes

## Changelog

> Fix s3 sensor for same timestamp values
