### PR TITLE
[components] Component is a BaseModel, add field_resolver

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -13,7 +13,10 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffoldRequest as ComponentScaffoldRequest,
     DefaultComponentScaffolder as DefaultComponentScaffolder,
 )
-from dagster_components.core.schema.base import ResolvableSchema as ResolvableSchema
+from dagster_components.core.schema.base import (
+    ResolvableSchema as ResolvableSchema,
+    field_resolver as field_resolver,
+)
 from dagster_components.core.schema.context import ResolutionContext as ResolutionContext
 from dagster_components.core.schema.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.core.schema.objects import (

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -1,23 +1,34 @@
-from collections.abc import Mapping, Set
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, get_args
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar
 
+from dagster._annotations import _get_annotation_target
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._record import record
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from dagster_components.core.schema.context import ResolutionContext
 
-FIELD_RESOLVER_PREFIX = "resolve_"
+FIELD_RESOLVER_ATTR = "__field_resolver__"
 
 T = TypeVar("T")
 
 
-class ResolvableSchema(BaseModel, Generic[T]):
-    model_config = ConfigDict(extra="forbid")
+def _get_default_field_resolver(field_name: str):
+    def _resolver(schema: "ResolvableSchema", context: "ResolutionContext"):
+        return context.resolve_value(getattr(schema, field_name))
 
-    @property
-    def _resolved_type(self) -> type:
-        generic_args = get_args(self.__class__.__pydantic_generic_metadata__)
+    return _resolver
+
+
+class ResolvableSchema(BaseModel, Generic[T]):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    def _get_resolved_type(self) -> Optional[type]:
+        generic_base = next(
+            base for base in self.__class__.__bases__ if issubclass(base, ResolvableSchema)
+        )
+        generic_args = generic_base.__pydantic_generic_metadata__["args"]
         if len(generic_args) == 0:
             # if no generic type is specified, resolve back to the base type
             return self.__class__
@@ -26,28 +37,88 @@ class ResolvableSchema(BaseModel, Generic[T]):
                 f"Expected at most one generic argument for type: `{self.__class__}`"
             )
         resolved_type = generic_args[0]
-        if isinstance(resolved_type, str):
+        return resolved_type if isinstance(resolved_type, type) else None
+
+    def _get_implicit_field_resolvers(self, target_type: type) -> Mapping[str, "FieldResolverInfo"]:
+        if issubclass(target_type, BaseModel):
+            # extract target field names directly from the target type if possible
+            field_names = target_type.model_fields.keys()
+        else:
+            # assume field names in target type align with field names in the schema
+            field_names = self.model_fields.keys()
+        return {
+            field_name: FieldResolverInfo(
+                field_name=field_name, fn=_get_default_field_resolver(field_name)
+            )
+            for field_name in field_names
+        }
+
+    def _get_field_resolvers(self, target_type: type) -> Mapping[str, "FieldResolverInfo"]:
+        return {
+            **self._get_implicit_field_resolvers(target_type),
+            **_get_explicit_field_resolvers(self.FieldResolvers),
+            **_get_explicit_field_resolvers(target_type),
+        }
+
+    @property
+    def _resolved_type(self) -> type:
+        resolved_type = self._get_resolved_type()
+        if resolved_type is None:
             raise DagsterInvalidDefinitionError(
-                f"Attempted to directly resolve a `ResolvableSchema` ({self.__class__}) with a ForwardRef: `{resolved_type}`. "
-                "Use `resolve_as` instead."
+                f"Could not extract resolved type instance from `{self.__class__}`. "
+                "This can happen when using a ForwardRef when defining your ResolvableModel "
+                '(`ResolvableModel["SomeType"]`). Consider using a concrete type or calling '
+                "`resolve_as` instead."
             )
         return resolved_type
 
-    def _resolve_field(self, context: "ResolutionContext", field: str) -> Any:
-        return context.resolve_value(getattr(self, field))
-
-    def resolve_fields(
-        self, context: "ResolutionContext", exclude: Optional[Set[str]] = None
-    ) -> Mapping[str, Any]:
+    def resolve_fields(self, target_type: type, context: "ResolutionContext") -> Mapping[str, Any]:
         """Returns a mapping of field names to resolved values for those fields."""
         return {
-            field: context.resolve_value(getattr(self, field))
-            for field in self.model_fields
-            if exclude is None or field not in exclude
+            field_name: resolver_info.fn(self, context)
+            for field_name, resolver_info in self._get_field_resolvers(target_type).items()
         }
 
-    def resolve_as(self, as_type: type[T], context: "ResolutionContext") -> T:
-        return as_type(**self.resolve_fields(context))
+    def resolve_as(self, target_type: type[T], context: "ResolutionContext") -> T:
+        return target_type(**self.resolve_fields(target_type, context))
 
     def resolve(self, context: "ResolutionContext") -> T:
         return self.resolve_as(self._resolved_type, context)
+
+    class FieldResolvers: ...
+
+
+@record
+class FieldResolverInfo:
+    field_name: str
+    fn: Callable[[ResolvableSchema, "ResolutionContext"], Any]
+
+
+FieldResolverArgs = [ResolvableSchema, "ResolutionContext"]
+
+
+def field_resolver(field_name: str) -> Any:
+    def decorator(
+        fn: Callable[[ResolvableSchema, "ResolutionContext"], T],
+    ) -> Callable[[ResolvableSchema, "ResolutionContext"], T]:
+        setattr(
+            _get_annotation_target(fn),
+            FIELD_RESOLVER_ATTR,
+            FieldResolverInfo(field_name=field_name, fn=fn),
+        )
+        return fn
+
+    return decorator
+
+
+def _get_field_resolver_info(obj: Any) -> Optional[FieldResolverInfo]:
+    return getattr(_get_annotation_target(obj), FIELD_RESOLVER_ATTR, None)
+
+
+def _get_explicit_field_resolvers(cls: type) -> dict[str, FieldResolverInfo]:
+    resolvers = {}
+    for attr_name in dir(cls):
+        info = _get_field_resolver_info(getattr(cls, attr_name))
+        if isinstance(info, FieldResolverInfo):
+            resolvers[info.field_name] = info
+    return resolvers

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -10,9 +10,9 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from pydantic import BaseModel
+from pydantic import computed_field
 
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, ComponentLoadContext, field_resolver
 from dagster_components.core.component import registered_component_type
 from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
@@ -26,50 +26,45 @@ from dagster_components.lib.dbt_project.scaffolder import DbtProjectComponentSca
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
-class ResolvedDbtProjectSchema(BaseModel):
-    dbt: DbtCliResource
-    op: OpSpecSchema
-    translator: DagsterDbtTranslator
-    transforms: Sequence[Callable[[Definitions], Definitions]]
-
-
-class DbtProjectSchema(ResolvableSchema[ResolvedDbtProjectSchema]):
+class DbtProjectSchema(ResolvableSchema["DbtProjectComponent"]):
     dbt: DbtCliResource
     op: Optional[OpSpecSchema] = None
     asset_attributes: Annotated[
-        Optional[AssetAttributesSchema], ResolvableFieldInfo(required_scope={"node"})
+        Optional[AssetAttributesSchema],
+        ResolvableFieldInfo(required_scope={"node"}),
     ] = None
     transforms: Optional[Sequence[AssetSpecTransformSchema]] = None
-
-    def resolve(self, context: ResolutionContext) -> ResolvedDbtProjectSchema:
-        return ResolvedDbtProjectSchema(
-            dbt=DbtCliResource(**context.resolve_value(self.dbt.model_dump())),
-            op=context.resolve_value(self.op) or OpSpecSchema(),
-            translator=get_wrapped_translator_class(DagsterDbtTranslator)(
-                resolving_info=TranslatorResolvingInfo(
-                    "node", self.asset_attributes or AssetAttributesSchema(), context
-                )
-            ),
-            transforms=context.resolve_value(self.transforms or []),
-        )
 
 
 @registered_component_type(name="dbt_project")
 class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
 
-    def __init__(
-        self,
-        dbt: DbtCliResource,
-        op: Optional[OpSpecSchema],
-        translator: DagsterDbtTranslator,
-        transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = None,
-    ):
-        self.resource = dbt
-        self.project = DbtProject(dbt.project_dir)
-        self.op_spec = op
-        self.transforms = transforms or []
-        self.translator = translator
+    dbt: DbtCliResource
+    op: Optional[OpSpecSchema]
+    translator: DagsterDbtTranslator
+    transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = None
+
+    @field_resolver("dbt")
+    @staticmethod
+    def resolve_dbt(schema: DbtProjectSchema, context: ResolutionContext) -> DbtCliResource:
+        return DbtCliResource(**context.resolve_value(schema.dbt.model_dump()))
+
+    @field_resolver("translator")
+    @staticmethod
+    def resolve_asset_attributes(
+        schema: DbtProjectSchema, context: ResolutionContext
+    ) -> DagsterDbtTranslator:
+        return get_wrapped_translator_class(DagsterDbtTranslator)(
+            resolving_info=TranslatorResolvingInfo(
+                "node", schema.asset_attributes or AssetAttributesSchema(), context
+            )
+        )
+
+    @computed_field
+    @property
+    def project(self) -> DbtProject:
+        return DbtProject(self.dbt.project_dir)
 
     @classmethod
     def get_scaffolder(cls) -> "DbtProjectComponentScaffolder":
@@ -78,16 +73,6 @@ class DbtProjectComponent(Component):
     @classmethod
     def get_schema(cls) -> type[DbtProjectSchema]:
         return DbtProjectSchema
-
-    @classmethod
-    def load(cls, context: ComponentLoadContext, schema: DbtProjectSchema) -> "DbtProjectComponent":
-        resolved_schema = context.resolution_context.resolve_value(schema)
-        return cls(
-            dbt=resolved_schema.dbt,
-            op=resolved_schema.op,
-            translator=resolved_schema.translator,
-            transforms=resolved_schema.transforms,
-        )
 
     def get_asset_selection(
         self, select: str, exclude: Optional[str] = None
@@ -105,15 +90,15 @@ class DbtProjectComponent(Component):
         @dbt_assets(
             manifest=self.project.manifest_path,
             project=self.project,
-            name=self.op_spec.name if self.op_spec else self.project.name,
-            op_tags=self.op_spec.tags if self.op_spec else None,
+            name=self.op.name if self.op else self.project.name,
+            op_tags=self.op.tags if self.op else None,
             dagster_dbt_translator=self.translator,
         )
         def _fn(context: AssetExecutionContext):
-            yield from self.execute(context=context, dbt=self.resource)
+            yield from self.execute(context=context, dbt=self.dbt)
 
         defs = Definitions(assets=[_fn])
-        for transform in self.transforms:
+        for transform in self.transforms or []:
             defs = transform(defs)
         return defs
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from dagster._core.definitions.definitions_class import Definitions
@@ -25,8 +24,7 @@ class DefinitionsParamSchema(ResolvableSchema):
 class DefinitionsComponent(Component):
     """Wraps an arbitrary set of Dagster definitions."""
 
-    def __init__(self, definitions_path: Optional[Path]):
-        self.definitions_path = definitions_path or Path("definitions.py")
+    definitions_path: Optional[str]
 
     @classmethod
     def get_scaffolder(cls) -> DefinitionsComponentScaffolder:
@@ -38,6 +36,8 @@ class DefinitionsComponent(Component):
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         with pushd(str(context.path)):
-            module = import_uncached_module_from_path("definitions", str(self.definitions_path))
+            module = import_uncached_module_from_path(
+                "definitions", self.definitions_path or "definitions.py"
+            )
 
         return load_definitions_from_module(module)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -8,13 +8,14 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
+from pydantic import BaseModel, ConfigDict
 
 from dagster_components.core.component import (
     Component,
     ComponentLoadContext,
     registered_component_type,
 )
-from dagster_components.core.schema.base import ResolvableSchema
+from dagster_components.core.schema.base import ResolvableSchema, field_resolver
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.objects import AssetSpecSchema
 
@@ -22,29 +23,34 @@ if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
 
 
-class PipesSubprocessScriptParams(ResolvableSchema[tuple[str, Sequence[AssetSpec]]]):
+class PipesSubprocessScriptSpec(BaseModel):
+    path: str
+    assets: Sequence[AssetSpec]
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+
+class PipesSubprocessScriptParams(ResolvableSchema[PipesSubprocessScriptSpec]):
     path: str
     assets: Sequence[AssetSpecSchema]
 
-    def resolve(self, context: ResolutionContext):
-        return context.resolve_value((self.path, self.assets))
 
-
-class PipesSubprocessScriptCollectionParams(ResolvableSchema):
+class PipesSubprocessScriptCollectionParams(ResolvableSchema["PipesSubprocessScriptCollection"]):
     scripts: Sequence[PipesSubprocessScriptParams]
-
-    def resolve_as(self, cls, context: ResolutionContext):
-        return cls(specs_by_path=dict(script.resolve(context) for script in self.scripts))
 
 
 @registered_component_type(name="pipes_subprocess_script_collection")
 class PipesSubprocessScriptCollection(Component):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
 
-    def __init__(self, specs_by_path: Mapping[str, Sequence[AssetSpec]]):
-        # mapping from the script name (e.g. /path/to/script_abc.py -> script_abc)
-        # to the specs it produces
-        self.specs_by_path = specs_by_path
+    specs_by_path: Mapping[str, Sequence[AssetSpec]]
+
+    @staticmethod
+    @field_resolver("specs_by_path")
+    def resolve_specs_by_path(
+        schema: PipesSubprocessScriptCollectionParams, context: ResolutionContext
+    ) -> Mapping[str, Sequence[AssetSpec]]:
+        return {spec.path: spec.assets for spec in context.resolve_value(schema.scripts)}
 
     @staticmethod
     def introspect_from_path(path: Path) -> "PipesSubprocessScriptCollection":

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -13,16 +13,11 @@ class MyComponentSchema(ResolvableSchema):
     a_string: str
     an_int: int
 
-    model_config = ConfigDict(extra="forbid")
-
 
 @registered_component_type
 class MyComponent(Component):
-    name = "my_component"
-
-    def __init__(self, a_string: str, an_int: int):
-        self.a_string = a_string
-        self.an_int = an_int
+    a_string: str
+    an_int: int
 
     @classmethod
     def get_schema(cls) -> type[MyComponentSchema]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -10,11 +10,8 @@ class MyComponentSchema(ResolvableSchema):
 
 @registered_component_type
 class MyComponent(Component):
-    name = "my_component"
-
-    def __init__(self, a_string: str, an_int: int):
-        self.a_string = a_string
-        self.an_int = an_int
+    a_string: str
+    an_int: int
 
     @classmethod
     def get_schema(cls):

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
@@ -1,8 +1,9 @@
 type: custom_scope_component@component.py
 
 params:
-  group_name: "{{ custom_str }}"
-  tags: "{{ custom_dict }}"
-  metadata:
-    prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
-  automation_condition: "{{ custom_automation_condition('@daily') }}"
+  asset_attributes:
+    group_name: "{{ custom_str }}"
+    tags: "{{ custom_dict }}"
+    metadata:
+      prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
+    automation_condition: "{{ custom_automation_condition('@daily') }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -3,43 +3,40 @@ from typing import Optional
 
 import pytest
 from dagster._check.functions import ParameterCheckError
-from dagster._record import record
-from dagster_components import ResolutionContext, ResolvableSchema
+from dagster_components import ResolutionContext, ResolvableSchema, field_resolver
+from pydantic import BaseModel
 
 
-@record
-class InnerObject:
+class InnerObject(BaseModel):
     val1_renamed: int
     val2: Optional[str]
 
+    @field_resolver("val1_renamed")
+    @staticmethod
+    def resolve_val1_renamed(schema: "InnerSchema", context: ResolutionContext) -> int:
+        return 20 + context.resolve_value(schema.val1, as_type=int)
 
-@record
-class TargetObject:
+
+class TargetObject(BaseModel):
     int_val: int
     str_val: str
     inners: Optional[Sequence[InnerObject]]
 
 
-class InnerParams(ResolvableSchema[InnerObject]):
+class InnerSchema(ResolvableSchema[InnerObject]):
     val1: str
     val2: Optional[str]
 
-    def resolve(self, context: ResolutionContext) -> InnerObject:
-        return InnerObject(
-            val1_renamed=context.resolve_value(self.val1, as_type=int) + 20,
-            val2=context.resolve_value(self.val2, as_type=Optional[str]),
-        )
 
-
-class TargetParams(ResolvableSchema):
+class TargetParams(ResolvableSchema[TargetObject]):
     int_val: str
     str_val: str
-    inners: Optional[Sequence[InnerParams]] = None
+    inners: Optional[Sequence[InnerSchema]] = None
 
 
 def test_valid_resolution_simple() -> None:
     context = ResolutionContext(scope={"some_int": 1, "some_str": "a"})
-    params = InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_b")
+    params = InnerSchema(val1="{{ some_int }}", val2="{{ some_str }}_b")
     assert context.resolve_value(params) == InnerObject(val1_renamed=21, val2="a_b")
 
 
@@ -48,7 +45,7 @@ def test_valid_resolution_nested() -> None:
     params = TargetParams(
         int_val="{{ some_int }}",
         str_val="{{ some_str }}_x",
-        inners=[InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_y")],
+        inners=[InnerSchema(val1="{{ some_int }}", val2="{{ some_str }}_y")],
     )
 
     assert context.resolve_value(params) == TargetObject(
@@ -62,4 +59,4 @@ def test_valid_resolution_nested() -> None:
 def test_invalid_resolution_simple() -> None:
     with pytest.raises(ParameterCheckError):
         context = ResolutionContext(scope={"some_int": "NOT_AN_INT"})
-        context.resolve_value(InnerParams(val1="{{ some_int }}", val2="abc"))
+        context.resolve_value(InnerSchema(val1="{{ some_int }}", val2="abc"))


### PR DESCRIPTION
## Summary & Motivation

This subjectively feels the best out of the options so far.

By making Component a BaseModel, we avoid needing to create a completely separate class to encode the types of individual resolved fields. This also means we get pydantic's type checking for free on Component class, and we have the option of auto-generating the schema for simple cases in the future if we so desire.

I don't include the code to do this in this PR, but it'd be fairly straightforward to automatically validate that a given Component class actually matches up with the data provided by its resolved schema.

This is also just about as terse as it's ever been.

## How I Tested These Changes

## Changelog

NOCHANGELOG
