### PR TITLE
[components] Add --json flag for dg component-type list

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component_type.py
@@ -159,18 +159,44 @@ def _serialize_json_schema(schema: Mapping[str, Any]) -> str:
 
 
 @component_type_group.command(name="list", cls=DgClickCommand)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON instead of a table.",
+)
 @dg_global_options
 @click.pass_context
-def component_type_list(context: click.Context, **global_options: object) -> None:
+def component_type_list(
+    context: click.Context, output_json: bool, **global_options: object
+) -> None:
     """List registered Dagster components in the current code location environment."""
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 
-    table = Table(border_style="dim")
-    table.add_column("Component Type", style="bold cyan", no_wrap=True)
-    table.add_column("Summary")
-    for key in sorted(registry.global_keys(), key=lambda k: k.to_typename()):
-        table.add_row(key.to_typename(), registry.get_global(key).summary)
-    console = Console()
-    console.print(table)
+    sorted_keys = sorted(registry.global_keys(), key=lambda k: k.to_typename())
+
+    # JSON
+    if output_json:
+        output: list[dict[str, object]] = []
+        for key in sorted_keys:
+            component_type_metadata = registry.get_global(key)
+            output.append(
+                {
+                    "key": key.to_typename(),
+                    "summary": component_type_metadata.summary,
+                }
+            )
+        click.echo(json.dumps(output, indent=4))
+
+    # TABLE
+    else:
+        table = Table(border_style="dim")
+        table.add_column("Component Type", style="bold cyan", no_wrap=True)
+        table.add_column("Summary")
+        for key in sorted(registry.global_keys(), key=lambda k: k.to_typename()):
+            table.add_row(key.to_typename(), registry.get_global(key).summary)
+        console = Console()
+        console.print(table)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_component_type_commands.py
@@ -384,3 +384,34 @@ def test_component_type_list_with_no_dagster_components_fails() -> None:
         result = runner.invoke("component-type", "list", env={"PATH": "/dev/null"})
         assert_runner_result(result, exit_0=False)
         assert "Could not find the `dagster-components` executable" in result.output
+
+
+def test_component_type_list_json_succeeds():
+    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+        result = runner.invoke("component-type", "list", "--json")
+        assert_runner_result(result)
+        # strip the first line of logging output
+        output = "\n".join(result.output.split("\n")[1:])
+        assert (
+            output.strip()
+            == textwrap.dedent("""
+                [
+                    {
+                        "key": "all_metadata_empty_asset@dagster_components.test",
+                        "summary": null
+                    },
+                    {
+                        "key": "complex_schema_asset@dagster_components.test",
+                        "summary": "An asset that has a complex params schema."
+                    },
+                    {
+                        "key": "simple_asset@dagster_components.test",
+                        "summary": "A simple asset that returns a constant string value."
+                    },
+                    {
+                        "key": "simple_pipes_script_asset@dagster_components.test",
+                        "summary": "A simple asset that runs a Python script with the Pipes subprocess client."
+                    }
+                ]
+            """).strip()
+        )


### PR DESCRIPTION
## Summary & Motivation
Added a new `--json` flag to the `component-type list` command, allowing users to output component type information in JSON format instead of the default table view. This enables easier programmatic consumption of component type data.

## How I Tested These Changes

- Added a new test case `test_component_type_list_json_succeeds` that verifies the JSON output format