### PR TITLE
[ui] Update the Backfills page sunset banner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -82,19 +82,13 @@ export const InstanceBackfills = () => {
         <Alert
           title={
             <>
-              <span>Backfills are moving:</span>
+              <span>
+                In the March 6th release, backfills are moving to the{' '}
+                <Link to="/runs?view=backfills">Runs page</Link>.
+              </span>{' '}
               <span style={{fontWeight: 'normal'}}>
-                {' '}
-                We&apos;re moving backfills to the <Link to="/runs?view=backfills">Runs</Link> page
-                to provide a unified view of executions. The Backfills page will be removed in a
-                future release.{' '}
-                <a
-                  href="https://github.com/dagster-io/dagster/discussions/24898"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Share feedback
-                </a>{' '}
+                The new Runs UI provides a unified view of executions as well as a dedicated
+                Backfills list.
               </span>
             </>
           }


### PR DESCRIPTION
## Summary & Motivation

We'll ship this in next week's release:
<img width="912" alt="image" src="https://github.com/user-attachments/assets/62b460df-9011-4c41-b1be-c2dc75622c48" />

and then merge this PR to remove the page for the March 6th release:
https://github.com/dagster-io/dagster/pull/27811

## Changelog

[ui] The Instance Backfills page is being removed in the upcoming March 6 release in favor of the new Runs > Backfills view.