### PR TITLE
Change dg check definitions to dg check defs

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -168,7 +168,7 @@ def check_yaml_command(
         click.echo("All components validated successfully.")
 
 
-@check_group.command(name="definitions", cls=DgClickCommand)
+@check_group.command(name="defs", cls=DgClickCommand)
 @click.option(
     "--log-level",
     help="Set the log level for dagster services.",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -65,7 +65,7 @@ WORKSPACE_CONTEXT_COMMANDS = [
 
 WORKSPACE_OR_PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("dev",)),
-    CommandSpec(("check", "definitions")),
+    CommandSpec(("check", "defs")),
 ]
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -34,9 +34,9 @@ def test_validate_command_deployment_context_success():
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_code_location_context_success():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
-        result = runner.invoke("check", "definitions")
+        result = runner.invoke("check", "defs")
         assert result.exit_code == 0
 
         (Path("foo_bar") / "definitions.py").write_text("invalid")
-        result = runner.invoke("check", "definitions")
+        result = runner.invoke("check", "defs")
         assert result.exit_code == 1


### PR DESCRIPTION
## Summary & Motivation

To be consistent with `defs` change `dg check definitions` to `dg check defs`

## How I Tested These Changes

```
(dagster-dev-3.11.11-2024-12-08) ➜  p1 dg check defs
Using /Users/schrockn/code/scratch/component_workspaces/dw-7/projects/p1/.venv/bin/dagster
```

## Changelog

NOCHANGELOG

