### PR TITLE
Only launch a single run in DA from keys that are materializable and part of multiple repositories when using DA sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -642,15 +642,20 @@ class RemoteWorkspaceAssetGraph(RemoteAssetGraph[RemoteWorkspaceAssetNode]):
     def build(cls, workspace: WorkspaceSnapshot):
         # Combine repository scoped asset graphs with additional context to form the global graph
 
-        code_locations = (
-            location_entry.code_location
-            for location_entry in workspace.code_location_entries.values()
-            if location_entry.code_location
+        code_locations = sorted(
+            (
+                location_entry.code_location
+                for location_entry in workspace.code_location_entries.values()
+                if location_entry.code_location
+            ),
+            key=lambda code_location: code_location.name,
         )
         repos = (
             repo
             for code_location in code_locations
-            for repo in code_location.get_repositories().values()
+            for repo in sorted(
+                code_location.get_repositories().values(), key=lambda repo: repo.name
+            )
         )
 
         asset_infos_by_key: dict[AssetKey, list[RepositoryScopedAssetInfo]] = defaultdict(list)


### PR DESCRIPTION
## Summary & Motivation
Ensures that if you inadvertently have the same asset key in two code locations, each with a DA sensor, that we don't create duplicate runs.

## How I Tested These Changes
New test case

## Changelog
Fixed an issue where if two separate code locations defined the same asset key with an automation condition, duplicate runs could be created by Declarative Automation.

