### PR TITLE
Fix code snippets in Fivetran integration docs

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/integrations/fivetran/customize_fivetran_asset_defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/integrations/fivetran/customize_fivetran_asset_defs.py
@@ -10,6 +10,7 @@ fivetran_workspace = FivetranWorkspace(
 
 
 @fivetran_assets(
+    # Replace with your connector ID
     connector_id="fivetran_connector_id",
     name="fivetran_connector_id",
     group_name="fivetran_connector_id",

--- a/examples/docs_beta_snippets/docs_beta_snippets/integrations/fivetran/fetch_column_metadata_fivetran_assets.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/integrations/fivetran/fetch_column_metadata_fivetran_assets.py
@@ -10,6 +10,7 @@ fivetran_workspace = FivetranWorkspace(
 
 
 @fivetran_assets(
+    # Replace with your connector ID
     connector_id="fivetran_connector_id",
     workspace=fivetran_workspace,
 )
@@ -17,3 +18,9 @@ def fivetran_connector_assets(
     context: dg.AssetExecutionContext, fivetran: FivetranWorkspace
 ):
     yield from fivetran.sync_and_poll(context=context).fetch_column_metadata()
+
+
+defs = dg.Definitions(
+    assets=[fivetran_connector_assets],
+    resources={"fivetran": fivetran_workspace},
+)


### PR DESCRIPTION
## Summary & Motivation
Add missing / implied `Definition` to an example code snippet for adding column-level metadata to a Fivetran asset. This makes it so users can copy-paste the code snippet into their Dagster project and use it without needing to add the `Definition` themselves.

Also adds some comments to make it clear where a user needs to replace placeholder with real value for Fivetran connector id.

## How I Tested These Changes
- Set up a Fivetran connector
- Set up new Dagster project
- Copy the example into `definitions.py`, replacing values as specified.
- Run `dagster dev`, verify no errors
- Verify the Fivetran asset has column-level metadata

## Changelog

> Insert changelog entry or delete this section.
