### PR TITLE
Add `dg scaffold workspace` command and make the workspace name configurable

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/1-dg-init.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/1-dg-init.txt
@@ -1,7 +1,8 @@
 dg init
 
-Scaffolded files for Dagster workspace at /.../workspace.
+Enter the name of your Dagster workspace [dagster-workspace]: 
+Scaffolded files for Dagster workspace at /.../dagster-workspace.
 Enter the name of your first Dagster project (or press Enter to continue without creating a project): project-1
-Creating a Dagster project at /.../workspace/projects/project-1.
-Scaffolded files for Dagster project at /.../workspace/projects/project-1.
+Creating a Dagster project at /.../dagster-workspace/projects/project-1.
+Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-1.
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/2-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/2-tree.txt
@@ -1,4 +1,4 @@
-cd workspace && tree
+cd dagster-workspace && tree
 
 .
 ├── libraries

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/6-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/6-component-type-list.txt
@@ -1,6 +1,6 @@
 dg list component-type
 
-Using /.../workspace/projects/project-1/.venv/bin/dagster-components
+Using /.../dagster-workspace/projects/project-1/.venv/bin/dagster-components
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Component Type                                        ┃ Summary                        ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/7-scaffold-project.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/7-scaffold-project.txt
@@ -1,5 +1,5 @@
 cd ../.. && dg scaffold project project-2
 
-Creating a Dagster project at /.../workspace/projects/project-2.
-Scaffolded files for Dagster project at /.../workspace/projects/project-2.
+Creating a Dagster project at /.../dagster-workspace/projects/project-2.
+Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-2.
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
@@ -25,14 +25,14 @@ COMPONENTS_SNIPPETS_DIR = (
     / "components"
     / "workspace"
 )
-MASK_MY_WORKSPACE = (r"\/.*?\/workspace", "/.../workspace")
+MASK_MY_WORKSPACE = (r"\/.*?\/dagster-workspace", "/.../dagster-workspace")
 
 
 def test_components_docs_workspace(update_snippets: bool) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         # Scaffold workspace
         run_command_and_snippet_output(
-            cmd='echo "project-1\n" | dg init --use-editable-dagster',
+            cmd='echo "\nproject-1\n" | dg init --use-editable-dagster',
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-dg-init.txt",
             update_snippets=update_snippets,
@@ -45,6 +45,10 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
                     r"\(or press Enter to continue without creating a project\): ",
                     "(or press Enter to continue without creating a project): project-1\n",
                 ),
+                (
+                    r"\[dagster-workspace\]: ",
+                    "[dagster-workspace]: \n",  # add newline
+                ),
             ],
             print_cmd="dg init",
         )
@@ -54,7 +58,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
         _run_command(r"find . -type d -name project_1.egg-info -exec rm -r {} \+")
 
         run_command_and_snippet_output(
-            cmd="cd workspace && tree",
+            cmd="cd dagster-workspace && tree",
             snippet_path=COMPONENTS_SNIPPETS_DIR / f"{get_next_snip_number()}-tree.txt",
             update_snippets=update_snippets,
             # Remove --sort size from tree output, sadly OSX and Linux tree

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -1,9 +1,9 @@
-from pathlib import Path
 from typing import Optional
 
 import click
 
 from dagster_dg.cli.global_options import dg_global_options
+from dagster_dg.cli.scaffold import DEFAULT_WORKSPACE_NAME
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.scaffold import scaffold_project, scaffold_workspace
@@ -33,7 +33,7 @@ def init_command(
     The scaffolded workspace folder has the following structure:
 
     \b
-    ├── workspace
+    ├── dagster-workspace
     │   ├── projects
     |   |   └── <Dagster projects go here>
     |   ├── libraries
@@ -43,15 +43,13 @@ def init_command(
     """  # noqa: D301
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    workspace_path = Path.cwd() / "workspace"
+    workspace_name = click.prompt(
+        "Enter the name of your Dagster workspace",
+        type=str,
+        default=DEFAULT_WORKSPACE_NAME,
+    ).strip()
 
-    # Check if workspace folder already exists
-    if workspace_path.exists():
-        exit_with_error(
-            f"Workspace directory already exists at {workspace_path}. Run `dg scaffold project` to add a new project to the workspace."
-        )
-
-    scaffold_workspace(workspace_path)
+    workspace_path = scaffold_workspace(workspace_name)
     workspace_dg_context = DgContext.from_config_file_discovery_and_cli_config(
         workspace_path, cli_config
     )
@@ -59,6 +57,8 @@ def init_command(
     project_name = click.prompt(
         "Enter the name of your first Dagster project (or press Enter to continue without creating a project)",
         type=str,
+        default="",
+        show_default=False,
     ).strip()
 
     if not project_name:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -21,6 +21,7 @@ from dagster_dg.scaffold import (
     scaffold_component_instance,
     scaffold_component_type,
     scaffold_project,
+    scaffold_workspace,
 )
 from dagster_dg.utils import (
     DgClickCommand,
@@ -32,10 +33,40 @@ from dagster_dg.utils import (
     parse_json_option,
 )
 
+DEFAULT_WORKSPACE_NAME = "dagster-workspace"
+
 
 @click.group(name="scaffold", cls=DgClickGroup)
 def scaffold_group():
     """Commands for scaffolding Dagster code."""
+
+
+# ########################
+# ##### WORKSPACE
+# ########################
+
+
+@scaffold_group.command(name="workspace", cls=DgClickCommand)
+@click.argument("name", type=str, default=DEFAULT_WORKSPACE_NAME)
+@dg_global_options
+def workspace_scaffold_command(
+    name: str,
+    **global_options: object,
+):
+    """Initialize a new Dagster workspace.
+
+    The scaffolded workspace folder has the following structure:
+
+    \b
+    ├── dagster-workspace
+    │   ├── projects
+    |   |   └── <Dagster projects go here>
+    |   ├── libraries
+    |   |   └── <Shared packages go here>
+    │   └── pyproject.toml
+
+    """  # noqa: D301
+    scaffold_workspace(name)
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -107,13 +107,15 @@ class DgContext:
         return context
 
     @classmethod
+    def discover_workspace_path(cls, path: Path) -> Optional[Path]:
+        return DgConfig.discover_config_file(path, lambda x: bool(x.get("is_workspace")))
+
+    @classmethod
     def from_config_file_discovery_and_cli_config(
         cls, path: Path, cli_config: DgPartialConfig
     ) -> Self:
         config_path = DgConfig.discover_config_file(path)
-        workspace_config_path = DgConfig.discover_config_file(
-            path, lambda x: bool(x.get("is_workspace"))
-        )
+        workspace_config_path = DgContext.discover_workspace_path(path)
 
         # Build the config in the following order: defaults, workspace, project, CLI
         config = DgConfig.default()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -33,6 +33,7 @@ DEFAULT_COMPONENT_TYPE = "simple_asset@dagster_components.test"
 NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "project"), "foo"),
     CommandSpec(("init",), "foo"),
+    CommandSpec(("scaffold", "workspace"), "foo"),
 ]
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -13,16 +13,48 @@ def test_dg_init_command_success(monkeypatch) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("init", "--use-editable-dagster", input="helloworld\n")
+        result = runner.invoke("init", "--use-editable-dagster", input="\nhelloworld\n")
         assert_runner_result(result)
-        assert Path("workspace").exists()
-        assert Path("workspace/pyproject.toml").exists()
-        assert Path("workspace/projects").exists()
-        assert Path("workspace/libraries").exists()
-        assert Path("workspace/projects/helloworld").exists()
-        assert Path("workspace/projects/helloworld/helloworld").exists()
-        assert Path("workspace/projects/helloworld/pyproject.toml").exists()
-        assert Path("workspace/projects/helloworld/helloworld_tests").exists()
+        assert Path("dagster-workspace").exists()
+        assert Path("dagster-workspace/pyproject.toml").exists()
+        assert Path("dagster-workspace/projects").exists()
+        assert Path("dagster-workspace/libraries").exists()
+        assert Path("dagster-workspace/projects/helloworld").exists()
+        assert Path("dagster-workspace/projects/helloworld/helloworld").exists()
+        assert Path("dagster-workspace/projects/helloworld/pyproject.toml").exists()
+        assert Path("dagster-workspace/projects/helloworld/helloworld_tests").exists()
+
+
+def test_dg_init_command_no_project(monkeypatch) -> None:
+    dagster_git_repo_dir = discover_git_root(Path(__file__))
+    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
+
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke("init", "--use-editable-dagster", input="\n\n")
+        assert_runner_result(result)
+        assert Path("dagster-workspace").exists()
+        assert Path("dagster-workspace/pyproject.toml").exists()
+        assert Path("dagster-workspace/projects").exists()
+        assert Path("dagster-workspace/libraries").exists()
+
+
+def test_dg_init_override_workspace_name(monkeypatch) -> None:
+    dagster_git_repo_dir = discover_git_root(Path(__file__))
+    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
+
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke(
+            "init", "--use-editable-dagster", input="my-workspace\ngoodbyeworld\n"
+        )
+        assert_runner_result(result)
+        assert Path("my-workspace").exists()
+        assert Path("my-workspace/pyproject.toml").exists()
+        assert Path("my-workspace/projects").exists()
+        assert Path("my-workspace/libraries").exists()
+        assert Path("my-workspace/projects/goodbyeworld").exists()
+        assert Path("my-workspace/projects/goodbyeworld/goodbyeworld").exists()
+        assert Path("my-workspace/projects/goodbyeworld/pyproject.toml").exists()
+        assert Path("my-workspace/projects/goodbyeworld/goodbyeworld_tests").exists()
 
 
 def test_dg_init_workspace_already_exists_failure(monkeypatch) -> None:
@@ -30,7 +62,7 @@ def test_dg_init_workspace_already_exists_failure(monkeypatch) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        os.mkdir("workspace")
-        result = runner.invoke("init", "--use-editable-dagster", input="helloworld\n")
+        os.mkdir("dagster-workspace")
+        result = runner.invoke("init", "--use-editable-dagster", input="\nhelloworld\n")
         assert_runner_result(result, exit_0=False)
         assert "already exists" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -29,6 +29,38 @@ from dagster_dg_tests.utils import (
     standardize_box_characters,
 )
 
+
+# ########################
+# ##### WORKSPACE
+# ########################
+def test_scaffold_workspace_command_success(monkeypatch) -> None:
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke("scaffold", "workspace")
+        assert_runner_result(result)
+        assert Path("dagster-workspace").exists()
+        assert Path("dagster-workspace/pyproject.toml").exists()
+        assert Path("dagster-workspace/projects").exists()
+        assert Path("dagster-workspace/libraries").exists()
+
+        result = runner.invoke("scaffold", "workspace")
+        assert_runner_result(result, exit_0=False)
+        assert "already exists" in result.output
+
+
+def test_scaffold_workspace_command_name_override_success(monkeypatch) -> None:
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke("scaffold", "workspace", "my-workspace")
+        assert_runner_result(result)
+        assert Path("my-workspace").exists()
+        assert Path("my-workspace/pyproject.toml").exists()
+        assert Path("my-workspace/projects").exists()
+        assert Path("my-workspace/libraries").exists()
+
+        result = runner.invoke("scaffold", "workspace", "my-workspace")
+        assert_runner_result(result, exit_0=False)
+        assert "already exists" in result.output
+
+
 # ########################
 # ##### PROJECT
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -62,8 +62,8 @@ def isolated_example_workspace(
 ) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     with runner.isolated_filesystem(), clear_module_from_cache("foo_bar"):
-        runner.invoke("init", input=f" {project_name or ''}\n")
-        with pushd("workspace"):
+        runner.invoke("init", input=f"\n{project_name or ''}\n")
+        with pushd("dagster-workspace"):
             # Create a venv capable of running dagster dev
             if create_venv:
                 subprocess.run(["uv", "venv", ".venv"], check=True)


### PR DESCRIPTION
## Summary & Motivation
Resolves https://linear.app/dagster-labs/issue/BUILD-734/allow-the-parameterization-of-the-name-of-the-workspace-directory.

Also changes the default name from "workspace" to "dagster-workspace", which probably merits a quick discussion.

## How I Tested These Changes
BK, run the two commands locally
