### PR TITLE
[ui] Fix reference to react-router’s useHistory

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
@@ -1,5 +1,5 @@
 import {Group} from '@dagster-io/ui-components';
-import {useHistory} from 'react-router';
+import {useHistory} from 'react-router-dom';
 
 import {gql, useMutation} from '../../apollo-client';
 import {BackfillActionsBackfillFragment} from './types/BackfillFragments.types';


### PR DESCRIPTION
## Summary & Motivation

https://dagsterlabs.slack.com/archives/C03KE7K92TT/p1740048483455839

https://app.datadoghq.com/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe%20%40issue.id%3Ae2aa3e7c-ef77-11ef-b02f-da7ad0900002&fromUser=false&issueId=e2aa3e7c-ef77-11ef-b02f-da7ad0900002&refresh_mode=sliding&source=all&from_ts=1740095728752&to_ts=1740110128752&live=true

## How I Tested These Changes

I'm unable to repro the exception in DD calling `history.createHref` and it has only impacted one user so far.  The `useReexecuteBackfill` code is also pretty much identical to `useReexecuteJob`.

This is the only import of `useHistory` from `react-router` and not `react-router-dom`, so I think this is a likely cause. The parent component uses useHistory from dom, which means both are in use at the same time in this tree.
