### PR TITLE
turn on the op concurrency counter for the run queue by default

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -656,7 +656,7 @@ class ConcurrencyConfig:
         if (
             not pool_granularity
             and run_coordinator_run_queue_config
-            and run_coordinator_run_queue_config.should_block_op_concurrency_limited_runs
+            and run_coordinator_run_queue_config.explicitly_enabled_concurrency_run_blocking
         ):
             # if this was explicitly configured in the run coordinator config, we should default to op granularity
             pool_granularity = PoolGranularity.OP

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -643,8 +643,7 @@ class ConcurrencyConfig:
                 ),
                 max_user_code_failure_retries=run_coordinator_run_queue_config.max_user_code_failure_retries,
                 user_code_failure_retry_delay=run_coordinator_run_queue_config.user_code_failure_retry_delay,
-                should_block_op_concurrency_limited_runs=bool(pool_settings)
-                or run_coordinator_run_queue_config.should_block_op_concurrency_limited_runs,
+                should_block_op_concurrency_limited_runs=run_coordinator_run_queue_config.should_block_op_concurrency_limited_runs,
                 op_concurrency_slot_buffer=pool_settings.get(
                     "op_granularity_run_buffer",
                     run_coordinator_run_queue_config.op_concurrency_slot_buffer,

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -39,7 +39,7 @@ class RunQueueConfig(
         tag_concurrency_limits: Optional[Sequence[Mapping[str, Any]]],
         max_user_code_failure_retries: int = 0,
         user_code_failure_retry_delay: int = 60,
-        should_block_op_concurrency_limited_runs: bool = False,
+        should_block_op_concurrency_limited_runs: bool = True,
         op_concurrency_slot_buffer: int = 0,
     ):
         return super().__new__(
@@ -66,8 +66,7 @@ class RunQueueConfig(
             ),
             max_user_code_failure_retries=self.max_user_code_failure_retries,
             user_code_failure_retry_delay=self.user_code_failure_retry_delay,
-            should_block_op_concurrency_limited_runs=bool(pool_settings)
-            or self.should_block_op_concurrency_limited_runs,
+            should_block_op_concurrency_limited_runs=self.should_block_op_concurrency_limited_runs,
             op_concurrency_slot_buffer=pool_settings.get(
                 "op_granularity_run_buffer", self.op_concurrency_slot_buffer
             ),
@@ -122,7 +121,8 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             user_code_failure_retry_delay, "user_code_failure_retry_delay", 60
         )
         self._should_block_op_concurrency_limited_runs: bool = bool(
-            block_op_concurrency_limited_runs and block_op_concurrency_limited_runs.get("enabled")
+            not block_op_concurrency_limited_runs
+            or block_op_concurrency_limited_runs.get("enabled", True)
         )
         self._op_concurrency_slot_buffer: int = (
             block_op_concurrency_limited_runs.get("op_concurrency_slot_buffer", 0)

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -30,6 +30,7 @@ class RunQueueConfig(
             ("user_code_failure_retry_delay", int),
             ("should_block_op_concurrency_limited_runs", bool),
             ("op_concurrency_slot_buffer", int),
+            ("explicitly_enabled_concurrency_run_blocking", bool),
         ],
     )
 ):
@@ -41,6 +42,7 @@ class RunQueueConfig(
         user_code_failure_retry_delay: int = 60,
         should_block_op_concurrency_limited_runs: bool = True,
         op_concurrency_slot_buffer: int = 0,
+        explicitly_enabled_concurrency_run_blocking: bool = False,
     ):
         return super().__new__(
             cls,
@@ -52,6 +54,10 @@ class RunQueueConfig(
                 should_block_op_concurrency_limited_runs, "should_block_op_concurrency_limited_runs"
             ),
             check.int_param(op_concurrency_slot_buffer, "op_concurrency_slot_buffer"),
+            check.bool_param(
+                explicitly_enabled_concurrency_run_blocking,
+                "explicitly_enabled_concurrency_run_blocking",
+            ),
         )
 
     def with_concurrency_settings(
@@ -70,6 +76,7 @@ class RunQueueConfig(
             op_concurrency_slot_buffer=pool_settings.get(
                 "op_granularity_run_buffer", self.op_concurrency_slot_buffer
             ),
+            explicitly_enabled_concurrency_run_blocking=self.explicitly_enabled_concurrency_run_blocking,
         )
 
 
@@ -124,6 +131,9 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             not block_op_concurrency_limited_runs
             or block_op_concurrency_limited_runs.get("enabled", True)
         )
+        self._explicitly_enabled_concurrency_run_blocking: bool = bool(
+            block_op_concurrency_limited_runs and block_op_concurrency_limited_runs.get("enabled")
+        )
         self._op_concurrency_slot_buffer: int = (
             block_op_concurrency_limited_runs.get("op_concurrency_slot_buffer", 0)
             if block_op_concurrency_limited_runs
@@ -150,6 +160,7 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             user_code_failure_retry_delay=self._user_code_failure_retry_delay,
             should_block_op_concurrency_limited_runs=self._should_block_op_concurrency_limited_runs,
             op_concurrency_slot_buffer=self._op_concurrency_slot_buffer,
+            explicitly_enabled_concurrency_run_blocking=self._explicitly_enabled_concurrency_run_blocking,
         )
 
     @property

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -1299,6 +1299,83 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             list(daemon.run_iteration(concurrency_limited_workspace_context))
             assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1, run_id_2])
 
+    @pytest.mark.parametrize(
+        "concurrency_config",
+        [
+            {"pools": {"granularity": "op", "default_limit": 1}},
+        ],
+    )
+    @pytest.mark.parametrize(
+        "run_coordinator_config",
+        [
+            {"block_op_concurrency_limited_runs": {"enabled": False}},
+        ],
+    )
+    def test_disable_concurrency_run_blocking(
+        self,
+        concurrency_limited_workspace_context,
+        daemon,
+        instance,
+    ):
+        run_id_1, run_id_2 = [make_new_run_id() for _ in range(2)]
+        workspace = concurrency_limited_workspace_context.create_request_context()
+        # concurrency_limited_asset_job
+        remote_job = self.get_concurrency_job(workspace)
+        foo_key = AssetKey(["prefix", "foo_limited_asset"])
+
+        # first submit a run that occupies the foo slot
+        self.submit_run(
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+        )
+        list(daemon.run_iteration(concurrency_limited_workspace_context))
+        assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1])
+
+        # submit a run that also occupies the foo slot
+        self.submit_run(
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
+        )
+
+        # the second run is launched
+        list(daemon.run_iteration(concurrency_limited_workspace_context))
+        assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1, run_id_2])
+
+    @pytest.mark.parametrize("concurrency_config", [{}])
+    @pytest.mark.parametrize("run_coordinator_config", [{}])
+    def test_concurrency_run_default(
+        self,
+        concurrency_limited_workspace_context,
+        daemon,
+        instance,
+    ):
+        run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
+        workspace = concurrency_limited_workspace_context.create_request_context()
+        # concurrency_limited_asset_job
+        remote_job = self.get_concurrency_job(workspace)
+        foo_key = AssetKey(["prefix", "foo_limited_asset"])
+        bar_key = AssetKey(["prefix", "bar_limited_asset"])
+
+        instance.event_log_storage.set_concurrency_slots("foo", 1)
+
+        # first submit a run that occupies the foo slot
+        self.submit_run(
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+        )
+        list(daemon.run_iteration(concurrency_limited_workspace_context))
+        assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1])
+
+        # submit a run that also occupies the foo slot, bar slot
+        self.submit_run(
+            instance,
+            remote_job,
+            workspace,
+            run_id=run_id_2,
+            asset_selection=set([foo_key, bar_key]),
+        )
+
+        # the second run is not launched
+        list(daemon.run_iteration(concurrency_limited_workspace_context))
+        assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1])
+
 
 class TestQueuedRunCoordinatorDaemon(QueuedRunCoordinatorDaemonTests):
     @pytest.fixture


### PR DESCRIPTION
## Summary & Motivation
Turns on the concurrency run-blocking by default... previously, since we didn't want to change behavior in a minor release, we used configuring a `pool` setting as a proxy for it.  That's no longer needed since this is for a major release and we should just change the behavior.

## How I Tested These Changes
BK

## Changelog
* Turns on run-blocking for concurrency keys / pools by default.  For op granularity, runs are dequeued if there exists at least one op that can execute once the run has started.  For run granularity, runs are dequeued if all pools have available slots.