### PR TITLE
[components] Make all executable resolution flow through DgContext (BUILD-712)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/code_location.py
@@ -47,6 +47,13 @@ def code_location_group():
     default=False,
     help="Do not create a virtual environment for the code location.",
 )
+@click.option(
+    "--populate-cache/--no-populate-cache",
+    is_flag=True,
+    default=True,
+    help="Whether to automatically populate the component type cache for the code location.",
+    hidden=True,
+)
 @dg_global_options
 @click.pass_context
 def code_location_scaffold_command(
@@ -54,6 +61,7 @@ def code_location_scaffold_command(
     name: str,
     use_editable_dagster: Optional[str],
     skip_venv: bool,
+    populate_cache: bool,
     **global_options: object,
 ) -> None:
     """Scaffold a Dagster code location file structure and a uv-managed virtual environment scoped
@@ -101,7 +109,11 @@ def code_location_scaffold_command(
         editable_dagster_root = None
 
     scaffold_code_location(
-        code_location_path, dg_context, editable_dagster_root, skip_venv=skip_venv
+        code_location_path,
+        dg_context,
+        editable_dagster_root,
+        skip_venv=skip_venv,
+        populate_cache=populate_cache,
     )
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -17,7 +17,7 @@ from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.error import DgError
-from dagster_dg.utils import DgClickCommand, exit_with_error, get_uv_run_executable_path, pushd
+from dagster_dg.utils import DgClickCommand, exit_with_error, pushd
 
 T = TypeVar("T")
 
@@ -102,8 +102,11 @@ def dev_command(
     # In a code location context, we can just run `dagster dev` directly, using `dagster` from the
     # code location's environment.
     if dg_context.is_code_location:
-        cmd = ["uv", "run", "dagster", "dev", *forward_options]
-        cmd_location = get_uv_run_executable_path("dagster")
+        cmd_location = dg_context.get_executable("dagster")
+        if dg_context.use_dg_managed_environment:
+            cmd = ["uv", "run", "dagster", "dev", *forward_options]
+        else:
+            cmd = [cmd_location, "dev", *forward_options]
         temp_workspace_file_cm = nullcontext()
 
     # In a deployment context, dg dev will construct a temporary

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -98,6 +98,7 @@ def scaffold_code_location(
     dg_context: DgContext,
     editable_dagster_root: Optional[str] = None,
     skip_venv: bool = False,
+    populate_cache: bool = True,
 ) -> None:
     click.echo(f"Creating a Dagster code location at {path}.")
 
@@ -125,7 +126,8 @@ def scaffold_code_location(
     cl_dg_context = dg_context.with_root_path(path)
     if cl_dg_context.use_dg_managed_environment and not skip_venv:
         cl_dg_context.ensure_uv_lock()
-        RemoteComponentRegistry.from_dg_context(cl_dg_context)  # Populate the cache
+        if populate_cache:
+            RemoteComponentRegistry.from_dg_context(cl_dg_context)  # Populate the cache
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -4,7 +4,6 @@ import json
 import os
 import posixpath
 import re
-import shutil
 import subprocess
 import sys
 import textwrap
@@ -110,10 +109,6 @@ def is_valid_json(value: str) -> bool:
         return True
     except json.JSONDecodeError:
         return False
-
-
-def is_executable_available(command: str) -> bool:
-    return bool(shutil.which(command)) or bool(get_uv_run_executable_path(command))
 
 
 # Short for "normalize path"-- use this to get the platform-correct string representation of an
@@ -500,15 +495,3 @@ def set_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], value: object
     path_list = list(path)
     inner_dict = get_toml_value(doc, path_list[:-1], dict)
     inner_dict[path_list[-1]] = value
-
-
-def get_executable_path(executable_name: str) -> Optional[str]:
-    return shutil.which(executable_name)
-
-
-def get_uv_run_executable_path(executable_name: str) -> Optional[str]:
-    uv_run_cmd = ["uv", "run", "which", executable_name]
-    try:
-        return subprocess.check_output(uv_run_cmd).decode("utf-8").strip()
-    except (subprocess.CalledProcessError, NotADirectoryError, FileNotFoundError):
-        return None

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_code_location_commands.py
@@ -150,6 +150,27 @@ def test_code_location_scaffold_skip_venv_success() -> None:
         assert not Path("foo-bar/uv.lock").exists()
 
 
+def test_code_location_scaffold_no_populate_cache_success() -> None:
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke("code-location", "scaffold", "--no-populate-cache", "foo-bar")
+        assert_runner_result(result)
+        assert Path("foo-bar").exists()
+        assert Path("foo-bar/foo_bar").exists()
+        assert Path("foo-bar/foo_bar/lib").exists()
+        assert Path("foo-bar/foo_bar/components").exists()
+        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/pyproject.toml").exists()
+
+        # Check venv created
+        assert Path("foo-bar/.venv").exists()
+        assert Path("foo-bar/uv.lock").exists()
+
+        with pushd("foo-bar"):
+            result = runner.invoke("component-type", "list", "--verbose")
+            assert_runner_result(result)
+            assert "CACHE [miss]" in result.output
+
+
 def test_code_location_scaffold_no_use_dg_managed_environment_success() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -183,8 +183,10 @@ def test_dynamic_subcommand_help_message():
                 "simple_pipes_script_asset@dagster_components.test",
                 "--help",
             )
+            # Strip interpreter logging line
+            output = "\n".join(result.output.split("\n")[1:])
         assert match_terminal_box_output(
-            result.output.strip(),
+            output.strip(),
             textwrap.dedent("""
 
                  Usage: dg component scaffold [GLOBAL OPTIONS] simple_pipes_script_asset@dagster_components.test [OPTIONS]

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -10,8 +10,8 @@ from dagster_dg_tests.utils import (
 
 # For all cache tests, avoid setting up venv in example code location so we do not prepopulate the
 # cache (which is part of the venv setup routine).
-example_code_location = partial(isolated_example_code_location_foo_bar, skip_venv=True)
-cache_runner_args = {"verbose": True, "require_local_venv": False}
+example_code_location = partial(isolated_example_code_location_foo_bar, populate_cache=False)
+cache_runner_args = {"verbose": True}
 
 
 def test_load_from_cache():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -79,6 +79,7 @@ def isolated_example_code_location_foo_bar(
     runner: Union[CliRunner, "ProxyRunner"],
     in_deployment: bool = True,
     skip_venv: bool = False,
+    populate_cache: bool = True,
     component_dirs: Sequence[Path] = [],
 ) -> Iterator[None]:
     """Scaffold a code location named foo_bar in an isolated filesystem.
@@ -104,6 +105,7 @@ def isolated_example_code_location_foo_bar(
             "--use-editable-dagster",
             dagster_git_repo_dir,
             *(["--no-use-dg-managed-environment"] if skip_venv else []),
+            *(["--no-populate-cache"] if not populate_cache else []),
             "foo-bar",
         )
         with clear_module_from_cache("foo_bar"), pushd(code_loc_path):


### PR DESCRIPTION
## Summary & Motivation

Our executable resolution story has gotten more complicated since explicit venv resolution was added in #27799. This PR refactors the way we resolve executables, getting rid of some standalone utility methods and making everything flow through the new `DgContext.resolve_executable`. In the process, we also fix a bug in executable resolution in the `dg dev` command run from a deployment, where the executable was being resolved with the wrong root directory, leading to `error: No project detected in pyproject.toml` warnings messages.

## How I Tested These Changes

Existing test suite, observed warning messages went away.