### PR TITLE
[ui] Alerts: Component instead of hook for shared schedule/sensor

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleAlertDetails.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleAlertDetails.oss.tsx
@@ -1,8 +1,8 @@
 import {RepoAddress} from '../workspace/types';
 
-export interface Config {
+export interface Props {
   repoAddress: RepoAddress;
   scheduleName: string;
 }
 
-export const useScheduleAlertDetails = (_config: Config) => null;
+export const ScheduleAlertDetails = (_props: Props) => null;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -8,7 +8,7 @@ import {
   Tag,
 } from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
-import {useScheduleAlertDetails} from 'shared/schedules/useScheduleAlertDetails.oss';
+import {ScheduleAlertDetails} from 'shared/schedules/ScheduleAlertDetails.oss';
 import styled from 'styled-components';
 
 import {SchedulePartitionStatus} from './SchedulePartitionStatus';
@@ -40,11 +40,6 @@ export const ScheduleDetails = (props: {
   const {status, ticks} = scheduleState;
   const latestTick = ticks.length > 0 ? ticks[0] : null;
   const running = status === InstigationStatus.RUNNING;
-
-  const alertDetails = useScheduleAlertDetails({
-    repoAddress,
-    scheduleName: name,
-  });
 
   return (
     <>
@@ -173,7 +168,7 @@ export const ScheduleDetails = (props: {
               <td>{executionTimezone}</td>
             </tr>
           ) : null}
-          {alertDetails}
+          <ScheduleAlertDetails repoAddress={repoAddress} scheduleName={name} />
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorAlertDetails.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorAlertDetails.oss.tsx
@@ -1,8 +1,8 @@
 import {RepoAddress} from '../workspace/types';
 
-export interface Config {
+export interface Props {
   repoAddress: RepoAddress;
   sensorName: string;
 }
 
-export const useSensorAlertDetails = (_config: Config) => null;
+export const SensorAlertDetails = (_props: Props) => null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -11,16 +11,16 @@ import {
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
 import {Link} from 'react-router-dom';
-import {useSensorAlertDetails} from 'shared/sensors/useSensorAlertDetails.oss';
+import {SensorAlertDetails} from 'shared/sensors/SensorAlertDetails.oss';
 import styled from 'styled-components';
 
 import {EditCursorDialog} from './EditCursorDialog';
 import {SensorMonitoredAssets} from './SensorMonitoredAssets';
 import {SensorResetButton} from './SensorResetButton';
 import {SensorSwitch} from './SensorSwitch';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {EvaluateTickButtonSensor} from '../ticks/EvaluateTickButtonSensor';
 import {SensorFragment} from './types/SensorFragment.types';
-import {usePermissionsForLocation} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {AutomationTargetList} from '../automation/AutomationTargetList';
 import {AutomationAssetSelectionFragment} from '../automation/types/AutomationAssetSelectionFragment.types';
@@ -79,11 +79,6 @@ export const SensorDetails = ({
     loading: loadingPermissions,
   } = usePermissionsForLocation(repoAddress.location);
   const {canUpdateSensorCursor} = permissions;
-
-  const alertDetails = useSensorAlertDetails({
-    repoAddress,
-    sensorName: sensor.name,
-  });
 
   const [isCursorEditing, setCursorEditing] = useState(false);
   const sensorSelector = {
@@ -239,7 +234,7 @@ export const SensorDetails = ({
               </td>
             </tr>
           ) : null}
-          {alertDetails}
+          <SensorAlertDetails repoAddress={repoAddress} sensorName={name} />
         </tbody>
       </MetadataTableWIP>
     </>


### PR DESCRIPTION
## Summary & Motivation

Corresponds to https://github.com/dagster-io/internal/pull/13892.

Shared pieces for displaying alerts on Schedules/Sensors can just be components instead of hooks.

## How I Tested These Changes

TS, lint, jest.