### PR TITLE
Remove fixed-server-id tracking from grpcserverregistry

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -646,7 +646,6 @@ class GrpcServerCodeLocation(CodeLocation):
         host: Optional[str] = None,
         port: Optional[int] = None,
         socket: Optional[str] = None,
-        server_id: Optional[str] = None,
         heartbeat: Optional[bool] = False,
         watch_server: Optional[bool] = True,
         grpc_server_registry: Optional[GrpcServerRegistry] = None,
@@ -697,7 +696,7 @@ class GrpcServerCodeLocation(CodeLocation):
             )
             list_repositories_response = sync_list_repositories_grpc(self.client)
 
-            self._server_id = server_id if server_id else sync_get_server_id(self.client)
+            self._server_id = sync_get_server_id(self.client)
             self.repository_names = set(
                 symbol.repository_name for symbol in list_repositories_response.repository_symbols
             )

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -281,7 +281,6 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
             endpoint = grpc_server_registry.get_grpc_endpoint(self)
             with GrpcServerCodeLocation(
                 origin=self,
-                server_id=endpoint.server_id,
                 port=endpoint.port,
                 socket=endpoint.socket,
                 host=endpoint.host,

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -804,7 +804,6 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                 )
                 location = GrpcServerCodeLocation(
                     origin=origin,
-                    server_id=endpoint.server_id,
                     port=endpoint.port,
                     socket=endpoint.socket,
                     host=endpoint.host,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -609,7 +609,6 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             host=None,
             port=None,
             socket=None,
-            server_id=None,
             heartbeat=False,
             watch_server=True,
             grpc_server_registry=None,
@@ -621,7 +620,6 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 host,  # pyright: ignore[reportArgumentType]
                 port,
                 socket,
-                server_id,
                 heartbeat,  # pyright: ignore[reportArgumentType]
                 watch_server,
                 grpc_server_registry,


### PR DESCRIPTION
## Summary & Motivation
This is causing issues when using the proxy server entrypoint because we set a fixed server ID (the value of which the frontend uses when deciding whether to reload information from the backend) and then don't update it when the underlying code server process changes. Instead, just rely on the code servers themselves to tell us what the underlying server ID is, which will automatically be updated correctly in both entrypoints when the process is reloaded.

## How I Tested These Changes
Existing test coverage 

Load definitions in dagster dev with one resource, add a second resource, reload definitions in the UI
Before: server ID is fixed and does not update, so the frontend doesn't update either
Now: server ID changes, and frontend updates


## Changelog

Fixed an issue where when using `dagster dev`, some changes were not reflected in the UI after pressing the "Reload Definitions" button.