### PR TITLE
[ui] Fix crash when a partition definitions has boolean partition keys

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -30,6 +30,7 @@ import {
   AssetViewDefinitionQuery,
   AssetViewDefinitionQueryVariables,
 } from './types/AssetView.types';
+import {useAssetViewParams} from './useAssetViewParams';
 import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 import {useReportEventsDialog} from './useReportEventsDialog';
@@ -47,7 +48,6 @@ import {
 } from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
-import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
@@ -59,7 +59,7 @@ interface Props {
 }
 
 export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPath}: Props) => {
-  const [params, setParams] = useQueryPersistedState<AssetViewParams>({});
+  const [params, setParams] = useAssetViewParams();
   const {useTabBuilder, renderFeatureView} = useContext(AssetFeatureContext);
 
   // Load the asset definition

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
@@ -8,12 +8,12 @@ import {AssetGlobalLineageLink, AssetPageHeader} from 'shared/assets/AssetPageHe
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
-import {AssetKey, AssetViewParams} from './types';
+import {AssetKey} from './types';
 import {gql} from '../apollo-client';
+import {useAssetViewParams} from './useAssetViewParams';
 import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
 export const AssetsOverviewRoot = ({
@@ -28,7 +28,8 @@ export const AssetsOverviewRoot = ({
   useTrackPageView();
 
   const params = useParams();
-  const [searchParams] = useQueryPersistedState<AssetViewParams>({});
+  const [searchParams] = useAssetViewParams();
+
   const history = useHistory();
 
   const currentPathStr = (params as any)['0'];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -782,8 +782,8 @@ const PartitionSelectionNotice = ({
 }) => {
   return (
     <Box padding={{horizontal: 16, top: 16, bottom: 8}} style={{position: 'relative'}} border="top">
-      <Alert intent="info" title={<Box style={{marginRight: 100, minHeight: 24}}>{text}</Box>} />
-      <div style={{position: 'absolute', top: 24, right: 24, zIndex: 4}}>
+      <Alert intent="info" title={<Box style={{marginRight: 100}}>{text}</Box>} />
+      <div style={{position: 'absolute', top: 20, right: 24, zIndex: 4}}>
         <Button
           data-testid={testId('backfill-preview-button')}
           intent="none"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAssetViewParams.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAssetViewParams.test.tsx
@@ -1,0 +1,47 @@
+import {renderHook} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+
+import {useAssetViewParams} from '../useAssetViewParams';
+
+describe('useAssetViewParams', () => {
+  it('supports boolean partition names', () => {
+    const {result} = renderHook(() => useAssetViewParams(), {
+      wrapper: ({children}) => (
+        <MemoryRouter
+          initialEntries={[
+            '/assets/boolean_partitioned?view=partitions&partition=true&status=MATERIALIZED%2CMATERIALIZING%2CMISSING',
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    expect(result.current[0]).toEqual({
+      partition: 'true',
+      status: 'MATERIALIZED,MATERIALIZING,MISSING',
+      view: 'partitions',
+    });
+  });
+
+  it('provides numeric lineage depth and showAllEvents using the correct data types', () => {
+    const {result} = renderHook(() => useAssetViewParams(), {
+      wrapper: ({children}) => (
+        <MemoryRouter
+          initialEntries={[
+            '/assets/boolean_partitioned?showAllEvents=true&view=lineage&lineageDepth=2&lineageScope=downstream',
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    expect(result.current[0]).toEqual({
+      lineageDepth: 2,
+      lineageScope: 'downstream',
+      showAllEvents: true,
+      view: 'lineage',
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetViewParams.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetViewParams.tsx
@@ -1,0 +1,18 @@
+import {AssetViewParams} from './types';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+
+export const decode = ({lineageDepth, showAllEvents, ...rest}: {[key: string]: any}) => {
+  const result: AssetViewParams = {...rest};
+  if (lineageDepth !== undefined) {
+    result.lineageDepth = Number(lineageDepth);
+  }
+  if (showAllEvents !== undefined) {
+    result.showAllEvents =
+      showAllEvents === 'true' ? true : showAllEvents === 'false' ? false : undefined;
+  }
+  return result;
+};
+
+export const useAssetViewParams = () => {
+  return useQueryPersistedState<AssetViewParams>({decode});
+};


### PR DESCRIPTION
## Summary & Motivation

If you don't provide useQueryPersistedState with a `decode` method, our default coerces boolean and number types (so it's easier to say `useQueryPersistedState<boolean>({queryKey: "enabled"})`).  It looks like the only place in the app we pass a partition as a clean query param is in `useAssetViewParams` and this was the source of the crash. Putting a custom decoder on here resolves the issue.

https://linear.app/dagster-labs/issue/FE-750/bug-error-tpartitionsplit-is-not-a-function-when-viewing

Fixes https://github.com/dagster-io/dagster/issues/26793

## How I Tested These Changes

I set up this asset and made sure I can view, launch, poke around through all the asset pages, etc. following the changes here. Also wrote new tests!

```
static_partitions_booleans = StaticPartitionsDefinition(["true", "false"])

@asset(partitions_def=static_partitions_booleans)
def boolean_partitioned(context):
    yield Output(value=1, output_name="result", metadata={"num_rows": 50})
```

## Changelog

- [ui] Fixed crash in the Dagster UI when a partition definitions has boolean partition keys
