### PR TITLE
[docs] Fix etl-pipeline-tutorial links

### DIFF
--- a/docs/docs/etl-pipeline-tutorial/create-and-materialize-a-downstream-asset.md
+++ b/docs/docs/etl-pipeline-tutorial/create-and-materialize-a-downstream-asset.md
@@ -40,4 +40,4 @@ As you can see, the new `joined_data` asset looks a lot like our previous ones, 
 
 ## Next steps
 
-- Continue this tutorial with by [creating and materializing a partitioned asset](ensure-data-quality-with-asset-checks).
+- Continue this tutorial with [ensuring data quality with asset checks](ensure-data-quality-with-asset-checks).

--- a/docs/docs/etl-pipeline-tutorial/ensure-data-quality-with-asset-checks.md
+++ b/docs/docs/etl-pipeline-tutorial/ensure-data-quality-with-asset-checks.md
@@ -49,4 +49,4 @@ Asset checks will run when an asset is materialized, but asset checks can also b
 
 ## Next steps
 
-- Continue this tutorial with [Asset Checks](create-and-materialize-partitioned-asset)
+- Continue this tutorial with [creating and materializing partitioned assets](create-and-materialize-partitioned-asset)


### PR DESCRIPTION
The text for these two links did not align with the page it took you to.