### PR TITLE
[dagster-postgres] Fix QueuePool overflow

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -43,6 +43,7 @@ class Webserver(BaseModel, extra="forbid"):
     enableReadOnly: bool
     dbStatementTimeout: Optional[int] = None
     dbPoolRecycle: Optional[int] = None
+    dbPoolMaxOverflow: Optional[int] = None
     logLevel: Optional[str] = None
     schedulerName: Optional[str] = None
     volumeMounts: Optional[list[kubernetes.VolumeMount]] = None

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -300,6 +300,18 @@ def test_webserver_db_pool_recycle(deployment_template: HelmTemplate):
     assert f"--db-pool-recycle {pool_recycle_s}" in command
 
 
+def test_webserver_db_pool_max_overflow(deployment_template: HelmTemplate):
+    pool_max_overflow_s = 30
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(dbPoolMaxOverflow=pool_max_overflow_s)
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--db-pool-max-overflow {pool_max_overflow_s}" in command
+
+
 def test_webserver_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -51,6 +51,7 @@ If release name contains chart name it will be used as a full name.
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
+{{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3402,6 +3402,18 @@
                     "default": null,
                     "title": "Dbpoolrecycle"
                 },
+                "dbPoolMaxOverflow": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dbpoolmaxoverflow"
+                },
                 "logLevel": {
                     "anyOf": [
                         {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -80,6 +80,9 @@ dagsterWebserver:
   # Set to -1 to disable.
   dbPoolRecycle: ~
 
+  # The maximum overflow size of the sqlalchemy pool. Set to -1 to disable.
+  dbPoolMaxOverflow: ~
+
   # The log level of the uvicorn web server, defaults to warning if not set
   logLevel: ~
 

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -41,6 +41,7 @@ DEFAULT_WEBSERVER_PORT = 3000
 
 DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
 DEFAULT_POOL_RECYCLE = 3600  # 1 hr
+DEFAULT_POOL_MAX_OVERFLOW = 20
 
 
 @click.command(
@@ -121,6 +122,16 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     show_default=True,
 )
 @click.option(
+    "--db-pool-max-overflow",
+    help=(
+        "The maximum overflow size of the sqlalchemy pool. Set to -1 to disable."
+        "Not respected in all configurations."
+    ),
+    default=DEFAULT_POOL_MAX_OVERFLOW,
+    type=click.INT,
+    show_default=True,
+)
+@click.option(
     "--read-only",
     help=(
         "Start server in read-only mode, where all mutations such as launching runs and "
@@ -187,6 +198,7 @@ def dagster_webserver(
     path_prefix: str,
     db_statement_timeout: int,
     db_pool_recycle: int,
+    db_pool_max_overflow: int,
     read_only: bool,
     suppress_warnings: bool,
     uvicorn_log_level: str,
@@ -215,7 +227,7 @@ def dagster_webserver(
         logger=logger,
     ) as instance:
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle)
+        instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle, db_pool_max_overflow)
 
         with get_workspace_process_context_from_kwargs(
             instance,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1008,16 +1008,24 @@ class DagsterInstance(DynamicPartitionsStore):
             self._schedule_storage.upgrade()  # type: ignore  # (possible none)
             self._schedule_storage.migrate(print_fn)  # type: ignore  # (possible none)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         if self._schedule_storage:
             self._schedule_storage.optimize_for_webserver(
-                statement_timeout=statement_timeout, pool_recycle=pool_recycle
+                statement_timeout=statement_timeout,
+                pool_recycle=pool_recycle,
+                max_overflow=max_overflow,
             )
         self._run_storage.optimize_for_webserver(
-            statement_timeout=statement_timeout, pool_recycle=pool_recycle
+            statement_timeout=statement_timeout,
+            pool_recycle=pool_recycle,
+            max_overflow=max_overflow,
         )
         self._event_storage.optimize_for_webserver(
-            statement_timeout=statement_timeout, pool_recycle=pool_recycle
+            statement_timeout=statement_timeout,
+            pool_recycle=pool_recycle,
+            max_overflow=max_overflow,
         )
 
     def reindex(self, print_fn: PrintFn = lambda _: None) -> None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -314,7 +314,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def dispose(self) -> None:
         """Explicit lifecycle management."""
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -302,8 +302,12 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def dispose(self) -> None:
         return self._storage.run_storage.dispose()
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        return self._storage.run_storage.optimize_for_webserver(statement_timeout, pool_recycle)
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
+        return self._storage.run_storage.optimize_for_webserver(
+            statement_timeout, pool_recycle, max_overflow
+        )
 
     def add_daemon_heartbeat(self, daemon_heartbeat: "DaemonHeartbeat") -> None:
         return self._storage.run_storage.add_daemon_heartbeat(daemon_heartbeat)
@@ -459,9 +463,13 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def dispose(self) -> None:
         return self._storage.event_log_storage.dispose()
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         return self._storage.event_log_storage.optimize_for_webserver(
-            statement_timeout, pool_recycle
+            statement_timeout,
+            pool_recycle,
+            max_overflow,
         )
 
     def get_event_records(
@@ -863,9 +871,13 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         return self._storage.schedule_storage.optimize(print_fn, force_rebuild_all)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         return self._storage.schedule_storage.optimize_for_webserver(
-            statement_timeout, pool_recycle
+            statement_timeout,
+            pool_recycle,
+            max_overflow,
         )
 
     def dispose(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -336,7 +336,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def dispose(self) -> None:
         """Explicit lifecycle management."""
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 
     # Daemon Heartbeat Storage

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -203,7 +203,9 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         """Call this method to run any optional data migrations for optimized reads."""
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 
     def alembic_version(self) -> Optional[AlembicVersion]:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -86,7 +86,9 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             SqlEventLogStorageMetadata.create_all(conn)
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -94,6 +96,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             isolation_level=mysql_isolation_level(),
             pool_size=1,
             pool_recycle=pool_recycle,
+            max_overflow=max_overflow,
         )
 
     def upgrade(self) -> None:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -89,7 +89,9 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             RunStorageSqlMetadata.create_all(conn)
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -97,6 +99,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             isolation_level=mysql_isolation_level(),
             pool_size=1,
             pool_recycle=pool_recycle,
+            max_overflow=max_overflow,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -87,7 +87,9 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -95,6 +97,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             isolation_level=mysql_isolation_level(),
             pool_size=1,
             pool_recycle=pool_recycle,
+            max_overflow=max_overflow,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -131,7 +131,9 @@ def test_statement_timeouts(conn_string):
     port = parse_result.port
 
     with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname, port))) as instance:
-        instance.optimize_for_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_webserver(
+            statement_timeout=500, pool_recycle=-1, max_overflow=20
+        )  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
@@ -7,7 +7,7 @@ from dagster_mysql.run_storage import MySQLRunStorage
 
 def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
     storage = MySQLRunStorage.create_clean_storage(conn_string)
-    storage.optimize_for_webserver(-1, pool_recycle=pool_recycle)
+    storage.optimize_for_webserver(-1, pool_recycle=pool_recycle, max_overflow=20)
 
     with storage.connect() as conn:
         conn.execute(db.text("SET SESSION wait_timeout = 2;"))

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -112,12 +112,15 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
+            "max_overflow": max_overflow,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -108,12 +108,15 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 # This revision may be shared by any other dagster storage classes using the same DB
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
+            "max_overflow": max_overflow,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -104,12 +104,15 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
+    def optimize_for_webserver(
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+    ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
+            "max_overflow": max_overflow,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -197,7 +197,9 @@ def test_connection_leak(hostname, conn_string):
 
 def test_statement_timeouts(hostname):
     with instance_for_test(overrides=yaml.safe_load(full_pg_config(hostname))) as instance:
-        instance.optimize_for_webserver(statement_timeout=500, pool_recycle=-1)  # 500ms
+        instance.optimize_for_webserver(
+            statement_timeout=500, pool_recycle=-1, max_overflow=20
+        )  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()
@@ -309,7 +311,7 @@ def test_configured_other_schema(hostname):
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()
-        instance.optimize_for_webserver(statement_timeout=100, pool_recycle=100)
+        instance.optimize_for_webserver(statement_timeout=100, pool_recycle=100, max_overflow=20)
         instance.get_runs()
         instance.all_asset_keys()
         instance.all_instigator_state()


### PR DESCRIPTION
## Summary & Motivation

Aims to fix issue #26400 where the QueuePool used by PostgresEventLogStorage overflows when manually launching a materialisation of a big number of assets.

The root cause seems to be the graphql client in the webserver launching multiple queries to fetch/update status of the many assets. It causes a spike in connections which overflows the pool.

Both `PostgresRunStorage` and `PostgresScheduleStorage` share the same default pool config. I chose not to change anything as we didn't experience any issues with those.

## How I Tested These Changes

Vendored dagster-postgres into our Dagster project. Launching manual materializations of 2000+ assets works, despite being quite slow.

## Changelog

Removed the cap on PostgresEventLogStorage QueuePool by setting max_overflow to -1 (see SQLAlchemy [docs](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.max_overflow)).