### PR TITLE
PLA-957 explicitly handle empty graph selector

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -702,7 +702,11 @@ class GrapheneQuery(graphene.ObjectType):
         graphene_info: ResolveInfo,
         selector: Optional[GrapheneGraphSelector] = None,
     ):
-        assert selector is not None
+        if selector is None:
+            raise DagsterInvariantViolationError(
+                "Must pass graph selector",
+            )
+
         graph_selector = graph_selector_from_graphql(selector)
         return get_graph_or_error(graphene_info, graph_selector)
 


### PR DESCRIPTION
## Summary & Motivation

If the selector is not passed via graphql, we currently raise a builtin assertion error, but lets handle that explicitly and throw a `DagsterInvariantViolationError` instead