### PR TITLE
Do not parallelize local API docs build

### DIFF
--- a/docs/docs/guides/deploy/execution/run-coordinators.md
+++ b/docs/docs/guides/deploy/execution/run-coordinators.md
@@ -18,6 +18,6 @@ The following run coordinators can be configured on your [Dagster instance](/gui
 
 ## Configuring run coordinators
 
-If you opt to use the `DefaultRunCoordinator`, no configuration is required on your part.
+If you use the `DefaultRunCoordinator`, no configuration is required on your part.
 
 However, if using the `QueuedRunCoordinator` or building a custom implementation, you can define [custom run prioritization rules](customizing-run-queue-priority) and [instance-level concurrency limits](/guides/operate/managing-concurrency).

--- a/docs/scripts/build-api-docs.sh
+++ b/docs/scripts/build-api-docs.sh
@@ -38,7 +38,7 @@ if [ "$VERCEL" = "1" ]; then
   tox -e sphinx-mdx-vercel
   cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
 
-  # Parallelize production sphinx build -- see tox.ini
+  # Parallelize production sphinx-inv build -- see tox.ini
   echo "Running sphinx and copying \`object.inv\` to \`static/\`"
   tox -e sphinx-inv-vercel
   cp sphinx/_build/json/objects.inv static/.
@@ -48,7 +48,7 @@ else
   tox -e sphinx-mdx-local
   cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
   
-  # Do not parallelize local sphinx-mdx build -- see tox.ini
+  # Do not parallelize local sphinx-inv build -- see tox.ini
   echo "Running sphinx and copying \`object.inv\` to \`static/\`"
   tox -e sphinx-inv-local
   cp sphinx/_build/json/objects.inv static/.

--- a/docs/scripts/build-api-docs.sh
+++ b/docs/scripts/build-api-docs.sh
@@ -32,12 +32,24 @@ if [ "$VERCEL" = "1" ]; then
   export LC_ALL=C.UTF-8
   uv_install
   uv_activate_venv
+
+  # Parallelize production sphinx-mdx build -- see tox.ini
+  echo "Running sphinx-mdx and copying files to \`docs/api/python-api\`"
+  tox -e sphinx-mdx-vercel
+  cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
+
+  # Parallelize production sphinx build -- see tox.ini
+  echo "Running sphinx and copying \`object.inv\` to \`static/\`"
+  tox -e sphinx-inv-vercel
+  cp sphinx/_build/json/objects.inv static/.
+else
+  # Do not parallelize local sphinx-mdx build -- see tox.ini
+  echo "Running sphinx-mdx and copying files to \`docs/api/python-api\`"
+  tox -e sphinx-mdx-local
+  cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
+  
+  # Do not parallelize local sphinx-mdx build -- see tox.ini
+  echo "Running sphinx and copying \`object.inv\` to \`static/\`"
+  tox -e sphinx-inv-local
+  cp sphinx/_build/json/objects.inv static/.
 fi
-
-echo "Running sphinx-mdx and copying files to \`docs/api/python-api\`"
-tox -e sphinx-mdx
-cp -rf sphinx/_build/mdx/sections/api/apidocs/* docs/api/python-api/
-
-echo "Running sphinx and copying \`object.inv\` to \`static/\`"
-tox -e sphinx
-cp sphinx/_build/json/objects.inv static/.

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,4 +1,3 @@
-#SPHINXOPTS    ?= -j auto -W --keep-going -v
 # All SPHINXOPTS should be specified in tox.ini or command line
 SPHINXOPTS	  ?=
 SPHINXBUILD   ?= sphinx-build 

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,4 +1,6 @@
-SPHINXOPTS    ?= -j auto -W --keep-going -v
+#SPHINXOPTS    ?= -j auto -W --keep-going -v
+# All SPHINXOPTS should be specified in tox.ini or command line
+SPHINXOPTS	  ?=
 SPHINXBUILD   ?= sphinx-build 
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -14,9 +14,8 @@ passenv =
 allowlist_externals =
   make
   uv
+  cp
 install_command = uv pip install {opts} {packages}
-
-[testenv:sphinx]
 deps =
   -r sphinx/requirements.txt
   -e sphinx/_ext/dagster-sphinx
@@ -54,46 +53,32 @@ deps =
   -e ../examples/airlift-migration-tutorial
   sling
 
+[testenv:sphinx-mdx-local]
+# Since M3 Macs and Windows systems cannot parallelize the build,
+# do not set -j flag
 commands =
   make --directory=sphinx clean
-  make --directory=sphinx json SPHINXOPTS="-W --keep-going"
+  make --directory=sphinx mdx SPHINXOPTS="-W"
 
-[testenv:sphinx-mdx]
-deps =
-  -r sphinx/requirements.txt
-  -e sphinx/_ext/dagster-sphinx
-  -e sphinx/_ext/sphinx-click
-  -e sphinx/_ext/sphinx-mdx-builder
-
-  # Can't stub deps because processed by sphinx-click
-  -e ../python_modules/dagster
-  -e ../python_modules/dagster-pipes
-  -e ../python_modules/dagster-graphql
-  -e ../python_modules/dagster-webserver
-  -e ../python_modules/libraries/dagster-celery
-
-  # Can't stub deps due to import-time use of at least one dep
-  -e ../python_modules/libraries/dagstermill
-  -e ../python_modules/libraries/dagster-aws
-  -e ../python_modules/libraries/dagster-datahub
-  -e ../python_modules/libraries/dagster-gcp[dataproc]
-  -e ../python_modules/libraries/dagster-pyspark
-  -e ../python_modules/libraries/dagster-ssh
-  -e ../python_modules/libraries/dagster-duckdb
-  -e ../python_modules/libraries/dagster-dbt
-  -e ../python_modules/libraries/dagster-dlt
-  -e ../python_modules/libraries/dagster-sling
-  -e ../python_modules/libraries/dagster-wandb
-  -e ../python_modules/libraries/dagster-deltalake
-  -e ../python_modules/libraries/dagster-deltalake-pandas
-  -e ../python_modules/libraries/dagster-deltalake-polars
-  -e ../python_modules/libraries/dagster-openai
-  -e ../python_modules/libraries/dagster-looker
-  -e ../python_modules/libraries/dagster-sigma
-  -e ../python_modules/libraries/dagster-tableau
-  -e ../python_modules/libraries/dagster-powerbi
-  sling
-
+[testenv:sphinx-mdx-vercel]
+# -j auto distributes the build over N parallel processes
+# If auto argument is given, Sphinx uses the number of CPUs as N
+# https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j
 commands =
   make --directory=sphinx clean
-  make --directory=sphinx mdx SPHINXOPTS="-W --keep-going"
+  make --directory=sphinx mdx SPHINXOPTS="-W -j auto"
+
+[testenv:sphinx-inv-local]
+# Since M3 Macs and Windows systems cannot parallelize the build,
+# do not set -j flag
+commands =
+  make --directory=sphinx clean
+  make --directory=sphinx json SPHINXOPTS="-W"
+
+[testenv:sphinx-inv-vercel]
+# -j auto distributes the build over N parallel processes
+# If auto argument is given, Sphinx uses the number of CPUs as N
+# https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j
+commands =
+  make --directory=sphinx clean
+  make --directory=sphinx json SPHINXOPTS="-W -j auto"

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -14,7 +14,6 @@ passenv =
 allowlist_externals =
   make
   uv
-  cp
 install_command = uv pip install {opts} {packages}
 deps =
   -r sphinx/requirements.txt


### PR DESCRIPTION
## Summary & Motivation

Parallelized Sphinx builds are not working on M3 Macs and don't work on Windows, so don't parallelize local builds. (We can still parallelize the Vercel/production build.)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
