### PR TITLE
[components] Replace `--builtin-component-lib` option with `--use-component-module`

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -25,8 +25,6 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ --use-dg-managed-enviro…    --no-use-dg-managed-en…          Enable management of the  │
 │                                                              virtual environment with  │
 │                                                              uv.                       │
-│ --builtin-component-lib                                TEXT  Specify a builitin        │
-│                                                              component library to use. │
 │ --verbose                                                    Enable verbose output for │
 │                                                              debugging.                │
 │ --disable-cache                                              Disable the cache..       │

--- a/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py
@@ -3,8 +3,6 @@ from dagster.version import __version__
 
 from dagster_components.cli.list import list_cli
 from dagster_components.cli.scaffold import scaffold_cli
-from dagster_components.core.component import BUILTIN_MAIN_COMPONENT_ENTRY_POINT
-from dagster_components.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
 
 
 def create_dagster_components_cli():
@@ -17,23 +15,14 @@ def create_dagster_components_cli():
         commands=commands,
         context_settings={"max_content_width": 120, "help_option_names": ["-h", "--help"]},
     )
-    @click.option(
-        "--builtin-component-lib",
-        type=str,
-        default=BUILTIN_MAIN_COMPONENT_ENTRY_POINT,
-        help="Specify the builitin component library to load.",
-    )
     @click.version_option(__version__, "--version", "-v")
-    @click.pass_context
-    def group(ctx: click.Context, builtin_component_lib: str):
+    def group():
         """Internal API for working with Dagster Components.
 
         This CLI is private and can be considered an implementation detail for `dg`. It is called by
         `dg` to execute commands related to Dagster Components in the context of a particular Python
         environment. This is necessary because `dg` itself always runs in an isolated environment.
         """
-        ctx.ensure_object(dict)
-        ctx.obj[CLI_BUILTIN_COMPONENT_LIB_KEY] = builtin_component_lib
 
     return group
 

--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import Any, Literal, Union
 
 import click
 from pydantic import ConfigDict, TypeAdapter, create_model
@@ -10,10 +10,7 @@ from dagster_components.core.component import (
     discover_component_types,
     discover_entry_point_component_types,
 )
-from dagster_components.utils import CLI_BUILTIN_COMPONENT_LIB_KEY
-
-if TYPE_CHECKING:
-    from dagster_components.core.component_key import ComponentKey
+from dagster_components.core.component_key import ComponentKey
 
 
 @click.group(name="list")
@@ -29,35 +26,29 @@ def list_component_types_command(
     ctx: click.Context, entry_points: bool, extra_modules: tuple[str, ...]
 ) -> None:
     """List registered Dagster components."""
-    builtin_component_lib = ctx.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
     output: dict[str, Any] = {}
-    registered_components: dict[ComponentKey, type[Component]] = {}
-    if entry_points:
-        registered_components.update(discover_entry_point_component_types(builtin_component_lib))
-    if extra_modules:
-        registered_components.update(discover_component_types(extra_modules))
-
-    for key in sorted(registered_components.keys(), key=lambda k: k.to_typename()):
+    component_types = _load_component_types(entry_points, extra_modules)
+    for key in sorted(component_types.keys(), key=lambda k: k.to_typename()):
         output[key.to_typename()] = ComponentTypeMetadata(
             name=key.name,
             namespace=key.namespace,
-            **registered_components[key].get_metadata(),
+            **component_types[key].get_metadata(),
         )
     click.echo(json.dumps(output))
 
 
 @list_cli.command(name="all-components-schema")
-@click.pass_context
-def list_all_components_schema_command(ctx: click.Context) -> None:
+@click.option("--entry-points/--no-entry-points", is_flag=True, default=True)
+@click.argument("extra_modules", nargs=-1, type=str)
+def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[str, ...]) -> None:
     """Builds a JSON schema which ORs the schema for a component
     file for all component types available in the current code location.
     """
-    builtin_component_lib = ctx.obj.get(CLI_BUILTIN_COMPONENT_LIB_KEY, False)
-    registered_components = discover_entry_point_component_types(builtin_component_lib)
+    component_types = _load_component_types(entry_points, extra_modules)
 
     schemas = []
-    for key in sorted(registered_components.keys(), key=lambda k: k.to_typename()):
-        component_type = registered_components[key]
+    for key in sorted(component_types.keys(), key=lambda k: k.to_typename()):
+        component_type = component_types[key]
         # Create ComponentFileModel schema for each type
         schema_type = component_type.get_schema()
         key_string = key.to_typename()
@@ -72,3 +63,19 @@ def list_all_components_schema_command(ctx: click.Context) -> None:
             )
     union_type = Union[tuple(schemas)]  # type: ignore
     click.echo(json.dumps(TypeAdapter(union_type).json_schema()))
+
+
+# ########################
+# ##### HELPERS
+# ########################
+
+
+def _load_component_types(
+    entry_points: bool, extra_modules: tuple[str, ...]
+) -> dict[ComponentKey, type[Component]]:
+    component_types = {}
+    if entry_points:
+        component_types.update(discover_entry_point_component_types())
+    if extra_modules:
+        component_types.update(discover_component_types(extra_modules))
+    return component_types

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -124,9 +124,6 @@ def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.m
 
 
 COMPONENTS_ENTRY_POINT_GROUP = "dagster.components"
-BUILTIN_COMPONENTS_ENTRY_POINT_BASE = "dagster_components"
-BUILTIN_MAIN_COMPONENT_ENTRY_POINT = BUILTIN_COMPONENTS_ENTRY_POINT_BASE
-BUILTIN_TEST_COMPONENT_ENTRY_POINT = ".".join([BUILTIN_COMPONENTS_ENTRY_POINT_BASE, "test"])
 
 
 def load_component_type(component_key: ComponentKey) -> type[Component]:
@@ -147,10 +144,7 @@ def load_component_type(component_key: ComponentKey) -> type[Component]:
         raise DagsterError(f"Error loading module `{module_name}`.") from e
 
 
-def discover_entry_point_component_types(
-    builtin_component_lib: str = BUILTIN_MAIN_COMPONENT_ENTRY_POINT,
-    extra_modules: Optional[Sequence[str]] = None,
-) -> dict[ComponentKey, type[Component]]:
+def discover_entry_point_component_types() -> dict[ComponentKey, type[Component]]:
     """Discover component types registered in the Python environment via the
     `dagster_components` entry point group.
 
@@ -158,23 +152,9 @@ def discover_entry_point_component_types(
     "builtin" component libraries. The `dagster_components` entry point resolves to published
     component types and is loaded by default. Other entry points resolve to various sets of test
     component types. This method will only ever load one builtin component library.
-
-    Args:
-        builtin-component-lib (str): Specifies the builtin components library to load. Built-in
-            component libraries are defined under entry points with names matching the pattern
-            `dagster_components*`. Only one built-in  component library can be loaded at a time.
-            Defaults to `dagster_components`, the standard set of published component types.
     """
     component_types: dict[ComponentKey, type[Component]] = {}
-    entry_points = [
-        ep
-        for ep in get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP)
-        # Skip built-in entry points that are not the specified builtin component library.
-        if not (
-            ep.name.startswith(BUILTIN_COMPONENTS_ENTRY_POINT_BASE)
-            and not ep.name == builtin_component_lib
-        )
-    ]
+    entry_points = get_entry_points_from_python_environment(COMPONENTS_ENTRY_POINT_GROUP)
 
     for entry_point in entry_points:
         try:

--- a/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/test_cases.py
@@ -63,19 +63,6 @@ COMPONENT_VALIDATION_TEST_CASES = [
     BASIC_INVALID_VALUE,
     BASIC_MISSING_VALUE,
     ComponentValidationTestCase(
-        component_path="validation/simple_asset_invalid_value",
-        component_type_filepath=None,
-        should_error=True,
-        validate_error_msg=msg_includes_all_of(
-            "component.yaml:5", "attributes.value", "Input should be a valid string"
-        ),
-        check_error_msg=msg_includes_all_of(
-            "component.yaml:5",
-            "attributes.value",
-            "{} is not of type 'string'",
-        ),
-    ),
-    ComponentValidationTestCase(
         component_path="validation/basic_component_extra_value",
         component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -22,8 +22,6 @@ from dagster_components.core.schema.objects import AssetAttributesSchema
 
 T = TypeVar("T")
 
-CLI_BUILTIN_COMPONENT_LIB_KEY = "builtin_component_lib"
-
 
 def ensure_dagster_components_tests_import() -> None:
     from dagster_components import __file__ as dagster_components_init_py

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -42,7 +42,6 @@ setup(
         ],
         "dagster.components": [
             "dagster_components = dagster_components.lib",
-            "dagster_components.test = dagster_components.lib.test",
         ],
     },
     extras_require={

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/global_options.py
@@ -1,3 +1,4 @@
+import textwrap
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, TypeVar, Union
 
@@ -30,10 +31,19 @@ GLOBAL_OPTIONS = {
             help="Enable verbose output for debugging.",
         ),
         click.Option(
-            ["--builtin-component-lib"],
+            ["--use-component-module", "use_component_modules"],
             type=str,
-            default=DgCliConfig.builtin_component_lib,
-            help="Specify a builitin component library to use.",
+            multiple=True,
+            default=DgCliConfig.__dataclass_fields__["use_component_modules"].default_factory(),
+            hidden=True,
+            help=textwrap.dedent("""
+                Specify a list of remote environment modules expected to contain components.
+                When retrieving the default set of components from the target environment, only
+                components from these modules will be fetched. This overrides the default behavior
+                of fetching all components registered under entry points in the remote environment.
+                This is useful primarily for testing, as it allows targeting of a stable set of test
+                components.
+            """).strip(),
         ),
         click.Option(
             ["--use-dg-managed-environment/--no-use-dg-managed-environment"],

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -33,7 +33,13 @@ class RemoteComponentRegistry:
         if dg_context.use_dg_managed_environment:
             dg_context.ensure_uv_lock()
 
-        component_data = _load_entry_point_components(dg_context)
+        if dg_context.config.cli.use_component_modules:
+            component_data = _load_module_components(
+                dg_context, dg_context.config.cli.use_component_modules
+            )
+        else:
+            component_data = _load_entry_point_components(dg_context)
+
         if extra_modules:
             component_data.update(_load_module_components(dg_context, extra_modules))
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -193,7 +193,7 @@ def scaffold_component_instance(
         "scaffold",
         "component",
         component_type,
-        path,
+        str(path),
         *(["--json-params", json.dumps(scaffold_params)] if scaffold_params else []),
     ]
     dg_context.external_components_command(scaffold_command)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -205,8 +205,6 @@ def test_dynamic_subcommand_help_message():
                 │ --cache-dir                                                        TEXT  Specify a directory to use for the cache.   │
                 │ --disable-cache                                                          Disable the cache..                         │
                 │ --verbose                                                                Enable verbose output for debugging.        │
-                │ --builtin-component-lib                                            TEXT  Specify a builitin component library to     │
-                │                                                                          use.                                        │
                 │ --use-dg-managed-environment    --no-use-dg-managed-environment          Enable management of the virtual            │
                 │                                                                          environment with uv.                        │
                 │ --require-local-venv            --no-require-local-venv                  Require use of a local virtual environment  │

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -123,7 +123,10 @@ def test_list_component_type_json_succeeds():
 # command. This subprocess inherits stderr from the parent process, for whatever reason `capsys` does
 # not work.
 def test_list_component_type_bad_entry_point_fails(capfd):
-    with ProxyRunner.test() as runner, isolated_example_component_library_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_entry_points=True) as runner,
+        isolated_example_component_library_foo_bar(runner),
+    ):
         # Delete the component lib package referenced by the entry point
         shutil.rmtree("foo_bar/lib")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -461,7 +461,10 @@ def test_scaffold_component_fails_components_package_does_not_exist() -> None:
 
 
 def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_entry_points=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         result = runner.invoke("scaffold", "component-type", "Baz")
         assert_runner_result(result)
         assert Path("foo_bar/lib/baz.py").exists()
@@ -489,7 +492,7 @@ dbt_project_path = Path("../stub_projects/dbt_project_location/components/jaffle
 )
 def test_scaffold_dbt_project_instance(params) -> None:
     with (
-        ProxyRunner.test(use_test_component_lib=False) as runner,
+        ProxyRunner.test(use_entry_points=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
         # We need to add dagster-dbt also because we are using editable installs. Only
@@ -534,7 +537,7 @@ def test_scaffold_component_type_success() -> None:
 
 def test_scaffold_component_type_already_exists_fails() -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_entry_points=True) as runner,
         isolated_example_component_library_foo_bar(runner),
     ):
         result = runner.invoke("scaffold", "component-type", "Baz")
@@ -546,7 +549,7 @@ def test_scaffold_component_type_already_exists_fails() -> None:
 
 def test_scaffold_component_type_succeeds_non_default_component_lib_package() -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_entry_points=True) as runner,
         isolated_example_component_library_foo_bar(runner, lib_module_name="foo_bar._lib"),
     ):
         result = runner.invoke(
@@ -563,7 +566,7 @@ def test_scaffold_component_type_succeeds_non_default_component_lib_package() ->
 
 def test_scaffold_component_type_fails_components_lib_package_does_not_exist(capfd) -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_entry_points=True) as runner,
         isolated_example_component_library_foo_bar(runner, lib_module_name="foo_bar.fake"),
     ):
         # Delete the entry point module

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -11,7 +11,7 @@ from dagster_dg_tests.utils import (
 # For all cache tests, avoid setting up venv in example project so we do not prepopulate the
 # cache (which is part of the venv setup routine).
 example_project = partial(isolated_example_project_foo_bar, populate_cache=False)
-cache_runner_args = {"verbose": True}
+cache_runner_args = {"use_entry_points": True, "verbose": True}
 
 
 def test_load_from_cache():


### PR DESCRIPTION
## Summary & Motivation

Remove the janky `--builtin-component-lib` option that got forwarded through `dagster-dg` to `dagster-components`. This was very weird and made entry point loading confusing. The new system:

`dg` has a new (hidden, bc for tests) option `--use-component-module` (can be passed multiple times). If this is set, then `dg` will instruct `dagster-components` to load only from these modules rather than loading from entry points (which is the default behavior). This is a much cleaner system.

Also:

- Remove the `dagster_components.test` entry point-- now no test components are exposed via entry points, you have to explicitly target them.
- Some config validation improvements necessitated by `use_component_modules` being a `list[str]`

Upstack we can move the test components out of `dagster_components` and into `dagster_components_tests`.

## How I Tested These Changes

Adapted existing unit tests.