### PR TITLE
Fix partitionKeysOrError for asset jobs with just unpartitioned assets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -980,7 +980,6 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
 
         return GrapheneRepository(self._remote_job.repository_handle)
 
-    @capture_error
     def resolve_partitionKeysOrError(
         self,
         graphene_info: ResolveInfo,


### PR DESCRIPTION
This resolver was failing if all the assets were unpartitioned.

## How I Tested These Changes
New test case

## Changelog
Fixed an issue where a "Message: Cannot return null for non-nullable field PartitionKeys.partitionKeys." error was raised in the launchpad for jobs with unpartitioned assets.
