### PR TITLE
[ui] Show warning on partitions that did not materialize due to canceled runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -266,14 +266,14 @@ export const AssetPartitionDetail = ({
         )}
         <div style={{flex: 1}} />
       </Box>
-      {currentRun?.status === RunStatus.FAILURE && (
+      {currentRun?.status === RunStatus.FAILURE || currentRun?.status === RunStatus.CANCELED ? (
         <FailedRunSinceMaterializationBanner
           run={currentRun}
           stepKey={stepKey}
           padding={{horizontal: 0, vertical: 16}}
           border="bottom"
         />
-      )}
+      ) : null}
       {currentRun && currentRunStatusMessage && (
         <Alert
           intent="info"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
@@ -1,4 +1,4 @@
-import {Alert, Box} from '@dagster-io/ui-components';
+import {Alert, Box, Mono} from '@dagster-io/ui-components';
 import {
   BorderSetting,
   BorderSide,
@@ -7,6 +7,7 @@ import {
 import {Link} from 'react-router-dom';
 
 import {AssetLatestInfoRunFragment} from '../asset-data/types/AssetBaseDataProvider.types';
+import {RunStatus} from '../graphql/types';
 import {titleForRun} from '../runs/RunUtils';
 import {useStepLogs} from '../runs/StepLogsDialog';
 
@@ -23,6 +24,36 @@ export const FailedRunSinceMaterializationBanner = ({
 }) => {
   const stepLogs = useStepLogs({runId: run?.id, stepKeys: stepKey ? [stepKey] : []});
 
+  const alertIntent = run?.status === RunStatus.CANCELED ? 'warning' : 'error';
+
+  const content = () => {
+    if (run?.status === RunStatus.CANCELED) {
+      return (
+        <>
+          Run{' '}
+          <Link to={`/runs/${run.id}`}>
+            <Mono style={{fontWeight: 600}}>{titleForRun(run)}</Mono>
+          </Link>{' '}
+          was canceled, and did not materialize this asset.
+        </>
+      );
+    }
+
+    if (run?.status === RunStatus.FAILURE) {
+      return (
+        <>
+          Run{' '}
+          <Link to={`/runs/${run.id}`}>
+            <Mono style={{fontWeight: 600}}>{titleForRun(run)}</Mono>
+          </Link>{' '}
+          failed, and did not materialize this asset.
+        </>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <>
       {stepLogs.dialog}
@@ -34,17 +65,7 @@ export const FailedRunSinceMaterializationBanner = ({
           style={{width: '100%'}}
         >
           <div style={{flex: 1}}>
-            <Alert
-              intent="error"
-              title={
-                <Box flex={{justifyContent: 'space-between'}}>
-                  <div style={{fontWeight: 400}}>
-                    Run <Link to={`/runs/${run.id}`}>{titleForRun(run)}</Link> failed to materialize
-                    this asset.
-                  </div>
-                </Box>
-              }
-            />
+            <Alert intent={alertIntent} title={content()} />
           </div>
           {stepLogs.button}
         </Box>


### PR DESCRIPTION
## Summary & Motivation

It is confusing for partitions that were not materialized due to canceled runs do not show any messaging indicating that a failure or cancellation occurred on the asset partition detail page.

This is because we only show the banner if the run failed. Update this to show a banner if it was canceled as well. Use a "warning" intent for the cancellation banner, to help visually distinguish it from the failed run.

Also updated the copy a bit, since it's the runs that fail or are canceled.

<img width="535" alt="Screenshot 2025-02-25 at 11 02 31" src="https://github.com/user-attachments/assets/a1605ebd-6e9a-4b96-bb16-a8cd96288b15" />
<img width="469" alt="Screenshot 2025-02-25 at 11 00 19" src="https://github.com/user-attachments/assets/09c4180f-c0e7-40fb-9826-43357c275f7b" />

## How I Tested These Changes

View partition that failed to materialize due to cancellation. Verify that the yellow banner appears.

View partition that failed to materialize due to failed run. Verify that the red banner appears.

## Changelog

[ui] For asset partitions that fail to materialize due to a run cancellation, show this information on the asset partition detail page.
