### PR TITLE
use repo-scoped asset graph when deciding whether or not a given asset key is eligible for a given sensor

### DIFF
--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/always_evaluates.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/always_evaluates.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+
+@dg.asset(automation_condition=~dg.AutomationCondition.in_progress())
+def always() -> None: ...
+
+
+defs = dg.Definitions(assets=[always])

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/defs_with_source_assets.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/defs_with_source_assets.py
@@ -1,0 +1,11 @@
+import dagster as dg
+
+
+@dg.observable_source_asset(auto_observe_interval_minutes=10)
+def foo_source_asset():
+    return dg.DataVersion("foo")
+
+
+always_asset_spec = dg.AssetSpec(key=dg.AssetKey("always"))
+
+defs = dg.Definitions(assets=[foo_source_asset, always_asset_spec])


### PR DESCRIPTION
Summary:
Prevents an issue where a source asset targeted by one sensor could incorrectly trigger the actual materializable asset key from another code location.

## Changelog
Fixed an issue where Declarative Automation sensors in code locations that included source assets referencing assets with automation conditions in other code locations would sometimes cause duplicate runs to be created.
