### PR TITLE
Revert asset backfill subset changes

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -273,7 +273,8 @@ def _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_
     updated_backfill = backfill.with_asset_backfill_data(
         result.backfill_data.with_run_requests_submitted(
             result.run_requests,
-            asset_graph_view=asset_graph_view,
+            asset_graph=graphql_context.asset_graph,
+            instance_queryer=asset_graph_view.get_inner_queryer_for_back_compat(),
         ),
         dynamic_partitions_store=graphql_context.instance,
         asset_graph=graphql_context.asset_graph,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,9 +10,9 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
@@ -34,6 +34,7 @@ from dagster._core.test_utils import create_run_for_test, environ
 from dagster._core.utils import make_new_backfill_id
 from dagster._seven import get_system_temp_directory
 from dagster._utils import safe_tempfile_path
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from dagster_graphql.client.query import (
     LAUNCH_PARTITION_BACKFILL_MUTATION,
     LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -240,25 +241,27 @@ def _get_run_stats(partition_statuses):
     }
 
 
-def _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id: str) -> None:
+def _execute_asset_backfill_iteration_no_side_effects(
+    graphql_context, backfill_id: str, asset_graph: RemoteWorkspaceAssetGraph
+) -> None:
     """Executes an asset backfill iteration and updates the serialized asset backfill data.
     However, does not execute side effects i.e. launching runs.
     """
     backfill = graphql_context.instance.get_backfill(backfill_id)
     asset_backfill_data = backfill.asset_backfill_data
     result = None
-    asset_graph_view = AssetGraphView(
-        temporal_context=TemporalContext(
-            effective_dt=asset_backfill_data.backfill_start_datetime, last_event_id=None
-        ),
-        instance=graphql_context.instance,
-        asset_graph=graphql_context.asset_graph,
+    instance_queryer = CachingInstanceQueryer(
+        graphql_context.instance,
+        asset_graph,
+        graphql_context,
+        asset_backfill_data.backfill_start_datetime,
     )
     with environ({"ASSET_BACKFILL_CURSOR_DELAY_TIME": "0"}):
         for result in execute_asset_backfill_iteration_inner(
             backfill_id=backfill_id,
             asset_backfill_data=asset_backfill_data,
-            asset_graph_view=asset_graph_view,
+            instance_queryer=instance_queryer,
+            asset_graph=asset_graph,
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
         ):
@@ -272,12 +275,10 @@ def _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_
 
     updated_backfill = backfill.with_asset_backfill_data(
         result.backfill_data.with_run_requests_submitted(
-            result.run_requests,
-            asset_graph=graphql_context.asset_graph,
-            instance_queryer=asset_graph_view.get_inner_queryer_for_back_compat(),
+            result.run_requests, asset_graph=asset_graph, instance_queryer=instance_queryer
         ),
         dynamic_partitions_store=graphql_context.instance,
-        asset_graph=graphql_context.asset_graph,
+        asset_graph=asset_graph,
     )
     graphql_context.instance.update_backfill(updated_backfill)
 
@@ -311,11 +312,12 @@ def _execute_job_backfill_iteration_with_side_effects(graphql_context, backfill_
 def _mock_asset_backfill_runs(
     graphql_context,
     asset_key: AssetKey,
+    asset_graph: RemoteWorkspaceAssetGraph,
     backfill_id: str,
     status: DagsterRunStatus,
     partition_key: Optional[str],
 ):
-    partitions_def = graphql_context.asset_graph.get(asset_key).partitions_def
+    partitions_def = asset_graph.get(asset_key).partitions_def
 
     @asset(
         partitions_def=partitions_def,
@@ -749,7 +751,10 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
         # Update asset backfill data to contain requested partition, but does not execute side effects,
         # since launching the run will cause test process will hang forever.
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # Launch the run that runs forever
         selector = infer_job_selector(graphql_context, "hanging_partition_asset_job")
@@ -825,8 +830,10 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
         # Update asset backfill data to contain requested partition, but does not execute side effects,
         # since launching the run will cause test process will hang forever.
-
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # Launch the run that runs forever
         selector = infer_job_selector(graphql_context, "hanging_partition_asset_job")
@@ -1137,7 +1144,11 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         for partition, status in [
             ("a", DagsterRunStatus.SUCCESS),
@@ -1146,9 +1157,11 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             ("e", DagsterRunStatus.SUCCESS),
             ("f", DagsterRunStatus.FAILURE),
         ]:
-            _mock_asset_backfill_runs(graphql_context, asset_key, backfill_id, status, partition)
+            _mock_asset_backfill_runs(
+                graphql_context, asset_key, asset_graph, backfill_id, status, partition
+            )
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -1174,6 +1187,10 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert asset_partition_status_counts[0]["numPartitionsFailed"] == 2
 
     def test_asset_backfill_status_with_upstream_failure(self, graphql_context):
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),
             AssetKey("upstream_daily_partitioned_asset"),
@@ -1196,23 +1213,25 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("unpartitioned_upstream_of_partitioned"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             None,
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.FAILURE,
             "2023-01-09",
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -1639,6 +1658,10 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 10
 
     def test_reexecute_asset_backfill_from_failure(self, graphql_context):
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),
             AssetKey("upstream_daily_partitioned_asset"),
@@ -1661,23 +1684,25 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("unpartitioned_upstream_of_partitioned"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             None,
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.FAILURE,
             "2023-01-09",
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # mark backfill as completed so we can retry it
         backfill = graphql_context.instance.get_backfill(backfill_id)
@@ -1730,6 +1755,10 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_reexecute_successful_asset_backfill(self, graphql_context):
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),
             AssetKey("upstream_daily_partitioned_asset"),
@@ -1751,23 +1780,25 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("unpartitioned_upstream_of_partitioned"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             None,
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             "2023-01-09",
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # mark backfill as complete so we can retry it
         backfill = graphql_context.instance.get_backfill(backfill_id)
@@ -1811,6 +1842,10 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_reexecute_asset_backfill_still_in_progress(self, graphql_context):
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),
             AssetKey("upstream_daily_partitioned_asset"),
@@ -1833,23 +1868,25 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("unpartitioned_upstream_of_partitioned"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             None,
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.FAILURE,
             "2023-01-09",
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # try to retry the backfill while it is still in progress
         result = execute_dagster_graphql(
@@ -1929,6 +1966,10 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_reexecute_asset_backfill_twice(self, graphql_context):
+        code_location = graphql_context.get_code_location(main_repo_location_name())
+        repository = code_location.get_repository("test_repo")
+        asset_graph = repository.asset_graph
+
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),
             AssetKey("upstream_daily_partitioned_asset"),
@@ -1951,23 +1992,25 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("unpartitioned_upstream_of_partitioned"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.SUCCESS,
             None,
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             backfill_id,
             DagsterRunStatus.FAILURE,
             "2023-01-09",
         )
-        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id)
+        _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # mark backfill as completed so we can retry it
         backfill = graphql_context.instance.get_backfill(backfill_id)
@@ -1997,18 +2040,19 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
         _execute_asset_backfill_iteration_no_side_effects(
-            graphql_context, retried_backfill.backfill_id
+            graphql_context, retried_backfill.backfill_id, asset_graph
         )
         # mark some partitions failed so we can retry again
         _mock_asset_backfill_runs(
             graphql_context,
             AssetKey("upstream_daily_partitioned_asset"),
+            asset_graph,
             retried_backfill.backfill_id,
             DagsterRunStatus.FAILURE,
             "2023-01-09",
         )
         _execute_asset_backfill_iteration_no_side_effects(
-            graphql_context, retried_backfill.backfill_id
+            graphql_context, retried_backfill.backfill_id, asset_graph
         )
 
         # refetch the backfill to get the updated statuses of all assets

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     )
     from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.partition import PartitionsDefinition
-    from dagster._core.definitions.partition_key_range import PartitionKeyRange
     from dagster._core.instance import DagsterInstance
     from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
     from dagster._core.storage.dagster_run import RunRecord
@@ -193,20 +192,6 @@ class AssetGraphView(LoadingContext):
         partitions_def = self._get_partitions_def(key)
         value = partitions_def.empty_subset() if partitions_def else False
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
-
-    def get_entity_subset_in_range(
-        self, asset_key: AssetKey, partition_key_range: "PartitionKeyRange"
-    ) -> EntitySubset[AssetKey]:
-        partitions_def = check.not_none(
-            self._get_partitions_def(asset_key), "Must have partitions def"
-        )
-        partition_subset_in_range = partitions_def.get_subset_in_range(
-            partition_key_range=partition_key_range,
-            dynamic_partitions_store=self._queryer,
-        )
-        return EntitySubset(
-            self, key=asset_key, value=_ValidatedEntitySubsetValue(partition_subset_in_range)
-        )
 
     def get_entity_subset_from_asset_graph_subset(
         self, asset_graph_subset: AssetGraphSubset, key: AssetKey

--- a/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/bfs.py
@@ -58,7 +58,7 @@ def bfs_filter_asset_graph_view(
 
     visited_graph_subset = initial_asset_graph_subset
 
-    result: AssetGraphSubset = AssetGraphSubset.create_empty_subset()
+    result: AssetGraphSubset = AssetGraphSubset.empty()
     failed_reasons: Sequence[tuple[AssetGraphSubset, str]] = []
 
     asset_graph = asset_graph_view.asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -61,10 +61,6 @@ class AssetGraphSubset(NamedTuple):
             len(subset) for subset in self.partitions_subsets_by_asset_key.values()
         )
 
-    @property
-    def is_empty(self) -> bool:
-        return len(self.asset_keys) == 0
-
     def get_asset_subset(
         self, asset_key: AssetKey, asset_graph: BaseAssetGraph
     ) -> SerializableEntitySubset[AssetKey]:
@@ -275,7 +271,7 @@ class AssetGraphSubset(NamedTuple):
         )
 
     @classmethod
-    def create_empty_subset(cls) -> "AssetGraphSubset":
+    def empty(cls) -> "AssetGraphSubset":
         return AssetGraphSubset({}, set())
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
-from functools import cached_property
+from functools import cached_property, total_ordering
+from heapq import heapify, heappop, heappush
 from typing import (  # noqa: UP035
     TYPE_CHECKING,
     AbstractSet,
@@ -751,6 +752,67 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
 
         return result
 
+    def bfs_filter_asset_partitions(
+        self,
+        dynamic_partitions_store: DynamicPartitionsStore,
+        condition_fn: Callable[
+            [Iterable[AssetKeyPartitionKey], AbstractSet[AssetKeyPartitionKey]],
+            tuple[bool, str],
+        ],
+        initial_asset_partitions: Iterable[AssetKeyPartitionKey],
+        evaluation_time: datetime,
+    ) -> tuple[
+        AbstractSet[AssetKeyPartitionKey],
+        Sequence[tuple[Iterable[AssetKeyPartitionKey], str]],
+    ]:
+        """Returns asset partitions within the graph that satisfy supplied criteria.
+
+        - Are >= initial_asset_partitions
+        - Match the condition_fn
+        - Any of their ancestors >= initial_asset_partitions match the condition_fn
+
+        Also returns a list of tuples, where each tuple is a candidated_unit (list of
+        AssetKeyPartitionKeys that must be materialized together - ie multi_asset) that do not
+        satisfy the criteria and the reason they were filtered out.
+
+        The condition_fn should return a tuple of a boolean indicating whether the asset partition meets
+        the condition and a string explaining why it does not meet the condition, if applicable.
+
+        Visits parents before children.
+
+        When asset partitions are part of the same execution set (non-subsettable multi-asset),
+        they're provided all at once to the condition_fn.
+        """
+        all_nodes = set(initial_asset_partitions)
+
+        # invariant: we never consider an asset partition before considering its ancestors
+        queue = ToposortedPriorityQueue(self, all_nodes, include_full_execution_set=True)
+
+        result: set[AssetKeyPartitionKey] = set()
+        failed_reasons: list[tuple[Iterable[AssetKeyPartitionKey], str]] = []
+
+        while len(queue) > 0:
+            candidates_unit = queue.dequeue()
+
+            meets_condition, fail_reason = condition_fn(candidates_unit, result)
+            if meets_condition:
+                result.update(candidates_unit)
+
+                for candidate in candidates_unit:
+                    for child in self.get_children_partitions(
+                        dynamic_partitions_store,
+                        evaluation_time,
+                        candidate.asset_key,
+                        candidate.partition_key,
+                    ):
+                        if child not in all_nodes:
+                            queue.enqueue(child)
+                            all_nodes.add(child)
+            else:
+                failed_reasons.append((candidates_unit, fail_reason))
+
+        return result, failed_reasons
+
     def split_entity_keys_by_repository(
         self, keys: AbstractSet[EntityKey]
     ) -> Sequence[AbstractSet[EntityKey]]:
@@ -790,3 +852,80 @@ def sort_key_for_asset_partition(
         # sort non-self dependencies from newest to oldest, as newer partitions are more relevant
         # than older ones
         return -1 * partition_timestamp
+
+
+class ToposortedPriorityQueue:
+    """Queue that returns parents before their children."""
+
+    @total_ordering
+    class QueueItem(NamedTuple):
+        level: int
+        partition_sort_key: Optional[float]
+        asset_partitions: Iterable[AssetKeyPartitionKey]
+
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, ToposortedPriorityQueue.QueueItem):
+                return (
+                    self.level == other.level
+                    and self.partition_sort_key == other.partition_sort_key
+                )
+            return False
+
+        def __lt__(self, other: object) -> bool:
+            if isinstance(other, ToposortedPriorityQueue.QueueItem):
+                return self.level < other.level or (
+                    self.level == other.level
+                    and self.partition_sort_key is not None
+                    and other.partition_sort_key is not None
+                    and self.partition_sort_key < other.partition_sort_key
+                )
+            raise TypeError()
+
+    def __init__(
+        self,
+        asset_graph: BaseAssetGraph,
+        items: Iterable[AssetKeyPartitionKey],
+        include_full_execution_set: bool,
+    ):
+        self._asset_graph = asset_graph
+        self._include_full_execution_set = include_full_execution_set
+
+        self._toposort_level_by_asset_key = {
+            asset_key: i
+            for i, asset_keys in enumerate(asset_graph.toposorted_asset_keys_by_level)
+            for asset_key in asset_keys
+        }
+        self._heap = [self._queue_item(asset_partition) for asset_partition in items]
+        heapify(self._heap)
+
+    def enqueue(self, asset_partition: AssetKeyPartitionKey) -> None:
+        heappush(self._heap, self._queue_item(asset_partition))
+
+    def dequeue(self) -> Iterable[AssetKeyPartitionKey]:
+        # For multi-assets, will include all required multi-asset keys if
+        # include_full_execution_set is set to True, or a list of size 1 with just the passed in
+        # asset key if it was not.
+        return heappop(self._heap).asset_partitions
+
+    def _queue_item(
+        self, asset_partition: AssetKeyPartitionKey
+    ) -> "ToposortedPriorityQueue.QueueItem":
+        asset_key = asset_partition.asset_key
+
+        if self._include_full_execution_set:
+            execution_set_keys = self._asset_graph.get(asset_key).execution_set_asset_keys
+        else:
+            execution_set_keys = {asset_key}
+
+        level = max(
+            self._toposort_level_by_asset_key[asset_key] for asset_key in execution_set_keys
+        )
+
+        return ToposortedPriorityQueue.QueueItem(
+            level,
+            sort_key_for_asset_partition(self._asset_graph, asset_partition),
+            [AssetKeyPartitionKey(ak, asset_partition.partition_key) for ak in execution_set_keys],
+        )
+
+    def __len__(self) -> int:
+        return len(self._heap)

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -167,17 +167,6 @@ class PartitionsDefinition(ABC, Generic[T_str]):
         partition_keys = self.get_partition_keys(current_time, dynamic_partitions_store)
         return partition_keys[0] if partition_keys else None
 
-    def get_subset_in_range(
-        self,
-        partition_key_range: PartitionKeyRange,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> "PartitionsSubset":
-        return self.empty_subset().with_partition_key_range(
-            partitions_def=self,
-            partition_key_range=partition_key_range,
-            dynamic_partitions_store=dynamic_partitions_store,
-        )
-
     def get_partition_keys_in_range(
         self,
         partition_key_range: PartitionKeyRange,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -659,7 +659,7 @@ def _get_requested_asset_graph_subset_from_run_requests(
     asset_graph_view: AssetGraphView,
 ) -> AssetGraphSubset:
     asset_graph = asset_graph_view.asset_graph
-    requested_subset = AssetGraphSubset.create_empty_subset()
+    requested_subset = AssetGraphSubset.empty()
     for run_request in run_requests:
         # Run request targets a range of partitions
         range_start = run_request.tags.get(ASSET_PARTITION_RANGE_START_TAG)
@@ -1492,7 +1492,7 @@ def execute_asset_backfill_iteration_inner(
         )
         logger.info(
             f"Assets materialized since last tick:\n{_asset_graph_subset_to_str(materialized_since_last_tick, asset_graph)}"
-            if not materialized_since_last_tick.is_empty
+            if not materialized_since_last_tick.empty
             else "No relevant assets materialized since last tick."
         )
 
@@ -1538,7 +1538,7 @@ def execute_asset_backfill_iteration_inner(
 
     logger.info(
         f"Asset partitions to request:\n{_asset_graph_subset_to_str(asset_subset_to_request, asset_graph)}"
-        if not asset_subset_to_request.is_empty
+        if not asset_subset_to_request.empty
         else "No asset partitions to request."
     )
 
@@ -1992,7 +1992,7 @@ def _get_failed_asset_graph_subset(
         )
     )
 
-    result: AssetGraphSubset = AssetGraphSubset.create_empty_subset()
+    result: AssetGraphSubset = AssetGraphSubset.empty()
     for run in runs:
         planned_asset_keys = instance_queryer.get_planned_materializations_for_run(
             run_id=run.run_id

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -3,22 +3,13 @@ import logging
 import os
 import sys
 import time
+from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional, Union, cast  # noqa: UP035
 
 import dagster._check as check
-from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
-from dagster._core.asset_graph_view.bfs import (
-    AssetGraphViewBfsFilterConditionResult,
-    bfs_filter_asset_graph_view,
-)
-from dagster._core.asset_graph_view.entity_subset import EntitySubset
-from dagster._core.asset_graph_view.serializable_entity_subset import (
-    EntitySubsetValue,
-    SerializableEntitySubset,
-)
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import KeysAssetSelection
 from dagster._core.definitions.automation_tick_evaluation_context import (
@@ -1009,17 +1000,12 @@ def execute_asset_backfill_iteration(
         check.failed("Backfill must be an asset backfill")
 
     backfill_start_datetime = datetime_from_timestamp(backfill.backfill_timestamp)
-
-    asset_graph_view = AssetGraphView(
-        temporal_context=TemporalContext(
-            effective_dt=backfill_start_datetime,
-            last_event_id=None,
-        ),
+    instance_queryer = CachingInstanceQueryer(
         instance=instance,
         asset_graph=asset_graph,
+        loading_context=workspace_context,
+        evaluation_time=backfill_start_datetime,
     )
-
-    instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
 
     previous_asset_backfill_data = _check_validity_and_deserialize_asset_backfill_data(
         workspace_context, backfill, asset_graph, instance_queryer, logger
@@ -1052,7 +1038,8 @@ def execute_asset_backfill_iteration(
             for result in execute_asset_backfill_iteration_inner(
                 backfill_id=backfill.backfill_id,
                 asset_backfill_data=previous_asset_backfill_data,
-                asset_graph_view=asset_graph_view,
+                instance_queryer=instance_queryer,
+                asset_graph=asset_graph,
                 backfill_start_timestamp=backfill.backfill_timestamp,
                 logger=logger,
             ):
@@ -1253,7 +1240,6 @@ def get_canceling_asset_backfill_iteration_data(
             " AssetGraphSubset object"
         )
 
-    # TODO: Make this use subsets throughout instead of a sequence of AssetKeyPartitionKeys
     failed_subset = AssetGraphSubset.from_asset_partition_set(
         set(
             _get_failed_asset_partitions(
@@ -1334,66 +1320,31 @@ def get_asset_backfill_iteration_materialized_partitions(
     yield updated_materialized_subset
 
 
-def _get_subset_in_target_subset(
-    asset_graph_view: AssetGraphView,
-    candidate_asset_graph_subset: AssetGraphSubset,
-    target_subset: AssetGraphSubset,
-) -> "AssetGraphSubset":
-    candidate_entity_subsets = list(
-        asset_graph_view.iterate_asset_subsets(candidate_asset_graph_subset)
-    )
-
-    assert (
-        len(candidate_entity_subsets) == 1
-    ), "Since include_execution_set=False, there should be exactly one candidate entity subset"
-
-    candidate_entity_subset = next(iter(candidate_entity_subsets))
-
-    subset_in_target_subset: EntitySubset[AssetKey] = candidate_entity_subset.compute_intersection(
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(
-            target_subset, candidate_entity_subset.key
-        )
-    )
-
-    return AssetGraphSubset.from_entity_subsets([subset_in_target_subset])
-
-
 def _get_failed_and_downstream_asset_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph_view: AssetGraphView,
+    asset_graph: RemoteWorkspaceAssetGraph,
+    instance_queryer: CachingInstanceQueryer,
+    backfill_start_timestamp: float,
     materialized_subset: AssetGraphSubset,
 ) -> AssetGraphSubset:
-    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
-
-    failed_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
-        set(
+    failed_and_downstream_subset = AssetGraphSubset.from_asset_partition_set(
+        asset_graph.bfs_filter_asset_partitions(
+            instance_queryer,
+            lambda asset_partitions, _: (
+                any(
+                    asset_partition in asset_backfill_data.target_subset
+                    for asset_partition in asset_partitions
+                ),
+                "",
+            ),
             _get_failed_asset_partitions(
-                asset_graph_view.get_inner_queryer_for_back_compat(),
-                backfill_id,
-                asset_graph,
-                materialized_subset,
-            )
-        ),
+                instance_queryer, backfill_id, asset_graph, materialized_subset
+            ),
+            evaluation_time=datetime_from_timestamp(backfill_start_timestamp),
+        )[0],
         asset_graph,
     )
-
-    failed_and_downstream_subset = bfs_filter_asset_graph_view(
-        asset_graph_view,
-        lambda candidate_asset_graph_subset, _: (
-            AssetGraphViewBfsFilterConditionResult(
-                passed_asset_graph_subset=_get_subset_in_target_subset(
-                    asset_graph_view,
-                    candidate_asset_graph_subset,
-                    asset_backfill_data.target_subset,
-                ),
-                excluded_asset_graph_subsets_and_reasons=[],
-            )
-        ),
-        initial_asset_graph_subset=failed_asset_graph_subset,
-        include_full_execution_set=False,
-    )[0]
-
     return failed_and_downstream_subset
 
 
@@ -1418,21 +1369,10 @@ def _partition_subset_str(
     if isinstance(partition_subset, TimeWindowPartitionsSubset) and isinstance(
         partitions_def, TimeWindowPartitionsDefinition
     ):
-        time_window_strs = []
-        for time_window in partition_subset.included_time_windows:
-            partition_key_range = partitions_def.get_partition_key_range_for_time_window(
-                time_window.to_public_time_window(), respect_bounds=False
-            )
-            num_partitions = partitions_def.get_num_partitions_in_window(
-                time_window.to_public_time_window()
-            )
-            if num_partitions == 1:
-                time_window_strs.append(f"1 partition: {partition_key_range.start}")
-            else:
-                time_window_strs.append(
-                    f"{num_partitions} partitions: {partition_key_range.start} -> {partition_key_range.end}"
-                )
-        return ", ".join(time_window_strs)
+        return ", ".join(
+            f"{partitions_def.get_num_partitions_in_window(time_window.to_public_time_window())} partitions: {time_window.start} -> {time_window.end}"
+            for time_window in partition_subset.included_time_windows
+        )
 
     return ", ".join(partition_subset.get_partition_keys())
 
@@ -1441,24 +1381,24 @@ def _asset_graph_subset_to_str(
     asset_graph_subset: AssetGraphSubset,
     asset_graph: BaseAssetGraph,
 ) -> str:
-    return_strs = []
+    return_str = ""
     asset_subsets = asset_graph_subset.iterate_asset_subsets(asset_graph)
-
     for subset in asset_subsets:
         if subset.is_partitioned:
             partitions_def = asset_graph.get(subset.key).partitions_def
             partition_ranges_str = _partition_subset_str(subset.subset_value, partitions_def)
-            return_strs.append(f"- {subset.key.to_user_string()}: {{{partition_ranges_str}}}")
+            return_str += f"- {subset.key.to_user_string()}: {{{partition_ranges_str}}}\n"
         else:
-            return_strs.append(f"- {subset.key.to_user_string()}")
+            return_str += f"- {subset.key.to_user_string()}\n"
 
-    return "\n".join(return_strs)
+    return return_str
 
 
 def execute_asset_backfill_iteration_inner(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph_view: AssetGraphView,
+    asset_graph: RemoteWorkspaceAssetGraph,
+    instance_queryer: CachingInstanceQueryer,
     backfill_start_timestamp: float,
     logger: logging.Logger,
 ) -> Iterable[Optional[AssetBackfillIterationResult]]:
@@ -1470,11 +1410,6 @@ def execute_asset_backfill_iteration_inner(
     This is a generator so that we can return control to the daemon and let it heartbeat during
     expensive operations.
     """
-    instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
-    asset_graph: RemoteWorkspaceAssetGraph = cast(
-        RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph
-    )
-
     initial_candidates: set[AssetKeyPartitionKey] = set()
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
     if request_roots:
@@ -1484,7 +1419,7 @@ def execute_asset_backfill_iteration_inner(
         target_roots = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
         initial_candidates.update(target_roots)
         logger.info(
-            f"Root assets that have not yet been requested:\n{_asset_graph_subset_to_str(AssetGraphSubset.from_asset_partition_set(set(target_roots), asset_graph), asset_graph)}"
+            f"Root assets that have not yet been requested:\n {_asset_graph_subset_to_str(AssetGraphSubset.from_asset_partition_set(set(target_roots), asset_graph), asset_graph)}"
         )
 
         yield None
@@ -1517,8 +1452,8 @@ def execute_asset_backfill_iteration_inner(
             updated_materialized_subset - asset_backfill_data.materialized_subset
         )
         logger.info(
-            f"Assets materialized since last tick:\n{_asset_graph_subset_to_str(materialized_since_last_tick, asset_graph)}"
-            if not materialized_since_last_tick.empty
+            f"Assets materialized since last tick:\n {_asset_graph_subset_to_str(materialized_since_last_tick, asset_graph)}"
+            if materialized_since_last_tick
             else "No relevant assets materialized since last tick."
         )
 
@@ -1538,45 +1473,54 @@ def execute_asset_backfill_iteration_inner(
         failed_and_downstream_subset = _get_failed_and_downstream_asset_partitions(
             backfill_id,
             asset_backfill_data,
-            asset_graph_view,
+            asset_graph,
+            instance_queryer,
+            backfill_start_timestamp,
             updated_materialized_subset,
         )
 
         yield None
 
-    initial_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
-        initial_candidates, asset_graph
-    )
+    backfill_start_datetime = datetime_from_timestamp(backfill_start_timestamp)
 
-    asset_subset_to_request, not_requested_and_reasons = bfs_filter_asset_graph_view(
-        asset_graph_view,
-        lambda candidate_asset_graph_subset,
-        visited: _should_backfill_atomic_asset_graph_subset_unit(
-            asset_graph_view=asset_graph_view,
-            candidate_asset_graph_subset_unit=candidate_asset_graph_subset,
-            asset_graph_subset_matched_so_far=visited,
-            materialized_subset=updated_materialized_subset,
-            requested_subset=asset_backfill_data.requested_subset,
-            target_subset=asset_backfill_data.target_subset,
-            failed_and_downstream_subset=failed_and_downstream_subset,
-        ),
-        initial_asset_graph_subset=initial_asset_graph_subset,
-        include_full_execution_set=True,
+    asset_partitions_to_request, not_requested_and_reasons = (
+        asset_graph.bfs_filter_asset_partitions(
+            instance_queryer,
+            lambda unit, visited: should_backfill_atomic_asset_partitions_unit(
+                candidates_unit=unit,
+                asset_partitions_to_request=visited,
+                asset_graph=asset_graph,
+                materialized_subset=updated_materialized_subset,
+                requested_subset=asset_backfill_data.requested_subset,
+                target_subset=asset_backfill_data.target_subset,
+                failed_and_downstream_subset=failed_and_downstream_subset,
+                dynamic_partitions_store=instance_queryer,
+                current_time=backfill_start_datetime,
+            ),
+            initial_asset_partitions=initial_candidates,
+            evaluation_time=backfill_start_datetime,
+        )
     )
 
     logger.info(
-        f"Asset partitions to request:\n{_asset_graph_subset_to_str(asset_subset_to_request, asset_graph)}"
-        if not asset_subset_to_request.empty
+        f"Asset partitions to request:\n {_asset_graph_subset_to_str(AssetGraphSubset.from_asset_partition_set(asset_partitions_to_request, asset_graph), asset_graph)}"
+        if asset_partitions_to_request
         else "No asset partitions to request."
     )
-
-    asset_partitions_to_request = set(asset_subset_to_request.iterate_asset_partitions())
-
     if len(not_requested_and_reasons) > 0:
-        not_requested_str = "\n\n".join(
+
+        def _format_keys(keys: Iterable[AssetKeyPartitionKey]):
+            return ", ".join(
+                f"({key.asset_key.to_user_string()}, {key.partition_key})"
+                if key.partition_key
+                else key.asset_key.to_user_string()
+                for key in keys
+            )
+
+        not_requested_str = "\n".join(
             [
-                f"{_asset_graph_subset_to_str(asset_graph_subset, asset_graph)}\nReason: {reason}"
-                for asset_graph_subset, reason in not_requested_and_reasons
+                f"[{_format_keys(keys)}] - Reason: {reason}."
+                for keys, reason in not_requested_and_reasons
             ]
         )
         logger.info(
@@ -1612,161 +1556,27 @@ def execute_asset_backfill_iteration_inner(
     )
 
 
-def _should_backfill_atomic_asset_subset_unit(
-    asset_graph_view: AssetGraphView,
-    entity_subset_to_filter: EntitySubset[AssetKey],
-    candidate_asset_graph_subset_unit: AssetGraphSubset,
-    asset_graph_subset_matched_so_far: AssetGraphSubset,
+def can_run_with_parent(
+    parent: AssetKeyPartitionKey,
+    candidate: AssetKeyPartitionKey,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_graph: RemoteWorkspaceAssetGraph,
     target_subset: AssetGraphSubset,
-    requested_subset: AssetGraphSubset,
-    materialized_subset: AssetGraphSubset,
-    failed_and_downstream_subset: AssetGraphSubset,
-) -> tuple[SerializableEntitySubset[AssetKey], Iterable[tuple[EntitySubsetValue, str]]]:
-    failure_subsets_with_reasons: list[tuple[EntitySubsetValue, str]] = []
-    asset_graph = asset_graph_view.asset_graph
-    asset_key = entity_subset_to_filter.key
-
-    missing_in_target_partitions = entity_subset_to_filter.compute_difference(
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(target_subset, asset_key)
-    )
-    if not missing_in_target_partitions.is_empty:
-        # Don't include a failure reason for this subset since it is unlikely to be
-        # useful to know that an untargeted subset was not included
-        entity_subset_to_filter = entity_subset_to_filter.compute_difference(
-            missing_in_target_partitions
-        )
-
-    failed_and_downstream_partitions = entity_subset_to_filter.compute_intersection(
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(
-            failed_and_downstream_subset, asset_key
-        )
-    )
-    if not failed_and_downstream_partitions.is_empty:
-        failure_subsets_with_reasons.append(
-            (
-                failed_and_downstream_partitions.get_internal_value(),
-                f"{failed_and_downstream_partitions} has failed or is downstream of a failed asset",
-            )
-        )
-        entity_subset_to_filter = entity_subset_to_filter.compute_difference(
-            failed_and_downstream_partitions
-        )
-
-    materialized_partitions = entity_subset_to_filter.compute_intersection(
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(materialized_subset, asset_key)
-    )
-    if not materialized_partitions.is_empty:
-        failure_subsets_with_reasons.append(
-            (
-                materialized_partitions.get_internal_value(),
-                f"{materialized_partitions} already materialized by backfill",
-            )
-        )
-        entity_subset_to_filter = entity_subset_to_filter.compute_difference(
-            materialized_partitions
-        )
-
-    requested_partitions = entity_subset_to_filter.compute_intersection(
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(requested_subset, asset_key)
-    )
-
-    if not requested_partitions.is_empty:
-        failure_subsets_with_reasons.append(
-            (
-                requested_partitions.get_internal_value(),
-                f"{requested_partitions} already requested by backfill",
-            )
-        )
-        entity_subset_to_filter = entity_subset_to_filter.compute_difference(requested_partitions)
-
-    for parent_key in asset_graph.get(asset_key).parent_keys:
-        if entity_subset_to_filter.is_empty:
-            break
-
-        parent_subset, required_but_nonexistent_subset = (
-            asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
-                parent_key,
-                entity_subset_to_filter,
-            )
-        )
-
-        if not required_but_nonexistent_subset.is_empty:
-            raise DagsterInvariantViolationError(
-                f"Asset partition subset {entity_subset_to_filter}"
-                f" depends on invalid partitions {required_but_nonexistent_subset}"
-            )
-
-        # Children with parents that are targeted but not materialized are eligible
-        # to be filtered out if the parent has not run yet
-        targeted_but_not_materialized_parent_subset: EntitySubset[AssetKey] = (
-            parent_subset.compute_intersection(
-                asset_graph_view.get_entity_subset_from_asset_graph_subset(
-                    target_subset, parent_key
-                )
-            )
-        ).compute_difference(
-            asset_graph_view.get_entity_subset_from_asset_graph_subset(
-                materialized_subset, parent_key
-            )
-        )
-
-        possibly_waiting_for_parent_subset = (
-            asset_graph_view.compute_child_subset(
-                asset_key, targeted_but_not_materialized_parent_subset
-            )
-        ).compute_intersection(entity_subset_to_filter)
-
-        not_waiting_for_parent_subset = entity_subset_to_filter.compute_difference(
-            possibly_waiting_for_parent_subset
-        )
-
-        if not possibly_waiting_for_parent_subset.is_empty:
-            can_run_with_parent_subset, parent_failure_subsets_with_reasons = (
-                get_can_run_with_parent_subsets(
-                    targeted_but_not_materialized_parent_subset,
-                    possibly_waiting_for_parent_subset,
-                    asset_graph_view,
-                    target_subset,
-                    asset_graph_subset_matched_so_far,
-                    candidate_asset_graph_subset_unit,
-                )
-            )
-            if parent_failure_subsets_with_reasons:
-                failure_subsets_with_reasons.extend(parent_failure_subsets_with_reasons)
-
-            entity_subset_to_filter = not_waiting_for_parent_subset.compute_union(
-                can_run_with_parent_subset
-            )
-
-    return (
-        entity_subset_to_filter.convert_to_serializable_subset(),
-        failure_subsets_with_reasons,
-    )
-
-
-def get_can_run_with_parent_subsets(
-    parent_subset: EntitySubset[AssetKey],
-    entity_subset_to_filter: EntitySubset[AssetKey],
-    asset_graph_view: AssetGraphView,
-    target_subset: AssetGraphSubset,
-    asset_graph_subset_matched_so_far: AssetGraphSubset,
-    candidate_asset_graph_subset_unit: AssetGraphSubset,
-) -> tuple[EntitySubset[AssetKey], Iterable[tuple[EntitySubsetValue, str]]]:
-    candidate_asset_key = entity_subset_to_filter.key
-    parent_asset_key = parent_subset.key
-
-    assert isinstance(asset_graph_view.asset_graph, RemoteWorkspaceAssetGraph)
-    asset_graph: RemoteWorkspaceAssetGraph = asset_graph_view.asset_graph
-
-    parent_node = asset_graph.get(parent_asset_key)
-    candidate_node = asset_graph.get(candidate_asset_key)
+    asset_partitions_to_request_map: Mapping[AssetKey, AbstractSet[Optional[str]]],
+) -> tuple[bool, str]:
+    """Returns if a given candidate can be materialized in the same run as a given parent on
+    this tick, and the reason it cannot be materialized, if applicable.
+    """
+    parent_target_subset = target_subset.get_asset_subset(parent.asset_key, asset_graph)
+    candidate_target_subset = target_subset.get_asset_subset(candidate.asset_key, asset_graph)
     partition_mapping = asset_graph.get_partition_mapping(
-        candidate_asset_key, parent_asset_key=parent_asset_key
+        candidate.asset_key, parent_asset_key=parent.asset_key
     )
 
-    # First filter out cases where even if the parent was requested this iteration, it wouldn't
-    # matter, because the parent and child can't execute in the same run
+    is_self_dependency = parent.asset_key == candidate.asset_key
 
+    parent_node = asset_graph.get(parent.asset_key)
+    candidate_node = asset_graph.get(candidate.asset_key)
     # checks if there is a simple partition mapping between the parent and the child
     has_identity_partition_mapping = (
         # both unpartitioned
@@ -1783,53 +1593,31 @@ def get_can_run_with_parent_subsets(
     )
     if parent_node.backfill_policy != candidate_node.backfill_policy:
         return (
-            asset_graph_view.get_empty_subset(key=candidate_asset_key),
-            [
-                (
-                    entity_subset_to_filter.get_internal_value(),
-                    f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different backfill policies so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key} is materialized.",
-                )
-            ],
+            False,
+            f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different backfill policies so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key} is materialized.",
         )
     if (
         parent_node.resolve_to_singular_repo_scoped_node().repository_handle
         != candidate_node.resolve_to_singular_repo_scoped_node().repository_handle
     ):
         return (
-            asset_graph_view.get_empty_subset(key=candidate_asset_key),
-            [
-                (
-                    entity_subset_to_filter.get_internal_value(),
-                    f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} are in different code locations so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",
-                )
-            ],
+            False,
+            f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} are in different code locations so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",
         )
-
     if parent_node.partitions_def != candidate_node.partitions_def:
         return (
-            asset_graph_view.get_empty_subset(key=candidate_asset_key),
-            [
-                (
-                    entity_subset_to_filter.get_internal_value(),
-                    f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different partitions definitions so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",
-                )
-            ],
+            False,
+            f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different partitions definitions so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",
         )
-
-    parent_target_subset = target_subset.get_asset_subset(parent_asset_key, asset_graph)
-    candidate_target_subset = target_subset.get_asset_subset(candidate_asset_key, asset_graph)
-
-    parent_being_requested_this_tick_subset = (
-        asset_graph_view.get_entity_subset_from_asset_graph_subset(
-            asset_graph_subset_matched_so_far, parent_asset_key
+    if (
+        parent.partition_key not in asset_partitions_to_request_map[parent.asset_key]
+        and parent not in candidates_unit
+    ):
+        return (
+            False,
+            f"parent {parent.asset_key.to_user_string()} with partition key {parent.partition_key} is not requested in this iteration",
         )
-    )
-
-    num_parent_partitions_being_requested_this_tick = parent_being_requested_this_tick_subset.size
-
-    is_self_dependency = parent_asset_key == candidate_asset_key
-
-    if not (
+    if (
         # if there is a simple mapping between the parent and the child, then
         # with the parent
         has_identity_partition_mapping
@@ -1845,15 +1633,17 @@ def get_can_run_with_parent_subsets(
                 parent_node.backfill_policy.max_partitions_per_run is None
                 # a single run can materialize all requested parent partitions
                 or parent_node.backfill_policy.max_partitions_per_run
-                > num_parent_partitions_being_requested_this_tick
+                > len(asset_partitions_to_request_map[parent.asset_key])
             )
-            # all targeted parents are being requested this tick, or its a self depdendancy
+            # all targeted parents are being requested this tick, or its a self dependency
             and (
-                num_parent_partitions_being_requested_this_tick == parent_target_subset.size
+                len(asset_partitions_to_request_map[parent.asset_key]) == parent_target_subset.size
                 or is_self_dependency
             )
         )
     ):
+        return True, ""
+    else:
         failed_reason = (
             f"partition mapping between {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} is not simple and "
             f"{parent_node.key.to_user_string()} does not meet requirements of: targeting the same partitions as "
@@ -1861,137 +1651,80 @@ def get_can_run_with_parent_subsets(
             "a backfill policy, and that backfill policy size limit is not exceeded by adding "
             f"{candidate_node.key.to_user_string()} to the run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized."
         )
-        return (
-            asset_graph_view.get_empty_subset(key=candidate_asset_key),
-            [
-                (
-                    entity_subset_to_filter.get_internal_value(),
-                    failed_reason,
-                )
-            ],
-        )
-
-    # We now know that the parent and child are eligible to happen in the same run, so pass
-    # any children of parents that actually are being requested in this iteration (by
-    # being in either the asset_graph_subset_matched_so_far subset, or more rarely in
-    # candidate_asset_graph_subset_unit if they are part of a non-subsettable multi-asset)
-    failure_subsets_with_reasons = []
-
-    candidate_subset = asset_graph_view.get_entity_subset_from_asset_graph_subset(
-        candidate_asset_graph_subset_unit, parent_asset_key
-    )
-
-    not_yet_requested_parent_subset = parent_subset.compute_difference(
-        parent_being_requested_this_tick_subset.compute_union(candidate_subset)
-    )
-
-    children_of_not_yet_requested_parents = asset_graph_view.compute_child_subset(
-        candidate_asset_key, not_yet_requested_parent_subset
-    ).compute_intersection(entity_subset_to_filter)
-
-    if not children_of_not_yet_requested_parents.is_empty:
-        failure_subsets_with_reasons.append(
-            (
-                children_of_not_yet_requested_parents.get_internal_value(),
-                f"Parent subset {not_yet_requested_parent_subset} is not requested in this iteration",
-            )
-        )
-        entity_subset_to_filter = entity_subset_to_filter.compute_difference(
-            children_of_not_yet_requested_parents
-        )
-
-    return (
-        entity_subset_to_filter,
-        failure_subsets_with_reasons,
-    )
+        return False, failed_reason
 
 
-def _should_backfill_atomic_asset_graph_subset_unit(
-    asset_graph_view: AssetGraphView,
-    candidate_asset_graph_subset_unit: AssetGraphSubset,
-    asset_graph_subset_matched_so_far: AssetGraphSubset,
+def should_backfill_atomic_asset_partitions_unit(
+    asset_graph: RemoteWorkspaceAssetGraph,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
     target_subset: AssetGraphSubset,
     requested_subset: AssetGraphSubset,
     materialized_subset: AssetGraphSubset,
     failed_and_downstream_subset: AssetGraphSubset,
-) -> AssetGraphViewBfsFilterConditionResult:
-    failure_subset_values_with_reasons: list[tuple[EntitySubsetValue, str]] = []
+    dynamic_partitions_store: DynamicPartitionsStore,
+    current_time: datetime,
+) -> tuple[bool, str]:
+    """Args:
+    candidates_unit: A set of asset partitions that must all be materialized if any is
+        materialized.
 
-    candidate_entity_subsets = list(
-        asset_graph_view.iterate_asset_subsets(candidate_asset_graph_subset_unit)
-    )
-
-    # this value is the same for all passed in asset keys since they are always part of the same
-    # execution set
-    passed_subset_value = candidate_entity_subsets[0].get_internal_value()
-
-    candidate_asset_keys = [
-        candidate_entity_subset.key for candidate_entity_subset in candidate_entity_subsets
-    ]
-
-    for candidate_asset_key in candidate_asset_keys:
-        # filter down the set of matching values for each asset key
-        passed_serializable_entity_subset = SerializableEntitySubset(
-            candidate_asset_key,
-            passed_subset_value,
-        )
-        entity_subset_to_filter = check.not_none(
-            asset_graph_view.get_subset_from_serializable_subset(passed_serializable_entity_subset)
-        )
-
-        if entity_subset_to_filter.is_empty:
-            break
-
-        entity_subset_to_filter, new_failure_subset_values_with_reasons = (
-            _should_backfill_atomic_asset_subset_unit(
-                asset_graph_view,
-                entity_subset_to_filter=entity_subset_to_filter,
-                candidate_asset_graph_subset_unit=candidate_asset_graph_subset_unit,
-                asset_graph_subset_matched_so_far=asset_graph_subset_matched_so_far,
-                target_subset=target_subset,
-                requested_subset=requested_subset,
-                materialized_subset=materialized_subset,
-                failed_and_downstream_subset=failed_and_downstream_subset,
+    returns if the candidates_unit can be materialized in this tick of the backfill, and the reason
+    it cannot, if applicable
+    """
+    for candidate in candidates_unit:
+        candidate_asset_partition_string = f"Asset {candidate.asset_key.to_user_string()} {f'with partition {candidate.partition_key}' if candidate.partition_key is not None else ''}"
+        if candidate not in target_subset:
+            return (
+                False,
+                f"{candidate_asset_partition_string} is not targeted by backfill",
             )
-        )
-        passed_subset_value = entity_subset_to_filter.value
-        failure_subset_values_with_reasons.extend(new_failure_subset_values_with_reasons)
+        elif candidate in failed_and_downstream_subset:
+            return (
+                False,
+                f"{candidate_asset_partition_string} has failed or is downstream of a failed asset",
+            )
+        elif candidate in materialized_subset:
+            return (
+                False,
+                f"{candidate_asset_partition_string} was already materialized by backfill",
+            )
+        elif candidate in requested_subset:
+            return (
+                False,
+                f"{candidate_asset_partition_string} was already requested by backfill",
+            )
 
-    passed_entity_subsets = []
-    for candidate_entity_subset in candidate_entity_subsets:
-        passed_entity_subsets.append(
-            check.not_none(
-                asset_graph_view.get_subset_from_serializable_subset(
-                    SerializableEntitySubset(candidate_entity_subset.key, passed_subset_value)
+        parent_partitions_result = asset_graph.get_parents_partitions(
+            dynamic_partitions_store, current_time, *candidate
+        )
+        if parent_partitions_result.required_but_nonexistent_parents_partitions:
+            raise DagsterInvariantViolationError(
+                f"Asset partition {candidate}"
+                " depends on invalid partition keys"
+                f" {parent_partitions_result.required_but_nonexistent_parents_partitions}"
+            )
+
+        asset_partitions_to_request_map: dict[AssetKey, set[Optional[str]]] = defaultdict(set)
+        for asset_partition in asset_partitions_to_request:
+            asset_partitions_to_request_map[asset_partition.asset_key].add(
+                asset_partition.partition_key
+            )
+
+        for parent in parent_partitions_result.parent_partitions:
+            if parent in target_subset and parent not in materialized_subset:
+                can_run, failed_reason = can_run_with_parent(
+                    parent,
+                    candidate,
+                    candidates_unit,
+                    asset_graph,
+                    target_subset,
+                    asset_partitions_to_request_map,
                 )
-            )
-        )
+                if not can_run:
+                    return False, failed_reason
 
-    failure_asset_graph_subsets_with_reasons = []
-    # Any failure partition values apply to all candidate asset keys, so construct a subset
-    # graph with that partition subset value for each key
-    for failure_subset_value, reason in failure_subset_values_with_reasons:
-        failure_entity_subsets = [
-            check.not_none(
-                asset_graph_view.get_subset_from_serializable_subset(
-                    SerializableEntitySubset(candidate_entity_subset.key, failure_subset_value)
-                )
-            )
-            for candidate_entity_subset in candidate_entity_subsets
-        ]
-        failure_asset_graph_subsets_with_reasons.append(
-            (
-                AssetGraphSubset.from_entity_subsets(
-                    entity_subsets=failure_entity_subsets,
-                ),
-                reason,
-            )
-        )
-
-    return AssetGraphViewBfsFilterConditionResult(
-        passed_asset_graph_subset=AssetGraphSubset.from_entity_subsets(passed_entity_subsets),
-        excluded_asset_graph_subsets_and_reasons=failure_asset_graph_subsets_with_reasons,
-    )
+    return True, ""
 
 
 def _get_failed_asset_partitions(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1617,7 +1617,7 @@ def _should_backfill_atomic_asset_subset_unit(
         failure_subsets_with_reasons.append(
             (
                 failed_and_downstream_partitions.get_internal_value(),
-                "Failed or is downstream of a failed asset",
+                f"{failed_and_downstream_partitions} has failed or is downstream of a failed asset",
             )
         )
         entity_subset_to_filter = entity_subset_to_filter.compute_difference(
@@ -1631,7 +1631,7 @@ def _should_backfill_atomic_asset_subset_unit(
         failure_subsets_with_reasons.append(
             (
                 materialized_partitions.get_internal_value(),
-                "Already materialized by backfill",
+                f"{materialized_partitions} already materialized by backfill",
             )
         )
         entity_subset_to_filter = entity_subset_to_filter.compute_difference(
@@ -1646,7 +1646,7 @@ def _should_backfill_atomic_asset_subset_unit(
         failure_subsets_with_reasons.append(
             (
                 requested_partitions.get_internal_value(),
-                "Already requested by backfill",
+                f"{requested_partitions} already requested by backfill",
             )
         )
         entity_subset_to_filter = entity_subset_to_filter.compute_difference(requested_partitions)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1124,9 +1124,8 @@ def execute_asset_backfill_iteration(
             updated_backfill_data.failed_and_downstream_subset
             - previous_asset_backfill_data.failed_and_downstream_subset
         )
-        updated_backfill_in_progress = updated_backfill_data.requested_subset - (
-            updated_backfill_data.materialized_subset
-            | updated_backfill_data.failed_and_downstream_subset
+        updated_backfill_in_progress = (
+            updated_backfill_data.requested_subset - updated_backfill_data.materialized_subset
         )
         previous_backfill_in_progress = (
             previous_asset_backfill_data.requested_subset

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional, Union, cast  # noqa: UP035
 
 import dagster._check as check
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
@@ -171,34 +171,36 @@ class AssetBackfillData(NamedTuple):
         )
 
     def all_requested_partitions_marked_as_materialized_or_failed(self) -> bool:
-        return (
-            len(
-                (
-                    self.requested_subset
-                    - self.materialized_subset
-                    - self.failed_and_downstream_subset
-                ).asset_keys
-            )
-            == 0
-        )
+        for partition in self.requested_subset.iterate_asset_partitions():
+            if (
+                partition not in self.materialized_subset
+                and partition not in self.failed_and_downstream_subset
+            ):
+                return False
+
+        return True
 
     def with_run_requests_submitted(
         self,
         run_requests: Sequence[RunRequest],
-        asset_graph_view: AssetGraphView,
+        asset_graph: RemoteAssetGraph,
+        instance_queryer: CachingInstanceQueryer,
     ) -> "AssetBackfillData":
-        requested_subset = _get_requested_asset_graph_subset_from_run_requests(
+        requested_partitions = get_requested_asset_partitions_from_run_requests(
             run_requests,
-            asset_graph_view,
+            asset_graph,
+            instance_queryer,
         )
 
-        submitted_partitions = self.requested_subset | requested_subset
+        submitted_partitions = self.requested_subset | AssetGraphSubset.from_asset_partition_set(
+            set(requested_partitions), asset_graph=asset_graph
+        )
 
         return self.replace_requested_subset(submitted_partitions)
 
-    def get_target_root_asset_graph_subset(
+    def get_target_root_asset_partitions(
         self, instance_queryer: CachingInstanceQueryer
-    ) -> AssetGraphSubset:
+    ) -> Iterable[AssetKeyPartitionKey]:
         def _get_self_and_downstream_targeted_subset(
             initial_subset: AssetGraphSubset,
         ) -> AssetGraphSubset:
@@ -270,7 +272,7 @@ class AssetBackfillData(NamedTuple):
                 " This is likely a system error. Please report this issue to the Dagster team."
             )
 
-        return root_subset
+        return list(root_subset.iterate_asset_partitions())
 
     def get_target_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
         # Return the targeted partitions for the root partitioned asset keys
@@ -654,12 +656,12 @@ class AssetBackfillIterationResult(NamedTuple):
     reserved_run_ids: Sequence[str]
 
 
-def _get_requested_asset_graph_subset_from_run_requests(
+def get_requested_asset_partitions_from_run_requests(
     run_requests: Sequence[RunRequest],
-    asset_graph_view: AssetGraphView,
-) -> AssetGraphSubset:
-    asset_graph = asset_graph_view.asset_graph
-    requested_subset = AssetGraphSubset.empty()
+    asset_graph: RemoteAssetGraph,
+    instance_queryer: CachingInstanceQueryer,
+) -> AbstractSet[AssetKeyPartitionKey]:
+    requested_partitions = set()
     for run_request in run_requests:
         # Run request targets a range of partitions
         range_start = run_request.tags.get(ASSET_PARTITION_RANGE_START_TAG)
@@ -669,24 +671,31 @@ def _get_requested_asset_graph_subset_from_run_requests(
             # have the same partitions def
             selected_assets = cast(Sequence[AssetKey], run_request.asset_selection)
             check.invariant(len(selected_assets) > 0)
-            partition_range = PartitionKeyRange(range_start, range_end)
-            entity_subsets = [
-                asset_graph_view.get_entity_subset_in_range(asset_key, partition_range)
-                for asset_key in selected_assets
-            ]
-            requested_subset = requested_subset | AssetGraphSubset.from_entity_subsets(
-                entity_subsets
+            partitions_defs = set(
+                asset_graph.get(asset_key).partitions_def for asset_key in selected_assets
             )
-        else:
-            requested_subset = requested_subset | AssetGraphSubset.from_asset_partition_set(
-                {
-                    AssetKeyPartitionKey(asset_key, run_request.partition_key)
-                    for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
-                },
-                asset_graph,
+            check.invariant(
+                len(partitions_defs) == 1,
+                "Expected all assets selected in partition range run request to have the same"
+                " partitions def",
             )
 
-    return requested_subset
+            partitions_def = cast(PartitionsDefinition, next(iter(partitions_defs)))
+            partitions_in_range = partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(range_start, range_end), instance_queryer
+            )
+            requested_partitions = requested_partitions | {
+                AssetKeyPartitionKey(asset_key, partition_key)
+                for asset_key in selected_assets
+                for partition_key in partitions_in_range
+            }
+        else:
+            requested_partitions = requested_partitions | {
+                AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
+            }
+
+    return requested_partitions
 
 
 def _write_updated_backfill_data(
@@ -711,18 +720,17 @@ def _write_updated_backfill_data(
 
 
 def _submit_runs_and_update_backfill_in_chunks(
-    asset_graph_view: AssetGraphView,
+    instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
     backfill_id: str,
     asset_backfill_iteration_result: AssetBackfillIterationResult,
+    asset_graph: RemoteWorkspaceAssetGraph,
     logger: logging.Logger,
     run_tags: Mapping[str, str],
+    instance_queryer: CachingInstanceQueryer,
 ) -> Iterable[None]:
     from dagster._core.execution.backfill import BulkActionStatus
     from dagster._daemon.utils import DaemonErrorCapture
-
-    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
-    instance = asset_graph_view.instance
 
     run_requests = asset_backfill_iteration_result.run_requests
 
@@ -782,7 +790,8 @@ def _submit_runs_and_update_backfill_in_chunks(
         updated_backfill_data: AssetBackfillData = (
             updated_backfill_data.with_run_requests_submitted(
                 [run_request],
-                asset_graph_view,
+                asset_graph,
+                instance_queryer,
             )
         )
 
@@ -1078,12 +1087,14 @@ def execute_asset_backfill_iteration(
 
         if result.run_requests:
             yield from _submit_runs_and_update_backfill_in_chunks(
-                asset_graph_view,
+                instance,
                 workspace_process_context,
                 updated_backfill.backfill_id,
                 result,
+                asset_graph,
                 logger,
                 run_tags=updated_backfill.tags,
+                instance_queryer=instance_queryer,
             )
 
         updated_backfill = cast(
@@ -1169,7 +1180,8 @@ def execute_asset_backfill_iteration(
         for updated_asset_backfill_data in get_canceling_asset_backfill_iteration_data(
             backfill.backfill_id,
             previous_asset_backfill_data,
-            asset_graph_view,
+            instance_queryer,
+            asset_graph,
             backfill.backfill_timestamp,
         ):
             yield None
@@ -1222,32 +1234,37 @@ def execute_asset_backfill_iteration(
 def get_canceling_asset_backfill_iteration_data(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph_view: AssetGraphView,
+    instance_queryer: CachingInstanceQueryer,
+    asset_graph: RemoteWorkspaceAssetGraph,
     backfill_start_timestamp: float,
 ) -> Iterable[Optional[AssetBackfillData]]:
     """For asset backfills in the "canceling" state, fetch the asset backfill data with the updated
     materialized and failed subsets.
     """
-    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
-    instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
     updated_materialized_subset = None
-    for updated_materialized_subset in get_asset_backfill_iteration_materialized_subset(
+    for updated_materialized_subset in get_asset_backfill_iteration_materialized_partitions(
         backfill_id, asset_backfill_data, asset_graph, instance_queryer
     ):
         yield None
 
     if not isinstance(updated_materialized_subset, AssetGraphSubset):
         check.failed(
-            "Expected get_asset_backfill_iteration_materialized_subset to return an"
+            "Expected get_asset_backfill_iteration_materialized_partitions to return an"
             " AssetGraphSubset object"
         )
 
-    failed_subset = _get_failed_asset_graph_subset(
-        asset_graph_view,
-        backfill_id,
-        materialized_subset=updated_materialized_subset,
+    # TODO: Make this use subsets throughout instead of a sequence of AssetKeyPartitionKeys
+    failed_subset = AssetGraphSubset.from_asset_partition_set(
+        set(
+            _get_failed_asset_partitions(
+                instance_queryer,
+                backfill_id,
+                asset_graph,
+                materialized_subset=updated_materialized_subset,
+            )
+        ),
+        asset_graph,
     )
-
     # we fetch the failed_subset to get any new assets that have failed and add that to the set of
     # assets we already know failed and their downstreams. However we need to remove any assets in
     # updated_materialized_subset to account for the case where a run retry successfully
@@ -1268,7 +1285,7 @@ def get_canceling_asset_backfill_iteration_data(
     yield updated_backfill_data
 
 
-def get_asset_backfill_iteration_materialized_subset(
+def get_asset_backfill_iteration_materialized_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
     asset_graph: RemoteWorkspaceAssetGraph,
@@ -1341,16 +1358,24 @@ def _get_subset_in_target_subset(
     return AssetGraphSubset.from_entity_subsets([subset_in_target_subset])
 
 
-def _get_failed_and_downstream_asset_graph_subset(
+def _get_failed_and_downstream_asset_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
     asset_graph_view: AssetGraphView,
     materialized_subset: AssetGraphSubset,
 ) -> AssetGraphSubset:
-    failed_asset_graph_subset = _get_failed_asset_graph_subset(
-        asset_graph_view,
-        backfill_id,
-        materialized_subset,
+    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
+
+    failed_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
+        set(
+            _get_failed_asset_partitions(
+                asset_graph_view.get_inner_queryer_for_back_compat(),
+                backfill_id,
+                asset_graph,
+                materialized_subset,
+            )
+        ),
+        asset_graph,
     )
 
     failed_and_downstream_subset = bfs_filter_asset_graph_view(
@@ -1450,15 +1475,16 @@ def execute_asset_backfill_iteration_inner(
         RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph
     )
 
+    initial_candidates: set[AssetKeyPartitionKey] = set()
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
     if request_roots:
         logger.info(
             "Not all root assets (assets in backfill that do not have parents in the backill) have been requested, finding root assets."
         )
-        target_roots = asset_backfill_data.get_target_root_asset_graph_subset(instance_queryer)
-        candidate_asset_graph_subset = target_roots
+        target_roots = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
+        initial_candidates.update(target_roots)
         logger.info(
-            f"Root assets that have not yet been requested:\n{_asset_graph_subset_to_str(target_roots, asset_graph)}"
+            f"Root assets that have not yet been requested:\n{_asset_graph_subset_to_str(AssetGraphSubset.from_asset_partition_set(set(target_roots), asset_graph), asset_graph)}"
         )
 
         yield None
@@ -1476,14 +1502,14 @@ def execute_asset_backfill_iteration_inner(
             time.sleep(cursor_delay_time)
 
         updated_materialized_subset = None
-        for updated_materialized_subset in get_asset_backfill_iteration_materialized_subset(
+        for updated_materialized_subset in get_asset_backfill_iteration_materialized_partitions(
             backfill_id, asset_backfill_data, asset_graph, instance_queryer
         ):
             yield None
 
         if not isinstance(updated_materialized_subset, AssetGraphSubset):
             check.failed(
-                "Expected get_asset_backfill_iteration_materialized_subset to return an"
+                "Expected get_asset_backfill_iteration_materialized_partitions to return an"
                 " AssetGraphSubset"
             )
 
@@ -1505,13 +1531,11 @@ def execute_asset_backfill_iteration_inner(
                 for asset_key in asset_backfill_data.target_subset.asset_keys
             )
         )
-        candidate_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
-            parent_materialized_asset_partitions, asset_graph
-        )
+        initial_candidates.update(parent_materialized_asset_partitions)
 
         yield None
 
-        failed_and_downstream_subset = _get_failed_and_downstream_asset_graph_subset(
+        failed_and_downstream_subset = _get_failed_and_downstream_asset_partitions(
             backfill_id,
             asset_backfill_data,
             asset_graph_view,
@@ -1519,6 +1543,10 @@ def execute_asset_backfill_iteration_inner(
         )
 
         yield None
+
+    initial_asset_graph_subset = AssetGraphSubset.from_asset_partition_set(
+        initial_candidates, asset_graph
+    )
 
     asset_subset_to_request, not_requested_and_reasons = bfs_filter_asset_graph_view(
         asset_graph_view,
@@ -1532,7 +1560,7 @@ def execute_asset_backfill_iteration_inner(
             target_subset=asset_backfill_data.target_subset,
             failed_and_downstream_subset=failed_and_downstream_subset,
         ),
-        initial_asset_graph_subset=candidate_asset_graph_subset,
+        initial_asset_graph_subset=initial_asset_graph_subset,
         include_full_execution_set=True,
     )
 
@@ -1966,12 +1994,13 @@ def _should_backfill_atomic_asset_graph_subset_unit(
     )
 
 
-def _get_failed_asset_graph_subset(
-    asset_graph_view: AssetGraphView,
+def _get_failed_asset_partitions(
+    instance_queryer: CachingInstanceQueryer,
     backfill_id: str,
+    asset_graph: RemoteAssetGraph,
     materialized_subset: AssetGraphSubset,
-) -> AssetGraphSubset:
-    """Returns asset subset that materializations were requested for as part of the backfill, but were
+) -> Sequence[AssetKeyPartitionKey]:
+    """Returns asset partitions that materializations were requested for as part of the backfill, but were
     not successfully materialized.
 
     This function gets a list of all runs for the backfill that have failed and extracts the asset partitions
@@ -1983,8 +2012,6 @@ def _get_failed_asset_graph_subset(
     Includes canceled asset partitions. Implementation assumes that successful runs won't have any
     failed partitions.
     """
-    instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
-
     runs = instance_queryer.instance.get_runs(
         filters=RunsFilter(
             tags={BACKFILL_ID_TAG: backfill_id},
@@ -1992,7 +2019,8 @@ def _get_failed_asset_graph_subset(
         )
     )
 
-    result: AssetGraphSubset = AssetGraphSubset.empty()
+    result: list[AssetKeyPartitionKey] = []
+
     for run in runs:
         planned_asset_keys = instance_queryer.get_planned_materializations_for_run(
             run_id=run.run_id
@@ -2012,22 +2040,25 @@ def _get_failed_asset_graph_subset(
                 start=run.tags[ASSET_PARTITION_RANGE_START_TAG],
                 end=run.tags[ASSET_PARTITION_RANGE_END_TAG],
             )
-            candidate_subset = AssetGraphSubset.from_entity_subsets(
-                [
-                    asset_graph_view.get_entity_subset_in_range(asset_key, partition_range)
-                    for asset_key in failed_asset_keys
-                ]
-            )
-
+            asset_partition_candidates = []
+            for asset_key in failed_asset_keys:
+                asset_partition_candidates.extend(
+                    asset_graph.get_partitions_in_range(
+                        asset_key, partition_range, instance_queryer
+                    )
+                )
         else:
             # a regular backfill run that run on a single partition
             partition_key = run.tags.get(PARTITION_NAME_TAG)
-            candidate_subset = AssetGraphSubset.from_asset_partition_set(
-                {AssetKeyPartitionKey(asset_key, partition_key) for asset_key in failed_asset_keys},
-                asset_graph_view.asset_graph,
-            )
+            asset_partition_candidates = [
+                AssetKeyPartitionKey(asset_key, partition_key) for asset_key in failed_asset_keys
+            ]
 
-        asset_subset_still_failed = candidate_subset - materialized_subset
-        result = result | asset_subset_still_failed
+        asset_partitions_still_failed = [
+            asset_partition
+            for asset_partition in asset_partition_candidates
+            if asset_partition not in materialized_subset
+        ]
+        result.extend(asset_partitions_still_failed)
 
     return result

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -33,7 +33,7 @@ def _get_subset_with_keys(graph_view, keys):
 def test_bfs_filter_empty_graph():
     """Test BFS filter on empty graph returns empty result."""
     graph_view = AssetGraphView.for_test(Definitions())
-    initial_subset = AssetGraphSubset.create_empty_subset()
+    initial_subset = AssetGraphSubset.empty()
 
     def condition_fn(subset, _visited):
         return AssetGraphViewBfsFilterConditionResult(subset, [])
@@ -42,7 +42,7 @@ def test_bfs_filter_empty_graph():
         graph_view, condition_fn, initial_subset, include_full_execution_set=False
     )
 
-    assert result == AssetGraphSubset.create_empty_subset()
+    assert result == AssetGraphSubset.empty()
     assert failed == []
 
 
@@ -81,7 +81,7 @@ def test_bfs_filter_dependency_chain():
             )
 
             return AssetGraphViewBfsFilterConditionResult(
-                AssetGraphSubset.create_empty_subset(),
+                AssetGraphSubset.empty(),
                 [(subset, "asset3 not allowed")],
             )
         return AssetGraphViewBfsFilterConditionResult(subset, [])

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -34,10 +34,6 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
-from dagster._core.asset_graph_view.bfs import (
-    AssetGraphViewBfsFilterConditionResult,
-    bfs_filter_asset_graph_view,
-)
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.decorators.repository_decorator import repository
@@ -83,7 +79,6 @@ from dagster_tests.declarative_automation_tests.legacy_tests.scenarios.asset_gra
     two_assets_in_sequence_fan_out_partitions,
 )
 from dagster_tests.declarative_automation_tests.legacy_tests.scenarios.partition_scenarios import (
-    daily_to_hourly_partitions,
     hourly_to_daily_partitions,
     non_partitioned_after_partitioned,
     one_asset_one_partition,
@@ -165,7 +160,7 @@ scenarios = {
     ),
     "unpartitioned_after_dynamic_asset": scenario(unpartitioned_after_dynamic_asset),
     "two_dynamic_assets": scenario(two_dynamic_assets),
-    "hourly_to_daily_partitions": scenario(
+    "hourly_to_daily_partiitons": scenario(
         hourly_to_daily_partitions,
         create_datetime(year=2013, month=1, day=7, hour=0),
         target_root_partition_keys=[
@@ -173,14 +168,6 @@ scenarios = {
             "2013-01-05-23:00",
             "2013-01-06-00:00",
             "2013-01-06-01:00",
-        ],
-    ),
-    "daily_to_hourly_partitions_non_contiguous": scenario(
-        daily_to_hourly_partitions,
-        create_datetime(year=2013, month=1, day=8, hour=0),
-        target_root_partition_keys=[
-            "2013-01-05",
-            "2013-01-07",
         ],
     ),
     "root_assets_different_partitions": scenario(root_assets_different_partitions_same_downstream),
@@ -249,25 +236,15 @@ def test_from_asset_partitions_target_subset(
     )
 
 
-def _get_asset_graph_view(
-    instance: DagsterInstance,
-    asset_graph: BaseAssetGraph,
-    evaluation_time: Optional[datetime.datetime] = None,
-) -> AssetGraphView:
+def _get_instance_queryer(
+    instance: DagsterInstance, asset_graph: BaseAssetGraph, evaluation_time: datetime.datetime
+) -> CachingInstanceQueryer:
     return AssetGraphView(
         temporal_context=TemporalContext(
             effective_dt=evaluation_time or get_current_datetime(), last_event_id=None
         ),
         instance=instance,
         asset_graph=asset_graph,
-    )
-
-
-def _get_instance_queryer(
-    instance: DagsterInstance, asset_graph: BaseAssetGraph, evaluation_time: datetime.datetime
-) -> CachingInstanceQueryer:
-    return _get_asset_graph_view(
-        instance, asset_graph, evaluation_time
     ).get_inner_queryer_for_back_compat()
 
 
@@ -323,21 +300,8 @@ def _single_backfill_iteration_create_but_do_not_submit_runs(
         )
 
 
-@pytest.mark.parametrize(
-    "some_or_all",
-    [
-        "all",
-        "some",
-    ],
-)
-@pytest.mark.parametrize(
-    "failures",
-    [
-        "no_failures",
-        "root_failures",
-        "random_half_failures",
-    ],
-)
+@pytest.mark.parametrize("some_or_all", ["all", "some"])
+@pytest.mark.parametrize("failures", ["no_failures", "root_failures", "random_half_failures"])
 @pytest.mark.parametrize("scenario", list(scenarios.values()), ids=list(scenarios.keys()))
 def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, some_or_all: str):
     with (
@@ -608,21 +572,11 @@ def make_random_subset(
             if i % 2 == 0:
                 root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
-    asset_graph_view = _get_asset_graph_view(instance, asset_graph, evaluation_time=evaluation_time)
+    target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
+        instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
+    )
 
-    return bfs_filter_asset_graph_view(
-        asset_graph_view=asset_graph_view,
-        condition_fn=lambda candidate_asset_graph_subset, _: (
-            AssetGraphViewBfsFilterConditionResult(
-                passed_asset_graph_subset=candidate_asset_graph_subset,
-                excluded_asset_graph_subsets_and_reasons=[],
-            )
-        ),
-        initial_asset_graph_subset=AssetGraphSubset.from_asset_partition_set(
-            root_asset_partitions, asset_graph
-        ),
-        include_full_execution_set=True,
-    )[0]
+    return AssetGraphSubset.from_asset_partition_set(target_asset_partitions, asset_graph)
 
 
 def make_subset_from_partition_keys(
@@ -641,21 +595,11 @@ def make_subset_from_partition_keys(
         else:
             root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
-    asset_graph_view = _get_asset_graph_view(instance, asset_graph, evaluation_time=evaluation_time)
+    target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
+        instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
+    )
 
-    return bfs_filter_asset_graph_view(
-        asset_graph_view=asset_graph_view,
-        condition_fn=lambda candidate_asset_graph_subset, _: (
-            AssetGraphViewBfsFilterConditionResult(
-                passed_asset_graph_subset=candidate_asset_graph_subset,
-                excluded_asset_graph_subsets_and_reasons=[],
-            )
-        ),
-        initial_asset_graph_subset=AssetGraphSubset.from_asset_partition_set(
-            root_asset_partitions, asset_graph
-        ),
-        include_full_execution_set=True,
-    )[0]
+    return AssetGraphSubset.from_asset_partition_set(target_asset_partitions, asset_graph)
 
 
 def get_asset_graph(
@@ -696,9 +640,10 @@ def execute_asset_backfill_iteration_consume_generator(
         for result in execute_asset_backfill_iteration_inner(
             backfill_id=backfill_id,
             asset_backfill_data=asset_backfill_data,
-            asset_graph_view=_get_asset_graph_view(
+            instance_queryer=_get_instance_queryer(
                 instance, asset_graph, asset_backfill_data.backfill_start_datetime
             ),
+            asset_graph=asset_graph,
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
         ):
@@ -723,22 +668,11 @@ def run_backfill_to_completion(
     # assert each asset partition only targeted once
     requested_asset_partitions: set[AssetKeyPartitionKey] = set()
 
-    asset_graph_view = _get_asset_graph_view(instance, asset_graph)
-
-    fail_and_downstream_asset_graph_subset, _ = bfs_filter_asset_graph_view(
-        asset_graph_view=asset_graph_view,
-        condition_fn=lambda candidate_asset_graph_subset, _: AssetGraphViewBfsFilterConditionResult(
-            passed_asset_graph_subset=candidate_asset_graph_subset,
-            excluded_asset_graph_subsets_and_reasons=[],
-        ),
-        initial_asset_graph_subset=AssetGraphSubset.from_asset_partition_set(
-            set(fail_asset_partitions), asset_graph
-        ),
-        include_full_execution_set=True,
-    )
-
-    fail_and_downstream_asset_partitions = set(
-        fail_and_downstream_asset_graph_subset.iterate_asset_partitions()
+    fail_and_downstream_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
+        instance,
+        lambda _a, _b: (True, ""),
+        fail_asset_partitions,
+        evaluation_time=backfill_data.backfill_start_datetime,
     )
 
     while not backfill_is_complete(
@@ -1228,7 +1162,7 @@ def test_asset_backfill_throw_error_on_invalid_upstreams():
     )
 
     instance = DagsterInstance.ephemeral()
-    with pytest.raises(DagsterInvariantViolationError, match="depends on invalid partitions"):
+    with pytest.raises(DagsterInvariantViolationError, match="depends on invalid partition keys"):
         run_backfill_to_completion(asset_graph, assets_by_repo_name, backfill_data, [], instance)
 
 
@@ -1254,7 +1188,7 @@ def test_asset_backfill_cancellation():
     asset_graph = get_asset_graph(assets_by_repo_name)
 
     backfill_id = "dummy_backfill_id"
-    backfill_start_datetime = create_datetime(2023, 1, 9, 1, 0, 0)
+    backfill_start_datetime = create_datetime(2023, 1, 9, 0, 0, 0)
     asset_selection = [
         upstream_hourly_partitioned_asset.key,
         downstream_daily_partitioned_asset.key,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2902,11 +2902,6 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
     assert "DefaultPartitionsSubset(subset={'foo_b'})" in logs
     assert "latest_storage_id=None" in logs
     assert "AssetBackfillData" in logs
-    assert (
-        """Asset partitions to request:
-- asset_a: {foo_a}"""
-        in logs
-    )
 
 
 def test_backfill_with_title_and_description(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2864,11 +2864,7 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
 
 
 def test_asset_backfill_logging(caplog, instance, workspace_context):
-    asset_selection = [
-        AssetKey("asset_a"),
-        AssetKey("asset_b"),
-        AssetKey("asset_c"),
-    ]
+    asset_selection = [AssetKey("asset_a"), AssetKey("asset_b"), AssetKey("asset_c")]
 
     partition_keys = partitions_a.get_partition_keys()
     backfill_id = "backfill_with_multiple_assets_selected"
@@ -2902,7 +2898,6 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
     )
 
     logs = caplog.text
-
     assert "Evaluating asset backfill backfill_with_multiple_assets_selected" in logs
     assert "DefaultPartitionsSubset(subset={'foo_b'})" in logs
     assert "latest_storage_id=None" in logs
@@ -2910,87 +2905,6 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
     assert (
         """Asset partitions to request:
 - asset_a: {foo_a}"""
-        in logs
-    )
-
-
-def test_asset_backfill_failure_logging(caplog, instance, workspace_context):
-    asset_selection = [
-        AssetKey("always_fails"),
-    ]
-
-    partition_keys = static_partitions.get_partition_keys()
-    backfill_id = "backfill_with_failure"
-
-    instance.add_backfill(
-        PartitionBackfill.from_asset_partitions(
-            asset_graph=workspace_context.create_request_context().asset_graph,
-            backfill_id=backfill_id,
-            tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=get_current_timestamp(),
-            asset_selection=asset_selection,
-            partition_names=partition_keys,
-            dynamic_partitions_store=instance,
-            all_partitions=False,
-            title=None,
-            description=None,
-        )
-    )
-    assert instance.get_runs_count() == 0
-    backfill = instance.get_backfill(backfill_id)
-    assert backfill
-    assert backfill.status == BulkActionStatus.REQUESTED
-
-    assert all(
-        not error
-        for error in list(
-            execute_backfill_iteration(
-                workspace_context, get_default_daemon_logger("BackfillDaemon")
-            )
-        )
-    )
-
-    logs = caplog.text
-
-    assert (
-        """Overall backfill status:
-**Materialized assets:**
-None
-**Failed assets and their downstream assets:**
-None
-**Assets requested or in progress:**
-- always_fails:"""
-        in logs
-    )
-
-    wait_for_all_runs_to_finish(instance)
-
-    caplog.clear()
-
-    assert all(
-        not error
-        for error in list(
-            execute_backfill_iteration(
-                workspace_context, get_default_daemon_logger("BackfillDaemon")
-            )
-        )
-    )
-    backfill = instance.get_backfill(backfill_id)
-    assert backfill
-    assert backfill.status == BulkActionStatus.COMPLETED_FAILED
-
-    logs = caplog.text
-    assert (
-        """Overall backfill status:
-**Materialized assets:**
-None
-**Failed assets and their downstream assets:**
-- always_fails:"""
-    ) in logs
-
-    assert (
-        """**Assets requested or in progress:**
-None"""
         in logs
     )
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/partition_scenarios.py
@@ -62,14 +62,6 @@ hourly_to_daily_partitions = [
     ),
 ]
 
-daily_to_hourly_partitions = [
-    asset_def(
-        "daily",
-        partitions_def=daily_partitions_def,
-    ),
-    asset_def("hourly", ["daily"], partitions_def=hourly_partitions_def),
-]
-
 unpartitioned_after_dynamic_asset = [
     asset_def("asset1"),
     asset_def("asset2", ["asset1"], partitions_def=DynamicPartitionsDefinition(name="foo")),


### PR DESCRIPTION
## Summary & Motivation
Sadly this change appears to have issues when backfilling self-dependant assets with a backfill policy using max_partitions_per_run - it launches all the batches at once instead of in the right order. Revert and regroup while we sort that out. This is a straight revert of the changes below.

- Revert "Exclude failed subset when logging "Assets requested or in progress" in asset backfills (#27900)"
- Revert "Clean up asset backfill failure reasons a bit (#27898)"
- Revert "Fix asset backfill subset logging (#27883)"
- Revert "Remove asset key iteration from backfill daemon, part 2 (#26727)"
- Revert "Make asset backfill eligibility logic subset-aware instead of iterating through partition keys individually (#25997)"

## How I Tested These Changes
BK

## Changelog
