### PR TITLE
Support `tags` for freshness checks sensor factory

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
@@ -1,6 +1,6 @@
 import datetime
-from collections.abc import Iterator, Sequence
-from typing import Optional, Union, cast
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Any, Optional, Union, cast
 
 from dagster import _check as check
 from dagster._annotations import beta
@@ -41,6 +41,7 @@ def build_sensor_for_freshness_checks(
     minimum_interval_seconds: Optional[int] = None,
     name: str = DEFAULT_FRESHNESS_SENSOR_NAME,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+    tags: Optional[Mapping[str, Any]] = None,
 ) -> SensorDefinition:
     """Builds a sensor which kicks off evaluation of freshness checks.
 
@@ -67,6 +68,8 @@ def build_sensor_for_freshness_checks(
             name may need to be provided in case of multiple calls of this function.
         default_status (Optional[DefaultSensorStatus]): The default status of the sensor. Defaults
             to stopped.
+        tags (Optional[Dict[str, Any]]): A dictionary of tags (string key-value pairs) to attach
+            to the launched run.
 
     Returns:
         SensorDefinition: The sensor that kicks off freshness evaluations.
@@ -112,7 +115,7 @@ def build_sensor_for_freshness_checks(
         new_cursor = check_key.to_user_string() if check_key else None
         context.update_cursor(new_cursor)
         if checks_to_evaluate:
-            return RunRequest(asset_check_keys=checks_to_evaluate)
+            return RunRequest(asset_check_keys=checks_to_evaluate, tags=tags)
         else:
             return SkipReason(
                 "No freshness checks need to be evaluated at this time, since all checks are either currently evaluating, have failed, or are not yet overdue."

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -66,7 +66,7 @@ class SkipReason(NamedTuple("_SkipReason", [("skip_message", PublicAttr[Optional
 class RunRequest(IHaveNew, LegacyNamedTupleMixin):
     run_key: Optional[str]
     run_config: Mapping[str, Any]
-    tags: Mapping[str, str]
+    tags: Mapping[str, Any]
     job_name: Optional[str]
     asset_selection: Optional[Sequence[AssetKey]]
     stale_assets_only: bool

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -66,7 +66,7 @@ class SkipReason(NamedTuple("_SkipReason", [("skip_message", PublicAttr[Optional
 class RunRequest(IHaveNew, LegacyNamedTupleMixin):
     run_key: Optional[str]
     run_config: Mapping[str, Any]
-    tags: Mapping[str, Any]
+    tags: Mapping[str, str]
     job_name: Optional[str]
     asset_selection: Optional[Sequence[AssetKey]]
     stale_assets_only: bool

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
@@ -117,7 +117,9 @@ def test_sensor_multi_asset_different_states(instance: DagsterInstance) -> None:
             )
         )
 
-        sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
+        sensor = build_sensor_for_freshness_checks(
+            freshness_checks=freshness_checks, tags={"foo": "FOO"}
+        )
         defs = Definitions(asset_checks=freshness_checks, assets=[my_asset], sensors=[sensor])
 
         context = build_sensor_context(instance=instance, definitions=defs)
@@ -129,6 +131,7 @@ def test_sensor_multi_asset_different_states(instance: DagsterInstance) -> None:
             AssetCheckKey(AssetKey("never_eval"), "freshness_check"),
             AssetCheckKey(AssetKey("success_eval_expired"), "freshness_check"),
         ]
+        assert run_request.tags == {"foo": "FOO"}
         # Cursor should be None, since we made it through all assets.
         assert context.cursor is None
 


### PR DESCRIPTION
## Summary & Motivation

Interface for [build_sensor_for_freshness_checks](https://github.com/dagster-io/dagster/blob/64ea57c11c086e91523525011eb52df006bb126d/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py#L38) is really limited; this helps add some flexibility.

## How I Tested These Changes

I don't know if it's necessary to add a whole test for this. I could modify one of the existing tests and check that the `run_request` in the test has the right tags?

## Changelog

Added support for passing `tags` to the created `RunRequest` when using `build_sensor_for_freshness_checks()`.