### PR TITLE
fix escaping in pool tag link

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/PoolTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/PoolTag.tsx
@@ -9,7 +9,7 @@ import {
 } from '../instance/types/InstanceConcurrencyKeyInfo.types';
 
 export const PoolTag = ({pool}: {pool: string}) => {
-  const path = `/deployment/concurrency/${pool}`;
+  const path = `/deployment/concurrency/${encodeURIComponent(pool)}`;
   const {data} = useQuery<ConcurrencyKeyDetailsQuery, ConcurrencyKeyDetailsQueryVariables>(
     CONCURRENCY_KEY_DETAILS_QUERY,
     {


### PR DESCRIPTION
## Summary & Motivation
Pools no longer accept `/` characters, but for back-compat for op tags, we should fix the pool tag links.


## How I Tested These Changes
BK


https://github.com/user-attachments/assets/bccf77be-6874-4031-add6-3d8d185549cf


## Changelog
- Fixed concurrency link escaping in the `View queue criteria` dialog
