### PR TITLE
[1/n] [Selection syntax input + catalog views] Move catalog view selector

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -20,6 +20,7 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {AssetGraphAssetSelectionInput} from 'shared/asset-graph/AssetGraphAssetSelectionInput.oss';
 import {useAssetGraphExplorerFilters} from 'shared/asset-graph/useAssetGraphExplorerFilters.oss';
 import {AssetSelectionInput} from 'shared/asset-selection/input/AssetSelectionInput.oss';
+import {CatalogViewSelector} from 'shared/assets/CatalogViewSelector.oss';
 import styled from 'styled-components';
 
 import {AssetEdges} from './AssetEdges';
@@ -761,7 +762,9 @@ const AssetGraphExplorerWithData = ({
                       />
                     </Tooltip>
                   )}
-                  {featureEnabled(FeatureFlag.flagSelectionSyntax) ? null : (
+                  {featureEnabled(FeatureFlag.flagSelectionSyntax) ? (
+                    <CatalogViewSelector />
+                  ) : (
                     <div>{filterButton}</div>
                   )}
                   <GraphQueryInputFlexWrap>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -5,6 +5,7 @@ import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {AssetGraphFilterBar} from 'shared/asset-graph/AssetGraphFilterBar.oss';
+import {CatalogViewSelector} from 'shared/assets/CatalogViewSelector.oss';
 import {useAssetCatalogFiltering} from 'shared/assets/useAssetCatalogFiltering.oss';
 
 import {AssetTable} from './AssetTable';
@@ -202,7 +203,7 @@ export const AssetsCatalogTable = ({
 
   const [view, setView] = useAssetView();
 
-  const {assets, query, error} = useAllAssets({groupSelector});
+  const {assets, loading: assetsLoading, query, error} = useAllAssets({groupSelector});
 
   const {
     filteredAssets: partiallyFiltered,
@@ -211,7 +212,8 @@ export const AssetsCatalogTable = ({
     filterButton,
     activeFiltersJsx,
     kindFilter,
-  } = useAssetCatalogFiltering({assets});
+  } = useAssetCatalogFiltering({assets, loading: assetsLoading});
+
   const {filterInput, filtered, loading, assetSelection, setAssetSelection} =
     useAssetSelectionInput({
       assets: partiallyFiltered,
@@ -266,9 +268,7 @@ export const AssetsCatalogTable = ({
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: featureEnabled(FeatureFlag.flagSelectionSyntax)
-              ? 'auto minmax(0, 1fr)'
-              : 'auto auto minmax(0, 1fr)',
+            gridTemplateColumns: 'auto auto minmax(0, 1fr)',
             gap: 12,
             alignItems: 'flex-start',
           }}
@@ -286,7 +286,7 @@ export const AssetsCatalogTable = ({
               }
             }}
           />
-          {featureEnabled(FeatureFlag.flagSelectionSyntax) ? null : filterButton}
+          {featureEnabled(FeatureFlag.flagSelectionSyntax) ? <CatalogViewSelector /> : filterButton}
           {filterInput}
         </div>
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CatalogViewSelector.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CatalogViewSelector.oss.tsx
@@ -1,0 +1,1 @@
+export const CatalogViewSelector = () => null;


### PR DESCRIPTION
## Summary & Motivation

Move Catalog view selector to be adjacent to the selection syntax input on the asset graph and in the catalog.

Companion to cloud PR https://github.com/dagster-io/internal/pull/13970

## How I Tested These Changes
<img width="1728" alt="Screenshot 2025-02-25 at 2 25 10 PM" src="https://github.com/user-attachments/assets/e28a73c5-e799-4e07-9a03-cb25822d75db" />
<img width="1728" alt="Screenshot 2025-02-25 at 2 15 39 PM" src="https://github.com/user-attachments/assets/7e77a4af-2f2e-410f-a25e-519898f920e6" />
