### PR TITLE
Ignore CHANGELOG.md in components/dg MANIFEST.in

### DIFF
--- a/python_modules/libraries/dagster-components/setup.cfg
+++ b/python_modules/libraries/dagster-components/setup.cfg
@@ -7,3 +7,4 @@ ignore =
     tox.ini
     pytest.ini
     dagster_components_tests/**
+    CHANGELOG.md

--- a/python_modules/libraries/dagster-dg/setup.cfg
+++ b/python_modules/libraries/dagster-dg/setup.cfg
@@ -7,3 +7,4 @@ ignore =
     tox.ini
     pytest.ini
     dagster_dg_tests/**
+    CHANGELOG.md


### PR DESCRIPTION
## Summary & Motivation

Ignore `CHANGELOG.md` in the `dagster-components` and `dagster-dg` `MANIFEST.in` files.

## How I Tested These Changes

Ran `check-manifest` locally