### PR TITLE
[RFC][dagster-fivetran] Implement ConnectorSelectorFn

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,7 +11,7 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
-    FivetranFilterFn as FivetranFilterFn,
+    ConnectionSelectorFn as FivetranFilterFn,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,7 +11,7 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
-    FivetranFilter as FivetranFilter,
+    FivetranFilterFn as FivetranFilterFn,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,7 +11,7 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
-    ConnectionSelectorFn as ConnectionSelectorFn,
+    ConnectorSelectorFn as ConnectorSelectorFn,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,7 +11,7 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
-    ConnectionSelectorFn as FivetranFilterFn,
+    ConnectionSelectorFn as ConnectionSelectorFn,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,6 +11,7 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
+    FivetranFilter as FivetranFilter,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import beta
 
-from dagster_fivetran.resources import ConnectionSelectorFn, FivetranWorkspace
+from dagster_fivetran.resources import ConnectorSelectorFn, FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
 
 
@@ -15,7 +15,7 @@ def fivetran_assets(
     name: Optional[str] = None,
     group_name: Optional[str] = None,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
+    connector_selector_fn: Optional[ConnectorSelectorFn] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to sync the tables of a given Fivetran connector.
 
@@ -28,8 +28,8 @@ def fivetran_assets(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        connection_selector_fn (Optional[ConnectionSelectorFn]):
-                A function that allows for filtering which Fivetran connection assets are created for.
+        connector_selector_fn (Optional[ConnectorSelectorFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
     Examples:
         Sync the tables of a Fivetran connector:
@@ -105,8 +105,8 @@ def fivetran_assets(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    connection_selector_fn = connection_selector_fn or (
-        lambda connection: connection.id == connector_id
+    connector_selector_fn = connector_selector_fn or (
+        lambda connector: connector.id == connector_id
     )
 
     return multi_asset(
@@ -117,7 +117,7 @@ def fivetran_assets(
             spec
             for spec in workspace.load_asset_specs(
                 dagster_fivetran_translator=dagster_fivetran_translator,
-                connection_selector_fn=connection_selector_fn,
+                connector_selector_fn=connector_selector_fn,
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import beta
 
-from dagster_fivetran.resources import FivetranFilterFn, FivetranWorkspace
+from dagster_fivetran.resources import ConnectionSelectorFn, FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
 
 
@@ -15,7 +15,7 @@ def fivetran_assets(
     name: Optional[str] = None,
     group_name: Optional[str] = None,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    fivetran_filter_fn: Optional[FivetranFilterFn] = None,
+    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to sync the tables of a given Fivetran connector.
 
@@ -28,8 +28,8 @@ def fivetran_assets(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        fivetran_filter_fn (Optional[FivetranFilterFn]):
-                A function that allows for filtering which Fivetran connector assets are created for.
+        connection_selector_fn (Optional[ConnectionSelectorFn]):
+                A function that allows for filtering which Fivetran connection assets are created for.
 
     Examples:
         Sync the tables of a Fivetran connector:
@@ -105,7 +105,7 @@ def fivetran_assets(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    fivetran_filter_fn = fivetran_filter_fn or (lambda connector: connector.id == connector_id)
+    connection_selector_fn = connection_selector_fn or (lambda connection: connection.id == connector_id)
 
     return multi_asset(
         name=name,
@@ -115,7 +115,7 @@ def fivetran_assets(
             spec
             for spec in workspace.load_asset_specs(
                 dagster_fivetran_translator=dagster_fivetran_translator,
-                fivetran_filter_fn=fivetran_filter_fn,
+                connection_selector_fn=connection_selector_fn,
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -105,7 +105,9 @@ def fivetran_assets(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    connection_selector_fn = connection_selector_fn or (lambda connection: connection.id == connector_id)
+    connection_selector_fn = connection_selector_fn or (
+        lambda connection: connection.id == connector_id
+    )
 
     return multi_asset(
         name=name,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import beta
 
-from dagster_fivetran.resources import FivetranFilter, FivetranWorkspace
+from dagster_fivetran.resources import FivetranFilterFn, FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
 
 
@@ -15,7 +15,7 @@ def fivetran_assets(
     name: Optional[str] = None,
     group_name: Optional[str] = None,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    fivetran_filter: Optional[FivetranFilter] = None,
+    fivetran_filter_fn: Optional[FivetranFilterFn] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to sync the tables of a given Fivetran connector.
 
@@ -28,7 +28,8 @@ def fivetran_assets(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
+        fivetran_filter_fn (Optional[FivetranFilterFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
     Examples:
         Sync the tables of a Fivetran connector:
@@ -104,7 +105,7 @@ def fivetran_assets(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    fivetran_filter = fivetran_filter or FivetranFilter(connector_ids=frozenset({connector_id}))
+    fivetran_filter_fn = fivetran_filter_fn or (lambda connector: connector.id == connector_id)
 
     return multi_asset(
         name=name,
@@ -114,7 +115,7 @@ def fivetran_assets(
             spec
             for spec in workspace.load_asset_specs(
                 dagster_fivetran_translator=dagster_fivetran_translator,
-                fivetran_filter=fivetran_filter,
+                fivetran_filter_fn=fivetran_filter_fn,
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -34,7 +34,7 @@ from dagster._utils.log import get_dagster_logger
 from dagster_fivetran.asset_decorator import fivetran_assets
 from dagster_fivetran.resources import (
     DEFAULT_POLL_INTERVAL,
-    FivetranFilterFn,
+    ConnectionSelectorFn,
     FivetranResource,
     FivetranWorkspace,
 )
@@ -738,7 +738,7 @@ def build_fivetran_assets_definitions(
     *,
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    fivetran_filter_fn: Optional[FivetranFilterFn] = None,
+    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
 ) -> Sequence[AssetsDefinition]:
     """The list of AssetsDefinition for all connectors in the Fivetran workspace.
 
@@ -747,8 +747,8 @@ def build_fivetran_assets_definitions(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        fivetran_filter_fn (Optional[FivetranFilterFn]):
-                A function that allows for filtering which Fivetran connector assets are created for.
+        connection_selector_fn (Optional[ConnectionSelectorFn]):
+                A function that allows for filtering which Fivetran connection assets are created for.
 
     Returns:
         List[AssetsDefinition]: The list of AssetsDefinition for all connectors in the Fivetran workspace.
@@ -815,11 +815,11 @@ def build_fivetran_assets_definitions(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    fivetran_filter_fn = fivetran_filter_fn or (lambda connector: connector)
+    connection_selector_fn = connection_selector_fn or (lambda connection: connection)
 
     all_asset_specs = workspace.load_asset_specs(
         dagster_fivetran_translator=dagster_fivetran_translator,
-        fivetran_filter_fn=fivetran_filter_fn,
+        connection_selector_fn=connection_selector_fn,
     )
 
     connector_ids = {
@@ -836,7 +836,7 @@ def build_fivetran_assets_definitions(
             name=connector_id,
             group_name=connector_id,
             dagster_fivetran_translator=dagster_fivetran_translator,
-            fivetran_filter_fn=fivetran_filter_fn,
+            connection_selector_fn=connection_selector_fn,
         )
         def _asset_fn(context: AssetExecutionContext, fivetran: FivetranWorkspace):
             yield from fivetran.sync_and_poll(context=context)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -34,7 +34,7 @@ from dagster._utils.log import get_dagster_logger
 from dagster_fivetran.asset_decorator import fivetran_assets
 from dagster_fivetran.resources import (
     DEFAULT_POLL_INTERVAL,
-    ConnectionSelectorFn,
+    ConnectorSelectorFn,
     FivetranResource,
     FivetranWorkspace,
 )
@@ -738,7 +738,7 @@ def build_fivetran_assets_definitions(
     *,
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
+    connector_selector_fn: Optional[ConnectorSelectorFn] = None,
 ) -> Sequence[AssetsDefinition]:
     """The list of AssetsDefinition for all connectors in the Fivetran workspace.
 
@@ -747,8 +747,8 @@ def build_fivetran_assets_definitions(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        connection_selector_fn (Optional[ConnectionSelectorFn]):
-                A function that allows for filtering which Fivetran connection assets are created for.
+        connector_selector_fn (Optional[ConnectorSelectorFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
     Returns:
         List[AssetsDefinition]: The list of AssetsDefinition for all connectors in the Fivetran workspace.
@@ -815,11 +815,11 @@ def build_fivetran_assets_definitions(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    connection_selector_fn = connection_selector_fn or (lambda connection: connection)
+    connector_selector_fn = connector_selector_fn or (lambda connector: connector)
 
     all_asset_specs = workspace.load_asset_specs(
         dagster_fivetran_translator=dagster_fivetran_translator,
-        connection_selector_fn=connection_selector_fn,
+        connector_selector_fn=connector_selector_fn,
     )
 
     connector_ids = {
@@ -836,7 +836,7 @@ def build_fivetran_assets_definitions(
             name=connector_id,
             group_name=connector_id,
             dagster_fivetran_translator=dagster_fivetran_translator,
-            connection_selector_fn=connection_selector_fn,
+            connector_selector_fn=connector_selector_fn,
         )
         def _asset_fn(context: AssetExecutionContext, fivetran: FivetranWorkspace):
             yield from fivetran.sync_and_poll(context=context)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -815,7 +815,7 @@ def build_fivetran_assets_definitions(
 
     """
     dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
-    connector_selector_fn = connector_selector_fn or (lambda connector: connector)
+    connector_selector_fn = connector_selector_fn or (lambda connector: bool(connector))
 
     all_asset_specs = workspace.load_asset_specs(
         dagster_fivetran_translator=dagster_fivetran_translator,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -921,7 +921,9 @@ class FivetranWorkspace(ConfigurableResource):
         fivetran_filter: Optional[FivetranFilter] = None,
     ) -> FivetranWorkspaceData:
         """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
-        fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
+
+        Args:
+            fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
 
         Returns:
             FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -474,7 +474,7 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
 # Reworked resources
 # ------------------
 
-ConnectionSelectorFn = Callable[[FivetranConnector], bool]
+ConnectorSelectorFn = Callable[[FivetranConnector], bool]
 
 
 @beta
@@ -876,13 +876,13 @@ class FivetranWorkspace(ConfigurableResource):
 
     def fetch_fivetran_workspace_data(
         self,
-        connection_selector_fn: Optional[ConnectionSelectorFn] = None,
+            connector_selector_fn: Optional[ConnectorSelectorFn] = None,
     ) -> FivetranWorkspaceData:
         """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
 
         Args:
-            connection_selector_fn (Optional[ConnectionSelectorFn]):
-                A function that allows for filtering which Fivetran connection assets are created for.
+            connector_selector_fn (Optional[ConnectorSelectorFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
         Returns:
             FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
@@ -918,7 +918,7 @@ class FivetranWorkspace(ConfigurableResource):
                 )
 
                 if (
-                    connection_selector_fn and not connection_selector_fn(connector)
+                    connector_selector_fn and not connector_selector_fn(connector)
                 ) or not connector.is_connected:
                     continue
 
@@ -935,7 +935,7 @@ class FivetranWorkspace(ConfigurableResource):
     def load_asset_specs(
         self,
         dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-        connection_selector_fn: Optional[ConnectionSelectorFn] = None,
+            connector_selector_fn: Optional[ConnectorSelectorFn] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -943,8 +943,8 @@ class FivetranWorkspace(ConfigurableResource):
             dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
                 to convert Fivetran content into :py:class:`dagster.AssetSpec`.
                 Defaults to :py:class:`DagsterFivetranTranslator`.
-            connection_selector_fn (Optional[ConnectionSelectorFn]):
-                A function that allows for filtering which Fivetran connection assets are created for.
+            connector_selector_fn (Optional[ConnectorSelectorFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
         Returns:
             List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -969,7 +969,7 @@ class FivetranWorkspace(ConfigurableResource):
         return load_fivetran_asset_specs(
             workspace=self,
             dagster_fivetran_translator=dagster_fivetran_translator or DagsterFivetranTranslator(),
-            connection_selector_fn=connection_selector_fn,
+            connector_selector_fn=connector_selector_fn,
         )
 
     def _generate_materialization(
@@ -1089,7 +1089,7 @@ class FivetranWorkspace(ConfigurableResource):
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
+        connector_selector_fn: Optional[ConnectorSelectorFn] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1098,8 +1098,8 @@ def load_fivetran_asset_specs(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        connection_selector_fn (Optional[ConnectionSelectorFn]):
-                A function that allows for filtering which Fivetran connection assets are created for.
+        connector_selector_fn (Optional[ConnectorSelectorFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1133,7 +1133,7 @@ def load_fivetran_asset_specs(
                 FivetranWorkspaceDefsLoader(
                     workspace=initialized_workspace,
                     translator=dagster_fivetran_translator,
-                    connection_selector_fn=connection_selector_fn,
+                    connector_selector_fn=connector_selector_fn,
                 )
                 .build_defs()
                 .assets,
@@ -1146,7 +1146,7 @@ def load_fivetran_asset_specs(
 class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
     workspace: FivetranWorkspace
     translator: DagsterFivetranTranslator
-    connection_selector_fn: Optional[ConnectionSelectorFn] = None
+    connector_selector_fn: Optional[ConnectorSelectorFn] = None
 
     @property
     def defs_key(self) -> str:
@@ -1154,7 +1154,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]
 
     def fetch_state(self) -> FivetranWorkspaceData:
         return self.workspace.fetch_fivetran_workspace_data(
-            connection_selector_fn=self.connection_selector_fn
+            connector_selector_fn=self.connector_selector_fn
         )
 
     def defs_from_state(self, state: FivetranWorkspaceData) -> Definitions:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1146,7 +1146,7 @@ def load_fivetran_asset_specs(
 class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
     workspace: FivetranWorkspace
     translator: DagsterFivetranTranslator
-    fivetran_filter_fn: Optional[Any] = None
+    fivetran_filter_fn: Optional[FivetranFilterFn] = None
 
     @property
     def defs_key(self) -> str:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import time
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from functools import partial
 from typing import Any, Callable, Optional, Union
@@ -474,49 +474,7 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
 # Reworked resources
 # ------------------
 
-
-@record
-class FivetranFilter:
-    """Filters the set of Fivetran objects to fetch.
-
-    Args:
-        connector_names (Optional[Set[str]]): A set of connector names to fetch.
-            All connectors for which the exact name is included in this list will be fetched.
-            If not provided, all connectors will be fetched.
-        connector_ids (Optional[Set[str]]): A set of connector IDs to fetch.
-            All connectors for which the ID is included in this list will be fetched.
-            If not provided, all connectors will be fetched.
-        databases (Optional[Set[str]]): A set of databases to fetch.
-            All connectors for which the destination database is included in this list will be fetched.
-            If not provided, all connectors will be fetched.
-        services (Optional[Set[str]]): A set of services to fetch.
-            All connectors for which the destination service is included in this list will be fetched.
-            If not provided, all connectors will be fetched.
-
-    """
-
-    connector_names: Optional[Set[str]] = None
-    connector_ids: Optional[Set[str]] = None
-    databases: Optional[Set[str]] = None
-    services: Optional[Set[str]] = None
-
-    def has_connector(self, connector: FivetranConnector) -> bool:
-        return self._has_connector_name(connector.name) and self._has_connector_id(connector.id)
-
-    def has_destination(self, destination: FivetranDestination) -> bool:
-        return self._has_database(destination.database) and self._has_service(destination.service)
-
-    def _has_connector_name(self, connector_name: str) -> bool:
-        return True if not self.connector_names or connector_name in self.connector_names else False
-
-    def _has_connector_id(self, connector_id: str) -> bool:
-        return True if not self.connector_ids or connector_id in self.connector_ids else False
-
-    def _has_database(self, database: Optional[str]) -> bool:
-        return True if not self.databases or database in self.databases else False
-
-    def _has_service(self, service: str) -> bool:
-        return True if not self.services or service in self.services else False
+FivetranFilterFn = Callable[[FivetranConnector], bool]
 
 
 @beta
@@ -918,18 +876,17 @@ class FivetranWorkspace(ConfigurableResource):
 
     def fetch_fivetran_workspace_data(
         self,
-        fivetran_filter: Optional[FivetranFilter] = None,
+        fivetran_filter_fn: Optional[FivetranFilterFn] = None,
     ) -> FivetranWorkspaceData:
         """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
 
         Args:
-            fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
+            fivetran_filter_fn (Optional[FivetranFilterFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
         Returns:
             FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
         """
-        fivetran_filter = fivetran_filter or FivetranFilter()
-
         connectors_by_id = {}
         destinations_by_id = {}
         schema_configs_by_connector_id = {}
@@ -945,8 +902,6 @@ class FivetranWorkspace(ConfigurableResource):
                 destination_details=destination_details
             )
 
-            if not fivetran_filter.has_destination(destination):
-                continue
             destinations_by_id[destination.id] = destination
 
             connectors_details = client.get_connectors_for_group(group_id=group_id)["items"]
@@ -955,13 +910,6 @@ class FivetranWorkspace(ConfigurableResource):
                     connector_details=connector_details,
                 )
 
-                if not connector.is_connected:
-                    continue
-
-                if not fivetran_filter.has_connector(connector):
-                    continue
-                connectors_by_id[connector.id] = connector
-
                 schema_config_details = client.get_schema_config_for_connector(
                     connector_id=connector.id
                 )
@@ -969,6 +917,12 @@ class FivetranWorkspace(ConfigurableResource):
                     schema_config_details=schema_config_details
                 )
 
+                if (
+                    fivetran_filter_fn and not fivetran_filter_fn(connector)
+                ) or not connector.is_connected:
+                    continue
+
+                connectors_by_id[connector.id] = connector
                 schema_configs_by_connector_id[connector.id] = schema_config
 
         return FivetranWorkspaceData(
@@ -981,7 +935,7 @@ class FivetranWorkspace(ConfigurableResource):
     def load_asset_specs(
         self,
         dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-        fivetran_filter: Optional[FivetranFilter] = None,
+        fivetran_filter_fn: Optional[FivetranFilterFn] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -989,7 +943,8 @@ class FivetranWorkspace(ConfigurableResource):
             dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
                 to convert Fivetran content into :py:class:`dagster.AssetSpec`.
                 Defaults to :py:class:`DagsterFivetranTranslator`.
-            fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
+            fivetran_filter_fn (Optional[FivetranFilterFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
         Returns:
             List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1014,7 +969,7 @@ class FivetranWorkspace(ConfigurableResource):
         return load_fivetran_asset_specs(
             workspace=self,
             dagster_fivetran_translator=dagster_fivetran_translator or DagsterFivetranTranslator(),
-            fivetran_filter=fivetran_filter,
+            fivetran_filter_fn=fivetran_filter_fn,
         )
 
     def _generate_materialization(
@@ -1134,7 +1089,7 @@ class FivetranWorkspace(ConfigurableResource):
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    fivetran_filter: Optional[FivetranFilter] = None,
+    fivetran_filter_fn: Optional[FivetranFilterFn] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1143,7 +1098,8 @@ def load_fivetran_asset_specs(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        fivetran_filter (Optional[FivetranFilter]): Filters the set of Fivetran objects to fetch.
+        fivetran_filter_fn (Optional[FivetranFilterFn]):
+                A function that allows for filtering which Fivetran connector assets are created for.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1177,7 +1133,7 @@ def load_fivetran_asset_specs(
                 FivetranWorkspaceDefsLoader(
                     workspace=initialized_workspace,
                     translator=dagster_fivetran_translator,
-                    fivetran_filter=fivetran_filter,
+                    fivetran_filter_fn=fivetran_filter_fn,
                 )
                 .build_defs()
                 .assets,
@@ -1190,14 +1146,16 @@ def load_fivetran_asset_specs(
 class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
     workspace: FivetranWorkspace
     translator: DagsterFivetranTranslator
-    fivetran_filter: Optional[FivetranFilter] = None
+    fivetran_filter_fn: Optional[Any] = None
 
     @property
     def defs_key(self) -> str:
         return f"{FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX}/{self.workspace.account_id}"
 
     def fetch_state(self) -> FivetranWorkspaceData:
-        return self.workspace.fetch_fivetran_workspace_data(fivetran_filter=self.fivetran_filter)
+        return self.workspace.fetch_fivetran_workspace_data(
+            fivetran_filter_fn=self.fivetran_filter_fn
+        )
 
     def defs_from_state(self, state: FivetranWorkspaceData) -> Definitions:
         all_asset_specs = [

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -474,7 +474,7 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
 # Reworked resources
 # ------------------
 
-FivetranFilterFn = Callable[[FivetranConnector], bool]
+ConnectionSelectorFn = Callable[[FivetranConnector], bool]
 
 
 @beta
@@ -876,13 +876,13 @@ class FivetranWorkspace(ConfigurableResource):
 
     def fetch_fivetran_workspace_data(
         self,
-        fivetran_filter_fn: Optional[FivetranFilterFn] = None,
+        connection_selector_fn: Optional[ConnectionSelectorFn] = None,
     ) -> FivetranWorkspaceData:
         """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
 
         Args:
-            fivetran_filter_fn (Optional[FivetranFilterFn]):
-                A function that allows for filtering which Fivetran connector assets are created for.
+            connection_selector_fn (Optional[ConnectionSelectorFn]):
+                A function that allows for filtering which Fivetran connection assets are created for.
 
         Returns:
             FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
@@ -918,7 +918,7 @@ class FivetranWorkspace(ConfigurableResource):
                 )
 
                 if (
-                    fivetran_filter_fn and not fivetran_filter_fn(connector)
+                    connection_selector_fn and not connection_selector_fn(connector)
                 ) or not connector.is_connected:
                     continue
 
@@ -935,7 +935,7 @@ class FivetranWorkspace(ConfigurableResource):
     def load_asset_specs(
         self,
         dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-        fivetran_filter_fn: Optional[FivetranFilterFn] = None,
+        connection_selector_fn: Optional[ConnectionSelectorFn] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -943,8 +943,8 @@ class FivetranWorkspace(ConfigurableResource):
             dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
                 to convert Fivetran content into :py:class:`dagster.AssetSpec`.
                 Defaults to :py:class:`DagsterFivetranTranslator`.
-            fivetran_filter_fn (Optional[FivetranFilterFn]):
-                A function that allows for filtering which Fivetran connector assets are created for.
+            connection_selector_fn (Optional[ConnectionSelectorFn]):
+                A function that allows for filtering which Fivetran connection assets are created for.
 
         Returns:
             List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -969,7 +969,7 @@ class FivetranWorkspace(ConfigurableResource):
         return load_fivetran_asset_specs(
             workspace=self,
             dagster_fivetran_translator=dagster_fivetran_translator or DagsterFivetranTranslator(),
-            fivetran_filter_fn=fivetran_filter_fn,
+            connection_selector_fn=connection_selector_fn,
         )
 
     def _generate_materialization(
@@ -1089,7 +1089,7 @@ class FivetranWorkspace(ConfigurableResource):
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-    fivetran_filter_fn: Optional[FivetranFilterFn] = None,
+    connection_selector_fn: Optional[ConnectionSelectorFn] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1098,8 +1098,8 @@ def load_fivetran_asset_specs(
         dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
-        fivetran_filter_fn (Optional[FivetranFilterFn]):
-                A function that allows for filtering which Fivetran connector assets are created for.
+        connection_selector_fn (Optional[ConnectionSelectorFn]):
+                A function that allows for filtering which Fivetran connection assets are created for.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1133,7 +1133,7 @@ def load_fivetran_asset_specs(
                 FivetranWorkspaceDefsLoader(
                     workspace=initialized_workspace,
                     translator=dagster_fivetran_translator,
-                    fivetran_filter_fn=fivetran_filter_fn,
+                    connection_selector_fn=connection_selector_fn,
                 )
                 .build_defs()
                 .assets,
@@ -1146,7 +1146,7 @@ def load_fivetran_asset_specs(
 class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
     workspace: FivetranWorkspace
     translator: DagsterFivetranTranslator
-    fivetran_filter_fn: Optional[FivetranFilterFn] = None
+    connection_selector_fn: Optional[ConnectionSelectorFn] = None
 
     @property
     def defs_key(self) -> str:
@@ -1154,7 +1154,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]
 
     def fetch_state(self) -> FivetranWorkspaceData:
         return self.workspace.fetch_fivetran_workspace_data(
-            fivetran_filter_fn=self.fivetran_filter_fn
+            connection_selector_fn=self.connection_selector_fn
         )
 
     def defs_from_state(self, state: FivetranWorkspaceData) -> Definitions:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -876,7 +876,7 @@ class FivetranWorkspace(ConfigurableResource):
 
     def fetch_fivetran_workspace_data(
         self,
-            connector_selector_fn: Optional[ConnectorSelectorFn] = None,
+        connector_selector_fn: Optional[ConnectorSelectorFn] = None,
     ) -> FivetranWorkspaceData:
         """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
 
@@ -935,7 +935,7 @@ class FivetranWorkspace(ConfigurableResource):
     def load_asset_specs(
         self,
         dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-            connector_selector_fn: Optional[ConnectorSelectorFn] = None,
+        connector_selector_fn: Optional[ConnectorSelectorFn] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1089,7 +1089,7 @@ class FivetranWorkspace(ConfigurableResource):
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-        connector_selector_fn: Optional[ConnectorSelectorFn] = None,
+    connector_selector_fn: Optional[ConnectorSelectorFn] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
@@ -19,6 +19,13 @@ TEST_API_KEY = "test_api_key"
 TEST_API_SECRET = "test_api_secret"
 TEST_ANOTHER_ACCOUNT_ID = "test_another_account_id"
 
+TEST_CONNECTOR_NAME = "test_connector_name"
+TEST_CONNECTOR_ID = "test_connector_id"
+TEST_DESTINATION_DATABASE = "test_destination_database"
+TEST_DESTINATION_SERVICE = "test_destination_service"
+TEST_DESTINATION_ID = "my_group_destination_id"
+TEST_GROUP_ID = "my_group_destination_id"
+
 TEST_SCHEMA_NAME = "schema_name_in_destination_1"
 TEST_TABLE_NAME = "table_name_in_destination_1"
 TEST_SECOND_SCHEMA_NAME = "schema_name_in_destination_2"
@@ -33,7 +40,7 @@ SAMPLE_GROUPS = {
     "data": {
         "items": [
             {
-                "id": "my_group_destination_id",
+                "id": TEST_GROUP_ID,
                 "name": "Group_Name",
                 "created_at": "2024-01-01T00:00:00Z",
             }
@@ -50,9 +57,9 @@ SAMPLE_CONNECTORS_FOR_GROUP = {
     "data": {
         "items": [
             {
-                "id": "connector_id",
-                "service": "adls",
-                "schema": "gsheets.table",
+                "id": TEST_CONNECTOR_ID,
+                "service": TEST_DESTINATION_SERVICE,
+                "schema": TEST_CONNECTOR_NAME,
                 "paused": False,
                 "status": {
                     "tasks": [
@@ -80,7 +87,7 @@ SAMPLE_CONNECTORS_FOR_GROUP = {
                 "daily_sync_time": "14:00",
                 "succeeded_at": "2024-12-01T15:45:29.013729Z",
                 "sync_frequency": 360,
-                "group_id": "my_group_destination_id",
+                "group_id": TEST_GROUP_ID,
                 "connected_by": "user_id",
                 "setup_tests": [
                     {
@@ -123,13 +130,13 @@ SAMPLE_DESTINATION_DETAILS = {
     "code": "Success",
     "message": "Operation performed.",
     "data": {
-        "id": "my_group_destination_id",
-        "service": "adls",
+        "id": TEST_DESTINATION_ID,
+        "service": TEST_DESTINATION_SERVICE,
         "region": "GCP_US_EAST4",
         "networking_method": "Directly",
         "setup_status": "CONNECTED",
         "daylight_saving_time_enabled": True,
-        "group_id": "my_group_destination_id",
+        "group_id": TEST_GROUP_ID,
         "time_zone_offset": "+3",
         "setup_tests": [
             {
@@ -143,6 +150,7 @@ SAMPLE_DESTINATION_DETAILS = {
         "private_link_id": "private_link_id",
         "hybrid_deployment_agent_id": "hybrid_deployment_agent_id",
         "config": {
+            "database": TEST_DESTINATION_DATABASE,
             "tenant_id": "service_principal_tenant_id",
             "auth_type": "PERSONAL_ACCESS_TOKEN | OAUTH2",
             "storage_account_name": "adls_storage_account_name",
@@ -174,7 +182,7 @@ def get_sample_connection_details(succeeded_at: str, failed_at: str) -> Mapping[
         "code": "Success",
         "message": "Operation performed.",
         "data": {
-            "id": "connector_id",
+            "id": TEST_CONNECTOR_ID,
             "service": "15five",
             "schema": "schema.table",
             "paused": False,
@@ -203,7 +211,7 @@ def get_sample_connection_details(succeeded_at: str, failed_at: str) -> Mapping[
             "daily_sync_time": "14:00",
             "succeeded_at": succeeded_at,
             "sync_frequency": 1440,
-            "group_id": "my_group_destination_id",
+            "group_id": TEST_GROUP_ID,
             "connected_by": "user_id",
             "setup_tests": [
                 {
@@ -458,17 +466,17 @@ def get_fivetran_connector_api_url(connector_id: str) -> str:
 
 @pytest.fixture(name="connector_id")
 def connector_id_fixture() -> str:
-    return "connector_id"
+    return TEST_CONNECTOR_ID
 
 
 @pytest.fixture(name="destination_id")
 def destination_id_fixture() -> str:
-    return "my_group_destination_id"
+    return TEST_DESTINATION_ID
 
 
 @pytest.fixture(name="group_id")
 def group_id_fixture() -> str:
-    return "my_group_destination_id"
+    return TEST_GROUP_ID
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -1,3 +1,7 @@
+from collections.abc import Set
+from typing import Optional
+
+import pytest
 import responses
 from dagster._config.field_utils import EnvVar
 from dagster._core.definitions.asset_spec import AssetSpec
@@ -5,6 +9,7 @@ from dagster._core.test_utils import environ
 from dagster_fivetran import (
     DagsterFivetranTranslator,
     FivetranConnectorTableProps,
+    FivetranFilter,
     FivetranWorkspace,
     load_fivetran_asset_specs,
 )
@@ -12,10 +17,18 @@ from dagster_fivetran.asset_defs import build_fivetran_assets_definitions
 from dagster_fivetran.translator import FivetranMetadataSet
 
 from dagster_fivetran_tests.beta.conftest import (
+    FIVETRAN_API_BASE,
+    FIVETRAN_API_VERSION,
     TEST_ACCOUNT_ID,
     TEST_ANOTHER_ACCOUNT_ID,
     TEST_API_KEY,
     TEST_API_SECRET,
+    TEST_CONNECTOR_ID,
+    TEST_CONNECTOR_NAME,
+    TEST_DESTINATION_DATABASE,
+    TEST_DESTINATION_ID,
+    TEST_DESTINATION_SERVICE,
+    get_fivetran_connector_api_url,
 )
 
 
@@ -29,6 +42,113 @@ def test_fetch_fivetran_workspace_data(
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     assert len(actual_workspace_data.connectors_by_id) == 1
     assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+@pytest.mark.parametrize(
+    "connector_names, connector_ids, databases, services, expected_result, skip_connector_call, skip_schema_config_call",
+    [
+        (None, None, None, None, 1, False, False),
+        ({TEST_CONNECTOR_NAME}, None, None, None, 1, False, False),
+        (None, {TEST_CONNECTOR_ID}, None, None, 1, False, False),
+        (None, None, {TEST_DESTINATION_DATABASE}, None, 1, False, False),
+        (None, None, None, {TEST_DESTINATION_SERVICE}, 1, False, False),
+        (
+            {TEST_CONNECTOR_NAME},
+            {TEST_CONNECTOR_ID},
+            {TEST_DESTINATION_DATABASE},
+            {TEST_DESTINATION_SERVICE},
+            1,
+            False,
+            False,
+        ),
+        ({"non_matching_connector_name"}, None, None, None, 0, False, True),
+        (None, {"non_matching_connector_id"}, None, None, 0, False, True),
+        (None, None, {"non_matching_database"}, None, 0, True, True),
+        (None, None, None, {"non_matching_service"}, 0, True, True),
+        (
+            {"non_matching_connector_name"},
+            {"non_matching_connector_id"},
+            {"non_matching_database"},
+            {"non_matching_service"},
+            0,
+            True,
+            True,
+        ),
+        (
+            {TEST_CONNECTOR_NAME},
+            {TEST_CONNECTOR_ID},
+            {"non_matching_database"},
+            None,
+            0,
+            True,
+            True,
+        ),
+        (
+            {"non_matching_connector_name"},
+            None,
+            {TEST_DESTINATION_DATABASE},
+            {TEST_DESTINATION_SERVICE},
+            0,
+            False,
+            True,
+        ),
+    ],
+    ids=[
+        "no_filter_present_connector",
+        "connector_name_filter_present_connector",
+        "connector_id_filter_present_connector",
+        "database_filter_present_connector",
+        "service_filter_present_connector",
+        "all_filters_present_connector",
+        "connector_name_filter_absent_connector",
+        "connector_id_filter_absent_connector",
+        "database_filter_absent_connector",
+        "service_filter_absent_connector",
+        "all_filters_absent_connector",
+        "one_non_matching_database_filter_absent_connector",
+        "one_non_matching_connector_filter_absent_connector",
+    ],
+)
+def test_fivetran_filter(
+    connector_names: Optional[Set[str]],
+    connector_ids: Optional[Set[str]],
+    databases: Optional[Set[str]],
+    services: Optional[Set[str]],
+    expected_result: int,
+    skip_connector_call: bool,
+    skip_schema_config_call: bool,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    # When a destination is filtered out, all its connector are filtered out
+    # and calls to the `/groups/{group_id}/connectors` endpoint are skipped.
+    # We remove the call from the mock calls to avoid the exception
+    # raised by RequestMock when not all requests are executed.
+    if skip_connector_call:
+        fetch_workspace_data_api_mocks.remove(
+            method_or_response=responses.GET,
+            url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{TEST_DESTINATION_ID}/connectors",
+        )
+    # When a connector is filtered out, the call to the `connectors/{connector_id}/schemas` endpoint is skipped.
+    # We remove the call from the mock calls to avoid the exception
+    # raised by RequestMock when not all requests are executed.
+    if skip_schema_config_call:
+        fetch_workspace_data_api_mocks.remove(
+            method_or_response=responses.GET,
+            url=f"{get_fivetran_connector_api_url(TEST_CONNECTOR_ID)}/schemas",
+        )
+
+    fivetran_filter = FivetranFilter(
+        connector_names=connector_names,
+        connector_ids=connector_ids,
+        databases=databases,
+        services=services,
+    )
+    actual_workspace_data = resource.fetch_fivetran_workspace_data(fivetran_filter=fivetran_filter)
+    assert len(actual_workspace_data.connectors_by_id) == expected_result
 
 
 def test_translator_spec(
@@ -56,7 +176,7 @@ def test_translator_spec(
         ]
 
         first_asset_metadata = next(asset.metadata for asset in all_assets)
-        assert FivetranMetadataSet.extract(first_asset_metadata).connector_id == "connector_id"
+        assert FivetranMetadataSet.extract(first_asset_metadata).connector_id == TEST_CONNECTOR_ID
 
 
 def test_cached_load_spec_single_resource(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -66,11 +66,11 @@ def test_fivetran_filter(
         account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
     )
 
-    fivetran_filter_fn = (
+    connection_selector_fn = (
         (lambda connector: getattr(connector, attribute) == value) if attribute else None
     )
     actual_workspace_data = resource.fetch_fivetran_workspace_data(
-        fivetran_filter_fn=fivetran_filter_fn
+        connection_selector_fn=connection_selector_fn
     )
     assert len(actual_workspace_data.connectors_by_id) == expected_result
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -47,16 +47,16 @@ def test_fetch_fivetran_workspace_data(
         ("service", "non_matching_service", 0),
     ],
     ids=[
-        "no_filter_present_connector",
-        "connector_name_filter_present_connector",
-        "connector_id_filter_present_connector",
-        "service_filter_present_connector",
-        "connector_name_filter_absent_connector",
-        "connector_id_filter_absent_connector",
-        "service_filter_absent_connector",
+        "no_selector_present_connector",
+        "connector_name_selector_present_connector",
+        "connector_id_selector_present_connector",
+        "service_selector_present_connector",
+        "connector_name_selector_absent_connector",
+        "connector_id_selector_absent_connector",
+        "service_selector_absent_connector",
     ],
 )
-def test_fivetran_filter(
+def test_fivetran_connector_selector(
     attribute: str,
     value: str,
     expected_result: int,
@@ -66,11 +66,11 @@ def test_fivetran_filter(
         account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
     )
 
-    connection_selector_fn = (
+    connector_selector_fn = (
         (lambda connector: getattr(connector, attribute) == value) if attribute else None
     )
     actual_workspace_data = resource.fetch_fivetran_workspace_data(
-        connection_selector_fn=connection_selector_fn
+        connector_selector_fn=connector_selector_fn
     )
     assert len(actual_workspace_data.connectors_by_id) == expected_result
 


### PR DESCRIPTION
## Summary & Motivation

Fixes [AD-780](https://linear.app/dagster-labs/issue/AD-780/[dagster-fivetran]-support-connection-filter).

This PR adds ConnectorSelectorFn to support connector selection/filter in the new integration. 

In the legacy integration, connectors could be filtered based on their name, id, database and service, using a callback of type `Callable[[FivetranConnectionMetadata], bool]`.

The new `ConnectorSelectorFn` is a callback of type `Callable[[FivetranConnector], bool]` - `FivetranConnector` is the container class that we are using in the new integration for Fivetran connectors

```
from dagster_fivetran import FivetranFilterFn, FivetranWorkspace, load_fivetran_asset_specs

import dagster as dg

fivetran_workspace = FivetranWorkspace(
    account_id=dg.EnvVar("FIVETRAN_ACCOUNT_ID"),
    api_key=dg.EnvVar("FIVETRAN_API_KEY"),
    api_secret=dg.EnvVar("FIVETRAN_API_SECRET"),
)

fivetran_specs = load_fivetran_asset_specs(
    fivetran_workspace, 
    connector_selector_fn=(
       lambda connector: connector.id == "my_connector_id"
    )
)
defs = dg.Definitions(assets=fivetran_specs, resources={"fivetran": fivetran_workspace})
```

## How I Tested These Changes

BK

## Changelog

[dagster-fivetran] Fivetran connectors fetched in Dagster can now be filtered and selected using the ConnectorSelectorFn.
