### PR TITLE
[components] Standardize duckdb table width when generating CLI snippet output

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
@@ -1,9 +1,8 @@
-import os
 import textwrap
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from typing import Callable
 
 from dagster._utils import pushd

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/utils.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/utils.py
@@ -6,6 +6,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
+import pexpect
+
 if TYPE_CHECKING:
     from selenium import webdriver
 
@@ -55,13 +57,16 @@ def _run_command(cmd: Union[str, Sequence[str]], expect_error: bool = False) -> 
         cmd = " ".join(cmd)
 
     try:
-        actual_output = (
-            subprocess.check_output(
-                f'{cmd} && echo "PWD=$(pwd);"', shell=True, stderr=subprocess.STDOUT
+        if cmd.startswith("duckdb"):
+            actual_output = _run_duckdb_command(cmd)
+        else:
+            actual_output = (
+                subprocess.check_output(
+                    f'{cmd} && echo "PWD=$(pwd);"', shell=True, stderr=subprocess.STDOUT
+                )
+                .decode("utf-8")
+                .strip()
             )
-            .decode("utf-8")
-            .strip()
-        )
         if expect_error:
             print(f"Ran command {cmd}")  # noqa: T201
             print("Got output:")  # noqa: T201
@@ -84,6 +89,50 @@ def _run_command(cmd: Union[str, Sequence[str]], expect_error: bool = False) -> 
     actual_output = ANSI_ESCAPE.sub("", actual_output)
 
     return actual_output
+
+
+# DuckDB modulates its output based on whether it is running in a terminal or not. In particular, it
+# will only respect `.maxwidth` when running in a terminal, as of version 1.2. This means to
+# standardize the output across environments (CI vs local dev on different machines), we need to
+# mimic a terminal. We do this using `pexpect` to spawn a child process connected to a
+# pseudo-terminal. This approach may also prove useful for other commands that modulate their output
+# based on the terminal.
+def _run_duckdb_command(cmd: str) -> str:
+    pattern = r'(duckdb .*) -c "(.*)"'
+    match = re.match(pattern, cmd)
+    if not match:
+        raise ValueError(f"Could not match pattern `{pattern}` in duckdb command {cmd}")
+
+    duckdb_launch_cmd = match.group(1)
+    sql_cmd = match.group(2)
+    child = pexpect.spawn(duckdb_launch_cmd, encoding="utf-8")
+    child.sendline(".maxwidth 110")
+    child.sendline(sql_cmd)
+    child.sendline(".quit")
+    child.expect(pexpect.EOF)
+    output = child.before
+    assert output is not None
+    output = ANSI_ESCAPE.sub("", output)
+    # \r\r can sometimes happen due to weird interactions between pexpect and DuckDB
+    output = output.replace("\r\r", "\r")
+    return _extract_output_table_from_duckdb_output(output)
+
+
+def _extract_output_table_from_duckdb_output(output: str) -> str:
+    lines = output.splitlines()
+    table_start_char = "┌"
+    table_end_char = "└"
+    start_idx = None
+    end_idx = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith(table_start_char):
+            start_idx = idx
+        if line.strip().startswith(table_end_char):
+            end_idx = idx
+            break
+    assert start_idx is not None, "Could not find start of table"
+    assert end_idx is not None, "Could not find end of table"
+    return "\n".join(lines[start_idx : end_idx + 1])
 
 
 def _assert_matches_or_update_snippet(

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -13,6 +13,7 @@ install_command = uv pip install {opts} {packages}
 deps =
   duckdb
   plotly
+  pexpect
   ####
   # need deps of dagster-cloud that we need to add since we --no-deps below to avoid reinstalling dagster packages
   opentelemetry-api


### PR DESCRIPTION
## Summary & Motivation

Standardize output width for duckdb commands in docs snippets. We do this by executing them in a pseudoterminal using `pexpect` and setting duckdb's `.maxwidth` setting.

DuckDB's `.maxwidth` setting is extremely finicky and annoying. It is often silently ignored. The only way I could get it to reliably actuate was when running interactively from the command line. It seems to change it's behavior based on the kind of output stream it's hooked up to.

The solution here is unfortunately complex, but so far as I can tell there is no way at all to get `duckdb` to respect `.maxwidth` outside of a terminal environment. I tried using an `-init` script and many other things. It just silently ignores `.maxwidth` unless you are in a terminal. So we simulate a terminal with `pexpect`, which works. This same approach may prove useful in the future for other CLIs that try to detect a terminal.

## How I Tested These Changes

Regenerated snippets locally, no changes-- previously it would generate a longer duckdb table than would be generated in CI.