### PR TITLE
[ui] Restore disabled checkbox fill color

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/theme/darkThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/darkThemeColors.tsx
@@ -120,6 +120,7 @@ export const darkThemeColors = css`
   --color-data-viz-yellow-alt: var(--color-dataviz-yellow100);
   --color-checkbox-unchecked: var(--color-core-gray500);
   --color-checkbox-checked: var(--color-core-blue400);
+  --color-checkbox-disabled: var(--color-core-gray700);
   --color-blue-gradient: linear-gradient(
     var(--color-core-gray950),
     var(--color-translucent-blue15) 100%

--- a/js_modules/dagster-ui/packages/ui-components/src/theme/lightThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/lightThemeColors.tsx
@@ -120,6 +120,7 @@ export const lightThemeColors = css`
   --color-data-viz-yellow-alt: var(--color-dataviz-yellow300);
   --color-checkbox-unchecked: var(--color-core-gray400);
   --color-checkbox-checked: var(--color-core-blue500);
+  --color-checkbox-disabled: var(--color-core-gray700);
   --color-blue-gradient: linear-gradient(
     var(--color-core-gray10),
     var(--color-translucent-blue10) 100%


### PR DESCRIPTION
## Summary & Motivation

Fix disabled state fill color of Checkbox switches, particularly in dark mode.

Prod:

<img width="396" alt="Screenshot 2025-02-25 at 09 50 12" src="https://github.com/user-attachments/assets/f3af03ea-f614-4b17-aa69-146f3e6e5340" />

<img width="386" alt="Screenshot 2025-02-25 at 09 49 50" src="https://github.com/user-attachments/assets/6ca24cd2-b957-49cf-905b-52774d3741b5" />

With this change:

<img width="394" alt="Screenshot 2025-02-25 at 09 55 14" src="https://github.com/user-attachments/assets/1b1c0c4f-2f2c-4006-92e4-962e8e29a49c" />

<img width="394" alt="Screenshot 2025-02-25 at 09 55 21" src="https://github.com/user-attachments/assets/7c47a3b5-dfca-4626-a316-66fa830a16b9" />

## How I Tested These Changes

yarn storybook