### PR TITLE
[docs] remove unused imports in `examples/docs_snippets`

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
@@ -1,5 +1,4 @@
-from collections.abc import Mapping, Sequence
-from typing import Any
+from collections.abc import Mapping
 from unittest.mock import MagicMock
 
 from dagster import (

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/test_asset_check.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/test_asset_check.py
@@ -7,7 +7,6 @@ def orders(): ...
 
 # start
 
-import pandas as pd
 
 from dagster import AssetCheckResult, asset_check
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
@@ -1,5 +1,3 @@
-from typing import List  # noqa: UP035
-
 import pandas as pd
 
 from dagster import AssetIn, Definitions, asset

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers_numpy.py
@@ -8,10 +8,8 @@ from dagster import (
     ConfigurableIOManager,
     Definitions,
     InputContext,
-    IOManager,
     OutputContext,
     asset,
-    io_manager,
 )
 
 from .asset_input_managers import (

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_retry.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_retry.py
@@ -1,11 +1,4 @@
-from dagster import (
-    AssetExecutionContext,
-    Backoff,
-    Jitter,
-    RetryPolicy,
-    RetryRequested,
-    asset,
-)
+from dagster import AssetExecutionContext, Backoff, Jitter, RetryPolicy, asset
 
 
 @asset(

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_testing.py
@@ -63,7 +63,7 @@ def test_uses_context():
 # end_test_with_context_asset
 
 
-from typing import Any, Dict  # noqa: UP035
+from typing import Any
 
 import requests
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/code_versions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/code_versions.py
@@ -1,6 +1,6 @@
 import json
 
-from dagster import AssetSpec, MaterializeResult, Output, asset, multi_asset
+from dagster import AssetSpec, MaterializeResult, asset, multi_asset
 
 
 # start_single_asset

--- a/examples/docs_snippets/docs_snippets/concepts/assets/cross_cl_code_location_2.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/cross_cl_code_location_2.py
@@ -2,7 +2,7 @@
 # code_location_2.py
 import json
 
-from dagster import AssetKey, Definitions, asset
+from dagster import Definitions, asset
 
 
 @asset(deps=["code_location_1_asset"])

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -1,13 +1,11 @@
 # ruff: isort: skip_file
 from dagster import (
-    AssetKey,
     load_assets_from_current_module,
     Out,
     Output,
     AssetSelection,
     define_asset_job,
     Definitions,
-    OpExecutionContext,
 )
 from unittest.mock import MagicMock
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/multi_assets.py
@@ -47,7 +47,7 @@ def split_actions(context: AssetExecutionContext):
 # end_subsettable_multi_asset
 
 # start_asset_deps_multi_asset
-from dagster import AssetKey, AssetSpec, asset, multi_asset
+from dagster import AssetSpec, asset, multi_asset
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -1,6 +1,5 @@
 # ruff: isort: skip_file
 
-from typing import List  # noqa: UP035
 from dagster import job, op
 
 
@@ -53,7 +52,6 @@ class MyIOManager(ConfigurableIOManager):
 # start_io_manager_factory_marker
 
 from dagster import IOManager, ConfigurableIOManagerFactory, OutputContext, InputContext
-import requests
 
 
 class ExternalIOManager(IOManager):
@@ -98,7 +96,7 @@ class MyPartitionedIOManager(IOManager):
 # end_partitioned_marker
 
 # start_df_marker
-from dagster import ConfigurableIOManager, io_manager
+from dagster import ConfigurableIOManager
 
 
 class DataframeTableIOManager(ConfigurableIOManager):

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
@@ -1,5 +1,5 @@
 # def_start_marker
-from typing import Dict, Union  # noqa: UP035
+from typing import Union
 
 from dagster import (
     DagsterTypeLoaderContext,

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict  # noqa: UP035
 
 import pandas as pd
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -1,13 +1,4 @@
-from dagster import (
-    ConfigurableIOManager,
-    InputContext,
-    IOManager,
-    Out,
-    OutputContext,
-    io_manager,
-    job,
-    op,
-)
+from dagster import ConfigurableIOManager, InputContext, Out, OutputContext, job, op
 
 
 def connect():

--- a/examples/docs_snippets/docs_snippets/concepts/metadata-tags/tags.py
+++ b/examples/docs_snippets/docs_snippets/concepts/metadata-tags/tags.py
@@ -1,4 +1,4 @@
-from dagster import asset, define_asset_job, graph, job, op, to_job
+from dagster import asset, define_asset_job, graph, job, op
 
 # start_asset_tags
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dynamic.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dynamic.py
@@ -162,7 +162,6 @@ def get_pages():
 
 # dyn_out_return_start
 from dagster import DynamicOut, DynamicOutput, op
-from typing import List  # noqa: UP035
 
 
 @op(out=DynamicOut())

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/fan_in_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/fan_in_job.py
@@ -1,6 +1,5 @@
 # start_marker
 
-from typing import List  # noqa: UP035
 
 from dagster import job, op
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/fan_in_graph.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/graphs/fan_in_graph.py
@@ -1,6 +1,5 @@
 # start_marker
 
-from typing import List  # noqa: UP035
 
 from dagster import graph, op
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/op_events.py
@@ -62,7 +62,6 @@ def my_metadata_output(context: OpExecutionContext) -> Output:
 
 # start_op_output_4
 from dagster import Output, op
-from typing import Tuple  # noqa: UP035
 
 
 # Using Output as type annotation without inner type

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
@@ -138,7 +138,6 @@ def return_annotation_op() -> int:
 # end_return_annotation
 # start_tuple_return
 from dagster import op
-from typing import Tuple  # noqa: UP035
 
 
 @op(out={"int_output": Out(), "str_output": Out()})
@@ -150,7 +149,6 @@ def my_multiple_output_annotation_op() -> tuple[int, str]:
 
 # start_single_output_tuple
 from dagster import op
-from typing import Tuple  # noqa: UP035
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -227,8 +227,6 @@ def test_op_with_resource():
 
 # end_test_op_resource_marker
 
-from dagster import resource
-
 
 # start_test_job_with_config
 from dagster import RunConfig

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
@@ -1,22 +1,10 @@
-from dagster import (
-    AssetSelection,
-    DailyPartitionsDefinition,
-    RunRequest,
-    SkipReason,
-    WeeklyPartitionsDefinition,
-    asset,
-    define_asset_job,
-    job,
-    multi_asset_sensor,
-)
+from dagster import RunRequest, SkipReason, asset, job
 
 
 @job
 def my_job():
     pass
 
-
-from typing import List  # noqa: UP035
 
 from dagster import Config
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -178,7 +178,6 @@ my_email_sensor(run_status_sensor_context)
 # end_run_status_sensor_testing_marker
 
 from dagster import SensorDefinition
-from typing import List  # noqa: UP035
 
 my_jobs: list[SensorDefinition] = []
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -6,7 +6,6 @@ from dagster import (
     DefaultSensorStatus,
     SkipReason,
     asset,
-    define_asset_job,
     JobSelector,
     CodeLocationSelector,
     DagsterRunStatus,

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -47,7 +47,7 @@ def new_resource_testing_with_nesting() -> None:
     test_my_resource_with_nesting()
 
 
-from typing import TYPE_CHECKING, Dict, Any  # noqa: UP035
+from typing import TYPE_CHECKING, Any
 
 
 def new_resources_assets_defs() -> "Definitions":
@@ -57,7 +57,7 @@ def new_resources_assets_defs() -> "Definitions":
     from dagster import ResourceParam
     import requests
 
-    from typing import Dict, Any  # noqa: UP035
+    from typing import Any
 
     @asset
     def data_from_url(data_url: ResourceParam[str]) -> dict[str, Any]:
@@ -740,10 +740,8 @@ def new_resource_on_sensor() -> None:
         ConfigurableResource,
         job,
         Definitions,
-        RunConfig,
     )
     import requests
-    from typing import List  # noqa: UP035
 
     class UsersAPI(ConfigurableResource):
         url: str
@@ -780,7 +778,7 @@ def new_resource_on_sensor() -> None:
 
     # start_test_resource_on_sensor
 
-    from dagster import build_sensor_context, validate_run_config
+    from dagster import build_sensor_context
 
     def test_process_new_users_sensor():
         class FakeUsersAPI:
@@ -802,11 +800,9 @@ def new_resource_on_schedule() -> None:
         ConfigurableResource,
         job,
         RunRequest,
-        RunConfig,
         Definitions,
     )
     from datetime import datetime
-    from typing import List  # noqa: UP035
 
     class DateFormatter(ConfigurableResource):
         format: str
@@ -837,7 +833,7 @@ def new_resource_on_schedule() -> None:
     # end_new_resource_on_schedule
     # start_test_resource_on_schedule
 
-    from dagster import build_schedule_context, validate_run_config
+    from dagster import build_schedule_context
 
     def test_process_data_schedule():
         context = build_schedule_context(

--- a/examples/docs_snippets/docs_snippets/docs_beta/guides/automation/simple-sensor-example.py
+++ b/examples/docs_snippets/docs_snippets/docs_beta/guides/automation/simple-sensor-example.py
@@ -1,5 +1,4 @@
 import random
-from typing import List  # noqa: UP035
 
 from dagster import (
     AssetExecutionContext,

--- a/examples/docs_snippets/docs_snippets/docs_beta/guides/data-assets/passing-data-assets/passing-data-rewrite-assets.py
+++ b/examples/docs_snippets/docs_snippets/docs_beta/guides/data-assets/passing-data-assets/passing-data-rewrite-assets.py
@@ -1,5 +1,3 @@
-from typing import List  # noqa: UP035
-
 from dagster import asset
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/s3_sensor.py
@@ -5,12 +5,10 @@ from dagster import (
     sensor,
     op,
     job,
-    build_sensor_context,
     RunRequest,
     SkipReason,
     OpExecutionContext,
 )
-import os
 
 
 @op(config_schema={"filename": str})

--- a/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/vanilla_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/automating_pipelines/vanilla_schedule.py
@@ -1,6 +1,5 @@
 # ruff: isort: skip_file
 
-from dagster import asset
 
 # vanilla_schedule_start
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/databricks/databricks_asset_client.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/databricks/databricks_asset_client.py
@@ -6,7 +6,7 @@ import sys
 
 from dagster_databricks import PipesDatabricksClient
 
-from dagster import AssetExecutionContext, Definitions, EnvVar, asset
+from dagster import AssetExecutionContext, Definitions, asset
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import jobs
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/ecs/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/ecs/dagster_code.py
@@ -1,10 +1,7 @@
 # start_asset_marker
-import os
 
 # dagster_glue_pipes.py
-import boto3
 from dagster_aws.pipes import PipesECSClient
-from docutils.nodes import entry
 
 from dagster import AssetExecutionContext, asset
 
@@ -25,7 +22,6 @@ def ecs_pipes_asset(context: AssetExecutionContext, pipes_ecs_client: PipesECSCl
 # start_definitions_marker
 
 from dagster import Definitions  # noqa
-from dagster_aws.pipes import PipesS3MessageReader
 
 
 defs = Definitions(

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/ecs/task.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/ecs/task.py
@@ -1,8 +1,4 @@
-from dagster_pipes import (
-    PipesEnvVarParamsLoader,
-    PipesS3ContextLoader,
-    open_dagster_pipes,
-)
+from dagster_pipes import open_dagster_pipes
 
 
 def main():

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-containers/dagster_code.py
@@ -35,7 +35,7 @@ def emr_containers_asset(
 
 # start_definitions_marker
 import boto3
-from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
+from dagster_aws.pipes import PipesS3MessageReader
 
 from dagster import Definitions
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-serverless/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr-serverless/dagster_code.py
@@ -1,7 +1,5 @@
 # start_asset_marker
-import os
 
-import boto3
 from dagster_aws.pipes import PipesEMRServerlessClient
 
 from dagster import AssetExecutionContext, asset

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/emr/dagster_code.py
@@ -3,7 +3,6 @@ import os
 
 import boto3
 from dagster_aws.pipes import PipesEMRClient, PipesS3MessageReader
-from mypy_boto3_emr.type_defs import InstanceFleetTypeDef
 
 from dagster import AssetExecutionContext, asset
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/gcp/dataproc_job/dagster_code.py
@@ -2,9 +2,7 @@
 # gcloud dataproc clusters create dagster --enable-component-gateway --bucket dagster-pipes --region us-central1 --subnet default --single-node --master-machine-type n2-standard-4 --master-boot-disk-type pd-balanced --master-boot-disk-size 100 --public-ip-address --image-version 2.2-debian12 --optional-components DOCKER --initialization-actions 'gs://dagster-pipes/init.sh' --metadata PEX_ENV_FILE_URI=gs://dagster-pipes/venv.pex --project dagster-infra
 
 # start_asset_marker
-import os
 
-import boto3
 from dagster_gcp.pipes import (
     PipesDataprocJobClient,
     PipesGCSContextInjector,

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import boto3

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_materialization/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_3_materialization/dagster_code.py
@@ -1,7 +1,6 @@
 import shutil
 
 from dagster import (
-    AssetCheckSpec,
     AssetExecutionContext,
     Definitions,
     PipesSubprocessClient,

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
@@ -4,7 +4,6 @@ from dagster import (
     AssetCheckExecutionContext,
     AssetCheckResult,
     Definitions,
-    MaterializeResult,
     PipesSubprocessClient,
     asset,
     asset_check,

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
@@ -1,6 +1,6 @@
 # start_resource
 # resources.py
-from typing import Any, Dict, Optional  # noqa: UP035
+from typing import Any, Optional
 
 import requests
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v2.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, Optional  # noqa: UP035
-
-from dagster import ConfigurableResource
+from typing import Any, Optional
 
 # start_mock
 # resources.py

--- a/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/managing_ml/managing_ml_code.py
@@ -17,7 +17,7 @@ def my_ml_model(my_data): ...
 
 ## lazy_materlization_start
 
-from dagster import AutoMaterializePolicy, asset, FreshnessPolicy
+from dagster import asset
 
 
 @asset
@@ -85,7 +85,6 @@ slack_token = "782823"
 
 ## fail_slack_start
 
-import os
 from dagster import define_asset_job
 from dagster_slack import make_slack_on_run_failure_sensor
 
@@ -118,10 +117,6 @@ def make_plot(eval_metric):
 
 ## ui_plot_end
 
-from docs_snippets.guides.dagster.ml_pipelines.ml_pipeline import (
-    transformed_test_data,
-    transformed_train_data,
-)
 
 ## metadata_use_start
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
@@ -97,7 +97,7 @@ def new_style_resource_on_context() -> Definitions:
 
 
 def new_style_resource_on_param() -> Definitions:
-    from dagster import ConfigurableResource, Definitions, OpExecutionContext, asset
+    from dagster import ConfigurableResource, Definitions, asset
 
     class FancyDbResource(ConfigurableResource):
         conn_string: str

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -1,9 +1,6 @@
 # ruff: isort: skip_file
 
 
-from typing import Dict, List  # noqa: UP035
-
-
 class Engine:
     def execute(self, query: str): ...
 
@@ -15,7 +12,7 @@ def get_engine(connection_url: str) -> Engine:
 def basic_resource_config() -> None:
     # start_basic_resource_config
 
-    from dagster import op, ConfigurableResource
+    from dagster import ConfigurableResource
 
     class MyDatabaseResource(ConfigurableResource):
         connection_url: str
@@ -115,7 +112,6 @@ def execute_with_config() -> None:
 def basic_data_structures_config() -> None:
     # start_basic_data_structures_config
     from dagster import Config, materialize, asset, RunConfig
-    from typing import List, Dict  # noqa: UP035
 
     class MyDataStructuresConfig(Config):
         user_names: list[str]
@@ -142,7 +138,6 @@ def basic_data_structures_config() -> None:
 def nested_schema_config() -> None:
     # start_nested_schema_config
     from dagster import asset, materialize, Config, RunConfig
-    from typing import Dict  # noqa: UP035
 
     class UserData(Config):
         age: int

--- a/examples/docs_snippets/docs_snippets/guides/migrations/migrating_airflow_to_dagster.py
+++ b/examples/docs_snippets/docs_snippets/guides/migrations/migrating_airflow_to_dagster.py
@@ -157,7 +157,6 @@ def scope_run_docker_image_with_airflow():
     from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
         KubernetesPodOperator,
     )
-    from pendulum import datetime
 
     with DAG(
         dag_id="example_kubernetes_dag", schedule_interval=None, catchup=False

--- a/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/airflow_dag.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/airflow_dag.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task

--- a/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/airflow_hook.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/airflow_hook.py
@@ -1,8 +1,6 @@
 # type: ignore
 # start_ex
-from datetime import datetime, timedelta
 
-from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 

--- a/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/scheduled_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift/equivalents/scheduled_asset.py
@@ -1,4 +1,4 @@
-from dagster import ScheduleDefinition, asset, define_asset_job
+from dagster import ScheduleDefinition, asset
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pandas_and_pyspark.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pandas_and_pyspark.py
@@ -14,7 +14,7 @@ def rose_data():
 # start_example
 
 from collections.abc import Sequence
-from typing import Optional, Type  # noqa: UP035
+from typing import Optional
 
 import pandas as pd
 from dagster_gcp import BigQueryIOManager

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
@@ -1,7 +1,7 @@
 from dagster_gcp_pyspark import BigQueryPySparkIOManager
 from dagster_pyspark import pyspark_resource
 from pyspark import SparkFiles
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import DataFrame
 from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, asset

--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,6 +1,5 @@
 from dagster import asset
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 
 
 # placeholder so that the test works. this isn't used in the docs

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -20,7 +20,7 @@ def scope_compile_dbt_manifest_with_dbt_project(manifest):
 
 
 def scope_schedule_assets_dbt_only(manifest):
-    from dagster import Config, RunConfig
+    from dagster import Config
 
     class MyDbtConfig(Config):
         full_refresh: bool
@@ -497,7 +497,6 @@ def scope_build_incremental_model():
 
 def scope_use_dbt_defer_with_dbt_project(manifest):
     # start_use_dbt_defer_with_dbt_project
-    import os
     from pathlib import Path
 
     from dagster import AssetExecutionContext

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/definitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/definitions.py
@@ -1,6 +1,5 @@
 # ruff: noqa: I001
 # start_defs
-import os
 
 from dagster import Definitions
 from dagster_dbt import DbtCliResource

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multiple_dataframe_types.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/multiple_dataframe_types.py
@@ -13,7 +13,7 @@ def rose_dataset():
 
 # start_example
 
-from typing import Optional, Type  # noqa: UP035
+from typing import Optional
 
 import pandas as pd
 from dagster_duckdb import DuckDBIOManager

--- a/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
+++ b/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
@@ -118,7 +118,6 @@ def scope_add_downstream_assets():
             load_assets_from_fivetran_instance,
         )
         from dagster import (
-            ScheduleDefinition,
             define_asset_job,
             asset,
             AssetIn,

--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/materialize-semantic-models-advanced.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/materialize-semantic-models-advanced.py
@@ -1,7 +1,6 @@
 from dagster_powerbi import (
     PowerBIServicePrincipal,
     PowerBIWorkspace,
-    build_semantic_model_refresh_asset_definition,
     load_powerbi_asset_specs,
 )
 

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/multi_partition.py
@@ -12,7 +12,6 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
-    MultiPartitionKey,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/pandas_and_pyspark.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/pandas_and_pyspark.py
@@ -13,7 +13,7 @@ def rose_dataset():
 
 # start_example
 
-from typing import Optional, Type  # noqa: UP035
+from typing import Optional
 
 import pandas as pd
 from dagster_snowflake import SnowflakeIOManager

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
@@ -1,12 +1,8 @@
-from datetime import datetime
-from importlib import resources
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from dagster_tests.cli_tests.command_tests.assets import fail_asset
 
-from dagster import Definitions
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from docs_snippets.concepts.assets.asset_checks.asset_with_check import (

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/io_management_tests/test_io_manager_per_output.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/io_management_tests/test_io_manager_per_output.py
@@ -1,5 +1,3 @@
-from dagster_aws_tests.conftest import mock_s3_bucket, mock_s3_resource
-
 from docs_snippets.concepts.io_management.io_manager_per_output import my_job
 
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/backfills_tests/test_single_run_backfill_io_manager.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/backfills_tests/test_single_run_backfill_io_manager.py
@@ -5,7 +5,6 @@ from dagster._core.storage.tags import (
 )
 from docs_snippets.concepts.partitions_schedules_sensors.backfills.single_run_backfill_io_manager import (
     MyIOManager,
-    daily_partition,
     events,
     raw_events,
 )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_dynamic_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_dynamic_partitioned_asset.py
@@ -2,11 +2,10 @@ import os
 import tempfile
 from unittest import mock
 
-from dagster import RunRequest, SensorResult, build_sensor_context, materialize
+from dagster import SensorResult, build_sensor_context
 from dagster._core.test_utils import instance_for_test
 from docs_snippets.concepts.partitions_schedules_sensors.dynamic_partitioned_asset import (
     image_sensor,
-    images,
 )
 
 DIR = "images"

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dagster import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 
-from dagster._core.definitions.run_config import RunConfig
 from dagster._core.errors import DagsterInvalidConfigError
 
 
@@ -31,8 +30,6 @@ def test_new_resources_assets_defs() -> None:
             return {"foo": "bar"}
 
     with mock.patch("requests.get", return_value=RequestsResponse()):
-        import requests
-
         defs = new_resources_assets_defs()
 
         res = defs.get_implicit_global_asset_job_def().execute_in_process()
@@ -50,8 +47,6 @@ def test_new_resources_configurable_defs() -> None:
             return {"foo": "bar"}
 
     with mock.patch("requests.get", return_value=RequestsResponse()):
-        import requests
-
         defs = new_resources_configurable_defs()
 
         res = defs.get_implicit_global_asset_job_def().execute_in_process()

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_pipes_tests/test_databricks.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_pipes_tests/test_databricks.py
@@ -2,12 +2,7 @@ import importlib.util
 import os
 import re
 
-import pytest
-from dagster_databricks._test_utils import (
-    databricks_client,
-    temp_dbfs_script,
-    upload_dagster_pipes_whl,
-)
+from dagster_databricks._test_utils import temp_dbfs_script
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 

--- a/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dbt.py
+++ b/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dbt.py
@@ -1,11 +1,7 @@
 import json
 from pathlib import Path
 
-from dagster_dbt import (
-    DbtCloudClientResource,
-    dbt_assets,
-    load_assets_from_dbt_cloud_job,
-)
+from dagster_dbt import DbtCloudClientResource, load_assets_from_dbt_cloud_job
 
 from dagster import asset
 from dagster._core.definitions import materialize

--- a/examples/docs_snippets/docs_snippets_tests/tutorial_tests/building_an_asset_graph/test_assets.py
+++ b/examples/docs_snippets/docs_snippets_tests/tutorial_tests/building_an_asset_graph/test_assets.py
@@ -6,7 +6,6 @@ import pandas as pd
 from dagster import build_asset_context
 from dagster._utils import pushd
 from docs_snippets.tutorial.building_an_asset_graph import (
-    asset_with_logger,
     assets_initial_state,
     assets_with_metadata,
 )

--- a/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
@@ -1,10 +1,6 @@
 from dagster import Definitions, EnvVar, asset
 from dagster._core.test_utils import environ
-from docs_snippets.tutorial.connecting import (
-    connecting,
-    connecting_with_config,
-    connecting_with_envvar,
-)
+from docs_snippets.tutorial.connecting import connecting
 from docs_snippets.tutorial.connecting.resources import DataGeneratorResource
 
 

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -10,12 +10,6 @@ line-length = 88
 
 # Use extend-ignore so that we ignore all the same codes ignored in root.
 extend-ignore = [
-
-  # (Unused import): When the same symbol is imported in multiple blocks, the
-  # last import takes precedence for python. This causes Ruff to think an
-  # import in an earlier block is unused and report F401.
-  "F401",
-
   # (Redefinition): This happens frequently in docs_snippets when we import the same symbol in multiple
   # snippets within the same file.
   "F811",


### PR DESCRIPTION
## Summary & Motivation

- Removes unused imports in `examples/docs_snippets`
- This does not impact any examples that use lineStart/lineEnd:

```
docs/guides/build/external-pipelines/using-dagster-pipes/create-subprocess-asset.md
21:<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_1/external_code.py" lineStart="3" />

docs/guides/build/external-pipelines/using-dagster-pipes/index.md
29:<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_1/external_code.py" lineStart="3" />

docs/guides/build/external-pipelines/using-dagster-pipes/modify-external-code.md
38:<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/part_2/step_1/external_code.py" lineStart="3" />

docs/guides/build/external-pipelines/using-dagster-pipes/reference.md
17:<CodeExample path="docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_extras_env/external_code.py" lineStart="3" />
```

## How I Tested These Changes

## Changelog

NOCHANGELOG
