### PR TITLE
[components] Remove is_component_lib, source component_lib_module from entry point

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
@@ -5,5 +5,4 @@ code_location_name = "jaffle-platform"
 
 [tool.dg]
 is_project = true
-is_component_lib = true
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
@@ -5,5 +5,4 @@ code_location_name = "project-1"
 
 [tool.dg]
 is_project = true
-is_component_lib = true
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -77,7 +77,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),
-                re_ignore_after("is_component_lib = true"),
+                re_ignore_after("is_project = true"),
             ],
         )
         check_file(

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
@@ -70,7 +70,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),
-                re_ignore_after("is_component_lib = true"),
+                re_ignore_after("is_project = true"),
             ],
         )
 
@@ -82,7 +82,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),
-                re_ignore_after("is_component_lib = true"),
+                re_ignore_after("is_project = true"),
             ],
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -52,12 +52,10 @@ class DgConfig:
     builtin_component_lib: str = DEFAULT_BUILTIN_COMPONENT_LIB
     use_dg_managed_environment: bool = True
     require_local_venv: bool = True
-    is_component_lib: bool = False
     is_project: bool = False
     is_workspace: bool = False
     root_package: Optional[str] = None
     component_package: Optional[str] = None
-    component_lib_package: Optional[str] = None
 
     @classmethod
     def discover_config_file(
@@ -87,9 +85,7 @@ class DgPartialConfig(TypedDict, total=False):
     use_dg_managed_environment: bool
     require_local_venv: bool
     component_package: str
-    component_lib_package: str
     is_project: bool
-    is_component_lib: bool
     is_workspace: bool
 
 
@@ -114,12 +110,8 @@ def _normalize_dg_partial_config(raw_dict: Mapping[str, object]) -> DgPartialCon
         raise DgValidationError("`require_local_venv` must be a boolean.")
     if "component_package" in config and not isinstance(config["component_package"], str):
         raise DgValidationError("`component_package` must be a string.")
-    if "component_lib_package" in config and not isinstance(config["component_lib_package"], str):
-        raise DgValidationError("`component_lib_package` must be a string.")
     if "is_project" in config and not isinstance(config["is_project"], bool):
         raise DgValidationError("`is_project` must be a boolean.")
-    if "is_component_lib" in config and not isinstance(config["is_component_lib"], bool):
-        raise DgValidationError("`is_component_lib` must be a boolean.")
 
     if "is_workspace" in config and not isinstance(config["is_workspace"], bool):
         raise DgValidationError("`is_workspace` must be a boolean.")

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,12 +1,14 @@
 import shlex
 import shutil
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from functools import cached_property
 from pathlib import Path
 from typing import Final, Optional
 
+import tomlkit
+import tomlkit.items
 from typing_extensions import Self
 
 from dagster_dg.cache import CachableDataType, DgCache, hash_paths
@@ -25,7 +27,9 @@ from dagster_dg.utils import (
     generate_missing_dagster_components_in_local_venv_error_message,
     get_path_for_module,
     get_path_for_package,
+    get_toml_value,
     get_venv_executable,
+    has_toml_value,
     is_package_installed,
     pushd,
     resolve_local_venv,
@@ -159,7 +163,7 @@ class DgContext:
         path_parts = [str(part) for part in self.root_path.parts if part != self.root_path.anchor]
         paths_to_hash = [
             self.root_path / "uv.lock",
-            *([self.components_lib_path] if self.is_component_library else []),
+            *([self.default_components_library_path] if self.is_component_library else []),
         ]
         env_hash = hash_paths(paths_to_hash)
         return ("_".join(path_parts), env_hash, data_type)
@@ -295,23 +299,24 @@ class DgContext:
     # ##### COMPONENT LIBRARY METHODS
     # ########################
 
+    # It is possible for a single package to define multiple entry points under the
+    # `dagster.components` entry point group. At present, `dg` only cares about the first one, which
+    # it uses for all component type scaffolding operations.
+
     @property
     def is_component_library(self) -> bool:
-        return self.config.is_component_lib
+        return bool(self._dagster_components_entry_points)
 
     @cached_property
-    def components_lib_package_name(self) -> str:
-        if not self.is_component_library:
+    def default_components_library_module(self) -> str:
+        if not self._dagster_components_entry_points:
             raise DgError(
                 "`components_lib_package_name` is only available in a component library context"
             )
-        return (
-            self.config.component_lib_package
-            or f"{self.root_package_name}.{_DEFAULT_PROJECT_COMPONENTS_LIB_SUBMODULE}"
-        )
+        return next(iter(self._dagster_components_entry_points.values()))
 
     @cached_property
-    def components_lib_path(self) -> Path:
+    def default_components_library_path(self) -> Path:
         if not self.is_component_library:
             raise DgError("`components_lib_path` is only available in a component library context")
         with ensure_loadable_path(self.root_path):
@@ -319,11 +324,25 @@ class DgContext:
                 raise DgError(
                     f"Could not find expected package `{self.root_package_name}` in the current environment. Components expects the package name to match the directory name of the project."
                 )
-            if not is_package_installed(self.components_lib_package_name):
+            if not is_package_installed(self.default_components_library_module):
                 raise DgError(
-                    f"Components lib package `{self.components_lib_package_name}` is not installed in the current environment."
+                    f"Components lib package `{self.default_components_library_module}` is not installed in the current environment."
                 )
-            return Path(get_path_for_package(self.components_lib_package_name))
+            return Path(get_path_for_package(self.default_components_library_module))
+
+    @cached_property
+    def _dagster_components_entry_points(self) -> Mapping[str, str]:
+        if not self.pyproject_toml_path.exists():
+            return {}
+        toml = tomlkit.parse(self.pyproject_toml_path.read_text())
+        if not has_toml_value(toml, ("project", "entry-points", "dagster.components")):
+            return {}
+        else:
+            return get_toml_value(
+                toml,
+                ("project", "entry-points", "dagster.components"),
+                (tomlkit.items.Table, tomlkit.items.InlineTable),
+            ).unwrap()
 
     # ########################
     # ##### HELPERS
@@ -410,6 +429,10 @@ class DgContext:
             return f"Python environment at {self.venv_path}"
         else:
             return "ambient Python environment"
+
+    @property
+    def pyproject_toml_path(self) -> Path:
+        return self.root_path / "pyproject.toml"
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -145,7 +145,7 @@ def scaffold_project(
 
 
 def scaffold_component_type(dg_context: DgContext, name: str) -> None:
-    root_path = Path(dg_context.components_lib_path)
+    root_path = Path(dg_context.default_components_library_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{name}.py.")
 
     scaffold_subtree(
@@ -158,7 +158,9 @@ def scaffold_component_type(dg_context: DgContext, name: str) -> None:
     )
 
     with open(root_path / "__init__.py", "a") as f:
-        f.write(f"from {dg_context.components_lib_package_name}.{name} import {camelcase(name)}\n")
+        f.write(
+            f"from {dg_context.default_components_library_module}.{name} import {camelcase(name)}\n"
+        )
 
     click.echo(f"Scaffolded files for Dagster component type at {root_path}/{name}..")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -20,7 +20,6 @@ code_location_name = "{{ code_location_name }}"
 
 [tool.dg]
 is_project = true
-is_component_lib = true
 
 [tool.setuptools.packages.find]
 exclude=["{{ project_name }}_tests"]

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -379,7 +379,7 @@ nearest pyproject.toml has `tool.dg.is_project = true` or `tool.dg.is_workspace 
 
 NOT_COMPONENT_LIBRARY_ERROR_MESSAGE = """
 This command must be run inside a Dagster component library directory. Ensure that the nearest
-pyproject.toml has `tool.dg.is_component_lib = true` set.
+pyproject.toml has an entry point defined under the `dagster.components` group.
 """
 
 MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE = """
@@ -468,7 +468,11 @@ def parse_json_option(context: click.Context, param: click.Option, value: str):
 # ########################
 
 
-def get_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], expected_type: type[T]) -> T:
+def get_toml_value(
+    doc: tomlkit.TOMLDocument,
+    path: Iterable[str],
+    expected_type: Union[type[T], tuple[type[T], ...]],
+) -> T:
     """Given a tomlkit-parsed document/table (`doc`),retrieve the nested value at `path` and ensure
     it is of type `expected_type`. Returns the value if so, or raises a KeyError / TypeError if not.
     """
@@ -481,11 +485,24 @@ def get_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], expected_type
 
     # Finally, ensure the found value is of the expected type
     if not isinstance(current, expected_type):
+        expected_types = expected_type if isinstance(expected_type, tuple) else (expected_type,)
+        type_str = " or ".join(t.__name__ for t in expected_types)
         raise TypeError(
-            f"Expected '{'.'.join(path)}' to be {expected_type.__name__}, "
+            f"Expected '{'.'.join(path)}' to be {type_str}, "
             f"but got {type(current).__name__} instead."
         )
     return current
+
+
+def has_toml_value(doc: tomlkit.TOMLDocument, path: Sequence[str]) -> bool:
+    """Given a tomlkit-parsed document/table (`doc`), return whether a value is defined at `path`."""
+    leading_path, key = path[:-1], path[-1]
+    current = doc
+    for leading_key in leading_path:
+        if not isinstance(current, dict) or leading_key not in current:
+            return False
+        current = current[leading_key]
+    return isinstance(current, dict) and key in current
 
 
 def set_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], value: object) -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -4,7 +4,10 @@ from pathlib import Path
 import click
 import pytest
 from dagster_dg.cli import cli
-from dagster_dg.utils import get_venv_executable, resolve_local_venv
+from dagster_dg.utils import ensure_dagster_dg_tests_import, get_venv_executable, resolve_local_venv
+
+ensure_dagster_dg_tests_import()
+
 from dagster_dg_tests.utils import ProxyRunner, assert_runner_result, isolated_components_venv
 
 # The tests in this file are designed to check error messages for basic precondition checks for

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -151,7 +151,6 @@ def isolated_example_component_library_foo_bar(
                 # We need to set any alternative lib package name _before_ we install into the
                 # environment, since it affects entry points which are set at install time.
                 if lib_package_name:
-                    set_toml_value(toml, ("tool", "dg", "component_lib_package"), lib_package_name)
                     set_toml_value(
                         toml,
                         ("project", "entry-points", "dagster.components", "foo_bar"),


### PR DESCRIPTION
## Summary & Motivation

Removes `is_component_lib` and `component_lib_package` settings. Instead, a package is now a component library if it has at least one entry point in the `"dagster.components"` group. The scaffolding location for new component types is the first defined entry point in this group.

## How I Tested These Changes

Tweaked existing unit tests.