### PR TITLE
[ui] Switch graph traversal operators to BFS to ensure shortest path is used

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/GraphQueryImpl.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/GraphQueryImpl.test.ts
@@ -1,3 +1,4 @@
+import {calculateGraphDistances} from '../../asset-graph/useAssetGraphData';
 import {GraphQueryItem, filterByQuery} from '../GraphQueryImpl';
 
 function mockQueryItem(name: string, dependsOn: string[], dependedBy: string[]): GraphQueryItem {
@@ -8,17 +9,39 @@ function mockQueryItem(name: string, dependsOn: string[], dependedBy: string[]):
   };
 }
 
+// E -> D -> C -> B -> A
+//           C ------> A
+const graph = [
+  mockQueryItem('A', ['B', 'C'], []),
+  mockQueryItem('B', ['C'], ['A']),
+  mockQueryItem('C', ['D'], ['A', 'B']),
+  mockQueryItem('D', ['E'], ['C']),
+  mockQueryItem('E', [], ['D']),
+];
+
 describe('filterByQuery', () => {
-  it('should properly traverse graphs with shortcuts', () => {
-    const graph = [
-      mockQueryItem('A', ['B', 'C'], []),
-      mockQueryItem('B', ['C'], ['A']),
-      mockQueryItem('C', ['D'], ['A', 'B']),
-      mockQueryItem('D', ['E'], ['C']),
-      mockQueryItem('E', [], ['D']),
-    ];
+  it('should properly resolve traversal operators', () => {
     expect(filterByQuery(graph, 'A').all.map((a) => a.name)).toEqual(['A']);
     expect(filterByQuery(graph, '+A').all.map((a) => a.name)).toEqual(['A', 'B', 'C']);
+    expect(filterByQuery(graph, '*A').all.map((a) => a.name)).toEqual(['A', 'B', 'C', 'D', 'E']);
+    expect(filterByQuery(graph, '+C+').all.map((a) => a.name)).toEqual(['C', 'D', 'A', 'B']);
+  });
+  it('should properly traverse graphs with shortcuts', () => {
+    // D is included only because of A -> C -> D, if you visited it via depth-first search
+    // you'd hit A -> B -> C -> D and mark C as visited at depth = 2
     expect(filterByQuery(graph, '++A').all.map((a) => a.name)).toEqual(['A', 'B', 'C', 'D']);
+  });
+});
+
+describe('calculateGraphDistances', () => {
+  it('should correctly determine the total depths from a node', () => {
+    expect(calculateGraphDistances(graph, {path: ['A']})).toEqual({
+      upstream: 3,
+      downstream: 0,
+    });
+    expect(calculateGraphDistances(graph, {path: ['C']})).toEqual({
+      upstream: 2,
+      downstream: 1,
+    });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/GraphQueryImpl.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/GraphQueryImpl.test.ts
@@ -1,0 +1,24 @@
+import {GraphQueryItem, filterByQuery} from '../GraphQueryImpl';
+
+function mockQueryItem(name: string, dependsOn: string[], dependedBy: string[]): GraphQueryItem {
+  return {
+    name,
+    inputs: [{dependsOn: dependsOn.map((name) => ({solid: {name}}))}],
+    outputs: [{dependedBy: dependedBy.map((name) => ({solid: {name}}))}],
+  };
+}
+
+describe('filterByQuery', () => {
+  it('should properly traverse graphs with shortcuts', () => {
+    const graph = [
+      mockQueryItem('A', ['B', 'C'], []),
+      mockQueryItem('B', ['C'], ['A']),
+      mockQueryItem('C', ['D'], ['A', 'B']),
+      mockQueryItem('D', ['E'], ['C']),
+      mockQueryItem('E', [], ['D']),
+    ];
+    expect(filterByQuery(graph, 'A').all.map((a) => a.name)).toEqual(['A']);
+    expect(filterByQuery(graph, '+A').all.map((a) => a.name)).toEqual(['A', 'B', 'C']);
+    expect(filterByQuery(graph, '++A').all.map((a) => a.name)).toEqual(['A', 'B', 'C', 'D']);
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

Now here's a long-standing one! The traversal code used to navigate the asset graph for `asset++` was doing depth-first and not breadth-first search, which meant an asset connected via multiple paths of varying length might not be included in the result.  This is important for the lineage view because under the hood, because a filter of "Distance: 3" might not include an asset that is connected via both distance=4 and distance=3 paths

https://linear.app/dagster-labs/issue/FE-779/lineage-ui-bug-displaying-upstream-assets-assigned-to-ui-team

## How I Tested These Changes

I added new tests and also manually verified the specific case in the ticket is resolved.

## Changelog

[ui] The traversal operators on the asset graph (`asset++`) correctly include assets connected to the target asset by paths of varying distance.