### PR TITLE
[Selection input autocomplete] Don't compare constructor names to hardcoded string

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/BaseSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/BaseSelectionVisitor.ts
@@ -6,6 +6,11 @@ import {RuleNode} from 'antlr4ts/tree/RuleNode';
 import {
   ParenthesizedExpressionContext,
   PostAttributeValueWhitespaceContext,
+  PostExpressionWhitespaceContext,
+  PostLogicalOperatorWhitespaceContext,
+  PostNeighborTraversalWhitespaceContext,
+  PostNotOperatorWhitespaceContext,
+  PostUpwardTraversalWhitespaceContext,
 } from './generated/SelectionAutoCompleteParser';
 import {SelectionAutoCompleteVisitor as _SelectionAutoCompleteVisitor} from './generated/SelectionAutoCompleteVisitor';
 
@@ -79,10 +84,9 @@ export class BaseSelectionVisitor
       // If child's start..stop doesn't include the cursor, skip
       // (unless forced)
       if (child.start && child.stop) {
-        const isWhitespace = child.constructor.name.endsWith('WhitespaceContext');
         if (
           !this.nodeIncludesCursor(child) &&
-          (!isWhitespace || child.start.startIndex !== this.cursorIndex) &&
+          (!isWhitespaceContext(child) || child.start.startIndex !== this.cursorIndex) &&
           !this.forceVisitCtx.has(child)
         ) {
           continue;
@@ -91,7 +95,8 @@ export class BaseSelectionVisitor
         const nextChild = i + 1 < childCount ? (node.getChild(i + 1) as ParserRuleContext) : null;
         if (
           !this.nodeIncludesCursor(child, 0) &&
-          nextChild?.constructor.name.endsWith('WhitespaceContext') &&
+          nextChild &&
+          isWhitespaceContext(nextChild) &&
           !this.forceVisitCtx.has(child)
         ) {
           continue;
@@ -151,4 +156,18 @@ export class BaseSelectionVisitor
   protected handleCursorOutsideAnyNode(): void {}
 
   public visitPostExpressionWhitespace(_ctx: any) {}
+}
+
+function isWhitespaceContext(ctx: ParserRuleContext) {
+  switch (ctx.constructor.name) {
+    case PostAttributeValueWhitespaceContext.name:
+    case PostExpressionWhitespaceContext.name:
+    case PostLogicalOperatorWhitespaceContext.name:
+    case PostNeighborTraversalWhitespaceContext.name:
+    case PostNotOperatorWhitespaceContext.name:
+    case PostUpwardTraversalWhitespaceContext.name:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
@@ -180,7 +180,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
 
     const parentChildren = ctx.parent?.children ?? [];
-    if (parentChildren[0]?.constructor.name === 'AttributeNameContext') {
+    if (parentChildren[0]?.constructor.name === AttributeNameContext.name) {
       const rawValue = getValueNodeValue(ctx.value());
       this.addAttributeValueResults(parentChildren[0].text, rawValue);
     }
@@ -192,12 +192,12 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
       let valueNode: ParserRuleContext | null = null;
 
       const parentChildren = ctx.parent?.children ?? [];
-      if (parentChildren[0]?.constructor.name === 'AttributeNameContext') {
+      if (parentChildren[0]?.constructor.name === AttributeNameContext.name) {
         attributeName = parentChildren[0] as ParserRuleContext;
       }
-      if (parentChildren[1]?.constructor.name === 'AttributeValueContext') {
+      if (parentChildren[1]?.constructor.name === AttributeValueContext.name) {
         valueNode = parentChildren[1] as ParserRuleContext;
-      } else if (parentChildren[2]?.constructor.name === 'AttributeValueContext') {
+      } else if (parentChildren[2]?.constructor.name === AttributeValueContext.name) {
         valueNode = parentChildren[2] as ParserRuleContext;
       }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputUtil.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputUtil.ts
@@ -47,9 +47,8 @@ export function isInsideExpressionlessParenthesizedExpression(
       case UnclosedExpressionlessFunctionExpressionContext.name:
         return true;
       default:
-        return isInsideExpressionlessParenthesizedExpression(context.parent);
+        return isInsideExpressionlessParenthesizedExpression(parent);
     }
-    return isInsideExpressionlessParenthesizedExpression(parent);
   }
   return false;
 }


### PR DESCRIPTION
## Summary & Motivation
Turns out the auto-complete suggestions weren't working as expected due to comparing constructor names which get minified in the built app. I will research a better approach than this but for now comparing to the name of the classes works.


## How I Tested These Changes

built the app and tested the auto-complete behavior