### PR TITLE
swap the default granularity displayed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
@@ -132,7 +132,7 @@ export const InstanceConcurrencyKeyInfo = ({concurrencyKey}: {concurrencyKey: st
                 <tbody>
                   <tr>
                     <td style={{verticalAlign: 'middle'}}>Granularity</td>
-                    <td>{granularity === 'run' ? 'Run' : 'Op'}</td>
+                    <td>{granularity === 'op' ? 'Op' : 'Run'}</td>
                   </tr>
                   <tr>
                     <td style={{verticalAlign: 'middle'}}>Limit</td>
@@ -161,7 +161,7 @@ export const InstanceConcurrencyKeyInfo = ({concurrencyKey}: {concurrencyKey: st
                 </tbody>
               </MetadataTableWIP>
             </Box>
-            {data?.instance.poolConfig?.poolGranularity !== 'run' ? (
+            {data?.instance.poolConfig?.poolGranularity === 'op' ? (
               <>
                 <Box
                   padding={{vertical: 16, horizontal: 24}}


### PR DESCRIPTION
## Summary & Motivation
Starting with `1.10.0`, the queued run coordinator treats unspecified granularity as run granularity.

## How I Tested These Changes
BK
