### PR TITLE
rearrange tabs for concurrency page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/ConcurrencyTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/ConcurrencyTabs.tsx
@@ -10,12 +10,12 @@ interface Props {
 export const ConcurrencyTabs = ({activeTab, onChange}: Props) => {
   return (
     <Tabs selectedTabId={activeTab} onChange={onChange}>
+      <Tab title="Pools" id="key-concurrency" selected={activeTab === 'key-concurrency'} />
       <Tab
-        title="Run concurrency"
+        title="Run tag concurrency"
         id="run-concurrency"
         selected={activeTab === 'run-concurrency'}
       />
-      <Tab title="Pools" id="key-concurrency" selected={activeTab === 'key-concurrency'} />
     </Tabs>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -60,7 +60,7 @@ export const InstanceConcurrencyIndexContent = React.memo(() => {
   >(INSTANCE_CONCURRENCY_LIMITS_QUERY, {
     notifyOnNetworkStatusChange: true,
   });
-  const [activeTab, setActiveTab] = React.useState<ConcurrencyTab>('run-concurrency');
+  const [activeTab, setActiveTab] = React.useState<ConcurrencyTab>('key-concurrency');
 
   const {data} = queryResult;
 


### PR DESCRIPTION
## Summary & Motivation
Put pools more prominently on the concurrency page

## How I Tested These Changes
Inspection, loaded dagit.

