### PR TITLE
Properly set up SIGBREAK handling for dagster dev on windows

### DIFF
--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -20,6 +20,7 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._grpc.server import GrpcServerCommand
 from dagster._serdes import serialize_value
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
+from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
 
 _SUBPROCESS_WAIT_TIMEOUT = 60
@@ -131,6 +132,9 @@ def dev_command(
                 f" {dagster_home_path}. The dagster.yaml file will not be used to configure Dagster"
                 " unless it is placed in the same folder as DAGSTER_HOME."
             )
+
+    # Essential on windows-- will set up windows signals to raise KeyboardInterrupt
+    setup_interrupt_handlers()
 
     with get_possibly_temporary_instance_for_cli("dagster dev", logger=logger) as instance:
         with _optionally_create_temp_workspace(


### PR DESCRIPTION
## Summary & Motivation

Previously I set up the `dagster dev` tests on Windows to manually terminate the full process tree. I did this because I could not get the full tree to terminate on its own from issuing an interrupt event. The theory was that `CTRL_BREAK_EVENT` was not propagating correctly in a windows CI environment due to the process tree not sharing a console.

I think this theory was wrong, and in fact what was happening is that `CTRL_BREAK_EVENT` (aka `SIGBREAK`) does not trigger a `KeyboardInterrupt` exception by default-- instead it just wipes out the process. The logic that handles graceful shutdown of the process tree relies on a `KeyboardException` being triggered.

This PR sets up the correct signal handling in `dagster dev` for `SIGBREAK` to trigger a `KeyboardInterrupt`. This causes the full process tree to shut down gracefully. The one caveat is that, for some reason in the legacy code server case (where webserver and daemon each spawn their own copy of the code server), it takes inordinately long on windows for the code server spawned from the webserver (but not daemon!) to self-delete after not receiving a heartbeat. I don't know why that is, but if we set timeout long enough (set to 120 seconds in this PR-- previously experimented up to 60, which wasn't enough) then it terminates successfully.

## How I Tested These Changes

Remove the explicit killing of child processes in the windows `dagster dev` tests, they now pass without that.