### PR TITLE
[utils] move validate_asset_owner condition to is_valid_asset_owner

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -150,11 +150,15 @@ def struct_to_string(name: str, **kwargs: object) -> str:
 
 
 def validate_asset_owner(owner: str, key: "AssetKey") -> None:
-    if not is_valid_email(owner) and not (owner.startswith("team:") and len(owner) > 5):
+    if not is_valid_asset_owner(owner):
         raise DagsterInvalidDefinitionError(
             f"Invalid owner '{owner}' for asset '{key}'. Owner must be an email address or a team "
             "name prefixed with 'team:'."
         )
+
+
+def is_valid_asset_owner(owner: str) -> bool:
+    return is_valid_email(owner) or (owner.startswith("team:") and len(owner) > 5)
 
 
 def validate_group_name(group_name: Optional[str]) -> None:


### PR DESCRIPTION
## Summary & Motivation

Decouple the condition `is_valid_asset_owner` from the `validate_asset_owner` function. 

The new `is_valid_asset_owner` will be used in subsequent PR to test asset owners in `dagster-powerbi`

## How I Tested These Changes

Existing tests

