### PR TITLE
[dagster-fivetran] Fix connector url in FivetranConnector

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -59,7 +59,7 @@ class FivetranConnector:
 
     @property
     def url(self) -> str:
-        return f"https://fivetran.com/dashboard/connectors/{self.service}/{self.name}"
+        return f"https://fivetran.com/dashboard/connectors/{self.id}"
 
     @property
     def destination_id(self) -> str:


### PR DESCRIPTION
## Summary & Motivation

Connector URL was previously broken - it should use only the connector ID, not the service and table names. It is now updated.

<img width="791" alt="Screenshot 2025-02-14 at 2 42 55 PM" src="https://github.com/user-attachments/assets/b461861f-2810-44c9-ac43-8b5ca0b86615" />


## How I Tested These Changes

Manually tested in Dagster and Fivetran

