### PR TITLE
MAp dbt tests to dagster data checks (description) 🏷️

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -591,7 +591,7 @@ def default_asset_check_fn(
     return AssetCheckSpec(
         name=test_resource_props["name"],
         asset=asset_key,
-        description=test_resource_props.get("meta", {}).get("description"),
+        description=test_resource_props.get("description"),
         additional_deps=additional_deps,
         metadata={DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: test_unique_id},
     )


### PR DESCRIPTION
## Description 

This PR fixes a bug in the dagster-dbt integration where test descriptions were not being displayed in the Dagster UI. The issue was in the `default_asset_check_fn` function in `asset_utils.py` where test descriptions were not being properly mapped from the dbt manifest to the Dagster asset check specification.

### Problem

When creating asset checks from dbt tests, the test descriptions were not being correctly passed through to the Dagster asset check specification. This resulted in tests appearing without descriptions in the Dagster UI.

The issue is noticeable with dbt 1.9, which defines how column test descriptions are set. (I might be imagining this and it was supported before)

ref: https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.9#quick-hits

ref: https://docs.getdbt.com/reference/data-test-configs#data-test-specific-configurations

Let's take the following dbt test as an example:

```yaml
    columns:
      - name: fruit_type
        description: "🍎 The type of fruit"
        tests:
          - not_null:
              description: "🚫 Ensures no empty fruitiness"
          - unique:
              description: "🔍 Validates that each fruit is unique, and prevents duplicates"
```

With the changes in this PR, they will be mapped to dagster check description meta data.

### Solution

I fixed the bug in the mapping in `default_asset_check_fn` to the right field in the `AssetCheck` object.

### Test Plan

I've verified that test descriptions now correctly appear in the Dagster UI for both generic and singular tests. This fix is compatible with dbt 1.9.

## Checklist

- [x] I have verified the fix works with dbt 1.9
- [x] I have manually tested the changes in a dbt project with tests that include descriptions
- [x] I have confirmed test descriptions now appear correctly in the Dagster UI
- [x] I have ran the tests locally
