### PR TITLE
[dagster-components] Merge dict asset_attributes fields

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -159,10 +159,16 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
             False,
         ),
         ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
-        ({"kinds": ["snowflake"]}, lambda asset_spec: "snowflake" in asset_spec.kinds, False),
+        (
+            {"kinds": ["snowflake"]},
+            lambda asset_spec: "snowflake" in asset_spec.kinds
+            and "dbt" in asset_spec.kinds,  # Ensure dbt-specific kind is not overwritten
+            False,
+        ),
         (
             {"tags": {"foo": "bar"}, "kinds": ["snowflake"]},
             lambda asset_spec: "snowflake" in asset_spec.kinds
+            and "dbt" in asset_spec.kinds  # Ensure dbt-specific kind is not overwritten
             and asset_spec.tags.get("foo") == "bar",
             False,
         ),
@@ -174,7 +180,9 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
         ),
         (
             {"metadata": {"foo": "bar"}},
-            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
+            lambda asset_spec: asset_spec.metadata.get("foo") == "bar"
+            and "dagster-dbt/materialization_type"
+            in asset_spec.metadata,  # Ensure dagster-dbt populated metadata is not overwritten
             False,
         ),
         ({"deps": ["customers"]}, None, True),


### PR DESCRIPTION
## Summary

Right now, when users specify custom e.g. `metadata` to attach to assets as part of  `asset_attributes`, this overrides any metadata set by the default translator.

I think in nearly every case, a user will want to keep these metadata keys and simply append their own. This PR changes that behavior.

Previously, the following would null out existing `dagster/...` and `dagster-dbt/...` metadata keys:
```yaml
type: dbt_project@dagster_components

attributes:
  asset_attributes:
    metadata:
      - foo: bar
```

## Test Plan

New unit test.

