### PR TITLE
Pin confluent-kafka<2.8.1 in dagster-datahub

### DIFF
--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -40,6 +40,7 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
+        "confluent-kafka<2.8.1",
     ],
     extras_require={},
     zip_safe=False,


### PR DESCRIPTION
Until wheels are published:

https://github.com/confluentinc/confluent-kafka-python/issues/1927
