### PR TITLE
Move utilities out of useGlobalSearch to avoid circular dependency.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {OpTags} from './OpTags';
 import {DefinitionTag} from '../graphql/types';
-import {linkToAssetTableWithKindFilter} from '../search/useGlobalSearch';
+import {linkToAssetTableWithKindFilter} from '../search/links';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
 
 export const LEGACY_COMPUTE_KIND_TAG = 'kind';

--- a/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
@@ -1,0 +1,44 @@
+import qs from 'qs';
+
+import {GroupMetadata} from './BuildAssetSearchResults';
+import {AssetOwner, DefinitionTag} from '../graphql/types';
+import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+export const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
+  return `/assets?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;
+};
+
+export const linkToAssetTableWithKindFilter = (kind: string) => {
+  return `/assets?${qs.stringify({
+    kinds: JSON.stringify([kind]),
+  })}`;
+};
+
+export const linkToAssetTableWithTagFilter = (tag: Omit<DefinitionTag, '__typename'>) => {
+  return `/assets?${qs.stringify({
+    tags: JSON.stringify([tag]),
+  })}`;
+};
+
+export const linkToAssetTableWithAssetOwnerFilter = (owner: AssetOwner) => {
+  return `/assets?${qs.stringify({
+    owners: JSON.stringify([owner]),
+  })}`;
+};
+
+export const linkToAssetTableWithColumnsFilter = (columns: string[]) => {
+  return `/assets?${qs.stringify({
+    columns: JSON.stringify(columns),
+  })}`;
+};
+
+export const linkToAssetTableWithColumnTagFilter = (tag: Omit<DefinitionTag, '__typename'>) => {
+  return `/assets?${qs.stringify({
+    columnTags: JSON.stringify([tag]),
+  })}`;
+};
+
+export const linkToCodeLocation = (repoAddress: RepoAddress) => {
+  return `/locations/${repoAddressAsURLString(repoAddress)}/assets`;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,9 +1,15 @@
-import qs from 'qs';
 import {useCallback, useContext, useEffect, useRef} from 'react';
 import {useAugmentSearchResults} from 'shared/search/useAugmentSearchResults.oss';
 
-import {GroupMetadata, buildAssetCountBySection} from './BuildAssetSearchResults';
+import {buildAssetCountBySection} from './BuildAssetSearchResults';
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
+import {
+  linkToAssetTableWithAssetOwnerFilter,
+  linkToAssetTableWithGroupFilter,
+  linkToAssetTableWithKindFilter,
+  linkToAssetTableWithTagFilter,
+  linkToCodeLocation,
+} from './links';
 import {AssetFilterSearchResultType, SearchResult, SearchResultType} from './types';
 import {
   SearchPrimaryQuery,
@@ -24,51 +30,10 @@ import {
 } from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetTableFragment} from '../assets/types/AssetTableFragment.types';
-import {AssetOwner, DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
 import {assetOwnerAsString} from '../workspace/assetOwnerAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
-import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
-import {RepoAddress} from '../workspace/types';
 import {workspacePath} from '../workspace/workspacePath';
-
-export const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
-  return `/assets?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;
-};
-
-export const linkToAssetTableWithKindFilter = (kind: string) => {
-  return `/assets?${qs.stringify({
-    kinds: JSON.stringify([kind]),
-  })}`;
-};
-
-export const linkToAssetTableWithTagFilter = (tag: Omit<DefinitionTag, '__typename'>) => {
-  return `/assets?${qs.stringify({
-    tags: JSON.stringify([tag]),
-  })}`;
-};
-
-export const linkToAssetTableWithAssetOwnerFilter = (owner: AssetOwner) => {
-  return `/assets?${qs.stringify({
-    owners: JSON.stringify([owner]),
-  })}`;
-};
-
-export const linkToAssetTableWithColumnsFilter = (columns: string[]) => {
-  return `/assets?${qs.stringify({
-    columns: JSON.stringify(columns),
-  })}`;
-};
-
-export const linkToAssetTableWithColumnTagFilter = (tag: Omit<DefinitionTag, '__typename'>) => {
-  return `/assets?${qs.stringify({
-    columnTags: JSON.stringify([tag]),
-  })}`;
-};
-
-export const linkToCodeLocation = (repoAddress: RepoAddress) => {
-  return `/locations/${repoAddressAsURLString(repoAddress)}/assets`;
-};
 
 const primaryDataToSearchResults = (input: {data?: SearchPrimaryQuery}) => {
   const {data} = input;


### PR DESCRIPTION
## Summary & Motivation

The link utilities are used broadly across the app which causes a circular dependency for our filtering utilities because they depend on KingTags.tsx which uses one of those link utilities which ends up in a circular dependency with our CatalogViewProvider in cloud.

## How I Tested These Changes

bk