### PR TITLE
[dagster-components] Fix component schema generation params->attributes

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -75,7 +75,7 @@ def list_all_components_schema_command(ctx: click.Context) -> None:
         if schema_type:
             schemas.append(
                 create_model(
-                    key.name, type=(Literal[key_string], key_string), params=(schema_type, None)
+                    key.name, type=(Literal[key_string], key_string), attributes=(schema_type, None)
                 )
             )
     union_type = Union[tuple(schemas)]  # type: ignore

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -187,6 +187,7 @@ def test_all_components_schema_command():
             component_type_schema_def["properties"]["type"]["const"]
             == f"{component_type_key}@dagster_components.test"
         )
+        assert "attributes" in component_type_schema_def["properties"]
 
 
 def test_scaffold_component_command():

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 from dagster._core.test_utils import new_cwd
 from dagster_components.cli import cli
 from dagster_components.utils import ensure_dagster_components_tests_import
+from jsonschema import Draft202012Validator
 
 ensure_dagster_components_tests_import()
 
@@ -188,6 +189,14 @@ def test_all_components_schema_command():
             == f"{component_type_key}@dagster_components.test"
         )
         assert "attributes" in component_type_schema_def["properties"]
+
+    top_level_component_validator = Draft202012Validator(schema=result)
+    top_level_component_validator.validate(
+        {
+            "type": "simple_asset@dagster_components.test",
+            "attributes": {"asset_key": "my_asset", "value": "my_value"},
+        }
+    )
 
 
 def test_scaffold_component_command():

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -48,6 +48,6 @@ setup(
     extras_require={
         "sling": ["dagster-sling"],
         "dbt": ["dagster-dbt"],
-        "test": ["dbt-duckdb", "dagster-dg", "tomlkit"],
+        "test": ["dbt-duckdb", "dagster-dg", "tomlkit", "jsonschema"],
     },
 )


### PR DESCRIPTION
## Summary

Fix `params`->`attributes` migration when generating schema for all component types, used in editor hinting.

## How I Tested These Changes

Update unit test to actually validate this schema against a component file.
