### PR TITLE
[cli-refactor] Clean up schedule/sensor CLI args

### DIFF
--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -148,6 +148,7 @@ def test_schedules_restart(gen_schedule_args):
                 schedule_start_command,
                 cli_args + ["foo_schedule"],
             )
+            assert result.exit_code == 0
 
             result = runner.invoke(
                 schedule_restart_command,


### PR DESCRIPTION
## Summary & Motivation

The schedule and sensor CLI groups both were using an unnecessarily complex scheme where schedule/sensor names were passed as a list but at most one could be used at a time. This was a hack to achieve an optional sensor/schedule argument.

This PR simplifies it to use the `required` field of `click.argument` without changing behavior. It also adds type annotations to the schedule/sensor CLI.

## How I Tested These Changes

Existing test suite.