### PR TITLE
[dagster-powerbi] Handle invalid asset owners for reports and semantic models

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSe
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.definitions.tags.tag_set import NamespacedTagSet
+from dagster._core.definitions.utils import is_valid_asset_owner
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
@@ -266,7 +267,7 @@ class DagsterPowerBITranslator:
             metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
             tags={**PowerBITagSet(asset_type="report")},
             kinds={"powerbi", "report"},
-            owners=[owner] if owner else None,
+            owners=[owner] if owner and is_valid_asset_owner(owner) else None,
         )
 
     @deprecated(
@@ -327,7 +328,7 @@ class DagsterPowerBITranslator:
             },
             tags={**PowerBITagSet(asset_type="semantic_model")},
             kinds={"powerbi", "semantic model"},
-            owners=[owner] if owner else None,
+            owners=[owner] if owner and is_valid_asset_owner(owner) else None,
         )
 
     @deprecated(


### PR DESCRIPTION
## Summary & Motivation

A bug was reported by a user, where the value of semantic model's `configuredBy` was a UUID instead of a valid email. The `configuredBy` field is used to set the asset owner value in AssetSpec - this causes an exception because a UUID is not a valid asset owner.

> configuredBy | string | The dataset owner

Looking at the `configuredBy` field in PowerBI API docs, the string format for this field is not mentioned. See in [this page](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-in-group-as-admin).

This is also true for report's `createdBy`.

To fix this, let's use `is_valid_asset_owner` for both cases to make sure we don't pass an invalid asset owner value to AssetSpec, which would cause an exception.

## How I Tested These Changes

Additional tests with BK
