### PR TITLE
[ui] Show the Materialize button faster when loading asset pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -308,7 +308,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
         }
         right={
           <Box style={{margin: '-4px 0'}} flex={{direction: 'row', gap: 8}}>
-            {cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 && upstream ? (
+            {cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 ? (
               <LaunchAssetExecutionButton
                 scope={{all: [cachedOrLiveDefinition]}}
                 showChangedAndMissingOption={false}


### PR DESCRIPTION
Related: 
https://linear.app/dagster-labs/issue/FE-775/why-does-the-materialize-button-take-so-long-to-appear
https://dagsterlabs.slack.com/archives/C03CCE471E0/p1738864658944059

Josh observed recently that the Materialize button takes a long time to appear on asset pages - it appears /after/ all of the overview content loads and after all the queries are finished, which is very odd.

There are two things going on:

We were waiting to show the button until we identified the `upstream` assets. This line was added long ago in https://github.com/dagster-io/dagster/pull/8143/files#diff-4364c6a0e68584bc05e5254172348b3bbee4dcf46dcf4c667ecdc10c915a7447R148, when we were passing the upstream assets into the button for one of the pre-flight checks that is run when you click Materialize. We stopped requiring that prop a long time ago - it’s retrieved when you click Materialize now. 

Removing `upstream` fixes the issue, but doesn't answer why this `upstream` data takes so long to load.

The data is slow to arrive because it's being throttled by this code in `useAssetGraphData.tsx`. Because this throttled function is defined at the top level in the file and not within the hook, it's a global thing. Navigating between two pages that both use `useAssetGraphData` results in 2s of throttling:

```
const computeGraphData = throttleLatest(
  indexedDBAsyncMemoize<
    Omit<ComputeGraphDataMessageType, 'id' | 'type'>,
    GraphDataState,
    typeof computeGraphDataWrapper
  >(computeGraphDataWrapper, (props) => {
    return JSON.stringify(props);
  }),
  2000,
);

```

I fixed this by moving the throttled version of  `computeGraphData`  inside `useAssetGraphData` so that the throttling is for the unique copy of the `useAssetGraphData` hook.  

I also observed that there is often throttling when the data arrives, because `computeGraphData` is called with "undefined" graph nodes then called again when the graph nodes load (screenshot below of the params passed in). I moved an early return from the very top of `computeGraphData` so that we skip the first call when there is no data to compute (and the first call is the one with data and is not throttled.)

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/b5de9a40-e617-4ff4-b040-dbbdca221bee" />

With these two changes, you can click from the Asset Catalog into an asset, and then use the back/forward buttons to flip between these two pages without seeing a 2s delay on the single-asset view.

## Changelog

[ui] The Materialize button appears more quickly on asset pages in the Dagster UI