### PR TITLE
[docs] adds CodeReferenceLink component

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,6 @@ After:
 
 Note that the `method` property causes the build to break -- use `object` instead, and prepend the class name to the method, if it is different from the module.
 
-
 ### Images
 
 #### Location
@@ -164,6 +163,16 @@ Some CLI invocations may be brief enough that we don't want to include them in a
 ```
 
 For more information on testing the CLI commands used in docs, see [the README in docs tests](../../examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/README.md).
+
+### Code reference links
+
+To create a custom admonition linking GitHub at the specific version of code used in the docs, the `CodeReferenceLink` component can be used.
+
+```
+<CodeReferenceLink filePath="examples/tutorial_notebook_assets/" />
+```
+
+On the 1.10 version of docs, this creates a link to `https://github.com/dagster-io/dagster/tree/1.10.0/examples/tutorial_notebook_assets/`.
 
 ### Diagrams
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -172,7 +172,7 @@ To create a custom admonition linking GitHub at the specific version of code use
 <CodeReferenceLink filePath="examples/tutorial_notebook_assets/" />
 ```
 
-On the 1.10 version of docs, this creates a link to `https://github.com/dagster-io/dagster/tree/1.10.0/examples/tutorial_notebook_assets/`.
+On the 1.10 version of docs this creates a link to `https://github.com/dagster-io/dagster/tree/1.10.0/examples/tutorial_notebook_assets/`.
 
 ### Diagrams
 

--- a/docs/docs/guides/deploy/deployment-options/aws.md
+++ b/docs/docs/guides/deploy/deployment-options/aws.md
@@ -31,12 +31,7 @@ Using RDS for run and event log storage doesn't require that the webserver be ru
 
 ## Deploying in ECS
 
-{/* TODO turn back into <CodeReferenceLink> once that's implemented */}
-:::tip
-
-You can find the code for this example on [GitHub](https://github.com/dagster-io/dagster/tree/master/examples/deploy_ecs).
-
-:::
+<CodeReferenceLink filePath="examples/deploy_ecs" />
 
 The Deploying on ECS example on GitHub demonstrates how to configure the [Docker Compose CLI integration with ECS](https://docs.docker.com/cloud/ecs-integration/) to manage all of the required AWS resources that Dagster needs to run on ECS. The example includes:
 

--- a/docs/docs/guides/deploy/dev-to-prod.md
+++ b/docs/docs/guides/deploy/dev-to-prod.md
@@ -25,13 +25,7 @@ Using these Dagster concepts we will:
 
 ## Setup
 
-{/* TODO turn back into <CodeReferenceLink path="docs_beta_snippets/docs_beta_snippets/examples/development_to_production/" /> once that's implemented */}
-
-:::tip
-
-You can find the code for this example on [GitHub](https://github.com/dagster-io/dagster/tree/master/examples/development_to_production/).
-
-:::
+<CodeReferenceLink filePath="examples/development_to_production" />
 
 To follow along with this guide, you can copy the full code example and install a few additional pip libraries:
 

--- a/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
+++ b/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
@@ -55,8 +55,6 @@ To complete this tutorial, you'll need:
     - `assets`, a subfolder containing Dagster assets. We'll use `/assets.py` to write these.
     - `notebooks`, a subfolder containing Jupyter notebooks. We'll use `/notebooks/iris-kmeans.ipynb` to write a Jupyter notebook.
 
-
-
 ## Step 1: Explore the Jupyter notebook
 
 In this tutorial, we'll analyze the Iris dataset, collected in 1936 by the American botanist Edgar Anderson and made famous by statistician Ronald Fisher. The Iris dataset is a basic example of machine learning because it contains three classes of observation: one class is straightforwardly linearly separable from the other two, which can only be distinguished by more sophisticated methods.

--- a/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
+++ b/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
@@ -3,13 +3,7 @@ title: "Using Jupyter notebooks with Papermill and Dagster"
 description: The Dagstermill package lets you run notebooks using the Dagster tools and integrate them into your data pipelines.
 ---
 
-{/* TODO add back when implemented <CodeReferenceLink filePath="examples/tutorial_notebook_assets/" /> */}
-
-:::tip
-
-You can find the code for this example on [GitHub](https://github.com/dagster-io/dagster/tree/master/examples/tutorial_notebook_assets/).
-
-:::
+<CodeReferenceLink filePath="examples/tutorial_notebook_assets/" />
 
 In this tutorial, we'll walk you through integrating a Jupyter notebook with Dagster using an example project. Before we get started, let's cover some common approaches to writing and integrating Jupyter notebooks with Dagster:
 

--- a/docs/src/components/CodeReferenceLink.tsx
+++ b/docs/src/components/CodeReferenceLink.tsx
@@ -4,22 +4,32 @@
  * Versioning is inferred from the version label using `useDocsPreferredVersion`.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Admonition from '@theme/Admonition';
+import Link from '@docusaurus/Link';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
-
-export const CodeReferenceLink = ({filePath, isInline, children}) => {
+export const CodeReferenceLink = ({
+  filePath,
+  isInline,
+  children,
+}: {
+  filePath: string;
+  isInline: boolean;
+  children: ReactNode;
+}) => {
   const preferredVersionLabel = useDocsPreferredVersion('default').preferredVersion?.label;
-  const siteVersion = preferredVersionLabel ? preferredVersionLabel.match(/^\d+\.\d+\.\d+/)?.[0] || 'master' : 'master';
+  const siteVersion = preferredVersionLabel
+    ? preferredVersionLabel.match(/^\d+\.\d+\.\d+/)?.[0] || 'master'
+    : 'master';
   const url = `https://github.com/dagster-io/dagster/tree/${siteVersion}/${filePath}`;
 
   if (isInline) {
-    return <a href={url}>{children}</a>;
+    return <Link href={url}>{children}</Link>;
   } else {
     return (
       <Admonition type="tip" title="Title">
-        You can find the code for this example on <a href={url}>GitHub</a>.
+        You can find the code for this example on <Link href={url}>GitHub</Link>.
       </Admonition>
     );
   }

--- a/docs/src/components/CodeReferenceLink.tsx
+++ b/docs/src/components/CodeReferenceLink.tsx
@@ -1,0 +1,26 @@
+/**
+ * Custom admonition linking to code examples in the GitHub repository.
+ *
+ * Versioning is inferred from the version label using `useDocsPreferredVersion`.
+ */
+
+import React from 'react';
+import Admonition from '@theme/Admonition';
+import {useDocsPreferredVersion} from '@docusaurus/theme-common';
+
+
+export const CodeReferenceLink = ({filePath, isInline, children}) => {
+  const preferredVersionLabel = useDocsPreferredVersion('default').preferredVersion?.label;
+  const siteVersion = preferredVersionLabel ? preferredVersionLabel.match(/^\d+\.\d+\.\d+/)?.[0] || 'master' : 'master';
+  const url = `https://github.com/dagster-io/dagster/tree/${siteVersion}/${filePath}`;
+
+  if (isInline) {
+    return <a href={url}>{children}</a>;
+  } else {
+    return (
+      <Admonition type="tip" title="Title">
+        You can find the code for this example on <a href={url}>GitHub</a>.
+      </Admonition>
+    );
+  }
+};

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -7,15 +7,17 @@ import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 import Link from '@docusaurus/Link';
 import CliInvocationExample from '../components/CliInvocationExample';
+import {CodeReferenceLink} from '../components/CodeReferenceLink';
 
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  PyObject,
-  Tabs,
-  TabItem,
-  CodeExample,
   CliInvocationExample,
-  TOCInline,
+  CodeExample,
+  CodeReferenceLink,
   Link,
+  PyObject,
+  TOCInline,
+  TabItem,
+  Tabs,
 };


### PR DESCRIPTION
## Summary & Motivation

Resolves DOC-685.

Creates component, and updates references marked with _TODO_.

## How I Tested These Changes

Verified links work as expected.

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/e741b00b-ba2e-407d-8182-8e8be1a4f83e" />
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/f008cd16-5bc3-4c75-8992-eb1578ed1c51" />

---

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/c4e3773c-ae03-45b1-ac32-bc8f250af785" />
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/e171d63e-ae6e-40b0-8ee4-5dbd069fe1b3" />

---

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/8fe58858-9ffc-4a7e-8a95-df91e6de4d1a" />
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/e109384a-b5d5-493e-b310-e7dc21976abe" />

## Changelog

NOCHANGELOG
