### PR TITLE
[docs] use beta partial in metadata-and-tags/index.md

### DIFF
--- a/docs/docs/guides/build/assets/metadata-and-tags/index.md
+++ b/docs/docs/guides/build/assets/metadata-and-tags/index.md
@@ -117,9 +117,9 @@ Dagster+ provides rich visualization and navigation of column lineage in the Ass
 
 ## Linking assets with source code \{#source-code}
 
-import Experimental from '../../../../partials/\_Experimental.md';
+import Beta from '../../../../partials/\_Beta.md';
 
-<Experimental />
+<Beta />
 
 
 To link assets with their source code, you can attach a code reference. Code references are a type of metadata that allow you to easily view those assets' source code from the Dagster UI, both in local development and in production.


### PR DESCRIPTION
## Summary & Motivation

As title - the correct flag for this feature is beta, and this is the last place where the experimental partial is used.
