### PR TITLE
[bk] add build-and-release script to lock-step release dg and components

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -5,6 +5,7 @@ from dagster_buildkite.pipelines.dagster_oss_main import build_dagster_oss_main_
 from dagster_buildkite.pipelines.dagster_oss_nightly_pipeline import (
     build_dagster_oss_nightly_steps,
 )
+from dagster_buildkite.pipelines.prerelease_dg import build_prerelease_dg_steps
 from dagster_buildkite.pipelines.prerelease_package import (
     build_prerelease_package_steps,
 )
@@ -36,5 +37,11 @@ def dagster_nightly() -> None:
 def prerelease_package() -> None:
     PythonPackages.load_from_git(GitInfo(directory=Path(".")))
     steps = build_prerelease_package_steps()
+    buildkite_yaml = buildkite_yaml_for_steps(steps)
+    print(buildkite_yaml)  # noqa: T201
+
+
+def prerelease_dg() -> None:
+    steps = build_prerelease_dg_steps()
     buildkite_yaml = buildkite_yaml_for_steps(steps)
     print(buildkite_yaml)  # noqa: T201

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
@@ -17,7 +17,6 @@ def build_prerelease_dg_steps() -> List[BuildkiteStep]:
                 "required": False,
                 "key": "version-to-release",
                 "default": None,
-                "hint": "Leave blank to auto-increment the minor version",
             },
         ],
     }

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
@@ -9,7 +9,7 @@ def build_prerelease_dg_steps() -> List[BuildkiteStep]:
     steps: List[BuildkiteStep] = []
 
     input_step: BlockStep = {
-        "block": ":question: Choose veresion",
+        "block": ":question: Choose version",
         "prompt": None,
         "fields": [
             {

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
@@ -17,6 +17,7 @@ def build_prerelease_dg_steps() -> List[BuildkiteStep]:
                 "required": False,
                 "key": "version-to-release",
                 "default": None,
+                "hint": "0.1.15",
             },
         ],
     }

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_dg.py
@@ -1,0 +1,36 @@
+from typing import List
+
+from dagster_buildkite.python_version import AvailablePythonVersion
+from dagster_buildkite.step_builder import CommandStepBuilder
+from dagster_buildkite.utils import BlockStep, BuildkiteStep
+
+
+def build_prerelease_dg_steps() -> List[BuildkiteStep]:
+    steps: List[BuildkiteStep] = []
+
+    input_step: BlockStep = {
+        "block": ":question: Choose veresion",
+        "prompt": None,
+        "fields": [
+            {
+                "text": "Enter the version to publish",
+                "required": False,
+                "key": "version-to-release",
+                "default": None,
+                "hint": "Leave blank to auto-increment the minor version",
+            },
+        ],
+    }
+    steps.append(input_step)
+
+    steps.append(
+        CommandStepBuilder(":package: Build and publish package")
+        .run(
+            "pip install build",
+            "sh ./scripts/build_and_publish_dg_and_components.sh",
+        )
+        .on_test_image(AvailablePythonVersion.get_default(), env=["PYPI_TOKEN"])
+        .build()
+    )
+
+    return steps

--- a/.buildkite/dagster-buildkite/setup.py
+++ b/.buildkite/dagster-buildkite/setup.py
@@ -31,6 +31,7 @@ setup(
             "dagster-buildkite = dagster_buildkite.cli:dagster",
             "dagster-buildkite-nightly = dagster_buildkite.cli:dagster_nightly",
             "dagster-buildkite-prerelease-package = dagster_buildkite.cli:prerelease_package",
+            "dagster-buildkite-prerelease-dg = dagster_buildkite.cli:prerelease_dg",
         ]
     },
 )

--- a/scripts/build_and_publish_dg_and_components.sh
+++ b/scripts/build_and_publish_dg_and_components.sh
@@ -1,0 +1,63 @@
+# This is a component-specific version of build_and_publish.sh
+# It is used to release dagster-components and dagster-dg at the same time
+
+VERSION_TO_RELEASE=$(buildkite-agent meta-data get version-to-release --default '')
+
+git checkout $BUILDKITE_BRANCH
+
+
+
+if [ -z "$VERSION_TO_RELEASE" ]; then
+    echo "Package does not have a fixed version in setup.py, please provide release candidate version to release."
+    exit 1
+fi
+
+
+# Update both a hardcoded version, if set, in setup.py, and
+# find where __version__ is set and update it
+echo "Updating version in source..."
+sed -i "s|version=\".*\"|version=\"$VERSION_TO_RELEASE\"|" "python_modules/libraries/dagster-components/setup.py"
+sed -i "s|version=\".*\"|version=\"$VERSION_TO_RELEASE\"|" "python_modules/libraries/dagster-dg/setup.py"
+grep -rl "__version__ = \".*\"" "python_modules/libraries/dagster-components" | xargs sed -i "s|__version__ = \".*\"|__version__ = \"$VERSION_TO_RELEASE\"|"
+grep -rl "__version__ = \".*\"" "python_modules/libraries/dagster-dg" | xargs sed -i "s|__version__ = \".*\"|__version__ = \"$VERSION_TO_RELEASE\"|"
+
+
+# Release dagster-components
+mkdir -p package_prerelease
+cp -R "python_modules/libraries/dagster-components" package_prerelease
+cd package_prerelease
+
+echo "Building package..."
+python3 -m build
+
+echo "Uploading to pypi..."
+python3 -m twine upload --username "__token__" --password "$PYPI_TOKEN" --repository pypi dist/* --verbose
+
+cd ..
+rm -rf package_prerelease
+
+
+# Release dagster-dg
+mkdir -p package_prerelease
+cp -R "python_modules/libraries/dagster-dg" package_prerelease
+cd package_prerelease
+
+echo "Building package..."
+python3 -m build
+
+echo "Uploading to pypi..."
+python3 -m twine upload --username "__token__" --password "$PYPI_TOKEN" --repository pypi dist/* --verbose
+
+cd ..
+rm -rf package_prerelease
+
+
+echo "Committing and tagging release..."
+PACKAGE_NAME="dagster-dg"
+git add -A
+git config --global user.email "devtools@dagsterlabs.com"
+git config --global user.name "Dagster Labs"
+git commit -m "$PACKAGE_NAME $VERSION_TO_RELEASE"
+
+git tag "$PACKAGE_NAME/v$VERSION_TO_RELEASE"
+git push origin "$PACKAGE_NAME/v$VERSION_TO_RELEASE"

--- a/scripts/build_and_publish_dg_and_components.sh
+++ b/scripts/build_and_publish_dg_and_components.sh
@@ -24,7 +24,7 @@ grep -rl "__version__ = \".*\"" "python_modules/libraries/dagster-dg" | xargs se
 
 # Release dagster-components
 mkdir -p package_prerelease
-cp -R "python_modules/libraries/dagster-components" package_prerelease
+cp -R python_modules/libraries/dagster-components/* package_prerelease
 cd package_prerelease
 
 echo "Building package..."
@@ -39,7 +39,7 @@ rm -rf package_prerelease
 
 # Release dagster-dg
 mkdir -p package_prerelease
-cp -R "python_modules/libraries/dagster-dg" package_prerelease
+cp -R python_modules/libraries/dagster-dg/* package_prerelease
 cd package_prerelease
 
 echo "Building package..."
@@ -53,11 +53,12 @@ rm -rf package_prerelease
 
 
 echo "Committing and tagging release..."
-PACKAGE_NAME="dagster-dg"
 git add -A
 git config --global user.email "devtools@dagsterlabs.com"
 git config --global user.name "Dagster Labs"
-git commit -m "$PACKAGE_NAME $VERSION_TO_RELEASE"
+git commit -m "dagster-dg $VERSION_TO_RELEASE"
 
-git tag "$PACKAGE_NAME/v$VERSION_TO_RELEASE"
-git push origin "$PACKAGE_NAME/v$VERSION_TO_RELEASE"
+git tag "dagster-dg/v$VERSION_TO_RELEASE"
+git push origin "dagster-dg/v$VERSION_TO_RELEASE"
+git tag "dagster-components/v$VERSION_TO_RELEASE"
+git push origin "dagster-components/v$VERSION_TO_RELEASE"


### PR DESCRIPTION
## Summary

Makes a variant of the single package ad-hoc release script for dg and components, to release in lock-step.

## Test Plan

https://buildkite.com/dagster/publish-dagster-dg-and-dagster-components/builds/1
