### PR TITLE
[branch deployments] change from base context to base asset graph

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -388,14 +388,11 @@ class GrapheneAssetNode(graphene.ObjectType):
         if self._asset_graph_differ is not None:
             return self._asset_graph_differ
 
-        base_deployment_context = graphene_info.context.get_base_deployment_context()
-
-        if base_deployment_context is None:
-            return None
+        base_deployment_asset_graph = graphene_info.context.get_base_deployment_asset_graph()
 
         self._asset_graph_differ = AssetGraphDiffer(
             branch_asset_graph=graphene_info.context.asset_graph,
-            base_asset_graph=base_deployment_context.asset_graph,
+            base_asset_graph=base_deployment_asset_graph,
         )
         return self._asset_graph_differ
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -350,7 +350,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         code_location = self.get_code_location(code_location_name)
         return code_location.get_notebook_data(notebook_path=notebook_path)
 
-    def get_base_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
+    def get_base_deployment_asset_graph(self) -> Optional["RemoteWorkspaceAssetGraph"]:
         return None
 
     def get_repository(


### PR DESCRIPTION
The full context is designed around serving the current live deployment, but if we want to be able to represent base deployments at a specific point and time we need more constrained target. Opted for the asset graph in this case. 

## How I Tested These Changes

bk

