### PR TITLE
Update configuration-reference.md

### DIFF
--- a/docs/docs/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/configuration-reference.md
+++ b/docs/docs/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/configuration-reference.md
@@ -38,12 +38,12 @@ locations:
         secrets_tags:
           - "my_tag_name"
         server_resources: # Resources for code servers launched by the agent for this location
-          cpu: 256
-          memory: 512
+          cpu: "256"
+          memory: "512"
           replica_count: 1
         run_resources: # Resources for runs launched by the agent for this location
-          cpu: 4096
-          memory: 16384
+          cpu: "4096"
+          memory: "16384"
         execution_role_arn: arn:aws:iam::123456789012:role/MyECSExecutionRole
         task_role_arn: arn:aws:iam::123456789012:role/MyECSTaskRole
         mount_points:


### PR DESCRIPTION
Fix example: the cpu and memory should be a string

## Summary & Motivation
The values should be a string (according to dagster_cloud_cli message on Github Actions failed run):
```
Exception: Unable to deploy locations: {'data': {'deployLocations': {'__typename': 'InvalidLocationError', 'errors': ['Invalid scalar at path root:locations[0]:container_context:ecs:run_resources:cpu. Value "4096" of type "<class \'int\'>" is not valid for expected type "String".', 'Invalid scalar at path root:locations[0]:container_context:ecs:run_resources:memory. Value "16384" of type "<class \'int\'>" is not valid for expected type "String".', 'Invalid scalar at path root:locations[0]:container_context:ecs:server_resources:cpu. Value "256" of type "<class \'int\'>" is not valid for expected type "String".', 'Invalid scalar at path root:locations[0]:container_context:ecs:server_resources:memory. Value "512" of type "<class \'int\'>" is not valid for expected type "String".']}}}
```
## How I Tested These Changes
I ran the code as I was deploying my own project
