### PR TITLE
[ui] Split Concurrency page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/ConcurrencyTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/ConcurrencyTabs.tsx
@@ -1,0 +1,35 @@
+import {Box, Tab, Tabs, Tag} from '@dagster-io/ui-components';
+
+import {useFeatureFlags} from '../app/Flags';
+
+export type ConcurrencyTab = 'run-concurrency' | 'key-concurrency';
+
+interface Props {
+  activeTab: ConcurrencyTab;
+  onChange: (tab: ConcurrencyTab) => void;
+}
+
+export const ConcurrencyTabs = ({activeTab, onChange}: Props) => {
+  const {flagPoolUI} = useFeatureFlags();
+  return (
+    <Tabs selectedTabId={activeTab} onChange={onChange}>
+      <Tab
+        title="Run concurrency"
+        id="run-concurrency"
+        selected={activeTab === 'run-concurrency'}
+      />
+      <Tab
+        title={
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+            <span>{flagPoolUI ? 'Pools' : 'Global op/asset concurrency'}</span>
+            <Tag>
+              <span style={{fontWeight: 'normal'}}>Experimental</span>
+            </Tag>
+          </Box>
+        }
+        id="key-concurrency"
+        selected={activeTab === 'key-concurrency'}
+      />
+    </Tabs>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
@@ -199,7 +199,7 @@ export const InstanceConcurrencyKeyInfo = ({concurrencyKey}: {concurrencyKey: st
             )}
           </Box>
         ) : (
-          <Box padding={{vertical: 64}}>
+          <Box flex={{direction: 'column', alignItems: 'center'}} padding={{vertical: 64}}>
             <SpinnerWithText label="Loading…" />
           </Box>
         )}
@@ -278,14 +278,16 @@ const EditConcurrencyLimitDialog = ({
     onClose();
   };
 
-  const title = (
-    <>
-      Edit <Mono>{concurrencyKey}</Mono>
-    </>
-  );
-
   return (
-    <Dialog isOpen={open} title={title} onClose={onClose}>
+    <Dialog
+      isOpen={open}
+      title={
+        <span>
+          Edit <Mono>{concurrencyKey}</Mono>
+        </span>
+      }
+      onClose={onClose}
+    >
       <DialogBody>
         <Box margin={{bottom: 4}}>{flagPoolUI ? 'Pool' : 'Concurrency key'}:</Box>
         <Box margin={{bottom: 16}}>


### PR DESCRIPTION
## Summary & Motivation

Split Concurrency page into tabs. This was previously done on Cloud and not here, but the virtualized concurrency key list doesn't work as desired in the single page view of all concurrency information.

<img width="825" alt="Screenshot 2025-02-07 at 10 39 31" src="https://github.com/user-attachments/assets/51f27aaf-a964-4a25-a973-8794a637d000" />

<img width="698" alt="Screenshot 2025-02-07 at 10 39 36" src="https://github.com/user-attachments/assets/4d222acc-5e60-46b1-9069-8072877cc1fa" />

## How I Tested These Changes

View Concurrency page. Verify that it is split into tabs, and that the tabs behave and render correctly. Verify that the concurrency key list is correctly virtualized, with batches of `SingleConcurrencyKeyQuery` requests appropriately sliced.

## Changelog

[ui] Fix excessive rendering and querying on Concurrency configuration page.
