### PR TITLE
[Docs] Temporarily remove blank OSS -> Dagster+ migration guide

### DIFF
--- a/docs/docs/dagster-plus/deployment/migration/self-hosted-to-dagster-plus.md
+++ b/docs/docs/dagster-plus/deployment/migration/self-hosted-to-dagster-plus.md
@@ -1,6 +1,0 @@
----
-title: Migrating from self-hosted to Dagster+
-sidebar_label: Self-hosted to Dagster+
-sidebar_position: 200
-unlisted: true
----

--- a/docs/docs/dagster-plus/index.md
+++ b/docs/docs/dagster-plus/index.md
@@ -30,5 +30,4 @@ Ready to [get started](/dagster-plus/getting-started)?
 - Learn more about Dagster+ [pricing and plan types](https://dagster.io/pricing) or [contact the Dagster team](https://dagster.io/contact)
 - Dagster+ includes support, [click here](https://dagster.io/support) to learn more.
 - Dagster+ is HIPAA compliant, SOC 2 Type II certified, and meets GDPR requirements. Learn more about Dagster+[ security](https://dagster.io/security).
-- Migrate [from a Dagster open source deployment to Dagster+](/dagster-plus/deployment/migration/self-hosted-to-dagster-plus)
 - Dagster+ [status page](https://dagstercloud.statuspage.io/)

--- a/docs/docs/guides/deploy/index.md
+++ b/docs/docs/guides/deploy/index.md
@@ -7,6 +7,4 @@ This section is about self-hosting Dagster.
 
 :::info
 To deploy to Dagster+, see the [Dagster+ getting started guide](/dagster-plus/getting-started).
-
-To migrate from self-hosted to Dagster+, see [Migrate from self-hosted to Dagster+](/dagster-plus/deployment/migration/self-hosted-to-dagster-plus).
 :::


### PR DESCRIPTION
## Summary & Motivation

Removing this unlisted doc and links to it for now, since it's a blank page that is being indexed by Google, possibly because there were internal links to it. I have a task to complete this guide end of March / beginning of April.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
