### PR TITLE
Add brief description to dagster-blueprints pointing to components

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/version.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/version.py
@@ -1,1 +1,1 @@
-__version__ = "1!0+dev"
+__version__ = "1.9.13.post1"

--- a/examples/experimental/dagster-blueprints/setup.py
+++ b/examples/experimental/dagster-blueprints/setup.py
@@ -11,9 +11,7 @@ def get_version() -> str:
     return version["__version__"]
 
 
-ver = get_version()
-# dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "1!0+dev" else f"=={ver}"
+ver = "1.9.13.post1"
 setup(
     name="dagster-blueprints",
     version=get_version(),
@@ -35,8 +33,8 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_blueprints_tests*", "examples*"]),
     install_requires=[
-        f"dagster{pin}",
-        f"dagster-databricks{pin}",
+        "dagster==1.9.13",
+        "dagster-databricks==1.9.13",
     ],
     zip_safe=False,
     entry_points={

--- a/examples/experimental/dagster-blueprints/setup.py
+++ b/examples/experimental/dagster-blueprints/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",
-    description="",  # TODO - fill out description
+    description="dagster-blueprints is no longer supported. Please consider using Dagster Components instead: https://docs.dagster.io/guides/preview/components/",
     url=(
         "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
         "dagster-blueprints"


### PR DESCRIPTION
## Summary

will manually publish a postfix release and ship this out to pypi, then archive the page
