### PR TITLE
[dagster-components] Add support for dbt select, exclude in dbt component

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -191,3 +191,39 @@ def test_asset_attributes(
         assets_def: AssetsDefinition = defs.get_assets_def("stg_customers")
     if assertion:
         assert assertion(assets_def.get_asset_spec(AssetKey("stg_customers")))
+
+
+def test_subselection(dbt_path: Path) -> None:
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="dbt_project",
+            attributes={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "select": "raw_customers",
+            },
+        ),
+    )
+    context = script_load_context(decl_node)
+    component = DbtProjectComponent.load(
+        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
+    )
+    assert get_asset_keys(component) == {AssetKey("raw_customers")}
+
+
+def test_exclude(dbt_path: Path) -> None:
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="dbt_project",
+            attributes={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "exclude": "customers",
+            },
+        ),
+    )
+    context = script_load_context(decl_node)
+    component = DbtProjectComponent.load(
+        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
+    )
+    assert get_asset_keys(component) == set(JAFFLE_SHOP_KEYS) - {AssetKey("customers")}


### PR DESCRIPTION
## Summary

Right now, the dbt component doesn't natively support subselection or exclusion. Adds two new top-level params to enable this functionality - taken from https://github.com/dagster-io/internal/pull/13989


```yaml

type: dbt_project@dagster_components

attributes:
  dbt:
    project_dir: jaffle_shop
  exclude: my_excluded_pattern
```

## Test Plan

New unit tests.
