### PR TITLE
sync deployment settings reference with the latest on concurrency

### DIFF
--- a/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
+++ b/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
@@ -38,7 +38,7 @@ sso_default_role: EDITOR
 
 For each deployment, you can configure settings for:
 
-- [Concurency](#concurrency-concurrency)
+- [Concurrency](#concurrency-concurrency)
 - [Run monitoring](#run-monitoring-run_monitoring)
 - [Run retries](#run-retries-run_retries)
 - [SSO default role](#sso-default-role)

--- a/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
+++ b/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
@@ -12,12 +12,16 @@ Refer to the [Managing deployments in Dagster+ guide](managing-deployments) for 
 Settings are formatted using YAML. For example:
 
 ```yaml
-run_queue:
-  max_concurrent_runs: 10
-  tag_concurrency_limits:
-    - key: "database"
-      value: "redshift"
-      limit: 5
+concurrency:
+  pools:
+    granularity: "run"
+    default_limit: 1
+  runs:
+    max_concurrent_runs: 10
+    tag_concurrency_limits:
+      - key: "database"
+        value: "redshift"
+        limit: 5
 
 run_monitoring:
   start_timeout_seconds: 1200
@@ -34,29 +38,36 @@ sso_default_role: EDITOR
 
 For each deployment, you can configure settings for:
 
-- [Run queue](#run-queue-run_queue)
+- [Concurency](#concurrency-concurrency)
 - [Run monitoring](#run-monitoring-run_monitoring)
 - [Run retries](#run-retries-run_retries)
 - [SSO default role](#sso-default-role)
 - [Non-isolated runs](#non-isolated-runs)
 
-### Run queue (run_queue)
+### Concurrency (concurrency)
 
-The `run_queue` settings allow you to specify how many runs can execute concurrently in the deployment.
+The `concurrency` settings allow you to specify concurrency controls for runs and pools in the deployment. Refer to the [Managing concurrency guide](../../../../guides/operate/managing-concurrency.md) for more information about concurrency.
 
 ```yaml
-run_queue:
-  max_concurrent_runs: 10
-  tag_concurrency_limits:
-    - key: "database"
-      value: "redshift"
-      limit: 5
+concurrency:
+  pools:
+    granularity: "run"
+    default_limit: 1
+  runs:
+    max_concurrent_runs: 10
+    tag_concurrency_limits:
+      - key: "database"
+        value: "redshift"
+        limit: 5
 ```
 
 | Property | Description |
 | --- | --- |
-| run_queue.max_concurrent_runs | The maximum number of runs that are allowed to be in progress at once. Set to 0 to stop any runs from launching. Negative values aren't permitted. <ul><li>**Default** - `10` (20 minutes)</li><li>**Maximum** - `500` ([Hybrid](/dagster-plus/deployment/deployment-types/hybrid/)), `50` ([Serverless](/dagster-plus/deployment/deployment-types/serverless/))</li></ul> |
-| run_queue.tag_concurrency_limits | A list of limits applied to runs with particular tags. <ul><li>**Defaults** - `[]`</li></ul> Each list item may have the following properties: <ul><li>`key`</li><li>`value`</li><ul><li>If defined, the `limit` is applied only to the `key-value` pair.</li><li>If set to a dict with applyLimitPerUniqueValue: true, the `limit` is applied to the number of unique values for the `key`.</li><li>If set to a dict with `applyLimitPerUniqueValue: true`, the limit is applied to the number of unique values for the `key`.</li></ul><li>`limit`</li></ul> |
+| concurrency.pools.default_limit | The default limit for pools that do not have an explicitly set limit. |
+| concurrency.pools.granularity | The granularity at which pool limits are applied. Can be one of `op` or `run`.<ul><li>**Defaults** - `op`</li></ul> If set to `run`, the pool limit caps the number of runs that can be in progress that contain an op marked with the given pool.  If set to `op`, the pool limit caps the number of ops that can be in progress across all runs.|
+| concurrency.pools.op_granularity_run_buffer | The number of runs over the available pool limit that can be in progress when the pool granularity is set to `op`. Even though the pool granularity is set to `op`, runs are only dequeued if there is at least one op in the run that will not be blocked by a pool limit, to limit the number of active run workers. |
+| concurrency.runs.max_concurrent_runs | The maximum number of runs that are allowed to be in progress at once. Set to 0 to stop any runs from launching. Negative values aren't permitted. <ul><li>**Default** - `10` (20 minutes)</li><li>**Maximum** - `500` ([Hybrid](/dagster-plus/deployment/deployment-types/hybrid/)), `50` ([Serverless](/dagster-plus/deployment/deployment-types/serverless/))</li></ul> |
+| concurrency.runs.tag_concurrency_limits | A list of limits applied to runs with particular tags. <ul><li>**Defaults** - `[]`</li></ul> Each list item may have the following properties: <ul><li>`key`</li><li>`value`</li><ul><li>If defined, the `limit` is applied only to the `key-value` pair.</li><li>If set to a dict with applyLimitPerUniqueValue: true, the `limit` is applied to the number of unique values for the `key`.</li><li>If set to a dict with `applyLimitPerUniqueValue: true`, the limit is applied to the number of unique values for the `key`.</li></ul><li>`limit`</li></ul> |
 
 ### Run monitoring (run_monitoring)
 

--- a/docs/docs/dagster-plus/deployment/management/deployments/managing-deployments.md
+++ b/docs/docs/dagster-plus/deployment/management/deployments/managing-deployments.md
@@ -103,11 +103,16 @@ Create a file with the settings you'd like to configure. For example:
 ```yaml
 # my-settings.yaml
 
-run_queue:
-  max_concurrent_runs: 10
-  tag_concurrency_limits:
-    - key: "special-runs"
-      limit: 5
+concurrency:
+  pools:
+    granularity: "run"
+    default_limit: 1
+  runs:
+    max_concurrent_runs: 10
+    tag_concurrency_limits:
+      - key: "database"
+        value: "redshift"
+        limit: 5
 
 run_monitoring:
   start_timeout_seconds: 1200

--- a/docs/docs/guides/deploy/execution/customizing-run-queue-priority.md
+++ b/docs/docs/guides/deploy/execution/customizing-run-queue-priority.md
@@ -3,11 +3,11 @@ title: "Customizing run queue priority"
 sidebar_position: 400
 ---
 
-When using a [run coordinator](run-coordinators), you can define custom prioritization rules for your Dagster instance.
+You can define custom prioritization rules for your Dagster instance using concurrency settings.
 
 By the end of this guide, you’ll:
 
-- Understand how the run queue works
+- Understand how run concurrency works
 - Learn how to define custom prioritization rules
 - Understand how prioritization rules and concurrency limits work together
 
@@ -21,7 +21,7 @@ For example, if three runs are submitted in the following order:
 2. Run `B`
 3. Run `C`
 
-Then the runs will be launched in the same order: Run `A`, then `B`, then `C`. This will be true unless there are [tag concurrency limits](/guides/operate/managing-concurrency) or prioritization rules in place, which we’ll cover later in this guide.
+Then the runs will be launched in the same order: Run `A`, then `B`, then `C`. This will be true unless there are [pool or run tag concurrency limits](/guides/operate/managing-concurrency) in place.  The launch order can also be customized using prioritization rules, which we’ll cover later in this guide.
 
 By default, all runs have a priority of `0`. Dagster launches runs with higher priority first. If multiple runs have the same priority, Dagster will launch the runs in the order they're submitted to the queue.
 
@@ -72,9 +72,12 @@ Without configured limits, these runs will be launched in the order they were su
 Before any more runs are launched, let’s add the following configuration to our instance’s settings:
 
 ```yaml
-tag_concurrency_limits:
-  - key: "team"
-    limit: 1
+concurrency:
+  runs:
+    tag_concurrency_limits:
+      - key: "team"
+        limit: 1
+
 ```
 
 Now, runs `A` and `B` can’t execute concurrently, while there isn’t a limit on run `C`. Assuming each run executes for a minimum of five minutes, the order in which the runs are launched will change.

--- a/docs/docs/guides/operate/managing-concurrency.md
+++ b/docs/docs/guides/operate/managing-concurrency.md
@@ -122,7 +122,7 @@ When limiting concurrency, you might run into some issues until you get the conf
 This only applies to Dagster Open Source.
 :::
 
-The `run_queue` key may not be set in your instance's settings. In the Dagster UI, navigate to **Deployment > Configuration** and verify that the `run_queue` key is set.
+If you are running a version older than `1.10.0`, you may need to manually configure your deployment to enable run queueing by setting the `run_queue` key in your instance's settings. In the Dagster UI, navigate to **Deployment > Configuration** and verify that the `run_queue` key is set.
 
 ### Runs remaining in QUEUED status
 


### PR DESCRIPTION
## Summary & Motivation
The `run_queue` is now superseded by `concurrency` in our deployment settings

## How I Tested These Changes
Inspection

## Changelog
- [docs] Changed our Dagster+ deployment settings reference to match the new concurrency config
