### PR TITLE
Add a "validate_partition_mapping" method on PartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -171,6 +171,28 @@ class TimeWindowPartitionMapping(
             mapping_downstream_to_upstream=True,
         )
 
+    def validate_partition_mapping(
+        self,
+        upstream_partitions_def: PartitionsDefinition,
+        downstream_partitions_def: PartitionsDefinition,
+    ):
+        check.invariant(
+            isinstance(upstream_partitions_def, TimeWindowPartitionsDefinition),
+            "Upstream partitions definition must be a TimeWindowPartitionsDefinition",
+        )
+        check.invariant(
+            isinstance(downstream_partitions_def, TimeWindowPartitionsDefinition),
+            "Downstream partitions definition must be a TimeWindowPartitionsDefinition",
+        )
+
+        upstream_partitions_def = cast(TimeWindowPartitionsDefinition, upstream_partitions_def)
+        downstream_partitions_def = cast(TimeWindowPartitionsDefinition, downstream_partitions_def)
+
+        if upstream_partitions_def.timezone != downstream_partitions_def.timezone:
+            raise DagsterInvalidDefinitionError(
+                f"Timezones {upstream_partitions_def.timezone} and {downstream_partitions_def.timezone} don't match"
+            )
+
     def get_downstream_partitions_for_partitions(
         self,
         upstream_partitions_subset: PartitionsSubset,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -85,6 +85,13 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
                 required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
             )
 
+        def validate_partition_mapping(
+            self,
+            upstream_partitions_def: PartitionsDefinition,
+            downstream_partitions_def: PartitionsDefinition,
+        ):
+            pass
+
         def get_downstream_partitions_for_partitions(
             self,
             upstream_partitions_subset: PartitionsSubset,
@@ -443,6 +450,17 @@ def test_partition_keys_in_range():
         resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
         partition_key="2022-09-11",
     ).success
+
+
+def test_timezone_error_partition_mapping():
+    utc = DailyPartitionsDefinition(start_date="2020-01-01")
+    pacific = DailyPartitionsDefinition(start_date="2020-01-01", timezone="US/Pacific")
+    partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=0)
+
+    with pytest.raises(Exception, match="Timezones UTC and US/Pacific don't match"):
+        partition_mapping.validate_partition_mapping(utc, pacific)
+
+    partition_mapping.validate_partition_mapping(utc, utc)
 
 
 def test_dependency_resolution_partition_mapping():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -246,6 +246,12 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
+        MultiToSingleDimensionPartitionMapping().validate_partition_mapping(
+            multipartitions_def,
+            single_dimension_def,
+        )
+
+    with pytest.raises(CheckError, match="dimension name must be specified"):
         MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
                 multipartitions_def,
@@ -772,18 +778,25 @@ def test_error_multipartitions_mapping():
         }
     )
 
+    error_mapping = MultiPartitionMapping(
+        {
+            "nonexistent dimension": DimensionPartitionMapping(
+                "other nonexistent dimension", SpecificPartitionsPartitionMapping(["c"])
+            )
+        }
+    )
+
     with pytest.raises(
         CheckError, match="upstream dimension name that is not in the upstream partitions def"
     ):
-        MultiPartitionMapping(
-            {
-                "nonexistent dimension": DimensionPartitionMapping(
-                    "other nonexistent dimension", SpecificPartitionsPartitionMapping(["c"])
-                )
-            }
-        ).get_upstream_mapped_partitions_result_for_partitions(
+        error_mapping.get_upstream_mapped_partitions_result_for_partitions(
             weekly_abc.empty_subset(), weekly_abc, daily_123
         )
+
+    with pytest.raises(
+        CheckError, match="upstream dimension name that is not in the upstream partitions def"
+    ):
+        error_mapping.validate_partition_mapping(weekly_abc, daily_123)
 
 
 def test_multi_partition_mapping_with_asset_deps():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -69,10 +69,22 @@ def test_error_on_extra_keys_in_mapping():
         )
 
     with pytest.raises(ValueError, match="OTHER"):
+        StaticPartitionMapping({"p": "p", "q": {"q", "OTHER"}}).validate_partition_mapping(
+            upstream_partitions_def=upstream_parts,
+            downstream_partitions_def=downstream_parts,
+        )
+
+    with pytest.raises(ValueError, match="OTHER"):
         StaticPartitionMapping(
             {"p": "p", "q": "q", "OTHER": "q"}
         ).get_upstream_mapped_partitions_result_for_partitions(
             downstream_partitions_subset=downstream_parts.empty_subset(),
+            downstream_partitions_def=downstream_parts,
+            upstream_partitions_def=upstream_parts,
+        )
+
+    with pytest.raises(ValueError, match="OTHER"):
+        StaticPartitionMapping({"p": "p", "q": "q", "OTHER": "q"}).validate_partition_mapping(
             downstream_partitions_def=downstream_parts,
             upstream_partitions_def=upstream_parts,
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -267,6 +267,13 @@ def test_custom_unsupported_partition_mapping():
                 required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
             )
 
+        def validate_partition_mapping(
+            self,
+            upstream_partitions_def: PartitionsDefinition,
+            downstream_partitions_def: PartitionsDefinition,
+        ):
+            pass
+
         def get_downstream_partitions_for_partitions(
             self,
             upstream_partitions_subset: PartitionsSubset,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -275,6 +275,13 @@ def test_fs_io_manager_partitioned_no_partitions():
                     required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
                 )
 
+            def validate_partition_mapping(
+                self,
+                upstream_partitions_def: PartitionsDefinition,
+                downstream_partitions_def: PartitionsDefinition,
+            ):
+                pass
+
             def get_downstream_partitions_for_partitions(
                 self,
                 upstream_partitions_subset,


### PR DESCRIPTION
## Summary ## 
Adds a new method that does basic sanity checking of the upstream and downstream defs to make sure that they are not incompatible. Can then be used during definitions loading or "dagster definitions validate" to verify that all partition mappings are valid. Previously the only way to get this information was to actually attempt a partition mapping, so it was cumbersome to check at definition time.

## Test Plan ## 
New test cases