### PR TITLE
[compute logs] standardize on fetching 1MB at a time

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
@@ -216,7 +216,7 @@ const CAPTURED_LOGS_METADATA_QUERY = gql`
   }
 `;
 
-const QUERY_LOG_LIMIT = 100000;
+const QUERY_LOG_LIMIT = 1048576; // 1MB
 const POLL_INTERVAL = 5000;
 
 const CapturedLogsSubscriptionProvider = ({

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -13,7 +13,7 @@ from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
 
-MAX_BYTES_CHUNK_READ: Final = 4194304  # 4 MB
+MAX_BYTES_CHUNK_READ: Final = 1048576  # 1 MB
 
 
 class ComputeIOType(Enum):


### PR DESCRIPTION
get websocket and polling versions aligned with a smaller chunk size 

## How I Tested These Changes

load large compute logs with websockets on and off