### PR TITLE
[docs] make version dropdown conditional on preview deployments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,8 @@ Which is hosted on the `archive` subdomain of dagster-docs.io where `release-1-9
 
 These versions are made available in the navigation bar as external links on the latest docs site, and a link to the "Latest docs" is presented on archived versions of the docs. See the conditional logic using `VERCEL_ENV` in docusaurus.config.ts.
 
+To validate the dropdown menu, you can run `VERCEL_ENV=production yarn start`.
+
 ---
 
 ## Deployment

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,16 @@ This command generates static content into the `build` directory and can be serv
 
 **NOTE:** the `make sphinx_objects_inv` command needs to be run before creating a new release. We plan to automate this procedure in the future.
 
+### Versioning
+
+Previous versions of the docs site are made accessible through preview deployments in Vercel, for example:
+
+* https://release-1-9-13.archive.dagster-docs.io/
+
+Which is hosted on the `archive` subdomain of dagster-docs.io where `release-1-9-13` is the release branch in version control.
+
+These versions are made available in the navigation bar as external links on the latest docs site, and a link to the "Latest docs" is presented on archived versions of the docs. See the conditional logic using `VERCEL_ENV` in docusaurus.config.ts.
+
 ---
 
 ## Deployment

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,9 +103,9 @@ Previous versions of the docs site are made accessible through preview deploymen
 
 Which is hosted on the `archive` subdomain of dagster-docs.io where `release-1-9-13` is the release branch in version control.
 
-These versions are made available in the navigation bar as external links on the latest docs site, and a link to the "Latest docs" is presented on archived versions of the docs. See the conditional logic using `VERCEL_ENV` in docusaurus.config.ts.
+These versions are accessible through the navigation bar as external links, and a link to the "Latest docs" is presented on archived deployments. See the conditional logic using `VERCEL_ENV` in docusaurus.config.ts.
 
-To validate the dropdown menu, you can run `VERCEL_ENV=production yarn start`.
+To validate the dropdown menu, you can run `VERCEL_ENV=preview yarn start`.
 
 ---
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -102,12 +102,12 @@ const config: Config = {
           position: 'left',
         },
 
-        // Conditionally display version dropdown when in Vercel production environment
+        // Conditionally display version dropdown when in local and Vercel production environments.
         //
         //     https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_ENV
         //
-        // Otherwise display a link to the latest docs site; this will used in local and preview builds.
-        process.env.VERCEL_ENV && process.env.VERCEL_ENV === 'production'
+        // Otherwise display a link to the latest docs site; this will used in preview builds.
+        !process.env.VERCEL_ENV || process.env.VERCEL_ENV === 'production'
           ? {
               label: 'Versions',
               type: 'docsVersionDropdown',

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,10 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import DagsterVersions from './dagsterVersions.json';
 
-const DagsterVersionsDropdownItems = Object.entries(DagsterVersions).splice(
-  0,
-  5,
-);
+const DagsterVersionsDropdownItems = Object.entries(DagsterVersions).splice(0, 5);
 
 const config: Config = {
   title: 'Dagster Docs',
@@ -104,35 +101,34 @@ const config: Config = {
           docId: 'api/index',
           position: 'left',
         },
-        {
-          label: 'Versions',
-          type: 'docsVersionDropdown',
-          position: 'right',
-          dropdownItemsAfter: [
-            ...DagsterVersionsDropdownItems.map(
-              ([versionName, versionUrl]) => ({
-                label: versionName,
-                href: versionUrl,
-              }),
-            ),
-            {
-              href: 'https://legacy-docs.dagster.io',
-              label: '1.9.9 and earlier'
+
+        // Conditionally display version dropdown when in Vercel production environment
+        //
+        //     https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_ENV
+        //
+        // Otherwise display a link to the latest docs site; this will used in local and preview builds.
+        process.env.VERCEL_ENV && process.env.VERCEL_ENV === 'production'
+          ? {
+              label: 'Versions',
+              type: 'docsVersionDropdown',
+              position: 'right',
+              dropdownItemsAfter: [
+                ...DagsterVersionsDropdownItems.map(([versionName, versionUrl]) => ({
+                  label: versionName,
+                  href: versionUrl,
+                })),
+                {
+                  href: 'https://legacy-docs.dagster.io',
+                  label: '1.9.9 and earlier',
+                },
+              ],
             }
-          ]
-        },
-        //{
-        //  label: 'Changelog',
-        //  type: 'doc',
-        //  docId: 'changelog',
-        //  position: 'right',
-        //},
-        // {
-        //    label: 'Feedback',
-        //    href: 'https://github.com/dagster-io/dagster/discussions/27332',
-        //    position: 'right',
-        //    className: 'feedback-nav-link',
-        //  },
+          : {
+              label: 'Latest version',
+              href: 'https://docs.dagster.io',
+              position: 'right',
+              className: 'feedback-nav-link',
+            },
       ],
     },
     image: 'images/og.png',
@@ -182,8 +178,8 @@ const config: Config = {
           versions: {
             current: {
               label: '1.10.0 (latest)',
-              path: '/'
-            }
+              path: '/',
+            },
           },
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',


### PR DESCRIPTION
## Summary & Motivation

* Adds conditional logic for displaying the versioned drop down menu in production releases and local development.
* Adds explanation of this to the README

## How I Tested These Changes

https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_ENV

Confirmed drop down menu displays correctly with these commands:

```
yarn start  # shows dropdown
```

```
VERCEL_ENV=production yarn start  # shows dropdown
```

```
VERCEL_ENV=preview yarn start  # shows "Latest version"
```

## Changelog

NOCHANGELOG
