### PR TITLE
Update error message when not every partition is completed in a canceling backfill

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1199,13 +1199,16 @@ def execute_asset_backfill_iteration(
                 BulkActionStatus.CANCELED
             ).with_end_timestamp(get_current_timestamp())
 
-        instance.update_backfill(updated_backfill)
-
         if all_runs_canceled and not all_partitions_marked_completed:
-            check.failed(
+            logger.warning(
                 "All runs have completed, but not all requested partitions have been marked as materialized or failed. "
-                "This is likely a system error. Please report this issue to the Dagster team."
+                "This may indicate that some runs succeeded without materializing their expected partitions."
             )
+            updated_backfill = updated_backfill.with_status(
+                BulkActionStatus.CANCELED
+            ).with_end_timestamp(get_current_timestamp())
+
+        instance.update_backfill(updated_backfill)
 
         logger.info(
             f"Asset backfill {backfill.backfill_id} completed cancellation iteration with status {updated_backfill.status}."

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2190,8 +2190,8 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
     assert updated_backfill.asset_backfill_data.requested_runs_for_target_roots
 
 
-def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
-    instance: DagsterInstance, workspace_context: WorkspaceProcessContext
+def test_backfill_warns_when_runs_completed_but_partitions_marked_as_in_progress(
+    instance: DagsterInstance, workspace_context: WorkspaceProcessContext, caplog
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
     asset_graph = workspace_context.create_request_context().asset_graph
@@ -2262,11 +2262,16 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
         )
     )
 
-    assert len(errors) == 1
-    error_msg = check.not_none(errors[0]).message
+    assert len(errors) == 0
+
+    updated_backfill = check.not_none(instance.get_backfill(backfill_id))
+    assert updated_backfill.status == BulkActionStatus.CANCELED
+
+    logs = caplog.text
+
     assert (
         "All runs have completed, but not all requested partitions have been marked as materialized or failed"
-    ) in error_msg
+    ) in logs
 
 
 # Job must have a partitions definition with a-b-c-d partitions


### PR DESCRIPTION
## Summary & Motivation
Since there are very plausible scenarios in which this can happen currently (e.g. a run that succeeds but doesn't materialize all its expected partitions), downgrade the severity of the error message here a bit. Make it a warning instead of an exception, no longer say "contact the Dagster team", and move it into a CANCELED state.

## How I Tested These Changes
Updated test

## Changelog
Asset backfills will now move into a CANCELED state instead of a FAILURE state when not every requested partition has been marked as materialized or failed by the backfill.
