### PR TITLE
Show queued runs on op granularity pool info page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
@@ -193,11 +193,18 @@ export const InstanceConcurrencyKeyInfo = ({concurrencyKey}: {concurrencyKey: st
                   padding={{vertical: 16, horizontal: 24}}
                   flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
                 >
-                  <Subheading>In progress</Subheading>
+                  <Subheading>In progress steps</Subheading>
                 </Box>
                 <Box style={{marginLeft: -1}}>
                   <PendingStepsTable keyInfo={concurrencyLimit} refresh={refetch} />
                 </Box>
+                <Box
+                  padding={{vertical: 16, horizontal: 24}}
+                  flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+                >
+                  <Subheading>Queued runs</Subheading>
+                </Box>
+                <PoolRunsTable pool={concurrencyKey} runStatuses={queuedStatuses} />
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary & Motivation
Adds queued run information on the pool info page, even if the pool granularity is set to "run".

<img width="1840" alt="Screenshot 2025-02-13 at 4 47 41 PM" src="https://github.com/user-attachments/assets/b0bf5339-6d65-4f41-96ef-322a8672f6dc" />

## How I Tested These Changes
Inspection

## Changelog
- Adds queued run information on the pool info page, even if the pool granularity is set to `run`.

