### PR TITLE
Fix docs snippets test with temp experimental decorator

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -292,6 +292,11 @@ def get_beta_info(obj: Annotatable) -> BetaInfo:
     return getattr(target, _BETA_ATTR_NAME)
 
 
+# Temporary experimental decorator to fix docs snippets relying on dagster-cloud
+# dagster-cloud is pulled from pypi and uses experimental in latest
+# https://buildkite.com/dagster/dagster-dagster/builds/111921#0194f5ea-3aa6-4538-983c-a5e51e790686
+experimental = beta
+
 # ########################
 # ##### BETA PARAM
 # ########################


### PR DESCRIPTION
## Summary & Motivation

Tests for docs snippets are failing because we dagster-cloud from pypi, which uses the experimental annotation/decorator.

This PR adds a temp experimental decorator using the beta decorator, to be removed after 1.10 is released - dagster-cloud was updated but changes will be reflected in pypi after the release.

## How I Tested These Changes

BK + tested locally

