### PR TITLE
[dagster-components] Fix Sling component scaffolding replication file in cwd

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/scaffolder.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 from typing import Any
 
 import yaml
@@ -14,6 +12,6 @@ from dagster_components.scaffold import scaffold_component_yaml
 class SlingReplicationComponentScaffolder(ComponentScaffolder):
     def scaffold(self, request: ComponentScaffoldRequest, params: Any) -> None:
         scaffold_component_yaml(request, {"replications": [{"path": "replication.yaml"}]})
-        replication_path = Path(os.getcwd()) / "replication.yaml"
+        replication_path = request.component_instance_root_path / "replication.yaml"
         with open(replication_path, "w") as f:
             yaml.dump({"source": {}, "target": {}, "streams": {}}, f)


### PR DESCRIPTION
## Summary

Explicitly specify that the replication YAML file should be placed in the component folder, based on user feedback:

> The command `dg scaffold component 'sling_replication_collection@dagster_components' ingest_files` generates the replication YAML file in the root of the project, while the component expects it in the component's folder next to component.yaml.

## Test Plan

todo
