### PR TITLE
[compute logs] remove early fetches from subscriptions

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -231,13 +231,9 @@ class PollingComputeLogSubscriptionManager:
         if not self._polling_thread:
             self._start_polling_thread()
 
-        if self.is_complete(subscription):
-            subscription.fetch()
-            subscription.complete()
-        else:
-            log_key = self._log_key(subscription)
-            watch_key = self._watch_key(log_key)
-            self._subscriptions[watch_key].append(subscription)
+        log_key = self._log_key(subscription)
+        watch_key = self._watch_key(log_key)
+        self._subscriptions[watch_key].append(subscription)
 
     def is_complete(self, subscription: CapturedLogSubscription) -> bool:
         return self._manager.is_capture_complete(subscription.log_key)

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -142,9 +142,6 @@ class CapturedLogSubscription:
 
     def __call__(self, observer: Optional[Callable[[CapturedLogData], None]]) -> Self:
         self._observer = observer
-        self.fetch()
-        if self._manager.is_capture_complete(self._log_key):
-            self.complete()
         return self
 
     @property


### PR DESCRIPTION
The compute log subscription doesn't work as it should due to thes attempts to eagerly fetch and complete. Instead let it always fall through to the normal subscription path 

## How I Tested These Changes

loaded larger than 4MB compute logs in ui and observed them all load instead of only the first chunk
