### PR TITLE
[BUILD-752] Use pydantic.BaseModel instead of pydantic.dataclass for builtin component types

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -10,8 +10,7 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from pydantic import ConfigDict, Field, computed_field
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from dagster_components import Component, ComponentLoadContext, FieldResolver
 from dagster_components.core.component import registered_component_type
@@ -52,9 +51,10 @@ def resolve_translator(
 
 
 @registered_component_type(name="dbt_project")
-@dataclass(config=ConfigDict(arbitrary_types_allowed=True))  # omits translator prop from schema
-class DbtProjectComponent(Component):
+class DbtProjectComponent(Component, BaseModel):
     """Expose a DBT project to Dagster as a set of assets."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
     op: Optional[OpSpecSchema] = Field(

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/component.py
@@ -5,8 +5,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
 )
-from pydantic import Field
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, Field
 
 from dagster_components import (
     Component,
@@ -22,8 +21,7 @@ class DefinitionsParamSchema(ResolvableSchema):
 
 
 @registered_component_type(name="definitions")
-@dataclass
-class DefinitionsComponent(Component):
+class DefinitionsComponent(Component, BaseModel):
     """Wraps an arbitrary set of Dagster definitions."""
 
     definitions_path: Optional[str] = Field(

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -9,7 +9,6 @@ from dagster._core.definitions.result import MaterializeResult
 from dagster_sling import DagsterSlingTranslator, SlingResource, sling_assets
 from dagster_sling.resources import AssetExecutionContext
 from pydantic import BaseModel, Field
-from pydantic.dataclasses import dataclass
 
 from dagster_components import Component, ComponentLoadContext, FieldResolver
 from dagster_components.core.component import registered_component_type
@@ -78,8 +77,7 @@ def resolve_resource(
 
 
 @registered_component_type
-@dataclass
-class SlingReplicationCollection(Component):
+class SlingReplicationCollection(Component, BaseModel):
     """Expose one or more Sling replications to Dagster as assets."""
 
     resource: Annotated[SlingResource, FieldResolver(resolve_resource)] = Field(


### PR DESCRIPTION
## Summary

Right now, it's not possible to subclass component types to add extra fields (I'm trying to do so with the DBT component for product-ops), because these classes are dataclasses.

Changing to `pydantic.BaseModel` retains existing functionality while getting around this subclassing restriction.