### PR TITLE
[components] Wrap all resolver/schema mapping interactions in functions

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -28,7 +28,7 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffolderUnavailableReason,
     DefaultComponentScaffolder,
 )
-from dagster_components.core.schema.base import ComponentSchema
+from dagster_components.core.schema.base import ComponentSchema, get_resolver_type_of_schema
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.utils import load_module_from_path
 
@@ -266,7 +266,8 @@ class ComponentLoadContext:
         return dataclasses.replace(self, decl_node=decl_node)
 
     def resolve(self, value: ComponentSchema, as_type: type[T]) -> T:
-        return value.__dagster_resolver__(value).resolve_as(as_type, self.resolution_context)
+        resolver_type = get_resolver_type_of_schema(type(value))
+        return resolver_type(value).resolve_as(as_type, self.resolution_context)
 
     def resolve_value(self, value: Any) -> Any:
         return self.resolution_context.resolve_value(value)

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -97,6 +97,16 @@ class ComponentSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+def set_resolver_type_of_schema(
+    schema_type: type[ComponentSchema], resolver_type: type[Resolver]
+) -> None:
+    schema_type.__dagster_resolver__ = resolver_type
+
+
+def get_resolver_type_of_schema(schema_type: type[ComponentSchema]) -> type[Resolver]:
+    return schema_type.__dagster_resolver__ or Resolver
+
+
 def resolver(
     *,
     fromtype: type[ComponentSchema],
@@ -107,7 +117,7 @@ def resolver(
         resolver_type.__resolver_data__ = _ResolverData(
             resolved_type=totype, exclude_fields=exclude_fields or set()
         )
-        fromtype.__dagster_resolver__ = resolver_type
+        set_resolver_type_of_schema(fromtype, resolver_type)
         return resolver_type
 
     return inner

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -92,7 +92,7 @@ class Resolver(Generic[T_ComponentSchema]):
 
 
 class ComponentSchema(BaseModel):
-    __dagster_resolver__: ClassVar[type[Resolver]] = Resolver
+    __dagster_resolver__: ClassVar[Optional[type[Resolver]]] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/context.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/context.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._record import record
 from jinja2.nativetypes import NativeTemplate
 
-from dagster_components.core.schema.base import ComponentSchema
+from dagster_components.core.schema.base import ComponentSchema, get_resolver_type_of_schema
 
 T = TypeVar("T")
 
@@ -43,7 +43,8 @@ class ResolutionContext:
     def _resolve_inner_value(self, val: Any) -> Any:
         """Resolves a single value, if it is a templated string."""
         if isinstance(val, ComponentSchema):
-            resolver = val.__dagster_resolver__(val)
+            resolver_type = get_resolver_type_of_schema(type(val))
+            resolver = resolver_type(val)
             return resolver.resolve(self)
         elif isinstance(val, str):
             return NativeTemplate(val).render(**self.scope)


### PR DESCRIPTION
## Summary & Motivation

In order to make the resolution system and the schema system more decoupled, we are going to move the resolver type class var off of schema classes. That way schema classes can "standalone" as pydantic classes without dependencies on the entire resolution runtime.

This first step wraps all accesses of that class var in functions so we can swap their representation.

## How I Tested These Changes

BK

## Changelog

NOCHANGELONG