### PR TITLE
[Selection input] Update error styles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
@@ -3,22 +3,40 @@
 import {Popover2, Popover2Props} from '@blueprintjs/popover2';
 import deepmerge from 'deepmerge';
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components';
+import {createGlobalStyle, css} from 'styled-components';
 
 import {Colors} from './Color';
 import {FontFamily} from './styles';
 import searchSVG from '../icon-svgs/search.svg';
 
+export const PopoverWrapperStyle = css`
+  box-shadow: ${Colors.shadowDefault()} 0px 2px 12px;
+`;
+
+export const PopoverContentStyle = css`
+  background-color: ${Colors.popoverBackground()};
+  border-radius: 4px;
+
+  > :first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  > :last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+`;
+
 export const GlobalPopoverStyle = createGlobalStyle`
   .dagster-popover.bp5-popover,
   .dagster-popover.bp5-popover {
-    box-shadow: ${Colors.shadowDefault()} 0px 2px 12px;
+    ${PopoverWrapperStyle}
   }
 
   .dagster-popover .bp5-popover-content,
   .dagster-popover .bp5-popover-content {
-    background-color: ${Colors.popoverBackground()};
-    border-radius: 4px;
+    ${PopoverContentStyle}
 
     .bp5-menu {
       background-color: ${Colors.popoverBackground()};
@@ -52,16 +70,6 @@ export const GlobalPopoverStyle = createGlobalStyle`
         }
       }
     }
-  }
-
-  .dagster-popover .bp5-popover-content > :first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
-
-  .dagster-popover .bp5-popover-content > :last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
   }
 
   .dagster-popover .bp5-popover-arrow-fill {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
@@ -1,8 +1,8 @@
-import type {Linter} from 'codemirror/addon/lint/lint';
 import {useAssetSelectionAutoCompleteProvider as defaultUseAssetSelectionAutoCompleteProvider} from 'shared/asset-selection/input/useAssetSelectionAutoCompleteProvider.oss';
 
 import {assetSelectionSyntaxSupportedAttributes, unsupportedAttributeMessages} from './util';
 import {AssetGraphQueryItem} from '../../asset-graph/useAssetGraphData';
+import {SyntaxError} from '../../selection/CustomErrorListener';
 import {SelectionAutoCompleteProvider} from '../../selection/SelectionAutoCompleteProvider';
 import {SelectionAutoCompleteInput} from '../../selection/SelectionInput';
 import {createSelectionLinter} from '../../selection/createSelectionLinter';
@@ -13,7 +13,7 @@ export interface AssetSelectionInputProps {
   assets: AssetGraphQueryItem[];
   value: string;
   onChange: (value: string) => void;
-  linter?: Linter<any>;
+  linter?: (content: string) => SyntaxError[];
   useAssetSelectionAutoComplete?: (
     assets: AssetGraphQueryItem[],
   ) => Pick<SelectionAutoCompleteProvider, 'useAutoComplete'>;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/CustomErrorListener.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/CustomErrorListener.ts
@@ -1,33 +1,54 @@
-import {ANTLRErrorListener, RecognitionException, Recognizer} from 'antlr4ts';
-import {Token} from 'antlr4ts/Token';
+import {ANTLRErrorListener, Parser, RecognitionException, Recognizer} from 'antlr4ts';
 
-export interface SyntaxError {
+export type SyntaxError = {
   message: string;
-  line: number;
-  column: number;
-  offendingSymbol: Token | null;
-}
+  from: number;
+  to: number;
+} & (
+  | {
+      mismatchedInput?: undefined;
+      expectedInput?: undefined;
+    }
+  | {
+      mismatchedInput: string;
+      expectedInput: string[];
+    }
+);
 
 export class CustomErrorListener implements ANTLRErrorListener<any> {
   private errors: SyntaxError[];
+  private parser: Parser | undefined;
 
-  constructor() {
+  constructor({parser}: {parser?: Parser}) {
+    this.parser = parser;
     this.errors = [];
   }
 
   syntaxError(
     _recognizer: Recognizer<any, any>,
     offendingSymbol: any,
-    line: number,
+    _line: number,
     charPositionInLine: number,
     msg: string,
     _e: RecognitionException | undefined,
   ): void {
+    const expectedTokens = this.parser?.getExpectedTokens()?.toArray();
+    const message = msg;
+    let mismatchedInput;
+    let expectedInput;
+    if (this.parser && expectedTokens?.length && expectedTokens[0] !== -1 && offendingSymbol) {
+      mismatchedInput = offendingSymbol.text;
+      expectedInput = expectedTokens
+        .map((token) => this.parser?.vocabulary.getLiteralName(token))
+        .filter(Boolean) as string[];
+    }
+
     this.errors.push({
-      message: msg,
-      line,
-      column: charPositionInLine,
-      offendingSymbol,
+      message,
+      from: charPositionInLine,
+      to: charPositionInLine + (offendingSymbol?.text?.length ?? Infinity),
+      mismatchedInput,
+      expectedInput,
     });
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/CustomErrorListener.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/CustomErrorListener.ts
@@ -1,26 +1,16 @@
-import {ANTLRErrorListener, Parser, RecognitionException, Recognizer} from 'antlr4ts';
+import {ANTLRErrorListener, RecognitionException, Recognizer} from 'antlr4ts';
 
 export type SyntaxError = {
   message: string;
   from: number;
   to: number;
-} & (
-  | {
-      mismatchedInput?: undefined;
-      expectedInput?: undefined;
-    }
-  | {
-      mismatchedInput: string;
-      expectedInput: string[];
-    }
-);
+  offendingSymbol?: string | null | undefined;
+};
 
 export class CustomErrorListener implements ANTLRErrorListener<any> {
   private errors: SyntaxError[];
-  private parser: Parser | undefined;
 
-  constructor({parser}: {parser?: Parser}) {
-    this.parser = parser;
+  constructor() {
     this.errors = [];
   }
 
@@ -32,23 +22,11 @@ export class CustomErrorListener implements ANTLRErrorListener<any> {
     msg: string,
     _e: RecognitionException | undefined,
   ): void {
-    const expectedTokens = this.parser?.getExpectedTokens()?.toArray();
-    const message = msg;
-    let mismatchedInput;
-    let expectedInput;
-    if (this.parser && expectedTokens?.length && expectedTokens[0] !== -1 && offendingSymbol) {
-      mismatchedInput = offendingSymbol.text;
-      expectedInput = expectedTokens
-        .map((token) => this.parser?.vocabulary.getLiteralName(token))
-        .filter(Boolean) as string[];
-    }
-
     this.errors.push({
-      message,
+      message: msg,
+      offendingSymbol: offendingSymbol?.text,
       from: charPositionInLine,
       to: charPositionInLine + (offendingSymbol?.text?.length ?? Infinity),
-      mismatchedInput,
-      expectedInput,
     });
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
@@ -42,7 +42,7 @@ export const parseInput = memoize((input: string): ParseResult => {
     const parser = new SelectionAutoCompleteParser(tokenStream);
 
     // Attach custom error listener
-    const errorListener = new CustomErrorListener({parser});
+    const errorListener = new CustomErrorListener();
     parser.removeErrorListeners();
 
     // Set the error handler to bail on error to prevent infinite loops

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
@@ -42,9 +42,8 @@ export const parseInput = memoize((input: string): ParseResult => {
     const parser = new SelectionAutoCompleteParser(tokenStream);
 
     // Attach custom error listener
-    const errorListener = new CustomErrorListener();
+    const errorListener = new CustomErrorListener({parser});
     parser.removeErrorListeners();
-    parser.addErrorListener(errorListener);
 
     // Set the error handler to bail on error to prevent infinite loops
     parser.errorHandler = new BailErrorStrategy();
@@ -64,7 +63,7 @@ export const parseInput = memoize((input: string): ParseResult => {
 
       if (currentErrors.length > 0) {
         const error = currentErrors[0]!;
-        const errorCharPos = error.column;
+        const errorCharPos = error.from;
         const errorIndex = currentPosition + errorCharPos;
 
         // Parse up to the error
@@ -89,9 +88,8 @@ export const parseInput = memoize((input: string): ParseResult => {
         // Add the error to the errors array
         errors.push({
           message: error.message,
-          line: error.line,
-          column: error.column + currentPosition,
-          offendingSymbol: error.offendingSymbol,
+          from: error.from + currentPosition,
+          to: error.to + currentPosition,
         });
 
         // Advance currentPosition beyond the error

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/createSelectionLinter.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/createSelectionLinter.test.ts
@@ -1,5 +1,3 @@
-import CodeMirror from 'codemirror';
-
 import {AssetSelectionLexer} from '../../asset-selection/generated/AssetSelectionLexer';
 import {AssetSelectionParser} from '../../asset-selection/generated/AssetSelectionParser';
 import {createSelectionLinter} from '../createSelectionLinter';
@@ -39,21 +37,18 @@ describe('createSelectionLinter', () => {
     expect(errors).toEqual([
       {
         message: 'tag filtering is not supported in this test',
-        severity: 'error',
-        from: CodeMirror.Pos(0, 0),
-        to: CodeMirror.Pos(0, 'tag'.length),
+        from: 0,
+        to: 'tag'.length,
       },
       {
         message: 'column filtering is not supported in this test',
-        severity: 'error',
-        from: CodeMirror.Pos(0, 'tag:value or '.length),
-        to: CodeMirror.Pos(0, 'tag:value or column'.length),
+        from: 'tag:value or '.length,
+        to: 'tag:value or column'.length,
       },
       {
-        message: 'Unsupported attribute: table_name', // default message
-        severity: 'error',
-        from: CodeMirror.Pos(0, 'tag:value or column:value or '.length),
-        to: CodeMirror.Pos(0, 'tag:value or column:value or table_name'.length),
+        message: 'Unsupported attribute: "table_name"', // default message
+        from: 'tag:value or column:value or '.length,
+        to: 'tag:value or column:value or table_name'.length,
       },
     ]);
   });
@@ -71,10 +66,9 @@ describe('createSelectionLinter', () => {
     // Only expect syntax errors, not attribute errors
     expect(errors).toEqual([
       expect.objectContaining({
-        from: CodeMirror.Pos(0, 0),
-        message: expect.stringContaining("mismatched input 'fake'"),
-        severity: 'error',
-        to: CodeMirror.Pos(0, 10),
+        from: 0,
+        offendingSymbol: 'fake',
+        to: 4,
       }),
     ]);
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
@@ -1,8 +1,7 @@
 import {CharStreams, CommonTokenStream, Lexer, Parser, ParserRuleContext} from 'antlr4ts';
 import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
-import CodeMirror from 'codemirror';
 
-import {CustomErrorListener} from './CustomErrorListener';
+import {CustomErrorListener, SyntaxError} from './CustomErrorListener';
 import {parseInput} from './SelectionInputParser';
 import {AttributeNameContext} from './generated/SelectionAutoCompleteParser';
 import {SelectionAutoCompleteVisitor} from './generated/SelectionAutoCompleteVisitor';
@@ -27,16 +26,17 @@ export function createSelectionLinter({
     if (!text.length) {
       return [];
     }
-    const errorListener = new CustomErrorListener();
 
     const inputStream = CharStreams.fromString(text);
     const lexer = new LexerKlass(inputStream);
 
-    lexer.removeErrorListeners();
-    lexer.addErrorListener(errorListener);
-
     const tokens = new CommonTokenStream(lexer);
     const parser = new ParserKlass(tokens);
+
+    const errorListener = new CustomErrorListener({parser});
+
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(errorListener);
 
     parser.removeErrorListeners(); // Remove default console error listener
     parser.addErrorListener(errorListener);
@@ -45,10 +45,8 @@ export function createSelectionLinter({
 
     // Map syntax errors to CodeMirror's lint format
     const lintErrors = errorListener.getErrors().map((error) => ({
+      ...error,
       message: error.message.replace('<EOF>, ', ''),
-      severity: 'error',
-      from: CodeMirror.Pos(0, error.column),
-      to: CodeMirror.Pos(0, text.length),
     }));
 
     const {parseTrees} = parseInput(text);
@@ -67,22 +65,17 @@ class InvalidAttributeVisitor
   extends AbstractParseTreeVisitor<void>
   implements SelectionAutoCompleteVisitor<void>
 {
-  private errors: {
-    message: string;
-    severity: 'error' | 'warning';
-    from: CodeMirror.Position;
-    to: CodeMirror.Position;
-  }[] = [];
-  private sortedLintErrors: {from: CodeMirror.Position; to: CodeMirror.Position}[];
+  private errors: SyntaxError[] = [];
+  private sortedLintErrors: SyntaxError[];
 
   constructor(
     private supportedAttributes: readonly string[],
     private unsupportedAttributeMessages: Record<string, string>,
-    lintErrors: {from: CodeMirror.Position; to: CodeMirror.Position}[],
+    lintErrors: SyntaxError[],
   ) {
     super();
     // Sort errors by start position for efficient searching
-    this.sortedLintErrors = [...lintErrors].sort((a, b) => a.from.ch - b.from.ch);
+    this.sortedLintErrors = [...lintErrors].sort((a, b) => a.from - b.from);
   }
 
   getErrors() {
@@ -93,7 +86,7 @@ class InvalidAttributeVisitor
     return undefined;
   }
 
-  private hasOverlap(from: CodeMirror.Position, to: CodeMirror.Position): boolean {
+  private hasOverlap(from: number, to: number): boolean {
     // Binary search to find the first error that could potentially overlap
     let low = 0;
     let high = this.sortedLintErrors.length - 1;
@@ -102,9 +95,9 @@ class InvalidAttributeVisitor
       const mid = Math.floor((low + high) / 2);
       const error = this.sortedLintErrors[mid]!;
 
-      if (error.to.ch < from.ch) {
+      if (error.to < from) {
         low = mid + 1;
-      } else if (error.from.ch > to.ch) {
+      } else if (error.from > to) {
         high = mid - 1;
       } else {
         // Found an overlapping error
@@ -117,15 +110,14 @@ class InvalidAttributeVisitor
   visitAttributeName(ctx: AttributeNameContext) {
     const attributeName = ctx.IDENTIFIER().text;
     if (!this.supportedAttributes.includes(attributeName)) {
-      const from = CodeMirror.Pos(0, ctx.start.startIndex);
-      const to = CodeMirror.Pos(0, ctx.stop!.stopIndex + 1);
+      const from = ctx.start.startIndex;
+      const to = ctx.stop!.stopIndex + 1;
 
       if (!this.hasOverlap(from, to)) {
         this.errors.push({
           message:
             this.unsupportedAttributeMessages[attributeName] ??
-            `Unsupported attribute: ${attributeName}`,
-          severity: 'error',
+            `Unsupported attribute: "${attributeName}"`,
           from,
           to,
         });

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
@@ -33,7 +33,7 @@ export function createSelectionLinter({
     const tokens = new CommonTokenStream(lexer);
     const parser = new ParserKlass(tokens);
 
-    const errorListener = new CustomErrorListener({parser});
+    const errorListener = new CustomErrorListener();
 
     lexer.removeErrorListeners();
     lexer.addErrorListener(errorListener);

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
@@ -50,7 +50,7 @@ export const useSelectionInputLintingAndHighlighting = ({
   const errorRef = useUpdatingRef(error);
 
   useLayoutEffect(() => {
-    document.body.addEventListener('mousemove', (ev) => {
+    const listener = (ev: MouseEvent) => {
       if (!(ev.target instanceof HTMLElement)) {
         return;
       }
@@ -71,7 +71,11 @@ export const useSelectionInputLintingAndHighlighting = ({
       if (errorRef.current) {
         setError(null);
       }
-    });
+    };
+    document.body.addEventListener('mousemove', listener);
+    return () => {
+      document.body.removeEventListener('mousemove', listener);
+    };
   }, [cmInstance, errorsRef, errorRef]);
 
   const message = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Colors,
   Icon,
+  MiddleTruncate,
   MonoSmall,
   PopoverContentStyle,
   PopoverWrapperStyle,
@@ -82,20 +83,17 @@ export const useSelectionInputLintingAndHighlighting = ({
     if (!error) {
       return null;
     }
-    if (error.error.mismatchedInput && error.error.expectedInput) {
+    if (error.error.offendingSymbol) {
       return (
-        <Box>
-          Mismatched input{' '}
-          <MonoSmall color={Colors.textRed()}>&apos;{error.error.mismatchedInput}&apos;</MonoSmall>.
-          Expected{' '}
-          {error.error.expectedInput.map((expectedInput, idx) => (
-            <>
-              {idx > 0 && ', '}
-              <MonoSmall key={expectedInput} color={Colors.textBlue()}>
-                {expectedInput}
-              </MonoSmall>
-            </>
-          ))}
+        <Box flex={{direction: 'row', alignItems: 'center'}}>
+          Unexpected input
+          <div style={{width: 4}} />
+          <MonoSmall color={Colors.textRed()}>
+            <div style={{maxWidth: 200}}>
+              <MiddleTruncate text={error.error.offendingSymbol} />
+            </div>
+          </MonoSmall>
+          .
         </Box>
       );
     }
@@ -129,7 +127,6 @@ const PortalElement = styled.div<{$bottom: number; $left: number}>`
   position: absolute;
   top: ${({$bottom}) => $bottom - 32}px;
   left: ${({$left}) => $left + 16}px;
-  min-width: 320px;
   max-width: 600px;
   z-index: 20; // Z-index 20 to match bp5-overlay
   ${PopoverWrapperStyle}

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
@@ -1,0 +1,136 @@
+import {
+  BodySmall,
+  Box,
+  Colors,
+  Icon,
+  MonoSmall,
+  PopoverContentStyle,
+  PopoverWrapperStyle,
+} from '@dagster-io/ui-components';
+import {useLayoutEffect, useMemo, useState} from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+import {SyntaxError} from './CustomErrorListener';
+import {applyStaticSyntaxHighlighting} from './SelectionInputHighlighter';
+import {useUpdatingRef} from '../hooks/useUpdatingRef';
+
+export const useSelectionInputLintingAndHighlighting = ({
+  cmInstance,
+  value,
+  linter,
+}: {
+  cmInstance: React.MutableRefObject<CodeMirror.Editor | null>;
+  value: string;
+  linter: (content: string) => SyntaxError[];
+}) => {
+  const errors = useMemo(() => {
+    const errors = linter(value);
+    return errors.map((error, idx) => ({
+      ...error,
+      idx,
+    }));
+  }, [linter, value]);
+
+  useLayoutEffect(() => {
+    if (!cmInstance.current) {
+      return;
+    }
+    applyStaticSyntaxHighlighting(cmInstance.current, errors);
+  }, [cmInstance, errors]);
+
+  const errorsRef = useUpdatingRef(errors);
+
+  const [error, setError] = useState<{
+    error: SyntaxError;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const errorRef = useUpdatingRef(error);
+
+  useLayoutEffect(() => {
+    document.body.addEventListener('mousemove', (ev) => {
+      if (!(ev.target instanceof HTMLElement)) {
+        return;
+      }
+      const error = ev.target.closest('.selection-input-error') as HTMLElement | null;
+      if (error) {
+        const regex = /selection-input-error-(\d+)/;
+        const errorIdx = parseInt(error.className.match(regex)?.[1] ?? '0', 10);
+        const errorAnnotation = errorsRef.current[errorIdx];
+        if (errorAnnotation) {
+          setError({
+            error: errorAnnotation,
+            x: ev.clientX,
+            y: ev.clientY,
+          });
+          return;
+        }
+      }
+      if (errorRef.current) {
+        setError(null);
+      }
+    });
+  }, [cmInstance, errorsRef, errorRef]);
+
+  const message = useMemo(() => {
+    if (!error) {
+      return null;
+    }
+    if (error.error.mismatchedInput && error.error.expectedInput) {
+      return (
+        <Box>
+          Mismatched input{' '}
+          <MonoSmall color={Colors.textRed()}>&apos;{error.error.mismatchedInput}&apos;</MonoSmall>.
+          Expected{' '}
+          {error.error.expectedInput.map((expectedInput, idx) => (
+            <>
+              {idx > 0 && ', '}
+              <MonoSmall key={expectedInput} color={Colors.textBlue()}>
+                {expectedInput}
+              </MonoSmall>
+            </>
+          ))}
+        </Box>
+      );
+    }
+    if (error.error.message) {
+      return error.error.message;
+    }
+    return null;
+  }, [error]);
+
+  if (!error) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <PortalElement $bottom={error.y} $left={error.x}>
+      <Box
+        as={Content}
+        padding={{horizontal: 12, vertical: 8}}
+        flex={{direction: 'row', gap: 4}}
+        color={Colors.textLight()}
+      >
+        <Icon name="run_failed" color={Colors.accentRed()} />
+        <BodySmall color={Colors.textLight()}>{message}</BodySmall>
+      </Box>
+    </PortalElement>,
+    document.body,
+  );
+};
+
+const PortalElement = styled.div<{$bottom: number; $left: number}>`
+  position: absolute;
+  top: ${({$bottom}) => $bottom - 32}px;
+  left: ${({$left}) => $left + 16}px;
+  min-width: 320px;
+  max-width: 600px;
+  z-index: 20; // Z-index 20 to match bp5-overlay
+  ${PopoverWrapperStyle}
+`;
+
+const Content = styled.div`
+  ${PopoverContentStyle}
+`;


### PR DESCRIPTION
## Summary & Motivation

Note that updating the usefulness of the error messages is outside of the scope of this PR. Currently just returning what ANTLR gives us but I think we can do better in the future.

Stop using CodeMirror's linter functionality and instead running linting ourselves in order to have control over the error tooltip rendering beyond just the class name.

## How I Tested These Changes

Manual testing

<img width="681" alt="Screenshot 2025-02-24 at 9 44 28 AM" src="https://github.com/user-attachments/assets/7c6c35ae-3b3f-440a-824c-a4a65fab7d07" />
<img width="521" alt="Screenshot 2025-02-24 at 9 59 06 AM" src="https://github.com/user-attachments/assets/d1e2907f-4442-47df-8323-7d9559030572" />

<img width="901" alt="Screenshot 2025-02-24 at 9 59 21 AM" src="https://github.com/user-attachments/assets/ba483141-e176-40ed-a581-59c0e3a640ac" />

