### PR TITLE
Revert "Pin confluenct-kafka<2.8.1 in dagster-datahub"

### DIFF
--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -40,7 +40,6 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
-        "confluent-kafka<2.8.1",
     ],
     extras_require={},
     zip_safe=False,


### PR DESCRIPTION
This reverts commit eafa35e9058d06b4c9db0ba56af31149c246c0b5.

To land once wheels are published. Ideally before we cut our next release.