### PR TITLE
[components] Fix flaky module -> path resolution

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -14,6 +14,7 @@ from dagster_graphql.client import DagsterGraphQLClient
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
+    assert_runner_result,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
 )
@@ -27,12 +28,14 @@ def test_dev_command_workspace_context_success(monkeypatch):
     # venv with `dagster` and `dagster-webserver` installed.
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
     with ProxyRunner.test() as runner, isolated_example_workspace(runner, create_venv=True):
-        runner.invoke(
+        result = runner.invoke(
             "scaffold", "project", "--use-editable-dagster", dagster_git_repo_dir, "project-1"
         )
-        runner.invoke(
+        assert_runner_result(result)
+        result = runner.invoke(
             "scaffold", "project", "--use-editable-dagster", dagster_git_repo_dir, "project-2"
         )
+        assert_runner_result(result)
         port = _find_free_port()
         dev_process = _launch_dev_command(["--port", str(port)])
         projects = {"project-1", "project-2"}

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -397,7 +397,7 @@ def test_scaffold_component_command_with_non_matching_module_name():
             "qux",
         )
         assert_runner_result(result, exit_0=False)
-        assert "Module `foo_bar` is not installed" in str(result.exception)
+        assert "Cannot find module `foo_bar.lib`" in str(result.exception)
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
@@ -456,7 +456,7 @@ def test_scaffold_component_fails_components_package_does_not_exist() -> None:
             "qux",
         )
         assert_runner_result(result, exit_0=False)
-        assert "Module `foo_bar._defs` is not installed" in str(result.exception)
+        assert "Cannot find module `foo_bar._defs`" in str(result.exception)
 
 
 def test_scaffold_component_succeeds_scaffolded_component_type() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -6,28 +6,30 @@ from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import, 
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
+    assert_runner_result,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
 )
 
 
-# @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
-@pytest.mark.skip  # Weirdness with environment, temporarily skipping
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_validate_command_deployment_context_success():
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
     with ProxyRunner.test() as runner, isolated_example_workspace(runner, create_venv=True):
-        runner.invoke(
+        result = runner.invoke(
             "scaffold", "project", "--use-editable-dagster", dagster_git_repo_dir, "project-1"
         )
-        runner.invoke(
+        assert_runner_result(result)
+        result = runner.invoke(
             "scaffold", "project", "--use-editable-dagster", dagster_git_repo_dir, "project-2"
         )
+        assert_runner_result(result)
 
-        result = runner.invoke("check", "definitions")
-        assert result.exit_code == 0
+        result = runner.invoke("check", "defs")
+        assert_runner_result(result)
 
         (Path("projects") / "project-1" / "project_1" / "definitions.py").write_text("invalid")
-        result = runner.invoke("check", "definitions")
+        result = runner.invoke("check", "defs")
         assert result.exit_code == 1
 
 
@@ -35,7 +37,7 @@ def test_validate_command_deployment_context_success():
 def test_validate_command_code_location_context_success():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         result = runner.invoke("check", "defs")
-        assert result.exit_code == 0
+        assert_runner_result(result)
 
         (Path("foo_bar") / "definitions.py").write_text("invalid")
         result = runner.invoke("check", "defs")


### PR DESCRIPTION
## Summary & Motivation

There was a method of resolution from modules to paths that relied on using `importlib.util.find_spec_from_module`. This was behaving flakily in certain test contexts, leading to mysterious failures. This PR changes the method of resolution to skip importlib and instead just perform a straightforward conversion to path. It only works for modules that are part of the project root but that's the only thing we were using it for anyway.

## How I Tested These Changes

Reenabled test that was failing before.