### PR TITLE
Update Vale and docs build GH actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,11 +8,19 @@ on:
     paths:
       - docs/**
       - examples/docs_beta_snippets/**
+      - examples/docs_snippets/**
+      - examples/docs_projects/**
+      - examples/getting_started_etl_tutorial/**
+      - examples/airlift-migration-tutorial/**
       - .github/workflows/build-docs.yml
   pull_request:
     paths:
       - docs/**
       - examples/docs_beta_snippets/**
+      - examples/docs_snippets/**
+      - examples/docs_projects/**
+      - examples/getting_started_etl_tutorial/**
+      - examples/airlift-migration-tutorial/**
       - .github/workflows/build-docs.yml
     types:
       - opened

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -4,6 +4,11 @@ on:
     paths:
       - 'docs/**'
       - .github/workflows/vale.yml
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master
@@ -24,6 +29,7 @@ jobs:
     name: runner / vale
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
## Summary & Motivation

Updates Vale and docs build GH actions:

- Vale: don't run on draft PRs
- Docs build: trigger when examples/docs_snippets, examples/docs_projects, examples/getting_started_etl_tutorial, and examples/airlift-migration-tutorial are updated, since code in these directories is referenced in docs.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
