### PR TITLE
[dagster-fivetran] Handle missing schemas for unsynced connectors

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -918,8 +918,13 @@ class FivetranWorkspace(ConfigurableResource):
                 )
 
                 if (
-                    connector_selector_fn and not connector_selector_fn(connector)
-                ) or not connector.is_connected:
+                    (connector_selector_fn and not connector_selector_fn(connector))
+                    or not connector.is_connected
+                    # A connection that has not been synced yet has no `schemas` field in its schema config.
+                    # Schemas are required for creating the asset definitions,
+                    # so connections for which the schemas are missing are discarded.
+                    or not schema_config.has_schemas
+                ):
                     continue
 
                 connectors_by_id[connector.id] = connector

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -920,9 +920,9 @@ class FivetranWorkspace(ConfigurableResource):
                 if (
                     (connector_selector_fn and not connector_selector_fn(connector))
                     or not connector.is_connected
-                    # A connection that has not been synced yet has no `schemas` field in its schema config.
+                    # A connector that has not been synced yet has no `schemas` field in its schema config.
                     # Schemas are required for creating the asset definitions,
-                    # so connections for which the schemas are missing are discarded.
+                    # so connectors for which the schemas are missing are discarded.
                     or not schema_config.has_schemas
                 ):
                     continue

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -194,6 +194,10 @@ class FivetranSchemaConfig:
 
     schemas: Mapping[str, FivetranSchema]
 
+    @property
+    def has_schemas(self) -> bool:
+        return bool(self.schemas)
+
     @classmethod
     def from_schema_config_details(
         cls, schema_config_details: Mapping[str, Any]
@@ -201,7 +205,7 @@ class FivetranSchemaConfig:
         return cls(
             schemas={
                 schema_key: FivetranSchema.from_schema_details(schema_details=schema_details)
-                for schema_key, schema_details in schema_config_details["schemas"].items()
+                for schema_key, schema_details in schema_config_details.get("schemas", {}).items()
             }
         )
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
@@ -250,166 +250,169 @@ def get_sample_connection_details(succeeded_at: str, failed_at: str) -> Mapping[
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/connector-schema/connector-schema-config
 # The sample is parameterized to test the sync and poll materialization method
-def get_sample_schema_config_for_connector(table_name: str) -> Mapping[str, Any]:
+def get_sample_schema_config_for_connector(
+    table_name: str, include_schemas: bool = True
+) -> Mapping[str, Any]:
+    schemas = {
+        "property1": {
+            "name_in_destination": "schema_name_in_destination_1",
+            "enabled": True,
+            "tables": {
+                "property1": {
+                    "sync_mode": "SOFT_DELETE",
+                    "name_in_destination": table_name,
+                    "enabled": True,
+                    "columns": {
+                        "property1": {
+                            "name_in_destination": "column_name_in_destination_1",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                        "property2": {
+                            "name_in_destination": "column_name_in_destination_2",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                    },
+                    "enabled_patch_settings": {
+                        "allowed": False,
+                        "reason": "...",
+                        "reason_code": "SYSTEM_TABLE",
+                    },
+                    "supports_columns_config": True,
+                },
+                "property2": {
+                    "sync_mode": "SOFT_DELETE",
+                    "name_in_destination": "table_name_in_destination_2",
+                    "enabled": True,
+                    "columns": {
+                        "property1": {
+                            "name_in_destination": "column_name_in_destination_1",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                        "property2": {
+                            "name_in_destination": "column_name_in_destination_2",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                    },
+                    "enabled_patch_settings": {
+                        "allowed": False,
+                        "reason": "...",
+                        "reason_code": "SYSTEM_TABLE",
+                    },
+                    "supports_columns_config": True,
+                },
+            },
+        },
+        "property2": {
+            "name_in_destination": "schema_name_in_destination_2",
+            "enabled": True,
+            "tables": {
+                "property1": {
+                    "sync_mode": "SOFT_DELETE",
+                    "name_in_destination": "table_name_in_destination_1",
+                    "enabled": True,
+                    "columns": {
+                        "property1": {
+                            "name_in_destination": "column_name_in_destination_1",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                        "property2": {
+                            "name_in_destination": "column_name_in_destination_2",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                    },
+                    "enabled_patch_settings": {
+                        "allowed": False,
+                        "reason": "...",
+                        "reason_code": "SYSTEM_TABLE",
+                    },
+                    "supports_columns_config": True,
+                },
+                "property2": {
+                    "sync_mode": "SOFT_DELETE",
+                    "name_in_destination": "table_name_in_destination_2",
+                    "enabled": True,
+                    "columns": {
+                        "property1": {
+                            "name_in_destination": "column_name_in_destination_1",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                        "property2": {
+                            "name_in_destination": "column_name_in_destination_2",
+                            "enabled": True,
+                            "hashed": False,
+                            "enabled_patch_settings": {
+                                "allowed": False,
+                                "reason": "...",
+                                "reason_code": "SYSTEM_COLUMN",
+                            },
+                            "is_primary_key": True,
+                        },
+                    },
+                    "enabled_patch_settings": {
+                        "allowed": False,
+                        "reason": "...",
+                        "reason_code": "SYSTEM_TABLE",
+                    },
+                    "supports_columns_config": True,
+                },
+            },
+        },
+    }
     return {
         "code": "Success",
         "message": "Operation performed.",
         "data": {
             "enable_new_by_default": True,
-            "schemas": {
-                "property1": {
-                    "name_in_destination": "schema_name_in_destination_1",
-                    "enabled": True,
-                    "tables": {
-                        "property1": {
-                            "sync_mode": "SOFT_DELETE",
-                            "name_in_destination": table_name,
-                            "enabled": True,
-                            "columns": {
-                                "property1": {
-                                    "name_in_destination": "column_name_in_destination_1",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                                "property2": {
-                                    "name_in_destination": "column_name_in_destination_2",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                            },
-                            "enabled_patch_settings": {
-                                "allowed": False,
-                                "reason": "...",
-                                "reason_code": "SYSTEM_TABLE",
-                            },
-                            "supports_columns_config": True,
-                        },
-                        "property2": {
-                            "sync_mode": "SOFT_DELETE",
-                            "name_in_destination": "table_name_in_destination_2",
-                            "enabled": True,
-                            "columns": {
-                                "property1": {
-                                    "name_in_destination": "column_name_in_destination_1",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                                "property2": {
-                                    "name_in_destination": "column_name_in_destination_2",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                            },
-                            "enabled_patch_settings": {
-                                "allowed": False,
-                                "reason": "...",
-                                "reason_code": "SYSTEM_TABLE",
-                            },
-                            "supports_columns_config": True,
-                        },
-                    },
-                },
-                "property2": {
-                    "name_in_destination": "schema_name_in_destination_2",
-                    "enabled": True,
-                    "tables": {
-                        "property1": {
-                            "sync_mode": "SOFT_DELETE",
-                            "name_in_destination": "table_name_in_destination_1",
-                            "enabled": True,
-                            "columns": {
-                                "property1": {
-                                    "name_in_destination": "column_name_in_destination_1",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                                "property2": {
-                                    "name_in_destination": "column_name_in_destination_2",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                            },
-                            "enabled_patch_settings": {
-                                "allowed": False,
-                                "reason": "...",
-                                "reason_code": "SYSTEM_TABLE",
-                            },
-                            "supports_columns_config": True,
-                        },
-                        "property2": {
-                            "sync_mode": "SOFT_DELETE",
-                            "name_in_destination": "table_name_in_destination_2",
-                            "enabled": True,
-                            "columns": {
-                                "property1": {
-                                    "name_in_destination": "column_name_in_destination_1",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                                "property2": {
-                                    "name_in_destination": "column_name_in_destination_2",
-                                    "enabled": True,
-                                    "hashed": False,
-                                    "enabled_patch_settings": {
-                                        "allowed": False,
-                                        "reason": "...",
-                                        "reason_code": "SYSTEM_COLUMN",
-                                    },
-                                    "is_primary_key": True,
-                                },
-                            },
-                            "enabled_patch_settings": {
-                                "allowed": False,
-                                "reason": "...",
-                                "reason_code": "SYSTEM_TABLE",
-                            },
-                            "supports_columns_config": True,
-                        },
-                    },
-                },
-            },
+            "schemas": schemas if include_schemas else {},
             "schema_change_handling": "ALLOW_ALL",
         },
     }
@@ -422,6 +425,11 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = get_sample_schema_config_for_connector(
 # We change the name of the original example to test the sync and poll materialization method
 ALTERED_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = get_sample_schema_config_for_connector(
     table_name=TEST_ANOTHER_TABLE_NAME
+)
+
+# Schemas are missing from schema config when a connection has never been synced
+MISSING_SCHEMAS_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = get_sample_schema_config_for_connector(
+    table_name=TEST_TABLE_NAME, include_schemas=False
 )
 
 SAMPLE_SUCCESS_MESSAGE = {"code": "Success", "message": "Operation performed."}
@@ -515,6 +523,24 @@ def fetch_workspace_data_api_mocks_fixture(
         )
 
         yield response
+
+
+@pytest.fixture(
+    name="missing_schemas_fetch_workspace_data_api_mocks",
+)
+def missing_schemas_fetch_workspace_data_api_mocks_fixture(
+    connector_id: str,
+    destination_id: str,
+    group_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.replace(
+        method_or_response=responses.GET,
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
+        json=MISSING_SCHEMAS_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR,
+        status=200,
+    )
+    yield fetch_workspace_data_api_mocks
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -75,6 +75,19 @@ def test_fivetran_connector_selector(
     assert len(actual_workspace_data.connectors_by_id) == expected_result
 
 
+def test_missing_schemas_fivetran_workspace_data(
+    missing_schemas_fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    actual_workspace_data = resource.fetch_fivetran_workspace_data()
+    # The connection is discarded because it's missing its schemas
+    assert len(actual_workspace_data.connectors_by_id) == 0
+    assert len(actual_workspace_data.destinations_by_id) == 1
+
+
 def test_translator_spec(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -83,7 +83,7 @@ def test_missing_schemas_fivetran_workspace_data(
     )
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
-    # The connection is discarded because it's missing its schemas
+    # The connector is discarded because it's missing its schemas
     assert len(actual_workspace_data.connectors_by_id) == 0
     assert len(actual_workspace_data.destinations_by_id) == 1
 


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-881.

The `schemas` field is marked as required in Fivetran docs for the `connections/{connection_id}/schemas`, but is missing for any connection that has not already been synced. 

Updating the logic to consider schemas as optional, and to discard connectors without schemas/that have not been synced yet.

## How I Tested These Changes

Additional test with BK

