### PR TITLE
[docs] add `yarn build-api-docs` directive

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,15 +10,24 @@ ruff_snippets:  ## Ruff linting and fixing on /examples/docs_snippets
 rebuild_kind_tags: ## Add all kind tags to the kind tags page
 	python scripts/regen_kind_tags.py
 
-sphinx_objects_inv:
-	tox -e sphinx
-	cp sphinx/_build/json/objects.inv static/.
-
 mdx:
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	@echo "DEPRECATED - use \`yarn build-api-docs\`"
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	tox -e sphinx-mdx
 
 mdx_copy:
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	@echo "DEPRECATED - use \`yarn build-api-docs\`"
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
+
+sphinx_objects_inv:
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	@echo "DEPRECATED - use \`yarn build-sphinx-object-inv\`"
+	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	tox -e sphinx
+	cp sphinx/_build/json/objects.inv static/.
 
 regenerate_cli_snippets:
 	cd ../examples/docs_beta_snippets && tox -e docs_snapshot_update && echo "\nSnippets regenerated!"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,23 +27,14 @@ For formatting guidelines, see the [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ## Installation
 
-The site uses `node` and [yarn](https://yarnpkg.com/) for package management. We recommend using `nvm` to install the long-term-support version of Node.
+The site uses [yarn](https://yarnpkg.com/) for package management. We recommend using `nvm` to install the long-term-support version of Node.
 
+```sh
+brew install nvm yarn vale
 ```
-brew install nvm yarn
+
+```sh
 nvm install --lts
-```
-
-```
-yarn install
-```
-
-The docs site also uses [Vale](https://vale.sh/) to check for issues in the documentation.
-
-Install Vale with:
-
-```bash
-brew install vale
 ```
 
 ---
@@ -52,13 +43,38 @@ brew install vale
 
 To start the local development server:
 
+```sh
+yarn install
+```
+
 ```bash
 yarn start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server. Access the website at [http://localhost:3050](http://localhost:3050).
+This command starts a local development server and opens [http://localhost:3050](http://localhost:3050) in a browser window.
+
+### Build
+
+To build the site for production:
+
+```bash
+# build and copy api markdown files
+yarn build-api-docs
+
+# build and copy the sphinx objects.inv
+yarn build-sphinx-object-inv
+
+# build the static site
+yarn build
+```
+
+This command generates static content into the `build` directory and can be served using any static contents hosting service. This also checks for any broken links in the documentation.
+
+**NOTE:** the `make sphinx_objects_inv` command needs to be run before creating a new release. We plan to automate this procedure in the future.
 
 ### Linters
+
+The docs site also uses [Vale](https://vale.sh/) to check for issues in the documentation.
 
 To check the documentation for different issues, use the following:
 
@@ -72,28 +88,6 @@ yarn vale
 yarn vale /path/to/file      ## check individual file
 yarn vale --no-wrap          ## remove wrapping from output
 ```
-
----
-
-## Build
-
-To build the site for production:
-
-```bash
-# build and copy API markdown files
-make mdx
-make mdx_copy
-
-# build and copy the Sphinx objects.inv
-make sphinx_objects_inv
-
-# build the static site
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service. This also checks for any broken links in the documentation.
-
-**NOTE:** the `make sphinx_objects_inv` command needs to be run before creating a new release. We plan to automate this procedure in the future.
 
 ### Versioning
 
@@ -113,15 +107,7 @@ To validate the dropdown menu, you can run `VERCEL_ENV=preview yarn start`.
 
 This site is built and deployed using Vercel.
 
-### API documentation
-
-API documentation is built in Vercel by overriding the _Build Command_ to the following:
-
-```sh
-yarn sync-api-docs && yarn build
-```
-
-This runs the `scripts/vercel-sync-api-docs.sh` script which builds the MDX files using the custom `sphinx-mdx-builder`, and copies the resulting MDX files to `docs/api/python-api`.
+The _build_ step in Vercel is overridden to build API documentation using the `scripts/vercel-sync-api-docs.sh` script; this should _not_ be used locally.
 
 ---
 

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -91,7 +91,10 @@ To run the Dagster documentation website locally, run the following commands:
 
 ```bash
 cd docs
-make next-watch-build   # Serves the docs website on http://localhost:3001
+```
+
+```sh
+yarn start
 ```
 
 Troubleshooting tip: You may need to run `make next-dev-install` first to install dependencies. Also make sure that your Node version is >=12.13.0.
@@ -101,23 +104,18 @@ The API documentation is generated from ReStructured Text files (`.rst`), which 
 If you change any `.rst` files, be sure to run the following command in the `docs` directory:
 
 ```bash
-make apidoc-build
+yarn build-api-docs
 ```
 
 The majority of our code snippets are pulled from real Python files. This allows us to test our code snippets and ensure they remain up-to-date.
 
-In `.mdx` files, you'll see a code snippet with `python file=/path/to/file.py startafter=start_marker endbefore=end_marker` at the beginning of the block. For example:
+This is done through the use of the `CodeExample` component, where `path` specifies a relative path to a file in the `examples/` directory.
 
-![Code snippet](/images/about/community/md-code-block.png)
-
-You can find the corresponding Python file at `dagster/examples/docs_snippets/docs_snippets/concepts/asset/asset_dependency.py`. The code included in each snippet is the code in the file between the `# start_marker` and `# end_marker` comments.
-
-![Code snippet between marker comments](/images/about/community/py-code-block.png)
-
-To change the code snippet, update the `.py` file, then run the following from the `docs` directory:
-
-```bash
-make mdx-format
+```
+<CodeExample
+  path="tutorial/tutorial/resources.py"
+  language="python"
+/>
 ```
 
 You can find more information about developing documentation in `docs/README.md`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,8 +16,10 @@
     "vale": "vale ./docs --ext=.md,.mdx",
     "lint": "eslint . --ext=.tsx,.ts,.js,.md,.mdx --ignore-pattern 'node_modules/*' --ignore-pattern 'versioned_docs/*' --ignore-pattern 'versioned_sidebars/*' --fix",
     "lint-and-vale": "yarn run lint && yarn run vale",
+    "generate-code-imports": "node scripts/generate-code-imports.js",
     "sync-api-docs": "/bin/sh scripts/vercel-sync-api-docs.sh",
-    "generate-code-imports": "node scripts/generate-code-imports.js"
+    "build-api-docs": "tox -e sphinx-mdx && cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/",
+    "build-sphinx-object-inv": "tox -e sphinx && cp sphinx/_build/json/objects.inv static/."
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",

--- a/docs/scripts/vercel-sync-api-docs.sh
+++ b/docs/scripts/vercel-sync-api-docs.sh
@@ -20,5 +20,5 @@ uv venv
 source .venv/bin/activate
 
 uv pip install tox
-uvx tox -e sphinx-mdx
-make mdx_copy
+
+yarn build-api-docs


### PR DESCRIPTION
## Summary & Motivation

* Deprecated `make mdx` and `make mdx-copy` for `yarn build-api-docs`.
* Update README and CONTRIBUTING to reference new directive

## How I Tested These Changes

- Ran `yarn build-api-docs` locally ✅ 
- Confirmed execution in Vercel ✅ 

## Changelog

NOCHANGELOG
