### PR TITLE
[components] Use `click.get_current_context()` instead of `click.pass_context`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -63,15 +63,14 @@ def create_dg_cli():
         default=False,
     )
     @click.version_option(__version__, "--version", "-v")
-    @click.pass_context
     def group(
-        context: click.Context,
         install_completion: bool,
         clear_cache: bool,
         rebuild_component_registry: bool,
         **global_options: object,
     ):
         """CLI for working with Dagster components."""
+        context = click.get_current_context()
         if install_completion:
             import dagster_dg.completion
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -67,9 +67,7 @@ class ErrorInput(NamedTuple):
 @check_group.command(name="yaml", cls=DgClickCommand)
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @dg_global_options
-@click.pass_context
 def check_yaml_command(
-    context: click.Context,
     paths: Sequence[str],
     **global_options: object,
 ) -> None:
@@ -77,7 +75,7 @@ def check_yaml_command(
     resolved_paths = [Path(path).absolute() for path in paths]
     top_level_component_validator = Draft202012Validator(schema=COMPONENT_FILE_SCHEMA)
 
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
 
     validation_errors: list[ErrorInput] = []
@@ -162,7 +160,7 @@ def check_yaml_command(
                     prefix=["attributes"] if component_key else [],
                 )
             )
-        context.exit(1)
+        click.get_current_context().exit(1)
     else:
         click.echo("All components validated successfully.")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -70,9 +70,7 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     required=False,
 )
 @dg_global_options
-@click.pass_context
 def dev_command(
-    context: click.Context,
     code_server_log_level: str,
     log_level: str,
     log_format: str,
@@ -86,7 +84,7 @@ def dev_command(
     If run inside a workspace directory, this command will launch all projects in the
     workspace. If launched inside a project directory, it will launch only that project.
     """
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
     forward_options = [

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
@@ -25,15 +25,13 @@ def docs_group():
 @click.argument("component_type", type=str)
 @click.option("--output", type=click.Choice(["browser", "cli"]), default="browser")
 @dg_global_options
-@click.pass_context
 def component_type_docs_command(
-    context: click.Context,
     component_type: str,
     output: str,
     **global_options: object,
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     component_key = GlobalComponentKey.from_typename(component_type)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -24,9 +24,7 @@ from dagster_dg.utils import DgClickCommand, exit_with_error
     ),
 )
 @dg_global_options
-@click.pass_context
 def init_command(
-    context: click.Context,
     use_editable_dagster: Optional[str],
     **global_options: object,
 ):
@@ -43,7 +41,7 @@ def init_command(
     │   └── pyproject.toml
 
     """  # noqa: D301
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
 
     workspace_path = Path.cwd() / "workspace"
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/inspect.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/inspect.py
@@ -34,9 +34,7 @@ def inspect_group():
 @click.option("--scaffold-params-schema", is_flag=True, default=False)
 @click.option("--component-schema", is_flag=True, default=False)
 @dg_global_options
-@click.pass_context
 def component_type_inspect_command(
-    context: click.Context,
     component_type: str,
     description: bool,
     scaffold_params_schema: bool,
@@ -44,7 +42,7 @@ def component_type_inspect_command(
     **global_options: object,
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
     component_key = GlobalComponentKey.from_typename(component_type)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -24,10 +24,9 @@ def list_group():
 
 @list_group.command(name="project", cls=DgClickCommand)
 @dg_global_options
-@click.pass_context
-def project_list_command(context: click.Context, **global_options: object) -> None:
+def project_list_command(**global_options: object) -> None:
     """List projects in the current workspace."""
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_environment(Path.cwd(), cli_config)
 
     for project in dg_context.get_project_names():
@@ -41,10 +40,9 @@ def project_list_command(context: click.Context, **global_options: object) -> No
 
 @list_group.command(name="component", cls=DgClickCommand)
 @dg_global_options
-@click.pass_context
-def component_list_command(context: click.Context, **global_options: object) -> None:
+def component_list_command(**global_options: object) -> None:
     """List Dagster component instances defined in the current project."""
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
 
     for component_instance_name in dg_context.get_component_instance_names():
@@ -65,12 +63,9 @@ def component_list_command(context: click.Context, **global_options: object) -> 
     help="Output as JSON instead of a table.",
 )
 @dg_global_options
-@click.pass_context
-def component_type_list(
-    context: click.Context, output_json: bool, **global_options: object
-) -> None:
+def component_type_list(output_json: bool, **global_options: object) -> None:
     """List registered Dagster components in the current project environment."""
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -24,16 +24,14 @@ def utils_group():
 @utils_group.command(name="configure-editor", cls=DgClickCommand)
 @dg_global_options
 @click.argument("editor", type=click.Choice(["vscode", "cursor"]))
-@click.pass_context
 def configure_editor_command(
-    context: click.Context,
     editor: str,
     **global_options: object,
 ) -> None:
     """Generates and installs a VS Code or Cursor extension which provides JSON schemas for Components types specified by YamlComponentsLoader objects."""
     executable_name = "code" if editor == "vscode" else "cursor"
 
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
 
     recommend_yaml_extension(executable_name)


### PR DESCRIPTION
## Summary & Motivation

This is a minor refactor that makes our CLI commands/signatures a bit more clear.

## How I Tested These Changes

Existing test suite.