### PR TITLE
[components] Rename params to attributes

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/5-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/deployments/5-tree.txt
@@ -4,9 +4,9 @@ tree
 ├── code_locations
 │   └── code-location-1
 │       ├── code_location_1
-│       │   ├── __init__.py
 │       │   ├── components
 │       │   ├── definitions.py
+│       │   ├── __init__.py
 │       │   └── lib
 │       │       └── __init__.py
 │       ├── code_location_1_tests

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/1-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/1-tree.txt
@@ -1,11 +1,11 @@
 tree
 
 .
-├── README.md
 ├── my_existing_project
-│   ├── __init__.py
 │   ├── assets.py
-│   └── definitions.py
-└── pyproject.toml
+│   ├── definitions.py
+│   └── __init__.py
+├── pyproject.toml
+└── README.md
 
 2 directories, 5 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
@@ -1,11 +1,11 @@
 tree jaffle_platform
 
 jaffle_platform
-├── __init__.py
 ├── components
 │   └── ingest_files
 │       └── component.yaml
 ├── definitions.py
+├── __init__.py
 └── lib
     └── __init__.py
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
@@ -1,5 +1,5 @@
 type: sling_replication_collection@dagster_components
 
-params:
+attributes:
   replications:
   - path: replication.yaml

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-component-type-info.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-component-type-info.txt
@@ -32,5 +32,5 @@ Scaffold params schema:
     "type": "object"
 }
 
-Component params schema:
+Component schema:
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/21-component-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/21-component-jdbt.yaml
@@ -1,5 +1,5 @@
 type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: ../../../dbt/jdbt

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/22-project-jdbt-incorrect.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/22-project-jdbt-incorrect.yaml
@@ -1,6 +1,6 @@
 type: dagster_components.dbt_project
 
-params:
+attributes:
   dbt:
     project_dir: ../../../dbt/jdbt
   asset_attributes:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/24-project-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/24-project-jdbt.yaml
@@ -1,6 +1,6 @@
 type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: ../../../dbt/jdbt
   asset_attributes:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
@@ -2,17 +2,17 @@ cd jaffle-platform && tree
 
 .
 ├── jaffle_platform
-│   ├── __init__.py
 │   ├── components
 │   ├── definitions.py
+│   ├── __init__.py
 │   └── lib
 │       └── __init__.py
 ├── jaffle_platform.egg-info
-│   ├── PKG-INFO
-│   ├── SOURCES.txt
 │   ├── dependency_links.txt
 │   ├── entry_points.txt
+│   ├── PKG-INFO
 │   ├── requires.txt
+│   ├── SOURCES.txt
 │   └── top_level.txt
 ├── jaffle_platform_tests
 │   └── __init__.py

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/1-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/1-tree.txt
@@ -1,19 +1,19 @@
 tree
 
 .
-├── README.md
 ├── my_existing_project
-│   ├── __init__.py
 │   ├── analytics
-│   │   ├── __init__.py
 │   │   ├── assets.py
+│   │   ├── __init__.py
 │   │   └── jobs.py
 │   ├── components
 │   ├── definitions.py
-│   └── elt
-│       ├── __init__.py
-│       ├── assets.py
-│       └── jobs.py
-└── pyproject.toml
+│   ├── elt
+│   │   ├── assets.py
+│   │   ├── __init__.py
+│   │   └── jobs.py
+│   └── __init__.py
+├── pyproject.toml
+└── README.md
 
 5 directories, 10 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/6-component-yaml.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/6-component-yaml.txt
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: definitions.py

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/8-tree-after.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/8-tree-after.txt
@@ -1,22 +1,22 @@
 tree
 
 .
-├── README.md
 ├── my_existing_project
-│   ├── __init__.py
 │   ├── analytics
-│   │   ├── __init__.py
 │   │   ├── assets.py
+│   │   ├── __init__.py
 │   │   └── jobs.py
 │   ├── components
 │   │   └── elt-definitions
-│   │       ├── __init__.py
 │   │       ├── assets.py
 │   │       ├── component.yaml
 │   │       ├── definitions.py
+│   │       ├── __init__.py
 │   │       └── jobs.py
-│   └── definitions.py
+│   ├── definitions.py
+│   └── __init__.py
 ├── pyproject.toml
+├── README.md
 └── uv.lock
 
 5 directories, 13 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/9-tree-after-all.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/9-tree-after-all.txt
@@ -1,24 +1,24 @@
 tree
 
 .
-├── README.md
 ├── my_existing_project
-│   ├── __init__.py
 │   ├── components
 │   │   ├── analytics-definitions
-│   │   │   ├── __init__.py
 │   │   │   ├── assets.py
 │   │   │   ├── component.yaml
 │   │   │   ├── definitions.py
+│   │   │   ├── __init__.py
 │   │   │   └── jobs.py
 │   │   └── elt-definitions
-│   │       ├── __init__.py
 │   │       ├── assets.py
 │   │       ├── component.yaml
 │   │       ├── definitions.py
+│   │       ├── __init__.py
 │   │       └── jobs.py
-│   └── definitions.py
+│   ├── definitions.py
+│   └── __init__.py
 ├── pyproject.toml
+├── README.md
 └── uv.lock
 
 5 directories, 15 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/5-dg-component-type-docs.html
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/5-dg-component-type-docs.html
@@ -14,7 +14,7 @@
 <textarea rows=24 cols=100>
 type: my_component_library.shell_command
 
-params:
+attributes:
   script_path: '...'
   asset_specs:
     - deps:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/7-scaffolded-component.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/7-scaffolded-component.yaml
@@ -1,6 +1,6 @@
 type: shell_command@my_component_library
 
-params:
+attributes:
   script_path: script.sh
   asset_specs:
   - key: my_asset

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -258,7 +258,7 @@ streams:
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-type-info.txt",
                 update_snippets=update_snippets,
-                snippet_replace_regex=[re_ignore_after("Component params schema:")],
+                snippet_replace_regex=[re_ignore_after("Component schema:")],
             )
 
             # Scaffold dbt project components
@@ -282,7 +282,7 @@ streams:
                 / f"{next_snip_no()}-project-jdbt-incorrect.yaml",
                 contents="""type: dagster_components.dbt_project
 
-params:
+attributes:
   dbt:
     project_dir: ../../../dbt/jdbt
   asset_attributes:
@@ -306,7 +306,7 @@ params:
                 / f"{next_snip_no()}-project-jdbt.yaml",
                 contents="""type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: ../../../dbt/jdbt
   asset_attributes:

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/test_migrating_definitions.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/test_migrating_definitions.py
@@ -120,7 +120,7 @@ defs = dg.Definitions(
             / "component.yaml",
             """type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: definitions.py
 """,
             COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-component-yaml.txt",
@@ -166,7 +166,7 @@ defs = dg.Definitions.merge(
 
         # validate loads
         _run_command(
-            "uv run dagster asset materialize --select '*' -m 'my_existing_project.definitions'"
+            "uv pip freeze && uv run dagster asset materialize --select '*' -m 'my_existing_project.definitions'"
         )
 
         # migrate analytics
@@ -200,7 +200,7 @@ defs = dg.Definitions(
             / "component.yaml",
             """type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: definitions.py
 """,
         )

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -66,8 +66,8 @@ class Component(ABC):
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...
 
     @classmethod
-    def load(cls, params: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
-        return params.resolve_as(cls, context.resolution_context) if params else cls()
+    def load(cls, attributes: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
+        return attributes.resolve_as(cls, context.resolution_context) if attributes else cls()
 
     @classmethod
     def get_metadata(cls) -> "ComponentTypeInternalMetadata":
@@ -81,7 +81,7 @@ class Component(ABC):
                 f"Component {cls.__name__} is not scaffoldable: {scaffolder.message}"
             )
 
-        component_params = cls.get_schema()
+        component_schema = cls.get_schema()
         scaffold_params = scaffolder.get_schema()
         return {
             "summary": clean_docstring.split("\n\n")[0] if clean_docstring else None,
@@ -89,9 +89,9 @@ class Component(ABC):
             "scaffold_params_schema": None
             if scaffold_params is None
             else scaffold_params.model_json_schema(),
-            "component_params_schema": None
-            if component_params is None
-            else component_params.model_json_schema(),
+            "component_schema": None
+            if component_schema is None
+            else component_schema.model_json_schema(),
         }
 
     @classmethod
@@ -113,7 +113,7 @@ class ComponentTypeInternalMetadata(TypedDict):
     summary: Optional[str]
     description: Optional[str]
     scaffold_params_schema: Optional[Any]  # json schema
-    component_params_schema: Optional[Any]  # json schema
+    component_schema: Optional[Any]  # json schema
 
 
 class ComponentTypeMetadata(ComponentTypeInternalMetadata):

--- a/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/test/complex_schema_asset.py
@@ -32,7 +32,7 @@ class ComplexAssetSchema(ResolvableSchema):
 
 @registered_component_type(name="complex_schema_asset")
 class ComplexSchemaAsset(Component):
-    """An asset that has a complex params schema."""
+    """An asset that has a complex schema."""
 
     @classmethod
     def get_schema(cls):

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -21,10 +21,10 @@ class ComponentDumper(yaml.Dumper):
 
 
 def scaffold_component_yaml(
-    request: ComponentScaffoldRequest, component_params: Optional[Mapping[str, Any]]
+    request: ComponentScaffoldRequest, attributes: Optional[Mapping[str, Any]]
 ) -> None:
     with open(request.component_instance_root_path / "component.yaml", "w") as f:
-        component_data = {"type": request.component_type_name, "params": component_params or {}}
+        component_data = {"type": request.component_type_name, "attributes": attributes or {}}
         yaml.dump(
             component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
         )

--- a/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
@@ -31,11 +31,11 @@ BASIC_INVALID_VALUE = ComponentValidationTestCase(
     component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
     should_error=True,
     validate_error_msg=msg_includes_all_of(
-        "component.yaml:5", "params.an_int", "Input should be a valid integer"
+        "component.yaml:5", "attributes.an_int", "Input should be a valid integer"
     ),
     check_error_msg=msg_includes_all_of(
         "component.yaml:5",
-        "params.an_int",
+        "attributes.an_int",
         "{} is not of type 'integer'",
     ),
 )
@@ -44,10 +44,10 @@ BASIC_MISSING_VALUE = ComponentValidationTestCase(
     component_path="validation/basic_component_missing_value",
     component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
     should_error=True,
-    validate_error_msg=msg_includes_all_of("component.yaml:3", "params.an_int", "required"),
+    validate_error_msg=msg_includes_all_of("component.yaml:3", "attributes.an_int", "required"),
     check_error_msg=msg_includes_all_of(
         "component.yaml:3",
-        "params",
+        "attributes",
         "'an_int' is a required property",
     ),
 )
@@ -67,11 +67,11 @@ COMPONENT_VALIDATION_TEST_CASES = [
         component_type_filepath=None,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
-            "component.yaml:5", "params.value", "Input should be a valid string"
+            "component.yaml:5", "attributes.value", "Input should be a valid string"
         ),
         check_error_msg=msg_includes_all_of(
             "component.yaml:5",
-            "params.value",
+            "attributes.value",
             "{} is not of type 'string'",
         ),
     ),
@@ -80,7 +80,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
         component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
-            "component.yaml:7", "params.a_bool", "Extra inputs are not permitted"
+            "component.yaml:7", "attributes.a_bool", "Extra inputs are not permitted"
         ),
         check_error_msg=msg_includes_all_of(
             "component.yaml:7",
@@ -93,18 +93,18 @@ COMPONENT_VALIDATION_TEST_CASES = [
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:7",
-            "params.nested.foo.an_int",
+            "attributes.nested.foo.an_int",
             "Input should be a valid integer",
             "component.yaml:12",
-            "params.nested.baz.a_string",
+            "attributes.nested.baz.a_string",
             "Input should be a valid string",
         ),
         check_error_msg=msg_includes_all_of(
             "component.yaml:7",
-            "params.nested.foo.an_int",
+            "attributes.nested.foo.an_int",
             "{} is not of type 'integer'",
             "component.yaml:12",
-            "params.nested.baz.a_string",
+            "attributes.nested.baz.a_string",
             "{} is not of type 'string'",
         ),
     ),
@@ -113,14 +113,14 @@ COMPONENT_VALIDATION_TEST_CASES = [
         component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,
         validate_error_msg=msg_includes_all_of(
-            "component.yaml:5", "params.nested.foo.an_int", "required"
+            "component.yaml:5", "attributes.nested.foo.an_int", "required"
         ),
         check_error_msg=msg_includes_all_of(
             "component.yaml:5",
-            "params.nested.foo",
+            "attributes.nested.foo",
             "'an_int' is a required property",
             "component.yaml:10",
-            "params.nested.baz",
+            "attributes.nested.baz",
             "'a_string' is a required property",
         ),
     ),
@@ -130,17 +130,17 @@ COMPONENT_VALIDATION_TEST_CASES = [
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:8",
-            "params.nested.foo.a_bool",
+            "attributes.nested.foo.a_bool",
             "Extra inputs are not permitted",
             "component.yaml:15",
-            "params.nested.baz.another_bool",
+            "attributes.nested.baz.another_bool",
         ),
         check_error_msg=msg_includes_all_of(
             "component.yaml:8",
-            "params.nested.foo",
+            "attributes.nested.foo",
             "'a_bool' was unexpected",
             "component.yaml:15",
-            "params.nested.baz",
+            "attributes.nested.baz",
             "'another_bool' was unexpected",
         ),
     ),
@@ -153,7 +153,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "type",
             "Input should be a valid string",
             "component.yaml:3",
-            "params",
+            "attributes",
             "Input should be an object",
         ),
         check_error_msg=msg_includes_all_of(
@@ -161,7 +161,7 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "type",
             "{} is not of type 'string'",
             "component.yaml:3",
-            "params",
+            "attributes",
             "'asdfasdf' is not of type 'object'",
         ),
     ),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -56,7 +56,7 @@ def test_list_component_types_command():
         "summary": "A simple asset that returns a constant string value.",
         "description": "A simple asset that returns a constant string value.",
         "scaffold_params_schema": None,
-        "component_params_schema": {
+        "component_schema": {
             "properties": {
                 "asset_key": {"title": "Asset Key", "type": "string"},
                 "value": {"title": "Value", "type": "string"},
@@ -83,7 +83,7 @@ def test_list_component_types_command():
         "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
         "description": "A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
         "scaffold_params_schema": pipes_script_params_schema,
-        "component_params_schema": pipes_script_params_schema,
+        "component_schema": pipes_script_params_schema,
     }
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/custom_sling_location/custom_sling_location/components/debug_sling_component/component.yaml
@@ -1,6 +1,6 @@
 type: .debug_sling_replication
 
-params:
+attributes:
   sling:
     connections:
       - name: snowflake

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,6 +1,6 @@
 type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: jaffle_shop
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
@@ -1,6 +1,6 @@
 type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: jaffle_shop
 
@@ -11,5 +11,5 @@ params:
         something: 1
       automation_condition:
         type: on_cron
-        params:
+        attributes:
           cron_schedule: "@daily"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/script_python_decl/component.py
@@ -10,7 +10,7 @@ from dagster_components.lib.pipes_subprocess_script_collection import (
 
 @component
 def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
-    params = PipesSubprocessScriptCollectionSchema(
+    attributes = PipesSubprocessScriptCollectionSchema(
         scripts=[
             PipesSubprocessScriptSchema(
                 path="cool_script.py",
@@ -23,4 +23,4 @@ def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollection:
             ),
         ]
     )
-    return PipesSubprocessScriptCollection.load(params=params, context=context)
+    return PipesSubprocessScriptCollection.load(attributes=attributes, context=context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
@@ -1,6 +1,6 @@
 type: pipes_subprocess_script_collection@dagster_components
 
-params:
+attributes:
   scripts:
     - path: script_one.py
       assets:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
@@ -1,6 +1,6 @@
 type: sling_replication_collection@dagster_components
 
-params:
+attributes:
   replications:
     - path: ./replication.yaml
       asset_attributes:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,6 +1,6 @@
 type: dbt_project@dagster_components
 
-params:
+attributes:
   dbt:
     project_dir: jaffle_shop
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
@@ -1,3 +1,3 @@
 type: definitions@dagster_components
 
-params: {}
+attributes: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports/component.yaml
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_complex/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_complex/component.yaml
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_init/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_init/component.yaml
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: __init__.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
@@ -1,5 +1,5 @@
 type: my_component@file:__init__.py
 
-params:
+attributes:
   a_string: "a string"
   an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
@@ -1,5 +1,5 @@
 type: .my_new_component
 
-params:
+attributes:
   a_string: "a string"
   an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
@@ -1,4 +1,4 @@
 type: definitions@dagster_components
 
-params:
+attributes:
   definitions_path: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
@@ -1,6 +1,6 @@
 type: my_component@__init__.py
 
-params:
+attributes:
   a_string: "a string"
   an_int: 5
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
@@ -1,6 +1,6 @@
 type: my_component@file:__init__.py
 
-params:
+attributes:
   a_string: "a string"
   an_int: 5
   # doesn't exist

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
@@ -1,5 +1,5 @@
 type: my_component@file:__init__.py
 
-params:
+attributes:
   a_string: "test"
   an_int: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
@@ -1,4 +1,4 @@
 type: my_component_does_not_exist@file:__init__.py
 
-params:
+attributes:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
@@ -1,4 +1,4 @@
 type: my_component@file:__init__.py
 
-params:
+attributes:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
@@ -1,5 +1,5 @@
 type: my_component@file:__init__.py
 
-params:
+attributes:
   a_string: "a string"
   an_int: 5

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_component_file_model/component.yaml
@@ -1,3 +1,3 @@
 type: {}
 
-params: asdfasdf
+attributes: asdfasdf

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_invalid_char/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/invalid_yaml_invalid_char/component.yaml
@@ -1,3 +1,3 @@
 type: @"bad char"
 
-params: {}
+attributes: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
@@ -1,6 +1,6 @@
 type: my_nested_component@file:__init__.py
 
-params:
+attributes:
   nested:
     foo:
       a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
@@ -1,6 +1,6 @@
 type: my_nested_component@file:__init__.py
 
-params:
+attributes:
   nested:
     foo:
       a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
@@ -1,6 +1,6 @@
 type: my_nested_component@file:__init__.py
 
-params:
+attributes:
   nested:
     foo:
       a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
@@ -1,5 +1,5 @@
 type: simple_asset@dagster_components.test
 
-params:
+attributes:
   asset_key: "test"
   value: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -48,7 +48,7 @@ def test_python_params(dbt_path: Path) -> None:
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
-            params={
+            attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
                 "op": {"name": "some_op", "tags": {"tag1": "value"}},
             },
@@ -56,7 +56,7 @@ def test_python_params(dbt_path: Path) -> None:
     )
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(
-        params=decl_node.get_params(DbtProjectComponent.get_schema()), context=context
+        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
     )
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
     defs = component.build_defs(script_load_context())

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -56,7 +56,7 @@ def sling_path() -> Iterator[Path]:
             defs_path = Path(temp_dir) / COMPONENT_RELPATH / "component.yaml"
 
             def _update_defs(data: dict[str, Any]) -> Mapping[str, Any]:
-                data["params"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
+                data["attributes"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
                 return data
 
             _update_yaml(defs_path, _update_defs)
@@ -64,17 +64,17 @@ def sling_path() -> Iterator[Path]:
             yield Path(temp_dir)
 
 
-def test_python_params(sling_path: Path) -> None:
+def test_python_attributes(sling_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=sling_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="sling_replication",
-            params={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
+            attributes={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(params, context)
+    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(attributes, context)
 
     replications = component.replications
     assert len(replications) == 1
@@ -90,12 +90,12 @@ def test_python_params(sling_path: Path) -> None:
     assert defs.get_assets_def("input_duckdb").op.name == "replication"
 
 
-def test_python_params_op_name(sling_path: Path) -> None:
+def test_python_attributes_op_name(sling_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=sling_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="sling_replication",
-            params={
+            attributes={
                 "sling": {},
                 "replications": [
                     {"path": "./replication.yaml", "op": {"name": "my_op"}},
@@ -104,8 +104,8 @@ def test_python_params_op_name(sling_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(params, context=context)
+    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(attributes, context=context)
 
     replications = component.replications
     assert len(replications) == 1
@@ -120,12 +120,12 @@ def test_python_params_op_name(sling_path: Path) -> None:
     assert defs.get_assets_def("input_duckdb").op.name == "my_op"
 
 
-def test_python_params_op_tags(sling_path: Path) -> None:
+def test_python_attributes_op_tags(sling_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=sling_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="sling_replication",
-            params={
+            attributes={
                 "sling": {},
                 "replications": [
                     {"path": "./replication.yaml", "op": {"tags": {"tag1": "value1"}}},
@@ -134,8 +134,8 @@ def test_python_params_op_tags(sling_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(params=params, context=context)
+    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+    component = SlingReplicationCollection.load(attributes=attributes, context=context)
     replications = component.replications
     assert len(replications) == 1
     op = replications[0].op
@@ -180,12 +180,12 @@ def test_sling_subclass() -> None:
         path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="debug_sling_replication",
-            params={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
+            attributes={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(DebugSlingReplicationComponent.get_schema())
-    component_inst = DebugSlingReplicationComponent.load(params=params, context=context)
+    attributes = decl_node.get_attributes(DebugSlingReplicationComponent.get_schema())
+    component_inst = DebugSlingReplicationComponent.load(attributes=attributes, context=context)
     assert component_inst.build_defs(context).get_asset_graph().get_all_asset_keys() == {
         AssetKey("input_csv"),
         AssetKey("input_duckdb"),

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -61,12 +61,12 @@ def dbt_path() -> Iterator[Path]:
         yield Path(temp_dir)
 
 
-def test_python_params_node_rename(dbt_path: Path) -> None:
+def test_python_attributes_node_rename(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
-            params={
+            attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
                 "asset_attributes": {
                     "key": "some_prefix/{{ node.name }}",
@@ -75,17 +75,17 @@ def test_python_params_node_rename(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(DbtProjectComponent.get_schema())
-    component = DbtProjectComponent.load(params=params, context=context)
+    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS_WITH_PREFIX
 
 
-def test_python_params_group(dbt_path: Path) -> None:
+def test_python_attributes_group(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
-            params={
+            attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
                 "asset_attributes": {
                     "group_name": "some_group",
@@ -94,8 +94,8 @@ def test_python_params_group(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    params = decl_node.get_params(DbtProjectComponent.get_schema())
-    comp = DbtProjectComponent.load(params=params, context=context)
+    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    comp = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
     defs: Definitions = comp.build_defs(script_load_context(None))
     for key in get_asset_keys(comp):
@@ -126,7 +126,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
             path=dbt_path / COMPONENT_RELPATH,
             component_file_model=ComponentFileModel(
                 type="dbt_project",
-                params={
+                attributes={
                     "dbt": {"project_dir": "jaffle_shop"},
                     "asset_attributes": {
                         "group_name": "{{ env('GROUP_AS_ENV') }}",
@@ -135,8 +135,8 @@ def test_render_vars_root(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        params = decl_node.get_params(DbtProjectComponent.get_schema())
-        comp = DbtProjectComponent.load(params=params, context=context)
+        attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+        comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
         defs: Definitions = comp.build_defs(script_load_context())
         for key in get_asset_keys(comp):
@@ -149,7 +149,7 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
             path=dbt_path / COMPONENT_RELPATH,
             component_file_model=ComponentFileModel(
                 type="dbt_project",
-                params={
+                attributes={
                     "dbt": {"project_dir": "jaffle_shop"},
                     "asset_attributes": {
                         "key": "{{ env('ASSET_KEY_PREFIX') }}/{{ node.name }}",
@@ -158,6 +158,6 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        params = decl_node.get_params(DbtProjectComponent.get_schema())
-        comp = DbtProjectComponent.load(params=params, context=context)
+        attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+        comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS_WITH_PREFIX

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
@@ -1,6 +1,6 @@
 type: custom_scope_component@file:component.py
 
-params:
+attributes:
   asset_attributes:
     group_name: "{{ custom_str }}"
     tags: "{{ custom_dict }}"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -35,7 +35,7 @@ COMPONENT_FILE_SCHEMA = {
     "type": "object",
     "properties": {
         "type": {"type": "string"},
-        "params": {"type": "object"},
+        "attributes": {"type": "object"},
     },
     "additionalProperties": False,
 }
@@ -131,10 +131,10 @@ def check_yaml_command(
     )
     for component_key, component_doc_tree in component_contents_by_key.items():
         try:
-            json_schema = component_registry.get(component_key).component_params_schema or {}
+            json_schema = component_registry.get(component_key).component_schema or {}
 
             v = Draft202012Validator(json_schema)
-            for err in v.iter_errors(component_doc_tree.value["params"]):
+            for err in v.iter_errors(component_doc_tree.value["attributes"]):
                 validation_errors.append(ErrorInput(component_key, err, component_doc_tree))
         except KeyError:
             # No matching component type found
@@ -156,7 +156,7 @@ def check_yaml_command(
                     component_key,
                     error,
                     source_position_tree=component_doc_tree.source_position_tree,
-                    prefix=["params"] if component_key else [],
+                    prefix=["attributes"] if component_key else [],
                 )
             )
         context.exit(1)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -81,8 +81,8 @@ def error_dict_to_formatted_error(
         source_position_tree: The SourcePositionTree object, which contains the source position of
             each line in the YAML file.
         prefix: A prefix to the JSON path of the location of the error in the YAML file. Used because
-            we validate params separately from the top-level component YAML fields, so this is often
-            set to e.g. ["params"] when validating the internal params of a component.
+            we validate attributes separately from the top-level component YAML fields, so this is often
+            set to e.g. ["attributes"] when validating the internal attributes of a component.
     """
     error_path = augment_error_path(error_details)
 
@@ -91,7 +91,7 @@ def error_dict_to_formatted_error(
     )
 
     # Retrieves dotted path representation of the location of the error in the YAML file, e.g.
-    # params.nested.foo.an_int
+    # attributes.nested.foo.an_int
     location = ".".join([*prefix, *[str(part) for part in error_path]]).split(" at ")[0]
 
     # Find the first source position that has a different start line than the current source position

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/inspect.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/inspect.py
@@ -32,7 +32,7 @@ def inspect_group():
 @click.argument("component_type", type=str)
 @click.option("--description", is_flag=True, default=False)
 @click.option("--scaffold-params-schema", is_flag=True, default=False)
-@click.option("--component-params-schema", is_flag=True, default=False)
+@click.option("--component-schema", is_flag=True, default=False)
 @dg_global_options
 @click.pass_context
 def component_type_inspect_command(
@@ -40,7 +40,7 @@ def component_type_inspect_command(
     component_type: str,
     description: bool,
     scaffold_params_schema: bool,
-    component_params_schema: bool,
+    component_schema: bool,
     **global_options: object,
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
@@ -50,9 +50,9 @@ def component_type_inspect_command(
     component_key = GlobalComponentKey.from_typename(component_type)
     if not registry.has_global(component_key):
         exit_with_error(generate_missing_component_type_error_message(component_type))
-    elif sum([description, scaffold_params_schema, component_params_schema]) > 1:
+    elif sum([description, scaffold_params_schema, component_schema]) > 1:
         exit_with_error(
-            "Only one of --description, --scaffold-params-schema, and --component-params-schema can be specified."
+            "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."
         )
 
     component_type_metadata = registry.get_global(component_key)
@@ -67,11 +67,11 @@ def component_type_inspect_command(
             click.echo(_serialize_json_schema(component_type_metadata.scaffold_params_schema))
         else:
             click.echo("No scaffold params schema defined.")
-    elif component_params_schema:
-        if component_type_metadata.component_params_schema:
-            click.echo(_serialize_json_schema(component_type_metadata.component_params_schema))
+    elif component_schema:
+        if component_type_metadata.component_schema:
+            click.echo(_serialize_json_schema(component_type_metadata.component_schema))
         else:
-            click.echo("No component params schema defined.")
+            click.echo("No component schema defined.")
 
     # print all available metadata
     else:
@@ -82,9 +82,9 @@ def component_type_inspect_command(
         if component_type_metadata.scaffold_params_schema:
             click.echo("\nScaffold params schema:\n")
             click.echo(_serialize_json_schema(component_type_metadata.scaffold_params_schema))
-        if component_type_metadata.component_params_schema:
-            click.echo("\nComponent params schema:\n")
-            click.echo(_serialize_json_schema(component_type_metadata.component_params_schema))
+        if component_type_metadata.component_schema:
+            click.echo("\nComponent schema:\n")
+            click.echo(_serialize_json_schema(component_type_metadata.component_schema))
 
 
 def _serialize_json_schema(schema: Mapping[str, Any]) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -19,7 +19,7 @@ class RemoteComponentType:
     summary: Optional[str]
     description: Optional[str]
     scaffold_params_schema: Optional[Mapping[str, Any]]  # json schema
-    component_params_schema: Optional[Mapping[str, Any]]  # json schema
+    component_schema: Optional[Mapping[str, Any]]  # json schema
 
 
 def _get_remote_type_mapping_from_raw_data(
@@ -113,7 +113,9 @@ class RemoteComponentRegistry:
             if dg_context.has_cache and cache_key and is_valid_json(raw_registry_data):
                 dg_context.cache.set(cache_key, raw_registry_data)
 
-        component_data.update(_get_remote_type_mapping_from_raw_data(json.loads(raw_registry_data)))
+        raw_registry_dict = json.loads(raw_registry_data)
+
+        component_data.update(_get_remote_type_mapping_from_raw_data(raw_registry_dict))
 
         if local_component_type_dirs:
             component_data.update(

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -135,7 +135,10 @@ def _get_source_position_comments(
 
 def generate_sample_yaml(component_type: str, json_schema: Mapping[str, Any]) -> str:
     raw = yaml.dump(
-        {"type": component_type, "params": _sample_value_for_subschema(json_schema, json_schema)},
+        {
+            "type": component_type,
+            "attributes": _sample_value_for_subschema(json_schema, json_schema),
+        },
         Dumper=ComponentDumper,
         sort_keys=False,
     )
@@ -184,7 +187,7 @@ def open_html_in_browser(html_content: str) -> None:
 def markdown_for_component_type(remote_component_type: RemoteComponentType) -> str:
     component_type_name = f"{remote_component_type.namespace}.{remote_component_type.name}"
     sample_yaml = generate_sample_yaml(
-        component_type_name, remote_component_type.component_params_schema or {}
+        component_type_name, remote_component_type.component_schema or {}
     )
     rows = len(sample_yaml.split("\n")) + 1
     return f"""

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
@@ -34,7 +34,7 @@ def test_docs_component_type_success_output_console():
         )
         assert_runner_result(result)
         assert "<html" in result.output
-        assert "An asset that has a complex params schema." in result.output
+        assert "An asset that has a complex schema." in result.output
 
         # Test that examples propagate into docs
         assert "value: example_for_value" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -40,7 +40,7 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
         "type": "object"
     }
 
-    Component params schema:
+    Component schema:
 
     {
         "properties": {
@@ -140,7 +140,7 @@ def test_inspect_component_type_flag_fields_success():
             "inspect",
             "component-type",
             "simple_pipes_script_asset@dagster_components.test",
-            "--component-params-schema",
+            "--component-schema",
         )
         assert_runner_result(result)
         assert result.output.strip().endswith(
@@ -178,7 +178,7 @@ def test_inspect_component_type_multiple_flags_fails() -> None:
         )
         assert_runner_result(result, exit_0=False)
         assert (
-            "Only one of --description, --scaffold-params-schema, and --component-params-schema can be specified."
+            "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."
             in result.output
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -70,7 +70,7 @@ _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
     ┃ Component Type                                    ┃ Summary                                                          ┃
     ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
     │ all_metadata_empty_asset@dagster_components.test  │                                                                  │
-    │ complex_schema_asset@dagster_components.test      │ An asset that has a complex params schema.                       │
+    │ complex_schema_asset@dagster_components.test      │ An asset that has a complex schema.                              │
     │ simple_asset@dagster_components.test              │ A simple asset that returns a constant string value.             │
     │ simple_pipes_script_asset@dagster_components.test │ A simple asset that runs a Python script with the Pipes          │
     │                                                   │ subprocess client.                                               │
@@ -85,7 +85,7 @@ _EXPECTED_COMPONENT_TYPES_JSON = textwrap.dedent("""
         },
         {
             "key": "complex_schema_asset@dagster_components.test",
-            "summary": "An asset that has a complex params schema."
+            "summary": "An asset that has a complex schema."
         },
         {
             "key": "simple_asset@dagster_components.test",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -161,7 +161,9 @@ def test_scaffold_code_location_skip_venv_success() -> None:
         assert not Path("foo-bar/uv.lock").exists()
 
 
-def test_scaffold_code_location_no_populate_cache_success() -> None:
+def test_scaffold_code_location_no_populate_cache_success(monkeypatch) -> None:
+    dagster_git_repo_dir = discover_git_root(Path(__file__))
+    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
             "scaffold",
@@ -188,7 +190,9 @@ def test_scaffold_code_location_no_populate_cache_success() -> None:
             assert "CACHE [miss]" in result.output
 
 
-def test_scaffold_code_location_no_use_dg_managed_environment_success() -> None:
+def test_scaffold_code_location_no_use_dg_managed_environment_success(monkeypatch) -> None:
+    dagster_git_repo_dir = discover_git_root(Path(__file__))
+    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
             "scaffold",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -163,7 +163,13 @@ def test_scaffold_code_location_skip_venv_success() -> None:
 
 def test_scaffold_code_location_no_populate_cache_success() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("scaffold", "code-location", "--no-populate-cache", "foo-bar")
+        result = runner.invoke(
+            "scaffold",
+            "code-location",
+            "--no-populate-cache",
+            "foo-bar",
+            "--use-editable-dagster",
+        )
         assert_runner_result(result)
         assert Path("foo-bar").exists()
         assert Path("foo-bar/foo_bar").exists()
@@ -185,7 +191,11 @@ def test_scaffold_code_location_no_populate_cache_success() -> None:
 def test_scaffold_code_location_no_use_dg_managed_environment_success() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
-            "scaffold", "code-location", "--no-use-dg-managed-environment", "foo-bar"
+            "scaffold",
+            "code-location",
+            "--no-use-dg-managed-environment",
+            "foo-bar",
+            "--use-editable-dagster",
         )
         assert_runner_result(result)
         assert Path("foo-bar").exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -25,7 +25,7 @@ def test_generate_sample_yaml():
         yaml
         == """type: .sample
 
-params:
+attributes:
   sub_scoped: # Available scope: {'outer_scope'}
     str_field: '...' # Available scope: {'outer_scope'}
     int_field: 0 # Available scope: {'outer_scope'}


### PR DESCRIPTION
## Summary & Motivation

From our notion doc:

Author: @Nick Schrock 

Consulted: @Ben Pankow @Sean Mackesey 

The top-level key of in `component.yaml` used to be `params:` which stems from our naming convention of the pydantic classes. They were suffixed with `Params`; now they are suffixed by `Schema`. Somehow `params` did not feel right as they usually apply to a function not an object.

Options considered

- `params`, as stated above, sounds like the parameters to a function.
- Properties in Python is a readonly function. (`props` or `properties`)
- `args` although technically is Pythonic and accurate, the difference between params and args is only enforced by the most exacting of us (e.g. the pyright guy)
- `fields` was considered by we think that applies to definitions, not instantiations.
- `config` was floated but collides with existing notion of config (which if could travel in time would name params, ironically)

We decided on `attributes` because it is a term of art in JSON and Python that represents a key value pair. That means they are “values” all the way down, which is true from the standpoint of a consumer of a component

Before

```yaml
type: sling_replication_collection@dagster_components

params:
  replications:
    - path: ./replication.yaml
      asset_attributes:
        key: "foo/{{ stream_definition.config.meta.dagster.asset_key }}"
  sling:
    connections:
      - name: DUCKDB
        type: duckdb
        instance: <PLACEHOLDER>
        password: "{{ env('SOME_PASSWORD') }}"

```

After:

```yaml
type: sling_replication_collection@dagster_components

attributes:
  replications:
    - path: ./replication.yaml
      asset_attributes:
        key: "foo/{{ stream_definition.config.meta.dagster.asset_key }}"
  sling:
    connections:
      - name: DUCKDB
        type: duckdb
        instance: <PLACEHOLDER>
        password: "{{ env('SOME_PASSWORD') }}"

```

## How I Tested These Changes

BK