### PR TITLE
[docs] Delete experimental and experimental_param annotations in Sphinx

### DIFF
--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -6,16 +6,12 @@ from dagster._annotations import (
     get_beta_params,
     get_deprecated_info,
     get_deprecated_params,
-    get_experimental_info,
-    get_experimental_params,
     get_preview_info,
     get_superseded_info,
     has_beta_params,
     has_deprecated_params,
-    has_experimental_params,
     is_beta,
     is_deprecated,
-    is_experimental,
     is_preview,
     is_public,
     is_superseded,
@@ -160,14 +156,6 @@ def process_docstring(
 
     if has_deprecated_params(obj):
         params = get_deprecated_params(obj)
-        for param, info in params.items():
-            inject_param_flag(lines, param, info)
-
-    if is_experimental(obj):
-        inject_object_flag(obj, get_experimental_info(obj), lines)
-
-    if has_experimental_params(obj):
-        params = get_experimental_params(obj)
         for param, info in params.items():
             inject_param_flag(lines, param, info)
 

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
@@ -3,13 +3,7 @@ from typing import Union
 
 import dagster._check as check
 import docutils.nodes as nodes
-from dagster._annotations import (
-    BetaInfo,
-    DeprecatedInfo,
-    ExperimentalInfo,
-    PreviewInfo,
-    SupersededInfo,
-)
+from dagster._annotations import BetaInfo, DeprecatedInfo, PreviewInfo, SupersededInfo
 from sphinx.util.docutils import SphinxDirective
 
 # ########################
@@ -21,19 +15,13 @@ from sphinx.util.docutils import SphinxDirective
 
 def inject_object_flag(
     obj: object,
-    info: Union[SupersededInfo, DeprecatedInfo, ExperimentalInfo, PreviewInfo, BetaInfo],
+    info: Union[SupersededInfo, DeprecatedInfo, PreviewInfo, BetaInfo],
     docstring: list[str],
 ) -> None:
     if isinstance(info, DeprecatedInfo):
         additional_text = f" {info.additional_warn_text}." if info.additional_warn_text else ""
         flag_type = "deprecated"
         message = f"This API will be removed in version {info.breaking_version}.\n{additional_text}"
-    elif isinstance(info, ExperimentalInfo):
-        additional_text = f" {info.additional_warn_text}." if info.additional_warn_text else ""
-        flag_type = "experimental"
-        message = (
-            f"This API may break in future versions, even between dot releases.\n{additional_text}"
-        )
     elif isinstance(info, SupersededInfo):
         additional_text = f" {info.additional_warn_text}." if info.additional_warn_text else ""
         flag_type = "superseded"
@@ -61,19 +49,13 @@ def inject_object_flag(
 def inject_param_flag(
     lines: list[str],
     param: str,
-    info: Union[BetaInfo, DeprecatedInfo, ExperimentalInfo],
+    info: Union[BetaInfo, DeprecatedInfo],
 ):
     additional_text = f" {info.additional_warn_text}" if info.additional_warn_text else ""
     if isinstance(info, DeprecatedInfo):
         flag = ":inline-flag:`deprecated`"
         message = (
             f"(This parameter will be removed in version {info.breaking_version}.{additional_text})"
-        )
-    elif isinstance(info, ExperimentalInfo):
-        flag = ":inline-flag:`experimental`"
-        message = (
-            "(This parameter may break in future versions, even between dot"
-            f" releases.{additional_text})"
         )
     elif isinstance(info, BetaInfo):
         flag = ":inline-flag:`beta`"

--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -1007,8 +1007,6 @@ class MdxTranslator(SphinxTranslator):
     def _flag_to_level(self, flag_type: str) -> str:
         """Maps flag type to style that will be using in CSS and admonitions."""
         level = "info"
-        if flag_type == "experimental":
-            level = "warning"
         if flag_type == "preview":
             level = "warning"
         if flag_type == "beta":


### PR DESCRIPTION
## Summary & Motivation

As title - the experimental language doesn't exist anymore with the new API lifecycle stages.