### PR TITLE
Validate partition mappings when a repository is first loaded

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import generate_asset_dep_graph
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -333,6 +334,28 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
                 *(ad for ad in self._assets_defs_by_check_key.values()),
             }
         )
+
+    def validate_partition_mappings(self):
+        for node in self.asset_nodes:
+            if node.partitions_def is None or node.is_external:
+                continue
+
+            parents = self.get_parents(node)
+            for parent in parents:
+                if parent.partitions_def is None or parent.is_external:
+                    continue
+
+                partition_mapping = self.get_partition_mapping(node.key, parent.key)
+
+                try:
+                    partition_mapping.validate_partition_mapping(
+                        parent.partitions_def,
+                        node.partitions_def,
+                    )
+                except Exception as e:
+                    raise DagsterInvalidDefinitionError(
+                        f"Invalid partition mapping from {node.key.to_user_string()} to {parent.key.to_user_string()}"
+                    ) from e
 
     def assets_defs_for_keys(self, keys: Iterable[EntityKey]) -> Sequence[AssetsDefinition]:
         return list({self.assets_def_for_key(key) for key in keys})

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -598,7 +598,7 @@ class Definitions(IHaveNew):
 
         Raises an error if any of the above are not true.
         """
-        defs.get_repository_def().load_all_definitions()
+        defs.get_repository_def().validate_loadable()
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -178,6 +178,10 @@ class RepositoryDefinition:
         # force load of all lazy constructed code artifacts
         self._repository_data.load_all_definitions()
 
+    def validate_loadable(self):
+        self.load_all_definitions()
+        self.asset_graph.validate_partition_mappings()
+
     @public
     @property
     def job_names(self) -> Sequence[str]:


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue where if you had an invalid partition mapping between two assets (like timezones not matching) it wouldn't be caught until DA tried to execute it. This doesn't capture every class of issues (notably invalid partition mappings between two different code locations or repositories within the same code location) but should help with the common case where the offending assets are in the same code location.

## How I Tested These Changes
Test Plan: New test case

## Changelog
`Definitions.validate_loadable` and `dagster definitions validate` will now raise an error on assets with invalid partition mappings, like a `TimeWindowPartitionMapping` between two time-based partitions definitions with different timezones. Previously, these invalid partition mappings would not raise an error until they were used to launch a run.