### PR TITLE
Fix inheritance type check fails on asset outputs

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -100,7 +100,7 @@ class DbIOManager(IOManager):
         io_manager_name: Optional[str] = None,
         default_load_type: Optional[type] = None,
     ):
-        self._handlers_by_type: dict[Optional[type[Any]], DbTypeHandler] = {}
+        self._handlers_by_type: dict[type[Any], DbTypeHandler] = {}
         self._io_manager_name = io_manager_name or self.__class__.__name__
         for type_handler in type_handlers:
             for handled_type in type_handler.supported_types:
@@ -143,10 +143,8 @@ class DbIOManager(IOManager):
             self._db_client.ensure_schema_exists(context, table_slice, conn)
             self._db_client.delete_table_slice(context, table_slice, conn)
 
-            handler = next(filter(lambda x: issubclass(obj_type, x[0]), self._handlers_by_type.items()))[1]
-            handler_metadata = handler.handle_output(
-                context, table_slice, obj, conn
-            )
+            handler = self._resolve_handler(obj_type)
+            handler_metadata = handler.handle_output(context, table_slice, obj, conn)
 
         context.add_output_metadata(
             {
@@ -176,7 +174,14 @@ class DbIOManager(IOManager):
         table_slice = self._get_table_slice(context, cast(OutputContext, context.upstream_output))
 
         with self._db_client.connect(context, table_slice) as conn:
-            return self._handlers_by_type[load_type].load_input(context, table_slice, conn)  # type: ignore  # (pyright bug)
+            return self._resolve_handler(load_type).load_input(context, table_slice, conn)  # type: ignore  # (pyright bug)
+
+    def _resolve_handler(self, obj_type: type) -> DbTypeHandler:
+        return next(
+            handler
+            for type_, handler in self._handlers_by_type.items()
+            if issubclass(obj_type, type_)
+        )
 
     def _get_table_slice(
         self, context: Union[OutputContext, InputContext], output_context: OutputContext

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -143,7 +143,8 @@ class DbIOManager(IOManager):
             self._db_client.ensure_schema_exists(context, table_slice, conn)
             self._db_client.delete_table_slice(context, table_slice, conn)
 
-            handler_metadata = self._handlers_by_type[obj_type].handle_output(
+            handler = next(filter(lambda x: issubclass(obj_type, x[0]), self._handlers_by_type.items()))[1]
+            handler_metadata = handler.handle_output(
                 context, table_slice, obj, conn
             )
 
@@ -271,7 +272,7 @@ class DbIOManager(IOManager):
         )
 
     def _check_supported_type(self, obj_type):
-        if obj_type not in self._handlers_by_type:
+        if not issubclass(obj_type, tuple(self._handlers_by_type.keys())):
             msg = (
                 f"{self._io_manager_name} does not have a handler for type '{obj_type}'. Has"
                 " handlers for types"

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -540,6 +540,30 @@ def test_handle_none_output():
         manager.handle_output(output_context, None)
 
 
+def test_handle_subclass_output():
+    handler = IntHandler()
+    db_client = MagicMock(
+        spec=DbClient,
+        get_select_statement=MagicMock(return_value=""),
+        get_table_name=mock_table_name,
+    )
+    manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
+
+    class TestClass(int):
+        pass
+
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = build_output_context(
+        asset_key=asset_key,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(type(TestClass)),
+        name="result",
+    )
+
+    # Check that it does not raise
+    assert manager.handle_output(output_context, TestClass(1)) is None
+
+
 def test_non_supported_type():
     handler = IntHandler()
     db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))


### PR DESCRIPTION
## Summary & Motivation

IO managers expect exact type matches, which means supplying classes inheriting of a supported type makes the asset fail.

## How I Tested These Changes

I privately added a test on `test_snowflake_io_manager.py` to ensure that this case failed on `master` and passed on my branch. There should be a better place to put a test on this, though. Let me know where.

## Changelog

Fix an issue with `DbIOManagers` being unable to process subclasses of handled types.
