### PR TITLE
[components] `dg configure-editor code-location` -> `dg utils configure-editor` [BUILD-727]

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -34,11 +34,11 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │                                                              use for the cache.        │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ check              Commands for checking the integrity of your Dagster code.           │
-│ configure-editor   Commands for configuring your editor.                               │
-│ dev                Start a local deployment of your Dagster project.                   │
-│ docs               Commands for generating docs from your Dagster code.                │
-│ inspect            Commands for inspecting Dagster entities.                           │
-│ list               Commands for listing Dagster entities.                              │
-│ scaffold           Commands for scaffolding Dagster code.                              │
+│ check      Commands for checking the integrity of your Dagster code.                   │
+│ dev        Start a local deployment of your Dagster project.                           │
+│ docs       Commands for generating docs from your Dagster code.                        │
+│ inspect    Commands for inspecting Dagster entities.                                   │
+│ list       Commands for listing Dagster entities.                                      │
+│ scaffold   Commands for scaffolding Dagster code.                                      │
+│ utils      Assorted utility commands.                                                  │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -3,13 +3,13 @@ from pathlib import Path
 import click
 
 from dagster_dg.cli.check import check_group
-from dagster_dg.cli.configure_editor import configure_editor_group
 from dagster_dg.cli.dev import dev_command
 from dagster_dg.cli.docs import docs_group
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.cli.inspect import inspect_group
 from dagster_dg.cli.list import list_group
 from dagster_dg.cli.scaffold import scaffold_group
+from dagster_dg.cli.utils import utils_group
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -26,7 +26,7 @@ def create_dg_cli():
             "check": check_group,
             "docs": docs_group,
             "inspect": inspect_group,
-            "configure-editor": configure_editor_group,
+            "utils": utils_group,
             "list": list_group,
             "scaffold": scaffold_group,
             "dev": dev_command,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -16,16 +16,16 @@ from dagster_dg.utils.editor import (
 _DEFAULT_SCHEMA_FOLDER_NAME = ".vscode"
 
 
-@click.group(name="configure-editor", cls=DgClickGroup)
-def configure_editor_group():
-    """Commands for configuring your editor."""
+@click.group(name="utils", cls=DgClickGroup)
+def utils_group():
+    """Assorted utility commands."""
 
 
-@configure_editor_group.command(name="code-location", cls=DgClickCommand)
+@utils_group.command(name="configure-editor", cls=DgClickCommand)
 @dg_global_options
 @click.argument("editor", type=click.Choice(["vscode", "cursor"]))
 @click.pass_context
-def configure_editor_code_location_command(
+def configure_editor_command(
     context: click.Context,
     editor: str,
     **global_options: object,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
@@ -15,7 +15,7 @@ def mock_vscode_cli_command(editor, args: list[str]) -> bytes:
 
 
 @pytest.mark.parametrize("editor", ["vscode", "cursor"])
-def test_configure_editor_code_location(editor: str) -> None:
+def test_utils_configure_editor(editor: str) -> None:
     with (
         ProxyRunner.test() as runner,
         TemporaryDirectory() as extension_dir,
@@ -26,7 +26,7 @@ def test_configure_editor_code_location(editor: str) -> None:
         ),
         isolated_example_code_location_foo_bar(runner, False),
     ):
-        out = runner.invoke("configure-editor", "code-location", editor)
+        out = runner.invoke("utils", "configure-editor", editor)
 
         assert out.exit_code == 0
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -47,7 +47,7 @@ REGISTRY_CONTEXT_COMMANDS = [
 ]
 
 CODE_LOCATION_CONTEXT_COMMANDS = [
-    CommandSpec(("configure-editor", "code-location"), "vscode"),
+    CommandSpec(("utils", "configure-editor"), "vscode"),
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
     CommandSpec(("scaffold", "component"), DEFAULT_COMPONENT_TYPE, "foot"),


### PR DESCRIPTION
## Summary & Motivation

Move `dg configure-editor code-location` -> `dg utils configure-editor`.

## How I Tested These Changes

Existing test suite.