### PR TITLE
[docs] fix broken link in defining-assets.md

### DIFF
--- a/docs/docs/guides/build/assets/defining-assets.md
+++ b/docs/docs/guides/build/assets/defining-assets.md
@@ -135,6 +135,6 @@ When an asset with a code version is materialized, the generated `AssetMateriali
 
 ## Next steps
 
-- Enrich Dagster's built-in data catalog with [asset metadata]/guides/build/assets/metadata-and-tags/)
+- Enrich Dagster's built-in data catalog with [asset metadata](/guides/build/assets/metadata-and-tags/)
 - Learn to [pass data between assets](/guides/build/assets/passing-data-between-assets)
 - Learn to use a [factory pattern](/guides/build/assets/creating-asset-factories) to create multiple, similar assets


### PR DESCRIPTION
Fixes the broken link in this section of the docs: https://docs.dagster.io/guides/build/assets/defining-assets#next-steps