### PR TITLE
[ui] Treat RESOURCE_INIT_FAILURE as a terminal step event

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
@@ -323,6 +323,9 @@ export function extractMetadataFromLogs(
       } else if (log.__typename === 'ExecutionStepFailureEvent') {
         upsertState(step, timestamp, IStepState.FAILED);
         step.end = Math.max(timestamp, step.end || 0);
+      } else if (log.__typename === 'ResourceInitFailureEvent') {
+        upsertState(step, timestamp, IStepState.FAILED);
+        step.end = Math.max(timestamp, step.end || 0);
       } else if (log.__typename === 'ExecutionStepUpForRetryEvent') {
         // We only get one event when the step fails/aborts and is queued for retry,
         // but we create an "exit" state separate from the "preparing for retry" state


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

Tested with the gzip run debug file in the ticket 

![image](https://github.com/user-attachments/assets/821810c2-1a0f-4e32-b09f-33ef0239d748)


## Changelog

[ui] Steps properly transition to failed in the Run gantt chart when resource initialization fails.