### PR TITLE
[ui] Fix `Contributing` docs (`Developing Docs` section) after Yarn & Docusaurus migration

### DIFF
--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -91,17 +91,17 @@ To run the Dagster documentation website locally, run the following commands:
 
 ```bash
 cd docs
-make next-watch-build   # Serves the docs website on http://localhost:3001
+yarn start   # Serves the docs website on  http://localhost:3050/
 ```
 
-Troubleshooting tip: You may need to run `make next-dev-install` first to install dependencies. Also make sure that your Node version is >=12.13.0.
+Troubleshooting tip: Make sure that Yarn is installed already and your Node version is >=12.13.0.
 
 The API documentation is generated from ReStructured Text files (`.rst`), which extracts Python docstrings from the library files. The `.rst` files can be found in the `docs/sphinx/sections/api/apidocs` directory.
 
 If you change any `.rst` files, be sure to run the following command in the `docs` directory:
 
 ```bash
-make apidoc-build
+yarn sync-api-docs
 ```
 
 The majority of our code snippets are pulled from real Python files. This allows us to test our code snippets and ensure they remain up-to-date.
@@ -117,7 +117,15 @@ You can find the corresponding Python file at `dagster/examples/docs_snippets/do
 To change the code snippet, update the `.py` file, then run the following from the `docs` directory:
 
 ```bash
-make mdx-format
+yarn generate-code-imports
+```
+
+For linting and formatting, use:
+
+```bash
+yarn lint        # Lints and fixes issues in .tsx, .ts, .js, .md, and .mdx files
+yarn vale        # Checks writing style in .md and .mdx files
+yarn lint-and-vale  # Runs both lint and vale checks
 ```
 
 You can find more information about developing documentation in `docs/README.md`.

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -94,14 +94,14 @@ cd docs
 yarn start   # Serves the docs website on  http://localhost:3050/
 ```
 
-Troubleshooting tip: Make sure that Yarn is installed already and your Node version is >=12.13.0.
+Troubleshooting tip: Make sure that Yarn is installed already and your Node version is >=18.0.
 
 The API documentation is generated from ReStructured Text files (`.rst`), which extracts Python docstrings from the library files. The `.rst` files can be found in the `docs/sphinx/sections/api/apidocs` directory.
 
 If you change any `.rst` files, be sure to run the following command in the `docs` directory:
 
 ```bash
-yarn sync-api-docs
+make apidoc-build
 ```
 
 The majority of our code snippets are pulled from real Python files. This allows us to test our code snippets and ensure they remain up-to-date.
@@ -117,7 +117,7 @@ You can find the corresponding Python file at `dagster/examples/docs_snippets/do
 To change the code snippet, update the `.py` file, then run the following from the `docs` directory:
 
 ```bash
-yarn generate-code-imports
+make mdx-format
 ```
 
 For linting and formatting, use:

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -91,7 +91,7 @@ To run the Dagster documentation website locally, run the following commands:
 
 ```bash
 cd docs
-yarn start   # Serves the docs website on  http://localhost:3050/
+yarn start   # Serves the docs website on http://localhost:3050/
 ```
 
 Troubleshooting tip: Make sure that Yarn is installed already and your Node version is >=18.0.


### PR DESCRIPTION
## Summary & Motivation
After the recent changes to the docs, it is no longer possible to deploy a local instance using:
```
cd docs
make next-watch-build 
```
Instead, one needs to use:
```
cd docs
yarn start
```

⚠️ I noticed that `apidoc-build` and `mdx-format` are also no longer available in `dagster/docs/Makefile`, but I wasn't sure which yarn command to replace them with. Maybe `yarn sync-api-docs` and `yarn generate-code-imports`, respectively?


## How I Tested These Changes
Launched the documentation website locally using:
```
cd docs
yarn start
```
and verified that the commands are updated in the `Developing Docs` section of the `Contributing` page (as in the screenshot below).
<img width="1512" alt="Screenshot 2025-02-16 at 16 12 43" src="https://github.com/user-attachments/assets/089ad64f-a37b-40dc-92e4-23039899f67c" />

## Changelog
> Fix `Contributing` docs (`Developing Docs` section) after Yarn & Docusaurus migration
