### PR TITLE
[components][rfc] Move resolvers onto the class

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -37,24 +37,24 @@ class DbtProjectSchema(ResolvableSchema["DbtProjectComponent"]):
     transforms: Optional[Sequence[AssetSpecTransformSchema]] = None
 
 
-def resolve_dbt(context: ResolutionContext, schema: DbtProjectSchema) -> DbtCliResource:
-    return DbtCliResource(**context.resolve_value(schema.dbt.model_dump()))
-
-
-def resolve_translator(
-    context: ResolutionContext, schema: DbtProjectSchema
-) -> DagsterDbtTranslator:
-    return get_wrapped_translator_class(DagsterDbtTranslator)(
-        resolving_info=TranslatorResolvingInfo(
-            "node", schema.asset_attributes or AssetAttributesSchema(), context
-        )
-    )
-
-
 @registered_component_type(name="dbt_project")
 @dataclass
 class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
+
+    @staticmethod
+    def resolve_dbt(context: ResolutionContext, schema: DbtProjectSchema) -> DbtCliResource:
+        return DbtCliResource(**context.resolve_value(schema.dbt.model_dump()))
+
+    @staticmethod
+    def resolve_translator(
+        context: ResolutionContext, schema: DbtProjectSchema
+    ) -> DagsterDbtTranslator:
+        return get_wrapped_translator_class(DagsterDbtTranslator)(
+            resolving_info=TranslatorResolvingInfo(
+                "node", schema.asset_attributes or AssetAttributesSchema(), context
+            )
+        )
 
     dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
     op: Optional[OpSpecSchema]

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -41,16 +41,16 @@ class PipesSubprocessScriptCollectionSchema(ResolvableSchema["PipesSubprocessScr
     scripts: Sequence[PipesSubprocessScriptSchema]
 
 
-def resolve_specs_by_path(
-    context: ResolutionContext, schema: PipesSubprocessScriptCollectionSchema
-) -> Mapping[str, Sequence[AssetSpec]]:
-    return {spec.path: spec.assets for spec in context.resolve_value(schema.scripts)}
-
-
 @registered_component_type(name="pipes_subprocess_script_collection")
 @dataclass
 class PipesSubprocessScriptCollection(Component):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
+
+    @staticmethod
+    def resolve_specs_by_path(
+        context: ResolutionContext, schema: PipesSubprocessScriptCollectionSchema
+    ) -> Mapping[str, Sequence[AssetSpec]]:
+        return {spec.path: spec.assets for spec in context.resolve_value(schema.scripts)}
 
     specs_by_path: Annotated[
         Mapping[str, Sequence[AssetSpec]], FieldResolver(resolve_specs_by_path)

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -58,20 +58,20 @@ class SlingReplicationCollectionSchema(ResolvableSchema["SlingReplicationCollect
     transforms: Optional[Sequence[AssetSpecTransformSchema]] = None
 
 
-def resolve_resource(
-    context: ResolutionContext, schema: SlingReplicationCollectionSchema
-) -> SlingResource:
-    return (
-        SlingResource(**context.resolve_value(schema.sling.model_dump()))
-        if schema.sling
-        else SlingResource()
-    )
-
-
 @registered_component_type
 @dataclass
 class SlingReplicationCollection(Component):
     """Expose one or more Sling replications to Dagster as assets."""
+
+    @staticmethod
+    def resolve_resource(
+        context: ResolutionContext, schema: SlingReplicationCollectionSchema
+    ) -> SlingResource:
+        return (
+            SlingResource(**context.resolve_value(schema.sling.model_dump()))
+            if schema.sling
+            else SlingResource()
+        )
 
     resource: Annotated[SlingResource, FieldResolver(resolve_resource)]
     replications: Sequence[SlingReplicationSpec]


### PR DESCRIPTION
## Summary & Motivation

This is an alternative pattern for where we define these field resolver functions. Just opening this up for thoughts, this is just a convention decision rather than a functionality change.

Pros:
- bundles together the resolver code a bit more obviously

Cons:
- these functions need to be defined above the annotations, which is a bit unsightly

## How I Tested These Changes

## Changelog

NOCHANGELOG
