### PR TITLE
[components] Update resolution engine, @field_resolver

### DIFF
--- a/docs/docs/guides/preview/components/creating-a-component.md
+++ b/docs/docs/guides/preview/components/creating-a-component.md
@@ -47,7 +47,6 @@ This will add a new file to your project in the `lib` directory:
 This file contains the basic structure for the new component type. There are two methods that you'll need to implement:
 
 - `get_schema`: This method should return a Pydantic model that defines the schema for the component. This is the schema for the data that goes into `component.yaml`.
-- `load`: This method takes the loading context and returns an instance of the component class. This is where you'll load the parameters from the `component.yaml` file.
 - `build_defs`: This method should return a `Definitions` object for this component.
 
 ## Defining a schema

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolver.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/defining-resolver.py
@@ -1,12 +1,12 @@
 from collections.abc import Sequence
 from typing import Annotated, Optional
 
-from dagster_components import ComponentSchema, ResolutionContext, Resolver, resolver
+from dagster_components import ResolutionContext, ResolvableSchema, Resolver, resolver
 from dagster_components.core.schema.objects import AssetAttributesSchema, OpSpecSchema
 from pydantic import BaseModel
 
 
-class ShellScriptSchema(ComponentSchema):
+class ShellScriptSchema(ResolvableSchema):
     script_path: str
     asset_attributes: Sequence[AssetAttributesSchema]
     op: Optional[OpSpecSchema] = None

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
@@ -3,12 +3,12 @@ from collections.abc import Sequence
 from dagster_components import (
     AssetSpecSchema,
     Component,
-    ComponentSchema,
+    ResolvableSchema,
     registered_component_type,
 )
 
 
-class ShellCommandParams(ComponentSchema):
+class ShellCommandParams(ResolvableSchema):
     path: str
     asset_specs: Sequence[AssetSpecSchema]
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -6,15 +6,15 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    ComponentSchema,
     OpSpecSchema,
+    ResolvableSchema,
     registered_component_type,
 )
 
 import dagster as dg
 
 
-class ShellScriptSchema(ComponentSchema):
+class ShellScriptSchema(ResolvableSchema):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
     op: Optional[OpSpecSchema] = None

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
@@ -5,8 +5,8 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    ComponentSchema,
     OpSpecSchema,
+    ResolvableSchema,
     registered_component_type,
 )
 from pydantic import BaseModel
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 import dagster as dg
 
 
-class ShellScriptSchema(ComponentSchema):
+class ShellScriptSchema(ResolvableSchema):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
     op: Optional[OpSpecSchema] = None

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -13,7 +13,10 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffoldRequest as ComponentScaffoldRequest,
     DefaultComponentScaffolder as DefaultComponentScaffolder,
 )
-from dagster_components.core.schema.base import ComponentSchema as ComponentSchema
+from dagster_components.core.schema.base import (
+    ResolvableSchema as ResolvableSchema,
+    field_resolver as field_resolver,
+)
 from dagster_components.core.schema.context import ResolutionContext as ResolutionContext
 from dagster_components.core.schema.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
@@ -21,7 +24,5 @@ from dagster_components.core.schema.objects import (
     AssetSpecSchema as AssetSpecSchema,
     AssetSpecTransformSchema as AssetSpecTransformSchema,
     OpSpecSchema as OpSpecSchema,
-    Resolver as Resolver,
-    resolver as resolver,
 )
 from dagster_components.version import __version__ as __version__

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, ClassVar, Optional, TypedDict, TypeVar, Union
+from typing import Any, Callable, Optional, TypedDict, TypeVar, Union
 
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
@@ -28,7 +28,7 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffolderUnavailableReason,
     DefaultComponentScaffolder,
 )
-from dagster_components.core.schema.base import ComponentSchema
+from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.utils import load_module_from_path
 
@@ -39,10 +39,8 @@ class ComponentDeclNode(ABC):
 
 
 class Component(ABC):
-    name: ClassVar[Optional[str]] = None
-
     @classmethod
-    def get_schema(cls) -> Optional[type[ComponentSchema]]:
+    def get_schema(cls) -> Optional[type[ResolvableSchema]]:
         return None
 
     @classmethod
@@ -64,8 +62,8 @@ class Component(ABC):
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...
 
     @classmethod
-    def load(cls, params: Optional[ComponentSchema], context: "ComponentLoadContext") -> Self:
-        return cls() if params is None else context.resolve(params, as_type=cls)
+    def load(cls, params: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
+        return params.resolve_as(cls, context.resolution_context) if params else cls()
 
     @classmethod
     def get_metadata(cls) -> "ComponentTypeInternalMetadata":
@@ -265,11 +263,8 @@ class ComponentLoadContext:
     def for_decl_node(self, decl_node: ComponentDeclNode) -> "ComponentLoadContext":
         return dataclasses.replace(self, decl_node=decl_node)
 
-    def resolve(self, value: ComponentSchema, as_type: type[T]) -> T:
-        return value.__dagster_resolver__(value).resolve_as(as_type, self.resolution_context)
-
-    def resolve_value(self, value: Any) -> Any:
-        return self.resolution_context.resolve_value(value)
+    def resolve(self, value: ResolvableSchema, as_type: type[T]) -> T:
+        return self.resolution_context.resolve_value(value, as_type=as_type)
 
 
 COMPONENT_REGISTRY_KEY_ATTR = "__dagster_component_registry_key"

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -11,18 +11,31 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
 from pydantic import BaseModel
 
-from dagster_components.core.schema.base import ComponentSchema, Resolver, resolver
+from dagster_components.core.schema.base import ResolvableSchema, field_resolver
 from dagster_components.core.schema.context import ResolutionContext
 
 
-class OpSpecSchema(ComponentSchema):
+def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
+    resolved_val = context.resolve_value(key, as_type=Union[str, AssetKey])
+    return (
+        AssetKey.from_user_string(resolved_val) if isinstance(resolved_val, str) else resolved_val
+    )
+
+
+class OpSpecSchema(ResolvableSchema):
     name: Optional[str] = None
     tags: Optional[dict[str, str]] = None
 
 
-class AssetDepSchema(ComponentSchema):
+class AssetDepSchema(ResolvableSchema[AssetDep]):
     asset: str
     partition_mapping: Optional[str] = None
+
+    class FieldResolvers:
+        @field_resolver("asset")
+        @staticmethod
+        def resolve_asset(context: ResolutionContext, schema: "AssetDepSchema") -> AssetKey:
+            return _resolve_asset_key(schema.asset, context)
 
 
 class _ResolvableAssetAttributesMixin(BaseModel):
@@ -38,21 +51,42 @@ class _ResolvableAssetAttributesMixin(BaseModel):
     automation_condition: Optional[str] = None
 
 
-class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ComponentSchema):
-    key: Optional[str] = None
-
-
-class AssetSpecSchema(_ResolvableAssetAttributesMixin, ComponentSchema):
+class AssetSpecSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[AssetSpec]):
     key: str
 
+    class FieldResolvers:
+        @field_resolver("key")
+        @staticmethod
+        def resolve_key(context: ResolutionContext, schema: "AssetSpecSchema") -> AssetKey:
+            return _resolve_asset_key(schema.key, context)
 
-class AssetSpecTransformSchema(ComponentSchema):
+
+class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[Mapping[str, Any]]):
+    """Resolves into a dictionary of asset attributes. This is similar to AssetSpecSchema, but
+    does not require a key. This is useful in contexts where you want to modify attributes of
+    an existing AssetSpec.
+    """
+
+    key: Optional[str] = None
+
+    def resolve(self, context: ResolutionContext) -> Mapping[str, Any]:
+        # only include fields that are explcitly set
+        set_fields = self.model_dump(exclude_unset=True).keys()
+        return {k: v for k, v in self.resolve_fields(dict, context).items() if k in set_fields}
+
+    class FieldResolvers:
+        @field_resolver("key")
+        @staticmethod
+        def resolve_key(
+            context: ResolutionContext, schema: "AssetAttributesSchema"
+        ) -> Optional[AssetKey]:
+            return _resolve_asset_key(schema.key, context) if schema.key else None
+
+
+class AssetSpecTransformSchema(ResolvableSchema):
     target: str = "*"
     operation: Literal["merge", "replace"] = "merge"
     attributes: AssetAttributesSchema
-
-    class Config:
-        arbitrary_types_allowed = True
 
     def apply_to_spec(self, spec: AssetSpec, context: ResolutionContext) -> AssetSpec:
         # add the original spec to the context and resolve values
@@ -88,38 +122,5 @@ class AssetSpecTransformSchema(ComponentSchema):
         ]
         return replace(defs, assets=assets)
 
-
-def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
-    resolved_val = context.resolve_value(key)
-    return (
-        AssetKey.from_user_string(resolved_val) if isinstance(resolved_val, str) else resolved_val
-    )
-
-
-@resolver(fromtype=AssetDepSchema, totype=AssetDep)
-class AssetDepResolver(Resolver[AssetDepSchema]):
-    def resolve_asset(self, context: ResolutionContext) -> AssetKey:
-        return _resolve_asset_key(self.schema.asset, context)
-
-
-@resolver(fromtype=AssetSpecSchema, totype=AssetSpec)
-class AssetSpecResolver(Resolver[AssetSpecSchema]):
-    def resolve_key(self, context: ResolutionContext) -> AssetKey:
-        return _resolve_asset_key(self.schema.key, context)
-
-
-@resolver(fromtype=AssetAttributesSchema)
-class AssetAttributesResolver(Resolver[AssetAttributesSchema]):
-    def resolve_key(self, context: ResolutionContext) -> Optional[AssetKey]:
-        return _resolve_asset_key(self.schema.key, context) if self.schema.key else None
-
-    def resolve(self, context: ResolutionContext) -> Mapping[str, Any]:
-        # only include fields that are explcitly set
-        set_fields = self.schema.model_dump(exclude_unset=True).keys()
-        return {k: v for k, v in self.get_resolved_fields(context).items() if k in set_fields}
-
-
-@resolver(fromtype=AssetSpecTransformSchema)
-class AssetSpecTransformResolver(Resolver[AssetSpecTransformSchema]):
     def resolve(self, context: ResolutionContext) -> Callable[[Definitions], Definitions]:
-        return lambda defs: self.schema.apply(defs, context)
+        return lambda defs: self.apply(defs, context)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Callable, Optional, Union
 
@@ -6,33 +7,44 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.result import MaterializeResult
-from dagster._record import record
 from dagster_sling import DagsterSlingTranslator, SlingResource, sling_assets
 from dagster_sling.resources import AssetExecutionContext
+from pydantic import BaseModel
 
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, ComponentLoadContext, field_resolver
 from dagster_components.core.component import registered_component_type
 from dagster_components.core.component_scaffolder import ComponentScaffolder
-from dagster_components.core.schema.base import Resolver, resolver
+from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesSchema,
     AssetSpecTransformSchema,
-    ComponentSchema,
     OpSpecSchema,
 )
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
-@record
-class SlingReplicationSpec:
+class SlingReplicationSpec(BaseModel):
     path: str
     op: Optional[OpSpecSchema]
     translator: Optional[DagsterSlingTranslator]
 
+    @field_resolver("translator")
+    @staticmethod
+    def resolve_translator(
+        context: ResolutionContext, schema: "SlingReplicationParams"
+    ) -> DagsterSlingTranslator:
+        return get_wrapped_translator_class(DagsterSlingTranslator)(
+            resolving_info=TranslatorResolvingInfo(
+                "stream_definition",
+                schema.asset_attributes or AssetAttributesSchema(),
+                context,
+            )
+        )
 
-class SlingReplicationParams(ComponentSchema):
+
+class SlingReplicationParams(ResolvableSchema[SlingReplicationSpec]):
     path: str
     op: Optional[OpSpecSchema] = None
     asset_attributes: Annotated[
@@ -41,63 +53,31 @@ class SlingReplicationParams(ComponentSchema):
     ] = None
 
 
-class SlingReplicationCollectionParams(ComponentSchema):
+class SlingReplicationCollectionParams(ResolvableSchema["SlingReplicationCollectionParams"]):
     sling: Optional[SlingResource] = None
     replications: Sequence[SlingReplicationParams]
     transforms: Optional[Sequence[AssetSpecTransformSchema]] = None
 
 
-@resolver(
-    fromtype=SlingReplicationParams,
-    totype=SlingReplicationSpec,
-    exclude_fields={"asset_attributes"},
-)
-class SlingReplicationResolver(Resolver):
-    def resolve_translator(self, resolver: ResolutionContext) -> DagsterSlingTranslator:
-        return get_wrapped_translator_class(DagsterSlingTranslator)(
-            resolving_info=TranslatorResolvingInfo(
-                "stream_definition",
-                self.schema.asset_attributes or AssetAttributesSchema(),
-                resolver,
-            ),
-        )
-
-
-@resolver(fromtype=SlingReplicationCollectionParams)
-class SlingReplicationCollectionResolver(Resolver[SlingReplicationCollectionParams]):
-    def resolve_sling(self, resolver: ResolutionContext) -> SlingResource:
-        return (
-            SlingResource(**resolver.resolve_value(self.schema.sling.model_dump()))
-            if self.schema.sling
-            else SlingResource()
-        )
-
-    def resolve_replications(self, resolver: ResolutionContext) -> Sequence[SlingReplicationSpec]:
-        return [resolver.resolve_value(replication) for replication in self.schema.replications]
-
-    def resolve_transforms(
-        self, resolver: ResolutionContext
-    ) -> Optional[Sequence[Callable[[Definitions], Definitions]]]:
-        return (
-            [resolver.resolve_value(transform) for transform in self.schema.transforms]
-            if self.schema.transforms
-            else None
-        )
-
-
 @registered_component_type
+@dataclass
 class SlingReplicationCollection(Component):
     """Expose one or more Sling replications to Dagster as assets."""
 
-    def __init__(
-        self,
-        sling: SlingResource,
-        replications: Sequence[SlingReplicationSpec],
-        transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = None,
-    ):
-        self.resource = sling
-        self.replications = replications
-        self.transforms = transforms or []
+    resource: SlingResource
+    replications: Sequence[SlingReplicationSpec]
+    transforms: Optional[Sequence[Callable[[Definitions], Definitions]]]
+
+    @field_resolver("resource")
+    @staticmethod
+    def resolve_sling(
+        context: ResolutionContext, schema: SlingReplicationCollectionParams
+    ) -> SlingResource:
+        return (
+            SlingResource(**context.resolve_value(schema.sling.model_dump()))
+            if schema.sling
+            else SlingResource()
+        )
 
     @classmethod
     def get_scaffolder(cls) -> ComponentScaffolder:
@@ -136,6 +116,6 @@ class SlingReplicationCollection(Component):
         defs = Definitions(
             assets=[self.build_asset(context, replication) for replication in self.replications],
         )
-        for transform in self.transforms:
+        for transform in self.transforms or []:
             defs = transform(defs)
         return defs

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -7,7 +7,7 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 
 from dagster_components import Component, ComponentLoadContext, registered_component_type
 from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
-from dagster_components.core.schema.base import ComponentSchema
+from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesSchema,
@@ -16,7 +16,7 @@ from dagster_components.core.schema.objects import (
 )
 
 
-class ComplexAssetParams(ComponentSchema):
+class ComplexAssetParams(ResolvableSchema):
     value: str
     op: Optional[OpSpecSchema] = None
     asset_attributes: Annotated[

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -2,27 +2,25 @@
 in integration_tests/components/validation.
 """
 
+from dataclasses import dataclass
+
 from dagster._core.definitions.definitions_class import Definitions
 from pydantic import BaseModel, ConfigDict
 
-from dagster_components import Component, ComponentSchema, registered_component_type
+from dagster_components import Component, ResolvableSchema, registered_component_type
 from dagster_components.core.component import ComponentLoadContext
 
 
-class MyComponentSchema(ComponentSchema):
+class MyComponentSchema(ResolvableSchema):
     a_string: str
     an_int: int
 
-    model_config = ConfigDict(extra="forbid")
-
 
 @registered_component_type
+@dataclass
 class MyComponent(Component):
-    name = "my_component"
-
-    def __init__(self, a_string: str, an_int: int):
-        self.a_string = a_string
-        self.an_int = an_int
+    a_string: str
+    an_int: int
 
     @classmethod
     def get_schema(cls) -> type[MyComponentSchema]:
@@ -47,8 +45,6 @@ class MyNestedComponentSchema(BaseModel):
 
 @registered_component_type
 class MyNestedComponent(Component):
-    name = "my_nested_component"
-
     @classmethod
     def get_schema(cls) -> type[MyNestedComponentSchema]:
         return MyNestedComponentSchema

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -1,20 +1,17 @@
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, ComponentSchema, registered_component_type
+from dagster_components import Component, ResolvableSchema, registered_component_type
 from dagster_components.core.component import ComponentLoadContext
 
 
-class MyComponentSchema(ComponentSchema):
+class MyComponentSchema(ResolvableSchema):
     a_string: str
     an_int: int
 
 
 @registered_component_type
 class MyComponent(Component):
-    name = "my_component"
-
-    def __init__(self, a_string: str, an_int: int):
-        self.a_string = a_string
-        self.an_int = an_int
+    a_string: str
+    an_int: int
 
     @classmethod
     def get_schema(cls):

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from dagster import AssetSpec, AutomationCondition, Definitions
@@ -6,6 +7,7 @@ from dagster_components import (
     AssetAttributesSchema,
     Component,
     ComponentLoadContext,
+    ResolvableSchema,
     registered_component_type,
 )
 
@@ -18,8 +20,15 @@ def my_custom_automation_condition(cron_schedule: str) -> AutomationCondition:
     return AutomationCondition.cron_tick_passed(cron_schedule) & ~AutomationCondition.in_progress()
 
 
+class CustomScopeSchema(ResolvableSchema):
+    asset_attributes: AssetAttributesSchema
+
+
 @registered_component_type(name="custom_scope_component")
+@dataclass
 class HasCustomScope(Component):
+    asset_attributes: Mapping[str, Any]
+
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:
         return {
@@ -29,16 +38,9 @@ class HasCustomScope(Component):
             "custom_automation_condition": my_custom_automation_condition,
         }
 
-    def __init__(self, attributes: Mapping[str, Any]):
-        self.attributes = attributes
-
     @classmethod
     def get_schema(cls):
-        return AssetAttributesSchema
-
-    @classmethod
-    def load(cls, params: AssetAttributesSchema, context: ComponentLoadContext):
-        return cls(attributes=context.resolve_value(params))
+        return CustomScopeSchema
 
     def build_defs(self, context: ComponentLoadContext):
-        return Definitions(assets=[AssetSpec(key="key", **self.attributes)])
+        return Definitions(assets=[AssetSpec(key="key", **self.asset_attributes)])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
@@ -1,8 +1,9 @@
 type: custom_scope_component@component.py
 
 params:
-  group_name: "{{ custom_str }}"
-  tags: "{{ custom_dict }}"
-  metadata:
-    prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
-  automation_condition: "{{ custom_automation_condition('@daily') }}"
+  asset_attributes:
+    group_name: "{{ custom_str }}"
+    tags: "{{ custom_dict }}"
+    metadata:
+      prefixed: "prefixed_{{ custom_fn('a', custom_str) }}"
+    automation_condition: "{{ custom_automation_condition('@daily') }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -3,48 +3,40 @@ from typing import Optional
 
 import pytest
 from dagster._check.functions import ParameterCheckError
-from dagster._record import record
-from dagster_components import ComponentSchema, ResolutionContext
-from dagster_components.core.schema.base import Resolver, resolver
+from dagster_components import ResolutionContext, ResolvableSchema, field_resolver
+from pydantic import BaseModel
 
 
-@record
-class InnerObject:
+class InnerObject(BaseModel):
     val1_renamed: int
     val2: Optional[str]
 
+    @field_resolver("val1_renamed")
+    @staticmethod
+    def resolve_val1_renamed(context: ResolutionContext, schema: "InnerSchema") -> int:
+        return 20 + context.resolve_value(schema.val1, as_type=int)
 
-@record
-class TargetObject:
+
+class TargetObject(BaseModel):
     int_val: int
     str_val: str
     inners: Optional[Sequence[InnerObject]]
 
 
-class InnerParams(ComponentSchema):
+class InnerSchema(ResolvableSchema[InnerObject]):
     val1: str
     val2: Optional[str]
 
 
-class TargetParams(ComponentSchema):
+class TargetParams(ResolvableSchema[TargetObject]):
     int_val: str
     str_val: str
-    inners: Optional[Sequence[InnerParams]] = None
-
-
-@resolver(fromtype=InnerParams, totype=InnerObject, exclude_fields={"val1"})
-class InnerParamsResolver(Resolver[InnerParams]):
-    def resolve_val1_renamed(self, context: ResolutionContext) -> int:
-        return context.resolve_value(self.schema.val1) + 20
-
-
-@resolver(fromtype=TargetParams, totype=TargetObject)
-class TargetParamsResolver(Resolver): ...
+    inners: Optional[Sequence[InnerSchema]] = None
 
 
 def test_valid_resolution_simple() -> None:
     context = ResolutionContext(scope={"some_int": 1, "some_str": "a"})
-    params = InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_b")
+    params = InnerSchema(val1="{{ some_int }}", val2="{{ some_str }}_b")
     assert context.resolve_value(params) == InnerObject(val1_renamed=21, val2="a_b")
 
 
@@ -53,7 +45,7 @@ def test_valid_resolution_nested() -> None:
     params = TargetParams(
         int_val="{{ some_int }}",
         str_val="{{ some_str }}_x",
-        inners=[InnerParams(val1="{{ some_int }}", val2="{{ some_str }}_y")],
+        inners=[InnerSchema(val1="{{ some_int }}", val2="{{ some_str }}_y")],
     )
 
     assert context.resolve_value(params) == TargetObject(
@@ -67,4 +59,4 @@ def test_valid_resolution_nested() -> None:
 def test_invalid_resolution_simple() -> None:
     with pytest.raises(ParameterCheckError):
         context = ResolutionContext(scope={"some_int": "NOT_AN_INT"})
-        context.resolve_value(InnerParams(val1="{{ some_int }}", val2="abc"))
+        context.resolve_value(InnerSchema(val1="{{ some_int }}", val2="abc"))

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -3,11 +3,11 @@ from dagster_components import (
     Component,
     ComponentLoadContext,
     DefaultComponentScaffolder,
-    ComponentSchema,
+    ResolvableSchema,
     registered_component_type,
 )
 
-class {{ component_type_class_name }}Params(ComponentSchema):
+class {{ component_type_class_name }}Schema(ResolvableSchema):
     ...
 
 @registered_component_type(name="{{ name }}")
@@ -17,11 +17,9 @@ class {{ component_type_class_name }}(Component):
     COMPONENT DESCRIPTION HERE.
     """
 
-    def __init__(self): ...
-
     @classmethod
     def get_schema(cls):
-        return {{ component_type_class_name }}Params
+        return {{ component_type_class_name }}Schema
 
     @classmethod
     def get_scaffolder(cls) -> DefaultComponentScaffolder:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Annotated
 
-from dagster_components import ComponentSchema, ResolvableFieldInfo
+from dagster_components import ResolvableFieldInfo, ResolvableSchema
 from dagster_dg.docs import generate_sample_yaml
 from pydantic import BaseModel
 
@@ -11,7 +11,7 @@ class SampleSubSchema(BaseModel):
     int_field: int
 
 
-class SampleSchema(ComponentSchema):
+class SampleSchema(ResolvableSchema):
     sub_scoped: Annotated[SampleSubSchema, ResolvableFieldInfo(required_scope={"outer_scope"})]
     sub_optional: SampleSubSchema
     sub_list: Sequence[SampleSubSchema]


### PR DESCRIPTION
## Summary & Motivation

This is (hopefully) the final change on the core engine side of the world

Now when we resolve from a ResolvableSchema, we check the target type to see if it has any `@field_resolvers` defined. If so, we invoke those methods when resolving into those fields. If not, we just do the basic `context.resolve_value()` on the given field. To handle cases where we don't want to modify the target type (e.g. AssetSpec), we can define a special class on the schema itself, called FieldResolvers. This bit is subject to change as for now this is an internal-only construct (i.e. users will not immediately need to do this sort of thing, so we can work out other options).

## How I Tested These Changes

## Changelog

NOCHANGELOG
