### PR TITLE
[Run Timeline] Don't drop job data if locations within the FutureTicksQuery fails

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -442,10 +442,16 @@ export const useRunsForTimeline = ({
     return Object.values(jobsWithCompletedRunsAndOngoingRuns);
   }, [jobsWithCompletedRunsAndOngoingRuns]);
 
+  const allKeys = useMemo(
+    () => Object.keys(jobsWithCompletedRunsAndOngoingRuns),
+    [jobsWithCompletedRunsAndOngoingRuns],
+  );
+
   const unsortedJobs: TimelineRow[] = useMemo(() => {
     if (!workspaceOrError || workspaceOrError.__typename === 'PythonError' || _end < Date.now()) {
       return jobsWithCompletedRunsAndOngoingRunsValues;
     }
+    const addedJobKeys = new Set();
     const addedAdHocJobs = new Set();
     const jobs: TimelineRow[] = [];
     for (const locationEntry of workspaceOrError.locationEntries) {
@@ -509,6 +515,7 @@ export const useRunsForTimeline = ({
           const runs = [...jobRuns, ...jobTicks];
 
           let row = jobsWithCompletedRunsAndOngoingRuns[jobKey];
+          addedJobKeys.add(jobKey);
           if (row) {
             row = {...row, runs};
           } else {
@@ -531,6 +538,11 @@ export const useRunsForTimeline = ({
         }
       }
     }
+    allKeys.forEach((key) => {
+      if (!addedJobKeys.has(key)) {
+        jobs.push(jobsWithCompletedRunsAndOngoingRuns[key]!);
+      }
+    });
     return jobs;
     // Don't add start/end time as a dependency here since it changes often.
     // Instead rely on the underlying runs changing in response to start/end changing
@@ -540,6 +552,7 @@ export const useRunsForTimeline = ({
     jobsWithCompletedRunsAndOngoingRunsValues,
     runsByJobKey,
     jobsWithCompletedRunsAndOngoingRuns,
+    allKeys,
   ]);
 
   const jobsWithRuns = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -507,6 +507,7 @@ export const useRunsForTimeline = ({
 
           const jobName = isAdHoc ? 'Ad hoc materializations' : pipeline.name;
 
+          addedJobKeys.add(jobKey);
           const jobRuns = Object.values(runsByJobKey[jobKey] || {});
           if (!jobTicks.length && !jobRuns.length) {
             continue;
@@ -515,7 +516,6 @@ export const useRunsForTimeline = ({
           const runs = [...jobRuns, ...jobTicks];
 
           let row = jobsWithCompletedRunsAndOngoingRuns[jobKey];
-          addedJobKeys.add(jobKey);
           if (row) {
             row = {...row, runs};
           } else {


### PR DESCRIPTION
## Summary & Motivation

Currently, if the FutureTicksQuery itself fails we recover by returning the ongoing runs and complete runs data that we have.

However, if the query doesn't fail then we end up iterating over all of the locations within it and constructing a `jobs` array with all of the rows of the timeline. The problem is that this construction relies on the jobs returned by FutureTicksQuery. If FutureTicksQuery doesn't return a particular job then we drop the data for that job completely. To fix this track which keys we've added via the FutureTicksQuery and then do a second pass where we add data for any jobs that were not in the FutureTicksQuery

## How I Tested These Changes

Loaded the Run timeline for a customer with a failing location entry


## Changelog

> Insert changelog entry or delete this section.
