### PR TITLE
Fix asset backfill subset logging

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
@@ -58,7 +58,7 @@ def bfs_filter_asset_graph_view(
 
     visited_graph_subset = initial_asset_graph_subset
 
-    result: AssetGraphSubset = AssetGraphSubset.empty()
+    result: AssetGraphSubset = AssetGraphSubset.create_empty_subset()
     failed_reasons: Sequence[tuple[AssetGraphSubset, str]] = []
 
     asset_graph = asset_graph_view.asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -61,6 +61,10 @@ class AssetGraphSubset(NamedTuple):
             len(subset) for subset in self.partitions_subsets_by_asset_key.values()
         )
 
+    @property
+    def is_empty(self) -> bool:
+        return len(self.asset_keys) == 0
+
     def get_asset_subset(
         self, asset_key: AssetKey, asset_graph: BaseAssetGraph
     ) -> SerializableEntitySubset[AssetKey]:
@@ -271,7 +275,7 @@ class AssetGraphSubset(NamedTuple):
         )
 
     @classmethod
-    def empty(cls) -> "AssetGraphSubset":
+    def create_empty_subset(cls) -> "AssetGraphSubset":
         return AssetGraphSubset({}, set())
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -659,7 +659,7 @@ def _get_requested_asset_graph_subset_from_run_requests(
     asset_graph_view: AssetGraphView,
 ) -> AssetGraphSubset:
     asset_graph = asset_graph_view.asset_graph
-    requested_subset = AssetGraphSubset.empty()
+    requested_subset = AssetGraphSubset.create_empty_subset()
     for run_request in run_requests:
         # Run request targets a range of partitions
         range_start = run_request.tags.get(ASSET_PARTITION_RANGE_START_TAG)
@@ -1492,7 +1492,7 @@ def execute_asset_backfill_iteration_inner(
         )
         logger.info(
             f"Assets materialized since last tick:\n{_asset_graph_subset_to_str(materialized_since_last_tick, asset_graph)}"
-            if not materialized_since_last_tick.empty
+            if not materialized_since_last_tick.is_empty
             else "No relevant assets materialized since last tick."
         )
 
@@ -1538,7 +1538,7 @@ def execute_asset_backfill_iteration_inner(
 
     logger.info(
         f"Asset partitions to request:\n{_asset_graph_subset_to_str(asset_subset_to_request, asset_graph)}"
-        if not asset_subset_to_request.empty
+        if not asset_subset_to_request.is_empty
         else "No asset partitions to request."
     )
 
@@ -1992,7 +1992,7 @@ def _get_failed_asset_graph_subset(
         )
     )
 
-    result: AssetGraphSubset = AssetGraphSubset.empty()
+    result: AssetGraphSubset = AssetGraphSubset.create_empty_subset()
     for run in runs:
         planned_asset_keys = instance_queryer.get_planned_materializations_for_run(
             run_id=run.run_id

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -33,7 +33,7 @@ def _get_subset_with_keys(graph_view, keys):
 def test_bfs_filter_empty_graph():
     """Test BFS filter on empty graph returns empty result."""
     graph_view = AssetGraphView.for_test(Definitions())
-    initial_subset = AssetGraphSubset.empty()
+    initial_subset = AssetGraphSubset.create_empty_subset()
 
     def condition_fn(subset, _visited):
         return AssetGraphViewBfsFilterConditionResult(subset, [])
@@ -42,7 +42,7 @@ def test_bfs_filter_empty_graph():
         graph_view, condition_fn, initial_subset, include_full_execution_set=False
     )
 
-    assert result == AssetGraphSubset.empty()
+    assert result == AssetGraphSubset.create_empty_subset()
     assert failed == []
 
 
@@ -81,7 +81,7 @@ def test_bfs_filter_dependency_chain():
             )
 
             return AssetGraphViewBfsFilterConditionResult(
-                AssetGraphSubset.empty(),
+                AssetGraphSubset.create_empty_subset(),
                 [(subset, "asset3 not allowed")],
             )
         return AssetGraphViewBfsFilterConditionResult(subset, [])

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2902,6 +2902,11 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
     assert "DefaultPartitionsSubset(subset={'foo_b'})" in logs
     assert "latest_storage_id=None" in logs
     assert "AssetBackfillData" in logs
+    assert (
+        """Asset partitions to request:
+- asset_a: {foo_a}"""
+        in logs
+    )
 
 
 def test_backfill_with_title_and_description(


### PR DESCRIPTION
Summary:
AssetGraphSubset.empty() returns an empty subset. What we wanted here was a boolean that tells you whether the subset was empty. This was (in master) causing asset backfills to always log that there was nothing to request, even if they then went on to request things

Test Plan:
New test case, Launch an asset backfill and view the logs, verify that output now includes the asset partitions being requested.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
