### PR TITLE
[docs] fix bug in Sphinx API doc build where text is truncate

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -15,11 +15,6 @@ install:
 	uv pip install -e _ext/dagster-sphinx
 	uv pip install -e _ext/sphinx-mdx-builder
 
-mdx_copy:
-	rm -rf ../docs/api/python-api/libraries
-	find ../docs/api/python-api/*.mdx ! -name index.mdx -exec rm {} +
-	cp -rf _build/mdx/sections/api/apidocs/* ../docs/api/python-api/
-	
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -137,7 +137,7 @@ def process_docstring(
     assert app.env is not None
 
     if has_attrs(lines):
-        record_error(f'Object {name} has "Attributes:" in docstring. Use "Args:" insetad.')
+        record_error(f'Object {name} has "Attributes:" in docstring. Use "Args:" instead.')
 
     if is_deprecated(obj):
         inject_object_flag(obj, get_deprecated_info(obj), lines)

--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -151,6 +151,7 @@ class MdxTranslator(SphinxTranslator):
         self.list_counter: list[int] = []
         self.in_literal = 0
         self.in_literal_block = 0
+        self.in_list_item = 0
         self.desc_count = 0
 
         self.max_line_width = self.config.mdx_max_line_width or 120
@@ -293,7 +294,9 @@ class MdxTranslator(SphinxTranslator):
                 do_format()
                 result.append((indent + itemindent, item))  # type: ignore[arg-type]
                 toformat = []
+
         do_format()
+
         if first is not None and result:
             # insert prefix into first line (ex. *, [1], See also, etc.)
             newindent = result[0][0] - indent
@@ -317,7 +320,6 @@ class MdxTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_Text(self, node: nodes.Text) -> None:
-        # print("->", type(node.parent), node.parent)
         if isinstance(node.parent, nodes.reference):
             return
 
@@ -331,8 +333,19 @@ class MdxTranslator(SphinxTranslator):
         if "This parameter will be removed" in content:
             return
 
+        # Prevents wrapped lines in list items, for example in parameter descriptions:
+        #
+        # Args:
+        #     group_name (Optional[str], optional): The name of the asset group.
+        #     dagster_airbyte_translator (Optional[DagsterAirbyteTranslator], optional): The translator to use
+        #         to convert Airbyte content into :py:class:`dagster.AssetSpec`.
+        #         Defaults to :py:class:`DagsterAirbyteTranslator`.
+        if self.in_list_item:
+            content = content.replace("\n", " ")
+
         if self.in_literal and not self.in_literal_block:
-            content = node.astext().replace("<", "\\<").replace("{", "\\{")
+            content = content.replace("<", "\\<").replace("{", "\\{")
+
         self.add_text(content)
 
     def depart_Text(self, node: Element) -> None:
@@ -723,6 +736,8 @@ class MdxTranslator(SphinxTranslator):
         pass
 
     def visit_list_item(self, node: Element) -> None:
+        self.in_list_item += 1
+
         if self.list_counter[-1] == -1:
             self.new_state(2)
             # bullet list
@@ -735,6 +750,7 @@ class MdxTranslator(SphinxTranslator):
             self.new_state(len(str(self.list_counter[-1])) + 2)
 
     def depart_list_item(self, node: Element) -> None:
+        self.in_list_item -= 1
         if self.list_counter[-1] == -1:
             self.end_state(first="- ", wrap=False)
             self.states[-1].pop()


### PR DESCRIPTION
## Summary & Motivation

Resolves DOC-653

*Before:*
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/f55f3ad8-1a9a-490c-a7a9-31194c13ca4e" />

*After*
<img width="985" alt="image" src="https://github.com/user-attachments/assets/21085b0e-5ce3-426b-a694-ac4a39fad1af" />

## How I Tested These Changes

`yarn start`

## Changelog

- [docs] Fixed bug where API docs were truncating doc strings for function parameters
