### PR TITLE
Fix issue where seeding the random number generator during import or resource init time could cause every step to write to the same compute log key

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/compute_logs.py
+++ b/python_modules/dagster/dagster/_core/execution/compute_logs.py
@@ -19,7 +19,11 @@ WIN_PY36_COMPUTE_LOG_DISABLED_MSG = """\u001b[33mWARNING: Compute log capture is
 
 
 def create_compute_log_file_key():
-    return "".join(random.choice(string.ascii_lowercase) for x in range(8))
+    # Ensure that if user code has seeded the random module that it
+    # doesn't cause the same file key for each step (but the random
+    # seed is still restored afterwards)
+    rng = random.Random(int.from_bytes(os.urandom(16), "big"))
+    return "".join(rng.choice(string.ascii_lowercase) for x in range(8))
 
 
 @contextmanager


### PR DESCRIPTION
## Summary & Motivation
If you had a resource that seeded the python RNG (or RLG in this case) in could cause every step to be assigned the same key, causing them to overwrite each other. This fixes that by temporarily reseeding the RNG during log key construction. 

## How I Tested These Changes
New test case that was failing before

## Changelog
Fixed issue where seeding the random number generator during code import or when initializing a resource could cause every step to write to the same stdout or stderr key.