### PR TITLE
Ignore vale failures

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -23,6 +23,7 @@ jobs:
   vale:
     name: runner / vale
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog

--- a/docs/docs/touch.md
+++ b/docs/docs/touch.md
@@ -1,0 +1,5 @@
+---
+unlisted: true
+---
+
+Just a temporary file to kick off the docs build and see if Vale is still considered blocking or not. I'll revert afterward.

--- a/docs/docs/touch.md
+++ b/docs/docs/touch.md
@@ -1,5 +1,0 @@
----
-unlisted: true
----
-
-Just a temporary file to kick off the docs build and see if Vale is still considered blocking or not. I'll revert afterward.


### PR DESCRIPTION
My understanding of this doc step is that we eventually want to use it, but we consider it non-blocking on docs PRs today?

In that case, should we tell GitHub Actions that it's okay for this step to fail? I think that'll prevent all of our docs PRs from having a big red failure status. Thoughts?