### PR TITLE
Rename `include_external_assets` back to `include_sources`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/antlr_asset_selection/antlr_asset_selection.py
@@ -34,8 +34,8 @@ def parse_traversal_depth(optional_digits):
 
 
 class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
-    def __init__(self, include_external_assets: bool):
-        self.include_external_assets = include_external_assets
+    def __init__(self, include_sources: bool):
+        self.include_sources = include_sources
 
     def visitStart(self, ctx: AssetSelectionParser.StartContext):
         return self.visit(ctx.expr())
@@ -75,7 +75,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitNotExpression(self, ctx: AssetSelectionParser.NotExpressionContext):
         selection: AssetSelection = self.visit(ctx.expr())
-        return AssetSelection.all(include_external_assets=self.include_external_assets) - selection
+        return AssetSelection.all(include_sources=self.include_sources) - selection
 
     def visitAndExpression(self, ctx: AssetSelectionParser.AndExpressionContext):
         left: AssetSelection = self.visit(ctx.expr(0))
@@ -88,7 +88,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
         return left | right
 
     def visitAllExpression(self, ctx: AssetSelectionParser.AllExpressionContext):
-        return AssetSelection.all(include_external_assets=self.include_external_assets)
+        return AssetSelection.all(include_sources=self.include_sources)
 
     def visitAttributeExpression(self, ctx: AssetSelectionParser.AttributeExpressionContext):
         return self.visit(ctx.attributeExpr())
@@ -123,7 +123,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
     def visitTagAttributeExpr(self, ctx: AssetSelectionParser.TagAttributeExprContext):
         key = self.visit(ctx.value(0))
         value = self.visit(ctx.value(1)) if ctx.EQUAL() else ""
-        return AssetSelection.tag(key, value, include_external_assets=self.include_external_assets)
+        return AssetSelection.tag(key, value, include_sources=self.include_sources)
 
     def visitOwnerAttributeExpr(self, ctx: AssetSelectionParser.OwnerAttributeExprContext):
         owner = self.visit(ctx.value())
@@ -131,13 +131,11 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
     def visitGroupAttributeExpr(self, ctx: AssetSelectionParser.GroupAttributeExprContext):
         group = self.visit(ctx.value())
-        return AssetSelection.groups(group, include_external_assets=self.include_external_assets)
+        return AssetSelection.groups(group, include_sources=self.include_sources)
 
     def visitKindAttributeExpr(self, ctx: AssetSelectionParser.KindAttributeExprContext):
         kind = self.visit(ctx.value())
-        return AssetSelection.tag(
-            f"{KIND_PREFIX}{kind}", "", include_external_assets=self.include_external_assets
-        )
+        return AssetSelection.tag(f"{KIND_PREFIX}{kind}", "", include_sources=self.include_sources)
 
     def visitCodeLocationAttributeExpr(
         self, ctx: AssetSelectionParser.CodeLocationAttributeExprContext
@@ -172,7 +170,7 @@ class AntlrAssetSelectionVisitor(AssetSelectionVisitor):
 
 
 class AntlrAssetSelectionParser:
-    def __init__(self, selection_str: str, include_external_assets: bool = False):
+    def __init__(self, selection_str: str, include_sources: bool = False):
         lexer = AssetSelectionLexer(InputStream(selection_str))
         lexer.removeErrorListeners()  # Remove the default listener that just writes to the console
         lexer.addErrorListener(AntlrInputErrorListener())
@@ -185,9 +183,7 @@ class AntlrAssetSelectionParser:
 
         self._tree = parser.start()
         self._tree_str = self._tree.toStringTree(recog=parser)
-        self._asset_selection = AntlrAssetSelectionVisitor(include_external_assets).visit(
-            self._tree
-        )
+        self._asset_selection = AntlrAssetSelectionVisitor(include_sources).visit(self._tree)
 
     @property
     def tree_str(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -94,14 +94,14 @@ class AssetSelection(ABC):
 
     @public
     @staticmethod
-    @beta_param(param="include_external_assets")
-    def all(include_external_assets: bool = False) -> "AllSelection":
+    @beta_param(param="include_sources")
+    def all(include_sources: bool = False) -> "AllSelection":
         """Returns a selection that includes all assets and their asset checks.
 
         Args:
-            include_external_assets (bool): If True, then include all external assets.
+            include_sources (bool): If True, then include all external assets.
         """
-        return AllSelection(include_external_assets=include_external_assets)
+        return AllSelection(include_sources=include_sources)
 
     @public
     @staticmethod
@@ -177,14 +177,14 @@ class AssetSelection(ABC):
 
     @public
     @staticmethod
-    @beta_param(param="include_external_assets")
+    @beta_param(param="include_sources")
     def key_prefixes(
-        *key_prefixes: CoercibleToAssetKeyPrefix, include_external_assets: bool = False
+        *key_prefixes: CoercibleToAssetKeyPrefix, include_sources: bool = False
     ) -> "KeyPrefixesAssetSelection":
         """Returns a selection that includes assets that match any of the provided key prefixes and all the asset checks that target them.
 
         Args:
-            include_external_assets (bool): If True, then include external assets matching the key prefix(es)
+            include_sources (bool): If True, then include external assets matching the key prefix(es)
                 in the selection.
 
         Examples:
@@ -200,18 +200,18 @@ class AssetSelection(ABC):
         _asset_key_prefixes = [key_prefix_from_coercible(key_prefix) for key_prefix in key_prefixes]
         return KeyPrefixesAssetSelection(
             selected_key_prefixes=_asset_key_prefixes,
-            include_external_assets=include_external_assets,
+            include_sources=include_sources,
         )
 
     @staticmethod
-    @beta_param(param="include_external_assets")
+    @beta_param(param="include_sources")
     def key_substring(
-        key_substring: str, include_external_assets: bool = False
+        key_substring: str, include_sources: bool = False
     ) -> "KeySubstringAssetSelection":
         """Returns a selection that includes assets whose string representation contains the provided substring and all the asset checks that target it.
 
         Args:
-            include_external_assets (bool): If True, then include external assets matching the substring
+            include_sources (bool): If True, then include external assets matching the substring
                 in the selection.
 
         Examples:
@@ -226,62 +226,54 @@ class AssetSelection(ABC):
               AssetSelection.key_substring("b/c")
         """
         return KeySubstringAssetSelection(
-            selected_key_substring=key_substring, include_external_assets=include_external_assets
+            selected_key_substring=key_substring, include_sources=include_sources
         )
 
     @public
     @staticmethod
-    @beta_param(param="include_external_assets")
-    def groups(*group_strs, include_external_assets: bool = False) -> "GroupsAssetSelection":
+    @beta_param(param="include_sources")
+    def groups(*group_strs, include_sources: bool = False) -> "GroupsAssetSelection":
         """Returns a selection that includes materializable assets that belong to any of the
         provided groups and all the asset checks that target them.
 
         Args:
-            include_external_assets (bool): If True, then include external assets matching the group in the
+            include_sources (bool): If True, then include external assets matching the group in the
                 selection.
         """
         check.tuple_param(group_strs, "group_strs", of_type=str)
-        return GroupsAssetSelection(
-            selected_groups=group_strs, include_external_assets=include_external_assets
-        )
+        return GroupsAssetSelection(selected_groups=group_strs, include_sources=include_sources)
 
     @public
     @staticmethod
-    @beta_param(param="include_external_assets")
-    def tag(key: str, value: str, include_external_assets: bool = False) -> "AssetSelection":
+    @beta_param(param="include_sources")
+    def tag(key: str, value: str, include_sources: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_external_assets (bool): If True, then include external assets matching the group in the
+            include_sources (bool): If True, then include external assets matching the group in the
                 selection.
         """
-        return TagAssetSelection(
-            key=key, value=value, include_external_assets=include_external_assets
-        )
+        return TagAssetSelection(key=key, value=value, include_sources=include_sources)
 
     @staticmethod
-    @beta_param(param="include_external_assets")
-    def tag_string(string: str, include_external_assets: bool = False) -> "AssetSelection":
+    @beta_param(param="include_sources")
+    def tag_string(string: str, include_sources: bool = False) -> "AssetSelection":
         """Returns a selection that includes materializable assets that have the provided tag, and
         all the asset checks that target them.
 
 
         Args:
-            include_external_assets (bool): If True, then include external assets matching the group in the
+            include_sources (bool): If True, then include external assets matching the group in the
                 selection.
         """
         split_by_equals_segments = string.split("=")
         if len(split_by_equals_segments) == 1:
-            return TagAssetSelection(
-                key=string, value="", include_external_assets=include_external_assets
-            )
+            return TagAssetSelection(key=string, value="", include_sources=include_sources)
         elif len(split_by_equals_segments) == 2:
             key, value = split_by_equals_segments
-            return TagAssetSelection(
-                key=key, value=value, include_external_assets=include_external_assets
-            )
+            return TagAssetSelection(key=key, value=value, include_sources=include_sources)
         else:
             check.failed(f"Invalid tag selection string: {string}. Must have no more than one '='.")
 
@@ -508,14 +500,14 @@ class AssetSelection(ABC):
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in asset_keys}
 
     @classmethod
-    @beta_param(param="include_external_assets")
-    def from_string(cls, string: str, include_external_assets=False) -> "AssetSelection":
+    @beta_param(param="include_sources")
+    def from_string(cls, string: str, include_sources=False) -> "AssetSelection":
         from dagster._core.definitions.antlr_asset_selection.antlr_asset_selection import (
             AntlrAssetSelectionParser,
         )
 
         try:
-            return AntlrAssetSelectionParser(string, include_external_assets).asset_selection
+            return AntlrAssetSelectionParser(string, include_sources).asset_selection
         except:
             pass
         if string == "*":
@@ -614,14 +606,14 @@ class AssetSelection(ABC):
 @whitelist_for_serdes
 @record
 class AllSelection(AssetSelection):
-    include_external_assets: Optional[bool] = None
+    include_sources: Optional[bool] = None
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         return (
             asset_graph.get_all_asset_keys()
-            if self.include_external_assets
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
 
@@ -927,14 +919,14 @@ class DownstreamAssetSelection(ChainedAssetSelection):
 @record
 class GroupsAssetSelection(AssetSelection):
     selected_groups: Sequence[str]
-    include_external_assets: bool
+    include_sources: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_external_assets
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -962,14 +954,14 @@ class GroupsAssetSelection(AssetSelection):
 class TagAssetSelection(AssetSelection):
     key: str
     value: str
-    include_external_assets: bool
+    include_sources: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_external_assets
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
 
@@ -1153,14 +1145,14 @@ class KeysAssetSelection(AssetSelection):
 @record
 class KeyPrefixesAssetSelection(AssetSelection):
     selected_key_prefixes: Sequence[Sequence[str]]
-    include_external_assets: bool
+    include_sources: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_external_assets
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
         return {
@@ -1177,14 +1169,14 @@ class KeyPrefixesAssetSelection(AssetSelection):
 @record
 class KeySubstringAssetSelection(AssetSelection):
     selected_key_substring: str
-    include_external_assets: bool
+    include_sources: bool
 
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.get_all_asset_keys()
-            if self.include_external_assets
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
         return {key for key in base_set if self.selected_key_substring in key.to_user_string()}

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -115,7 +115,7 @@ def evaluate_automation_conditions(
 
     if asset_selection is None:
         asset_selection = (
-            AssetSelection.all(include_external_assets=True) | AssetSelection.all_asset_checks()
+            AssetSelection.all(include_sources=True) | AssetSelection.all_asset_checks()
         )
 
     asset_graph = defs.get_asset_graph()

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -50,7 +50,7 @@ def observe(
 
     with disable_dagster_warnings():
         observation_job = define_asset_job(
-            "in_process_observation_job", selection=AssetSelection.all(include_external_assets=True)
+            "in_process_observation_job", selection=AssetSelection.all(include_sources=True)
         )
         defs = Definitions(
             assets=assets,

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -374,9 +374,7 @@ def get_default_automation_condition_sensor_selection(
         # Use AssetSelection.all if the default sensor is the only sensor - otherwise
         # enumerate the assets that are not already included in some other
         # non-default sensor
-        default_sensor_asset_selection = AssetSelection.all(
-            include_external_assets=has_auto_observe_keys
-        )
+        default_sensor_asset_selection = AssetSelection.all(include_sources=has_auto_observe_keys)
 
         # if there are any asset checks, include checks in the selection
         if any(isinstance(k, AssetCheckKey) for k in default_sensor_keys):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
@@ -81,7 +81,7 @@ from dagster._core.storage.tags import KIND_PREFIX
     ],
 )
 def test_antlr_tree(selection_str, expected_tree_str) -> None:
-    asset_selection = AntlrAssetSelectionParser(selection_str, include_external_assets=True)
+    asset_selection = AntlrAssetSelectionParser(selection_str, include_sources=True)
     assert asset_selection.tree_str == expected_tree_str
 
     generated_selection = asset_selection.asset_selection
@@ -89,7 +89,7 @@ def test_antlr_tree(selection_str, expected_tree_str) -> None:
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_external_assets=True,
+        include_sources=True,
     ).asset_selection
     assert regenerated_selection == generated_selection
 
@@ -124,7 +124,7 @@ def test_antlr_tree_invalid(selection_str):
         ('key_substring:"*/a+"', AssetSelection.key_substring("*/a+")),
         (
             "not key:a",
-            AssetSelection.all(include_external_assets=True) - AssetSelection.assets("a"),
+            AssetSelection.all(include_sources=True) - AssetSelection.assets("a"),
         ),
         ("key:a and key:b", AssetSelection.assets("a") & AssetSelection.assets("b")),
         ("key:a or key:b", AssetSelection.assets("a") | AssetSelection.assets("b")),
@@ -154,13 +154,13 @@ def test_antlr_tree_invalid(selection_str):
         ),
         ("sinks(key:a)", AssetSelection.assets("a").sinks()),
         ("roots(key:c)", AssetSelection.assets("c").roots()),
-        ("tag:foo", AssetSelection.tag("foo", "", include_external_assets=True)),
-        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_external_assets=True)),
+        ("tag:foo", AssetSelection.tag("foo", "", include_sources=True)),
+        ("tag:foo=bar", AssetSelection.tag("foo", "bar", include_sources=True)),
         ('owner:"owner@owner.com"', AssetSelection.owner("owner@owner.com")),
-        ("group:my_group", AssetSelection.groups("my_group", include_external_assets=True)),
+        ("group:my_group", AssetSelection.groups("my_group", include_sources=True)),
         (
             "kind:my_kind",
-            AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_external_assets=True),
+            AssetSelection.tag(f"{KIND_PREFIX}my_kind", "", include_sources=True),
         ),
         (
             "code_location:my_location",
@@ -187,14 +187,14 @@ def test_antlr_visit_basic(selection_str, expected_assets) -> None:
     def c(): ...
 
     generated_selection = AntlrAssetSelectionParser(
-        selection_str, include_external_assets=True
+        selection_str, include_sources=True
     ).asset_selection
     assert generated_selection == expected_assets
 
     # Ensure the generated selection can be converted back to a selection string, and then back to the same selection
     regenerated_selection = AntlrAssetSelectionParser(
         generated_selection.to_selection_str(),
-        include_external_assets=True,
+        include_sources=True,
     ).asset_selection
     assert regenerated_selection == expected_assets
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -144,8 +144,8 @@ def test_asset_selection_all(all_assets: _AssetList):
     sel = AssetSelection.all()
     assert sel.resolve(all_assets) == _asset_keys_of(all_assets) - {earth.key}
 
-    sel_include_external_assets = AssetSelection.all(include_external_assets=True)
-    assert sel_include_external_assets.resolve(all_assets) == _asset_keys_of(all_assets)
+    sel_include_sources = AssetSelection.all(include_sources=True)
+    assert sel_include_sources.resolve(all_assets) == _asset_keys_of(all_assets)
 
 
 def test_asset_selection_and(all_assets: _AssetList):
@@ -169,7 +169,7 @@ def test_asset_selection_groups(all_assets: _AssetList):
     assert sel.resolve(all_assets) == _asset_keys_of({alice, candace, fiona})
 
     # includes source assets if flag set
-    sel = AssetSelection.groups("planets", include_external_assets=True)
+    sel = AssetSelection.groups("planets", include_sources=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -200,7 +200,7 @@ def test_asset_selection_key_prefixes(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_prefixes("celestial", include_external_assets=True)
+    sel = AssetSelection.key_prefixes("celestial", include_sources=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -216,7 +216,7 @@ def test_asset_selection_key_substring(all_assets: _AssetList):
     assert sel.resolve(all_assets) == set()
 
     # includes source assets if flag set
-    sel = AssetSelection.key_substring("celestial/e", include_external_assets=True)
+    sel = AssetSelection.key_substring("celestial/e", include_sources=True)
     assert sel.resolve(all_assets) == {earth.key}
 
 
@@ -558,9 +558,7 @@ def test_asset_selection_type_checking():
     test = DownstreamAssetSelection(child=valid_asset_selection, depth=0, include_self=False)
     assert isinstance(test, DownstreamAssetSelection)
 
-    test = GroupsAssetSelection(
-        selected_groups=valid_string_sequence, include_external_assets=False
-    )
+    test = GroupsAssetSelection(selected_groups=valid_string_sequence, include_sources=False)
     assert isinstance(test, GroupsAssetSelection)
 
     with pytest.raises(CheckError):
@@ -569,15 +567,13 @@ def test_asset_selection_type_checking():
     assert isinstance(test, KeysAssetSelection)
 
     with pytest.raises(CheckError):
-        GroupsAssetSelection(selected_groups=invalid_argument, include_external_assets=False)
+        GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
 
     with pytest.raises(CheckError):
-        KeyPrefixesAssetSelection(
-            selected_key_prefixes=invalid_argument, include_external_assets=False
-        )
+        KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
 
     test = KeyPrefixesAssetSelection(
-        selected_key_prefixes=valid_string_sequence_sequence, include_external_assets=False
+        selected_key_prefixes=valid_string_sequence_sequence, include_sources=False
     )
     assert isinstance(test, KeyPrefixesAssetSelection)
 
@@ -779,11 +775,11 @@ def test_empty_namedtuple_truthy():
 def test_deserialize_old_all_asset_selection():
     old_serialized_value = '{"__class__": "AllSelection"}'
     new_unserialized_value = deserialize_value(old_serialized_value, AllSelection)
-    assert not new_unserialized_value.include_external_assets
+    assert not new_unserialized_value.include_sources
 
 
 def test_from_string():
-    assert AssetSelection.from_string("*") == AssetSelection.all(include_external_assets=False)
+    assert AssetSelection.from_string("*") == AssetSelection.all(include_sources=False)
     assert AssetSelection.from_string("my_asset") == AssetSelection.assets("my_asset")
     assert AssetSelection.from_string("*my_asset") == AssetSelection.assets("my_asset").upstream(
         depth=MAX_NUM, include_self=True

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -117,9 +117,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
-        include_external_assets=True
-    )
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
 
 
 def test_default_auto_materialize_sensors_without_observable(
@@ -149,9 +147,7 @@ def test_default_auto_materialize_sensors_without_observable(
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
     assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
-    assert auto_materialize_sensor.asset_selection == AssetSelection.all(
-        include_external_assets=False
-    )
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
 
 
 def test_opt_out_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -73,7 +73,7 @@ class AssetSpecTransformSchema(ComponentSchema):
             check.failed(f"Unsupported operation: {self.operation}")
 
     def apply(self, defs: Definitions, context: ResolutionContext) -> Definitions:
-        target_selection = AssetSelection.from_string(self.target, include_external_assets=True)
+        target_selection = AssetSelection.from_string(self.target, include_sources=True)
         target_keys = target_selection.resolve(defs.get_asset_graph())
 
         mappable = [d for d in defs.assets or [] if isinstance(d, (AssetsDefinition, AssetSpec))]


### PR DESCRIPTION
## Summary & Motivation

This is a whitelist_for_serdes field, and while we can handle the backcompat case through the serdes layer, I don't have conviction that this is a useful change to begin with given that:

- this is a very niche option
- we might want to represent this parameter in a different way in the future anyway (i.e. a separate class or something), so not worth the thrash in the short term

## How I Tested These Changes

## Changelog

NOCHANGELOG
