### PR TITLE
[dagster-components] Introduce resolved OpSpec, backfill_policy

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -29,12 +29,12 @@ PostProcessorFn: TypeAlias = Callable[[Definitions], Definitions]
 
 
 @dataclass
-class SingleRunBackfillPolicy:
+class SingleRunBackfillPolicySchema:
     type: Literal["single_run"] = "single_run"
 
 
 @dataclass
-class MultiRunBackfillPolicy:
+class MultiRunBackfillPolicySchema:
     type: Literal["multi_run"] = "multi_run"
     max_partitions_per_run: int = 1
 
@@ -69,9 +69,9 @@ class OpSpecSchema(ResolvableSchema[OpSpec]):
     tags: Optional[dict[str, str]] = Field(
         default=None, description="Arbitrary metadata for the op."
     )
-    backfill_policy: Optional[Union[SingleRunBackfillPolicy, MultiRunBackfillPolicy]] = Field(
-        default=None, description="The backfill policy to use for the assets."
-    )
+    backfill_policy: Optional[
+        Union[SingleRunBackfillPolicySchema, MultiRunBackfillPolicySchema]
+    ] = Field(default=None, description="The backfill policy to use for the assets.")
 
 
 class AssetDepSchema(ResolvableSchema[AssetDep]):

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -7,9 +7,11 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.asset_spec import AssetSpec, map_asset_specs
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
 from pydantic import BaseModel, Field
+from pydantic.dataclasses import dataclass
 from typing_extensions import TypeAlias
 
 from dagster_components.core.schema.base import FieldResolver, ResolvableSchema
@@ -26,10 +28,49 @@ def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
 PostProcessorFn: TypeAlias = Callable[[Definitions], Definitions]
 
 
-class OpSpecSchema(ResolvableSchema):
+@dataclass
+class SingleRunBackfillPolicy:
+    type: Literal["single_run"] = "single_run"
+
+
+@dataclass
+class MultiRunBackfillPolicy:
+    type: Literal["multi_run"] = "multi_run"
+    max_partitions_per_run: int = 1
+
+
+def resolve_backfill_policy(
+    context: ResolutionContext, schema: "OpSpecSchema"
+) -> Optional[BackfillPolicy]:
+    if schema.backfill_policy is None:
+        return None
+
+    if schema.backfill_policy.type == "single_run":
+        return BackfillPolicy.single_run()
+    elif schema.backfill_policy.type == "multi_run":
+        return BackfillPolicy.multi_run(
+            max_partitions_per_run=schema.backfill_policy.max_partitions_per_run
+        )
+
+    raise ValueError(f"Invalid backfill policy: {schema.backfill_policy}")
+
+
+@dataclass
+class OpSpec:
+    name: Optional[str] = None
+    tags: Optional[dict[str, str]] = None
+    backfill_policy: Annotated[Optional[BackfillPolicy], FieldResolver(resolve_backfill_policy)] = (
+        None
+    )
+
+
+class OpSpecSchema(ResolvableSchema[OpSpec]):
     name: Optional[str] = Field(default=None, description="The name of the op.")
     tags: Optional[dict[str, str]] = Field(
         default=None, description="Arbitrary metadata for the op."
+    )
+    backfill_policy: Optional[Union[SingleRunBackfillPolicy, MultiRunBackfillPolicy]] = Field(
+        default=None, description="The backfill policy to use for the assets."
     )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -19,6 +19,7 @@ from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
     AssetAttributesSchema,
     AssetPostProcessorSchema,
+    OpSpec,
     OpSpecSchema,
     PostProcessorFn,
     ResolutionContext,
@@ -61,7 +62,7 @@ class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
 
     dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
-    op: Optional[OpSpecSchema] = Field(
+    op: Optional[OpSpec] = Field(
         None, description="Customizations to the op underlying the dbt run."
     )
     translator: Annotated[DagsterDbtTranslator, FieldResolver(resolve_translator)] = Field(
@@ -111,6 +112,7 @@ class DbtProjectComponent(Component):
             dagster_dbt_translator=self.translator,
             select=self.select,
             exclude=self.exclude,
+            backfill_policy=self.op.backfill_policy if self.op else None,
         )
         def _fn(context: AssetExecutionContext):
             yield from self.execute(context=context, dbt=self.dbt)


### PR DESCRIPTION
## Summary

Introduces a new `backfill_policy` schema entry to `OpSpecSchema`, which is resolved to an actual `BackfillPolicy` during its conversion to an `OpSpec`:

```yaml

type: dbt_project@dagster_components

attributes:
  op:
    backfill_policy:
      type: multi_run
      max_partitions_per_run: 5
```


## How I Tested These Changes

New unit tests.
