### PR TITLE
[dagster-components] Ignore top-level files in the components dir

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -100,6 +100,10 @@ def build_component_defs(
 
     all_defs: list[Definitions] = []
     for component_path in components_root.iterdir():
+        if not component_path.is_dir():
+            # Skip non-directories
+            continue
+
         defs = build_defs_from_component_path(
             path=component_path,
             registry=registry,


### PR DESCRIPTION
## Summary

Ran into this adding a `README.md` to an empty components directory. Can scope this down to only ignore pattern-matched files (e.g. `.md`, no-filename files like `.gitignore` etc)

