### PR TITLE
[record] Fix handling of record classes with pydantic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -4,22 +4,22 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Union
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.partition_mapping import (
     PartitionMapping,
     warn_if_partition_mapping_not_builtin,
 )
-from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._utils.warnings import deprecation_warning
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_spec import AssetSpec
     from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.source_asset import SourceAsset
 
 
 CoercibleToAssetDep = Union[
-    CoercibleToAssetKey, AssetSpec, "AssetsDefinition", SourceAsset, "AssetDep"
+    CoercibleToAssetKey, "AssetSpec", "AssetsDefinition", "SourceAsset", "AssetDep"
 ]
 
 
@@ -58,11 +58,13 @@ class AssetDep(
 
     def __new__(
         cls,
-        asset: Union[CoercibleToAssetKey, AssetSpec, "AssetsDefinition", SourceAsset],
+        asset: Union[CoercibleToAssetKey, "AssetSpec", "AssetsDefinition", "SourceAsset"],
         *,
         partition_mapping: Optional[PartitionMapping] = None,
     ):
+        from dagster._core.definitions.asset_spec import AssetSpec
         from dagster._core.definitions.assets import AssetsDefinition
+        from dagster._core.definitions.source_asset import SourceAsset
 
         if isinstance(asset, list):
             check.list_param(asset, "asset", of_type=str)
@@ -101,7 +103,9 @@ class AssetDep(
 
 
 def _get_asset_key(arg: "CoercibleToAssetDep") -> AssetKey:
+    from dagster._core.definitions.asset_spec import AssetSpec
     from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.source_asset import SourceAsset
 
     if isinstance(arg, (AssetsDefinition, SourceAsset, AssetSpec)):
         return arg.key

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -6,7 +6,6 @@ from typing import (  # noqa: UP035
     AbstractSet,
     Any,
     Callable,
-    NamedTuple,
     Optional,
     Union,
     overload,
@@ -19,6 +18,7 @@ from dagster._annotations import (
     only_allow_hidden_params_in_kwargs,
     public,
 )
+from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -34,13 +34,13 @@ from dagster._core.definitions.utils import (
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import KIND_PREFIX
+from dagster._record import IHaveNew, LegacyNamedTupleMixin, record_custom
 from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.internal_init import IHasInternalInit
 from dagster._utils.tags import normalize_tags
 from dagster._utils.warnings import disable_dagster_warnings
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
     from dagster._core.definitions.assets import AssetsDefinition
 
 # SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE lives on the metadata of an asset
@@ -107,26 +107,8 @@ def validate_kind_tags(kinds: Optional[AbstractSet[str]]) -> None:
     breaking_version="1.10.0",
     additional_warn_text="use `automation_condition` instead",
 )
-class AssetSpec(
-    NamedTuple(
-        "_AssetSpec",
-        [
-            ("key", PublicAttr[AssetKey]),
-            ("deps", PublicAttr[Iterable["AssetDep"]]),
-            ("description", PublicAttr[Optional[str]]),
-            ("metadata", PublicAttr[Mapping[str, Any]]),
-            ("group_name", PublicAttr[Optional[str]]),
-            ("skippable", PublicAttr[bool]),
-            ("code_version", PublicAttr[Optional[str]]),
-            ("freshness_policy", PublicAttr[Optional[FreshnessPolicy]]),
-            ("automation_condition", PublicAttr[Optional[AutomationCondition]]),
-            ("owners", PublicAttr[Sequence[str]]),
-            ("tags", PublicAttr[Mapping[str, str]]),
-            ("partitions_def", PublicAttr[Optional[PartitionsDefinition]]),
-        ],
-    ),
-    IHasInternalInit,
-):
+@record_custom
+class AssetSpec(IHasInternalInit, IHaveNew, LegacyNamedTupleMixin):
     """Specifies the core attributes of an asset, except for the function that materializes or
     observes it.
 
@@ -158,6 +140,19 @@ class AssetSpec(
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
     """
+
+    key: PublicAttr[AssetKey]
+    deps: PublicAttr[Iterable[AssetDep]]
+    description: PublicAttr[Optional[str]]
+    metadata: PublicAttr[Mapping[str, Any]]
+    group_name: PublicAttr[Optional[str]]
+    skippable: PublicAttr[bool]
+    code_version: PublicAttr[Optional[str]]
+    freshness_policy: PublicAttr[Optional[FreshnessPolicy]]
+    automation_condition: PublicAttr[Optional[AutomationCondition]]
+    owners: PublicAttr[Sequence[str]]
+    tags: PublicAttr[Mapping[str, str]]
+    partitions_def: PublicAttr[Optional[PartitionsDefinition]]
 
     def __new__(
         cls,

--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -169,6 +169,7 @@ def _namedtuple_record_transform(
         "__qualname__": cls.__qualname__,
         "__annotations__": field_set,
         "__doc__": cls.__doc__,
+        "__get_pydantic_core_schema__": _pydantic_core_schema,
     }
 
     # Due to MRO issues, we can not support both @record_custom __new__ and record inheritance
@@ -629,3 +630,13 @@ def _defines_own_new(cls) -> bool:
 
 def _do_defensive_checks():
     return bool(os.getenv("DAGSTER_RECORD_DEFENSIVE_CHECKS"))
+
+
+@classmethod
+def _pydantic_core_schema(cls, source: Any, handler):
+    """Forces pydantic_core to treat records as normal types instead of namedtuples. In particular,
+    pydantic assumes that all namedtuples can be constructed with posargs, while records are kw-only.
+    """
+    from pydantic_core import core_schema
+
+    return core_schema.is_instance_schema(cls)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import cast
 
 import dagster as dg
@@ -14,6 +15,7 @@ from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from pydantic import BaseModel, TypeAdapter
 
 
 def test_validate_asset_owner() -> None:
@@ -398,3 +400,12 @@ def test_static_partition_mapping_dep() -> None:
     c_dep = next(iter(dep for dep in a_spec.deps if dep.asset_key == AssetKey("c")))
     assert b_dep.partition_mapping == dg.StaticPartitionMapping({"1": "1", "2": "2"})
     assert c_dep.partition_mapping == dg.StaticPartitionMapping({"1": "1", "2": "2"})
+
+
+def test_pydantic_spec() -> None:
+    class SpecHolder(BaseModel):
+        spec: AssetSpec
+        spec_list: Sequence[AssetSpec]
+
+    holder = SpecHolder(spec=AssetSpec(key="foo"), spec_list=[AssetSpec(key="bar")])
+    assert TypeAdapter(SpecHolder).validate_python(holder)

--- a/python_modules/dagster/dagster_tests/general_tests/test_record.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_record.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Annotated, Any, Generic, NamedTuple, Optional, TypeVar, Union
 
@@ -22,6 +22,7 @@ from dagster._record import (
 from dagster._serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster._utils import hash_collection
 from dagster._utils.cached_method import cached_method
+from pydantic import BaseModel, TypeAdapter
 
 if TYPE_CHECKING:
     from dagster._core.test_utils import TestType
@@ -874,3 +875,41 @@ def test_posargs_inherit():
         @record(kw_only=False)
         class B(A):
             b: int
+
+
+def test_pydantic() -> None:
+    @record
+    class Simple:
+        a: str
+        b: str
+
+    class SimpleHolder(BaseModel):
+        simple: Simple
+
+    holder = SimpleHolder(simple=Simple(a="a", b="b"))
+    assert TypeAdapter(SimpleHolder).validate_python(holder)
+
+    @record_custom
+    class Custom(IHaveNew):
+        ab: str
+        c: str
+
+        def __new__(cls, a: str, b: str, c: int):
+            return super().__new__(cls, ab=a + b, c=str(c))
+
+    class CustomHolder(BaseModel):
+        custom: Custom
+        custom_list: Sequence[Custom]
+        custom_mapping: Mapping[str, Custom]
+        custom_list_mapping: Mapping[str, Sequence[Custom]]
+        optional_custom_list_mapping: Optional[Mapping[str, Sequence[Custom]]]
+
+    c = Custom("a", "b", 1)
+    holder = CustomHolder(
+        custom=c,
+        custom_list=[c],
+        custom_mapping={"c": c},
+        custom_list_mapping={"c": [c]},
+        optional_custom_list_mapping={"c": [c]},
+    )
+    assert TypeAdapter(CustomHolder).validate_python(holder)


### PR DESCRIPTION
## Summary & Motivation

Prior to these changes, both added tests would fail. Updated AssetSpec to be an `@record` so that it could take advantage of these changes.

The core issue is that the pydantic internals assume that all namedtuple subclasses can be instnatiated with positional args based on their fields, which is not the case for records, which are kw-only (and is not the case for explicit NamedTuple subclasses which define `__new__`).

This was the least-gross way I could find to handle this behavior, and in reality is not particularly invasive to the `record` framework (import is deferred, just a single extra attribute)

## How I Tested These Changes

## Changelog

NOCHANGELOG
