### PR TITLE
[components] Inline the Component subclass discovery logic for Component discovery

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
@@ -41,12 +41,12 @@ def find_objects_in_module_of_types(
 def find_subclasses_in_module(
     module: ModuleType,
     types: Union[type, tuple[type, ...]],
-) -> Iterator[tuple[str, type]]:
+) -> Iterator[type]:
     """Yields instances or subclasses of the given type(s)."""
     for attr in dir(module):
         value = getattr(module, attr)
         if isinstance(value, type) and issubclass(value, types):
-            yield attr, value
+            yield value
 
 
 AssetLoaderTypes = Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition, AssetSpec]

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -192,13 +192,14 @@ def discover_component_types(modules: Sequence[str]) -> dict[ComponentKey, type[
 def get_component_types_in_module(
     module: ModuleType,
 ) -> Iterable[tuple[str, type[Component]]]:
-    from dagster._core.definitions.module_loaders.load_assets_from_modules import (
-        find_subclasses_in_module,
-    )
-
-    for name, component in find_subclasses_in_module(module, (Component,)):
-        if not inspect.isabstract(component):
-            yield name, component
+    for attr in dir(module):
+        value = getattr(module, attr)
+        if (
+            isinstance(value, type)
+            and issubclass(value, Component)
+            and not inspect.isabstract(value)
+        ):
+            yield attr, value
 
 
 T = TypeVar("T")


### PR DESCRIPTION
## Summary & Motivation

In 0.1.17 relies on behavior of modified utility `find_subclasses_in_module` in `dagster`. But a `dagster` with the updated utility is not published yet, leading to an error using newest `dg` in the wild. This reverts the change to the utility function and inlines the logic in `dagster-components`.

## How I Tested These Changes

Existing test suite + manually using editable `dagster-components` w/ published `dagster`.