### PR TITLE
[dg] Add filesystem watch utils, `dg components check --watch`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -1,19 +1,11 @@
-import hashlib
 import shutil
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Final, Literal, Optional
 
 from typing_extensions import Self, TypeAlias
 
 from dagster_dg.config import DgConfig
-from dagster_dg.utils import (
-    DEFAULT_FILE_EXCLUDE_PATTERNS,
-    hash_directory_metadata,
-    hash_file_metadata,
-    is_macos,
-    is_windows,
-)
+from dagster_dg.utils import is_macos, is_windows
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
@@ -27,20 +19,6 @@ def get_default_cache_dir() -> Path:
         return Path.home() / "Library" / "Caches" / "dg"
     else:
         return Path.home() / ".cache" / "dg"
-
-
-def hash_paths(
-    paths: Sequence[Path],
-    includes: Optional[Sequence[str]] = None,
-    excludes: Sequence[str] = DEFAULT_FILE_EXCLUDE_PATTERNS,
-) -> str:
-    hasher = hashlib.md5()
-    for path in paths:
-        if path.is_dir():
-            hash_directory_metadata(hasher, path, includes=includes, excludes=excludes)
-        else:
-            hash_file_metadata(hasher, path)
-    return hasher.hexdigest()
 
 
 class DgCache:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -11,7 +11,7 @@ import tomlkit
 import tomlkit.items
 from typing_extensions import Self
 
-from dagster_dg.cache import CachableDataType, DgCache, hash_paths
+from dagster_dg.cache import CachableDataType, DgCache
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import (
     DgConfig,
@@ -39,6 +39,7 @@ from dagster_dg.utils import (
     resolve_local_venv,
     strip_activated_venv_from_env_vars,
 )
+from dagster_dg.utils.filesystem import hash_paths
 
 # Project
 _DEFAULT_PROJECT_DEFS_SUBMODULE: Final = "defs"
@@ -209,6 +210,13 @@ class DgContext:
     @property
     def has_cache(self) -> bool:
         return self._cache is not None
+
+    def component_registry_paths(self) -> list[Path]:
+        """Paths that should be watched for changes to the component registry."""
+        return [
+            self.root_path / "uv.lock",
+            *([self.default_component_library_path] if self.is_component_library else []),
+        ]
 
     # Allowing open-ended str data_type for now so we can do module names
     def get_cache_key(self, data_type: Union[CachableDataType, str]) -> tuple[str, str, str]:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -277,7 +277,7 @@ def hash_directory_metadata(
     path: Union[str, Path],
     includes: Optional[Sequence[str]],
     excludes: Sequence[str],
-    error_on_missing: bool = False,
+    error_on_missing: bool,
 ) -> None:
     """Hashes the metadata of all files in the given directory.
 
@@ -296,12 +296,10 @@ def hash_directory_metadata(
             if includes and not any(fnmatch(name, pattern) for pattern in includes):
                 continue
             filepath = os.path.join(root, name)
-            hash_file_metadata(hasher, filepath)
+            hash_file_metadata(hasher, filepath, error_on_missing)
 
 
-def hash_file_metadata(
-    hasher: Hash, path: Union[str, Path], error_on_missing: bool = False
-) -> None:
+def hash_file_metadata(hasher: Hash, path: Union[str, Path], error_on_missing) -> None:
     """Hashes the metadata of a file.
 
     Args:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/filesystem.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/filesystem.py
@@ -20,7 +20,7 @@ def hash_paths(
     paths: Sequence[Path],
     includes: Optional[Sequence[str]] = None,
     excludes: Sequence[str] = DEFAULT_FILE_EXCLUDE_PATTERNS,
-    error_on_missing: bool = False,
+    error_on_missing: bool = True,
 ) -> str:
     """Hash the given paths, including their metadata.
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/filesystem.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/filesystem.py
@@ -1,0 +1,116 @@
+import datetime
+import hashlib
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from dagster_dg.utils import (
+    DEFAULT_FILE_EXCLUDE_PATTERNS,
+    clear_screen,
+    hash_directory_metadata,
+    hash_file_metadata,
+)
+
+
+def hash_paths(
+    paths: Sequence[Path],
+    includes: Optional[Sequence[str]] = None,
+    excludes: Sequence[str] = DEFAULT_FILE_EXCLUDE_PATTERNS,
+    error_on_missing: bool = False,
+) -> str:
+    """Hash the given paths, including their metadata.
+
+    Args:
+        paths: The paths to hash.
+        includes: A list of glob patterns to target, excluding files that don't match any of the patterns.
+        excludes: A list of glob patterns to exclude, including files that match any of the patterns. Defaults to
+            various Python-related files that are not relevant to the contents of the project.
+
+    Returns:
+        The hash of the paths.
+    """
+    hasher = hashlib.md5()
+    for path in paths:
+        if path.is_dir():
+            hash_directory_metadata(
+                hasher,
+                path,
+                includes=includes,
+                excludes=excludes,
+                error_on_missing=error_on_missing,
+            )
+        else:
+            hash_file_metadata(hasher, path, error_on_missing=error_on_missing)
+    return hasher.hexdigest()
+
+
+class PathChangeHandler(FileSystemEventHandler):
+    """Basic handler that clears the screen and re-executes the callback when any of the watched paths change
+    in a way that would affect the hash of the paths. Passes the new hash to the callback.
+    """
+
+    def __init__(
+        self,
+        paths: Sequence[Path],
+        includes: Optional[Sequence[str]],
+        excludes: Sequence[str],
+        callback: Callable[[str], Any],
+    ):
+        self._callback = callback
+        self._paths = paths
+        self._includes = includes
+        self._excludes = excludes
+        self._prev_hash = hash_paths(self._paths, self._includes, self._excludes)
+        self.clear_and_execute(self._prev_hash)
+
+    def dispatch(self, _event: FileSystemEvent):
+        new_hash = hash_paths(self._paths, self._includes, self._excludes, error_on_missing=False)
+
+        if new_hash != self._prev_hash:
+            self.clear_and_execute(new_hash)
+            self._prev_hash = new_hash
+
+    def clear_and_execute(self, new_hash: str):
+        clear_screen()
+        self._callback(new_hash)
+        current_time = datetime.datetime.now().strftime("%H:%M:%S")
+        print(f"\nUpdated at {current_time}, watching for changes...")  # noqa: T201
+
+
+# This is a global variable that is used to signal the watcher to exit in tests
+SHOULD_WATCHER_EXIT = False
+
+
+def watch_paths(
+    paths: Sequence[Path],
+    callback: Callable[[str], Any],
+    includes: Optional[Sequence[str]] = None,
+    excludes: Sequence[str] = DEFAULT_FILE_EXCLUDE_PATTERNS,
+):
+    """Watches the given paths for changes and calls the callback when they change.
+    The callback should take a single argument, the new hash of the paths.
+
+    Runs synchronously until the observer is stopped, or keyboard interrupt is received.
+
+    Args:
+        paths: The paths to watch.
+        callback: The callback to call when path contents change.
+        includes: A list of glob patterns to target, excluding files that don't match any of the patterns.
+        excludes: A list of glob patterns to exclude, including files that match any of the patterns. Defaults to
+            various Python-related files that are not relevant to the contents of the project.
+    """
+    observer = Observer()
+    handler = PathChangeHandler(paths, includes, excludes, callback)
+    for path in paths:
+        observer.schedule(handler, str(path), recursive=True)
+    observer.start()
+    try:
+        while observer.is_alive() and not SHOULD_WATCHER_EXIT:
+            time.sleep(0.5)
+    finally:
+        observer.stop()
+        observer.join()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -162,7 +162,7 @@ def test_check_cli_with_watch() -> None:
             check_thread.daemon = True  # Make thread daemon so it exits when main thread exits
             check_thread.start()
 
-            time.sleep(2)  # Give the check command time to start
+            time.sleep(10)  # Give the check command time to start
 
             # Copy the invalid component into the valid code location
             shutil.copy(


### PR DESCRIPTION
## Summary

Adds some filesystem watching utils, used to power `dg component check --watch`. Users can run this in the background to get near-instant updates on the correctness of their components when they save a component file, add/remove a Python dependency etc.

I also imagine this being useful to auto-update the language server YAML schema file, e.g. `dg code-location generate-schema --watch`.

```sh
/Users/ben/repos/components_demo/my-deployment/code_locations/jaffle-platform/jaffle_platform/components/defs_example/component.yaml:1 -  Component type 'definidtions@dagster_components' not found.
     | 
   1 | type: definidtions@dagster_components
     | ^ Component type 'definidtions@dagster_components' not found.
   2 | 
   3 | params:
   4 |   definitions_path: definitions.py
     | 


Updated at 12:56:36, watching for changes...
```

## How I Tested These Changes

Unit test