### PR TITLE
only fetch the concurrency info for configured keys

### DIFF
--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -91,9 +91,13 @@ class GlobalOpConcurrencyLimitsCounter:
         # initialize all the pool limits to the default if necessary
         self._initialize_pool_limits(instance, queued_pool_names)
 
+        # fetch all the configured pool keys
+        all_configured_pool_names = instance.event_log_storage.get_concurrency_keys()
+        configured_queued_pool_names = all_configured_pool_names.intersection(queued_pool_names)
+
         # fetch all the concurrency info for all of the runs at once, so we can claim in the correct
         # priority order
-        self._fetch_concurrency_info(instance, queued_pool_names)
+        self._fetch_concurrency_info(instance, configured_queued_pool_names)
 
         # fetch all the outstanding pools for in-progress runs
         self._process_in_progress_runs(in_progress_run_records)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -1376,6 +1376,35 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1])
 
+    @pytest.mark.parametrize(
+        "concurrency_config",
+        [
+            {"pools": {"granularity": "op"}},
+            {"pools": {"granularity": "run"}},
+            {},
+        ],
+    )
+    @pytest.mark.parametrize("run_coordinator_config", [{}])
+    def test_concurrency_run_unconfigured(
+        self,
+        concurrency_limited_workspace_context,
+        daemon,
+        instance,
+    ):
+        run_id_1 = make_new_run_id()
+        workspace = concurrency_limited_workspace_context.create_request_context()
+
+        # concurrency_limited_asset_job
+        remote_job = self.get_concurrency_job(workspace)
+        foo_key = AssetKey(["prefix", "foo_limited_asset"])
+
+        # there are no configured slots, the run should be launched
+        self.submit_run(
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+        )
+        list(daemon.run_iteration(concurrency_limited_workspace_context))
+        assert set(self.get_run_ids(instance.run_launcher.queue())) == set([run_id_1])
+
 
 class TestQueuedRunCoordinatorDaemon(QueuedRunCoordinatorDaemonTests):
     @pytest.fixture


### PR DESCRIPTION
## Summary & Motivation
Fix run blocking with unconfigured keys to fail open

## How I Tested These Changes
tests

## Changelog

