### PR TITLE
Switch dagster dev IPC mechanism to pipe from signal

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -22,7 +22,9 @@ from dagster._core.telemetry import START_DAGSTER_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread
 from dagster._core.workspace.context import IWorkspaceProcessContext, WorkspaceProcessContext
 from dagster._serdes import deserialize_value
+from dagster._serdes.ipc import interrupt_on_ipc_shutdown_message
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, find_free_port, is_port_in_use
+from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
 from dagster_webserver.app import create_app_from_workspace_process_context
@@ -179,6 +181,13 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     default=2000,
     show_default=True,
 )
+@click.option(
+    "--shutdown-pipe",
+    type=click.INT,
+    required=False,
+    hidden=True,
+    help="Internal use only. Pass a readable pipe file descriptor to the webserver process that will be monitored for a shutdown signal.",
+)
 @click.version_option(version=__version__, prog_name="dagster-webserver")
 @workspace_options
 def dagster_webserver(
@@ -195,6 +204,7 @@ def dagster_webserver(
     code_server_log_level: str,
     instance_ref: Optional[str],
     live_data_poll_rate: int,
+    shutdown_pipe: Optional[int],
     **other_opts: object,
 ):
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -212,11 +222,20 @@ def dagster_webserver(
             " `dagster-webserver` instead."
         )
 
-    with get_possibly_temporary_instance_for_cli(
-        cli_command="dagster-webserver",
-        instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
-        logger=logger,
-    ) as instance:
+    # Set up windows interrupt signals to raise KeyboardInterrupt. Note that these handlers are
+    # not used if we are using the shutdown pipe.
+    setup_interrupt_handlers()
+
+    with contextlib.ExitStack() as stack:
+        if shutdown_pipe:
+            stack.enter_context(interrupt_on_ipc_shutdown_message(shutdown_pipe))
+        instance = stack.enter_context(
+            get_possibly_temporary_instance_for_cli(
+                cli_command="dagster-webserver",
+                instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
+                logger=logger,
+            )
+        )
         # Allow the instance components to change behavior in the context of a long running server process
         instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle)
 

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Optional
 
@@ -19,7 +19,12 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._grpc.server import GrpcServerCommand
 from dagster._serdes import serialize_value
-from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
+from dagster._serdes.ipc import (
+    get_ipc_shutdown_pipe,
+    interrupt_on_ipc_shutdown_message,
+    open_ipc_subprocess,
+    send_ipc_shutdown_message,
+)
 from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
@@ -87,6 +92,13 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--shutdown-pipe",
+    type=click.INT,
+    required=False,
+    hidden=True,
+    help="Internal use only. Pass a readable pipe file descriptor to the dev process that will be monitored for a shutdown signal.",
+)
 @workspace_options
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
@@ -99,6 +111,7 @@ def dev_command(
     host: Optional[str],
     live_data_poll_rate: Optional[str],
     use_legacy_code_server_behavior: bool,
+    shutdown_pipe: Optional[int],
     **other_opts: object,
 ) -> None:
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -133,10 +146,17 @@ def dev_command(
                 " unless it is placed in the same folder as DAGSTER_HOME."
             )
 
-    # Essential on windows-- will set up windows signals to raise KeyboardInterrupt
+    # Set up windows interrupt signals to raise KeyboardInterrupt. Note that these handlers are
+    # not used if we are using the shutdown pipe.
     setup_interrupt_handlers()
 
-    with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
+    with ExitStack() as stack:
+        if shutdown_pipe:
+            stack.enter_context(interrupt_on_ipc_shutdown_message(shutdown_pipe))
+        instance = stack.enter_context(
+            get_possibly_temporary_instance_for_cli("dagster dev", logger=logger)
+        )
+
         with _optionally_create_temp_workspace(
             use_legacy_code_server_behavior=use_legacy_code_server_behavior,
             workspace_opts=workspace_opts,
@@ -152,6 +172,7 @@ def dev_command(
                 *workspace_args,
             ]
 
+            webserver_read_fd, webserver_write_fd = get_ipc_shutdown_pipe()
             webserver_process = open_ipc_subprocess(
                 [sys.executable, "-m", "dagster_webserver"]
                 + (["--port", port] if port else [])
@@ -159,8 +180,12 @@ def dev_command(
                 + (["--dagster-log-level", log_level])
                 + (["--log-format", log_format])
                 + (["--live-data-poll-rate", live_data_poll_rate] if live_data_poll_rate else [])
-                + args
+                + ["--shutdown-pipe", str(webserver_read_fd)]
+                + args,
+                pass_fds=[webserver_read_fd],
             )
+
+            daemon_read_fd, daemon_write_fd = get_ipc_shutdown_pipe()
             daemon_process = open_ipc_subprocess(
                 [
                     sys.executable,
@@ -171,8 +196,11 @@ def dev_command(
                     log_level,
                     "--log-format",
                     log_format,
+                    "--shutdown-pipe",
+                    str(daemon_read_fd),
                 ]
-                + args
+                + args,
+                pass_fds=[daemon_read_fd],
             )
             try:
                 while True:
@@ -196,8 +224,8 @@ def dev_command(
                 logger.exception("An unexpected exception has occurred")
             finally:
                 logger.info("Shutting down Dagster services...")
-                interrupt_ipc_subprocess(daemon_process)
-                interrupt_ipc_subprocess(webserver_process)
+                send_ipc_shutdown_message(webserver_write_fd)
+                send_ipc_shutdown_message(daemon_write_fd)
 
                 try:
                     webserver_process.wait(timeout=_SUBPROCESS_WAIT_TIMEOUT)

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -2,16 +2,18 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from io import TextIOWrapper
 from subprocess import Popen
 from time import sleep
-from typing import Any, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._core.errors import DagsterError
 from dagster._serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
+from dagster._utils import send_interrupt
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -196,6 +198,13 @@ def open_ipc_subprocess(parts: Sequence[str], **kwargs: Any) -> "Popen[Any]":
     if sys.platform == "win32":
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
 
+        # pass_fds is not supported on Windows. Instead we set close_fds to False, which will allow
+        # any inheritable file descriptors marked as inheritable to be inherited by the child
+        # process.
+        if kwargs.get("pass_fds"):
+            del kwargs["pass_fds"]
+            kwargs["close_fds"] = False
+
     return subprocess.Popen(
         parts,
         creationflags=creationflags,
@@ -203,12 +212,9 @@ def open_ipc_subprocess(parts: Sequence[str], **kwargs: Any) -> "Popen[Any]":
     )
 
 
-def interrupt_ipc_subprocess(proc: "Popen[Any]") -> None:
+def interrupt_ipc_subprocess(proc: "Popen[Any]", sig: Optional[int] = None) -> None:
     """Send CTRL_BREAK on Windows, SIGINT on other platforms."""
-    if sys.platform == "win32":
-        proc.send_signal(signal.CTRL_BREAK_EVENT)
-    else:
-        proc.send_signal(signal.SIGINT)
+    proc.send_signal(sig or get_default_interrupt_signal())
 
 
 def interrupt_then_kill_ipc_subprocess(proc: "Popen[Any]", wait_time: int = 10) -> None:
@@ -219,11 +225,92 @@ def interrupt_then_kill_ipc_subprocess(proc: "Popen[Any]", wait_time: int = 10) 
         proc.kill()
 
 
-def interrupt_ipc_subprocess_pid(pid: int) -> None:
+def interrupt_ipc_subprocess_pid(pid: int, sig: Optional[int] = None) -> None:
     """Send CTRL_BREAK_EVENT on Windows, SIGINT on other platforms."""
-    check.int_param(pid, "pid")
+    os.kill(pid, sig or get_default_interrupt_signal())
 
+
+def get_default_interrupt_signal() -> int:
+    return signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGINT
+
+
+# ########################
+# ##### SHUTDOWN PIPE
+# ########################
+
+_PIPE_SHUTDOWN_INDICATOR = "SHUTDOWN"
+
+
+def get_ipc_shutdown_pipe() -> tuple[int, int]:
+    r_fd, w_fd = os.pipe()
+
+    # On windows, convert fd to a Windows handle so it can be reliably passed across processes.
     if sys.platform == "win32":
-        os.kill(pid, signal.CTRL_BREAK_EVENT)
-    else:
-        os.kill(pid, signal.SIGINT)
+        import msvcrt
+
+        os.set_inheritable(r_fd, True)
+        r_fd = msvcrt.get_osfhandle(r_fd)
+    return r_fd, w_fd
+
+
+@contextmanager
+def monitor_ipc_shutdown_pipe(pipe_fd: int, handler: Callable[[], None]) -> Iterator[None]:
+    """Monitor the passed in pipe file descriptor for the shutdown indicator message.
+    When received, trigger the handler.
+
+    Args:
+        pipe_fd: The file descriptor of the pipe to monitor. Must be readable.
+            If on windows, this is assumed to be a Windows handle rather than a regular file
+            descriptor.
+        handler: The handler to call when the shutdown indicator is received.
+    """
+    # On windows, we expect to receive a raw Windows handle rather than a regular file descriptor.
+    # Convert to a file descriptor before reading.
+    if sys.platform == "win32":
+        import msvcrt
+
+        pipe_fd = msvcrt.open_osfhandle(pipe_fd, os.O_RDONLY)
+
+    break_event = threading.Event()
+
+    def _watch_pipe_for_shutdown():
+        with open(pipe_fd) as pipe:
+            while not break_event.is_set():
+                line = pipe.readline()
+                if not line:  # EOF or pipe closed
+                    break_event.set()
+                elif _PIPE_SHUTDOWN_INDICATOR in line.strip():
+                    break_event.set()
+                    handler()
+
+    # Start a background thread that watches the pipe
+    monitor_thread = threading.Thread(target=_watch_pipe_for_shutdown, daemon=True)
+    monitor_thread.start()
+
+    try:
+        yield
+    finally:
+        # Signal the thread to exit and wait for it to stop
+        break_event.set()
+        monitor_thread.join()
+
+
+@contextmanager
+def interrupt_on_ipc_shutdown_message(pipe_fd: int) -> Iterator[None]:
+    """Monitor the passed in pipe file descriptor for the shutdown indicator message. Interrupt the
+    current process when the message is received.
+
+    Args:
+        pipe_fd: The file descriptor of the pipe to monitor. Must be readable.
+            If on windows, this is assumed to be raw Windows handle rather than a regular file
+            descriptor.
+    """
+    # Important to use `send_interrupt` here rather than unconditionally sending a signal. Sending a
+    # signal, even to the process itself, often has strange behavior on windows.
+    with monitor_ipc_shutdown_pipe(pipe_fd, handler=lambda: send_interrupt()):
+        yield
+
+
+def send_ipc_shutdown_message(w_fd: int) -> None:
+    os.write(w_fd, f"{_PIPE_SHUTDOWN_INDICATOR}\n".encode())
+    os.close(w_fd)

--- a/python_modules/dagster/dagster_tests/cli_tests/test_shutdown_pipe.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_shutdown_pipe.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+import psutil
+from dagster._serdes.ipc import (
+    get_ipc_shutdown_pipe,
+    interrupt_on_ipc_shutdown_message,
+    open_ipc_subprocess,
+    send_ipc_shutdown_message,
+)
+from dagster._utils.interrupts import setup_interrupt_handlers
+
+_PROCESS_DEPTH = 20
+
+
+def test_shutdown_pipe():
+    proc, write_fd = _run_script(_PROCESS_DEPTH, stdout=subprocess.PIPE, text=True, bufsize=1)
+    _wait_for_processes_to_start(proc)
+    child_procs = psutil.Process(proc.pid).children(recursive=True)
+    send_ipc_shutdown_message(write_fd)
+    proc.wait(timeout=10)
+    assert proc.stdout
+    output = proc.stdout.read()
+    for i in range(_PROCESS_DEPTH):
+        assert f"({i}) Keyboard interrupt received" in output
+
+    # Make sure all child processes are terminated
+    for child_proc in child_procs:
+        try:
+            assert not child_proc.is_running()
+        except psutil.NoSuchProcess:
+            pass
+
+
+def _wait_for_processes_to_start(proc: subprocess.Popen[str]):
+    assert proc.stdout
+    for line in iter(proc.stdout.readline, ""):
+        print(line.strip())  # noqa: T201
+        if "(0) Started" in line:
+            break
+
+
+def _run_script(counter: int, **proc_kwargs: Any) -> tuple[subprocess.Popen, int]:
+    read_fd, write_fd = get_ipc_shutdown_pipe()
+    proc = open_ipc_subprocess(
+        # Use -u to force unbuffered output
+        [sys.executable, "-u", __file__, str(read_fd)],
+        pass_fds=[read_fd],
+        env={**os.environ, "DAGSTER_TEST_COUNTER": str(counter)},
+        **proc_kwargs,
+    )
+    return proc, write_fd
+
+
+def main(counter: int, shutdown_pipe_fd: int):
+    setup_interrupt_handlers()
+    proc, write_fd = _run_script(counter - 1) if counter > 0 else (None, None)
+    with interrupt_on_ipc_shutdown_message(shutdown_pipe_fd):
+        print(f"({counter}) Started")  # noqa: T201
+        try:
+            while True:
+                time.sleep(0.01)
+        except KeyboardInterrupt:
+            print(f"({counter}) Keyboard interrupt received")  # noqa: T201
+            if proc and write_fd:
+                send_ipc_shutdown_message(write_fd)
+                proc.wait(timeout=10)
+            print(f"({counter}) Exiting")  # noqa: T201
+
+
+if __name__ == "__main__":
+    counter = int(os.environ["DAGSTER_TEST_COUNTER"])
+    shutdown_pipe_fd = int(sys.argv[1])
+    main(counter, shutdown_pipe_fd)

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -40,7 +40,7 @@ commands =
 
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   asset_defs_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/asset_defs_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests/  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests {env:COVERAGE_ARGS} --durations 10 {posargs}
   core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -71,6 +71,7 @@ def test_dev_command_has_options_of_dagster_dev():
         "use_ssl",
         # Misc others to exclude
         "use_legacy_code_server_behavior",
+        "shutdown_pipe",
     }
 
     dg_dev_param_names = {param.name for param in dev_command.params}


### PR DESCRIPTION
## Summary & Motivation

`dagster dev` spins up webserver and daemon subprocesses. Currently, on being interrupted,  it attempts to shutdown those processes by sending an interrupt signal to each of them.

This is an unreliable mechanism for shutting down subprocesses on Windows, because the ability of one process to signal another process is dependent on them sharing a console. This is a particularly unreliable condition in a CI environment. Quoting ChatGPT:

>On Windows, CTRL_BREAK_EVENT (and similarly CTRL_C_EVENT) only works when the calling process and the target processes share a console. By default, Python’s subprocess.Popen with CREATE_NEW_PROCESS_GROUP spawns the child into its own new process group but does not automatically attach it to the same console as the parent (and in many CI environments, there may be no real console at all). As a result, sending CTRL_BREAK_EVENT to that child process group essentially does nothing—Windows never delivers the interrupt to those child processes, and they keep running.

There are also other weird effects that arise in niche conditions from sending signals on windows. For instance, if a windows process gets interrupted in the middle of a `print()` call, it disrupts stdout and raises a confusing `OSError: invalid argument`.

While there is probably some way to robustly handle signals on windows,  I have encountered enough puzzling behavior that it seemed worthwhile to explore an alternative and more reliable approach to IPC.

This PR adds a new "shutdown pipe" API useful for IPC. A process can monitor a pipe for a shutdown signal, which can be configured to trigger an interrupt to the _current_ process. Importantly, on windows we can entirely skip signals by making use of `_thread.interrupt_main()`, which will raise a `KeyboardInterrupt` in the main thread the same way that receiving `SIGINT` etc do, but without any of the other signal side effects.

`dagster dev`, `dagster-webserver` and `dagster daemon` have all had a (hidden) option added called `--shutdown-pipe`. This accepts a readable file descriptor which can be passed into the shutdown pipe API. The idea is that a parent process can invoke the child and pass `--shutdown-pipe`, then send the shutdown message over the pipe in lieu of relying on the OS to deliver an inter-process signal. `dagster dev` has been changed to use this mechanism for its child `dagster-webserver` and `dagster daemon` processes.

## How I Tested These Changes

New tests + existing dagster dev tests (on windows also)