### PR TITLE
[dagster-components] Ensure we properly wrap all translator fields

### DIFF
--- a/python_modules/libraries/dagster-components/CHANGELOG.md
+++ b/python_modules/libraries/dagster-components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.17
 
 - User-supplied code version, description, owners, kinds, and metadata in `asset_attributes` for dbt and sling assets now properly flow through to the generated assets.
+
 ## 0.1.15
 
 - Revamped component schema resolution logic, making it easier and more straightforward to convert from a Component's schema to an instance of the Python class. See the docs on creating a custom component to learn more!

--- a/python_modules/libraries/dagster-components/CHANGELOG.md
+++ b/python_modules/libraries/dagster-components/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.17
+
+- User-supplied code version, description, owners, kinds, and metadata in `asset_attributes` for dbt and sling assets now properly flow through to the generated assets.
 ## 0.1.15
 
 - Revamped component schema resolution logic, making it easier and more straightforward to convert from a Component's schema to an instance of the Python class. See the docs on creating a custom component to learn more!

--- a/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/dbt_project/component.py
@@ -44,6 +44,9 @@ def resolve_dbt(context: ResolutionContext, schema: DbtProjectSchema) -> DbtCliR
 def resolve_translator(
     context: ResolutionContext, schema: DbtProjectSchema
 ) -> DagsterDbtTranslator:
+    if schema.asset_attributes and schema.asset_attributes.deps:
+        # TODO: Consider supporting alerting deps in the future
+        raise ValueError("deps are not supported for dbt_project component")
     return get_wrapped_translator_class(DagsterDbtTranslator)(
         resolving_info=TranslatorResolvingInfo(
             "node", schema.asset_attributes or AssetAttributesSchema(), context

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -29,6 +29,11 @@ from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_transl
 def resolve_translator(
     context: ResolutionContext, schema: "SlingReplicationSchema"
 ) -> DagsterSlingTranslator:
+    # TODO: Consider supporting owners and code_version in the future
+    if schema.asset_attributes and schema.asset_attributes.owners:
+        raise ValueError("owners are not supported for sling_replication_collection component")
+    if schema.asset_attributes and schema.asset_attributes.code_version:
+        raise ValueError("code_version is not supported for sling_replication_collection component")
     return get_wrapped_translator_class(DagsterSlingTranslator)(
         resolving_info=TranslatorResolvingInfo(
             "stream_definition",

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -168,11 +168,10 @@ def get_wrapped_translator_class(translator_type: type):
             )
 
         def get_code_version(self, obj: Any) -> Optional[str]:
-            return str(
-                self.resolving_info.get_resolved_attribute(
-                    "code_version", obj, self.base_translator.get_code_version
-                )
+            version = self.resolving_info.get_resolved_attribute(
+                "code_version", obj, self.base_translator.get_code_version
             )
+            return str(version) if version else None
 
         def get_description(self, obj: Any) -> Optional[str]:
             return self.resolving_info.get_resolved_attribute(

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -132,10 +132,14 @@ def get_wrapped_translator_class(translator_type: type):
             )
 
         def get_tags(self, obj: Any) -> Mapping[str, str]:
-            kinds = self.resolving_info.get_resolved_attribute(
-                "kinds", obj, self.base_translator.get_kinds
-            )
             tags = {}
+
+            base_kinds = (
+                self.base_translator.get_kinds
+                if hasattr(self.base_translator, "get_kinds")
+                else lambda *args: []
+            )
+            kinds = self.resolving_info.get_resolved_attribute("kinds", obj, base_kinds)
             for kind in kinds:
                 tags.update(build_kind_tag(kind))
 
@@ -164,8 +168,10 @@ def get_wrapped_translator_class(translator_type: type):
             )
 
         def get_code_version(self, obj: Any) -> Optional[str]:
-            return self.resolving_info.get_resolved_attribute(
-                "code_version", obj, self.base_translator.get_code_version
+            return str(
+                self.resolving_info.get_resolved_attribute(
+                    "code_version", obj, self.base_translator.get_code_version
+                )
             )
 
         def get_description(self, obj: Any) -> Optional[str]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -254,8 +254,8 @@ def test_asset_attributes(
         ) as decl_node,
     ):
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
-        component = SlingReplicationCollection.load(attributes=attributes, context=context)
+        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
         defs = component.build_defs(context)
 
         assets_def: AssetsDefinition = defs.get_assets_def("input_duckdb")

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -254,8 +254,8 @@ def test_asset_attributes(
         ) as decl_node,
     ):
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
-        component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
+        attrs = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
         defs = component.build_defs(context)
 
         assets_def: AssetsDefinition = defs.get_assets_def("input_duckdb")

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -1,12 +1,14 @@
 import shutil
 import tempfile
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+import pytest
 import yaml
 from dagster import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.result import MaterializeResult
@@ -21,6 +23,9 @@ from dagster_components.lib.sling_replication_collection.component import (
 from dagster_sling import SlingResource
 
 from dagster_components_tests.utils import script_load_context
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
 
 STUB_LOCATION_PATH = Path(__file__).parent.parent / "code_locations" / "sling_location"
 COMPONENT_RELPATH = "components/ingest"
@@ -191,3 +196,68 @@ def test_sling_subclass() -> None:
         AssetKey("input_csv"),
         AssetKey("input_duckdb"),
     }
+
+
+@pytest.mark.parametrize(
+    "attributes, assertion, should_error",
+    [
+        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
+        ({"owners": ["team:analytics"]}, None, True),
+        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
+        ({"kinds": ["snowflake"]}, lambda asset_spec: "snowflake" in asset_spec.kinds, False),
+        (
+            {"tags": {"foo": "bar"}, "kinds": ["snowflake"]},
+            lambda asset_spec: "snowflake" in asset_spec.kinds
+            and asset_spec.tags.get("foo") == "bar",
+            False,
+        ),
+        ({"code_version": "1"}, None, True),
+        (
+            {"description": "some description"},
+            lambda asset_spec: asset_spec.description == "some description",
+            False,
+        ),
+        (
+            {"metadata": {"foo": "bar"}},
+            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
+            False,
+        ),
+        (
+            {"deps": ["customers"]},
+            lambda asset_spec: {dep.asset_key for dep in asset_spec.deps}
+            == {AssetKey("customers")},
+            False,
+        ),
+    ],
+    ids=[
+        "group_name",
+        "owners",
+        "tags",
+        "kinds",
+        "tags-and-kinds",
+        "code-version",
+        "description",
+        "metadata",
+        "deps",
+    ],
+)
+def test_asset_attributes(
+    attributes: Mapping[str, Any],
+    assertion: Optional[Callable[[AssetSpec], bool]],
+    should_error: bool,
+) -> None:
+    wrapper = pytest.raises(ValueError) if should_error else nullcontext()
+    with (
+        wrapper,
+        temp_sling_component_instance(
+            [{"path": "./replication.yaml", "asset_attributes": attributes}]
+        ) as decl_node,
+    ):
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(SlingReplicationCollection.get_schema())
+        component = SlingReplicationCollection.load(attributes=attributes, context=context)
+        defs = component.build_defs(context)
+
+        assets_def: AssetsDefinition = defs.get_assets_def("input_duckdb")
+    if assertion:
+        assert assertion(assets_def.get_asset_spec(AssetKey("input_duckdb")))

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from dagster_components.utils import get_wrapped_translator_class
+from dagster_dbt import DagsterDbtTranslator
+from dagster_sling import DagsterSlingTranslator
+
+EXCLUDED_METHODS = [
+    "get_auto_materialize_policy",  # Not supported by asset_attributes
+    "get_asset_spec",  # Not supported by asset_attributes
+    "get_freshness_policy",  # Not supported by asset_attributes
+    "get_partition_mapping",  # Not supported by asset_attributes
+    "get_partitions_def",  # Not supported by asset_attributes
+    "get_kinds",  # included in get_tags
+    #
+    # Misc internal methods
+    "settings",
+    "sanitize_stream_name",
+    "target",
+    "target_prefix",
+]
+
+
+@pytest.mark.parametrize("translator_type", [DagsterDbtTranslator, DagsterSlingTranslator])
+def test_get_wrapped_translator_class(translator_type):
+    wrapped = get_wrapped_translator_class(translator_type)
+
+    # Ensure all translator methods are properly specified in the wrapped class,
+    # so user input actually flows through to the generated assets.
+    for method in dir(translator_type):
+        if method.startswith("_") or method in EXCLUDED_METHODS:
+            continue
+        assert method in dir(wrapped)
+        assert getattr(wrapped, method) != getattr(
+            translator_type, method
+        ), f"{method} is not overridden by get_wrapped_translator_class"


### PR DESCRIPTION
## Summary

`get_wrapped_translator_class` is a utility for converting user-supplied `asset_attributes` into a translator, for Sling and dbt. It currently omits some fields, so e.g. user-supplied `metadata`, `description` etc for  `asset_attributes` are silently swallowed, not setting the relevant attributes on the targeted assets.

e.g. the following does not set owners, but validates and loads just fine
```yaml
type: dbt_project@dagster_components

attributes:
  asset_attributes:
    owners:
      - ben@dagsterlabs.com
```

This PR fixes these missing connections, explicitly erroring on any the base integration translators do not support, and puts the list of translator fields under test.

## Test Plan

New unit test to sanity check `get_wrapped_translator_class` wraps expected fields.

Also iterate over all fields and ensure they apply properly in the dbt & sling cases.


