### PR TITLE
[dagster-dg] Add separate command to generate JSON schema for code location

### DIFF
--- a/js_modules/dagster-ui/packages/dg-docs-site/.next/trace
+++ b/js_modules/dagster-ui/packages/dg-docs-site/.next/trace
@@ -1,0 +1,1 @@
+[{"name":"next-dev","duration":685238606744,"timestamp":229110716454,"id":1,"tags":{},"startTime":1744669819967,"traceId":"ebf0f8e80f62f8dd"}]

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -29,7 +29,7 @@ from dagster_dg.utils.editor import (
 from dagster_dg.utils.mcp_client.claude_desktop import get_claude_desktop_config_path
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
-_DEFAULT_SCHEMA_FOLDER_NAME = ".dg"
+DEFAULT_SCHEMA_FOLDER_NAME = ".dg"
 
 
 @click.group(name="utils", cls=DgClickGroup)
@@ -40,7 +40,7 @@ def utils_group():
 def _generate_component_schema(dg_context: DgContext, output_path: Optional[Path] = None) -> Path:
     schema_path = output_path
     if not schema_path:
-        schema_folder = dg_context.root_path / _DEFAULT_SCHEMA_FOLDER_NAME
+        schema_folder = dg_context.root_path / DEFAULT_SCHEMA_FOLDER_NAME
         schema_folder.mkdir(exist_ok=True)
 
         schema_path = schema_folder / "schema.json"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -29,12 +29,38 @@ from dagster_dg.utils.editor import (
 from dagster_dg.utils.mcp_client.claude_desktop import get_claude_desktop_config_path
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
-_DEFAULT_SCHEMA_FOLDER_NAME = ".vscode"
+_DEFAULT_SCHEMA_FOLDER_NAME = ".dg"
 
 
 @click.group(name="utils", cls=DgClickGroup)
 def utils_group():
     """Assorted utility commands."""
+
+
+def _generate_component_schema(dg_context: DgContext, output_path: Optional[Path] = None) -> Path:
+    schema_path = output_path
+    if not schema_path:
+        schema_folder = dg_context.root_path / _DEFAULT_SCHEMA_FOLDER_NAME
+        schema_folder.mkdir(exist_ok=True)
+
+        schema_path = schema_folder / "schema.json"
+
+    schema_path.write_text(json.dumps(all_components_schema_from_dg_context(dg_context), indent=2))
+    return schema_path
+
+
+@utils_group.command(name="generate-component-schema", cls=DgClickCommand)
+@dg_global_options
+@click.option("--output-path", type=click.Path(exists=False, file_okay=True, dir_okay=False))
+def generate_component_schema(
+    output_path: Optional[str],
+    **global_options: object,
+) -> None:
+    """Generates a JSON schema for the component types installed in the current project."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+
+    _generate_component_schema(dg_context, Path(output_path) if output_path else None)
 
 
 @utils_group.command(name="configure-editor", cls=DgClickCommand)
@@ -54,13 +80,7 @@ def configure_editor_command(
     dg_context = DgContext.for_project_environment(path, cli_config)
 
     recommend_yaml_extension(executable_name)
-
-    schema_folder = dg_context.root_path / _DEFAULT_SCHEMA_FOLDER_NAME
-    schema_folder.mkdir(exist_ok=True)
-
-    schema_path = schema_folder / "schema.json"
-    schema_path.write_text(json.dumps(all_components_schema_from_dg_context(dg_context), indent=2))
-
+    schema_path = _generate_component_schema(dg_context)
     install_or_update_yaml_schema_extension(executable_name, dg_context.root_path, schema_path)
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -51,6 +51,7 @@ def _generate_component_schema(dg_context: DgContext, output_path: Optional[Path
 
 @utils_group.command(name="generate-component-schema", cls=DgClickCommand)
 @dg_global_options
+@cli_telemetry_wrapper
 @click.option("--output-path", type=click.Path(exists=False, file_okay=True, dir_okay=False))
 def generate_component_schema(
     output_path: Optional[str],

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
@@ -4,6 +4,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
+from dagster_dg.cli.utils import DEFAULT_SCHEMA_FOLDER_NAME
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
 ensure_dagster_dg_tests_import()
@@ -32,7 +33,7 @@ def test_utils_configure_editor(editor: str) -> None:
 
         assert out.exit_code == 0
 
-        sample_project_dg_path = Path.cwd() / ".dg"
+        sample_project_dg_path = Path.cwd() / DEFAULT_SCHEMA_FOLDER_NAME
         assert (sample_project_dg_path / "schema.json").exists()
 
         expected_vscode_plugin_folder_filepath = Path(extension_dir) / "dagster-components-schema"
@@ -57,7 +58,7 @@ def test_generate_component_schema(output_path: Optional[str]) -> None:
 
         assert out.exit_code == 0
 
-        sample_project_dg_path = Path.cwd() / ".dg"
+        sample_project_dg_path = Path.cwd() / DEFAULT_SCHEMA_FOLDER_NAME
 
         output_file = Path(output_path) if output_path else sample_project_dg_path / "schema.json"
         assert output_file.exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -31,8 +32,8 @@ def test_utils_configure_editor(editor: str) -> None:
 
         assert out.exit_code == 0
 
-        sample_project_vscode_path = Path.cwd() / ".vscode"
-        assert (sample_project_vscode_path / "schema.json").exists()
+        sample_project_dg_path = Path.cwd() / ".dg"
+        assert (sample_project_dg_path / "schema.json").exists()
 
         expected_vscode_plugin_folder_filepath = Path(extension_dir) / "dagster-components-schema"
         assert expected_vscode_plugin_folder_filepath.exists()
@@ -40,3 +41,23 @@ def test_utils_configure_editor(editor: str) -> None:
             expected_vscode_plugin_folder_filepath / "dagster-components-schema.vsix"
         )
         assert expected_compiled_plugin_filepath.exists()
+
+
+@pytest.mark.parametrize("output_path", [None, "schema.json"])
+def test_generate_component_schema(output_path: Optional[str]) -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, False),
+    ):
+        out = runner.invoke(
+            "utils",
+            "generate-component-schema",
+            *(["--output-path", output_path] if output_path else []),
+        )
+
+        assert out.exit_code == 0
+
+        sample_project_dg_path = Path.cwd() / ".dg"
+
+        output_file = Path(output_path) if output_path else sample_project_dg_path / "schema.json"
+        assert output_file.exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -63,7 +63,7 @@ REGISTRY_CONTEXT_COMMANDS = [
 PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("launch",), "--assets", "foo"),
     CommandSpec(("utils", "configure-editor"), "vscode"),
-    CommandSpec(("code-location", "generate-component-schema")),
+    CommandSpec(("utils", "generate-component-schema")),
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
     CommandSpec(("list", "defs")),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -63,6 +63,7 @@ REGISTRY_CONTEXT_COMMANDS = [
 PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("launch",), "--assets", "foo"),
     CommandSpec(("utils", "configure-editor"), "vscode"),
+    CommandSpec(("code-location", "generate-component-schema")),
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
     CommandSpec(("list", "defs")),


### PR DESCRIPTION
## Summary

Adds a command to generate a JSON schema for a given code location. Drops the schema in the location referenced by the VS Code extension, so this can be used to update the schema without the other rigamarole involved with that command.

```sh
dg code-location generate-component-schema --output-file foo.json
```

When #27863 lands, I intend to add a `--watch` flag to this command as well, so you can live-update the schema if the set of components changes.

## Test Plan

Brief test, the underlying `dagster-components` CLI tests correctness.
