### PR TITLE
[ui] Remove hover style on disabled text input

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -147,7 +147,7 @@ const StyledInput = styled.input<StyledInputProps>`
   box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderDefault()} inset 0px 0px 0px 1px;
   padding: ${({$hasIcon}) => ($hasIcon ? '6px 6px 6px 28px' : '6px 6px 6px 12px')};
 
-  :hover {
+  :hover:not(:disabled) {
     box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px;
   }
 


### PR DESCRIPTION
## Summary & Motivation

I noticed that disabled text inputs have a hover state in which the box-shadow changes color. I don't think it should, so I'm removing it.

## How I Tested These Changes

Hover on disabled text input, verify that the box shadow doesn't change color.