### PR TITLE
Exclude failed subset when logging "Assets requested or in progress" in asset backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1124,8 +1124,9 @@ def execute_asset_backfill_iteration(
             updated_backfill_data.failed_and_downstream_subset
             - previous_asset_backfill_data.failed_and_downstream_subset
         )
-        updated_backfill_in_progress = (
-            updated_backfill_data.requested_subset - updated_backfill_data.materialized_subset
+        updated_backfill_in_progress = updated_backfill_data.requested_subset - (
+            updated_backfill_data.materialized_subset
+            | updated_backfill_data.failed_and_downstream_subset
         )
         previous_backfill_in_progress = (
             previous_asset_backfill_data.requested_subset


### PR DESCRIPTION
## Summary & Motivation
We were including failed partitions in both the in progress list and the failed list. Now we aren't.

Test Plan:
Launch a backfill that fails an asset, view backfill log output
New test case

## Changelog
Fixed an issue where asset backfills included failed partitions in the in-progress list in logging output.