### PR TITLE
[docs] fix multi-asset-sensor code example

### DIFF
--- a/docs/docs/guides/automate/asset-sensors.md
+++ b/docs/docs/guides/automate/asset-sensors.md
@@ -110,7 +110,7 @@ The `@multi_asset_sensor` has been marked as deprecated, but will not be removed
 
 When building a pipeline, you may want to monitor multiple assets with a single sensor. This can be accomplished with a multi-asset sensor.
 
-The following example uses a `@multi_asset_sensor` to monitor multiple assets and trigger a job when any of the assets are materialized:
+The following example uses a `@multi_asset_sensor` to monitor two assets that triggers an asset job once both have been materialized. You can also trigger op jobs this way.
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/automation/multi-asset-sensor.py" language="python" />
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/automation/multi-asset-sensor.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/automation/multi-asset-sensor.py
@@ -17,8 +17,8 @@ def asset_c():
 
 
 asset_job = dg.define_asset_job(
-    "asset_b_job",
-    selection=[dg.AssetKey("asset_a"), dg.AssetKey("asset_b"), dg.AssetKey("asset_c")],
+    "asset_c_job",
+    selection=[dg.AssetKey("asset_c")],
 )
 
 


### PR DESCRIPTION
## Summary & Motivation
Fixes `multi-asset-sensor.py` example to remove circular reference and clarifies `multi_asset_sensor` can also trigger op jobs.

## How I Tested These Changes
👀 and ran example locally