### PR TITLE
[docs] fix scroll into view for sidebar

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -26,6 +26,7 @@ const config: Config = {
     require.resolve('docusaurus-plugin-image-zoom'),
     require.resolve('./src/plugins/scoutos'),
     require.resolve('./src/plugins/segment'),
+    require.resolve('./src/plugins/sidebar-scroll-into-view'),
   ],
   themeConfig: {
     ...(process.env.ALGOLIA_APP_ID &&

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -13,17 +13,15 @@
 
 const INNER_HTML = `
   function handleScrollIntoView() {
-    window.requestAnimationFrame(() => {
-      const observer = new MutationObserver(() => {
-      const element = document.querySelector('aside .menu__link--active');
-        if (element) {
-          observer.disconnect();
-          element.scrollIntoView();
-        }
-      });
-
-      observer.observe(document.body, { childList: true, subtree: true });
+    const observer = new MutationObserver(() => {
+    const element = document.querySelector('aside .menu__link--active');
+      if (element) {
+        observer.disconnect();
+        element.scrollIntoView();
+      }
     });
+
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 
   document.addEventListener("DOMContentLoaded", function() {

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -27,6 +27,13 @@ const INNER_HTML = `
   document.addEventListener("DOMContentLoaded", function() {
     handleScrollIntoView();
   });
+
+  const originalPushState = history.pushState;
+  history.pushState = function (...args) {
+    originalPushState.apply(this, args);
+    window.dispatchEvent(new Event('pushstate'));  // Dispatch an event for programmatic push state
+  };
+
   window.addEventListener('popstate', () => handleScrollIntoView());
   window.addEventListener('pushstate', () => handleScrollIntoView());
 `;

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -1,0 +1,46 @@
+// Fixes an issue where the sidebar is not scrolled into view on navigation.
+//
+//     https://github.com/facebook/docusaurus/issues/823
+//
+// USAGE
+//
+//     Include the plugin in your `docusaurus.config.js`:
+//
+//          plugins: [
+//            require.resolve('./src/plugins/sidebar-scroll-into-view'),
+//          ],
+//
+
+const INNER_HTML = `
+  function handleScrollIntoView() {
+    window.requestAnimationFrame(() => {
+      //$('aside .menu__link--active').scrollIntoView();
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    handleScrollIntoView();
+  });
+
+  window.addEventListener('popstate', () => handleScrollIntoView());
+  window.addEventListener('pushstate', () => handleScrollIntoView());
+`;
+
+module.exports = function (context, options) {
+  return {
+    name: 'sidebar-scroll-into-view',
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              type: 'text/javascript',
+            },
+            innerHTML: INNER_HTML,
+          },
+        ],
+      };
+    },
+  };
+};

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -17,9 +17,11 @@ const INNER_HTML = `
     const element = document.querySelector('aside .menu__link--active');
       if (element) {
         observer.disconnect();
-        element.scrollIntoView();
+        element.scrollIntoView(); // scroll sidebar
+        document.querySelector('body').scrollIntoView(); // scroll main body back to top
       }
     });
+
 
     observer.observe(document.body, { childList: true, subtree: true });
   }
@@ -27,13 +29,6 @@ const INNER_HTML = `
   document.addEventListener("DOMContentLoaded", function() {
     handleScrollIntoView();
   });
-
-  const originalPushState = history.pushState;
-  history.pushState = function (...args) {
-    originalPushState.apply(this, args);
-    window.dispatchEvent(new Event('pushstate'));  // Dispatch an event for programmatic push state
-  };
-
   window.addEventListener('popstate', () => handleScrollIntoView());
   window.addEventListener('pushstate', () => handleScrollIntoView());
 `;

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -27,6 +27,8 @@ const INNER_HTML = `
   document.addEventListener("DOMContentLoaded", function() {
     handleScrollIntoView();
   });
+  window.addEventListener('popstate', () => handleScrollIntoView());
+  window.addEventListener('pushstate', () => handleScrollIntoView());
 `;
 
 module.exports = function (context, options) {

--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -14,16 +14,21 @@
 const INNER_HTML = `
   function handleScrollIntoView() {
     window.requestAnimationFrame(() => {
-      //$('aside .menu__link--active').scrollIntoView();
+      const observer = new MutationObserver(() => {
+      const element = document.querySelector('aside .menu__link--active');
+        if (element) {
+          observer.disconnect();
+          element.scrollIntoView();
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
     });
   }
 
   document.addEventListener("DOMContentLoaded", function() {
     handleScrollIntoView();
   });
-
-  window.addEventListener('popstate', () => handleScrollIntoView());
-  window.addEventListener('pushstate', () => handleScrollIntoView());
 `;
 
 module.exports = function (context, options) {


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-888.

Introduces plugin to automatically `scrollIntoView()`the active left sidebar item.

```
plugins: [
  require.resolve('./src/plugins/sidebar-scroll-into-view'),
],
``` 

This is a temporary workaround until it is re-introduced upstream (pending since 2022): [see source code](https://github.com/facebook/docusaurus/blob/f31bfec3c9a7e9e032a36ccd9b405b0e2c2f6957/packages/docusaurus-theme-common/src/hooks/useTOCHighlight.ts#L158).

* https://github.com/facebook/docusaurus/pull/6748
* https://github.com/facebook/docusaurus/issues/6319
* https://github.com/facebook/docusaurus/issues/7980

## How I Tested These Changes

Confirmed working as expected on localhost.

## Changelog

- [docs] automatically scroll left sidebar into view on direct link to documentation
