### PR TITLE
error message resource generator sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -308,7 +308,7 @@ class SensorEvaluationContext:
                 raise DagsterInvariantViolationError(
                     "At least one provided resource is a generator, but attempting to access"
                     " resources outside of context manager scope. You can use the following syntax"
-                    " to open a context manager: `with build_schedule_context(...) as context:`"
+                    " to open a context manager: `with build_sensor_context(...) as context:`"
                 )
 
         return self._resources

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -292,11 +292,12 @@ def test_sensor_invocation_resources_context_manager() -> None:
     # Fails bc resource is a contextmanager and sensor context is not entered
     with pytest.raises(
         DagsterInvariantViolationError, match="At least one provided resource is a generator"
-    ):
+    ) as exc_info:
         basic_sensor_str_resource_req(
             build_sensor_context(resources={"my_resource": my_cm_resource})
         )
 
+    assert "with build_sensor_context" in str(exc_info.value)
     with build_sensor_context(resources={"my_resource": my_cm_resource}) as context:
         assert cast(RunRequest, basic_sensor_str_resource_req(context)).run_config == {"foo": "foo"}
 


### PR DESCRIPTION
## Summary & Motivation
Fix the error message recommending workaround for the resource generator contextmanager issue

## How I Tested These Changes
BK

## Changelog
- Fixed the issue where a resource initialization error within a sensor definition test incorrectly recommended using `build_schedule_context` instead of `build_sensor_context`.
