### PR TITLE
[components] Update component key naming scheme

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/8-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/8-dg-list-component-types.txt
@@ -1,13 +1,13 @@
 dg list component-type
 
 Using /.../my-existing-project/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/11-component.yaml
@@ -1,4 +1,4 @@
-type: sling_replication_collection@dagster_components
+type: dagster_components.lib.SlingReplicationCollection
 
 attributes:
   replications:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
@@ -1,18 +1,18 @@
 dg list component-type
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dbt_project@dagster_components                        │ Expose a DBT project to        │
-│                                                       │ Dagster as a set of assets.    │
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
-│                                                       │ replications to Dagster as     │
-│                                                       │ assets.                        │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DbtProjectComponent             │ Expose a DBT project to       │
+│                                                        │ Dagster as a set of assets.   │
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+│ dagster_components.lib.SlingReplicationCollection      │ Expose one or more Sling      │
+│                                                        │ replications to Dagster as    │
+│                                                        │ assets.                       │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-scaffold-jdbt.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-scaffold-jdbt.txt
@@ -1,4 +1,4 @@
-dg scaffold component dbt_project@dagster_components jdbt --project-path dbt/jdbt
+dg scaffold component dagster_components.lib.DbtProjectComponent jdbt --project-path dbt/jdbt
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/components/jdbt.
 Using /.../jaffle-platform/.venv/bin/dagster-components

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/20-component-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/20-component-jdbt.yaml
@@ -1,4 +1,4 @@
-type: dbt_project@dagster_components
+type: dagster_components.lib.DbtProjectComponent
 
 attributes:
   dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/23-project-jdbt.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/23-project-jdbt.yaml
@@ -1,4 +1,4 @@
-type: dbt_project@dagster_components
+type: dagster_components.lib.DbtProjectComponent
 
 attributes:
   dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
@@ -1,12 +1,12 @@
 dg list component-type
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
@@ -1,16 +1,16 @@
 dg list component-type
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
-│                                                       │ replications to Dagster as     │
-│                                                       │ assets.                        │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+│ dagster_components.lib.SlingReplicationCollection      │ Expose one or more Sling      │
+│                                                        │ replications to Dagster as    │
+│                                                        │ assets.                       │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
@@ -1,4 +1,4 @@
-dg scaffold component 'sling_replication_collection@dagster_components' ingest_files
+dg scaffold component 'dagster_components.lib.SlingReplicationCollection' ingest_files
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/components/ingest_files.
 Using /.../jaffle-platform/.venv/bin/dagster-components

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/3-scaffold.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/3-scaffold.txt
@@ -1,4 +1,4 @@
-dg scaffold component 'definitions@dagster_components' elt-definitions
+dg scaffold component 'dagster_components.lib.DefinitionsComponent' elt-definitions
 
 Using /.../my-existing-project/.venv/bin/dagster-components
 Creating a Dagster component instance folder at /.../my-existing-project/my_existing_project/components/elt-definitions.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/6-component-yaml.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/migrating-definitions/6-component-yaml.txt
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: definitions.py

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
@@ -1,4 +1,4 @@
-dg scaffold component-type shell_command
+dg scaffold component-type ShellCommand
 
 Creating a Dagster component type at /.../my-component-library/my_component_library/lib/shell_command.py.
-Scaffolded files for Dagster component type at /.../my-component-library/my_component_library/lib/shell_command..
+Scaffolded files for Dagster component type at /.../my-component-library/my_component_library/lib/shell_command.py.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -10,7 +10,7 @@ from dagster_components import (
 class ShellCommandSchema(ResolvableSchema):
     ...
 
-@registered_component_type(name="shell_command")
+@registered_component_type
 class ShellCommand(Component):
     """COMPONENT SUMMARY HERE.
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
@@ -1,15 +1,15 @@
 dg list component-type
 
 Using /.../my-component-library/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-│ shell_command@my_component_library                    │ Models a shell script as a     │
-│                                                       │ Dagster asset.                 │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+│ my_component_library.lib.ShellCommand                  │ Models a shell script as a    │
+│                                                        │ Dagster asset.                │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/4-dg-component-type-docs.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/4-dg-component-type-docs.txt
@@ -1,1 +1,1 @@
-dg docs component-type shell_command@my_component_library
+dg docs component-type my_component_library.lib.ShellCommand

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/5-dg-component-type-docs.html
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/5-dg-component-type-docs.html
@@ -7,12 +7,12 @@
         <title>Markdown Preview</title>
     </head>
     <body>
-        <h2>Component: <code>my_component_library.shell_command</code></h2>
+        <h2>Component: <code>my_component_library.lib.ShellCommand</code></h2>
 <h3>Description:</h3>
 <p>Models a shell script as a Dagster asset.</p>
 <h3>Sample Component Params:</h3>
 <textarea rows=24 cols=100>
-type: my_component_library.shell_command
+type: my_component_library.lib.ShellCommand
 
 attributes:
   script_path: '...'

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/6-scaffold-instance-of-component.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/6-scaffold-instance-of-component.txt
@@ -1,4 +1,4 @@
-dg scaffold component 'shell_command@my_component_library' my_shell_command
+dg scaffold component 'my_component_library.lib.ShellCommand' my_shell_command
 
 Using /.../my-component-library/.venv/bin/dagster-components
 Creating a Dagster component instance folder at /.../my-component-library/my_component_library/components/my_shell_command.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/7-scaffolded-component.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/7-scaffolded-component.yaml
@@ -1,4 +1,4 @@
-type: shell_command@my_component_library
+type: my_component_library.lib.ShellCommand
 
 attributes:
   script_path: script.sh

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/5-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/5-component-type-list.txt
@@ -1,12 +1,12 @@
 cd projects/project-1 && dg list component-type
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/6-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/6-component-type-list.txt
@@ -1,16 +1,16 @@
 dg list component-type
 
 Using /.../dagster-workspace/projects/project-1/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-│ sling_replication_collection@dagster_components       │ Expose one or more Sling       │
-│                                                       │ replications to Dagster as     │
-│                                                       │ assets.                        │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+│ dagster_components.lib.SlingReplicationCollection      │ Expose one or more Sling      │
+│                                                        │ replications to Dagster as    │
+│                                                        │ assets.                       │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/9-component-type-list.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/9-component-type-list.txt
@@ -1,12 +1,12 @@
 cd projects/project-2 && dg list component-type
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                        ┃ Summary                        ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ definitions@dagster_components                        │ Wraps an arbitrary set of      │
-│                                                       │ Dagster definitions.           │
-│ pipes_subprocess_script_collection@dagster_components │ Assets that wrap Python        │
-│                                                       │ scripts executed with          │
-│                                                       │ Dagster's                      │
-│                                                       │ PipesSubprocessClient.         │
-└───────────────────────────────────────────────────────┴────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Component Type                                         ┃ Summary                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster_components.lib.DefinitionsComponent            │ Wraps an arbitrary set of     │
+│                                                        │ Dagster definitions.          │
+│ dagster_components.lib.PipesSubprocessScriptCollection │ Assets that wrap Python       │
+│                                                        │ scripts executed with         │
+│                                                        │ Dagster's                     │
+│                                                        │ PipesSubprocessClient.        │
+└────────────────────────────────────────────────────────┴───────────────────────────────┘

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -119,7 +119,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
         # Scaffold new ingestion, validate new files
         run_command_and_snippet_output(
-            cmd="dg scaffold component 'sling_replication_collection@dagster_components' ingest_files",
+            cmd="dg scaffold component 'dagster_components.lib.SlingReplicationCollection' ingest_files",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-dg-scaffold-sling-replication.txt",
             update_snippets=update_snippets,
@@ -251,7 +251,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
             # Scaffold dbt project components
             run_command_and_snippet_output(
-                cmd="dg scaffold component dbt_project@dagster_components jdbt --project-path dbt/jdbt",
+                cmd="dg scaffold component dagster_components.lib.DbtProjectComponent jdbt --project-path dbt/jdbt",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-scaffold-jdbt.txt",
                 update_snippets=update_snippets,
@@ -294,7 +294,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-project-jdbt.yaml",
                 contents=format_multiline("""
-                    type: dbt_project@dagster_components
+                    type: dagster_components.lib.DbtProjectComponent
 
                     attributes:
                       dbt:

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -45,7 +45,7 @@ def test_components_docs_index(
 
         # Scaffold new component type
         run_command_and_snippet_output(
-            cmd="dg scaffold component-type shell_command",
+            cmd="dg scaffold component-type ShellCommand",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-dg-scaffold-shell-command.txt",
             update_snippets=update_snippets,
@@ -87,7 +87,7 @@ def test_components_docs_index(
         )
 
         run_command_and_snippet_output(
-            cmd="dg docs component-type shell_command@my_component_library --output cli > docs.html",
+            cmd="dg docs component-type my_component_library.lib.ShellCommand --output cli > docs.html",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-dg-component-type-docs.txt",
             update_snippets=update_snippets,
@@ -130,7 +130,7 @@ def test_components_docs_index(
             contents=(COMPONENTS_SNIPPETS_DIR / "with-scaffolder.py").read_text(),
         )
         run_command_and_snippet_output(
-            cmd="dg scaffold component 'shell_command@my_component_library' my_shell_command",
+            cmd="dg scaffold component 'my_component_library.lib.ShellCommand' my_shell_command",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffold-instance-of-component.txt",
             update_snippets=update_snippets,

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/test_migrating_definitions.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/test_migrating_definitions.py
@@ -61,7 +61,7 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
         )
 
         run_command_and_snippet_output(
-            cmd="dg scaffold component 'definitions@dagster_components' elt-definitions",
+            cmd="dg scaffold component 'dagster_components.lib.DefinitionsComponent' elt-definitions",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffold.txt",
             update_snippets=update_snippets,
@@ -102,7 +102,7 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
             / "elt-definitions"
             / "component.yaml",
             format_multiline("""
-            type: definitions@dagster_components
+            type: dagster_components.lib.DefinitionsComponent
 
             attributes:
               definitions_path: definitions.py
@@ -156,7 +156,7 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
 
         # migrate analytics
         _run_command(
-            cmd="dg scaffold component 'definitions@dagster_components' analytics-definitions",
+            cmd="dg scaffold component 'dagster_components.lib.DefinitionsComponent' analytics-definitions",
         )
         _run_command(
             cmd="mv my_existing_project/analytics/* my_existing_project/components/analytics-definitions && rm -rf my_existing_project/analytics",
@@ -185,7 +185,7 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
             / "analytics-definitions"
             / "component.yaml",
             format_multiline("""
-                type: definitions@dagster_components
+                type: dagster_components.lib.DefinitionsComponent
 
                 attributes:
                   definitions_path: definitions.py

--- a/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
+++ b/examples/experimental/components/examples/hello_world_deployment/code_locations/hello_world/hello_world/definitions.py
@@ -1,22 +1,9 @@
 from pathlib import Path
 
 import dagster as dg
-from dagster_components import ComponentTypeRegistry, build_component_defs
-from dagster_components.core.component_key import GlobalComponentKey
-from dagster_components.lib.pipes_subprocess_script_collection import (
-    PipesSubprocessScriptCollection,
-)
+from dagster_components import build_component_defs
 
-defs = build_component_defs(
-    Path(__file__).parent / "components",
-    registry=ComponentTypeRegistry(
-        {
-            GlobalComponentKey.from_typename(
-                "pipes_subprocess_script_collection@here"
-            ): PipesSubprocessScriptCollection
-        }
-    ),
-)
+defs = build_component_defs(Path(__file__).parent / "components")
 
 if __name__ == "__main__":
     dg.Definitions.validate_loadable(defs)

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
@@ -41,12 +41,12 @@ def find_objects_in_module_of_types(
 def find_subclasses_in_module(
     module: ModuleType,
     types: Union[type, tuple[type, ...]],
-) -> Iterator:
+) -> Iterator[tuple[str, type]]:
     """Yields instances or subclasses of the given type(s)."""
     for attr in dir(module):
         value = getattr(module, attr)
         if isinstance(value, type) and issubclass(value, types):
-            yield value
+            yield attr, value
 
 
 AssetLoaderTypes = Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec]

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -1,7 +1,6 @@
 from dagster_components.core.component import (
     Component as Component,
     ComponentLoadContext as ComponentLoadContext,
-    ComponentTypeRegistry as ComponentTypeRegistry,
     component as component,
     registered_component_type as registered_component_type,
 )

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -1,4 +1,3 @@
-import copy
 import dataclasses
 import importlib
 import importlib.metadata
@@ -18,11 +17,7 @@ from dagster._core.errors import DagsterError
 from dagster._utils import pushd, snakecase
 from typing_extensions import Self
 
-from dagster_components.core.component_key import (
-    ComponentKey,
-    GlobalComponentKey,
-    LocalComponentKey,
-)
+from dagster_components.core.component_key import ComponentKey
 from dagster_components.core.component_scaffolder import (
     ComponentScaffolder,
     ComponentScaffolderUnavailableReason,
@@ -30,7 +25,7 @@ from dagster_components.core.component_scaffolder import (
 )
 from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
-from dagster_components.utils import format_error_message, load_module_from_path
+from dagster_components.utils import format_error_message
 
 
 class ComponentsEntryPointLoadError(DagsterError):
@@ -134,101 +129,96 @@ BUILTIN_MAIN_COMPONENT_ENTRY_POINT = BUILTIN_COMPONENTS_ENTRY_POINT_BASE
 BUILTIN_TEST_COMPONENT_ENTRY_POINT = ".".join([BUILTIN_COMPONENTS_ENTRY_POINT_BASE, "test"])
 
 
-class ComponentTypeRegistry:
-    @classmethod
-    def from_entry_point_discovery(
-        cls, builtin_component_lib: str = BUILTIN_MAIN_COMPONENT_ENTRY_POINT
-    ) -> "ComponentTypeRegistry":
-        """Discover component types registered in the Python environment via the
-        `dagster_components` entry point group.
+def load_component_type(component_key: ComponentKey) -> type[Component]:
+    module_name, attr = component_key.namespace, component_key.name
+    try:
+        module = importlib.import_module(module_name)
+        if not hasattr(module, attr):
+            raise DagsterError(f"Module `{module_name}` has no attribute `{attr}`.")
+        component_type = getattr(module, attr)
+        if not issubclass(component_type, Component):
+            raise DagsterError(
+                f"Attribute `{attr}` in module `{module_name}` is not a subclass of `dagster_components.Component`."
+            )
+        return component_type
+    except ModuleNotFoundError as e:
+        raise DagsterError(f"Module `{module_name}` not found.") from e
+    except ImportError as e:
+        raise DagsterError(f"Error loading module `{module_name}`.") from e
 
-        `dagster-components` itself registers multiple component entry points. We call these
-        "builtin" component libraries. The `dagster_components` entry point resolves to published
-        component types and is loaded by default. Other entry points resolve to various sets of test
-        component types. This method will only ever load one builtin component library.
 
-        Args:
-            builtin-component-lib (str): Specifies the builtin components library to load. Built-in
+def discover_entry_point_component_types(
+    builtin_component_lib: str = BUILTIN_MAIN_COMPONENT_ENTRY_POINT,
+    extra_modules: Optional[Sequence[str]] = None,
+) -> dict[ComponentKey, type[Component]]:
+    """Discover component types registered in the Python environment via the
+    `dagster_components` entry point group.
+
+    `dagster-components` itself registers multiple component entry points. We call these
+    "builtin" component libraries. The `dagster_components` entry point resolves to published
+    component types and is loaded by default. Other entry points resolve to various sets of test
+    component types. This method will only ever load one builtin component library.
+
+    Args:
+        builtin-component-lib (str): Specifies the builtin components library to load. Built-in
             component libraries are defined under entry points with names matching the pattern
             `dagster_components*`. Only one built-in  component library can be loaded at a time.
             Defaults to `dagster_components`, the standard set of published component types.
-        """
-        component_types: dict[ComponentKey, type[Component]] = {}
-        for entry_point in get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP):
-            # Skip built-in entry points that are not the specified builtin component library.
-            if (
-                entry_point.name.startswith(BUILTIN_COMPONENTS_ENTRY_POINT_BASE)
-                and not entry_point.name == builtin_component_lib
-            ):
-                continue
+    """
+    component_types: dict[ComponentKey, type[Component]] = {}
+    entry_points = [
+        ep
+        for ep in get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP)
+        # Skip built-in entry points that are not the specified builtin component library.
+        if not (
+            ep.name.startswith(BUILTIN_COMPONENTS_ENTRY_POINT_BASE)
+            and not ep.name == builtin_component_lib
+        )
+    ]
 
-            try:
-                root_module = entry_point.load()
-            except Exception as e:
-                raise ComponentsEntryPointLoadError(
-                    format_error_message(f"""
-                        Error loading entry point `{entry_point.name}` in group `{COMPONENTS_ENTRY_POINT_GROUP}`.
-                        Please fix the error or uninstall the package that defines this entry point.
-                    """)
-                ) from e
+    for entry_point in entry_points:
+        try:
+            root_module = entry_point.load()
+        except Exception as e:
+            raise ComponentsEntryPointLoadError(
+                format_error_message(f"""
+                    Error loading entry point `{entry_point.name}` in group `{COMPONENTS_ENTRY_POINT_GROUP}`.
+                    Please fix the error or uninstall the package that defines this entry point.
+                """)
+            ) from e
 
-            if not isinstance(root_module, ModuleType):
-                raise DagsterError(
-                    f"Invalid entry point {entry_point.name} in group {COMPONENTS_ENTRY_POINT_GROUP}. "
-                    f"Value expected to be a module, got {root_module}."
-                )
-            for component_type in get_registered_component_types_in_module(root_module):
-                key = GlobalComponentKey(
-                    name=get_component_type_name(component_type), namespace=entry_point.name
-                )
-                component_types[key] = component_type
-
-        return cls(component_types)
-
-    def __init__(self, component_types: dict[ComponentKey, type[Component]]):
-        self._component_types: dict[ComponentKey, type[Component]] = copy.copy(component_types)
-
-    @staticmethod
-    def empty() -> "ComponentTypeRegistry":
-        return ComponentTypeRegistry({})
-
-    def register(self, key: ComponentKey, component_type: type[Component]) -> None:
-        if key in self._component_types:
-            raise DagsterError(f"There is an existing component registered under {key}")
-        self._component_types[key] = component_type
-
-    def has(self, key: ComponentKey) -> bool:
-        return key in self._component_types
-
-    def get(self, key: ComponentKey) -> type[Component]:
-        if isinstance(key, LocalComponentKey):
-            for component_type in find_component_types_in_file(key.python_file):
-                if get_component_type_name(component_type) == key.name:
-                    return component_type
-            raise ValueError(
-                f"Could not find component type {key.to_typename()} in {key.python_file}"
+        if not isinstance(root_module, ModuleType):
+            raise DagsterError(
+                f"Invalid entry point {entry_point.name} in group {COMPONENTS_ENTRY_POINT_GROUP}. "
+                f"Value expected to be a module, got {root_module}."
             )
-        else:
-            return self._component_types[key]
-
-    def keys(self) -> Iterable[ComponentKey]:
-        return self._component_types.keys()
-
-    def items(self) -> Iterable[tuple[ComponentKey, type[Component]]]:
-        return self._component_types.items()
-
-    def __repr__(self) -> str:
-        return f"<ComponentRegistry {list(self._component_types.keys())}>"
+        for name, component_type in get_component_types_in_module(root_module):
+            key = ComponentKey(name=name, namespace=entry_point.value)
+            component_types[key] = component_type
+    return component_types
 
 
-def get_registered_component_types_in_module(module: ModuleType) -> Iterable[type[Component]]:
+def discover_component_types(modules: Sequence[str]) -> dict[ComponentKey, type[Component]]:
+    component_types: dict[ComponentKey, type[Component]] = {}
+    for extra_module in modules:
+        for name, component_type in get_component_types_in_module(
+            importlib.import_module(extra_module)
+        ):
+            key = ComponentKey(name=name, namespace=extra_module)
+            component_types[key] = component_type
+    return component_types
+
+
+def get_component_types_in_module(
+    module: ModuleType,
+) -> Iterable[tuple[str, type[Component]]]:
     from dagster._core.definitions.module_loaders.load_assets_from_modules import (
         find_subclasses_in_module,
     )
 
-    for component in find_subclasses_in_module(module, (Component,)):
-        if is_registered_component_type(component):
-            yield component
+    for name, component in find_subclasses_in_module(module, (Component,)):
+        if not inspect.isabstract(component):
+            yield name, component
 
 
 T = TypeVar("T")
@@ -238,7 +228,6 @@ T = TypeVar("T")
 class ComponentLoadContext:
     module_name: str
     resources: Mapping[str, object]
-    registry: ComponentTypeRegistry
     decl_node: Optional[ComponentDeclNode]
     resolution_context: ResolutionContext
 
@@ -246,13 +235,11 @@ class ComponentLoadContext:
     def for_test(
         *,
         resources: Optional[Mapping[str, object]] = None,
-        registry: Optional[ComponentTypeRegistry] = None,
         decl_node: Optional[ComponentDeclNode] = None,
     ) -> "ComponentLoadContext":
         return ComponentLoadContext(
             module_name="test",
             resources=resources or {},
-            registry=registry or ComponentTypeRegistry.empty(),
             decl_node=decl_node,
             resolution_context=ResolutionContext.default(),
         )
@@ -280,6 +267,9 @@ class ComponentLoadContext:
 
     def resolve(self, value: ResolvableSchema, as_type: type[T]) -> T:
         return self.resolution_context.resolve_value(value, as_type=as_type)
+
+    def normalize_component_type_str(self, type_str: str) -> str:
+        return f"{self.module_name}{type_str}" if type_str.startswith(".") else type_str
 
     def load_component_relative_python_module(self, file_path: Path) -> ModuleType:
         """Load a python module relative to the component's context path. This is useful for loading code
@@ -311,7 +301,7 @@ class ComponentLoadContext:
             # Problematic
             # See https://linear.app/dagster-labs/issue/BUILD-736/highly-suspect-hardcoding-of-components-string-is-component-relative
             component_module_relative_path = abs_context_path.parts[
-                abs_context_path.parts.index("components") + 1 :
+                abs_context_path.parts.index("components") + 2 :
             ]
             component_module_name = ".".join([self.module_name, *component_module_relative_path])
             if abs_file_path.name != "__init__.py":
@@ -381,30 +371,3 @@ def component(
 
 def is_component_loader(obj: Any) -> bool:
     return getattr(obj, COMPONENT_LOADER_FN_ATTR, False)
-
-
-def find_component_types_in_file(file_path: Path) -> list[type[Component]]:
-    """Find all component types defined in a specific file."""
-    component_types = []
-    for _name, obj in inspect.getmembers(
-        load_module_from_path(file_path.stem, file_path), inspect.isclass
-    ):
-        assert isinstance(obj, type)
-        if is_registered_component_type(obj):
-            component_types.append(obj)
-    return component_types
-
-
-def find_local_component_types(component_path: Path) -> Mapping[LocalComponentKey, type[Component]]:
-    """Find all component types defined in a component directory, and their respective paths."""
-    component_types = {}
-    for py_file in component_path.glob("*.py"):
-        for component_type in find_component_types_in_file(py_file):
-            component_types[
-                LocalComponentKey(
-                    name=get_component_type_name(component_type),
-                    namespace=f"file:{py_file.name}",
-                    dirpath=py_file.parent,
-                )
-            ] = component_type
-    return component_types

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_key.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_key.py
@@ -1,74 +1,29 @@
-import re
 import textwrap
-from abc import ABC
 from dataclasses import dataclass
-from pathlib import Path
-
-LOCAL_COMPONENT_IDENTIFIER = "file:"
-
-_COMPONENT_NAME_REGEX = r"[a-zA-Z0-9_]+"
-_FILE_PATH_REGEX = r"[a-zA-Z0-9_\.\/-]+"
-_LOCAL_NAMESPACE_REGEX = rf"{LOCAL_COMPONENT_IDENTIFIER}{_FILE_PATH_REGEX}"
-_GLOBAL_NAMESPACE_REGEX = r"[a-zA-Z0-9_\.]+"
-
-COMPONENT_TYPENAME_REGEX = re.compile(
-    rf"^({_COMPONENT_NAME_REGEX})@(({_LOCAL_NAMESPACE_REGEX})|({_GLOBAL_NAMESPACE_REGEX}))$"
-)
 
 
 def _generate_invalid_component_typename_error_message(typename: str) -> str:
     return textwrap.dedent(f"""
         Invalid component type name: `{typename}`.
-        Type names must match regex: `{COMPONENT_TYPENAME_REGEX.pattern}`.
+        Type names must be a "."-separated string of valid Python identifiers with at least two segments.
     """)
 
 
-def _name_and_namespace_from_type(typename: str) -> tuple[str, str]:
-    match = COMPONENT_TYPENAME_REGEX.match(typename)
-    if not match:
-        raise ValueError(_generate_invalid_component_typename_error_message(typename))
-    return match.group(1), match.group(2)
-
-
 @dataclass(frozen=True)
-class ComponentKey(ABC):
-    name: str
+class ComponentKey:
     namespace: str
+    name: str
 
     def to_typename(self) -> str:
-        return f"{self.name}@{self.namespace}"
+        return f"{self.namespace}.{self.name}"
 
     @staticmethod
-    def from_typename(typename: str, dirpath: Path) -> "ComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        if namespace.startswith(LOCAL_COMPONENT_IDENTIFIER):
-            return LocalComponentKey(name, namespace, dirpath)
-        else:
-            return GlobalComponentKey(name, namespace)
-
-
-@dataclass(frozen=True)
-class GlobalComponentKey(ComponentKey):
-    @staticmethod
-    def from_typename(typename: str) -> "GlobalComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        return GlobalComponentKey(name=name, namespace=namespace)
-
-
-@dataclass(frozen=True)
-class LocalComponentKey(ComponentKey):
-    dirpath: Path
-
-    def __post_init__(self) -> None:
-        if not self.python_file.resolve().is_relative_to(self.dirpath.resolve()):
-            raise ValueError(f"File {self.namespace} must be within directory: {self.dirpath}")
-
-    @staticmethod
-    def from_typename(typename: str, dirpath: Path) -> "LocalComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        return LocalComponentKey(name=name, namespace=namespace, dirpath=dirpath)
-
-    @property
-    def python_file(self) -> Path:
-        relative_path = self.namespace[len(LOCAL_COMPONENT_IDENTIFIER) :]
-        return self.dirpath / relative_path
+    def from_typename(typename: str) -> "ComponentKey":
+        parts = typename.split(".")
+        for part in parts:
+            if not part.isidentifier():
+                raise ValueError(_generate_invalid_component_typename_error_message(typename))
+        if len(parts) < 2:
+            raise ValueError(_generate_invalid_component_typename_error_message(typename))
+        namespace, _, name = typename.rpartition(".")
+        return ComponentKey(name=name, namespace=namespace)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dbt_project@dagster_components
+type: dagster_components.lib.DbtProjectComponent
 
 attributes:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dbt_project@dagster_components
+type: dagster_components.lib.DbtProject
 
 attributes:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/components/scripts/component.yaml
@@ -1,4 +1,4 @@
-type: pipes_subprocess_script_collection@dagster_components
+type: dagster_components.lib.PipesSubprocessScriptCollection
 
 attributes:
   scripts:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/sling_location/components/ingest/component.yaml
@@ -1,4 +1,4 @@
-type: sling_replication_collection@dagster_components
+type: dagster_components.lib.SlingReplicationCollection
 
 attributes:
   replications:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/templated_custom_keys_dbt_project_location/components/jaffle_shop_dbt/component.yaml
@@ -1,4 +1,4 @@
-type: dbt_project@dagster_components
+type: dagster_components.lib.DbtProjectComponent
 
 attributes:
   dbt:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/component_loader.py
@@ -1,18 +1,11 @@
-import importlib
 import sys
 from pathlib import Path
 from typing import Optional
 
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components.core.component import (
-    ComponentTypeRegistry,
-    get_component_type_name,
-    get_registered_component_types_in_module,
-)
 from dagster_components.core.component_defs_builder import build_defs_from_component_path
-from dagster_components.core.component_key import GlobalComponentKey
 
-from dagster_components_tests.utils import create_code_location_from_components
+from dagster_components_tests.utils import create_project_from_components
 
 
 def load_test_component_defs(
@@ -21,35 +14,13 @@ def load_test_component_defs(
     """Loads a component from a test component project, making the provided local component defn
     available in that component's __init__.py.
     """
-    with create_code_location_from_components(
+    with create_project_from_components(
         src_path, local_component_defn_to_inject=local_component_defn_to_inject
     ) as code_location_dir:
-        registry = load_test_component_project_registry(include_test=True)
-
         sys.path.append(str(code_location_dir))
 
         return build_defs_from_component_path(
             components_root=Path(code_location_dir) / "my_location" / "components",
             path=Path(code_location_dir) / "my_location" / "components" / Path(src_path).stem,
-            registry=registry,
             resources={},
         )
-
-
-def load_test_component_project_registry(include_test: bool = False) -> ComponentTypeRegistry:
-    components = {}
-    package_name = "dagster_components.lib"
-
-    packages = ["dagster_components.lib"] + (
-        ["dagster_components.lib.test"] if include_test else []
-    )
-    for package_name in packages:
-        dc_module = importlib.import_module(package_name)
-
-        for component in get_registered_component_types_in_module(dc_module):
-            key = GlobalComponentKey(
-                name=get_component_type_name(component),
-                namespace=f"dagster_components{'.test' if package_name.endswith('test') else ''}",
-            )
-            components[key] = component
-    return ComponentTypeRegistry(components)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/default_file/component.yaml
@@ -1,3 +1,3 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file/component.yaml
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports/component.yaml
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_complex/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_complex/component.yaml
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: some_file.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_init/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/explicit_file_relative_imports_init/component.yaml
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: __init__.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@file:__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/other_local_component_sample/component.yaml
@@ -1,4 +1,4 @@
-type: .my_new_component
+type: .MyNewComponent
 
 attributes:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/validation_error_file/component.yaml
@@ -1,4 +1,4 @@
-type: definitions@dagster_components
+type: dagster_components.lib.DefinitionsComponent
 
 attributes:
   definitions_path: {}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_top_level_value/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_extra_value/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@file:__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_invalid_value/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@file:__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_type/component.yaml
@@ -1,4 +1,4 @@
-type: my_component_does_not_exist@file:__init__.py
+type: .MyComponentDoesNotExist
 
 attributes:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_missing_value/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@file:__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/basic_component_success/component.yaml
@@ -1,4 +1,4 @@
-type: my_component@file:__init__.py
+type: .MyComponent
 
 attributes:
   a_string: "a string"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_extra_values/component.yaml
@@ -1,4 +1,4 @@
-type: my_nested_component@file:__init__.py
+type: .MyNestedComponent
 
 attributes:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_invalid_values/component.yaml
@@ -1,4 +1,4 @@
-type: my_nested_component@file:__init__.py
+type: .MyNestedComponent
 
 attributes:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/nested_component_missing_values/component.yaml
@@ -1,4 +1,4 @@
-type: my_nested_component@file:__init__.py
+type: .MyNestedComponent
 
 attributes:
   nested:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/validation/simple_asset_invalid_value/component.yaml
@@ -1,4 +1,4 @@
-type: simple_asset@dagster_components.test
+type: dagster_components.lib.test.SimpleAsset
 
 attributes:
   asset_key: "test"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.yaml
@@ -1,4 +1,4 @@
-type: custom_scope_component@file:component.py
+type: .component.HasCustomScope
 
 attributes:
   asset_attributes:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_custom_scope.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_custom_scope.py
@@ -3,14 +3,11 @@ from pathlib import Path
 from dagster import AssetSpec, AutomationCondition
 from dagster_components.core.component_defs_builder import build_defs_from_component_path
 
-from dagster_components_tests.utils import registry
-
 
 def test_custom_scope() -> None:
     defs = build_defs_from_component_path(
         components_root=Path(__file__).parent / "components",
         path=Path(__file__).parent / "custom_scope_component",
-        registry=registry(),
         resources={},
     )
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_key.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_key.py
@@ -2,11 +2,7 @@ import inspect
 from pathlib import Path
 
 import pytest
-from dagster_components.core.component_key import (
-    ComponentKey,
-    GlobalComponentKey,
-    LocalComponentKey,
-)
+from dagster_components.core.component_key import ComponentKey
 
 
 def test_component_key_synced() -> None:
@@ -27,28 +23,23 @@ dirpath = Path(".")
 @pytest.mark.parametrize(
     ["component_typename", "component_key"],
     [
-        ("foo@bar", GlobalComponentKey("foo", "bar")),
-        ("foo@bar.baz", GlobalComponentKey("foo", "bar.baz")),
-        ("foo@file.xyz", GlobalComponentKey("foo", "file.xyz")),
-        ("foo@file:bar.py", LocalComponentKey("foo", "file:bar.py", dirpath)),
-        ("foo@file:bar/baz.py", LocalComponentKey("foo", "file:bar/baz.py", dirpath)),
+        ("foo.bar", ComponentKey("foo", "bar")),
+        ("foo.Bar", ComponentKey("foo", "Bar")),
+        ("foo.bar.baz", ComponentKey("foo.bar", "baz")),
     ],
 )
 def test_valid_component_keys(component_typename: str, component_key: ComponentKey) -> None:
-    assert ComponentKey.from_typename(component_typename, dirpath) == component_key
+    assert ComponentKey.from_typename(component_typename) == component_key
 
 
 @pytest.mark.parametrize(
     "component_typename",
     [
-        "foo@bar@baz",
-        "foo@something:bar.py",
-        "foo@file:bar:baz.py",
-        "foo@file:../baz.py",
-        "foo@blah:baz.py",
-        "foo@not_a_file:baz.py",
+        "foo",
+        "foo@bar",
+        ".foo.bar",
     ],
 )
 def test_invalid_component_keys(component_typename: str) -> None:
     with pytest.raises(ValueError):
-        ComponentKey.from_typename(component_typename, dirpath)
+        ComponentKey.from_typename(component_typename)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -40,7 +40,6 @@ def test_load_from_location_path() -> None:
     defs = build_defs_from_component_path(
         LOCATION_PATH / "components",
         LOCATION_PATH / "components" / "scripts",
-        script_load_context().registry,
         {},
     )
     assert defs.get_asset_graph().get_all_asset_keys() == {

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
@@ -4,7 +4,7 @@ import click
 
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
-from dagster_dg.component_key import GlobalComponentKey
+from dagster_dg.component_key import ComponentKey
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.docs import html_from_markdown, markdown_for_component_type, open_html_in_browser
@@ -34,11 +34,11 @@ def component_type_docs_command(
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalComponentKey.from_typename(component_type)
-    if not registry.has_global(component_key):
+    component_key = ComponentKey.from_typename(component_type)
+    if not registry.has(component_key):
         exit_with_error(f"Component type `{component_type}` not found.")
 
-    markdown = markdown_for_component_type(registry.get_global(component_key))
+    markdown = markdown_for_component_type(registry.get(component_key))
     if output == "browser":
         open_html_in_browser(html_from_markdown(markdown))
     else:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -69,13 +69,13 @@ def component_type_list(output_json: bool, **global_options: object) -> None:
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 
-    sorted_keys = sorted(registry.global_keys(), key=lambda k: k.to_typename())
+    sorted_keys = sorted(registry.keys(), key=lambda k: k.to_typename())
 
     # JSON
     if output_json:
         output: list[dict[str, object]] = []
         for key in sorted_keys:
-            component_type_metadata = registry.get_global(key)
+            component_type_metadata = registry.get(key)
             output.append(
                 {
                     "key": key.to_typename(),
@@ -89,7 +89,7 @@ def component_type_list(output_json: bool, **global_options: object) -> None:
         table = Table(border_style="dim")
         table.add_column("Component Type", style="bold cyan", no_wrap=True)
         table.add_column("Summary")
-        for key in sorted(registry.global_keys(), key=lambda k: k.to_typename()):
-            table.add_row(key.to_typename(), registry.get_global(key).summary)
+        for key in sorted(registry.keys(), key=lambda k: k.to_typename()):
+            table.add_row(key.to_typename(), registry.get(key).summary)
         console = Console()
         console.print(table)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -7,7 +7,7 @@ import click
 
 from dagster_dg.cli.global_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry, all_components_schema_from_dg_context
-from dagster_dg.component_key import GlobalComponentKey
+from dagster_dg.component_key import ComponentKey
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.utils import (
@@ -75,15 +75,15 @@ def inspect_component_type_command(
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
-    component_key = GlobalComponentKey.from_typename(component_type)
-    if not registry.has_global(component_key):
+    component_key = ComponentKey.from_typename(component_type)
+    if not registry.has(component_key):
         exit_with_error(generate_missing_component_type_error_message(component_type))
     elif sum([description, scaffold_params_schema, component_schema]) > 1:
         exit_with_error(
             "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."
         )
 
-    component_type_metadata = registry.get_global(component_key)
+    component_type_metadata = registry.get(component_key)
 
     if description:
         if component_type_metadata.description:

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -1,11 +1,10 @@
 import copy
 import json
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
-from pathlib import Path
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
-from dagster_dg.component_key import ComponentKey, GlobalComponentKey, LocalComponentKey
+from dagster_dg.component_key import ComponentKey
 from dagster_dg.utils import is_valid_json
 
 if TYPE_CHECKING:
@@ -22,22 +21,46 @@ class RemoteComponentType:
     component_schema: Optional[Mapping[str, Any]]  # json schema
 
 
-def _get_remote_type_mapping_from_raw_data(
-    raw_data: Mapping[str, Any],
-) -> Mapping[ComponentKey, RemoteComponentType]:
-    data = {}
-    for typename, metadata in raw_data.items():
-        data[GlobalComponentKey.from_typename(typename)] = RemoteComponentType(**metadata)
-    return data
+class RemoteComponentRegistry:
+    @staticmethod
+    def from_dg_context(
+        dg_context: "DgContext", extra_modules: Optional[Sequence[str]] = None
+    ) -> "RemoteComponentRegistry":
+        """Fetches the set of available component types. The default set includes everything
+        discovered under the "dagster.components" entry point group in the target environment. If
+        `extra_modules` is provided, these will also be searched for component types.
+        """
+        if dg_context.use_dg_managed_environment:
+            dg_context.ensure_uv_lock()
 
+        component_data = _load_entry_point_components(dg_context)
+        if extra_modules:
+            component_data.update(_load_module_components(dg_context, extra_modules))
 
-def _get_local_type_mapping_from_raw_data(
-    raw_data: Mapping[str, Any], dirpath: Path
-) -> Mapping[LocalComponentKey, RemoteComponentType]:
-    data = {}
-    for typename, metadata in raw_data.items():
-        data[LocalComponentKey.from_typename(typename, dirpath)] = RemoteComponentType(**metadata)
-    return data
+        return RemoteComponentRegistry(component_data)
+
+    def __init__(self, components: dict[ComponentKey, RemoteComponentType]):
+        self._components: dict[ComponentKey, RemoteComponentType] = copy.copy(components)
+
+    @staticmethod
+    def empty() -> "RemoteComponentRegistry":
+        return RemoteComponentRegistry({})
+
+    def get(self, key: ComponentKey) -> RemoteComponentType:
+        """Resolves a component type within the scope of a given component directory."""
+        return self._components[key]
+
+    def has(self, key: ComponentKey) -> bool:
+        return key in self._components
+
+    def keys(self) -> Iterable[ComponentKey]:
+        yield from sorted(self._components.keys(), key=lambda k: k.to_typename())
+
+    def items(self) -> Iterable[tuple[ComponentKey, RemoteComponentType]]:
+        yield from self._components.items()
+
+    def __repr__(self) -> str:
+        return f"<RemoteComponentRegistry {list(self._components.keys())}>"
 
 
 def all_components_schema_from_dg_context(dg_context: "DgContext") -> Mapping[str, Any]:
@@ -52,105 +75,75 @@ def all_components_schema_from_dg_context(dg_context: "DgContext") -> Mapping[st
     return json.loads(schema_raw)
 
 
-def _retrieve_local_component_types(
-    dg_context: "DgContext", paths: Sequence[Path]
-) -> Mapping[LocalComponentKey, RemoteComponentType]:
-    paths_to_fetch = set(paths)
-    data: dict[LocalComponentKey, RemoteComponentType] = {}
+# ########################
+# ##### HELPERS
+# ########################
+
+
+def _load_entry_point_components(
+    dg_context: "DgContext",
+) -> dict[ComponentKey, RemoteComponentType]:
     if dg_context.has_cache:
-        for path in paths:
-            cache_key = dg_context.get_cache_key_for_local_components(path)
+        cache_key = dg_context.get_cache_key("component_registry_data")
+        raw_registry_data = dg_context.cache.get(cache_key)
+    else:
+        cache_key = None
+        raw_registry_data = None
+
+    if not raw_registry_data:
+        raw_registry_data = dg_context.external_components_command(["list", "component-types"])
+        if dg_context.has_cache and cache_key and is_valid_json(raw_registry_data):
+            dg_context.cache.set(cache_key, raw_registry_data)
+
+    return _parse_raw_registry_data(raw_registry_data)
+
+
+def _load_module_components(
+    dg_context: "DgContext", modules: Sequence[str]
+) -> dict[ComponentKey, RemoteComponentType]:
+    modules_to_fetch = set(modules)
+    data: dict[ComponentKey, RemoteComponentType] = {}
+    if dg_context.has_cache:
+        for module in modules:
+            cache_key = dg_context.get_cache_key_for_module(module)
             raw_data = dg_context.cache.get(cache_key)
             if raw_data:
-                data.update(_get_local_type_mapping_from_raw_data(json.loads(raw_data), path))
-                paths_to_fetch.remove(path)
+                data.update(_parse_raw_registry_data(raw_data))
+                modules_to_fetch.remove(module)
 
-    if paths_to_fetch:
+    if modules_to_fetch:
         raw_local_component_data = dg_context.external_components_command(
             [
                 "list",
-                "local-component-types",
-                *[str(path) for path in paths_to_fetch],
+                "component-types",
+                "--no-entry-points",
+                *modules_to_fetch,
             ]
         )
-        local_component_data = json.loads(raw_local_component_data)
-        for path in paths_to_fetch:
-            data.update(
-                _get_local_type_mapping_from_raw_data(local_component_data.get(str(path), {}), path)
-            )
+        all_fetched_components = _parse_raw_registry_data(raw_local_component_data)
+        for module in modules_to_fetch:
+            components = {k: v for k, v in all_fetched_components.items() if k.namespace == module}
+            data.update(components)
 
-        if dg_context.has_cache:
-            for path in paths_to_fetch:
-                cache_key = dg_context.get_cache_key_for_local_components(path)
-                data_for_path_json = json.dumps(local_component_data.get(str(path), {}))
-                if cache_key and is_valid_json(data_for_path_json):
-                    dg_context.cache.set(cache_key, data_for_path_json)
+            if dg_context.has_cache:
+                cache_key = dg_context.get_cache_key_for_module(module)
+                dg_context.cache.set(cache_key, _dump_raw_registry_data(components))
 
     return data
 
 
-class RemoteComponentRegistry:
-    @staticmethod
-    def from_dg_context(
-        dg_context: "DgContext", local_component_type_dirs: Optional[Sequence[Path]] = None
-    ) -> "RemoteComponentRegistry":
-        """Fetches the set of available component types, including local component types for the
-        specified directories. Caches the result if possible.
-        """
-        component_data = {}
-        if dg_context.use_dg_managed_environment:
-            dg_context.ensure_uv_lock()
+def _parse_raw_registry_data(
+    raw_registry_data: str,
+) -> dict[ComponentKey, RemoteComponentType]:
+    return {
+        ComponentKey.from_typename(typename): RemoteComponentType(**metadata)
+        for typename, metadata in json.loads(raw_registry_data).items()
+    }
 
-        if dg_context.has_cache:
-            cache_key = dg_context.get_cache_key("component_registry_data")
-            raw_registry_data = dg_context.cache.get(cache_key)
-        else:
-            cache_key = None
-            raw_registry_data = None
 
-        if not raw_registry_data:
-            raw_registry_data = dg_context.external_components_command(["list", "component-types"])
-            if dg_context.has_cache and cache_key and is_valid_json(raw_registry_data):
-                dg_context.cache.set(cache_key, raw_registry_data)
-
-        raw_registry_dict = json.loads(raw_registry_data)
-
-        component_data.update(_get_remote_type_mapping_from_raw_data(raw_registry_dict))
-
-        if local_component_type_dirs:
-            component_data.update(
-                _retrieve_local_component_types(dg_context, local_component_type_dirs)
-            )
-
-        return RemoteComponentRegistry(component_data)
-
-    def __init__(self, components: dict[ComponentKey, RemoteComponentType]):
-        self._components: dict[ComponentKey, RemoteComponentType] = copy.copy(components)
-
-    @staticmethod
-    def empty() -> "RemoteComponentRegistry":
-        return RemoteComponentRegistry({})
-
-    def has_global(self, key: ComponentKey) -> bool:
-        return key in self._components
-
-    def get(self, key: ComponentKey) -> RemoteComponentType:
-        """Resolves a component type within the scope of a given component directory."""
-        return self._components[key]
-
-    def get_global(self, key: GlobalComponentKey) -> RemoteComponentType:
-        if not isinstance(key, GlobalComponentKey):
-            raise ValueError(f"Expected GlobalRemoteComponentKey, got {key}")
-        return self._components[key]
-
-    def global_keys(self) -> Iterable[GlobalComponentKey]:
-        for key in sorted(self._components.keys(), key=lambda k: k.to_typename()):
-            if isinstance(key, GlobalComponentKey):
-                yield key
-
-    def global_items(self) -> Iterable[tuple[GlobalComponentKey, RemoteComponentType]]:
-        for key in self.global_keys():
-            yield key, self.get_global(key)
-
-    def __repr__(self) -> str:
-        return f"<RemoteComponentRegistry {list(self._components.keys())}>"
+def _dump_raw_registry_data(
+    registry_data: Mapping[ComponentKey, RemoteComponentType],
+) -> str:
+    return json.dumps(
+        {key.to_typename(): asdict(component) for key, component in registry_data.items()}
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg/component_key.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component_key.py
@@ -1,74 +1,29 @@
-import re
 import textwrap
-from abc import ABC
 from dataclasses import dataclass
-from pathlib import Path
-
-LOCAL_COMPONENT_IDENTIFIER = "file:"
-
-_COMPONENT_NAME_REGEX = r"[a-zA-Z0-9_]+"
-_FILE_PATH_REGEX = r"[a-zA-Z0-9_\.\/-]+"
-_LOCAL_NAMESPACE_REGEX = rf"{LOCAL_COMPONENT_IDENTIFIER}{_FILE_PATH_REGEX}"
-_GLOBAL_NAMESPACE_REGEX = r"[a-zA-Z0-9_\.]+"
-
-COMPONENT_TYPENAME_REGEX = re.compile(
-    rf"^({_COMPONENT_NAME_REGEX})@(({_LOCAL_NAMESPACE_REGEX})|({_GLOBAL_NAMESPACE_REGEX}))$"
-)
 
 
 def _generate_invalid_component_typename_error_message(typename: str) -> str:
     return textwrap.dedent(f"""
         Invalid component type name: `{typename}`.
-        Type names must match regex: `{COMPONENT_TYPENAME_REGEX.pattern}`.
+        Type names must be a "."-separated string of valid Python identifiers with at least two segments.
     """)
 
 
-def _name_and_namespace_from_type(typename: str) -> tuple[str, str]:
-    match = COMPONENT_TYPENAME_REGEX.match(typename)
-    if not match:
-        raise ValueError(_generate_invalid_component_typename_error_message(typename))
-    return match.group(1), match.group(2)
-
-
 @dataclass(frozen=True)
-class ComponentKey(ABC):
-    name: str
+class ComponentKey:
     namespace: str
+    name: str
 
     def to_typename(self) -> str:
-        return f"{self.name}@{self.namespace}"
+        return f"{self.namespace}.{self.name}"
 
     @staticmethod
-    def from_typename(typename: str, dirpath: Path) -> "ComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        if namespace.startswith(LOCAL_COMPONENT_IDENTIFIER):
-            return LocalComponentKey(name, namespace, dirpath)
-        else:
-            return GlobalComponentKey(name, namespace)
-
-
-@dataclass(frozen=True)
-class GlobalComponentKey(ComponentKey):
-    @staticmethod
-    def from_typename(typename: str) -> "GlobalComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        return GlobalComponentKey(name=name, namespace=namespace)
-
-
-@dataclass(frozen=True)
-class LocalComponentKey(ComponentKey):
-    dirpath: Path
-
-    def __post_init__(self) -> None:
-        if not self.python_file.resolve().is_relative_to(self.dirpath.resolve()):
-            raise ValueError(f"File {self.namespace} must be within directory: {self.dirpath}")
-
-    @staticmethod
-    def from_typename(typename: str, dirpath: Path) -> "LocalComponentKey":
-        name, namespace = _name_and_namespace_from_type(typename)
-        return LocalComponentKey(name=name, namespace=namespace, dirpath=dirpath)
-
-    @property
-    def python_file(self) -> Path:
-        relative_path = self.namespace[len(LOCAL_COMPONENT_IDENTIFIER) :]
-        return self.dirpath / relative_path
+    def from_typename(typename: str) -> "ComponentKey":
+        parts = typename.split(".")
+        for part in parts:
+            if not part.isidentifier():
+                raise ValueError(_generate_invalid_component_typename_error_message(typename))
+        if len(parts) < 2:
+            raise ValueError(_generate_invalid_component_typename_error_message(typename))
+        namespace, _, name = typename.rpartition(".")
+        return ComponentKey(name=name, namespace=namespace)

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -9,7 +9,7 @@ import click
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import discover_workspace_root
 from dagster_dg.context import DgContext
-from dagster_dg.utils import camelcase, exit_with_error, scaffold_subtree
+from dagster_dg.utils import exit_with_error, scaffold_subtree
 
 # ########################
 # ##### PROJECT
@@ -156,25 +156,24 @@ def scaffold_project(
 # ########################
 
 
-def scaffold_component_type(dg_context: DgContext, name: str) -> None:
+def scaffold_component_type(dg_context: DgContext, class_name: str, module_name: str) -> None:
     root_path = Path(dg_context.default_components_library_path)
-    click.echo(f"Creating a Dagster component type at {root_path}/{name}.py.")
+    click.echo(f"Creating a Dagster component type at {root_path}/{module_name}.py.")
 
     scaffold_subtree(
         path=root_path,
         name_placeholder="COMPONENT_TYPE_NAME_PLACEHOLDER",
         templates_path=str(Path(__file__).parent / "templates" / "COMPONENT_TYPE"),
-        project_name=name,
-        component_type_class_name=camelcase(name),
-        name=name,
+        project_name=module_name,
+        name=class_name,
     )
 
     with open(root_path / "__init__.py", "a") as f:
         f.write(
-            f"from {dg_context.default_components_library_module}.{name} import {camelcase(name)}\n"
+            f"from {dg_context.default_components_library_module}.{module_name} import {class_name}\n"
         )
 
-    click.echo(f"Scaffolded files for Dagster component type at {root_path}/{name}..")
+    click.echo(f"Scaffolded files for Dagster component type at {root_path}/{module_name}.py.")
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -7,11 +7,11 @@ from dagster_components import (
     registered_component_type,
 )
 
-class {{ component_type_class_name }}Schema(ResolvableSchema):
+class {{ name }}Schema(ResolvableSchema):
     ...
 
-@registered_component_type(name="{{ name }}")
-class {{ component_type_class_name }}(Component):
+@registered_component_type
+class {{ name }}(Component):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.
@@ -19,7 +19,7 @@ class {{ component_type_class_name }}(Component):
 
     @classmethod
     def get_schema(cls):
-        return {{ component_type_class_name }}Schema
+        return {{ name }}Schema
 
     @classmethod
     def get_scaffolder(cls) -> DefaultComponentScaffolder:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -89,18 +89,14 @@ def _get_spec_for_module(module_name: str) -> ModuleSpec:
 
 def get_path_for_module(module_name: str) -> str:
     spec = _get_spec_for_module(module_name)
-    file_path = spec.origin
-    if not file_path:
-        raise DgError(f"Cannot find file path for module: {module_name}")
-    return file_path
-
-
-def get_path_for_package(package_name: str) -> str:
-    spec = _get_spec_for_module(package_name)
     submodule_search_locations = spec.submodule_search_locations
-    if not submodule_search_locations:
-        raise DgError(f"Package does not have any locations for submodules: {package_name}")
-    return submodule_search_locations[0]
+    if submodule_search_locations:  # branch module (i.e. package), a directory
+        return submodule_search_locations[0]
+    else:  # leaf module, not a directory
+        file_path = spec.origin
+        if not file_path:
+            raise DgError(f"Cannot find file path for module: {module_name}")
+        return file_path
 
 
 def is_valid_json(value: str) -> bool:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -41,7 +41,7 @@ CLI_TEST_CASES = [
         should_error=True,
         check_error_msg=msg_includes_all_of(
             "component.yaml:1",
-            "Component type 'my_component_does_not_exist@file:__init__.py' not found",
+            "Component type 'foo_bar.components.basic_component_missing_type.MyComponentDoesNotExist' not found",
         ),
     ),
     ComponentValidationTestCase(
@@ -119,13 +119,12 @@ def test_validation_cli(test_case: ComponentValidationTestCase) -> None:
         with pushd(tmpdir):
             result = runner.invoke("check", "yaml")
             if test_case.should_error:
-                assert result.exit_code != 0, str(result.stdout)
-
+                assert_runner_result(result, exit_0=False)
                 assert test_case.check_error_msg
                 test_case.check_error_msg(str(result.stdout))
 
             else:
-                assert result.exit_code == 0
+                assert_runner_result(result)
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -180,18 +180,19 @@ def test_dynamic_subcommand_help_message():
             result = runner.invoke(
                 "scaffold",
                 "component",
-                "simple_pipes_script_asset@dagster_components.test",
+                "dagster_components.lib.test.SimplePipesScriptAsset",
                 "--help",
             )
+            assert_runner_result(result)
             # Strip interpreter logging line
             output = "\n".join(result.output.split("\n")[1:])
         assert match_terminal_box_output(
             output.strip(),
             textwrap.dedent("""
 
-                 Usage: dg scaffold component [GLOBAL OPTIONS] simple_pipes_script_asset@dagster_components.test [OPTIONS]
-                 COMPONENT_INSTANCE_NAM
-                 E
+                 Usage: dg scaffold component [GLOBAL OPTIONS] dagster_components.lib.test.SimplePipesScriptAsset [OPTIONS]
+                 COMPONENT_INSTANCE_NA 
+                 ME
 
                 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
                 │ *    component_instance_name      TEXT  [required]                                                                   │

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
@@ -11,7 +11,7 @@ from dagster_dg_tests.utils import ProxyRunner, assert_runner_result, isolated_c
 
 def test_docs_component_type_success():
     with ProxyRunner.test() as runner, isolated_components_venv(runner):
-        result = runner.invoke("docs", "component-type", "simple_asset@dagster_components.test")
+        result = runner.invoke("docs", "component-type", "dagster_components.lib.test.SimpleAsset")
         assert_runner_result(result)
 
 
@@ -28,7 +28,7 @@ def test_docs_component_type_success_output_console():
         result = runner.invoke(
             "docs",
             "component-type",
-            "complex_schema_asset@dagster_components.test",
+            "dagster_components.lib.test.ComplexSchemaAsset",
             "--output",
             "cli",
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -31,7 +31,7 @@ class CommandSpec:
         return (*self.command, *self.args)
 
 
-DEFAULT_COMPONENT_TYPE = "simple_asset@dagster_components.test"
+DEFAULT_COMPONENT_TYPE = "dagster_components.lib.test.SimpleAsset"
 
 NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "project"), "foo"),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -11,7 +11,7 @@ from dagster_dg_tests.utils import ProxyRunner, assert_runner_result, isolated_c
 # ########################
 
 _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
-    simple_pipes_script_asset@dagster_components.test
+    dagster_components.lib.test.SimplePipesScriptAsset
 
     Description:
 
@@ -68,7 +68,7 @@ def test_inspect_component_type_all_metadata_success():
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "simple_pipes_script_asset@dagster_components.test",
+            "dagster_components.lib.test.SimplePipesScriptAsset",
         )
         assert_runner_result(result)
         assert result.output.strip().endswith(_EXPECTED_INSPECT_COMPONENT_TYPE_FULL)
@@ -79,12 +79,12 @@ def test_inspect_component_type_all_metadata_empty_success():
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "all_metadata_empty_asset@dagster_components.test",
+            "dagster_components.lib.test.AllMetadataEmptyAsset",
         )
         assert_runner_result(result)
         assert result.output.strip().endswith(
             textwrap.dedent("""
-                all_metadata_empty_asset@dagster_components.test
+                dagster_components.lib.test.AllMetadataEmptyAsset
             """).strip()
         )
 
@@ -94,7 +94,7 @@ def test_inspect_component_type_flag_fields_success():
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "simple_pipes_script_asset@dagster_components.test",
+            "dagster_components.lib.test.SimplePipesScriptAsset",
             "--description",
         )
         assert_runner_result(result)
@@ -109,7 +109,7 @@ def test_inspect_component_type_flag_fields_success():
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "simple_pipes_script_asset@dagster_components.test",
+            "dagster_components.lib.test.SimplePipesScriptAsset",
             "--scaffold-params-schema",
         )
         assert_runner_result(result)
@@ -139,7 +139,7 @@ def test_inspect_component_type_flag_fields_success():
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "simple_pipes_script_asset@dagster_components.test",
+            "dagster_components.lib.test.SimplePipesScriptAsset",
             "--component-schema",
         )
         assert_runner_result(result)
@@ -172,7 +172,7 @@ def test_inspect_component_type_multiple_flags_fails() -> None:
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "simple_pipes_script_asset@dagster_components.test",
+            "dagster_components.lib.test.SimplePipesScriptAsset",
             "--description",
             "--scaffold-params-schema",
         )
@@ -188,7 +188,7 @@ def test_inspect_component_type_undefined_component_type_fails() -> None:
         result = runner.invoke(
             "utils",
             "inspect-component-type",
-            "fake@fake",
+            "fake.Fake",
         )
         assert_runner_result(result, exit_0=False)
-        assert "No component type `fake@fake` is registered" in result.output
+        assert "No component type `fake.Fake` is registered" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -47,7 +47,7 @@ def test_list_components_succeeds():
         result = runner.invoke(
             "scaffold",
             "component",
-            "all_metadata_empty_asset@dagster_components.test",
+            "dagster_components.lib.test.AllMetadataEmptyAsset",
             "qux",
         )
         assert_runner_result(result)
@@ -66,33 +66,33 @@ def test_list_components_succeeds():
 # ########################
 
 _EXPECTED_COMPONENT_TYPES = textwrap.dedent("""
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃ Component Type                                    ┃ Summary                                                          ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │ all_metadata_empty_asset@dagster_components.test  │                                                                  │
-    │ complex_schema_asset@dagster_components.test      │ An asset that has a complex schema.                              │
-    │ simple_asset@dagster_components.test              │ A simple asset that returns a constant string value.             │
-    │ simple_pipes_script_asset@dagster_components.test │ A simple asset that runs a Python script with the Pipes          │
-    │                                                   │ subprocess client.                                               │
-    └───────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┘
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ Component Type                                     ┃ Summary                                                         ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ dagster_components.lib.test.AllMetadataEmptyAsset  │                                                                 │
+    │ dagster_components.lib.test.ComplexSchemaAsset     │ An asset that has a complex schema.                             │
+    │ dagster_components.lib.test.SimpleAsset            │ A simple asset that returns a constant string value.            │
+    │ dagster_components.lib.test.SimplePipesScriptAsset │ A simple asset that runs a Python script with the Pipes         │
+    │                                                    │ subprocess client.                                              │
+    └────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┘
 """).strip()
 
 _EXPECTED_COMPONENT_TYPES_JSON = textwrap.dedent("""
     [
         {
-            "key": "all_metadata_empty_asset@dagster_components.test",
+            "key": "dagster_components.lib.test.AllMetadataEmptyAsset",
             "summary": null
         },
         {
-            "key": "complex_schema_asset@dagster_components.test",
+            "key": "dagster_components.lib.test.ComplexSchemaAsset",
             "summary": "An asset that has a complex schema."
         },
         {
-            "key": "simple_asset@dagster_components.test",
+            "key": "dagster_components.lib.test.SimpleAsset",
             "summary": "A simple asset that returns a constant string value."
         },
         {
-            "key": "simple_pipes_script_asset@dagster_components.test",
+            "key": "dagster_components.lib.test.SimplePipesScriptAsset",
             "summary": "A simple asset that runs a Python script with the Pipes subprocess client."
         }
     ]

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -34,10 +34,10 @@ def test_context_in_workspace():
 
 
 def test_context_in_project_in_workspace():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner, project_name="foo"):
-        project_path = Path.cwd() / "projects" / "foo"
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, project_name="foo-bar"):
+        project_path = Path.cwd() / "projects" / "foo-bar"
         # go into a project subdirectory to make sure root resolution works
-        path_arg = project_path / "foo_tests"
+        path_arg = project_path / "foo_bar_tests"
 
         context = DgContext.for_project_environment(path_arg, {})
         assert context.root_path == project_path


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/14017

## Summary & Motivation
 
Update `dagster-dg` and `dagster-components` to use the new `some.module.MyComponent` naming scheme instead of `my-component@some.module`.

- `ComponentTypeRegistry` in `dagster-components` has been deleted (we retain `RemoteComponentTypeRegistry` in `dagster-dg`).
	- `ComponentTypeRegistry.from_entry_point_discovery` has been extracted to `discover_entry_point_component_types`
	- There is now an additional function `discover_component_types` that takes arbitrary module names as an argument and returns the component types in those modules.
	- Previously where we would fetch components from the registry, we now call a new function `load_component_type` that is a simple import wrapper.
- Component references in the `type` field of `component.yaml` no longer distinguish between "local" and "global" components. What would have been a local component with a `file:` reference previously is now a python reference relative to `component.yaml` position in the module tree:

```
### my_project/components/foo/component.yaml

type: foo.bar.BazComponent  # absolute reference
type: .bar.BazComponent  # resolves to my_project.components.foo.bar.BazComponent
type: .BazComponent  # resolves to my_project.components.foo.BazComponent
```

To be done upstack:

- Change the `dagster_components` entry point to export from top-level `dagster_components.components` rather than `dagster_components.lib`.
- Remove `@registered_component_type` (which now doesn't really do anything)
- Maybe some renames of vars where "registered"/"registry" still used inappropriately

## How I Tested These Changes

Existing test suite.
