### PR TITLE
[dagster-components][rfc] Allow users to inject node-specific scope for DbtProjectComponent subclasses

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/base.py
@@ -66,7 +66,7 @@ class ResolvableSchema(BaseModel, Generic[T]):
     def resolve_fields(self, target_type: type, context: "ResolutionContext") -> Mapping[str, Any]:
         """Returns a mapping of field names to resolved values for those fields."""
         return {
-            field_name: resolver.fn(context, self)
+            field_name: resolver.fn(context, target_type, self)
             for field_name, resolver in self._get_field_resolvers(target_type).items()
         }
 
@@ -80,7 +80,7 @@ class ResolvableSchema(BaseModel, Generic[T]):
 class FieldResolver(FieldInfo):
     """Contains information on how to resolve this field from a ResolvableSchema."""
 
-    def __init__(self, fn: Callable[["ResolutionContext", Any], Any]):
+    def __init__(self, fn: Callable[["ResolutionContext", type, Any], Any]):
         self.fn = fn
         super().__init__()
 
@@ -92,7 +92,7 @@ class FieldResolver(FieldInfo):
             if resolver:
                 return resolver
         return FieldResolver(
-            lambda context, schema: context.resolve_value(getattr(schema, field_name))
+            lambda context, _type, schema: context.resolve_value(getattr(schema, field_name))
         )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -35,7 +35,7 @@ class OpSpecSchema(ResolvableSchema):
 
 class AssetDepSchema(ResolvableSchema[AssetDep]):
     asset: Annotated[
-        str, FieldResolver(lambda context, schema: _resolve_asset_key(schema.asset, context))
+        str, FieldResolver(lambda context, _type, schema: _resolve_asset_key(schema.asset, context))
     ]
     partition_mapping: Optional[str]
 
@@ -91,7 +91,7 @@ class _ResolvableAssetAttributesMixin(BaseModel):
 
 class AssetSpecSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[AssetSpec]):
     key: Annotated[
-        str, FieldResolver(lambda context, schema: _resolve_asset_key(schema.key, context))
+        str, FieldResolver(lambda context, _type, schema: _resolve_asset_key(schema.key, context))
     ] = Field(..., description="A unique identifier for the asset.")
 
 
@@ -104,7 +104,9 @@ class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ResolvableSchema[Ma
     key: Annotated[
         Optional[str],
         FieldResolver(
-            lambda context, schema: _resolve_asset_key(schema.key, context) if schema.key else None
+            lambda context, _type, schema: _resolve_asset_key(schema.key, context)
+            if schema.key
+            else None
         ),
     ] = Field(default=None, description="A unique identifier for the asset.")
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/pipes_subprocess_script_collection.py
@@ -42,7 +42,7 @@ class PipesSubprocessScriptCollectionSchema(ResolvableSchema["PipesSubprocessScr
 
 
 def resolve_specs_by_path(
-    context: ResolutionContext, schema: PipesSubprocessScriptCollectionSchema
+    context: ResolutionContext, _type: type, schema: PipesSubprocessScriptCollectionSchema
 ) -> Mapping[str, Sequence[AssetSpec]]:
     return {spec.path: spec.assets for spec in context.resolve_value(schema.scripts)}
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/sling_replication_collection/component.py
@@ -28,7 +28,7 @@ from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_transl
 
 
 def resolve_translator(
-    context: ResolutionContext, schema: "SlingReplicationSchema"
+    context: ResolutionContext, _type: type, schema: "SlingReplicationSchema"
 ) -> DagsterSlingTranslator:
     return get_wrapped_translator_class(DagsterSlingTranslator)(
         resolving_info=TranslatorResolvingInfo(
@@ -78,7 +78,7 @@ class SlingReplicationCollectionSchema(ResolvableSchema["SlingReplicationCollect
 
 
 def resolve_resource(
-    context: ResolutionContext, schema: SlingReplicationCollectionSchema
+    context: ResolutionContext, _type: type, schema: SlingReplicationCollectionSchema
 ) -> SlingResource:
     return (
         SlingResource(**context.resolve_value(schema.sling.model_dump()))

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import click
 from dagster._core.definitions.asset_key import AssetKey
@@ -75,10 +75,12 @@ class TranslatorResolvingInfo:
     obj_name: str
     asset_attributes: AssetAttributesSchema
     resolution_context: ResolutionContext
+    additional_scope_fn: Optional[Callable[[Any], Mapping[str, Any]]] = None
 
     def get_resolved_attribute(self, attribute: str, obj: Any, default_method) -> Any:
         resolved_attributes = self.resolution_context.with_scope(
-            **{self.obj_name: obj}
+            **{self.obj_name: obj},
+            **(self.additional_scope_fn(obj) if self.additional_scope_fn else {}),
         ).resolve_value(self.asset_attributes)
         return (
             resolved_attributes[attribute]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -7,7 +7,7 @@ from dagster_components import FieldResolver, ResolutionContext, ResolvableSchem
 from pydantic import BaseModel
 
 
-def resolve_val1(context: ResolutionContext, schema: "InnerSchema") -> int:
+def resolve_val1(context: ResolutionContext, _type: type, schema: "InnerSchema") -> int:
     return context.resolve_value(schema.val1, as_type=int) + 20
 
 


### PR DESCRIPTION
## Summary

We expect a common pattern for integration components such as DBT will be to replicate existing Translator functionality - that is, remapping of data from integration object to asset specs.

We already support a basic version of this through *scopes*, available to the Jinja templating engine. For example, a user can pull data out of DBT resource props to populate tags in their component:

```yaml
type: dbt_project@dagster_components

attributes:
  asset_attributes:
    tags:
      - model_id: "{{ node.name }}"
```

The question is what happens when these transformations are complex - at some point Jinja's ternary operators etc are insufficient and, it will need to be offloaded to Python code.

Right now, the only way to accomplish complex translation logic is to subclass `DbtProjectComponent` and inject a custom translator or other remapping. This is complex and intractible - it means that output asset specs no longer treat component YAML as the source of truth.

This PR presents a different approach, where complex transformation logic can be performed in a `DbtProjectComponent` subclass and then subsequently exposed to the YAML consumer:

```python
@registered_component_type(name="custom_dbt_project")
class CustomDbtProjectComponent(DbtProjectComponent):
    @classmethod
    def get_additional_scope_for_node(cls, node: dict[str, Any]) -> Mapping[str, Any]:
        # Here, we directly expose a transformation function, which the YAML consumer can
        # invoke as they see fit.
        return {"get_id_from_model_name": lambda s: s.replace("_", "-")}
```

```yaml
type: custom_dbt_project@my_dagster_module

attributes:
  asset_attributes:
    tags:
      - model_id: "{{ get_id_from_model_name(node.name) }}"
```


## Test Plan

New unit tests.
