### PR TITLE
Filter parent materialized partitions before iterating over them during asset backfill BFS

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1505,8 +1505,21 @@ def execute_asset_backfill_iteration_inner(
                 for asset_key in asset_backfill_data.target_subset.asset_keys
             )
         )
-        candidate_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
+
+        parent_materialized_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
             parent_materialized_asset_partitions, asset_graph
+        )
+
+        # Filter out parent materializations for partitions outside the range
+        # that existed when the backfill was created
+        full_subsets = [
+            asset_graph_view.get_full_subset(key=asset_key)
+            for asset_key in parent_materialized_asset_graph_subset.asset_keys
+        ]
+
+        candidate_asset_graph_subset = (
+            parent_materialized_asset_graph_subset
+            & AssetGraphSubset.from_entity_subsets(full_subsets)
         )
 
         yield None


### PR DESCRIPTION
Summary:
This fixes an issue where:
- You start a backfill on day N
- It lasts long enougn that it is a new day and the partition set expands
- A parent partition is materialized from one of those new partitions that didn't exist when the backfill was created
- the old backfill fails because it tries to iterate over the new partition and finds it doesn't exist

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
