### PR TITLE
[Markup] Ignore missing language errors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -133,7 +133,10 @@ export const MarkdownWithPlugins = (props: Props) => {
         {...props}
         className="dagster-markdown"
         remarkPlugins={[gfm]}
-        rehypePlugins={[rehypeHighlight, [rehypeSanitize, sanitizeConfig]]}
+        rehypePlugins={[
+          [rehypeHighlight, {ignoreMissing: true}],
+          [rehypeSanitize, sanitizeConfig],
+        ]}
       />
     </>
   );


### PR DESCRIPTION
## Summary & Motivation

Adding the ignoreMissing flag as recommended here: https://github.com/orgs/remarkjs/discussions/1013

Attempted first to upgrade rehype + react-markdown but saw an error so backed that out for now. Did not investigate deeply.

## How I Tested These Changes

Loaded a asset page that was previously crashing:
<img width="672" alt="Screenshot 2025-02-19 at 2 30 45 PM" src="https://github.com/user-attachments/assets/4c86188c-ebe6-424a-a216-88aa66811025" />


after:
<img width="1212" alt="Screenshot 2025-02-19 at 2 31 01 PM" src="https://github.com/user-attachments/assets/4c59965d-2bc7-48f9-b0b1-c3001c94fe42" />


## Changelog

[ui] Fixed an issue that caused markdown with code blocks in languages not supported for syntax highlighting to crash the page.
