### PR TITLE
[Selection syntax] Add custom error messages for invalid attributes.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
@@ -1,6 +1,7 @@
 import type {Linter} from 'codemirror/addon/lint/lint';
 import {useAssetSelectionAutoCompleteProvider as defaultUseAssetSelectionAutoCompleteProvider} from 'shared/asset-selection/input/useAssetSelectionAutoCompleteProvider.oss';
 
+import {assetSelectionSyntaxSupportedAttributes, unsupportedAttributeMessages} from './util';
 import {AssetGraphQueryItem} from '../../asset-graph/useAssetGraphData';
 import {SelectionAutoCompleteProvider} from '../../selection/SelectionAutoCompleteProvider';
 import {SelectionAutoCompleteInput} from '../../selection/SelectionInput';
@@ -21,6 +22,8 @@ export interface AssetSelectionInputProps {
 const defaultLinter = createSelectionLinter({
   Lexer: AssetSelectionLexer,
   Parser: AssetSelectionParser,
+  supportedAttributes: assetSelectionSyntaxSupportedAttributes,
+  unsupportedAttributeMessages,
 });
 
 export const AssetSelectionInput = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
@@ -79,3 +79,14 @@ export const attributeToIcon: Record<Attribute, IconName> = {
   owner: 'owner',
   tag: 'tag',
 };
+
+export const assetSelectionSyntaxSupportedAttributes: Attribute[] = Object.keys(
+  attributeToIcon,
+) as Attribute[];
+
+export const unsupportedAttributeMessages = {
+  column_tag: 'column_tag filtering is available in Dagster+',
+  column: 'column filtering is available in Dagster+',
+  table_name: 'table_name filtering is available in Dagster+',
+  changed_in_branch: 'changed_in_branch filtering is available in Dagster+ branch deployments',
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartSelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartSelectionInput.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 import {RunGraphQueryItem} from './toGraphQueryItems';
-import {useGanttChartSelectionAutoCompleteProvider} from './useGanttChartSelectionAutoCompleteProvider';
+import {
+  ganttChartSelectionSyntaxSupportedAttributes,
+  useGanttChartSelectionAutoCompleteProvider,
+} from './useGanttChartSelectionAutoCompleteProvider';
 import {RunSelectionLexer} from '../run-selection/generated/RunSelectionLexer';
 import {RunSelectionParser} from '../run-selection/generated/RunSelectionParser';
 import {InputDiv, SelectionAutoCompleteInput} from '../selection/SelectionInput';
@@ -31,7 +34,11 @@ export const GanttChartSelectionInput = ({
   );
 };
 const getLinter = weakMapMemoize(() =>
-  createSelectionLinter({Lexer: RunSelectionLexer, Parser: RunSelectionParser}),
+  createSelectionLinter({
+    Lexer: RunSelectionLexer,
+    Parser: RunSelectionParser,
+    supportedAttributes: ganttChartSelectionSyntaxSupportedAttributes,
+  }),
 );
 
 const Wrapper = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/useGanttChartSelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/useGanttChartSelectionAutoCompleteProvider.tsx
@@ -8,6 +8,8 @@ import {
   createProvider,
 } from '../selection/SelectionAutoCompleteProvider';
 
+export const ganttChartSelectionSyntaxSupportedAttributes = ['name', 'status'] as const;
+
 export function useGanttChartSelectionAutoCompleteProvider(
   items: RunGraphQueryItem[],
 ): Pick<SelectionAutoCompleteProvider, 'useAutoComplete'> {

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/OpGraphSelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/OpGraphSelectionInput.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
-import {useOpGraphSelectionAutoCompleteProvider} from './useOpGraphSelectionAutoCompleteProvider';
+import {
+  opGraphSelectionSyntaxSupportedAttributes,
+  useOpGraphSelectionAutoCompleteProvider,
+} from './useOpGraphSelectionAutoCompleteProvider';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {OpSelectionLexer} from '../op-selection/generated/OpSelectionLexer';
 import {OpSelectionParser} from '../op-selection/generated/OpSelectionParser';
@@ -32,7 +35,11 @@ export const OpGraphSelectionInput = ({
 };
 
 const getLinter = weakMapMemoize(() =>
-  createSelectionLinter({Lexer: OpSelectionLexer, Parser: OpSelectionParser}),
+  createSelectionLinter({
+    Lexer: OpSelectionLexer,
+    Parser: OpSelectionParser,
+    supportedAttributes: opGraphSelectionSyntaxSupportedAttributes,
+  }),
 );
 
 const Wrapper = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/useOpGraphSelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/useOpGraphSelectionAutoCompleteProvider.tsx
@@ -8,6 +8,8 @@ import {
   createProvider,
 } from '../selection/SelectionAutoCompleteProvider';
 
+export const opGraphSelectionSyntaxSupportedAttributes = ['name'] as const;
+
 export const useOpGraphSelectionAutoCompleteProvider = (
   items: GraphQueryItem[],
 ): Pick<SelectionAutoCompleteProvider, 'useAutoComplete'> => {

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
@@ -274,7 +274,7 @@ export const createProvider = <
     options?: {includeParenthesis?: boolean};
   }) {
     const functionName = func[0]!.toUpperCase() + func.slice(1);
-    const displayText = options?.includeParenthesis ? `${functionName}()` : functionName;
+    const rightLabel = options?.includeParenthesis ? `${func}()` : func;
     let icon: IconName;
     switch (func) {
       case 'roots':
@@ -288,7 +288,7 @@ export const createProvider = <
     }
     return {
       text,
-      jsx: <SuggestionJSXBase label={functionName} icon={icon} rightLabel={displayText} />,
+      jsx: <SuggestionJSXBase label={functionName} icon={icon} rightLabel={rightLabel} />,
     };
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -113,6 +113,7 @@ export const SelectionAutoCompleteInput = ({
       });
 
       cmInstance.current.setSize('100%', 20);
+      setCurrentHeight(20);
 
       // Enforce single line by preventing newlines
       cmInstance.current.on('beforeChange', (_instance: Editor, change) => {
@@ -170,6 +171,8 @@ export const SelectionAutoCompleteInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const [currentHeight, setCurrentHeight] = useState(20);
+
   const adjustHeight = useCallback(() => {
     const lines = cmInstance.current?.getWrapperElement().querySelector('.CodeMirror-lines');
     if (!lines || !cmInstance.current || !focusRef.current) {
@@ -179,6 +182,7 @@ export const SelectionAutoCompleteInput = ({
       const linesHeight = lines?.clientHeight;
       if (linesHeight && focusRef.current) {
         cmInstance.current?.setSize('100%', `${linesHeight}px`);
+        setCurrentHeight(linesHeight);
       }
     });
   }, []);
@@ -318,6 +322,7 @@ export const SelectionAutoCompleteInput = ({
     focusRef.current = false;
     cmInstance.current?.setOption('lineWrapping', false);
     cmInstance.current?.setSize('100%', '20px');
+    setCurrentHeight(20);
   }, []);
 
   useResizeObserver(inputRef, adjustHeight);
@@ -355,13 +360,13 @@ export const SelectionAutoCompleteInput = ({
             setShowResults({current: true});
           }}
         >
-          <div style={{alignSelf: 'flex-start'}}>
+          <div style={{alignSelf: currentHeight > 20 ? 'flex-start' : 'center'}}>
             <Icon name="search" style={{marginTop: 2}} />
           </div>
           <div ref={editorRef} />
           <Box
             flex={{direction: 'row', alignItems: 'center', gap: 4}}
-            style={{alignSelf: 'flex-end'}}
+            style={{alignSelf: currentHeight > 20 ? 'flex-end' : 'center'}}
           >
             {innerValue !== '' && (
               <UnstyledButton

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/createSelectionLinter.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/createSelectionLinter.test.ts
@@ -1,0 +1,81 @@
+import CodeMirror from 'codemirror';
+
+import {AssetSelectionLexer} from '../../asset-selection/generated/AssetSelectionLexer';
+import {AssetSelectionParser} from '../../asset-selection/generated/AssetSelectionParser';
+import {createSelectionLinter} from '../createSelectionLinter';
+
+const supportedAttributes = ['key', 'kind'];
+const unsupportedAttributeMessages = {
+  tag: 'tag filtering is not supported in this test',
+  column: 'column filtering is not supported in this test',
+};
+
+const linter = createSelectionLinter({
+  Lexer: AssetSelectionLexer,
+  Parser: AssetSelectionParser,
+  supportedAttributes,
+  unsupportedAttributeMessages,
+});
+
+describe('createSelectionLinter', () => {
+  it('returns a linter function', () => {
+    expect(typeof linter).toBe('function');
+  });
+
+  it('handles empty input', () => {
+    const errors = linter('');
+    expect(errors).toEqual([]);
+  });
+
+  it('handles valid input with supported attributes', () => {
+    const input = 'key:value';
+    const errors = linter(input);
+    expect(errors).toEqual([]);
+  });
+
+  it('handles multiple unsupported attributes', () => {
+    const input = 'tag:value or column:value or table_name:value';
+    const errors = linter(input);
+    expect(errors).toEqual([
+      {
+        message: 'tag filtering is not supported in this test',
+        severity: 'error',
+        from: CodeMirror.Pos(0, 0),
+        to: CodeMirror.Pos(0, 'tag'.length),
+      },
+      {
+        message: 'column filtering is not supported in this test',
+        severity: 'error',
+        from: CodeMirror.Pos(0, 'tag:value or '.length),
+        to: CodeMirror.Pos(0, 'tag:value or column'.length),
+      },
+      {
+        message: 'Unsupported attribute: table_name', // default message
+        severity: 'error',
+        from: CodeMirror.Pos(0, 'tag:value or column:value or '.length),
+        to: CodeMirror.Pos(0, 'tag:value or column:value or table_name'.length),
+      },
+    ]);
+  });
+
+  it('does not report unsupported attributes when they overlap with syntax errors', () => {
+    const mockLinter = createSelectionLinter({
+      Lexer: AssetSelectionLexer,
+      Parser: AssetSelectionParser,
+      supportedAttributes,
+    });
+
+    const input = 'fake:value';
+    const errors = mockLinter(input);
+
+    // Only expect syntax errors, not attribute errors
+    expect(errors).toEqual([
+      expect.objectContaining({
+        from: CodeMirror.Pos(0, 0),
+        message: expect.stringContaining("mismatched input 'fake'"),
+        severity: 'error',
+        to: CodeMirror.Pos(0, 10),
+      }),
+    ]);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
@@ -1,8 +1,11 @@
 import {CharStreams, CommonTokenStream, Lexer, Parser, ParserRuleContext} from 'antlr4ts';
+import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
 import CodeMirror from 'codemirror';
-import {Linter} from 'codemirror/addon/lint/lint';
 
 import {CustomErrorListener} from './CustomErrorListener';
+import {parseInput} from './SelectionInputParser';
+import {AttributeNameContext} from './generated/SelectionAutoCompleteParser';
+import {SelectionAutoCompleteVisitor} from './generated/SelectionAutoCompleteVisitor';
 
 type LexerConstructor = new (...args: any[]) => Lexer;
 type ParserConstructor = new (...args: any[]) => Parser & {
@@ -12,11 +15,18 @@ type ParserConstructor = new (...args: any[]) => Parser & {
 export function createSelectionLinter({
   Lexer: LexerKlass,
   Parser: ParserKlass,
+  supportedAttributes,
+  unsupportedAttributeMessages = {},
 }: {
   Lexer: LexerConstructor;
   Parser: ParserConstructor;
-}): Linter<any> {
+  supportedAttributes: readonly string[];
+  unsupportedAttributeMessages?: Record<string, string>;
+}) {
   return (text: string) => {
+    if (!text.length) {
+      return [];
+    }
     const errorListener = new CustomErrorListener();
 
     const inputStream = CharStreams.fromString(text);
@@ -41,6 +51,85 @@ export function createSelectionLinter({
       to: CodeMirror.Pos(0, text.length),
     }));
 
-    return lintErrors;
+    const {parseTrees} = parseInput(text);
+    const attributeVisitor = new InvalidAttributeVisitor(
+      supportedAttributes,
+      unsupportedAttributeMessages,
+      lintErrors,
+    );
+    parseTrees.forEach(({tree}) => tree.accept(attributeVisitor));
+
+    return lintErrors.concat(attributeVisitor.getErrors());
   };
+}
+
+class InvalidAttributeVisitor
+  extends AbstractParseTreeVisitor<void>
+  implements SelectionAutoCompleteVisitor<void>
+{
+  private errors: {
+    message: string;
+    severity: 'error' | 'warning';
+    from: CodeMirror.Position;
+    to: CodeMirror.Position;
+  }[] = [];
+  private sortedLintErrors: {from: CodeMirror.Position; to: CodeMirror.Position}[];
+
+  constructor(
+    private supportedAttributes: readonly string[],
+    private unsupportedAttributeMessages: Record<string, string>,
+    lintErrors: {from: CodeMirror.Position; to: CodeMirror.Position}[],
+  ) {
+    super();
+    // Sort errors by start position for efficient searching
+    this.sortedLintErrors = [...lintErrors].sort((a, b) => a.from.ch - b.from.ch);
+  }
+
+  getErrors() {
+    return this.errors;
+  }
+
+  defaultResult() {
+    return undefined;
+  }
+
+  private hasOverlap(from: CodeMirror.Position, to: CodeMirror.Position): boolean {
+    // Binary search to find the first error that could potentially overlap
+    let low = 0;
+    let high = this.sortedLintErrors.length - 1;
+
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const error = this.sortedLintErrors[mid]!;
+
+      if (error.to.ch < from.ch) {
+        low = mid + 1;
+      } else if (error.from.ch > to.ch) {
+        high = mid - 1;
+      } else {
+        // Found an overlapping error
+        return true;
+      }
+    }
+    return false;
+  }
+
+  visitAttributeName(ctx: AttributeNameContext) {
+    const attributeName = ctx.IDENTIFIER().text;
+    if (!this.supportedAttributes.includes(attributeName)) {
+      const from = CodeMirror.Pos(0, ctx.start.startIndex);
+      const to = CodeMirror.Pos(0, ctx.stop!.stopIndex + 1);
+
+      if (!this.hasOverlap(from, to)) {
+        this.errors.push({
+          message:
+            this.unsupportedAttributeMessages[attributeName] ??
+            `Unsupported attribute: ${attributeName}`,
+          severity: 'error',
+          from,
+          to,
+        });
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary & Motivation

Recently we consolidated all of our asset selection grammars (branch deployment, OSS, Cloud) into just a single grammar in OSS that includes the attributes of all the grammars combined. This is to allow the AssetSelection parser in python to to parse strings from the UI and store/transport them to the UI, but also so that we can throw custom error messages rather than returning the default Antlr error which isn't very human friendly.

## How I Tested These Changes

Used this in OSS / Branch Deployments / Cloud / Alerts

<img width="458" alt="Screenshot 2025-02-12 at 1 38 14 AM" src="https://github.com/user-attachments/assets/8f0f1634-dce9-4868-8a1a-6053bdea0b4c" />
<img width="773" alt="Screenshot 2025-02-12 at 1 38 00 AM" src="https://github.com/user-attachments/assets/ca2761d1-52a3-436c-bba2-e737d2276db2" />
