### PR TITLE
[components] Add attributes to control metadata on materialized sling assets

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -1,19 +1,20 @@
 import shutil
 import tempfile
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
-import pytest
 import yaml
 from dagster import AssetKey
 from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.instance_for_test import instance_for_test
 from dagster._utils.env import environ
 from dagster_components import registered_component_type
-from dagster_components.core.component_decl_builder import ComponentFileModel, path_to_decl_node
+from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import YamlComponentDecl, build_component_defs
 from dagster_components.lib.sling_replication_collection.component import SlingReplicationCollection
 from dagster_sling import SlingResource
@@ -24,17 +25,19 @@ STUB_LOCATION_PATH = Path(__file__).parent.parent / "code_locations" / "sling_lo
 COMPONENT_RELPATH = "components/ingest"
 
 
-def _update_yaml(path: Path, fn) -> None:
-    # applies some arbitrary fn to an existing yaml dictionary
+@contextmanager
+def _modify_yaml(path: Path) -> Iterator[dict[str, Any]]:
     with open(path) as f:
         data = yaml.safe_load(f)
+    yield data  # modify data here
     with open(path, "w") as f:
-        yaml.dump(fn(data), f)
+        yaml.dump(data, f)
 
 
 @contextmanager
-@pytest.fixture(scope="module")
-def sling_path() -> Iterator[Path]:
+def temp_sling_component_instance(
+    replication_specs: Optional[list[dict[str, Any]]] = None,
+) -> Iterator[YamlComponentDecl]:
     """Sets up a temporary directory with a replication.yaml and component.yaml file that reference
     the proper temp path.
     """
@@ -43,129 +46,127 @@ def sling_path() -> Iterator[Path]:
             shutil.copytree(STUB_LOCATION_PATH, temp_dir, dirs_exist_ok=True)
 
             # update the replication yaml to reference a CSV file in the tempdir
-            replication_path = Path(temp_dir) / COMPONENT_RELPATH / "replication.yaml"
-
-            def _update_replication(data: dict[str, Any]) -> Mapping[str, Any]:
+            with _modify_yaml(Path(temp_dir) / COMPONENT_RELPATH / "replication.yaml") as data:
                 placeholder_data = data["streams"].pop("<PLACEHOLDER>")
                 data["streams"][f"file://{temp_dir}/input.csv"] = placeholder_data
-                return data
 
-            _update_yaml(replication_path, _update_replication)
+            with _modify_yaml(Path(temp_dir) / COMPONENT_RELPATH / "component.yaml") as data:
+                # If replication specs were provided, overwrite the default one in the component.yaml
+                if replication_specs:
+                    data["attributes"]["replications"] = replication_specs
 
-            # update the defs yaml to add a duckdb instance
-            defs_path = Path(temp_dir) / COMPONENT_RELPATH / "component.yaml"
-
-            def _update_defs(data: dict[str, Any]) -> Mapping[str, Any]:
+                # update the defs yaml to add a duckdb instance
                 data["attributes"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
-                return data
 
-            _update_yaml(defs_path, _update_defs)
-
-            yield Path(temp_dir)
+            yield YamlComponentDecl.from_path(Path(temp_dir) / COMPONENT_RELPATH)
 
 
-def test_python_attributes(sling_path: Path) -> None:
-    decl_node = YamlComponentDecl(
-        path=sling_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
-            type="sling_replication",
-            attributes={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
-        ),
-    )
-    context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(attributes, context)
+def test_python_attributes() -> None:
+    with temp_sling_component_instance([{"path": "./replication.yaml"}]) as decl_node:
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+        component = SlingReplicationCollection.load(attributes, context)
 
-    replications = component.replications
-    assert len(replications) == 1
-    op = replications[0].op
-    assert op is None
+        replications = component.replications
+        assert len(replications) == 1
+        op = replications[0].op
+        assert op is None
 
-    defs = component.build_defs(context)
-    assert defs.get_asset_graph().get_all_asset_keys() == {
-        AssetKey("input_csv"),
-        AssetKey("input_duckdb"),
-    }
-    # inherited from directory name
-    assert defs.get_assets_def("input_duckdb").op.name == "replication"
+        defs = component.build_defs(context)
+        assert defs.get_asset_graph().get_all_asset_keys() == {
+            AssetKey("input_csv"),
+            AssetKey("input_duckdb"),
+        }
+        # inherited from directory name
+        assert defs.get_assets_def("input_duckdb").op.name == "replication"
 
 
-def test_python_attributes_op_name(sling_path: Path) -> None:
-    decl_node = YamlComponentDecl(
-        path=sling_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
-            type="sling_replication",
-            attributes={
-                "sling": {},
-                "replications": [
-                    {"path": "./replication.yaml", "op": {"name": "my_op"}},
-                ],
-            },
-        ),
-    )
-    context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(attributes, context=context)
-
-    replications = component.replications
-    assert len(replications) == 1
-    op = replications[0].op
-    assert op
-    assert op.name == "my_op"
-    defs = component.build_defs(context)
-    assert defs.get_asset_graph().get_all_asset_keys() == {
-        AssetKey("input_csv"),
-        AssetKey("input_duckdb"),
-    }
-    assert defs.get_assets_def("input_duckdb").op.name == "my_op"
+def test_python_attributes_op_name() -> None:
+    with temp_sling_component_instance(
+        [
+            {"path": "./replication.yaml", "op": {"name": "my_op"}},
+        ]
+    ) as decl_node:
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+        component = SlingReplicationCollection.load(attributes, context=context)
+        replications = component.replications
+        assert len(replications) == 1
+        op = replications[0].op
+        assert op
+        assert op.name == "my_op"
+        defs = component.build_defs(context)
+        assert defs.get_asset_graph().get_all_asset_keys() == {
+            AssetKey("input_csv"),
+            AssetKey("input_duckdb"),
+        }
+        assert defs.get_assets_def("input_duckdb").op.name == "my_op"
 
 
-def test_python_attributes_op_tags(sling_path: Path) -> None:
-    decl_node = YamlComponentDecl(
-        path=sling_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
-            type="sling_replication",
-            attributes={
-                "sling": {},
-                "replications": [
-                    {"path": "./replication.yaml", "op": {"tags": {"tag1": "value1"}}},
-                ],
-            },
-        ),
-    )
-    context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
-    component = SlingReplicationCollection.load(attributes=attributes, context=context)
-    replications = component.replications
-    assert len(replications) == 1
-    op = replications[0].op
-    assert op
-    assert op.tags == {"tag1": "value1"}
-    defs = component.build_defs(context)
-    assert defs.get_assets_def("input_duckdb").op.tags == {"tag1": "value1"}
+def test_python_attributes_op_tags() -> None:
+    with temp_sling_component_instance(
+        [
+            {"path": "./replication.yaml", "op": {"tags": {"tag1": "value1"}}},
+        ]
+    ) as decl_node:
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+        component = SlingReplicationCollection.load(attributes=attributes, context=context)
+        replications = component.replications
+        assert len(replications) == 1
+        op = replications[0].op
+        assert op
+        assert op.tags == {"tag1": "value1"}
+        defs = component.build_defs(context)
+        assert defs.get_assets_def("input_duckdb").op.tags == {"tag1": "value1"}
 
 
-def test_load_from_path(sling_path: Path) -> None:
-    decl_node = path_to_decl_node(sling_path / "components")
-    assert decl_node
-    context = script_load_context(decl_node)
-    components = decl_node.load(context)
-    assert len(components) == 1
-    component = components[0]
-    assert isinstance(component, SlingReplicationCollection)
+def test_python_params_include_metadata() -> None:
+    with temp_sling_component_instance(
+        [
+            {"path": "./replication.yaml", "include_metadata": ["column_metadata", "row_count"]},
+        ]
+    ) as decl_node:
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+        component = SlingReplicationCollection.load(attributes=attributes, context=context)
+        replications = component.replications
+        assert len(replications) == 1
+        include_metadata = replications[0].include_metadata
+        assert include_metadata == ["column_metadata", "row_count"]
 
-    resource = getattr(component, "resource")
-    assert isinstance(resource, SlingResource)
-    assert len(resource.connections) == 1
-    assert resource.connections[0].name == "DUCKDB"
-    assert resource.connections[0].type == "duckdb"
-    assert resource.connections[0].password == "password"
+        defs = component.build_defs(context)
+        input_duckdb = defs.get_assets_def("input_duckdb")
 
-    defs = build_component_defs(components_root=sling_path / "components")
-    assert defs.get_asset_graph().get_all_asset_keys() == {
-        AssetKey("input_csv"),
-        AssetKey(["foo", "input_duckdb"]),
-    }
+        with instance_for_test() as instance:
+            result = materialize([input_duckdb], instance=instance)
+        materializations = result.get_asset_materialization_events()
+        assert len(materializations) == 1
+        materialization = materializations[0].materialization
+        assert "dagster/row_count" in materialization.metadata
+        assert "dagster/column_schema" in materialization.metadata
+
+
+def test_load_from_path() -> None:
+    with temp_sling_component_instance() as decl_node:
+        context = script_load_context(decl_node)
+        components = decl_node.load(context)
+        assert len(components) == 1
+        component = components[0]
+        assert isinstance(component, SlingReplicationCollection)
+
+        resource = getattr(component, "resource")
+        assert isinstance(resource, SlingResource)
+        assert len(resource.connections) == 1
+        assert resource.connections[0].name == "DUCKDB"
+        assert resource.connections[0].type == "duckdb"
+        assert resource.connections[0].password == "password"
+
+        defs = build_component_defs(components_root=decl_node.path.parent)
+        assert defs.get_asset_graph().get_all_asset_keys() == {
+            AssetKey("input_csv"),
+            AssetKey(["foo", "input_duckdb"]),
+        }
 
 
 def test_sling_subclass() -> None:

--- a/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
@@ -39,7 +39,7 @@ def _get_logs_for_stream(
     corresponding_logs = []
     recording_logs = False
     for log in sling_cli.stream_raw_logs():
-        if (f"running stream {stream_name}") in log:
+        if stream_name in log:
             corresponding_logs.append(log)
             recording_logs = True
         elif recording_logs:


### PR DESCRIPTION
## Summary & Motivation

This adds a top level attribute `include_metadata` on `SlingReplicationCollection`. This is a list that can include `"column_metadata"` and `"row_count"` to match the methods on the `SlingEventIterator`. The default value includes both these fields.

Also cleans up the test code for sling a little bit.

## How I Tested These Changes

New unit test.