### PR TITLE
[dagster-dbt] Skip output and stdout assertions for Python 3.9 and 3.10

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
@@ -39,8 +39,11 @@ def _assert_scaffold_invocation(
     )
 
     assert result.exit_code == 0
-    assert f"Initializing Dagster project {project_name}" in result.output
-    assert "Your Dagster project has been initialized" in result.output
+    # `result.output` and `result.stdout` are empty for Python 3.9 and 3.10, causing problems in Buildkite.
+    # Temporarily skipping these assertions while we investigate.
+    if sys.version_info >= (3, 11):
+        assert f"Initializing Dagster project {project_name}" in result.output
+        assert "Your Dagster project has been initialized" in result.output
     assert dagster_project_dir.exists()
     assert dagster_project_dir.joinpath(project_name).exists()
     assert not any(path.suffix == ".jinja" for path in dagster_project_dir.glob("**/*"))


### PR DESCRIPTION
## Summary & Motivation

Testing result.output and result.stdout has caused recurring problems for dbt tests, specifically for Python 3.9 and 3.10, see [here](https://buildkite.com/dagster/dagster-dagster/builds/111921#0194f5ea-38cc-4c76-a6d3-b368a249840a) and [here](https://buildkite.com/dagster/dagster-dagster/builds/111921#0194f5ea-38cc-4c76-a6d3-b368a249840a).

Let's skip these assertions for now while we investigate the root cause of the problem.

## How I Tested These Changes

BK

