### PR TITLE
[ui] Alerts: Add shared components for Schedules/Sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -8,6 +8,7 @@ import {
   Tag,
 } from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
+import {useScheduleAlertDetails} from 'shared/schedules/useScheduleAlertDetails.oss';
 import styled from 'styled-components';
 
 import {SchedulePartitionStatus} from './SchedulePartitionStatus';
@@ -39,6 +40,11 @@ export const ScheduleDetails = (props: {
   const {status, ticks} = scheduleState;
   const latestTick = ticks.length > 0 ? ticks[0] : null;
   const running = status === InstigationStatus.RUNNING;
+
+  const alertDetails = useScheduleAlertDetails({
+    repoAddress,
+    scheduleName: name,
+  });
 
   return (
     <>
@@ -167,6 +173,7 @@ export const ScheduleDetails = (props: {
               <td>{executionTimezone}</td>
             </tr>
           ) : null}
+          {alertDetails}
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/useScheduleAlertDetails.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/useScheduleAlertDetails.oss.tsx
@@ -1,0 +1,8 @@
+import {RepoAddress} from '../workspace/types';
+
+export interface Config {
+  repoAddress: RepoAddress;
+  scheduleName: string;
+}
+
+export const useScheduleAlertDetails = (_config: Config) => null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -11,6 +11,7 @@ import {
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
 import {Link} from 'react-router-dom';
+import {useSensorAlertDetails} from 'shared/sensors/useSensorAlertDetails.oss';
 import styled from 'styled-components';
 
 import {EditCursorDialog} from './EditCursorDialog';
@@ -78,6 +79,11 @@ export const SensorDetails = ({
     loading: loadingPermissions,
   } = usePermissionsForLocation(repoAddress.location);
   const {canUpdateSensorCursor} = permissions;
+
+  const alertDetails = useSensorAlertDetails({
+    repoAddress,
+    sensorName: sensor.name,
+  });
 
   const [isCursorEditing, setCursorEditing] = useState(false);
   const sensorSelector = {
@@ -233,6 +239,7 @@ export const SensorDetails = ({
               </td>
             </tr>
           ) : null}
+          {alertDetails}
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/useSensorAlertDetails.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/useSensorAlertDetails.oss.tsx
@@ -1,0 +1,8 @@
+import {RepoAddress} from '../workspace/types';
+
+export interface Config {
+  repoAddress: RepoAddress;
+  sensorName: string;
+}
+
+export const useSensorAlertDetails = (_config: Config) => null;


### PR DESCRIPTION
## Summary & Motivation

Corresponds to https://github.com/dagster-io/internal/pull/13887.

Add shared components for rendering Alert details in schedule and sensor details. This is effectively a no-op in OSS.

## How I Tested These Changes

TS, lint, jest.

See test plan on internal change.