### PR TITLE
[dagster-sling] Fix replication key capitalization

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/integrations/sling.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/integrations/sling.py
@@ -25,8 +25,8 @@ target = SlingConnectionResource(
 
 @sling_assets(
     replication_config={
-        "SOURCE": "MY_PG",
-        "TARGET": "MY_SF",
+        "source": "MY_PG",
+        "target": "MY_SF",
         "defaults": {
             "mode": "full-refresh",
             "object": "{stream_schema}_{stream_table}",


### PR DESCRIPTION
## Summary & Motivation

Sling won't find the keys otherwise, e.g.:

```python
2025-02-12 14:51:21 -0700 - dagster - ERROR - __ASSET_JOB - a73dbc0a-8b73-4d72-adde-1955ff7b825f - 23923 - my_sling_assets - STEP_FAILURE - Execution of step "my_sling_assets" failed.

dagster._core.errors.DagsterExecutionStepExecutionError: Error occurred while executing op "my_sling_assets"::

Exception: 2:51PM INF Sling CLI | https://slingdata.io
fatal:
~ Error parsing replication config
did not find 'source' key
Sling command failed

Stack Trace:
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 56, in op_execution_error_boundary
    yield
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/dagster/_utils/__init__.py", line 480, in iterate_with_context
    next_output = next(iterator)
                  ^^^^^^^^^^^^^^
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/example.py", line 62, in my_sling_assets
    yield from sling.replicate(context=context)
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/dagster_sling/sling_event_iterator.py", line 189, in __next__
    return next(self._inner_iterator)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/dagster_sling/resources.py", line 388, in _replicate
    results = sling._run(  # noqa
              ^^^^^^^^^^^^^^^^^^^
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/sling/__init__.py", line 600, in _run
    raise Exception('\n'.join(lines))

The above exception occurred during handling of the following exception:
Exception: Sling command failed

Stack Trace:
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/sling/__init__.py", line 587, in _run
    for line in _exec_cmd(cmd, env=env, stdin=stdin):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deepyaman/github/dagster-io/dogfood-sling/.venv/lib/python3.12/site-packages/sling/__init__.py", line 661, in _exec_cmd
    raise Exception(f'Sling command failed')

2025-02-12 14:51:22 -0700 - dagster - DEBUG - __ASSET_JOB - a73dbc0a-8b73-4d72-adde-1955ff7b825f - 23919 - ENGINE_EVENT - Multiprocess executor: parent process exiting after 1.02s (pid: 23919)
2025-02-12 14:51:22 -0700 - dagster - ERROR - __ASSET_JOB - a73dbc0a-8b73-4d72-adde-1955ff7b825f - 23919 - RUN_FAILURE - Execution of run for "__ASSET_JOB" failed. Steps failed: ['my_sling_assets'].
```
