### PR TITLE
Remove beta banner from airlift docs site

### DIFF
--- a/docs/docs/integrations/libraries/airlift.md
+++ b/docs/docs/integrations/libraries/airlift.md
@@ -19,10 +19,6 @@ sidebar_custom_props:
   logo: images/integrations/airflow.svg
 ---
 
-import Beta from '../../partials/\_Beta.md';
-
-<Beta />
-
 Airlift is a toolkit for integrating Dagster and Airflow. Using [`dagster-airflift`](/api/python-api/libraries/dagster-airlift), you can:
 
 - Observe Airflow instances from within Dagster


### PR DESCRIPTION
## Summary & Motivation
Removes beta banner from airlift docs now that we have technical validation.
## How I Tested These Changes
eyes