### PR TITLE
fix database error in setting concurrency key

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2303,11 +2303,18 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
         else:
-            conn.execute(
-                ConcurrencyLimitsTable.update()
-                .where(ConcurrencyLimitsTable.c.concurrency_key == concurrency_key)
-                .values(limit=num, using_default_limit=False)
-            )
+            if has_default_pool_limit_col:
+                conn.execute(
+                    ConcurrencyLimitsTable.update()
+                    .where(ConcurrencyLimitsTable.c.concurrency_key == concurrency_key)
+                    .values(limit=num, using_default_limit=False)
+                )
+            else:
+                conn.execute(
+                    ConcurrencyLimitsTable.update()
+                    .where(ConcurrencyLimitsTable.c.concurrency_key == concurrency_key)
+                    .values(limit=num)
+                )
 
     def set_concurrency_slots(self, concurrency_key: str, num: int) -> None:
         """Allocate a set of concurrency slots.

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1787,4 +1787,11 @@ def test_add_default_concurrency_limit_col():
     src_dir = file_relative_path(__file__, "snapshot_1_9_11_add_concurrency_limits_default/sqlite")
     with copy_directory(src_dir) as test_dir:
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
+            instance.event_log_storage.get_pool_limits()
+            instance.event_log_storage.set_concurrency_slots("foo", 1)
+            instance.event_log_storage.initialize_concurrency_limit_to_default("bar")
             instance.upgrade()
+            instance.event_log_storage.get_pool_limits()
+            instance.event_log_storage.set_concurrency_slots("foo", 2)
+            instance.event_log_storage.set_concurrency_slots("new_foo", 1)
+            instance.event_log_storage.initialize_concurrency_limit_to_default("baz")


### PR DESCRIPTION
## Summary & Motivation
Makes the code safe even on unmigrated instances

https://github.com/dagster-io/dagster/issues/27876

## How I Tested These Changes
BK

## Changelog
- Fixes the `psycopg2.errors.UndefinedColumn` database error when trying to set a concurrency key without first having run `dagster instance migrate`
