### PR TITLE
[dg] add check definitions command

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -9,6 +9,7 @@ from jsonschema import Draft202012Validator, ValidationError
 from yaml.scanner import ScannerError
 
 from dagster_dg.cli.check_utils import error_dict_to_formatted_error
+from dagster_dg.cli.dev import format_forwarded_option, temp_workspace_file
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.component_key import ComponentKey, LocalComponentKey
@@ -22,8 +23,6 @@ from dagster_dg.yaml_utils.source_position import (
     SourcePositionTree,
     ValueAndSourcePositionTree,
 )
-
-from .dev import _format_forwarded_option, _temp_workspace_file
 
 
 @click.group(name="check", cls=DgClickGroup)
@@ -208,8 +207,8 @@ def check_definitions_command(
     dg_context = DgContext.for_deployment_or_code_location_environment(Path.cwd(), cli_config)
 
     forward_options = [
-        *_format_forwarded_option("--log-level", log_level),
-        *_format_forwarded_option("--log-format", log_format),
+        *format_forwarded_option("--log-level", log_level),
+        *format_forwarded_option("--log-format", log_format),
     ]
 
     # In a code location context, we can just run `dagster definitions validate` directly, using `dagster` from the
@@ -234,7 +233,7 @@ def check_definitions_command(
             *forward_options,
         ]
         cmd_location = "ephemeral dagster definitions validate"
-        temp_workspace_file_cm = _temp_workspace_file(dg_context)
+        temp_workspace_file_cm = temp_workspace_file(dg_context)
     else:
         exit_with_error("This command must be run inside a code location or deployment directory.")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -204,7 +204,7 @@ def check_definitions_command(
 
     """
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.for_deployment_or_code_location_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
     forward_options = [
         *format_forwarded_option("--log-level", log_level),
@@ -213,7 +213,7 @@ def check_definitions_command(
 
     # In a code location context, we can just run `dagster definitions validate` directly, using `dagster` from the
     # code location's environment.
-    if dg_context.is_code_location:
+    if dg_context.is_project:
         cmd = ["uv", "run", "dagster", "definitions", "validate", *forward_options]
         cmd_location = dg_context.get_executable("dagster")
         temp_workspace_file_cm = nullcontext()
@@ -222,7 +222,7 @@ def check_definitions_command(
     # workspace file that points at all defined code locations and invoke:
     #
     #     uv tool run --with dagster-webserver dagster definitions validate
-    elif dg_context.is_deployment:
+    elif dg_context.is_workspace:
         cmd = [
             "uv",
             "tool",

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -1,4 +1,6 @@
-from collections.abc import Sequence
+import subprocess
+from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
@@ -12,7 +14,7 @@ from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.component_key import ComponentKey, LocalComponentKey
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
-from dagster_dg.utils import DgClickCommand, DgClickGroup
+from dagster_dg.utils import DgClickCommand, DgClickGroup, exit_with_error, pushd
 from dagster_dg.yaml_utils import parse_yaml_with_source_positions
 from dagster_dg.yaml_utils.source_position import (
     LineCol,
@@ -20,6 +22,8 @@ from dagster_dg.yaml_utils.source_position import (
     SourcePositionTree,
     ValueAndSourcePositionTree,
 )
+
+from .dev import _format_forwarded_option, _temp_workspace_file
 
 
 @click.group(name="check", cls=DgClickGroup)
@@ -162,3 +166,81 @@ def check_yaml_command(
         context.exit(1)
     else:
         click.echo("All components validated successfully.")
+
+
+@check_group.command(name="definitions", cls=DgClickCommand)
+@click.option(
+    "--log-level",
+    help="Set the log level for dagster services.",
+    show_default=True,
+    default="info",
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
+)
+@click.option(
+    "--log-format",
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="colored",
+    help="Format of the logs for dagster services",
+)
+@dg_global_options
+@click.pass_context
+def check_definitions_command(
+    context: click.Context,
+    log_level: str,
+    log_format: str,
+    **global_options: Mapping[str, object],
+) -> None:
+    """Loads and validates your Dagster definitions using a Dagster instance.
+
+    If run inside a deployment directory, this command will launch all code locations in the
+    deployment. If launched inside a code location directory, it will launch only that code
+    location.
+
+    When running, this command sets the environment variable `DAGSTER_IS_DEFS_VALIDATION_CLI=1`.
+    This environment variable can be used to control the behavior of your code in validation mode.
+
+    This command returns an exit code 1 when errors are found, otherwise an exit code 0.
+
+    """
+    cli_config = normalize_cli_config(global_options, context)
+    dg_context = DgContext.for_deployment_or_code_location_environment(Path.cwd(), cli_config)
+
+    forward_options = [
+        *_format_forwarded_option("--log-level", log_level),
+        *_format_forwarded_option("--log-format", log_format),
+    ]
+
+    # In a code location context, we can just run `dagster definitions validate` directly, using `dagster` from the
+    # code location's environment.
+    if dg_context.is_code_location:
+        cmd = ["uv", "run", "dagster", "definitions", "validate", *forward_options]
+        cmd_location = dg_context.get_executable("dagster")
+        temp_workspace_file_cm = nullcontext()
+
+    # In a deployment context, dg validate will construct a temporary
+    # workspace file that points at all defined code locations and invoke:
+    #
+    #     uv tool run --with dagster-webserver dagster definitions validate
+    elif dg_context.is_deployment:
+        cmd = [
+            "uv",
+            "tool",
+            "run",
+            "dagster",
+            "definitions",
+            "validate",
+            *forward_options,
+        ]
+        cmd_location = "ephemeral dagster definitions validate"
+        temp_workspace_file_cm = _temp_workspace_file(dg_context)
+    else:
+        exit_with_error("This command must be run inside a code location or deployment directory.")
+
+    with pushd(dg_context.root_path), temp_workspace_file_cm as workspace_file:
+        print(f"Using {cmd_location}")  # noqa: T201
+        if workspace_file:  # only non-None deployment context
+            cmd.extend(["--workspace", workspace_file])
+
+        subprocess.run(cmd, check=True)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -90,12 +90,12 @@ def dev_command(
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
     forward_options = [
-        *_format_forwarded_option("--code-server-log-level", code_server_log_level),
-        *_format_forwarded_option("--log-level", log_level),
-        *_format_forwarded_option("--log-format", log_format),
-        *_format_forwarded_option("--port", port),
-        *_format_forwarded_option("--host", host),
-        *_format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
+        *format_forwarded_option("--code-server-log-level", code_server_log_level),
+        *format_forwarded_option("--log-level", log_level),
+        *format_forwarded_option("--log-format", log_format),
+        *format_forwarded_option("--port", port),
+        *format_forwarded_option("--host", host),
+        *format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
     ]
 
     # In a project context, we can just run `dagster dev` directly, using `dagster` from the
@@ -129,7 +129,7 @@ def dev_command(
             *forward_options,
         ]
         cmd_location = "ephemeral dagster dev"
-        temp_workspace_file_cm = _temp_workspace_file(dg_context)
+        temp_workspace_file_cm = temp_workspace_file(dg_context)
     else:
         exit_with_error("This command must be run inside a project or workspace directory.")
 
@@ -166,7 +166,7 @@ def dev_command(
 
 
 @contextmanager
-def _temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
+def temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
     with NamedTemporaryFile(mode="w+", delete=True) as temp_workspace_file:
         entries = []
         for project_name in dg_context.get_project_names():
@@ -185,7 +185,7 @@ def _temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
         yield temp_workspace_file.name
 
 
-def _format_forwarded_option(option: str, value: object) -> list[str]:
+def format_forwarded_option(option: str, value: object) -> list[str]:
     return [] if value is None else [option, str(value)]
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -61,6 +61,7 @@ WORKSPACE_CONTEXT_COMMANDS = [
 
 WORKSPACE_OR_PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("dev",)),
+    CommandSpec(("check", "definitions")),
 ]
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+from dagster_dg.utils import ensure_dagster_dg_tests_import, is_windows
+
+ensure_dagster_dg_tests_import()
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    isolated_example_code_location_foo_bar,
+    isolated_example_deployment_foo,
+)
+
+
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
+def test_validate_command_deployment_context_success():
+    with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner, create_venv=True):
+        runner.invoke("code-location", "scaffold", "code-location-1")
+        runner.invoke("code-location", "scaffold", "code-location-2")
+
+        result = runner.invoke("definitions", "validate")
+        assert result.exit_code == 0
+
+        (
+            Path("code_locations") / "code-location-1" / "code_location_1" / "definitions.py"
+        ).write_text("invalid")
+        result = runner.invoke("definitions", "validate")
+        assert result.exit_code == 1
+
+
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
+def test_validate_command_code_location_context_success():
+    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+        result = runner.invoke("definitions", "validate")
+        assert result.exit_code == 0
+
+        (Path("foo_bar") / "definitions.py").write_text("invalid")
+        result = runner.invoke("definitions", "validate")
+        assert result.exit_code == 1

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -14,25 +14,25 @@ from dagster_dg_tests.utils import (
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_deployment_context_success():
     with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner, create_venv=True):
-        runner.invoke("code-location", "scaffold", "code-location-1")
-        runner.invoke("code-location", "scaffold", "code-location-2")
+        runner.invoke("scaffold", "code-location", "code-location-1")
+        runner.invoke("scaffold", "code-location", "code-location-2")
 
-        result = runner.invoke("definitions", "validate")
+        result = runner.invoke("check", "definitions")
         assert result.exit_code == 0
 
         (
             Path("code_locations") / "code-location-1" / "code_location_1" / "definitions.py"
         ).write_text("invalid")
-        result = runner.invoke("definitions", "validate")
+        result = runner.invoke("check", "definitions")
         assert result.exit_code == 1
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_code_location_context_success():
     with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
-        result = runner.invoke("definitions", "validate")
+        result = runner.invoke("check", "definitions")
         assert result.exit_code == 0
 
         (Path("foo_bar") / "definitions.py").write_text("invalid")
-        result = runner.invoke("definitions", "validate")
+        result = runner.invoke("check", "definitions")
         assert result.exit_code == 1

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -6,30 +6,30 @@ from dagster_dg.utils import ensure_dagster_dg_tests_import, is_windows
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
-    isolated_example_code_location_foo_bar,
-    isolated_example_deployment_foo,
+    isolated_example_project_foo_bar,
+    isolated_example_workspace,
 )
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_deployment_context_success():
-    with ProxyRunner.test() as runner, isolated_example_deployment_foo(runner, create_venv=True):
-        runner.invoke("scaffold", "code-location", "code-location-1")
-        runner.invoke("scaffold", "code-location", "code-location-2")
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, create_venv=True):
+        runner.invoke("scaffold", "project", "code-location-1")
+        runner.invoke("scaffold", "project", "code-location-2")
 
         result = runner.invoke("check", "definitions")
         assert result.exit_code == 0
 
-        (
-            Path("code_locations") / "code-location-1" / "code_location_1" / "definitions.py"
-        ).write_text("invalid")
+        (Path("projects") / "code-location-1" / "code_location_1" / "definitions.py").write_text(
+            "invalid"
+        )
         result = runner.invoke("check", "definitions")
         assert result.exit_code == 1
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_code_location_context_success():
-    with ProxyRunner.test() as runner, isolated_example_code_location_foo_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         result = runner.invoke("check", "definitions")
         assert result.exit_code == 0
 


### PR DESCRIPTION
## Summary

Introduces `dg definitions validate`, which calls the underlying `dagster definitions validate` with appropriate parameters for the current deployment or code location project. Largely cribbed from `dg dev`.

We could rename this to just `dg validate` or `dg definitions-validate` to avoid adding another top-level CLI.

```sh
dagster ~/repos/components_demo/my-deployment-2
$ dg definitions validate

Using ephemeral dagster definitions validate
2025-02-14 16:02:57 -0800 - dagster - INFO - Using temporary directory /Users/ben/repos/components_demo/my-deployment-2/tmpaxze6pxy for storage. This will be removed when dagster definitions validate exits.
2025-02-14 16:02:57 -0800 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2025-02-14 16:02:58 -0800 - dagster.code_server - INFO - Starting Dagster code server for file /Users/ben/repos/components_demo/my-deployment-2/code_locations/analytics/analytics/definitions.py in process 55388
2025-02-14 16:02:58 -0800 - dagster - WARNING - /Users/ben/repos/components_demo/my-deployment-2/code_locations/analytics/.venv/lib/python3.12/site-packages/dagster/_core/utils.py:125: UserWarning: Found version mismatch between `dagster` (1.10.1) expected library version (0.26.1) and `dagster-sling` (1!0+dev).
  warnings.warn(message)

2025-02-14 16:02:58 -0800 - dagster.code_server - INFO - Started Dagster code server for file /Users/ben/repos/components_demo/my-deployment-2/code_locations/analytics/analytics/definitions.py in process 55388
2025-02-14 16:02:59 -0800 - dagster.code_server - INFO - Starting Dagster code server for file /Users/ben/repos/components_demo/my-deployment-2/code_locations/jaffle-platform/jaffle_platform/definitions.py in process 55392
2025-02-14 16:03:00 -0800 - dagster.code_server - INFO - Started Dagster code server for file /Users/ben/repos/components_demo/my-deployment-2/code_locations/jaffle-platform/jaffle_platform/definitions.py in process 55392
INFO:dagster.code_server:Started Dagster code server for file /Users/ben/repos/components_demo/my-deployment-2/code_locations/jaffle-platform/jaffle_platform/definitions.py in process 55392
2025-02-14 16:03:00 -0800 - dagster - INFO - Validation successful for code location analytics.
2025-02-14 16:03:00 -0800 - dagster - INFO - Validation successful for code location jaffle-platform.
2025-02-14 16:03:00 -0800 - dagster - INFO - All code locations passed validation.
```

There's also a fair amount of logspew on the `dagster definitions validate` end that a stacked PR can clean up.

## Test Plan

Some brief test cases, tested manually.