### PR TITLE
[ui] Fix link to deployment concurrency, stop modal from closing as runs arrive

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
@@ -33,7 +33,8 @@ type TagConcurrencyLimit = {
   limit: number;
 };
 
-interface DialogProps extends ContentProps {
+interface DialogProps {
+  run: Pick<RunFragment, 'id' | 'tags'> | undefined;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -49,7 +50,7 @@ export const QueuedRunCriteriaDialog = (props: DialogProps) => {
       onClose={onClose}
       style={{width: 700}}
     >
-      <QueuedRunCriteriaDialogContent run={run} />
+      {run ? <QueuedRunCriteriaDialogContent run={run} /> : undefined}
       <DialogFooter topBorder>
         <Button intent="primary" onClick={onClose}>
           Close
@@ -188,7 +189,7 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
               {rootConcurrencyKeys!.map((key, i) =>
                 runQueueConfig ? (
                   <Tag interactive key={`rootConcurrency:${i}`}>
-                    <Link to={`/concurrency?key=${key}`}>{key}</Link>
+                    <Link to={`/deployment/concurrency/${encodeURIComponent(key)}`}>{key}</Link>
                   </Tag>
                 ) : (
                   <Tag interactive key={`rootConcurrency:${i}`}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -13,7 +13,6 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {CreatedByTagCell} from './CreatedByTag';
-import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
 import {RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
@@ -21,6 +20,7 @@ import {DagsterTag} from './RunTag';
 import {RunTags} from './RunTags';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
+import {RunsFeedDialogState} from './RunsFeedTable';
 import {getBackfillPath} from './RunsFeedUtils';
 import {RunFilterToken} from './RunsFilterInput';
 import {RunTimeFragment} from './types/RunUtils.types';
@@ -35,7 +35,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 export const RunsFeedRow = ({
   entry,
   onAddTag,
-  onShowPartitions,
+  onShowDialog,
   checked,
   onToggleChecked,
   refetch,
@@ -43,7 +43,7 @@ export const RunsFeedRow = ({
 }: {
   entry: RunsFeedTableEntryFragment;
   refetch: () => void;
-  onShowPartitions: () => void;
+  onShowDialog: (dialog: RunsFeedDialogState) => void;
   onAddTag?: (token: RunFilterToken) => void;
   checked?: boolean;
   onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
@@ -74,7 +74,6 @@ export const RunsFeedRow = ({
     [entry],
   );
 
-  const [showQueueCriteria, setShowQueueCriteria] = React.useState(false);
   const [isHovered, setIsHovered] = React.useState(false);
 
   const runTime: RunTimeFragment = {
@@ -134,9 +133,7 @@ export const RunsFeedRow = ({
             {entry.runStatus === RunStatus.QUEUED ? (
               <Caption>
                 <ButtonLink
-                  onClick={() => {
-                    setShowQueueCriteria(true);
-                  }}
+                  onClick={() => onShowDialog({type: 'queue-criteria', entry})}
                   color={Colors.textLight()}
                 >
                   View queue criteria
@@ -164,7 +161,7 @@ export const RunsFeedRow = ({
             backfill={entry}
             repoAddress={null}
             useTags={true}
-            onShowPartitions={onShowPartitions}
+            onShowPartitions={() => onShowDialog({type: 'partitions', backfillId: entry.id})}
           />
         )}
       </RowCell>
@@ -202,11 +199,6 @@ export const RunsFeedRow = ({
           <RunActionsMenu run={entry} onAddTag={onAddTag} anchorLabel="View" />
         )}
       </RowCell>
-      <QueuedRunCriteriaDialog
-        run={entry}
-        isOpen={showQueueCriteria}
-        onClose={() => setShowQueueCriteria(false)}
-      />
     </RowGrid>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
@@ -10,6 +10,7 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
+import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunBulkActionsMenu} from './RunActionsMenu';
 import {RunTableEmptyState} from './RunTableEmptyState';
 import {RunsQueryRefetchContext} from './RunUtils';
@@ -47,7 +48,9 @@ interface RunsFeedTableProps {
 }
 
 // Potentially other modals in the future
-type RunsFeedDialogState = {type: 'partitions'; backfillId: string};
+export type RunsFeedDialogState =
+  | {type: 'partitions'; backfillId: string}
+  | {type: 'queue-criteria'; entry: RunsFeedTableEntryFragment};
 
 export const RunsFeedTable = ({
   entries,
@@ -192,6 +195,12 @@ export const RunsFeedTable = ({
           backfillId={dialog?.type === 'partitions' ? dialog.backfillId : undefined}
           onClose={() => setDialog(null)}
         />
+        <QueuedRunCriteriaDialog
+          run={dialog?.type === 'queue-criteria' ? dialog.entry : undefined}
+          isOpen={dialog?.type === 'queue-criteria'}
+          onClose={() => setDialog(null)}
+        />
+
         <IndeterminateLoadingBar $loading={loading} />
         <Container ref={parentRef} style={scroll ? {overflow: 'auto'} : {overflow: 'visible'}}>
           {header}
@@ -214,7 +223,7 @@ export const RunsFeedTable = ({
                       entry={entry}
                       checked={checkedIds.has(entry.id)}
                       onToggleChecked={onToggleFactory(entry.id)}
-                      onShowPartitions={() => setDialog({type: 'partitions', backfillId: entry.id})}
+                      onShowDialog={setDialog}
                       refetch={refetch}
                       onAddTag={onAddTag}
                       hideTags={hideTags}


### PR DESCRIPTION
## Summary & Motivation

Fixes the two issues Daniel flagged in https://linear.app/dagster-labs/issue/FE-777/fix-deep-linking-for-concurrency-keys-in-queue-criteria-dialog

## How I Tested These Changes

Tested against elementl prod which has a few concurrency keys. Opened the queue modal, clicked a link to make sure its fixed, and left the modal open for ~5 minutes to make sure it is not closed when the row disappears from view.

## Changelog

[ui] The queue details modal for a run no longer closes as new runs arrive and links to the correct concurrency page.