### PR TITLE
[ui] Stop defaulting the launch backfill asset selection to “all”

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -81,6 +81,7 @@ export const AssetPartitions = ({
     modifyQueryString: true,
     assetHealth,
     shouldReadPartitionQueryStringParam: false,
+    defaultSelection: 'all',
   });
 
   const [sortTypes, setSortTypes] = useState<Array<SortType>>([]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -192,6 +192,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
     skipPartitionKeyValidation:
       displayedPartitionDefinition?.type === PartitionDefinitionType.DYNAMIC,
     shouldReadPartitionQueryStringParam: true,
+    defaultSelection: 'empty',
   });
 
   const [launchWithRangesAsTags, setLaunchWithRangesAsTags] = useState(false);
@@ -378,16 +379,20 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       );
     }
 
+    const disabled = target.type === 'pureAll' ? false : keysFiltered.length === 0;
+
     return (
-      <Button
-        data-testid={testId('launch-button')}
-        intent="primary"
-        onClick={onLaunch}
-        disabled={target.type === 'pureAll' ? false : keysFiltered.length === 0}
-        loading={launching}
-      >
-        {launching ? 'Launching...' : launchAsBackfill ? 'Launch backfill' : `Launch 1 run`}
-      </Button>
+      <Tooltip canShow={disabled} content="Choose one or more partitions to backfill">
+        <Button
+          data-testid={testId('launch-button')}
+          intent="primary"
+          onClick={onLaunch}
+          disabled={disabled}
+          loading={launching}
+        >
+          {launching ? 'Launching...' : launchAsBackfill ? 'Launch backfill' : `Launch 1 run`}
+        </Button>
+      </Tooltip>
     );
   };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -358,9 +358,26 @@ describe('LaunchAssetExecutionButton', () => {
       });
       await clickMaterializeButton();
       await screen.findByTestId('choose-partitions-dialog');
+      await userEvent.click(await screen.findByTestId('all-partition-button'));
 
       // verify that the executed mutation is correct
       await expectLaunchExecutesMutationAndCloses('Launch backfill', launchMock);
+    });
+
+    it('should default the backfill modal to an empty selection', async () => {
+      renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: 'my_asset_job',
+      });
+      await clickMaterializeButton();
+      await screen.findByTestId('choose-partitions-dialog');
+
+      const launchButton = await screen.findByTestId('launch-button');
+      expect(launchButton.textContent).toEqual('Launch backfill');
+      expect(launchButton).toBeDisabled();
+
+      await userEvent.click(await screen.findByTestId('all-partition-button'));
+      expect(await screen.findByTestId('launch-button')).toBeEnabled();
     });
 
     it('should launch backfills with only missing partitions if requested', async () => {
@@ -381,6 +398,9 @@ describe('LaunchAssetExecutionButton', () => {
       });
       await clickMaterializeButton();
       await screen.findByTestId('choose-partitions-dialog');
+
+      // choose "All" partitions
+      await userEvent.click(await screen.findByTestId('all-partition-button'));
 
       // verify that the preview option is not shown
       expect(screen.queryByTestId('backfill-preview-button')).toBeNull();
@@ -451,6 +471,9 @@ describe('LaunchAssetExecutionButton', () => {
         await clickMaterializeButton();
         await screen.findByTestId('choose-partitions-dialog');
 
+        // choose "All" partitions
+        await userEvent.click(await screen.findByTestId('all-partition-button'));
+
         // missing-and-failed only option is available
         expect(screen.getByTestId('missing-only-checkbox')).toBeEnabled();
 
@@ -487,6 +510,9 @@ describe('LaunchAssetExecutionButton', () => {
         });
         await clickMaterializeButton();
         await screen.findByTestId('choose-partitions-dialog');
+
+        // choose "All" partitions
+        await userEvent.click(await screen.findByTestId('all-partition-button'));
 
         const rangesAsTags = screen.getByTestId('ranges-as-tags-true-radio');
         await waitFor(async () => expect(rangesAsTags).toBeEnabled());
@@ -547,6 +573,9 @@ describe('LaunchAssetExecutionButton', () => {
 
       // expect the dialog to be displayed
       await screen.findByTestId('choose-partitions-dialog');
+
+      // choose "All" partitions
+      await userEvent.click(await screen.findByTestId('all-partition-button'));
 
       // expect the anchor asset to be labeled
       expect(screen.getByTestId('anchor-asset-label')).toHaveTextContent('asset_daily');

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
@@ -158,6 +158,7 @@ const ReportEventDialogBody = ({
     modifyQueryString: false,
     skipPartitionKeyValidation: isDynamic,
     shouldReadPartitionQueryStringParam: true,
+    defaultSelection: 'empty',
   });
 
   const keysFiltered = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -65,7 +65,11 @@ export const DimensionRangeWizard = ({
             Latest
           </Button>
         )}
-        <Button small={true} onClick={() => setSelected(partitionKeys)}>
+        <Button
+          small={true}
+          onClick={() => setSelected(partitionKeys)}
+          data-testid={testId('all-partition-button')}
+        >
           All
         </Button>
       </Box>


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-786/dont-default-the-backfill-modal-to-all-partitions-make-the-user-choose
https://app.usepylon.com/issues?conversationID=ca84fb9d-928b-4992-b2d9-0e11e3ff7926

## How I Tested These Changes

I tested this manually and added additional tests. This behavior is a bit nuanced because on the asset partitions page, your selection on the page is transferred into the modal via the query param. I verified that still works (for all selections other than "All"). I also tested with Dynamic / Static partitions as well as time range partitions just to be safe.

I added a new disabled tooltip in case this change is jarring to users and they don't know what they need to do:

<img width="811" alt="image" src="https://github.com/user-attachments/assets/b9a65d8a-cefb-4f46-bf37-01cd41a02e74" />


## Changelog

- [ui] The launch backfill modal no longer defaults to the "All" partition selection - choose All, Latest, or a custom range before clicking Launch.