### PR TITLE
[dagster-components] Disallow extra top-level fields on "all components schema"

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Literal, Union
 
 import click
-from pydantic import TypeAdapter, create_model
+from pydantic import ConfigDict, TypeAdapter, create_model
 
 from dagster_components.core.component import (
     ComponentTypeMetadata,
@@ -75,7 +75,10 @@ def list_all_components_schema_command(ctx: click.Context) -> None:
         if schema_type:
             schemas.append(
                 create_model(
-                    key.name, type=(Literal[key_string], key_string), attributes=(schema_type, None)
+                    key.name,
+                    type=(Literal[key_string], key_string),
+                    attributes=(schema_type, None),
+                    __config__=ConfigDict(extra="forbid"),
                 )
             )
     union_type = Union[tuple(schemas)]  # type: ignore

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -1,11 +1,12 @@
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from dagster._core.test_utils import new_cwd
 from dagster_components.cli import cli
 from dagster_components.utils import ensure_dagster_components_tests_import
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, ValidationError
 
 ensure_dagster_components_tests_import()
 
@@ -197,6 +198,14 @@ def test_all_components_schema_command():
             "attributes": {"asset_key": "my_asset", "value": "my_value"},
         }
     )
+    with pytest.raises(ValidationError):
+        top_level_component_validator.validate(
+            {
+                "type": "simple_asset@dagster_components.test",
+                "attributes": {"asset_key": "my_asset", "value": "my_value"},
+                "extra_key": "extra_value",
+            }
+        )
 
 
 def test_scaffold_component_command():


### PR DESCRIPTION
## Summary

The Pydantic schema we construct for component files defaults to permissively allowing extra keys. This PR changes that config to explicitly disallow extra keys, so they'll e.g. error in the user's editor.

Nested component schemas should by default already disallow extra fields: https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py#L28

Though this may not always be the case if user-defined schema classes don't inherit from one of our bases classes with this property.

## How I Tested These Changes

Update unit test.
