### PR TITLE
[ez] Brew install tree when rebuilding component docs on  mac

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/ensure_snapshot_deps.sh
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/ensure_snapshot_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Validate that tree is installed, install it if not (for bk purposes)
-(which tree > /dev/null && echo "tree command found") ||
-(which brew > /dev/null && echo "tree command not found, installing using brew..." && brew install tree) ||
+(command -v tree > /dev/null && echo "tree command found") ||
+(command -v brew > /dev/null && echo "tree command not found, installing using brew..." && brew install tree) ||
 (echo "tree command not found, installing using apt-get..." && apt-get install tree)

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/ensure_snapshot_deps.sh
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/ensure_snapshot_deps.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-which tree || apt-get install tree
+# Validate that tree is installed, install it if not (for bk purposes)
+(which tree > /dev/null && echo "tree command found") ||
+(which brew > /dev/null && echo "tree command not found, installing using brew..." && brew install tree) ||
+(echo "tree command not found, installing using apt-get..." && apt-get install tree)


### PR DESCRIPTION
## Summary

We need `tree` for our component tutorials, which is by default not available in buildkite. This script installs it using `apt-get`, but we want to install using `brew` if developers on OSX run the command without having `tree` installed.