### PR TITLE
[FE-769] Show other automations if an asset has an automation condition

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
@@ -72,6 +72,15 @@ export const AutomationDetailsSection = ({
         <SectionSkeleton />
       ),
     },
+    {
+      label: 'Automation condition',
+      children: assetNode?.automationCondition?.label ? (
+        <EvaluationUserLabel
+          userLabel={assetNode?.automationCondition.label}
+          expandedLabel={assetNode?.automationCondition.expandedLabel}
+        />
+      ) : null,
+    },
   ];
 
   if (
@@ -85,15 +94,6 @@ export const AutomationDetailsSection = ({
         learnMoreLink="https://docs.dagster.io/concepts/automation#automation"
       />
     );
-  } else {
-    if (assetNode?.automationCondition && assetNode?.automationCondition.label) {
-      return (
-        <EvaluationUserLabel
-          userLabel={assetNode?.automationCondition.label}
-          expandedLabel={assetNode?.automationCondition.expandedLabel}
-        />
-      );
-    }
   }
 
   return (


### PR DESCRIPTION
## Summary & Motivation

As titled.

## How I Tested These Changes

before:
<img width="260" alt="Screenshot 2025-02-28 at 10 03 43 AM" src="https://github.com/user-attachments/assets/2c8d97a0-d6ea-4014-8554-f0e2dfb113d5" />

after:
<img width="306" alt="Screenshot 2025-02-28 at 10 03 51 AM" src="https://github.com/user-attachments/assets/9f31d5fc-302d-45e0-ad6b-4db9b8f2d0bd" />


## Changelog

[ui] Fixed an issue where assets with automation conditions wouldn't show the jobs/sensors/schedules targeting them.
