### PR TITLE
[dagster-dbt] Fix tests for dbt scaffold

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
@@ -39,8 +39,8 @@ def _assert_scaffold_invocation(
     )
 
     assert result.exit_code == 0
-    assert f"Initializing Dagster project {project_name}" in result.stdout
-    assert "Your Dagster project has been initialized" in result.stdout
+    assert f"Initializing Dagster project {project_name}" in result.output
+    assert "Your Dagster project has been initialized" in result.output
     assert dagster_project_dir.exists()
     assert dagster_project_dir.joinpath(project_name).exists()
     assert not any(path.suffix == ".jinja" for path in dagster_project_dir.glob("**/*"))


### PR DESCRIPTION
## Summary & Motivation

Using `result.stdout` causes problems in BK, see [here](https://buildkite.com/dagster/dagster-dagster/builds/111921#0194f5ea-38cc-4c76-a6d3-b368a249840a), let's use `result.output` instead which fixes the issue.

## How I Tested These Changes

BK
