### PR TITLE
[components] [RFC] Overhaul DgConfig, replace `is_{workspace,project}` with `directory_type` field

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/2-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/2-pyproject.toml
@@ -1,6 +1,10 @@
 ...
 [tool.dg]
-is_project = true
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "my_existing_project"
+components_module = "my_existing_project.components"
 
 [tool.dagster]
 module_name = "my_existing_project.definitions"

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -30,7 +30,7 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ --verbose                                                    Enable verbose output for │
 │                                                              debugging.                │
 │ --disable-cache                                              Disable the cache..       │
-│ --cache-dir                                            PATH  Specify a directory to    │
+│ --cache-dir                                            TEXT  Specify a directory to    │
 │                                                              use for the cache.        │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
@@ -4,5 +4,8 @@ module_name = "jaffle_platform.definitions"
 code_location_name = "jaffle-platform"
 
 [tool.dg]
-is_project = true
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "jaffle_platform"
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
@@ -1,2 +1,4 @@
 [tool.dg]
-is_workspace = true
+directory_type = "workspace"
+
+[tool.dg.workspace]

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
@@ -4,5 +4,8 @@ module_name = "project_1.definitions"
 code_location_name = "project-1"
 
 [tool.dg]
-is_project = true
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "project_1"
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -77,7 +77,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),
-                re_ignore_after("is_project = true"),
+                re_ignore_after('root_module = "jaffle_platform"'),
             ],
         )
         check_file(

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_existing_project/test_existing_code_location.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_existing_project/test_existing_code_location.py
@@ -46,7 +46,11 @@ def test_components_docs_index(update_snippets: bool) -> None:
         pyproject_contents = Path("pyproject.toml").read_text()
         tool_dg_section = format_multiline("""
             [tool.dg]
-            is_project = true
+            directory_type = "project"
+
+            [tool.dg.project]
+            root_module = "my_existing_project"
+            components_module = "my_existing_project.components"
         """)
         pyproject_contents = pyproject_contents.replace(
             "[tool.dagster]", f"{tool_dg_section}\n\n[tool.dagster]"

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/my-existing-project/pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/my-existing-project/pyproject.toml
@@ -20,7 +20,11 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dg]
-is_project = true
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "my_existing_project"
+components_module = "my_existing_project.components"
 
 [tool.dagster]
 module_name = "my_existing_project.definitions"

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
@@ -86,7 +86,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),
-                re_ignore_after("is_project = true"),
+                re_ignore_after('root_module = "project_1"'),
             ],
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -51,8 +51,8 @@ class DgCache:
     @classmethod
     def from_config(cls, config: DgConfig) -> Self:
         return cls.from_parent_path(
-            parent_path=config.cache_dir,
-            logging_enabled=config.verbose,
+            parent_path=config.cli.cache_dir,
+            logging_enabled=config.cli.verbose,
         )
 
     # This is the preferred constructor to use when creating a cache. It ensures that all data is

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -78,7 +78,9 @@ def create_dg_cli():
             exit_with_error("Cannot specify both --clear-cache and --rebuild-component-registry.")
         elif clear_cache:
             cli_config = normalize_cli_config(global_options, context)
-            dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+            dg_context = DgContext.from_file_discovery_and_command_line_config(
+                Path.cwd(), cli_config
+            )
             dg_context.cache.clear_all()
             if context.invoked_subcommand is None:
                 context.exit(0)
@@ -98,7 +100,7 @@ def create_dg_cli():
 def _rebuild_component_registry(dg_context: DgContext):
     if not dg_context.has_cache:
         exit_with_error("Cache is disabled. This command cannot be run without a cache.")
-    elif not dg_context.config.use_dg_managed_environment:
+    elif not dg_context.config.cli.use_dg_managed_environment:
         exit_with_error(
             "Cannot rebuild the component registry with environment management disabled."
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
@@ -1,10 +1,9 @@
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar, Union
 
 import click
 
-from dagster_dg.config import DgConfig
+from dagster_dg.config import DgCliConfig
 from dagster_dg.utils import set_option_help_output_group
 
 T_Command = TypeVar("T_Command", bound=Union[Callable[..., Any], click.Command])
@@ -15,38 +14,37 @@ GLOBAL_OPTIONS = {
     for option in [
         click.Option(
             ["--cache-dir"],
-            type=Path,
-            default=DgConfig.cache_dir,
+            default=str(DgCliConfig.cache_dir),
             help="Specify a directory to use for the cache.",
         ),
         click.Option(
             ["--disable-cache"],
             is_flag=True,
-            default=DgConfig.disable_cache,
+            default=DgCliConfig.disable_cache,
             help="Disable the cache..",
         ),
         click.Option(
             ["--verbose"],
             is_flag=True,
-            default=DgConfig.verbose,
+            default=DgCliConfig.verbose,
             help="Enable verbose output for debugging.",
         ),
         click.Option(
             ["--builtin-component-lib"],
             type=str,
-            default=DgConfig.builtin_component_lib,
+            default=DgCliConfig.builtin_component_lib,
             help="Specify a builitin component library to use.",
         ),
         click.Option(
             ["--use-dg-managed-environment/--no-use-dg-managed-environment"],
             is_flag=True,
-            default=DgConfig.use_dg_managed_environment,
+            default=DgCliConfig.use_dg_managed_environment,
             help="Enable management of the virtual environment with uv.",
         ),
         click.Option(
             ["--require-local-venv/--no-require-local-venv"],
             is_flag=True,
-            default=DgConfig.require_local_venv,
+            default=DgCliConfig.require_local_venv,
             help="Require use of a local virtual environment (`.venv` found in ancestors of the working directory).",
         ),
     ]

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -50,7 +50,7 @@ def init_command(
     ).strip()
 
     workspace_path = scaffold_workspace(workspace_name)
-    workspace_dg_context = DgContext.from_config_file_discovery_and_cli_config(
+    workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
         workspace_path, cli_config
     )
 
@@ -66,7 +66,7 @@ def init_command(
             "Continuing without adding a project. You can create one later by running `dg scaffold project`."
         )
     else:
-        workspace_dg_context = DgContext.from_config_file_discovery_and_cli_config(
+        workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
             workspace_path, cli_config
         )
         if workspace_dg_context.has_project(project_name):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -102,7 +102,9 @@ def workspace_scaffold_command(
     hidden=True,
 )
 @dg_global_options
+@click.pass_context
 def project_scaffold_command(
+    context: click.Context,
     name: str,
     use_editable_dagster: Optional[str],
     skip_venv: bool,
@@ -133,8 +135,8 @@ def project_scaffold_command(
     component`).  The `<name>.lib` directory holds custom component types scoped to the project
     (which can be created with `dg scaffold component-type`).
     """  # noqa: D301
-    cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), cli_config)
+    cli_config = normalize_cli_config(global_options, context)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
     if dg_context.is_workspace:
         if dg_context.has_project(name):
             exit_with_error(f"A project named {name} already exists.")
@@ -239,13 +241,13 @@ class ComponentScaffoldSubCommand(DgClickCommand):
 )
 @click.option("-h", "--help", "help_", is_flag=True, help="Show this message and exit.")
 @dg_global_options
-def component_scaffold_group(help_: bool, **global_options: object) -> None:
+@click.pass_context
+def component_scaffold_group(context: click.Context, help_: bool, **global_options: object) -> None:
     """Scaffold of a Dagster component."""
     # Click attempts to resolve subcommands BEFORE it invokes this callback.
     # Therefore we need to manually invoke this callback during subcommand generation to make sure
     # it runs first. It will be invoked again later by Click. We make it idempotent to deal with
     # that.
-    context = click.get_current_context()
     if not has_config_on_cli_context(context):
         cli_config = normalize_cli_config(global_options, context)
         set_config_on_cli_context(context, cli_config)
@@ -354,16 +356,19 @@ def _create_component_scaffold_subcommand(
 @scaffold_group.command(name="component-type", cls=DgClickCommand)
 @click.argument("name", type=str)
 @dg_global_options
-def component_type_scaffold_command(name: str, **global_options: object) -> None:
+@click.pass_context
+def component_type_scaffold_command(
+    context: click.Context, name: str, **global_options: object
+) -> None:
     """Scaffold of a custom Dagster component type.
 
     This command must be run inside a Dagster project directory. The component type scaffold
     will be placed in submodule `<project_name>.lib.<name>`.
     """
-    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalComponentKey(name=name, namespace=dg_context.root_package_name)
+    component_key = GlobalComponentKey(name=name, namespace=dg_context.root_module_name)
     if registry.has_global(component_key):
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,12 +1,25 @@
+import functools
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, TypedDict, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    TypedDict,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 import click
 import tomlkit
 import tomlkit.items
 from click.core import ParameterSource
+from typing_extensions import Never, NotRequired, Required, Self, TypeAlias, TypeGuard
 
 from dagster_dg.error import DgError, DgValidationError
 from dagster_dg.utils import get_toml_value, is_macos, is_windows
@@ -28,9 +41,112 @@ def _get_default_cache_dir() -> Path:
 DEFAULT_CACHE_DIR = _get_default_cache_dir()
 
 
+def discover_workspace_root(path: Path) -> Optional[Path]:
+    workspace_config_path = discover_config_file(
+        path, lambda config: config["directory_type"] == "workspace"
+    )
+    return workspace_config_path.parent if workspace_config_path else None
+
+
+def discover_config_file(
+    path: Path,
+    predicate: Optional[Callable[[Mapping[str, Any]], bool]] = None,
+) -> Optional[Path]:
+    current_path = path.absolute()
+    while True:
+        config_path = current_path / "pyproject.toml"
+        if config_path.exists() and has_dg_file_config(config_path, predicate):
+            return config_path
+        if current_path == current_path.parent:  # root
+            return
+        current_path = current_path.parent
+
+
+# NOTE: The set/has/get_config_from_cli_context is only used for the dynamically generated scaffold
+# component commands. Hopefully we can get rid of it in the future.
+
+_CLI_CONTEXT_CONFIG_KEY = "config"
+
+
+def set_config_on_cli_context(cli_context: click.Context, config: "DgRawCliConfig") -> None:
+    cli_context.ensure_object(dict)
+    cli_context.obj[_CLI_CONTEXT_CONFIG_KEY] = config
+
+
+def has_config_on_cli_context(cli_context: click.Context) -> bool:
+    return _CLI_CONTEXT_CONFIG_KEY in cli_context.ensure_object(dict)
+
+
+def get_config_from_cli_context(cli_context: click.Context) -> "DgRawCliConfig":
+    cli_context.ensure_object(dict)
+    return cli_context.obj[_CLI_CONTEXT_CONFIG_KEY]
+
+
+# ########################
+# ##### MAIN
+# ########################
+
+
 @dataclass
 class DgConfig:
-    """Global configuration for Dg.
+    cli: "DgCliConfig"
+    project: Optional["DgProjectConfig"] = None
+    workspace: Optional["DgWorkspaceConfig"] = None
+
+    @classmethod
+    def default(cls) -> Self:
+        return cls(DgCliConfig.default())
+
+    # Note that this function takes an argument called `container_workspace_file_config` instead of
+    # just `workspace_file_config` because this is only to be passed when the root file config
+    # points to a project inside of a workspace. If there is no package and the
+    # root is itself a workspace, then `root_file_config` corresponds to the workspace and
+    # `container_workspace_file_config` should be None.
+    @classmethod
+    def from_partial_configs(
+        cls,
+        root_file_config: Optional["DgFileConfig"] = None,
+        container_workspace_file_config: Optional["DgWorkspaceFileConfig"] = None,
+        command_line_config: Optional["DgRawCliConfig"] = None,
+    ) -> Self:
+        cli_partials: list[DgRawCliConfig] = []
+
+        if container_workspace_file_config:
+            if "cli" in container_workspace_file_config:
+                cli_partials.append(container_workspace_file_config["cli"])
+            workspace_config = DgWorkspaceConfig.from_raw(container_workspace_file_config)
+
+        if root_file_config:
+            if "cli" in root_file_config:
+                cli_partials.append(root_file_config["cli"])
+
+            if is_workspace_file_config(root_file_config):
+                project_config = None
+                workspace_config = DgWorkspaceConfig.from_raw(root_file_config["workspace"])
+            elif is_project_file_config(root_file_config):
+                project_config = DgProjectConfig.from_raw(root_file_config["project"])
+                if not container_workspace_file_config:
+                    workspace_config = None
+
+        else:
+            project_config = None
+            workspace_config = None
+
+        if command_line_config:
+            cli_partials.append(command_line_config)
+        cli_config = DgCliConfig.from_raw(*cli_partials) if cli_partials else DgCliConfig.default()
+
+        return cls(cli_config, project_config, workspace_config)
+
+
+# ########################
+# ##### CLI
+# ########################
+
+
+@dataclass
+class DgCliConfig:
+    """CLI configuration for Dg.
 
     Args:
         disable_cache (bool): If True, disable caching. Defaults to False.
@@ -52,115 +168,152 @@ class DgConfig:
     builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
     use_dg_managed_environment: bool = True
     require_local_venv: bool = True
-    is_project: bool = False
-    is_workspace: bool = False
-    root_package: Optional[str] = None
-    component_package: Optional[str] = None
 
     @classmethod
-    def discover_config_file(
-        cls,
-        path: Path,
-        predicate: Optional[Callable[[Mapping[str, Any]], bool]] = None,
-    ) -> Optional[Path]:
-        current_path = path.absolute()
-        while True:
-            config_path = current_path / "pyproject.toml"
-            if config_path.exists() and is_dg_config_file(config_path, predicate):
-                return config_path
-            if current_path == current_path.parent:  # root
-                return
-            current_path = current_path.parent
-
-    @classmethod
-    def default(cls) -> "DgConfig":
+    def default(cls) -> Self:
         return cls()
 
+    @classmethod
+    def from_raw(cls, *partials: "DgRawCliConfig") -> Self:
+        merged = cast("DgRawCliConfig", functools.reduce(lambda acc, x: {**acc, **x}, partials))  # type: ignore
+        return cls(
+            disable_cache=merged.get("disable_cache", DgCliConfig.disable_cache),
+            cache_dir=Path(merged["cache_dir"]) if "cache_dir" in merged else DgCliConfig.cache_dir,
+            verbose=merged.get("verbose", DgCliConfig.verbose),
+            builtin_component_lib=merged.get(
+                "builtin_component_lib", DgCliConfig.builtin_component_lib
+            ),
+            use_dg_managed_environment=merged.get(
+                "use_dg_managed_environment", DgCliConfig.use_dg_managed_environment
+            ),
+            require_local_venv=merged.get("require_local_venv", DgCliConfig.require_local_venv),
+        )
 
-class DgPartialConfig(TypedDict, total=False):
+
+# All fields are optional
+class DgRawCliConfig(TypedDict, total=False):
     disable_cache: bool
-    cache_dir: Path
+    cache_dir: str
     verbose: bool
     builtin_component_lib: str
     use_dg_managed_environment: bool
     require_local_venv: bool
-    component_package: str
-    is_project: bool
-    is_workspace: bool
-
-
-def _normalize_dg_partial_config(raw_dict: Mapping[str, object]) -> DgPartialConfig:
-    config = {**raw_dict}  # copy so we can modify it
-    if "disable_cache" in config and not isinstance(config["disable_cache"], bool):
-        raise DgValidationError("`disable_cache` must be a boolean.")
-    if "cache_dir" in config:
-        if not isinstance(config["cache_dir"], (Path, str)):
-            raise DgValidationError("`cache_dir` must be a string.")
-        elif isinstance(config["cache_dir"], str):
-            config["cache_dir"] = Path(config["cache_dir"])
-    if "verbose" in config and not isinstance(config["verbose"], bool):
-        raise DgValidationError("`verbose` must be a boolean.")
-    if "builtin_component_lib" in config and not isinstance(config["builtin_component_lib"], str):
-        raise DgValidationError("`builtin_component_lib` must be a string.")
-    if "use_dg_managed_environment" in config and not isinstance(
-        config["use_dg_managed_environment"], bool
-    ):
-        raise DgValidationError("`use_dg_managed_environment` must be a boolean.")
-    if "require_local_venv" in config and not isinstance(config["require_local_venv"], bool):
-        raise DgValidationError("`require_local_venv` must be a boolean.")
-    if "component_package" in config and not isinstance(config["component_package"], str):
-        raise DgValidationError("`component_package` must be a string.")
-    if "is_project" in config and not isinstance(config["is_project"], bool):
-        raise DgValidationError("`is_project` must be a boolean.")
-
-    if "is_workspace" in config and not isinstance(config["is_workspace"], bool):
-        raise DgValidationError("`is_workspace` must be a boolean.")
-
-    if unrecognized_keys := [k for k in config.keys() if k not in DgPartialConfig.__annotations__]:
-        raise DgValidationError(f"Unrecognized fields in configuration: {unrecognized_keys}")
-    return cast(DgPartialConfig, config)
 
 
 # ########################
-# ##### CONFIG CLI OPTIONS
+# ##### PROJECT
+# ########################
+
+
+@dataclass
+class DgProjectConfig:
+    root_module: str
+    components_module: Optional[str] = None
+
+    @classmethod
+    def from_raw(cls, raw: "DgRawProjectConfig") -> Self:
+        return cls(
+            root_module=raw["root_module"],
+            components_module=raw.get("components_module", DgProjectConfig.components_module),
+        )
+
+
+class DgRawProjectConfig(TypedDict):
+    root_module: Required[str]
+    components_module: NotRequired[str]
+
+
+# ########################
+# ##### WORKSPACE
+# ########################
+
+
+@dataclass
+class DgWorkspaceConfig:
+    pass
+
+    @classmethod
+    def from_raw(cls, raw: "DgRawWorkspaceConfig") -> Self:
+        return cls()
+
+
+class DgRawWorkspaceConfig(TypedDict):
+    pass
+
+
+# ########################
+# ##### CLI CONFIG
 # ########################
 
 
 def normalize_cli_config(
     cli_options: Mapping[str, object], cli_context: click.Context
-) -> DgPartialConfig:
+) -> DgRawCliConfig:
     # Remove any options that weren't explicitly provided.
     filtered_options = {
         key: value
         for key, value in cli_options.items()
         if cli_context.get_parameter_source(key) != ParameterSource.DEFAULT
     }
-    return _normalize_dg_partial_config(filtered_options)
+    return _validate_cli_config(filtered_options)
 
 
-_CLI_CONTEXT_CONFIG_KEY = "config"
+def _validate_cli_config(cli_opts: Mapping[str, object]) -> DgRawCliConfig:
+    try:
+        for key, type_ in DgRawCliConfig.__annotations__.items():
+            _validate_cli_config_setting(cli_opts, key, type_)
+        _validate_cli_config_no_extraneous_keys(cli_opts)
+    except DgValidationError as e:
+        _raise_cli_config_validation_error(str(e))
+    return cast(DgRawCliConfig, cli_opts)
 
 
-def set_config_on_cli_context(cli_context: click.Context, config: DgPartialConfig) -> None:
-    cli_context.ensure_object(dict)
-    cli_context.obj[_CLI_CONTEXT_CONFIG_KEY] = config
+def _validate_cli_config_setting(cli_opts: Mapping[str, object], key: str, type_: type) -> None:
+    if key in cli_opts and not isinstance(cli_opts[key], type_):
+        raise DgValidationError(f"`{key}` must be a {type_.__name__}.")
 
 
-def has_config_on_cli_context(cli_context: click.Context) -> bool:
-    return _CLI_CONTEXT_CONFIG_KEY in cli_context.ensure_object(dict)
+def _validate_cli_config_no_extraneous_keys(cli_opts: Mapping[str, object]) -> None:
+    extraneous_keys = [k for k in cli_opts.keys() if k not in DgRawCliConfig.__annotations__]
+    if extraneous_keys:
+        raise DgValidationError(f"Unrecognized fields: {extraneous_keys}")
 
 
-def get_config_from_cli_context(cli_context: click.Context) -> DgPartialConfig:
-    cli_context.ensure_object(dict)
-    return cli_context.obj[_CLI_CONTEXT_CONFIG_KEY]
+def _raise_cli_config_validation_error(message: str) -> None:
+    raise DgError(f"Error in CLI options: {message}")
 
 
 # ########################
-# ##### CONFIG FILE LOADING
+# ##### FILE CONFIG
 # ########################
 
+DgFileConfigDirectoryType = Literal["workspace", "project"]
 
-def is_dg_config_file(
+
+class DgWorkspaceFileConfig(TypedDict):
+    directory_type: Required[Literal["workspace"]]
+    workspace: Required[DgRawWorkspaceConfig]
+    cli: NotRequired[DgRawCliConfig]
+
+
+def is_workspace_file_config(config: "DgFileConfig") -> TypeGuard[DgWorkspaceFileConfig]:
+    return config["directory_type"] == "workspace"
+
+
+class DgProjectFileConfig(TypedDict):
+    directory_type: Required[Literal["project"]]
+    project: Required[DgRawProjectConfig]
+    cli: NotRequired[DgRawCliConfig]
+
+
+def is_project_file_config(config: "DgFileConfig") -> TypeGuard[DgProjectFileConfig]:
+    return config["directory_type"] == "project"
+
+
+DgFileConfig: TypeAlias = Union[DgWorkspaceFileConfig, DgProjectFileConfig]
+
+
+def has_dg_file_config(
     path: Path, predicate: Optional[Callable[[Mapping[str, Any]], bool]] = None
 ) -> bool:
     toml = tomlkit.parse(path.read_text())
@@ -169,15 +322,157 @@ def is_dg_config_file(
     )
 
 
-def load_dg_config_file(path: Path) -> DgPartialConfig:
+def load_dg_root_file_config(path: Path) -> DgFileConfig:
+    return _load_dg_file_config(path)
+
+
+def load_dg_workspace_file_config(path: Path) -> "DgWorkspaceFileConfig":
+    config = _load_dg_file_config(path)
+    if is_workspace_file_config(config):
+        return config
+    else:
+        _raise_file_config_validation_error("Expected a workspace configuration.", path)
+
+
+def _load_dg_file_config(path: Path) -> DgFileConfig:
     toml = tomlkit.parse(path.read_text())
     raw_dict = get_toml_value(toml, ["tool", "dg"], tomlkit.items.Table).unwrap()
     try:
-        _normalize_dg_partial_config({k: v for k, v in raw_dict.items()})
+        config = _validate_dg_file_config({k: v for k, v in raw_dict.items()})
     except DgValidationError as e:
         _raise_file_config_validation_error(str(e), path)
-    return cast(DgPartialConfig, raw_dict)
+    return config
 
 
-def _raise_file_config_validation_error(message: str, file_path: Path) -> None:
+def _validate_dg_file_config(raw_dict: Mapping[str, object]) -> DgFileConfig:
+    # For now we special case this because it needs to match a Literal, but later we should adapt
+    # the _validate_file_config_setting function to support Literal, especially if we introduce more
+    # fields with Literal types.
+    if "directory_type" not in raw_dict:
+        _raise_missing_required_key_error(
+            "tool.dg.directory_type", _get_literal_values_str(DgFileConfigDirectoryType)
+        )
+    if raw_dict["directory_type"] not in get_args(DgFileConfigDirectoryType):
+        _raise_mistyped_key_error(
+            "tool.dg.directory_type",
+            _get_literal_values_str(DgFileConfigDirectoryType),
+            raw_dict["directory_type"],
+        )
+
+    _validate_dg_config_file_cli_section(raw_dict.get("cli", {}))
+    if raw_dict["directory_type"] == "workspace":
+        _validate_file_config_setting(raw_dict, "workspace", dict, "tool.dg")
+        _validate_file_config_workspace_section(raw_dict.get("workspace", {}))
+        _validate_file_config_no_extraneous_keys(
+            set(DgWorkspaceFileConfig.__annotations__.keys()), raw_dict, "tool.dg"
+        )
+        return cast(DgWorkspaceFileConfig, raw_dict)
+    elif raw_dict["directory_type"] == "project":
+        _validate_file_config_setting(raw_dict, "project", dict, "tool.dg")
+        _validate_file_config_project_section(raw_dict.get("project", {}))
+        _validate_file_config_no_extraneous_keys(
+            set(DgProjectFileConfig.__annotations__.keys()), raw_dict, "tool.dg"
+        )
+        return cast(DgProjectFileConfig, raw_dict)
+    else:
+        raise DgError("Unreachable")
+
+
+def _validate_dg_config_file_cli_section(section: object) -> None:
+    if not isinstance(section, dict):
+        raise DgValidationError("`tool.dg.cli` must be a table.")
+    for key, type_ in DgRawCliConfig.__annotations__.items():
+        _validate_file_config_setting(section, key, type_, "tool.dg.cli")
+    _validate_file_config_no_extraneous_keys(
+        set(DgRawCliConfig.__annotations__.keys()), section, "tool.dg.cli"
+    )
+
+
+def _validate_file_config_project_section(section: object) -> None:
+    if not isinstance(section, dict):
+        raise DgValidationError("`tool.dg.project` must be a table.")
+    for key, type_ in DgRawProjectConfig.__annotations__.items():
+        _validate_file_config_setting(section, key, type_, "tool.dg.project")
+    _validate_file_config_no_extraneous_keys(
+        set(DgRawProjectConfig.__annotations__.keys()), section, "tool.dg.project"
+    )
+
+
+def _validate_file_config_workspace_section(section: object) -> None:
+    if not isinstance(section, dict):
+        raise DgValidationError("`tool.dg.workspace` must be a table.")
+    for key, type_ in DgRawWorkspaceConfig.__annotations__.items():
+        _validate_file_config_setting(section, key, type_, "tool.dg.workspace")
+    _validate_file_config_no_extraneous_keys(
+        set(DgRawWorkspaceConfig.__annotations__.keys()), section, "tool.dg.workspace"
+    )
+
+
+def _validate_file_config_no_extraneous_keys(
+    valid_keys: set[str], section: Mapping[str, object], toml_path: str
+) -> None:
+    extraneous_keys = [k for k in section.keys() if k not in valid_keys]
+    if extraneous_keys:
+        raise DgValidationError(f"Unrecognized fields in `{toml_path}`: {extraneous_keys}")
+
+
+# Eventually we should get this to support Literal[...] but for no we special case that above.
+# We may also want to support Unions
+def _validate_file_config_setting(
+    section: Mapping[str, object],
+    key: str,
+    type_: type,
+    path_prefix: Optional[str] = None,
+) -> None:
+    origin = get_origin(type_)
+    is_required = origin is Required
+    class_ = type_ if origin is None else get_args(type_)[0]
+
+    error_type = None
+    if is_required and key not in section:
+        error_type = "required"
+    if key in section and not isinstance(section[key], class_):
+        error_type = "mistype"
+    if error_type:
+        full_key = f"{path_prefix}.{key}" if path_prefix else key
+        type_str = _get_types_str(type_)
+        if error_type == "required":
+            _raise_missing_required_key_error(full_key, type_str)
+        if error_type == "mistype":
+            _raise_mistyped_key_error(full_key, type_str, section[key])
+
+
+def _raise_missing_required_key_error(key: str, type_str: str) -> Never:
+    raise DgValidationError(f"Missing required value for `{key}`. Expected {type_str}.")
+
+
+def _raise_mistyped_key_error(key: str, type_str: str, value: object) -> Never:
+    raise DgValidationError(f"`Invalid value for `{key}`. Expected {type_str}, got `{value}`.")
+
+
+def _raise_file_config_validation_error(message: str, file_path: Path) -> Never:
     raise DgError(f"Error in configuration file {file_path}: {message}")
+
+
+def _get_types_str(type_: Union[type, tuple[type, ...]]) -> str:
+    types = type_ if isinstance(type_, tuple) else (type_,)
+    return " or ".join(_get_type_str(t) for t in types)
+
+
+# now way to type Literal
+def _get_literal_values(type_: Any) -> tuple[object, ...]:
+    val = type_
+    while get_origin(val) is not Literal:
+        val = get_origin(val)
+    return get_args(val)
+
+
+def _get_literal_values_str(type_: Any) -> str:
+    return " or ".join(f'"{v}"' for v in _get_literal_values(type_))
+
+
+def _get_type_str(type_: type) -> str:
+    # strip away Required/NotRequired
+    origin = get_origin(type_)
+    class_ = type_ if origin is None else get_args(type_)[0]
+    return class_.__name__

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -2,7 +2,6 @@ import shlex
 import shutil
 import subprocess
 from collections.abc import Iterable, Mapping
-from dataclasses import replace
 from functools import cached_property
 from pathlib import Path
 from typing import Final, Optional
@@ -13,7 +12,13 @@ from typing_extensions import Self
 
 from dagster_dg.cache import CachableDataType, DgCache, hash_paths
 from dagster_dg.component import RemoteComponentRegistry
-from dagster_dg.config import DgConfig, DgPartialConfig, load_dg_config_file
+from dagster_dg.config import (
+    DgConfig,
+    DgRawCliConfig,
+    discover_config_file,
+    load_dg_root_file_config,
+    load_dg_workspace_file_config,
+)
 from dagster_dg.error import DgError
 from dagster_dg.utils import (
     MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE,
@@ -46,21 +51,34 @@ _WORKSPACE_PROJECTS_DIR: Final = "projects"
 
 class DgContext:
     root_path: Path
+    workspace_root_path: Optional[Path]
     config: DgConfig
+    cli_opts: Optional[DgRawCliConfig] = None
     _cache: Optional[DgCache] = None
 
-    def __init__(self, config: DgConfig, root_path: Path):
+    # We need to preserve CLI options for the context to be able to derive new contexts, because
+    # cli_options override everything else. If we didn't maintain them we wouldn't be able to tell
+    # whether a given config option should be overridden in a new derived context.
+    def __init__(
+        self,
+        config: DgConfig,
+        root_path: Path,
+        workspace_root_path: Optional[Path] = None,
+        cli_opts: Optional[DgRawCliConfig] = None,
+    ):
         self.config = config
         self.root_path = root_path
-        if config.disable_cache or not self.use_dg_managed_environment:
+        self.workspace_root_path = workspace_root_path
+        self.cli_opts = cli_opts
+        if config.cli.disable_cache or not self.use_dg_managed_environment:
             self._cache = None
         else:
             self._cache = DgCache.from_config(config)
         self.component_registry = RemoteComponentRegistry.empty()
 
     @classmethod
-    def for_workspace_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
-        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+    def for_workspace_environment(cls, path: Path, command_line_config: DgRawCliConfig) -> Self:
+        context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
         # Commands that operate on a workspace need to be run inside a workspace context.
         if not context.is_workspace:
@@ -68,8 +86,8 @@ class DgContext:
         return context
 
     @classmethod
-    def for_project_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
-        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+    def for_project_environment(cls, path: Path, command_line_config: DgRawCliConfig) -> Self:
+        context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
         # Commands that operate on a project need to be run (a) with dagster-components
         # available; and (b) inside a Dagster project context.
@@ -80,8 +98,10 @@ class DgContext:
         return context
 
     @classmethod
-    def for_workspace_or_project_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
-        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+    def for_workspace_or_project_environment(
+        cls, path: Path, commmand_line_config: DgRawCliConfig
+    ) -> Self:
+        context = cls.from_file_discovery_and_command_line_config(path, commmand_line_config)
 
         # Commands that operate on a workspace need to be run inside a workspace or project
         # context.
@@ -90,8 +110,10 @@ class DgContext:
         return context
 
     @classmethod
-    def for_component_library_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
-        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+    def for_component_library_environment(
+        cls, path: Path, command_line_config: DgRawCliConfig
+    ) -> Self:
+        context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
         # Commands that operate on a component library need to be run (a) with dagster-components
         # available; (b) in a component library context.
@@ -102,8 +124,10 @@ class DgContext:
         return context
 
     @classmethod
-    def for_defined_registry_environment(cls, path: Path, cli_config: DgPartialConfig) -> Self:
-        context = cls.from_config_file_discovery_and_cli_config(path, cli_config)
+    def for_defined_registry_environment(
+        cls, path: Path, command_line_config: DgRawCliConfig
+    ) -> Self:
+        context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
         # Commands that access the component registry need to be run with dagster-components
         # available.
@@ -111,29 +135,50 @@ class DgContext:
         return context
 
     @classmethod
-    def discover_workspace_path(cls, path: Path) -> Optional[Path]:
-        return DgConfig.discover_config_file(path, lambda x: bool(x.get("is_workspace")))
-
-    @classmethod
-    def from_config_file_discovery_and_cli_config(
-        cls, path: Path, cli_config: DgPartialConfig
+    def from_file_discovery_and_command_line_config(
+        cls,
+        path: Path,
+        command_line_config: DgRawCliConfig,
     ) -> Self:
-        config_path = DgConfig.discover_config_file(path)
-        workspace_config_path = DgContext.discover_workspace_path(path)
+        config_path = discover_config_file(path)
+        workspace_config_path = discover_config_file(
+            path, lambda x: bool(x.get("directory_type") == "workspace")
+        )
 
-        # Build the config in the following order: defaults, workspace, project, CLI
-        config = DgConfig.default()
         if config_path:
-            # Add workspace config only if it's different from the project config
-            if workspace_config_path and config_path != workspace_config_path:
-                config = replace(config, **load_dg_config_file(workspace_config_path))
-            config = replace(config, **load_dg_config_file(config_path))
             root_path = config_path.parent
-        else:
-            root_path = path
-        config = replace(config, **cli_config)
+            root_file_config = load_dg_root_file_config(config_path)
+            if workspace_config_path:
+                workspace_root_path = workspace_config_path.parent
 
-        return cls(config=config, root_path=root_path)
+                # If the workspace config is different from the root config, we need to load the
+                # workspace config.
+                container_workspace_file_config = (
+                    load_dg_workspace_file_config(workspace_config_path)
+                    if config_path != workspace_config_path
+                    else None
+                )
+
+            else:
+                container_workspace_file_config = None
+                workspace_root_path = None
+        else:
+            root_path = Path.cwd()
+            workspace_root_path = None
+            root_file_config = None
+            container_workspace_file_config = None
+        config = DgConfig.from_partial_configs(
+            root_file_config=root_file_config,
+            container_workspace_file_config=container_workspace_file_config,
+            command_line_config=command_line_config,
+        )
+
+        return cls(
+            config=config,
+            root_path=root_path,
+            workspace_root_path=workspace_root_path,
+            cli_opts=command_line_config,
+        )
 
     @classmethod
     def default(cls) -> Self:
@@ -141,11 +186,11 @@ class DgContext:
 
     # Use to derive a new context for a project while preserving existing settings
     def with_root_path(self, root_path: Path) -> Self:
-        config_path = root_path / "pyproject.toml"
         if not root_path / "pyproject.toml":
             raise DgError(f"Cannot find `pyproject.toml` at {root_path}")
-        new_config = replace(self.config, **load_dg_config_file(config_path))
-        return self.__class__(config=new_config, root_path=root_path)
+        return self.__class__.from_file_discovery_and_command_line_config(
+            root_path, self.cli_opts or {}
+        )
 
     # ########################
     # ##### CACHE METHODS
@@ -181,20 +226,11 @@ class DgContext:
 
     @property
     def is_workspace(self) -> bool:
-        return self.config.is_workspace
-
-    @cached_property
-    def workspace_root_path(self) -> Path:
-        if not self.is_workspace:
-            raise DgError("`workspace_root_path` is only available in a workspace context")
-        workspace_config_path = DgConfig.discover_config_file(
-            self.root_path, lambda x: x.get("is_workspace", False)
-        )
-        if not workspace_config_path:
-            raise DgError("Cannot find workspace configuration file")
-        return workspace_config_path.parent
+        return self.workspace_root_path is not None
 
     def get_workspace_project_path(self, name: str) -> Path:
+        if not self.workspace_root_path:
+            raise DgError("`get_workspace_project_path` is only available in a workspace context")
         return self.workspace_root_path / _WORKSPACE_PROJECTS_DIR / name
 
     def has_project(self, name: str) -> bool:
@@ -205,7 +241,7 @@ class DgContext:
 
     @property
     def project_root_path(self) -> Path:
-        if not self.is_workspace:
+        if not self.workspace_root_path:
             raise DgError("`project_root_path` is only available in a workspace context")
         return self.workspace_root_path / _WORKSPACE_PROJECTS_DIR
 
@@ -223,8 +259,13 @@ class DgContext:
     # ########################
 
     @property
-    def root_package_name(self) -> str:
-        return self.config.root_package or self.root_path.name.replace("-", "_")
+    def root_module_name(self) -> str:
+        if self.config.project:
+            return self.config.project.root_module
+        elif self.is_component_library:
+            return self.default_components_library_module.split(".")[0]
+        else:
+            raise DgError("Cannot determine root package name")
 
     # ########################
     # ##### PROJECT METHODS
@@ -232,7 +273,7 @@ class DgContext:
 
     @property
     def is_project(self) -> bool:
-        return self.config.is_project
+        return self.config.project is not None
 
     @property
     def project_name(self) -> str:
@@ -249,14 +290,12 @@ class DgContext:
         return self.root_path / get_venv_executable(Path(".venv"))
 
     @cached_property
-    def components_package_name(self) -> str:
-        if not self.is_project:
-            raise DgError(
-                "`components_package_name` is only available in a Dagster project context"
-            )
+    def components_module_name(self) -> str:
+        if not self.config.project:
+            raise DgError("`components_module_name` is only available in a Dagster project context")
         return (
-            self.config.component_package
-            or f"{self.root_package_name}.{_DEFAULT_PROJECT_COMPONENTS_SUBMODULE}"
+            self.config.project.components_module
+            or f"{self.root_module_name}.{_DEFAULT_PROJECT_COMPONENTS_SUBMODULE}"
         )
 
     @cached_property
@@ -264,15 +303,15 @@ class DgContext:
         if not self.is_project:
             raise DgError("`components_path` is only available in a Dagster project context")
         with ensure_loadable_path(self.root_path):
-            if not is_package_installed(self.root_package_name):
+            if not is_package_installed(self.root_module_name):
                 raise DgError(
-                    f"Could not find expected package `{self.root_package_name}` in the current environment. Components expects the package name to match the directory name of the project."
+                    f"Could not find expected package `{self.root_module_name}` in the current environment. Components expects the package name to match the directory name of the project."
                 )
-            if not is_package_installed(self.components_package_name):
+            if not is_package_installed(self.components_module_name):
                 raise DgError(
-                    f"Components package `{self.components_package_name}` is not installed in the current environment."
+                    f"Components package `{self.components_module_name}` is not installed in the current environment."
                 )
-            return Path(get_path_for_package(self.components_package_name))
+            return Path(get_path_for_package(self.components_module_name))
 
     def get_component_instance_names(self) -> Iterable[str]:
         return [str(instance_path.name) for instance_path in self.components_path.iterdir()]
@@ -281,21 +320,21 @@ class DgContext:
         return (self.components_path / name).is_dir()
 
     @property
-    def definitions_package_name(self) -> str:
+    def definitions_module_name(self) -> str:
         if not self.is_project:
             raise DgError(
-                "`definitions_package_name` is only available in a Dagster project context"
+                "`definitions_module_name` is only available in a Dagster project context"
             )
-        return f"{self.root_package_name}.definitions"
+        return f"{self.root_module_name}.definitions"
 
     @cached_property
     def definitions_path(self) -> Path:
         with ensure_loadable_path(self.root_path):
-            if not is_package_installed(self.definitions_package_name):
+            if not is_package_installed(self.definitions_module_name):
                 raise DgError(
-                    f"Definitions package `{self.definitions_package_name}` is not installed in the current environment."
+                    f"Definitions package `{self.definitions_module_name}` is not installed in the current environment."
                 )
-            return Path(get_path_for_module(self.definitions_package_name))
+            return Path(get_path_for_module(self.definitions_module_name))
 
     # ########################
     # ##### COMPONENT LIBRARY METHODS
@@ -313,7 +352,7 @@ class DgContext:
     def default_components_library_module(self) -> str:
         if not self._dagster_components_entry_points:
             raise DgError(
-                "`components_lib_package_name` is only available in a component library context"
+                "`default_components_library_module_name` is only available in a component library context"
             )
         return next(iter(self._dagster_components_entry_points.values()))
 
@@ -322,9 +361,9 @@ class DgContext:
         if not self.is_component_library:
             raise DgError("`components_lib_path` is only available in a component library context")
         with ensure_loadable_path(self.root_path):
-            if not is_package_installed(self.root_package_name):
+            if not is_package_installed(self.root_module_name):
                 raise DgError(
-                    f"Could not find expected package `{self.root_package_name}` in the current environment. Components expects the package name to match the directory name of the project."
+                    f"Could not find expected package `{self.root_module_name}` in the current environment. Components expects the package name to match the directory name of the project."
                 )
             if not is_package_installed(self.default_components_library_module):
                 raise DgError(
@@ -362,8 +401,8 @@ class DgContext:
         full_command = [
             *project_command_prefix,
             *(
-                ["--builtin-component-lib", self.config.builtin_component_lib]
-                if self.config.builtin_component_lib
+                ["--builtin-component-lib", self.config.cli.builtin_component_lib]
+                if self.config.cli.builtin_component_lib
                 else []
             ),
             *command,
@@ -392,7 +431,7 @@ class DgContext:
 
     @property
     def use_dg_managed_environment(self) -> bool:
-        return self.config.use_dg_managed_environment and self.is_project
+        return self.config.cli.use_dg_managed_environment and self.is_project
 
     @property
     def has_venv(self) -> bool:
@@ -443,7 +482,7 @@ class DgContext:
 
 
 def _validate_dagster_components_availability(context: DgContext) -> None:
-    if context.config.require_local_venv:
+    if context.config.cli.require_local_venv:
         if not context.has_venv:
             exit_with_error(NO_LOCAL_VENV_ERROR_MESSAGE)
         elif not get_venv_executable(context.venv_path, "dagster-components").exists():

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import click
 
 from dagster_dg.component import RemoteComponentRegistry
+from dagster_dg.config import discover_workspace_root
 from dagster_dg.context import DgContext
 from dagster_dg.utils import camelcase, exit_with_error, scaffold_subtree
 
@@ -80,20 +81,14 @@ def scaffold_workspace(
     workspace_name: str,
 ) -> Path:
     # Can't create a workspace that is a child of another workspace
-    existing_workspace_path = DgContext.discover_workspace_path(Path.cwd())
+    new_workspace_path = Path.cwd() / workspace_name
+    existing_workspace_path = discover_workspace_root(new_workspace_path)
     if existing_workspace_path:
         exit_with_error(
-            f"Workspace already found at {existing_workspace_path}.  Run `dg scaffold project` to add a new project to that workspace."
+            f"Workspace already exists at {existing_workspace_path}.  Run `dg scaffold project` to add a new project to that workspace."
         )
-
-    new_workspace_path = Path.cwd() / workspace_name
-    if new_workspace_path.exists():
-        if DgContext.discover_workspace_path(new_workspace_path):
-            exit_with_error(
-                f"Workspace already exists at {new_workspace_path}.  Run `dg scaffold project` to add a new project to that workspace."
-            )
-        else:
-            exit_with_error(f"Folder already exists at {new_workspace_path}.")
+    elif new_workspace_path.exists():
+        exit_with_error(f"Folder already exists at {new_workspace_path}.")
 
     scaffold_subtree(
         path=new_workspace_path,

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -19,7 +19,10 @@ module_name = "{{ project_name }}.definitions"
 code_location_name = "{{ code_location_name }}"
 
 [tool.dg]
-is_project = true
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "{{ project_name }}"
 
 [tool.setuptools.packages.find]
 exclude=["{{ project_name }}_tests"]

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/WORKSPACE_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/WORKSPACE_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -1,2 +1,4 @@
 [tool.dg]
-is_workspace = true
+directory_type = "workspace"
+
+[tool.dg.workspace]

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -81,7 +81,9 @@ def test_check_component_succeeds_non_default_component_package() -> None:
         ),
     ):
         with modify_pyproject_toml() as toml:
-            set_toml_value(toml, ("tool", "dg", "component_package"), "foo_bar._components")
+            set_toml_value(
+                toml, ("tool", "dg", "project", "components_module"), "foo_bar._components"
+            )
 
         # We need to do all of this copying here rather than relying on the project setup
         # fixture because that fixture assumes a default component package.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -203,7 +203,7 @@ def test_dynamic_subcommand_help_message():
                 │ --help         -h            Show this message and exit.                                                             │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                 ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ --cache-dir                                                        PATH  Specify a directory to use for the cache.   │
+                │ --cache-dir                                                        TEXT  Specify a directory to use for the cache.   │
                 │ --disable-cache                                                          Disable the cache..                         │
                 │ --verbose                                                                Enable verbose output for debugging.        │
                 │ --builtin-component-lib                                            TEXT  Specify a builitin component library to     │

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -1,9 +1,12 @@
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Union, get_args
 
 import pytest
+from dagster_dg.config import DgFileConfigDirectoryType
 from dagster_dg.context import DgContext
 from dagster_dg.error import DgError
-from dagster_dg.utils import pushd, set_toml_value
+from dagster_dg.utils import delete_toml_value, pushd, set_toml_value
 
 from dagster_dg_tests.utils import (
     ProxyRunner,
@@ -21,12 +24,13 @@ def test_context_in_workspace():
 
         context = DgContext.for_workspace_environment(path_arg, {})
         assert context.root_path == Path.cwd()
+        assert context.workspace_root_path == Path.cwd()
 
         # Test config properly set
         with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "verbose"), True)
+            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_workspace_environment(path_arg, {})
-        assert context.config.verbose is True
+        assert context.config.cli.verbose is True
 
 
 def test_context_in_project_in_workspace():
@@ -37,49 +41,171 @@ def test_context_in_project_in_workspace():
 
         context = DgContext.for_project_environment(path_arg, {})
         assert context.root_path == project_path
-        assert context.config.verbose is False  # default
+        assert context.workspace_root_path == Path.cwd()
+        assert context.config.cli.verbose is False  # default
 
         # Test config inheritance from workspace
         with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "verbose"), True)
+            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
-        assert context.config.verbose is True
+        assert context.config.cli.verbose is True
 
         # Test config from project overrides workspace
         with pushd(project_path), modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "verbose"), False)
+            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), False)
         context = DgContext.for_project_environment(path_arg, {})
-        assert context.config.verbose is False
+        assert context.config.cli.verbose is False
 
 
 def test_context_in_project_outside_workspace():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner, in_workspace=False):
         project_path = Path.cwd()
         # go into a project subdirectory to make sure root resolution works
         path_arg = project_path / "foo_tests"
 
         context = DgContext.for_project_environment(path_arg, {})
         assert context.root_path == project_path
-        assert context.config.verbose is False
+        assert context.workspace_root_path is None
+        assert context.config.cli.verbose is False
 
         with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "verbose"), True)
+            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
-        assert context.config.verbose is True
+        assert context.config.cli.verbose is True
 
 
 def test_context_outside_project_or_workspace():
     with ProxyRunner.test() as runner, isolated_components_venv(runner):
-        context = DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
+        context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
         assert context.root_path == Path.cwd()
-        assert context.config.verbose is False
+        assert context.workspace_root_path is None
+        assert context.config.cli.verbose is False
 
 
-def test_invalid_key_in_config():
+# ########################
+# ##### CONFIG TESTS
+# ########################
+
+# Combine the many cases inside each test function for each speed, we don't want to set up
+# isolated projects etc for every case.
+
+
+def test_invalid_config_type():
     with ProxyRunner.test() as runner, isolated_example_workspace(runner):
-        with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "invalid_key"), True)
-        with pytest.raises(
-            DgError, match=r"Unrecognized fields in configuration: \['invalid_key'\]"
-        ):
-            DgContext.from_config_file_discovery_and_cli_config(Path.cwd(), {})
+        with _reset_pyproject_toml():
+            _set_and_detect_missing_required_key(
+                ("tool", "dg", "directory_type"), get_args(DgFileConfigDirectoryType)
+            )
+        with _reset_pyproject_toml():
+            _set_and_detect_mistyped_value(
+                ("tool", "dg", "directory_type"), get_args(DgFileConfigDirectoryType), 1
+            )
+
+
+def test_invalid_config_workspace():
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, "foo-bar"):
+        paths = [
+            ("tool", "dg", "invalid_key"),
+            ("tool", "dg", "project"),
+            ("tool", "dg", "library"),
+            ("tool", "dg", "cli", "invalid_key"),
+        ]
+        for case in paths:
+            with _reset_pyproject_toml():
+                _set_and_detect_invalid_key(case)
+
+        cases = [
+            [("tool", "dg", "cli", "disable_cache"), bool, 1],
+            [("tool", "dg", "cli", "cache_dir"), str, 1],
+            [("tool", "dg", "cli", "verbose"), bool, 1],
+            [("tool", "dg", "cli", "builtin_component_lib"), str, 1],
+            [("tool", "dg", "cli", "use_dg_managed_environment"), bool, 1],
+            [("tool", "dg", "cli", "require_local_venv"), bool, 1],
+        ]
+        for path, expected_type, val in cases:
+            with _reset_pyproject_toml():
+                _set_and_detect_mistyped_value(path, expected_type, val)
+
+
+def test_invalid_config_project():
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+        paths = [
+            ("tool", "dg", "invalid_key"),
+            ("tool", "dg", "project", "invalid_key"),
+            ("tool", "dg", "library"),
+            ("tool", "dg", "cli", "invalid_key"),
+        ]
+        for case in paths:
+            with _reset_pyproject_toml():
+                _set_and_detect_invalid_key(case)
+
+        cases = [
+            [("tool", "dg", "cli", "verbose"), bool, 1],
+            [("tool", "dg", "project", "root_module"), str, 1],
+            [("tool", "dg", "project", "components_module"), str, 1],
+        ]
+        for path, expected_type, val in cases:
+            with _reset_pyproject_toml():
+                _set_and_detect_mistyped_value(path, expected_type, val)
+
+        cases = [
+            [("tool", "dg", "project", "root_module"), str],
+        ]
+        for path, expected_type in cases:
+            with _reset_pyproject_toml():
+                _set_and_detect_missing_required_key(path, expected_type)
+
+
+# ########################
+# ##### HELPERS
+# ########################
+
+
+@contextmanager
+def _reset_pyproject_toml():
+    original = Path("pyproject.toml").read_text()
+    yield
+    Path("pyproject.toml").write_text(original)
+
+
+def _set_and_detect_error(path: tuple[str, ...], config_value: object, error_message: str):
+    with modify_pyproject_toml() as toml:
+        set_toml_value(toml, path, config_value)
+    with pytest.raises(DgError, match=error_message):
+        DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
+
+
+def _set_and_detect_invalid_key(path: tuple[str, ...], config_value: object = True):
+    leading_path, key = ".".join(path[:-1]), path[-1]
+    error_message = rf"Unrecognized fields in `{leading_path}`: \['{key}'\]"
+    _set_and_detect_error(path, config_value, error_message)
+
+
+# Accept tuple[str, ...] for literals
+def _set_and_detect_mistyped_value(
+    path: tuple[str, ...], expected_type: Union[type, tuple[str, ...]], config_value: object
+):
+    key = ".".join(path)
+    expected_str = _get_expected_type_str(expected_type)
+    error_message = rf"Invalid value for `{key}`. Expected {expected_str}, got `{config_value}`"
+    _set_and_detect_error(path, config_value, error_message)
+
+
+def _set_and_detect_missing_required_key(
+    path: tuple[str, ...], expected_type: Union[type, tuple[str, ...]]
+):
+    key = ".".join(path)
+    expected_str = _get_expected_type_str(expected_type)
+    error_message = rf"Missing required value for `{key}`. Expected {expected_str}"
+    with modify_pyproject_toml() as toml:
+        delete_toml_value(toml, path)
+    with pytest.raises(DgError, match=error_message):
+        DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
+
+
+def _get_expected_type_str(expected_type: Union[type, tuple[str, ...]]) -> str:
+    return (
+        expected_type.__name__
+        if isinstance(expected_type, type)
+        else " or ".join([f'"{t}"' for t in expected_type])
+    )


### PR DESCRIPTION
## Summary & Motivation

Overhaul the `dg` config system. This is essential for a stable foundation going forward.

### Status quo

The config system reads config from three sources and merges them all together.

- the context root config file
- a containing workspace config file
- CLI options

Even though the kinds of options you can set in these different locations differ (for example, you can't set `is_workspace` from the CLI), they are currently all treated as having the same type. This:

- makes our validation much looser than it should be
- makes the code harder to follow
 
The implicit complexity will become a problem as we scale.

### This PR

- The basic approach of reading config from the above three sources is unchanged, but there is now much stronger typing and consequently tighter validation. Error messages for missing or wrong values in the config are now clear and immediate, no invalid config penetrates the internals.
- The config file now takes a `directory_type` argument instead of setting booleans (`is_workspace`, `is_project`). There are only two types:
    - `"workspace"`
    - `"project"`
- The config file now has subsections corresponding to the type.
    - `tool.dg.project`: this is _required_ when `tool.dg.directory_type = "project"`. At a minimum you must specify the root package name of your project (comes automatically in scaffolding).
        - `root_module`
        - `components_module` (defaults to `<root_module>.components`)
    - `tool.dg.workspace` is added in this PR, but is currently empty. Entries will be added upstack.
    - `tool.dg.cli` takes CLI settings, the same stuff you pass on the command line, `verbose` etc.
- The config object now has sub-objects that correspond to different kinds of settings:
    - `cli`: always defined
    - `project` only defined in a project context
    - `workspace` only defined in a library context

Example workspace config:

```
[tool.dg]
directory_type = "workspace"

[tool.dg.workspace]  # currently empty

[tool.dg.cli]
disable_cache = True
```

Example project config:

```
[tool.dg]
directory_type = "project"

[tool.dg.project]  # required
root_module = "foo"  # required
components_module = "foo.alternate_components"  # optional

[tool.dg.cli]  # optional
verbose = true
```

Planning on an additional upstack PR that breaks up `DgContext` with constituent `Workspace` and `Project` objects, which is easy with the new sectioned config.

## How I Tested These Changes

Added unit tests.