### PR TITLE
[DOCS] pin non-breaking version of confluent-kafka

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -52,6 +52,9 @@ deps =
   -e ../examples/airlift-migration-tutorial
   sling
 
+  # temporary fix for https://github.com/confluentinc/confluent-kafka-python/issues/1927
+  confluent-kafka==2.8.0
+
 [testenv:sphinx-mdx-local]
 # Since M3 Macs and Windows systems cannot parallelize the build,
 # do not set -j flag

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -51,9 +51,9 @@ deps =
   -e ../python_modules/libraries/dagster-airlift[tutorial,core,in-airflow,dbt]
   -e ../examples/airlift-migration-tutorial
   sling
-
+  
   # temporary fix for https://github.com/confluentinc/confluent-kafka-python/issues/1927
-  confluent-kafka==2.8.0
+  # confluent-kafka==2.8.0
 
 [testenv:sphinx-mdx-local]
 # Since M3 Macs and Windows systems cannot parallelize the build,


### PR DESCRIPTION
## Summary & Motivation

Temporary fix for https://github.com/confluentinc/confluent-kafka-python/issues/1927

## How I Tested These Changes

Locally ran `yarn build-api-docs`

## Changelog

> Insert changelog entry or delete this section.
