### PR TITLE
Document our dagster+ IP addresses

### DIFF
--- a/docs/docs/dagster-plus/deployment/deployment-types/serverless/dagster-ips.md
+++ b/docs/docs/dagster-plus/deployment/deployment-types/serverless/dagster-ips.md
@@ -24,4 +24,6 @@ Serverless code will make requests from one of the following IP addresses. You m
 54.71.18.84
 ```
 
-**Note**: Additional IP addresses may be added over time. This list was last updated on **October 24, 2024**.
+:::note
+Additional IP addresses may be added over time. This list was last updated on **October 24, 2024**.
+:::

--- a/docs/docs/dagster-plus/deployment/management/dagster-ips.md
+++ b/docs/docs/dagster-plus/deployment/management/dagster-ips.md
@@ -19,4 +19,6 @@ The Dagster+ agent interacts with the following IP addresses:
 54.188.126.120
 ```
 
-**Note**: Additional IP addresses may be added over time. This list was last updated on **February 7, 2025**.
+:::note
+Additional IP addresses may be added over time. This list was last updated on **February 7, 2025**.
+:::

--- a/docs/docs/dagster-plus/deployment/management/dagster-ips.md
+++ b/docs/docs/dagster-plus/deployment/management/dagster-ips.md
@@ -1,0 +1,22 @@
+---
+title: Dagster+ IP addresses
+sidebar_label: IP addresses
+sidebar_position: 400
+---
+
+The Dagster+ web interface, CLI, and GraphQL API use [AWS Cloudfront's content delivery network](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html).
+
+The Dagster+ agent interacts with the following IP addresses:
+
+```
+34.215.239.157
+35.165.239.109
+35.83.161.124
+44.236.154.129
+44.236.31.202
+44.239.93.251
+54.185.29.42
+54.188.126.120
+```
+
+**Note**: Additional IP addresses may be added over time. This list was last updated on **February 7, 2025**.


### PR DESCRIPTION
We already did this once before as a statuspage update:

https://dagstercloud.statuspage.io/incidents/qgrszl3p61b7

We get asked from time to time and these don't really change that often so let's stick them in a doc for now. Similar to how we treat our Serverless IPs.