### PR TITLE
docs: Update typo in `asset-versioning-and-caching.md`

### DIFF
--- a/docs/docs/guides/build/assets/asset-versioning-and-caching.md
+++ b/docs/docs/guides/build/assets/asset-versioning-and-caching.md
@@ -81,9 +81,9 @@ Tracking changes becomes more powerful when there are dependencies in play. Let'
 
 <CodeExample path="docs_snippets/docs_snippets/guides/dagster/asset_versioning_and_caching/dependencies_code_version_only.py" />
 
-In the Dagster UI, click **Reload definitions**. The `multipled_number` asset will be marked as **Never materialized**.
+In the Dagster UI, click **Reload definitions**. The `multiplied_number` asset will be marked as **Never materialized**.
 
-Next, click the toggle to the right side of the **Materialize** button to display the **Propagate changes** option. As the **Materialize** button ignores versioning, we need this option to ensure the `multipled_number` asset is properly materialized.
+Next, click the toggle to the right side of the **Materialize** button to display the **Propagate changes** option. As the **Materialize** button ignores versioning, we need this option to ensure the `multiplied_number` asset is properly materialized.
 
 In the created run, only the step associated with `multiplied_number` is run. The system knows that `versioned_number` is up to date and therefore can safely skip that computation. You can see this on the details page for the run:
 


### PR DESCRIPTION
## Summary & Motivation
Just fixing a small typo on https://docs.dagster.io/guides/build/assets/asset-versioning-and-caching
`multipled_number` -> `multiplied_number`

## How I Tested These Changes
I didn't.