### PR TITLE
[docs] Standardize mermaid diagrams palette

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -176,6 +176,24 @@ flowchart LR
 
 Refer to the [Mermaid.js documentation](https://mermaid.js.org/) for more info.
 
+Generally try and match the Dagster color palette:
+
+```
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#4F43DD',
+      'primaryTextColor': '#FFFFFF',
+      'primaryBorderColor': '#231F1B',
+      'lineColor': '#DEDDFF',
+      'secondaryColor': '#BDBAB7',
+      'tertiaryColor': '#FFFFFF'
+    }
+  }
+}%%
+```
+
 ### Tabs
 
 Tabs are formatted as follows:

--- a/docs/docs/getting-started/concepts.md
+++ b/docs/docs/getting-started/concepts.md
@@ -11,14 +11,13 @@ Dagster provides a variety of abstractions for building and orchestrating data p
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
-
 }%%
   graph TD
 
@@ -108,11 +107,11 @@ Dagster provides a variety of abstractions for building and orchestrating data p
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -164,11 +163,11 @@ An <PyObject section="assets" module="dagster" object="asset" /> represents a lo
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -198,11 +197,11 @@ An <PyObject section="asset-checks" module="dagster" object="asset_check" /> is 
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -228,11 +227,11 @@ A `code location` is a collection of <PyObject section="definitions" module="dag
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -267,11 +266,11 @@ A <PyObject section="config" module="dagster" object="RunConfig" /> is a set sch
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -320,11 +319,11 @@ A <PyObject section="config" module="dagster" object="RunConfig" /> is a set sch
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -357,11 +356,11 @@ A <PyObject section="graphs" module="dagster" object="GraphDefinition" method="t
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -391,11 +390,11 @@ An <PyObject section="io-managers" module="dagster" object="IOManager" /> define
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -437,11 +436,11 @@ A <PyObject section="jobs" module="dagster" object="job" /> is a subset of <PyOb
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -471,11 +470,11 @@ An <PyObject section="ops" module="dagster" object="op" /> is a computational un
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -501,11 +500,11 @@ A <PyObject section="partitions" object="PartitionsDefinition" /> represents a l
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -540,11 +539,11 @@ A <PyObject section="resources" module="dagster" object="ConfigurableResource"/>
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -570,11 +569,11 @@ A `type` is a way to define and validate the data passed between <PyObject secti
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%
@@ -609,11 +608,11 @@ A <PyObject section="schedules-sensors" module="dagster" object="ScheduleDefinit
     'theme': 'base',
     'themeVariables': {
       'primaryColor': '#4F43DD',
-      'primaryTextColor': '#fff',
+      'primaryTextColor': '#FFFFFF',
       'primaryBorderColor': '#231F1B',
       'lineColor': '#DEDDFF',
       'secondaryColor': '#BDBAB7',
-      'tertiaryColor': '#BDBAB7'
+      'tertiaryColor': '#FFFFFF'
     }
   }
 }%%

--- a/docs/docs/guides/automate/asset-sensors.md
+++ b/docs/docs/guides/automate/asset-sensors.md
@@ -26,6 +26,20 @@ For example, you may wish to monitor an asset that's materialized daily, but don
 Asset sensors enable dependencies across different jobs and different code locations. This flexibility allows for modular and decoupled workflows.
 
 ```mermaid
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#4F43DD',
+      'primaryTextColor': '#FFFFFF',
+      'primaryBorderColor': '#231F1B',
+      'lineColor': '#DEDDFF',
+      'secondaryColor': '#BDBAB7',
+      'tertiaryColor': '#FFFFFF'
+    }
+  }
+}%%
+
 graph LR;
 
 AssetToWatch(AssetToWatch) --> AssetSensor(AssetSensor);
@@ -57,7 +71,7 @@ You can customize the evaluation function of an asset sensor to include specific
 stateDiagram-v2
     direction LR
 
-    classDef userDefined fill: lightblue
+    classDef userDefined fill: #lightblue
 
     [*] --> AssetMaterialization
     AssetMaterialization --> [*]

--- a/docs/docs/guides/automate/asset-sensors.md
+++ b/docs/docs/guides/automate/asset-sensors.md
@@ -71,7 +71,7 @@ You can customize the evaluation function of an asset sensor to include specific
 stateDiagram-v2
     direction LR
 
-    classDef userDefined fill: #lightblue
+    classDef userDefined fill: lightblue
 
     [*] --> AssetMaterialization
     AssetMaterialization --> [*]

--- a/docs/docs/guides/build/assets/defining-assets.md
+++ b/docs/docs/guides/build/assets/defining-assets.md
@@ -51,6 +51,20 @@ In this example, `my_multi_asset` produces two assets: `asset_one` and `asset_tw
 This example could be expressed as:
 
 ```mermaid
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#4F43DD',
+      'primaryTextColor': '#FFFFFF',
+      'primaryBorderColor': '#231F1B',
+      'lineColor': '#DEDDFF',
+      'secondaryColor': '#BDBAB7',
+      'tertiaryColor': '#FFFFFF'
+    }
+  }
+}%%
+
 flowchart LR
   multi(my_multi_asset) --> one(asset_one)
   multi(my_multi_asset) --> two(asset_two)
@@ -67,6 +81,21 @@ In this example, `complex_asset` is an asset that's the result of two operations
 This example could be expressed as:
 
 ```mermaid
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#4F43DD',
+      'primaryTextColor': '#FFFFFF',
+      'primaryBorderColor': '#231F1B',
+      'lineColor': '#DEDDFF',
+      'secondaryColor': '#BDBAB7',
+      'tertiaryColor': '#FFFFFF'
+    }
+  }
+
+}%%
+
 flowchart LR
   one((step_one)) --> asset(complex_asset)
   two((step_two)) --> asset(complex_asset)


### PR DESCRIPTION
## Summary & Motivation
Applying the same color palette to the other mermaid diagrams to match concepts page. Not as profound of a difference as expected:

**Before**
![Screenshot 2025-02-12 at 9 15 17 AM](https://github.com/user-attachments/assets/01d65109-d5db-4127-90ad-dd4d80939f57)
![Screenshot 2025-02-12 at 9 15 31 AM](https://github.com/user-attachments/assets/18e9c97a-0fb9-4cba-8692-cc1f39d26c08)

**After**
![Screenshot 2025-02-12 at 9 15 10 AM](https://github.com/user-attachments/assets/64b38e87-29c0-4490-8bd1-a781b365a041)
![Screenshot 2025-02-12 at 9 15 47 AM](https://github.com/user-attachments/assets/38efa712-4f73-49d4-99d7-830c7395934b)

Leaving the stateDiagram in `asset-sensors` the same since that already had custom colors set

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
