### PR TITLE
[components] Move to tomlkit from tomli/tomli_w for TOML handling

### DIFF
--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -34,7 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_components_tests*", "examples*"]),
-    install_requires=["dagster>=1.9.5", "tomli", "typer"],
+    install_requires=["dagster>=1.9.5", "typer"],
     zip_safe=False,
     entry_points={
         "console_scripts": [

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -14,7 +14,7 @@ from dagster_components.test.test_cases import (
     ComponentValidationTestCase,
     msg_includes_all_of,
 )
-from dagster_dg.utils import ensure_dagster_dg_tests_import, pushd
+from dagster_dg.utils import ensure_dagster_dg_tests_import, pushd, set_toml_value
 
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
@@ -85,8 +85,8 @@ def test_component_check_succeeds_non_default_component_package() -> None:
             runner,
         ),
     ):
-        with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_package"] = "foo_bar._components"
+        with modify_pyproject_toml() as toml:
+            set_toml_value(toml, ("tool", "dg", "component_package"), "foo_bar._components")
 
         # We need to do all of this copying here rather than relying on the code location setup
         # fixture because that fixture assumes a default component package.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_component_commands.py
@@ -4,7 +4,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from dagster_dg.utils import ensure_dagster_dg_tests_import
+from dagster_dg.utils import ensure_dagster_dg_tests_import, set_toml_value
 
 ensure_dagster_dg_tests_import()
 
@@ -180,8 +180,8 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
         alt_lib_path = Path("foo_bar/_components")
         alt_lib_path.mkdir(parents=True)
-        with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_package"] = "foo_bar._components"
+        with modify_pyproject_toml() as toml:
+            set_toml_value(toml, ("tool", "dg", "component_package"), "foo_bar._components")
         result = runner.invoke(
             "component",
             "scaffold",
@@ -200,8 +200,8 @@ def test_component_scaffold_succeeds_non_default_component_package() -> None:
 
 def test_component_scaffold_fails_components_package_does_not_exist() -> None:
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
-        with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_package"] = "bar._components"
+        with modify_pyproject_toml() as toml:
+            set_toml_value(toml, ("tool", "dg", "component_package"), "bar._components")
         result = runner.invoke(
             "component",
             "scaffold",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.component_key import GlobalComponentKey
 from dagster_dg.context import DgContext
-from dagster_dg.utils import ensure_dagster_dg_tests_import
+from dagster_dg.utils import ensure_dagster_dg_tests_import, set_toml_value
 
 ensure_dagster_dg_tests_import()
 
@@ -86,8 +86,8 @@ def test_component_type_scaffold_fails_components_lib_package_does_not_exist() -
         ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner),
     ):
-        with modify_pyproject_toml() as pyproject_toml:
-            pyproject_toml["tool"]["dg"]["component_lib_package"] = "foo_bar._lib"
+        with modify_pyproject_toml() as toml:
+            set_toml_value(toml, ("tool", "dg", "component_lib_package"), "foo_bar._lib")
         result = runner.invoke(
             "component-type",
             "scaffold",

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(exclude=["dagster_dg_tests*"]),
     install_requires=[
         "Jinja2",
-        "tomli",
+        "tomlkit",
         "click>=8",
         "typing_extensions>=4.4.0,<5",
         "markdown",
@@ -59,7 +59,6 @@ setup(
             "dagster-graphql",
             "pydantic",
             "pytest",
-            "tomli-w",
         ],
     },
 )


### PR DESCRIPTION
## Summary & Motivation

`tomlkit` will allow us to programmatically manipulate TOML while preserving comments and spacing.

## How I Tested These Changes

Existing test suite.