### PR TITLE
[docs] fix metadata docs link

### DIFF
--- a/docs/docs/guides/build/assets/metadata-and-tags/index.md
+++ b/docs/docs/guides/build/assets/metadata-and-tags/index.md
@@ -55,7 +55,7 @@ Using definition metadata to describe assets can make it easy to provide context
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/data-modeling/metadata/definition-metadata.py" language="python" />
 
-To learn more about the different types of metadata you can attach, see the [`MetadataValue`](/api/python-api/metadata#class dagster.MetadataValue) API docs.
+To learn more about the different types of metadata you can attach, see the <PyObject section="metadata" module="dagster" object="MetadataValue" /> API docs.
 
 Some metadata keys will be given special treatment in the Dagster UI. See the [Standard metadata types](#standard-metadata-types) section for more information.
 


### PR DESCRIPTION
## Summary & Motivation
Fix a broken link in the [Asset Metadata](https://docs.dagster.io/guides/build/assets/metadata-and-tags) page.

## How I Tested These Changes
[Local development and build](https://github.com/dagster-io/dagster/tree/master/docs#local-development)

Before:
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/0bcbd71d-87b5-425d-8080-264bfa36172a" />

After:
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/3ac6c7bc-714b-4139-9146-5b0be78fd028" />