### PR TITLE
add materialization failure attrs to AssetEntry and `fetch_failed_materialization` method stubs

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2127,7 +2127,7 @@ class DagsterInstance(DynamicPartitionsStore):
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> "EventRecordsResult":
-        """Return a list of materialization records stored in the event log storage.
+        """Return a list of AssetFailedToMaterialization records stored in the event log storage.
 
         Args:
             records_filter (Union[AssetKey, AssetRecordsFilter]): the filter by which to

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2120,6 +2120,31 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.fetch_materializations(records_filter, limit, cursor, ascending)
 
     @traced
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of materialization records stored in the event log storage.
+
+        Args:
+            records_filter (Union[AssetKey, AssetRecordsFilter]): the filter by which to
+                filter event records.
+            limit (int): Number of results to get.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.fetch_failed_materializations(
+            records_filter, limit, cursor, ascending
+        )
+
+    @traced
     @deprecated(breaking_version="2.0")
     def fetch_planned_materializations(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -61,11 +61,13 @@ class AssetEntry(
             ("last_run_id", Optional[str]),
             ("asset_details", Optional[AssetDetails]),
             ("cached_status", Optional["AssetStatusCacheValue"]),
-            # This is an optional field which can be used for more performant last observation
+            # Below optional fields which can be used for more performant last observation
             # queries if the underlying storage supports it
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),
             ("last_planned_materialization_run_id", Optional[str]),
+            ("last_planned_materialization_failure_storage_id", Optional[int]),
+            ("last_planned_materialization_failure_run_id", Optional[str]),
         ],
     )
 ):
@@ -79,6 +81,8 @@ class AssetEntry(
         last_observation_record: Optional[EventLogRecord] = None,
         last_planned_materialization_storage_id: Optional[int] = None,
         last_planned_materialization_run_id: Optional[str] = None,
+        last_planned_materialization_failure_storage_id: Optional[int] = None,
+        last_planned_materialization_failure_run_id: Optional[str] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -105,6 +109,14 @@ class AssetEntry(
             last_planned_materialization_run_id=check.opt_str_param(
                 last_planned_materialization_run_id,
                 "last_planned_materialization_run_id",
+            ),
+            last_planned_materialization_failure_storage_id=check.opt_int_param(
+                last_planned_materialization_failure_storage_id,
+                "last_planned_materialization_failure_storage_id",
+            ),
+            last_planned_materialization_failure_run_id=check.opt_str_param(
+                last_planned_materialization_failure_run_id,
+                "last_planned_materialization_failure_run_id",
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -66,8 +66,7 @@ class AssetEntry(
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),
             ("last_planned_materialization_run_id", Optional[str]),
-            ("last_planned_materialization_failure_storage_id", Optional[int]),
-            ("last_planned_materialization_failure_run_id", Optional[str]),
+            ("last_planned_materialization_failure_record", Optional[EventLogRecord]),
         ],
     )
 ):
@@ -81,8 +80,7 @@ class AssetEntry(
         last_observation_record: Optional[EventLogRecord] = None,
         last_planned_materialization_storage_id: Optional[int] = None,
         last_planned_materialization_run_id: Optional[str] = None,
-        last_planned_materialization_failure_storage_id: Optional[int] = None,
-        last_planned_materialization_failure_run_id: Optional[str] = None,
+        last_planned_materialization_failure_record: Optional[EventLogRecord] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -110,13 +108,10 @@ class AssetEntry(
                 last_planned_materialization_run_id,
                 "last_planned_materialization_run_id",
             ),
-            last_planned_materialization_failure_storage_id=check.opt_int_param(
-                last_planned_materialization_failure_storage_id,
-                "last_planned_materialization_failure_storage_id",
-            ),
-            last_planned_materialization_failure_run_id=check.opt_str_param(
-                last_planned_materialization_failure_run_id,
-                "last_planned_materialization_failure_run_id",
+            last_planned_materialization_failure_record=check.opt_inst_param(
+                last_planned_materialization_failure_record,
+                "last_planned_materialization_failure_record",
+                EventLogRecord,
             ),
         )
 
@@ -137,6 +132,18 @@ class AssetEntry(
         if self.last_materialization_record is None:
             return None
         return self.last_materialization_record.storage_id
+
+    @property
+    def last_planned_materialization_failure(self) -> Optional["EventLogEntry"]:
+        if self.last_planned_materialization_failure_record is None:
+            return None
+        return self.last_planned_materialization_failure_record.event_log_entry
+
+    @property
+    def last_planned_materialization_failure_storage_id(self) -> Optional[int]:
+        if self.last_planned_materialization_failure_record is None:
+            return None
+        return self.last_planned_materialization_failure_record.storage_id
 
 
 class AssetRecord(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -653,6 +653,16 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, AssetRecordsFilter],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
     def fetch_observations(
         self,
         records_filter: Union[AssetKey, AssetRecordsFilter],

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -61,7 +61,7 @@ class AssetEntry(
             ("last_run_id", Optional[str]),
             ("asset_details", Optional[AssetDetails]),
             ("cached_status", Optional["AssetStatusCacheValue"]),
-            # Below optional fields which can be used for more performant last observation
+            # Below are optional fields which can be used for more performant
             # queries if the underlying storage supports it
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -134,7 +134,7 @@ class AssetEntry(
         return self.last_materialization_record.storage_id
 
     @property
-    def last_failed_to_materialize(self) -> Optional["EventLogEntry"]:
+    def last_failed_to_materialize_entry(self) -> Optional["EventLogEntry"]:
         if self.last_failed_to_materialize_record is None:
             return None
         return self.last_failed_to_materialize_record.event_log_entry

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -66,7 +66,7 @@ class AssetEntry(
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),
             ("last_planned_materialization_run_id", Optional[str]),
-            ("last_planned_materialization_failure_record", Optional[EventLogRecord]),
+            ("last_failed_to_materialize_record", Optional[EventLogRecord]),
         ],
     )
 ):
@@ -80,7 +80,7 @@ class AssetEntry(
         last_observation_record: Optional[EventLogRecord] = None,
         last_planned_materialization_storage_id: Optional[int] = None,
         last_planned_materialization_run_id: Optional[str] = None,
-        last_planned_materialization_failure_record: Optional[EventLogRecord] = None,
+        last_failed_to_materialize_record: Optional[EventLogRecord] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -108,9 +108,9 @@ class AssetEntry(
                 last_planned_materialization_run_id,
                 "last_planned_materialization_run_id",
             ),
-            last_planned_materialization_failure_record=check.opt_inst_param(
-                last_planned_materialization_failure_record,
-                "last_planned_materialization_failure_record",
+            last_failed_to_materialize_record=check.opt_inst_param(
+                last_failed_to_materialize_record,
+                "last_failed_to_materialize_record",
                 EventLogRecord,
             ),
         )
@@ -134,16 +134,16 @@ class AssetEntry(
         return self.last_materialization_record.storage_id
 
     @property
-    def last_planned_materialization_failure(self) -> Optional["EventLogEntry"]:
-        if self.last_planned_materialization_failure_record is None:
+    def last_failed_to_materialize(self) -> Optional["EventLogEntry"]:
+        if self.last_failed_to_materialize_record is None:
             return None
-        return self.last_planned_materialization_failure_record.event_log_entry
+        return self.last_failed_to_materialize_record.event_log_entry
 
     @property
-    def last_planned_materialization_failure_storage_id(self) -> Optional[int]:
-        if self.last_planned_materialization_failure_record is None:
+    def last_failed_to_materialize_storage_id(self) -> Optional[int]:
+        if self.last_failed_to_materialize_record is None:
             return None
-        return self.last_planned_materialization_failure_record.storage_id
+        return self.last_failed_to_materialize_record.storage_id
 
 
 class AssetRecord(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -991,6 +991,15 @@ class SqlEventLogStorage(EventLogStorage):
 
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, AssetRecordsFilter],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return EventRecordsResult(records=[], cursor=cursor, has_more=False)
+
     def fetch_observations(
         self,
         records_filter: Union[AssetKey, AssetRecordsFilter],

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -998,7 +998,7 @@ class SqlEventLogStorage(EventLogStorage):
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
-        return EventRecordsResult(records=[], cursor=cursor, has_more=False)
+        return EventRecordsResult(records=[], cursor=cursor or "", has_more=False)
 
     def fetch_observations(
         self,

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -493,6 +493,17 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             filters, limit, cursor, ascending
         )
 
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.fetch_failed_materializations(
+            records_filter, limit, cursor, ascending
+        )
+
     def fetch_observations(
         self,
         filters: Union[AssetKey, "AssetRecordsFilter"],

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6637,7 +6637,7 @@ class TestEventLogStorage:
         else:
             assert len(all_failed_records_result.records) == 5
             assert all(
-                failed_record.asset_key == asset_key_1.to_string()
+                failed_record.asset_key == asset_key_1
                 for failed_record in all_failed_records_result.records
             )
             assert not all_failed_records_result.has_more
@@ -6647,7 +6647,7 @@ class TestEventLogStorage:
             )
             assert len(first_two_failed_records_result.records) == 2
             assert all(
-                failed_record.asset_key == asset_key_1.to_string()
+                failed_record.asset_key == asset_key_1
                 for failed_record in first_two_failed_records_result.records
             )
             assert first_two_failed_records_result.has_more
@@ -6658,14 +6658,16 @@ class TestEventLogStorage:
             )
             assert len(remaining_failed_records_result.records) == 3
             assert all(
-                failed_record.asset_key == asset_key_1.to_string()
+                failed_record.asset_key == asset_key_1
                 for failed_record in remaining_failed_records_result.records
             )
             assert not remaining_failed_records_result.has_more
 
-            assert set(first_two_failed_records_result.records) | set(
-                remaining_failed_records_result.records
-            ) == set(all_failed_records_result.records)
+            assert set(
+                record.storage_id for record in first_two_failed_records_result.records
+            ) | set(record.storage_id for record in remaining_failed_records_result.records) == set(
+                record.storage_id for record in all_failed_records_result.records
+            )
 
             failed_records_for_partitions = storage.fetch_failed_materializations(
                 records_filter=AssetRecordsFilter(
@@ -6675,6 +6677,6 @@ class TestEventLogStorage:
             )
             assert len(failed_records_for_partitions.records) == 2
             assert all(
-                failed_record.asset_key == asset_key_1.to_string()
+                failed_record.asset_key == asset_key_1
                 for failed_record in failed_records_for_partitions.records
             )

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6603,3 +6603,78 @@ class TestEventLogStorage:
         assert limit.name == "bar"
         assert limit.limit == 1
         assert limit.from_default
+
+    def test_fetch_failed_materializations(self, test_run_id, storage: EventLogStorage):
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
+        asset_key_1 = AssetKey("asset_1")
+        asset_key_2 = AssetKey("asset_2")
+        asset_keys = [asset_key_1, asset_key_2]
+        for i in range(5):
+            for asset_key in asset_keys:
+                event_to_store = EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=test_run_id,
+                    timestamp=time.time(),
+                    dagster_event=DagsterEvent.build_asset_failed_to_materialize_event(
+                        job_name="the_job",
+                        step_key="the_step",
+                        asset_failed_to_materialize=AssetFailedToMaterialize(
+                            asset_key=asset_key,
+                            partition=str(i),
+                            reason=AssetFailedToMaterializeReason.COMPUTE_FAILED,
+                        ),
+                    ),
+                )
+                storage.store_event(event_to_store)
+
+        all_failed_records_result = storage.fetch_failed_materializations(
+            records_filter=asset_key_1, limit=10
+        )
+        if not storage.asset_records_have_last_planned_and_failed_materializations:
+            assert len(all_failed_records_result.records) == 0
+        else:
+            assert len(all_failed_records_result.records) == 5
+            assert all(
+                failed_record.asset_key == asset_key_1.to_string()
+                for failed_record in all_failed_records_result.records
+            )
+            assert not all_failed_records_result.has_more
+
+            first_two_failed_records_result = storage.fetch_failed_materializations(
+                records_filter=asset_key_1, limit=2
+            )
+            assert len(first_two_failed_records_result.records) == 2
+            assert all(
+                failed_record.asset_key == asset_key_1.to_string()
+                for failed_record in first_two_failed_records_result.records
+            )
+            assert first_two_failed_records_result.has_more
+            assert first_two_failed_records_result.cursor
+
+            remaining_failed_records_result = storage.fetch_failed_materializations(
+                records_filter=asset_key_1, limit=5, cursor=first_two_failed_records_result.cursor
+            )
+            assert len(remaining_failed_records_result.records) == 3
+            assert all(
+                failed_record.asset_key == asset_key_1.to_string()
+                for failed_record in remaining_failed_records_result.records
+            )
+            assert not remaining_failed_records_result.has_more
+
+            assert set(first_two_failed_records_result.records) | set(
+                remaining_failed_records_result.records
+            ) == set(all_failed_records_result.records)
+
+            failed_records_for_partitions = storage.fetch_failed_materializations(
+                records_filter=AssetRecordsFilter(
+                    asset_key=asset_key_1, asset_partitions=["1", "2"]
+                ),
+                limit=5,
+            )
+            assert len(failed_records_for_partitions.records) == 2
+            assert all(
+                failed_record.asset_key == asset_key_1.to_string()
+                for failed_record in failed_records_for_partitions.records
+            )

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6620,10 +6620,10 @@ class TestEventLogStorage:
                     dagster_event=DagsterEvent.build_asset_failed_to_materialize_event(
                         job_name="the_job",
                         step_key="the_step",
-                        asset_failed_to_materialize=AssetFailedToMaterialize(
+                        asset_materialization_failure=AssetMaterializationFailure(
                             asset_key=asset_key,
                             partition=str(i),
-                            reason=AssetFailedToMaterializeReason.COMPUTE_FAILED,
+                            reason=AssetMaterializationFailureReason.COMPUTE_FAILED,
                         ),
                     ),
                 )


### PR DESCRIPTION
## Summary & Motivation
OSS counterpart to https://github.com/dagster-io/internal/pull/14334
Allows us to store failed to materialize events on the `AssetEntry`. Also has the event log storage stub method for `fetch_failed_materializations`

## How I Tested These Changes

