### PR TITLE
Handle self-dependant assets with backfill policies that limit the number of partitions that can be materialized per run

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -503,10 +503,9 @@ def _build_run_request_for_partition_key_range(
         ASSET_PARTITION_RANGE_START_TAG: partition_range_start,
         ASSET_PARTITION_RANGE_END_TAG: partition_range_end,
     }
-    partition_key = partition_range_start if partition_range_start == partition_range_end else None
     return RunRequest(
         asset_selection=asset_keys,
-        partition_key=partition_key,
+        partition_key=None,
         tags=tags,
         asset_check_keys=asset_check_keys,
     )

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1711,6 +1711,65 @@ def _should_backfill_atomic_asset_subset_unit(
                 can_run_with_parent_subset
             )
 
+            is_self_dependency = parent_key == asset_key
+
+            if is_self_dependency:
+                self_dependent_node = asset_graph.get(asset_key)
+                # ensure that we don't produce more than max_partitions_per_run partitions
+                # if a backfill policy is set
+                if (
+                    self_dependent_node.backfill_policy is not None
+                    and self_dependent_node.backfill_policy.max_partitions_per_run is not None
+                ):
+                    num_partitions_already_being_requested_this_tick = (
+                        asset_graph_view.get_entity_subset_from_asset_graph_subset(
+                            asset_graph_subset_matched_so_far, asset_key
+                        )
+                    ).size
+
+                    # only the first N partitions can be requested
+                    num_allowed_partitions = max(
+                        0,
+                        self_dependent_node.backfill_policy.max_partitions_per_run
+                        - num_partitions_already_being_requested_this_tick,
+                    )
+                    # TODO add a method for paginating through the keys in order
+                    # and returning the first N instead of listing all of them
+                    # (can't use expensively_compute_asset_partitions because it returns
+                    # an unordered set)
+                    internal_value = entity_subset_to_filter.get_internal_value()
+                    partition_keys_to_include = (
+                        list(internal_value.get_partition_keys())
+                        if isinstance(internal_value, PartitionsSubset)
+                        else [None]
+                    )[:num_allowed_partitions]
+                    partition_subset_to_include = AssetGraphSubset.from_asset_partition_set(
+                        {
+                            AssetKeyPartitionKey(self_dependent_node.key, partition_key)
+                            for partition_key in partition_keys_to_include
+                        },
+                        asset_graph=asset_graph,
+                    )
+                    entity_subset_to_include = (
+                        asset_graph_view.get_entity_subset_from_asset_graph_subset(
+                            partition_subset_to_include, self_dependent_node.key
+                        )
+                    )
+
+                    entity_subset_to_reject = entity_subset_to_filter.compute_difference(
+                        entity_subset_to_include
+                    )
+
+                    if not entity_subset_to_reject.is_empty:
+                        failure_subsets_with_reasons.append(
+                            (
+                                entity_subset_to_reject.get_internal_value(),
+                                "Respecting the maximum number of partitions per run for the backfill policy of a self-dependant asset",
+                            )
+                        )
+
+                    entity_subset_to_filter = entity_subset_to_include
+
     return (
         entity_subset_to_filter.convert_to_serializable_subset(),
         failure_subsets_with_reasons,
@@ -1846,8 +1905,9 @@ def get_can_run_with_parent_subsets(
 
     # We now know that the parent and child are eligible to happen in the same run, so pass
     # any children of parents that actually are being requested in this iteration (by
-    # being in either the asset_graph_subset_matched_so_far subset, or more rarely in
-    # candidate_asset_graph_subset_unit if they are part of a non-subsettable multi-asset)
+    # being in either the parent_being_requested_this_tick_subset subset, or more rarely in
+    # candidate_asset_graph_subset_unit if they are part of a non-subsettable multi-asset
+    # or a self-dependant asset)
     failure_subsets_with_reasons = []
 
     candidate_subset = asset_graph_view.get_entity_subset_from_asset_graph_subset(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -1114,11 +1114,6 @@ def test_max_partitions_per_range_1_sets_run_request_partition_key():
         "apple", asset_backfill_data, asset_graph, DagsterInstance.ephemeral()
     )
 
-    assert [run_request.partition_key for run_request in result.run_requests] == [
-        "2023-10-05",
-        "2023-10-06",
-    ]
-
     assert [run_request.partition_key_range for run_request in result.run_requests] == [
         PartitionKeyRange("2023-10-05", "2023-10-05"),
         PartitionKeyRange("2023-10-06", "2023-10-06"),

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
@@ -1,4 +1,5 @@
 from dagster import (
+    BackfillPolicy,
     DailyPartitionsDefinition,
     DimensionPartitionMapping,
     HourlyPartitionsDefinition,
@@ -44,6 +45,24 @@ one_asset_self_dependency = [
         "asset1",
         partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
         deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+    )
+]
+
+self_dependant_asset_with_grouped_run_backfill_policy = [
+    asset_def(
+        "self_dependant",
+        partitions_def=DailyPartitionsDefinition("2023-01-01"),
+        deps={"self_dependant": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+        backfill_policy=BackfillPolicy.multi_run(3),
+    )
+]
+
+self_dependant_asset_with_single_run_backfill_policy = [
+    asset_def(
+        "self_dependant",
+        partitions_def=DailyPartitionsDefinition("2023-01-01"),
+        deps={"self_dependant": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+        backfill_policy=BackfillPolicy.single_run(),
     )
 ]
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -608,6 +608,7 @@ def asset_def(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     code_version: Optional[str] = None,
     config_schema: Optional[Mapping[str, Field]] = None,
+    **asset_def_kwargs,
 ) -> AssetsDefinition:
     if deps is None:
         non_argument_deps = None
@@ -631,6 +632,7 @@ def asset_def(
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
         code_version=code_version,
+        **asset_def_kwargs,
     )
     def _asset(context, **kwargs):
         del kwargs
@@ -638,7 +640,7 @@ def asset_def(
         if context.op_execution_context.op_config["fail"]:
             raise ValueError("")
 
-    return _asset
+    return _asset  # type: ignore
 
 
 def multi_asset_def(


### PR DESCRIPTION
## Summary & Motivation
When using self-dependant assets and backfill policies, runs need to go one at a time.

Now that we're using subsets we can no longer rely on the backfill iteration going partition by partition and stopping once the total number of partitions being materialized has exceeded the max_partitions_per_run setting on the backfill policy. Instead, we add an explicit filtering step that detects this case and returns the first N partitions.

## How I Tested These Changes
New test cases, wondering if I should add some other weird ones though
Run an asset like that manually, verify that it sequences the runs individually again

