### PR TITLE
[components] Change top level attribute "transforms" to "post_processors" (BUILD-725)

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -22,8 +22,8 @@ from dagster_components.core.schema.context import ResolutionContext as Resoluti
 from dagster_components.core.schema.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesSchema as AssetAttributesSchema,
+    AssetPostProcessorSchema as AssetPostProcessorSchema,
     AssetSpecSchema as AssetSpecSchema,
-    AssetSpecTransformSchema as AssetSpecTransformSchema,
     OpSpecSchema as OpSpecSchema,
 )
 from dagster_components.scaffold import scaffold_component_yaml as scaffold_component_yaml

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
 from pydantic import BaseModel, Field
+from typing_extensions import TypeAlias
 
 from dagster_components.core.schema.base import FieldResolver, ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
@@ -20,6 +21,9 @@ def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
     return (
         AssetKey.from_user_string(resolved_val) if isinstance(resolved_val, str) else resolved_val
     )
+
+
+PostProcessorFn: TypeAlias = Callable[[Definitions], Definitions]
 
 
 class OpSpecSchema(ResolvableSchema):
@@ -110,7 +114,7 @@ class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[Ma
         return {k: v for k, v in self.resolve_fields(dict, context).items() if k in set_fields}
 
 
-class AssetSpecTransformSchema(ResolvableSchema):
+class AssetPostProcessorSchema(ResolvableSchema):
     target: str = "*"
     operation: Literal["merge", "replace"] = "merge"
     attributes: AssetAttributesSchema

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -4,7 +4,7 @@ attributes:
   dbt:
     project_dir: jaffle_shop
 
-  transforms:
+  asset_post_processors:
     - attributes:
         tags:
           foo: bar

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
@@ -3,12 +3,12 @@ from collections.abc import Sequence
 import pytest
 from dagster import AssetKey, AssetSpec, AutomationCondition, Definitions
 from dagster_components.core.schema.context import ResolutionContext
-from dagster_components.core.schema.objects import AssetAttributesSchema, AssetSpecTransformSchema
+from dagster_components.core.schema.objects import AssetAttributesSchema, AssetPostProcessorSchema
 from pydantic import BaseModel, TypeAdapter
 
 
 class M(BaseModel):
-    asset_attributes: Sequence[AssetSpecTransformSchema] = []
+    asset_attributes: Sequence[AssetPostProcessorSchema] = []
 
 
 defs = Definitions(
@@ -21,7 +21,7 @@ defs = Definitions(
 
 
 def test_replace_attributes() -> None:
-    op = AssetSpecTransformSchema(
+    op = AssetPostProcessorSchema(
         operation="replace",
         target="group:g2",
         attributes=AssetAttributesSchema(tags={"newtag": "newval"}),
@@ -35,7 +35,7 @@ def test_replace_attributes() -> None:
 
 
 def test_merge_attributes() -> None:
-    op = AssetSpecTransformSchema(
+    op = AssetPostProcessorSchema(
         operation="merge",
         target="group:g2",
         attributes=AssetAttributesSchema(tags={"newtag": "newval"}),
@@ -49,7 +49,7 @@ def test_merge_attributes() -> None:
 
 
 def test_render_attributes_asset_context() -> None:
-    op = AssetSpecTransformSchema(
+    op = AssetPostProcessorSchema(
         attributes=AssetAttributesSchema(tags={"group_name_tag": "group__{{ asset.group_name }}"})
     )
 
@@ -61,7 +61,7 @@ def test_render_attributes_asset_context() -> None:
 
 
 def test_render_attributes_custom_context() -> None:
-    op = AssetSpecTransformSchema(
+    op = AssetPostProcessorSchema(
         operation="replace",
         target="group:g2",
         attributes=AssetAttributesSchema(
@@ -99,11 +99,11 @@ def test_render_attributes_custom_context() -> None:
         # default to merge and a * target
         (
             {"attributes": {"tags": {"a": "b"}}},
-            AssetSpecTransformSchema(target="*", attributes=AssetAttributesSchema(tags={"a": "b"})),
+            AssetPostProcessorSchema(target="*", attributes=AssetAttributesSchema(tags={"a": "b"})),
         ),
         (
             {"operation": "replace", "attributes": {"tags": {"a": "b"}}},
-            AssetSpecTransformSchema(
+            AssetPostProcessorSchema(
                 operation="replace",
                 target="*",
                 attributes=AssetAttributesSchema(tags={"a": "b"}),
@@ -112,14 +112,14 @@ def test_render_attributes_custom_context() -> None:
         # explicit target
         (
             {"attributes": {"tags": {"a": "b"}}, "target": "group:g2"},
-            AssetSpecTransformSchema(
+            AssetPostProcessorSchema(
                 target="group:g2",
                 attributes=AssetAttributesSchema(tags={"a": "b"}),
             ),
         ),
         (
             {"operation": "replace", "attributes": {"tags": {"a": "b"}}, "target": "group:g2"},
-            AssetSpecTransformSchema(
+            AssetPostProcessorSchema(
                 operation="replace",
                 target="group:g2",
                 attributes=AssetAttributesSchema(tags={"a": "b"}),
@@ -128,6 +128,6 @@ def test_render_attributes_custom_context() -> None:
     ],
 )
 def test_load_attributes(python, expected) -> None:
-    loaded = TypeAdapter(Sequence[AssetSpecTransformSchema]).validate_python([python])
+    loaded = TypeAdapter(Sequence[AssetPostProcessorSchema]).validate_python([python])
     assert len(loaded) == 1
     assert loaded[0] == expected


### PR DESCRIPTION
## Summary & Motivation

This changes the name of the top-level "transforms" attribute of the sling and dbt components to "post_processors". "transforms" was quite confusing because it communicates nothing about when it is applied relative to the dbt/sling translator, which is configured by `"asset_attributes"`. `"post_processors"` still requires some explanation (we should probably inject explanatory commentary when generating the component.yaml) but is more clear.

## How I Tested These Changes

Existing test suite.