### PR TITLE
:bug: fix loading unpartitioned assets for partitioned runs with `BranchingIOManager`

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -79,7 +79,9 @@ class BranchingIOManager(ConfigurableIOManager):
                 latest_materialization_log_entry(
                     instance=context.instance,
                     asset_key=context.asset_key,
-                    partition_key=partition_key,
+                    partition_key=context.upstream_output.partition_key
+                    if context.upstream_output and context.upstream_output.has_asset_partitions
+                    else None,
                 )
                 for partition_key in partition_keys
             ]


### PR DESCRIPTION
## Summary & Motivation

This PR fixes an issue with the `BranchingIOManager` interaction with partitions.

Previously, it would fail to load a (parent) non-partitioned asset during a partitioned run. 

## How I Tested These Changes

Added tests for all combinations of partitioned/unpartitioned upstream/downstream assets. 

## Changelog

[bugfix] Fixed a bug with  `BranchingIOManager`  when loading unpartitioned assets for partitioned runs