### PR TITLE
[ui] Add Latest Execution and Description to Execution History table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailDialog.tsx
@@ -7,8 +7,10 @@ import {
   DialogBody,
   DialogFooter,
   FontFamily,
+  Icon,
   Mono,
   NonIdealState,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
 
@@ -17,18 +19,30 @@ import {MetadataEntries} from '../../metadata/MetadataEntry';
 import {METADATA_ENTRY_FRAGMENT} from '../../metadata/MetadataEntryFragment';
 import {MetadataEntryFragment} from '../../metadata/types/MetadataEntryFragment.types';
 
-export function MetadataCell({metadataEntries}: {metadataEntries?: MetadataEntryFragment[]}) {
+export function MetadataCell({
+  metadataEntries,
+  type,
+}: {
+  type: 'inline-or-dialog' | 'dialog';
+  metadataEntries?: MetadataEntryFragment[];
+}) {
   const [showMetadata, setShowMetadata] = useState(false);
 
   if (!metadataEntries || !metadataEntries.length) {
     return <span>{' - '}</span>;
   }
-  if (canShowMetadataInline(metadataEntries)) {
+  if (canShowMetadataInline(metadataEntries) && type === 'inline-or-dialog') {
     return <MetadataEntries entries={metadataEntries} />;
   }
   return (
     <div>
-      <Button onClick={() => setShowMetadata(true)}>View metadata</Button>
+      {type === 'inline-or-dialog' ? (
+        <Button onClick={() => setShowMetadata(true)}>View metadata</Button>
+      ) : (
+        <Tooltip content="View metadata">
+          <Button onClick={() => setShowMetadata(true)} icon={<Icon name="metadata" />} />
+        </Tooltip>
+      )}
       <Dialog
         title="Metadata"
         isOpen={showMetadata}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckExecutionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckExecutionList.tsx
@@ -1,7 +1,10 @@
 import {
   Box,
+  Colors,
   CursorHistoryControls,
   CursorPaginationProps,
+  Icon,
+  Popover,
   SpinnerWithText,
   Table,
 } from '@dagster-io/ui-components';
@@ -10,6 +13,7 @@ import {Link} from 'react-router-dom';
 import {MetadataCell} from './AssetCheckDetailDialog';
 import {AssetCheckStatusTag} from './AssetCheckStatusTag';
 import {AssetCheckDetailsQuery} from './types/AssetCheckDetailDialog.types';
+import {Description} from '../../pipelines/Description';
 import {linkToRunEvent} from '../../runs/RunUtils';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 
@@ -39,7 +43,24 @@ export const AssetCheckExecutionList = ({
               <th style={{width: '160px'}}>Evaluation result</th>
               <th style={{width: '200px'}}>Timestamp</th>
               <th style={{width: '200px'}}>Target materialization</th>
-              <th>Metadata</th>
+              <th>
+                <Box flex={{gap: 4}}>
+                  Description
+                  <PopoverToDocs
+                    href="https://docs.dagster.io/_apidocs/asset-checks#dagster.AssetCheckResult.description"
+                    label="Learn how to add a description to asset checks"
+                  />
+                </Box>
+              </th>
+              <th style={{width: '100px'}}>
+                <Box flex={{gap: 4}}>
+                  Metadata
+                  <PopoverToDocs
+                    href="https://docs.dagster.io/concepts/assets/asset-checks/define-execute-asset-checks#adding-metadata"
+                    label="Learn how to add metadata to asset checks"
+                  />
+                </Box>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -75,7 +96,17 @@ export const AssetCheckExecutionList = ({
                     )}
                   </td>
                   <td>
-                    <MetadataCell metadataEntries={execution.evaluation?.metadataEntries} />
+                    {execution.evaluation?.description ? (
+                      <Description fontSize="14px" description={execution.evaluation.description} />
+                    ) : (
+                      ' - '
+                    )}
+                  </td>
+                  <td style={{textAlign: 'right'}}>
+                    <MetadataCell
+                      metadataEntries={execution.evaluation?.metadataEntries}
+                      type="dialog"
+                    />
                   </td>
                 </tr>
               );
@@ -89,3 +120,25 @@ export const AssetCheckExecutionList = ({
     </Box>
   );
 };
+
+const PopoverToDocs = ({href, label}: {href: string; label: string}) => (
+  <Popover
+    position="top"
+    interactionKind="hover"
+    content={
+      <a target="_blank" href={href} rel="noreferrer">
+        <Box
+          padding={8}
+          flex={{direction: 'row', gap: 4, alignItems: 'center'}}
+          style={{whiteSpace: 'nowrap'}}
+        >
+          {label}
+          <Icon name="open_in_new" color={Colors.linkDefault()} />
+        </Box>
+      </a>
+    }
+    hoverOpenDelay={100}
+  >
+    <Icon name="info" color={Colors.accentGray()} />
+  </Popover>
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dagster-io/ui-components';
 import {RowProps} from '@dagster-io/ui-components/src/components/VirtualizedTable';
 import {useVirtualizer} from '@tanstack/react-virtual';
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 
 import {AssetCheckAutomationList} from './AssetCheckAutomationList';
@@ -108,7 +108,6 @@ export const AssetChecks = ({
   const {paginationProps, executions, executionsLoading} = useHistoricalCheckExecutions(
     selectedCheck ? {assetKey, checkName: selectedCheck.name} : null,
   );
-  const pastExecutions = useMemo(() => executions.slice(1), [executions]);
 
   if (!data) {
     return null;
@@ -258,10 +257,7 @@ export const AssetChecks = ({
             />
           ) : null}
           {activeTab === 'execution-history' ? (
-            <AssetCheckExecutionList
-              executions={pastExecutions}
-              paginationProps={paginationProps}
-            />
+            <AssetCheckExecutionList executions={executions} paginationProps={paginationProps} />
           ) : null}
           {activeTab === 'automation-history' ? (
             <AssetCheckAutomationList assetCheck={selectedCheck} checkName={selectedCheck.name} />
@@ -327,6 +323,7 @@ const CheckRow = styled(Row)<{$selected: boolean} & RowProps>`
   padding: 5px 8px 5px 12px;
   cursor: pointer;
   border-radius: 8px;
+  user-select: none;
   &:hover {
     background: ${Colors.backgroundLightHover()};
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -104,7 +104,10 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
           )}
         </RowCell>
         <RowCell>
-          <MetadataCell metadataEntries={execution?.evaluation?.metadataEntries} />
+          <MetadataCell
+            metadataEntries={execution?.evaluation?.metadataEntries}
+            type="inline-or-dialog"
+          />
         </RowCell>
         <RowCell>
           <Box flex={{justifyContent: 'flex-end'}}>

--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -35,10 +35,19 @@ def checked_asset():
 @asset_check(asset=checked_asset, description="A check that fails half the time.")
 def random_fail_check(checked_asset):
     random.seed(time.time())
-    return AssetCheckResult(
-        passed=random.choice([False, True]),
-        metadata={"timestamp": MetadataValue.float(time.time())},
-    )
+    passed = random.choice([False, True])
+    if passed:
+        return AssetCheckResult(
+            passed=True,
+            description="Data quality check passed with zero null values detected in critical columns.",
+            metadata={"timestamp": MetadataValue.float(time.time())},
+        )
+    else:
+        return AssetCheckResult(
+            passed=False,
+            description="Data quality check failed - check the column schema!",
+            metadata={"timestamp": MetadataValue.float(time.time())},
+        )
 
 
 @asset_check(
@@ -330,6 +339,7 @@ def graph_multi_asset_check_3(staged_asset):
     yield AssetCheckResult(
         asset_key="graph_multi_asset_one",
         check_name="check_3",
+        description="This check failed, and here's a link to more information in our internal system: https://www.test.com/should-be-clickable-in-ui",
         passed=False,
         severity=AssetCheckSeverity.WARN,
         metadata={"sample": "metadata"},
@@ -340,6 +350,7 @@ def graph_multi_asset_check_3(staged_asset):
 def graph_multi_asset_2_check_1(staged_asset):
     result = AssetCheckResult(
         asset_key="graph_multi_asset_two",
+        description=f"Data quality check failed - {random.randint(1, 10)!s} null values detected in critical columns.",
         check_name="check_1",
         passed=False,
         metadata={"sample": "metadata"},


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-569/add-latest-execution-and-description-to-execution-history-table

Figma: https://www.figma.com/design/irNgXWVRRcoNAItvtPaqOS/Dagster-UI-2024-Q3?node-id=779-2017&t=aCrjpJ4t82kw7CG6-0

<img width="1400" alt="image" src="https://github.com/user-attachments/assets/c8fc24d1-2621-40f9-8509-169eacbf6e09" />


## How I Tested These Changes

- I tested these changes using the asset checks repo in `toys`. I updated the checks to emit descriptions, including a description with a link that validates the rendering is markdown.

## Changelog

[ui] The latest asset check evaluation is shown in the Evaluation History tab, and `AssetCheckResult` descriptions are rendered in the table making it easier to publish a summary of check evaluation.