### PR TITLE
add section on run-scoped op concurrency limits

### DIFF
--- a/docs/docs/guides/operate/managing-concurrency.md
+++ b/docs/docs/guides/operate/managing-concurrency.md
@@ -108,7 +108,7 @@ concurrency:
 ## Limit the number of ops concurrently executing for a single run
 
 While pool limits allow you to [limit the number of ops executing across all runs](#limit-the-number-of-assets-or-ops-actively-executing-across-all-runs), to limit the number of ops executing *within a single run*, you need to configure your [run executor](/guides/operate/run-executors). You can
-limit concurrency for ops and assets in runs, by using `max_concurrent` in the run config, either in Python on the job definition or using the Launchpad in the Dagster UI.
+limit concurrency for ops and assets in runs, by using `max_concurrent` in the run config, either in Python or using the Launchpad in the Dagster UI.
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py" language="python" title="Limit concurrent op execution for a single run" />
 

--- a/docs/docs/guides/operate/managing-concurrency.md
+++ b/docs/docs/guides/operate/managing-concurrency.md
@@ -105,6 +105,15 @@ concurrency:
         limit: 10
 ```
 
+## Limit the number of ops concurrently executing for a single run
+
+While pool limits allow you to [limit the number of ops executing across all runs](#limit-the-number-of-assets-or-ops-actively-executing-across-all-runs), to limit the number of ops executing *within a single run*, you need to configure your [run executor](/guides/operate/run-executors). You can
+limit concurrency for ops and assets in runs, by using `max_concurrent` in the run config, either in Python on the job definition or using the Launchpad in the Dagster UI.
+
+<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py" language="python" title="Limit concurrent op execution for a single run" />
+
+The default limit for op execution within a run depends on which executor you are using.  For example, the <PyObject section="execution" module="dagster" object="multiprocess_executor" /> by default limits the number of ops executing to the value of `multiprocessing.cpu_count()` in the launched run.
+
 ## Prevent runs from starting if another run is already occurring (advanced)
 
 You can use Dagster's rich metadata to use a schedule or a sensor to only start a run when there are no currently running jobs.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py
@@ -21,21 +21,16 @@ def third_asset(context: dg.AssetExecutionContext):
     context.log.info("third asset executing")
 
 
+# limits concurrent asset execution for `my_job` runs to 2, overrides the limit set on the Definitions object
 my_job = dg.define_asset_job(
     name="my_job",
     selection=[first_asset, second_asset, third_asset],
-    config={
-        "execution": {
-            "config": {
-                "multiprocess": {
-                    "max_concurrent": 2,  # limits concurrent asset execution to 2
-                },
-            }
-        }
-    },
+    executor_def=dg.multiprocess_executor.configured({"max_concurrent": 2}),
 )
 
+# limits concurrent asset execution for all runs in this code location to 4
 defs = dg.Definitions(
     assets=[first_asset, second_asset, third_asset],
     jobs=[my_job],
+    executor=dg.multiprocess_executor.configured({"max_concurrent": 4}),
 )

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/operate/concurrency-run-scoped-op-concurrency.py
@@ -1,0 +1,41 @@
+import time
+
+import dagster as dg
+
+
+@dg.asset
+def first_asset(context: dg.AssetExecutionContext):
+    time.sleep(75)
+    context.log.info("first asset executing")
+
+
+@dg.asset
+def second_asset(context: dg.AssetExecutionContext):
+    time.sleep(75)
+    context.log.info("second asset executing")
+
+
+@dg.asset
+def third_asset(context: dg.AssetExecutionContext):
+    time.sleep(75)
+    context.log.info("third asset executing")
+
+
+my_job = dg.define_asset_job(
+    name="my_job",
+    selection=[first_asset, second_asset, third_asset],
+    config={
+        "execution": {
+            "config": {
+                "multiprocess": {
+                    "max_concurrent": 2,  # limits concurrent asset execution to 2
+                },
+            }
+        }
+    },
+)
+
+defs = dg.Definitions(
+    assets=[first_asset, second_asset, third_asset],
+    jobs=[my_job],
+)


### PR DESCRIPTION
## Summary & Motivation
Seeing uptick in questions about run-scoped op concurrency limits since `1.10.0`... Hopefully will head some of that off.

## How I Tested These Changes
Inspection

## Changelog
[docs] added concurrency section about run-scoped op concurrency
