### PR TITLE
Add one more missing current_time callsite in IdentityPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -131,7 +131,8 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         # different asset keys
         upstream_partition_keys = set(
             upstream_partitions_def.get_partition_keys(
-                dynamic_partitions_store=dynamic_partitions_store
+                current_time=current_time,
+                dynamic_partitions_store=dynamic_partitions_store,
             )
         )
         downstream_partition_keys = set(downstream_partitions_subset.get_partition_keys())


### PR DESCRIPTION
## Summary & Motivation
Similar to https://github.com/dagster-io/dagster/pull/27681 but for upstream traversal instead of downstream traversal. Haven't found any actual problems that this was causing yet, but was just looking for other places we might not be setting current_time correctly since other similar issues were causing bugs.

## How I Tested These Changes
New test case that was failing before

## Changelog
NOCHANGELOG