### PR TITLE
Update Airlift Migrate Redirect on docs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1913,6 +1913,11 @@
       "source": "/next/:path*/",
       "destination": "/:path*/",
       "permanent": false
+    },
+    {
+      "source": "/integrations/airlift/tutorial/migrate",
+      "destination": "/integrations/libraries/airlift/airflow-to-dagster",
+      "permanent": false
     }
   ]
 }


### PR DESCRIPTION
## Summary & Motivation
Add additional redirect for https://docs.dagster.io/integrations/airlift/tutorial/migrate to 
https://docs.dagster.io/integrations/libraries/airlift/airflow-to-dagster/
