### PR TITLE
[dagster-components] Layer field descriptions into built-in components

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -23,8 +23,10 @@ def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
 
 
 class OpSpecSchema(ResolvableSchema):
-    name: Optional[str] = Field(None, description="The name of the op.")
-    tags: Optional[dict[str, str]] = Field(None, description="Arbitrary metadata for the op.")
+    name: Optional[str] = Field(default=None, description="The name of the op.")
+    tags: Optional[dict[str, str]] = Field(
+        default=None, description="Arbitrary metadata for the op."
+    )
 
 
 class AssetDepSchema(ResolvableSchema[AssetDep]):
@@ -39,19 +41,21 @@ class _ResolvableAssetAttributesMixin(BaseModel):
         default_factory=list,
         description="The asset keys for the upstream assets that this asset depends on.",
     )
-    description: Optional[str] = Field(None, description="Human-readable description of the asset.")
+    description: Optional[str] = Field(
+        default=None, description="Human-readable description of the asset."
+    )
     metadata: Union[str, Mapping[str, Any]] = Field(
         default_factory=dict, description="Additional metadata for the asset."
     )
     group_name: Optional[str] = Field(
-        None, description="Used to organize assets into groups, defaults to 'default'."
+        default=None, description="Used to organize assets into groups, defaults to 'default'."
     )
     skippable: bool = Field(
-        False,
+        default=False,
         description="Whether this asset can be omitted during materialization, causing downstream dependencies to skip.",
     )
     code_version: Optional[str] = Field(
-        None,
+        default=None,
         description="A version representing the code that produced the asset. Increment this value when the code changes.",
     )
     owners: Sequence[str] = Field(
@@ -62,11 +66,11 @@ class _ResolvableAssetAttributesMixin(BaseModel):
         default_factory=dict, description="Tags for filtering and organizing."
     )
     kinds: Optional[Sequence[str]] = Field(
-        None,
+        default=None,
         description="A list of strings representing the kinds of the asset. These will be made visible in the Dagster UI.",
     )
     automation_condition: Optional[str] = Field(
-        None,
+        default=None,
         description="The condition under which the asset will be automatically materialized.",
     )
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.asset_spec import AssetSpec, map_asset_specs
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from dagster_components.core.schema.base import FieldResolver, ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
@@ -23,8 +23,8 @@ def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
 
 
 class OpSpecSchema(ResolvableSchema):
-    name: Optional[str] = None
-    tags: Optional[dict[str, str]] = None
+    name: Optional[str] = Field(None, description="The name of the op.")
+    tags: Optional[dict[str, str]] = Field(None, description="Arbitrary metadata for the op.")
 
 
 class AssetDepSchema(ResolvableSchema[AssetDep]):
@@ -35,22 +35,46 @@ class AssetDepSchema(ResolvableSchema[AssetDep]):
 
 
 class _ResolvableAssetAttributesMixin(BaseModel):
-    deps: Sequence[str] = []
-    description: Optional[str] = None
-    metadata: Union[str, Mapping[str, Any]] = {}
-    group_name: Optional[str] = None
-    skippable: bool = False
-    code_version: Optional[str] = None
-    owners: Sequence[str] = []
-    tags: Union[str, Mapping[str, str]] = {}
-    kinds: Optional[Sequence[str]] = None
-    automation_condition: Optional[str] = None
+    deps: Sequence[str] = Field(
+        default_factory=list,
+        description="The asset keys for the upstream assets that this asset depends on.",
+    )
+    description: Optional[str] = Field(None, description="Human-readable description of the asset.")
+    metadata: Union[str, Mapping[str, Any]] = Field(
+        default_factory=dict, description="Additional metadata for the asset."
+    )
+    group_name: Optional[str] = Field(
+        None, description="Used to organize assets into groups, defaults to 'default'."
+    )
+    skippable: bool = Field(
+        False,
+        description="Whether this asset can be omitted during materialization, causing downstream dependencies to skip.",
+    )
+    code_version: Optional[str] = Field(
+        None,
+        description="A version representing the code that produced the asset. Increment this value when the code changes.",
+    )
+    owners: Sequence[str] = Field(
+        default_factory=list,
+        description="A list of strings representing owners of the asset. Each string can be a user's email address, or a team name prefixed with `team:`, e.g. `team:finops`.",
+    )
+    tags: Union[str, Mapping[str, str]] = Field(
+        default_factory=dict, description="Tags for filtering and organizing."
+    )
+    kinds: Optional[Sequence[str]] = Field(
+        None,
+        description="A list of strings representing the kinds of the asset. These will be made visible in the Dagster UI.",
+    )
+    automation_condition: Optional[str] = Field(
+        None,
+        description="The condition under which the asset will be automatically materialized.",
+    )
 
 
 class AssetSpecSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[AssetSpec]):
     key: Annotated[
         str, FieldResolver(lambda context, schema: _resolve_asset_key(schema.key, context))
-    ]
+    ] = Field(..., description="A unique identifier for the asset.")
 
 
 class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[Mapping[str, Any]]):

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -10,7 +10,7 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from pydantic import Field, computed_field
+from pydantic import ConfigDict, Field, computed_field
 from pydantic.dataclasses import dataclass
 
 from dagster_components import Component, ComponentLoadContext, FieldResolver
@@ -52,7 +52,7 @@ def resolve_translator(
 
 
 @registered_component_type(name="dbt_project")
-@dataclass
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))  # omits translator prop from schema
 class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator, Sequence
-from dataclasses import dataclass, field
 from typing import Annotated, Callable, Optional
 
 from dagster._core.definitions.definitions_class import Definitions
@@ -11,7 +10,8 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from pydantic import computed_field
+from pydantic import Field, computed_field
+from pydantic.dataclasses import dataclass
 
 from dagster_components import Component, ComponentLoadContext, FieldResolver
 from dagster_components.core.component import registered_component_type
@@ -57,8 +57,10 @@ class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
 
     dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
-    op: Optional[OpSpecSchema] = None
-    translator: Annotated[DagsterDbtTranslator, FieldResolver(resolve_translator)] = field(
+    op: Optional[OpSpecSchema] = Field(
+        None, description="Customizations to the op underlying the dbt run."
+    )
+    translator: Annotated[DagsterDbtTranslator, FieldResolver(resolve_translator)] = Field(
         default_factory=lambda: DagsterDbtTranslator()
     )
     transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = None

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
@@ -1,5 +1,4 @@
 import importlib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -8,6 +7,8 @@ from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
 )
 from dagster._utils import pushd
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 from dagster_components import (
     Component,
@@ -27,7 +28,9 @@ class DefinitionsParamSchema(ResolvableSchema):
 class DefinitionsComponent(Component):
     """Wraps an arbitrary set of Dagster definitions."""
 
-    definitions_path: Optional[str]
+    definitions_path: Optional[str] = Field(
+        ..., description="Relative path to a file containing Dagster definitions."
+    )
 
     @classmethod
     def get_scaffolder(cls) -> DefinitionsComponentScaffolder:

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -1,6 +1,5 @@
 import shutil
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -9,7 +8,8 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.dataclasses import dataclass
 
 from dagster_components import FieldResolver
 from dagster_components.core.component import (
@@ -54,7 +54,10 @@ class PipesSubprocessScriptCollection(Component):
 
     specs_by_path: Annotated[
         Mapping[str, Sequence[AssetSpec]], FieldResolver(resolve_specs_by_path)
-    ]
+    ] = Field(
+        ...,
+        description="A mapping from Python script paths to the assets that are produced by the script.",
+    )
 
     @staticmethod
     def introspect_from_path(path: Path) -> "PipesSubprocessScriptCollection":

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -88,7 +88,10 @@ class SlingReplicationCollection(Component):
     replications: Sequence[SlingReplicationSpec] = Field(
         ..., description="A set of Sling replications to expose as assets."
     )
-    transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = Field(None)
+    transforms: Optional[Sequence[Callable[[Definitions], Definitions]]] = Field(
+        default=None,
+        description="Transformations to apply to the Sling definitions produced by this component.",
+    )
 
     @classmethod
     def get_scaffolder(cls) -> ComponentScaffolder:


### PR DESCRIPTION
## Summary

Drops in a bunch of Pydantic field description metadata to most of our core components.

Switches to using Pydantic dataclasses - sadly `dataclasses.field` does not have a description field. I don't think perf will be meaningfully different.

## Test Plan

Existing unit tests, test schema hinting locally.