### PR TITLE
update queue criteria to use pool terminology

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -121,7 +121,7 @@
   "CapturedLogsQuery": "872b617b4f33ee5f6feeba9a4c76ec986fca357695a114e3d7b63172e4600b57",
   "PipelineRunLogsSubscription": "9f7f83476b6839dabd890487982ba453adb7cee3340c47aebb7f189492784023",
   "RunLogsQuery": "6086ddc4fb1ea5e12a73049ba83df08747ecd1a9d3443eeb7e2875fddd55fa9e",
-  "QueuedRunCriteriaQuery": "da19aeed8a0a7e6f47619c6ba9efd721345481d8f08223282ea774e468400f21",
+  "QueuedRunCriteriaQuery": "f925e1576792948317528a64856c3c020591feefac39f1aaebb3092d0fd3cd0b",
   "QueueDaemonStatusQuery": "aa51c596ee907346e60e2fe173bba10ae2ead067d45109225a2cd400a2278841",
   "PipelineEnvironmentQuery": "3b668b028997fb35b17b4d8a90a18b78dd8a70910f2c12aac63065c0584e3a10",
   "RunAssetChecksQuery": "6946372fc625c6aba249a54be1943c0858c8efbd5e6f5c64c55723494dc199e4",

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
@@ -185,9 +185,11 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
                 <Tooltip
                   placement="bottom"
                   content={
-                    poolOpGranularityRunLimited
-                      ? 'Pool limits are set on all of the initial steps in this run. This run will not start until there are available slots for at least one step.'
-                      : 'Pool limits are set on ops for this run. This run will not start until there are available slots for all pools.'
+                    <div style={{maxWidth: 300}}>
+                      {poolOpGranularityRunLimited
+                        ? 'Pool limits are set on all of the initial steps in this run. This run will not start until there are available slots for at least one step.'
+                        : 'Pool limits are set on ops for this run. This run will not start until there are available slots for all pools.'}
+                    </div>
                   }
                 >
                   <Icon name="info" color={Colors.accentGray()} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
@@ -13,7 +13,6 @@ import {
 } from '@dagster-io/ui-components';
 import isPlainObject from 'lodash/isPlainObject';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 import * as yaml from 'yaml';
 
 import {QUEUED_RUN_CRITERIA_QUERY} from './QueuedRunCriteriaQuery';
@@ -23,6 +22,7 @@ import {
   QueuedRunCriteriaQueryVariables,
 } from './types/QueuedRunCriteriaQuery.types';
 import {RunFragment} from './types/RunFragments.types';
+import {PoolTag} from '../instance/PoolTag';
 import {useRunQueueConfig} from '../instance/useRunQueueConfig';
 import {StructuredContentTable} from '../metadata/MetadataEntry';
 import {numberFormatter} from '../ui/formatters';
@@ -76,6 +76,7 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
     },
   );
 
+  const granularity = data?.instance.poolConfig?.poolGranularity;
   const runTagMap = Object.fromEntries(run.tags.map(({key, value}) => [key, value]));
   const maxConcurrentRuns = runQueueConfig?.maxConcurrentRuns;
   const runTagLimits = React.useMemo(() => {
@@ -117,14 +118,18 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
     );
   }
 
-  const {rootConcurrencyKeys, hasUnconstrainedRootNodes} = data.runOrError;
+  const {rootConcurrencyKeys, hasUnconstrainedRootNodes, allPools} = data.runOrError;
 
   const priority = runTagMap['dagster/priority'];
-  const runIsOpConcurrencyLimited =
+  const poolOpGranularityRunLimited =
     runQueueConfig?.isOpConcurrencyAware &&
+    (!granularity || granularity === 'op') &&
     rootConcurrencyKeys &&
     rootConcurrencyKeys.length > 0 &&
     !hasUnconstrainedRootNodes;
+
+  const poolRunGranularityRunLimited =
+    runQueueConfig?.isOpConcurrencyAware && allPools && allPools.length > 0;
 
   return (
     <Table>
@@ -172,31 +177,27 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
             </td>
           </tr>
         ) : null}
-        {runIsOpConcurrencyLimited ? (
+        {poolOpGranularityRunLimited || poolRunGranularityRunLimited ? (
           <tr>
             <td>
               <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                <div>Initial concurrency keys</div>
+                <div>Pools</div>
                 <Tooltip
                   placement="bottom"
-                  content="Op/asset concurrency limits are set on all of the initial steps in this run. This run will not start until there are available slots for at least one step."
+                  content={
+                    poolOpGranularityRunLimited
+                      ? 'Pool limits are set on all of the initial steps in this run. This run will not start until there are available slots for at least one step.'
+                      : 'Pool limits are set on ops for this run. This run will not start until there are available slots for all pools.'
+                  }
                 >
                   <Icon name="info" color={Colors.accentGray()} />
                 </Tooltip>
               </Box>
             </td>
             <td>
-              {rootConcurrencyKeys!.map((key, i) =>
-                runQueueConfig ? (
-                  <Tag interactive key={`rootConcurrency:${i}`}>
-                    <Link to={`/deployment/concurrency/${encodeURIComponent(key)}`}>{key}</Link>
-                  </Tag>
-                ) : (
-                  <Tag interactive key={`rootConcurrency:${i}`}>
-                    {key}
-                  </Tag>
-                ),
-              )}
+              {(poolOpGranularityRunLimited ? rootConcurrencyKeys : allPools)!.map((pool) => (
+                <PoolTag key={pool} pool={pool} />
+              ))}
             </td>
           </tr>
         ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaQuery.tsx
@@ -2,11 +2,18 @@ import {gql} from '../apollo-client';
 
 export const QUEUED_RUN_CRITERIA_QUERY = gql`
   query QueuedRunCriteriaQuery($runId: ID!) {
+    instance {
+      id
+      poolConfig {
+        poolGranularity
+      }
+    }
     runOrError(runId: $runId) {
       ... on Run {
         id
         rootConcurrencyKeys
         hasUnconstrainedRootNodes
+        allPools
       }
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
@@ -8,6 +8,11 @@ export type QueuedRunCriteriaQueryVariables = Types.Exact<{
 
 export type QueuedRunCriteriaQuery = {
   __typename: 'Query';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    poolConfig: {__typename: 'PoolConfig'; poolGranularity: string | null} | null;
+  };
   runOrError:
     | {__typename: 'PythonError'}
     | {
@@ -15,8 +20,9 @@ export type QueuedRunCriteriaQuery = {
         id: string;
         rootConcurrencyKeys: Array<string> | null;
         hasUnconstrainedRootNodes: boolean;
+        allPools: Array<string> | null;
       }
     | {__typename: 'RunNotFoundError'};
 };
 
-export const QueuedRunCriteriaQueryVersion = 'da19aeed8a0a7e6f47619c6ba9efd721345481d8f08223282ea774e468400f21';
+export const QueuedRunCriteriaQueryVersion = 'f925e1576792948317528a64856c3c020591feefac39f1aaebb3092d0fd3cd0b';


### PR DESCRIPTION
## Summary & Motivation
Instead of referencing root concurrency keys, we should reference pools and use the pool tags component.

<img width="1840" alt="Screenshot 2025-02-13 at 4 46 05 PM" src="https://github.com/user-attachments/assets/8174999f-3c53-415c-9987-8ee7eb3d12fe" />

## How I Tested These Changes
Inspection

## Changelog
- Changed the queue criteria dialog to reference pools instead of concurrency keys
