### PR TITLE
[bk] re-enable examples tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -8,7 +8,10 @@ from dagster_buildkite.python_version import AvailablePythonVersion
 from dagster_buildkite.step_builder import CommandStepBuilder
 from dagster_buildkite.steps.helm import build_helm_steps
 from dagster_buildkite.steps.integration import build_integration_steps
-from dagster_buildkite.steps.packages import build_library_packages_steps
+from dagster_buildkite.steps.packages import (
+    build_example_packages_steps,
+    build_library_packages_steps,
+)
 from dagster_buildkite.steps.test_project import build_test_project_steps
 from dagster_buildkite.utils import (
     UV_PIN,
@@ -46,6 +49,8 @@ def build_dagster_steps() -> List[BuildkiteStep]:
     # instance, a directory of unrelated scripts counts as a package. All packages must have a
     # toxfile that defines the tests for that package.
     steps += build_library_packages_steps()
+
+    steps += build_example_packages_steps()
 
     steps += build_helm_steps()
     steps += build_sql_schema_check_steps()


### PR DESCRIPTION
## Summary

These were being run as part of the legacy docs test suite, which was dropped in #27627