### PR TITLE
[components] Rename `dg check component` -> `dg check yaml`

### DIFF
--- a/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
+++ b/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
@@ -185,7 +185,7 @@ We need to update the configuration of the `dagster_components.dbt_project` comp
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/22-project-jdbt-incorrect.yaml" language="YAML" title="jaffle-platform/jaffle_platform/components/jdbt/component.yaml" />
 
-You might notice the typo in the above file--after updating a component file, it's useful to validate that the changes match the component's schema. You can do this by running `dg check component`:
+You might notice the typo in the above file--after updating a component file, it's useful to validate that the changes match the component's schema. You can do this by running `dg check yaml`:
 
 <CliInvocationExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/23-dg-component-check-error.txt" />
 
@@ -193,7 +193,7 @@ You can see that the error message includes the filename, line number, and a cod
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/24-project-jdbt.yaml" language="YAML" title="jaffle-platform/jaffle_platform/components/jdbt/component.yaml" />
 
-Finally, run `dg check component` again to validate the fix:
+Finally, run `dg check yaml` again to validate the fix:
 
 <CliInvocationExample path="docs_beta_snippets/docs_beta_snippets/guides/components/index/25-dg-component-check.txt" />
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/23-dg-component-check-error.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/23-dg-component-check-error.txt
@@ -1,4 +1,4 @@
-dg check component
+dg check yaml
 
 /.../jaffle-platform/jaffle_platform/components/jdbt/component.yaml:8 -  Unable to parse YAML: while scanning a quoted scalar, found unexpected end of stream
      | 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/25-dg-component-check.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/25-dg-component-check.txt
@@ -1,3 +1,3 @@
-dg check component
+dg check yaml
 
 All components validated successfully.

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -290,7 +290,7 @@ params:
 """,
             )
             run_command_and_snippet_output(
-                cmd="dg check component",
+                cmd="dg check yaml",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-check-error.txt",
                 update_snippets=update_snippets,
@@ -314,7 +314,7 @@ params:
 """,
             )
             run_command_and_snippet_output(
-                cmd="dg check component",
+                cmd="dg check yaml",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-check.txt",
                 update_snippets=update_snippets,

--- a/python_modules/libraries/dagster-dg/CHANGELOG.md
+++ b/python_modules/libraries/dagster-dg/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 0.1.16
 
 - The entire dg CLI has been changed from noun-first to verb-first, e.g. dg code-location scaffold is now dg scaffold code-location.
-- The `info` command has been renamed to `inspect`. Combining this change with the new verb-first orientation, `dg component-type info` is now `dg inspect component-type`.
+- Some commands have also been renamed beyond the switch in order:
+  - The `info` command has been renamed to `inspect`. `dg component-type info` is now `dg inspect component-type`.
+  - `dg component check` command is now `dg check yaml`.
 
 ## 0.1.15
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -41,10 +41,6 @@ COMPONENT_FILE_SCHEMA = {
 }
 
 
-def _is_local_component(component_name: str) -> bool:
-    return component_name.endswith(".py")
-
-
 def _scaffold_value_and_source_position_tree(
     filename: str, row: int, col: int
 ) -> ValueAndSourcePositionTree:
@@ -65,16 +61,16 @@ class ErrorInput(NamedTuple):
     source_position_tree: ValueAndSourcePositionTree
 
 
-@check_group.command(name="component", cls=DgClickCommand)
+@check_group.command(name="yaml", cls=DgClickCommand)
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @dg_global_options
 @click.pass_context
-def component_check_command(
+def check_yaml_command(
     context: click.Context,
     paths: Sequence[str],
     **global_options: object,
 ) -> None:
-    """Check component files against their schemas, showing validation errors."""
+    """Check component.yaml files against their schemas, showing validation errors."""
     resolved_paths = [Path(path).absolute() for path in paths]
     top_level_component_validator = Draft202012Validator(schema=COMPONENT_FILE_SCHEMA)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -93,7 +93,7 @@ def test_check_component_succeeds_non_default_component_package() -> None:
         assert BASIC_VALID_VALUE.component_type_filepath
         shutil.copy(BASIC_VALID_VALUE.component_type_filepath, components_dir / "__init__.py")
 
-        result = runner.invoke("check", "component")
+        result = runner.invoke("check", "yaml")
         assert_runner_result(result, exit_0=True)
 
 
@@ -115,7 +115,7 @@ def test_validation_cli(test_case: ComponentValidationTestCase) -> None:
         ) as tmpdir,
     ):
         with pushd(tmpdir):
-            result = runner.invoke("check", "component")
+            result = runner.invoke("check", "yaml")
             if test_case.should_error:
                 assert result.exit_code != 0, str(result.stdout)
 
@@ -150,7 +150,7 @@ def test_validation_cli_multiple_components(scope_check_run: bool) -> None:
         with pushd(str(tmpdir)):
             result = runner.invoke(
                 "check",
-                "component",
+                "yaml",
                 *(
                     [
                         str(Path("foo_bar") / "components" / "basic_component_missing_value"),
@@ -181,7 +181,7 @@ def test_validation_cli_multiple_components_filter() -> None:
         with pushd(tmpdir):
             result = runner.invoke(
                 "check",
-                "component",
+                "yaml",
                 str(Path("foo_bar") / "components" / "basic_component_missing_value"),
             )
             assert result.exit_code != 0, str(result.stdout)
@@ -206,7 +206,7 @@ def test_validation_cli_local_component_cache() -> None:
         ) as code_location_dir,
     ):
         with pushd(code_location_dir):
-            result = runner.invoke("check", "component")
+            result = runner.invoke("check", "yaml")
             assert re.search(
                 r"CACHE \[write\].*basic_component_success.*local_component_registry", result.stdout
             )
@@ -216,7 +216,7 @@ def test_validation_cli_local_component_cache() -> None:
             )
 
             # Local components should all be cached
-            result = runner.invoke("check", "component")
+            result = runner.invoke("check", "yaml")
             assert not re.search(
                 r"CACHE \[write\].*basic_component_success.*local_component_registry", result.stdout
             )
@@ -242,7 +242,7 @@ def test_validation_cli_local_component_cache() -> None:
             ).write_text(contents + "\n")
 
             # basic_component_success local component is now be invalidated and needs to be re-cached, the other one should still be cached
-            result = runner.invoke("check", "component")
+            result = runner.invoke("check", "yaml")
             assert re.search(
                 r"CACHE \[write\].*basic_component_success.*local_component_registry", result.stdout
             )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -48,7 +48,7 @@ REGISTRY_CONTEXT_COMMANDS = [
 
 CODE_LOCATION_CONTEXT_COMMANDS = [
     CommandSpec(("configure-editor", "code-location"), "vscode"),
-    CommandSpec(("check", "component")),
+    CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
     CommandSpec(("scaffold", "component"), DEFAULT_COMPONENT_TYPE, "foot"),
 ]


### PR DESCRIPTION
## Summary & Motivation

Renames `dg check component` to `dg check yaml`. This opens the door for `dg check definitions`.

## How I Tested These Changes

Existing test suite.