### PR TITLE
[docs] hard code names of GraphQL API Python client method

### DIFF
--- a/docs/docs/guides/operate/graphql/graphql-client.md
+++ b/docs/docs/guides/operate/graphql/graphql-client.md
@@ -27,25 +27,25 @@ Note that all GraphQL methods on the API are not yet available in Python - the `
   module="dagster_graphql"
   object="DagsterGraphQLClient"
   method="submit_job_execution"
-  />
+  /> [submit_job_execution](#submitting-a-job-run)
 - <PyObject
   section="libraries"
   module="dagster_graphql"
   object="DagsterGraphQLClient"
   method="get_run_status"
-  />
+  /> [get_run_status](#getting-a-job-runs-status)
 - <PyObject
   section="libraries"
   module="dagster_graphql"
   object="DagsterGraphQLClient"
   method="reload_repository_location"
-  />
+  /> [reload_repository_location](#reloading-all-repositories-in-a-repository-location)
 - <PyObject
   section="libraries"
   module="dagster_graphql"
   object="DagsterGraphQLClient"
   method="shutdown_repository_location"
-  />
+  /> [shutdown_repository_location](#shutting-down-a-repository-location-server)
 
 ## Using the GraphQL Client
 


### PR DESCRIPTION
## Summary & Motivation
For some reason the `PyObject` that links to [the API docs for the GraphQL Python Client](https://docs.dagster.io/api/python-api/libraries/dagster-graphql#python-client) does not display the name of the client methods. This PR hard codes in the method names and links to their sections.

Before:
 ![Screenshot 2025-02-27 at 00 28 43](https://github.com/user-attachments/assets/86a11f91-8439-423f-9a84-a203f0241d84)

After:
![Screenshot 2025-02-27 at 00 29 01](https://github.com/user-attachments/assets/f01e02fa-931d-49b0-9f2e-6b4932b2d406)

## How I Tested These Changes
👀