### PR TITLE
[BUILD-706][dg components check] Error on extra top-level keys, better extra param errors

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
@@ -24,9 +24,11 @@ def msg_includes_all_of(*substrings: str) -> Callable[[str], None]:
     return _validate_error_msg
 
 
+BASIC_COMPONENT_TYPE_FILEPATH = Path(__file__).parent / "basic_components.py"
+
 BASIC_INVALID_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_invalid_value",
-    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
     should_error=True,
     validate_error_msg=msg_includes_all_of(
         "component.yaml:5", "params.an_int", "Input should be a valid integer"
@@ -40,7 +42,7 @@ BASIC_INVALID_VALUE = ComponentValidationTestCase(
 
 BASIC_MISSING_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_missing_value",
-    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
     should_error=True,
     validate_error_msg=msg_includes_all_of("component.yaml:3", "params.an_int", "required"),
     check_error_msg=msg_includes_all_of(
@@ -52,7 +54,7 @@ BASIC_MISSING_VALUE = ComponentValidationTestCase(
 
 BASIC_VALID_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_success",
-    component_type_filepath=Path(__file__).parent / "basic_components.py",
+    component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
     should_error=False,
 )
 
@@ -75,19 +77,19 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/basic_component_extra_value",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:7", "params.a_bool", "Extra inputs are not permitted"
         ),
         check_error_msg=msg_includes_all_of(
-            "component.yaml:3",
+            "component.yaml:7",
             "'a_bool' was unexpected",
         ),
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_invalid_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:7",
@@ -108,7 +110,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_missing_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:5", "params.nested.foo.an_int", "required"
@@ -124,7 +126,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
     ),
     ComponentValidationTestCase(
         component_path="validation/nested_component_extra_values",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:8",
@@ -134,17 +136,17 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "params.nested.baz.another_bool",
         ),
         check_error_msg=msg_includes_all_of(
-            "component.yaml:5",
+            "component.yaml:8",
             "params.nested.foo",
             "'a_bool' was unexpected",
-            "component.yaml:12",
+            "component.yaml:15",
             "params.nested.baz",
             "'another_bool' was unexpected",
         ),
     ),
     ComponentValidationTestCase(
         component_path="validation/invalid_component_file_model",
-        component_type_filepath=Path(__file__).parent / "basic_components.py",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:1",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
@@ -1,0 +1,7 @@
+type: my_component@__init__.py
+
+params:
+  a_string: "a string"
+  an_int: 5
+
+an_extra_top_level_value: "extra top level value"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/component.py
@@ -269,6 +269,7 @@ COMPONENT_FILE_SCHEMA = {
         "type": {"type": "string"},
         "params": {"type": "object"},
     },
+    "additionalProperties": False,
 }
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/component_command_tests/test_check.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pytest
 from dagster_components.test.test_cases import (
+    BASIC_COMPONENT_TYPE_FILEPATH,
     BASIC_INVALID_VALUE,
     BASIC_MISSING_VALUE,
     BASIC_VALID_VALUE,
@@ -42,6 +43,15 @@ CLI_TEST_CASES = [
         check_error_msg=msg_includes_all_of(
             "component.yaml:1",
             "Component type 'my_component_does_not_exist@__init__.py' not found",
+        ),
+    ),
+    ComponentValidationTestCase(
+        component_path="validation/basic_component_extra_top_level_value",
+        component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
+        should_error=True,
+        check_error_msg=msg_includes_all_of(
+            "component.yaml:7",
+            "'an_extra_top_level_value' was unexpected",
         ),
     ),
 ]


### PR DESCRIPTION
## Summary

Sets `additionalProperties` to `False` on the top-level component file decl schema, ensuring we error on `dg component check` when extra top-level fields are provided.

Also improves extra field errors to point to the offending field instead of its parent, which `jsonschema` points to by default.

```sh
dg component check
/Users/ben/repos/components_demo/my-deployment/code_locations/jaffle-platform/jaffle_platform/components/defs_example/component.yaml:6 - asset_attributes Additional properties are not allowed ('asset_attributes' was unexpected)
     | 
   1 | type: definitions@dagster_components
   2 | 
   3 | params:
   4 |   definitions_path: definitions.py
   5 | 
   6 | asset_attributes: foo
     | ^ Additional properties are not allowed ('asset_attributes' was unexpected)
     | 
```

## How I Tested These Changes

New test case.

