### PR TITLE
Fix current_time not being passed through in IdentityPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -162,7 +162,8 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         upstream_partition_keys = set(upstream_partitions_subset.get_partition_keys())
         downstream_partition_keys = set(
             downstream_partitions_def.get_partition_keys(
-                dynamic_partitions_store=dynamic_partitions_store
+                current_time=current_time,
+                dynamic_partitions_store=dynamic_partitions_store,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -9,9 +9,11 @@ from dagster import (
     AssetIn,
     AssetMaterialization,
     AssetsDefinition,
+    DagsterInstance,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     DailyPartitionsDefinition,
+    Definitions,
     IdentityPartitionMapping,
     IOManager,
     IOManagerDefinition,
@@ -32,11 +34,12 @@ from dagster import (
     materialize,
     op,
 )
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
     DynamicPartitionsDefinition,
@@ -50,6 +53,7 @@ from dagster._core.definitions.partition_mapping import (
 )
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.test_utils import assert_namedtuple_lists_equal
+from dagster._time import create_datetime
 
 
 def test_access_partition_keys_from_context_non_identity_partition_mapping():
@@ -177,6 +181,41 @@ def test_from_graph():
         resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
         partition_key="a",
     ).success
+
+
+def test_identity_mapping_between_time_window_partitions():
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2025-02-01", end_offset=1))
+    def asset1():
+        pass
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition(start_date="2025-02-01", end_offset=0),
+        ins={"asset1": AssetIn(partition_mapping=IdentityPartitionMapping())},
+    )
+    def asset2(asset1):
+        pass
+
+    defs = Definitions(assets=[asset1, asset2])
+
+    with DagsterInstance.ephemeral() as instance:
+        asset_graph_view = AssetGraphView.for_test(
+            defs, instance, effective_dt=create_datetime(2025, 2, 6)
+        )
+
+        # at midnight on 2025-02-06, 2025-02-06 exists on parent asset but not on child asset
+        parent_subset = asset_graph_view.get_asset_subset_from_asset_partitions(
+            asset1.key,
+            {
+                AssetKeyPartitionKey(asset1.key, "2025-02-05"),
+                AssetKeyPartitionKey(asset1.key, "2025-02-06"),
+            },
+        )
+
+        child_subset = asset_graph_view.compute_child_subset(asset2.key, parent_subset)
+
+        assert child_subset.expensively_compute_asset_partitions() == {
+            AssetKeyPartitionKey(asset2.key, "2025-02-05"),
+        }
 
 
 def test_non_partitioned_depends_on_last_partition():

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
@@ -163,13 +163,13 @@ def test_observable_asset_defs() -> None:
         (
             HourlyPartitionsDefinition("2020-01-01-00:00"),
             StaticPartitionsDefinition(
-                ["2020-01-02-00:00", "2020-01-03-00:00", "2020-01-04-00:00"]
+                ["2020-01-01-01:00", "2020-01-01-04:00", "2020-01-01-08:00"]
             ),
             3,
         ),
         (
             HourlyPartitionsDefinition("2020-01-01-00:00"),
-            StaticPartitionsDefinition(["2019-01-02-00:00", "a", "2020-01-02-00:00"]),
+            StaticPartitionsDefinition(["2019-01-01-08:00", "a", "2020-01-01-16:00"]),
             1,
         ),
         (


### PR DESCRIPTION
Summary:
Only needed in cases like the one in the added test, but could produce an invalid subset before.

## How I Tested These Changes
BK (new test)

## Changelog
NOCHANGELOG
