### PR TITLE
Fetch RunAssetsQuery on all runs, even hidden asset jobs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
@@ -1,18 +1,14 @@
 import {useMemo} from 'react';
 
 import {AssetKeyTagCollection} from './AssetTagCollections';
-import {assetKeysForRun} from './RunUtils';
 import {gql, useQuery} from '../apollo-client';
 import {RunAssetsQuery, RunAssetsQueryVariables} from './types/RunAssetTags.types';
 import {RunFragment} from './types/RunFragments.types';
-import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 export const RunAssetTags = (props: {run: RunFragment}) => {
   const {run} = props;
-  const skip = isHiddenAssetGroupJob(run.pipelineName);
   const queryResult = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {
     variables: {runId: run.id},
-    skip,
     fetchPolicy: 'no-cache',
   });
 
@@ -22,8 +18,8 @@ export const RunAssetTags = (props: {run: RunFragment}) => {
       return null;
     }
 
-    return skip ? assetKeysForRun(run) : data.pipelineRunOrError.assets.map((a) => a.key);
-  }, [queryResult, run, skip]);
+    return data.pipelineRunOrError.assets.map((a) => a.key);
+  }, [queryResult]);
 
   return <AssetKeyTagCollection useTags assetKeys={assetKeys} />;
 };


### PR DESCRIPTION
Summary:
The fallback logic here to check run.assetSelection doesn't always work, notably for runs created by DA or asset backfills.

Load the runs page for a DA or asset backfill run, the asset tags should now appear

Fixed an issue where the list of asset keys targeted by a run didn't always appear at the top of the page for that run in the Dagster UI.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
