### PR TITLE
fix: set typing_type to `polars.DataFrame` for Polars schemas and models

### DIFF
--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -126,6 +126,11 @@ def pandera_schema_to_dagster_type(
     )
     tschema = _pandera_schema_to_table_schema(norm_schema)
     type_check_fn = _pandera_schema_to_type_check_fn(norm_schema, tschema)
+    typing_type = (
+        pd.DataFrame
+        if not pl or issubclass(schema, pa.DataFrameModel) or isinstance(schema, pa.DataFrameSchema)
+        else pl.DataFrame
+    )
 
     return DagsterType(
         type_check_fn=type_check_fn,
@@ -134,7 +139,7 @@ def pandera_schema_to_dagster_type(
         metadata={
             "schema": MetadataValue.table_schema(tschema),
         },
-        typing_type=pd.DataFrame,
+        typing_type=typing_type,
     )
 
 

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -128,7 +128,9 @@ def pandera_schema_to_dagster_type(
     type_check_fn = _pandera_schema_to_type_check_fn(norm_schema, tschema)
     typing_type = (
         pd.DataFrame
-        if not pl or issubclass(schema, pa.DataFrameModel) or isinstance(schema, pa.DataFrameSchema)
+        if not pl 
+        or (isinstance(schema, type) and issubclass(schema, pa.DataFrameModel)) 
+        or isinstance(schema, pa.DataFrameSchema)
         else pl.DataFrame
     )
 


### PR DESCRIPTION
## Summary & Motivation

- When I use this library with an asset that returns a Polars dataframe I get the following error.

```python
class Schema(pandera.polars.DataFrameModel):
    ...

@asset(schema=Schema)
async def my_asset() -> polars.DataFrame:
    ...


DEFINITIONS = dagster.Definitions(
    assets=[features],
    resources={
        "io_manager": dagster_polars.PolarsParquetIOManager(base_dir="gs://..."),
    },
)
```

```bash
dagster._core.errors.DagsterExecutionHandleOutputError: Error occurred while handling output "result" of step "catalog__features"::

RuntimeError: Could not resolve type router for <class 'pandas.core.frame.DataFrame'>
```
- I think this is because the `typing_type` is getting hard-coded to `pandas.DataFrame`.
- I think the right thing the to do here is to infer the `typing_type` from type of the Pandera schema.

## How I Tested These Changes

- Figuring out how to run the test suite, praying ci passes

## Changelog

> Insert changelog entry or delete this section.
