### PR TITLE
[resources] support async yield_for_execution

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -49,7 +49,11 @@ from dagster._core.definitions.resource_definition import (
     has_at_least_one_parameter,
 )
 from dagster._core.definitions.resource_requirement import ResourceRequirement
-from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
+from dagster._core.errors import (
+    DagsterError,
+    DagsterInvalidConfigError,
+    DagsterInvalidDefinitionError,
+)
 from dagster._core.execution.context.init import InitResourceContext, build_init_resource_context
 from dagster._model.pydantic_compat_layer import model_fields
 from dagster._record import record
@@ -406,15 +410,41 @@ class ConfigurableResourceFactory(
             return updated_resource.create_resource(context)
 
     @contextlib.contextmanager
+    def _async_to_sync_cm(
+        self,
+        context: InitResourceContext,
+        async_cm: contextlib.AbstractAsyncContextManager,
+    ):
+        aio_exit_stack = contextlib.AsyncExitStack()
+        loop = context.event_loop
+        if loop is None:
+            raise DagsterError(
+                "Unable to handle resource with async def yield_for_execution in the current context. "
+                "If using direct execution utilities like build_context, pass an event loop in and use "
+                "the same event loop to execute your asset/op."
+            )
+
+        try:
+            value = loop.run_until_complete(aio_exit_stack.enter_async_context(async_cm))
+            yield value
+        finally:
+            loop.run_until_complete(aio_exit_stack.aclose())
+
+    @contextlib.contextmanager
     def _initialize_and_run_cm(
-        self, context: InitResourceContext
+        self,
+        context: InitResourceContext,
     ) -> Generator[TResValue, None, None]:
         with self._resolve_and_update_nested_resources(context) as has_nested_resource:
             updated_resource = has_nested_resource.with_replaced_resource_context(  # noqa: SLF001
                 context
             )._with_updated_values(context.resource_config)
 
-            with updated_resource.yield_for_execution(context) as value:
+            resource_cm = updated_resource.yield_for_execution(context)
+            if isinstance(resource_cm, contextlib.AbstractAsyncContextManager):
+                resource_cm = self._async_to_sync_cm(context, resource_cm)
+
+            with resource_cm as value:
                 yield value
 
     def setup_for_execution(self, context: InitResourceContext) -> None:

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -1,3 +1,4 @@
+from asyncio import AbstractEventLoop
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from typing import Any, Optional, cast
@@ -45,6 +46,7 @@ def build_resources(
     resource_config: Optional[Mapping[str, Any]] = None,
     dagster_run: Optional[DagsterRun] = None,
     log_manager: Optional[DagsterLogManager] = None,
+    event_loop: Optional[AbstractEventLoop] = None,
 ) -> Generator[Resources, None, None]:
     """Context manager that yields resources using provided resource definitions and run config.
 
@@ -67,6 +69,8 @@ def build_resources(
             teardown, this must be provided, or initialization will fail.
         log_manager (Optional[DagsterLogManager]): Log Manager to use during resource
             initialization. Defaults to system log manager.
+        event_loop (Optional[AbstractEventLoop]): An event loop for handling resources
+            with async context managers.
 
     Examples:
         .. code-block:: python
@@ -99,6 +103,7 @@ def build_resources(
             resource_keys_to_init=set(resource_defs.keys()),
             instance=dagster_instance,
             emit_persistent_events=False,
+            event_loop=event_loop,
         )
         try:
             list(resources_manager.generate_setup_events())

--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Mapping
 from typing import Any, Optional, Union
 
@@ -38,6 +39,7 @@ class InitResourceContext:
         instance: Optional[DagsterInstance] = None,
         dagster_run: Optional[DagsterRun] = None,
         log_manager: Optional[DagsterLogManager] = None,
+        event_loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         self._resource_config = resource_config
         self._resource_def = resource_def
@@ -46,6 +48,7 @@ class InitResourceContext:
         self._instance = instance
         self._resources = resources
         self._dagster_run = dagster_run
+        self._event_loop = event_loop
 
     @public
     @property
@@ -114,6 +117,10 @@ class InitResourceContext:
             dagster_run=self.dagster_run,
             log_manager=self.log,
         )
+
+    @property
+    def event_loop(self) -> Optional[asyncio.AbstractEventLoop]:
+        return self._event_loop
 
 
 class UnboundInitResourceContext(InitResourceContext):

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from asyncio import AbstractEventLoop
 from collections.abc import Mapping, Sequence
 from contextlib import ExitStack
 from typing import AbstractSet, Any, NamedTuple, Optional, Union, cast  # noqa: UP035
@@ -177,6 +178,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         partition_key_range: Optional[PartitionKeyRange],
         mapping_key: Optional[str],
         run_tags: Mapping[str, str],
+        event_loop: Optional[AbstractEventLoop],
     ):
         from dagster._core.execution.api import ephemeral_instance_if_missing
         from dagster._core.execution.context_creation_job import initialize_console_manager
@@ -198,6 +200,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
                 resources=self._resource_defs,
                 instance=self._instance,
                 resource_config=resources_config,
+                event_loop=event_loop,
             )
         )
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
@@ -212,6 +215,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         self._partition_key = partition_key
         self._partition_key_range = partition_key_range
         self._run_tags = run_tags
+        self._event_loop = event_loop
 
         # Maintains the properties on the context that are bound to a particular invocation
         # of an op
@@ -298,7 +302,11 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
             resource_defs = wrap_resources_for_execution(resources_from_args)
             # add new resources context to the stack to be cleared on exit
             resources = self._exit_stack.enter_context(
-                build_resources(resource_defs, self.instance)
+                build_resources(
+                    resource_defs,
+                    self.instance,
+                    event_loop=self._event_loop,
+                )
             )
         elif assets_def and assets_def.resource_defs:
             for key in sorted(list(assets_def.resource_defs.keys())):
@@ -313,7 +321,12 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
             )
             # add new resources context to the stack to be cleared on exit
             resources = self._exit_stack.enter_context(
-                build_resources(resource_defs, self.instance, self._resources_config)
+                build_resources(
+                    resource_defs,
+                    self.instance,
+                    self._resources_config,
+                    event_loop=self._event_loop,
+                )
             )
         else:
             # this runs the check in resources() to ensure we are in a context manager if necessary
@@ -863,6 +876,7 @@ def build_op_context(
     partition_key_range: Optional[PartitionKeyRange] = None,
     mapping_key: Optional[str] = None,
     run_tags: Optional[Mapping[str, str]] = None,
+    event_loop: Optional[AbstractEventLoop] = None,
 ) -> DirectOpExecutionContext:
     """Builds op execution context from provided parameters.
 
@@ -883,6 +897,8 @@ def build_op_context(
         partition_key (Optional[str]): String value representing partition key to execute with.
         partition_key_range (Optional[PartitionKeyRange]): Partition key range to execute with.
         run_tags: Optional[Mapping[str, str]]: The tags for the executing run.
+        event_loop: Optional[AbstractEventLoop]: An event loop for handling resources
+            with async context managers.
 
     Examples:
         .. code-block:: python
@@ -913,6 +929,7 @@ def build_op_context(
         ),
         mapping_key=check.opt_str_param(mapping_key, "mapping_key"),
         run_tags=check.opt_mapping_param(run_tags, "run_tags", key_type=str),
+        event_loop=event_loop,
     )
 
 
@@ -924,6 +941,7 @@ def build_asset_context(
     partition_key: Optional[str] = None,
     partition_key_range: Optional[PartitionKeyRange] = None,
     run_tags: Optional[Mapping[str, str]] = None,
+    event_loop: Optional[AbstractEventLoop] = None,
 ) -> DirectAssetExecutionContext:
     """Builds asset execution context from provided parameters.
 
@@ -942,6 +960,9 @@ def build_asset_context(
         partition_key (Optional[str]): String value representing partition key to execute with.
         partition_key_range (Optional[PartitionKeyRange]): Partition key range to execute with.
         run_tags: Optional[Mapping[str, str]]: The tags for the executing run.
+        event_loop: Optional[AbstractEventLoop]: An event loop for handling resources
+            with async context managers.
+
 
     Examples:
         .. code-block:: python
@@ -960,6 +981,7 @@ def build_asset_context(
         partition_key_range=partition_key_range,
         instance=instance,
         run_tags=run_tags,
+        event_loop=event_loop,
     )
 
     return DirectAssetExecutionContext(op_execution_context=op_context)

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -1,4 +1,5 @@
 import inspect
+from asyncio import AbstractEventLoop
 from collections import deque
 from collections.abc import Generator, Mapping
 from contextlib import ContextDecorator
@@ -45,6 +46,7 @@ def resource_initialization_manager(
     resource_keys_to_init: Optional[AbstractSet[str]],
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
+    event_loop: Optional[AbstractEventLoop],
 ):
     generator = resource_initialization_event_generator(
         resource_defs=resource_defs,
@@ -55,6 +57,7 @@ def resource_initialization_manager(
         resource_keys_to_init=resource_keys_to_init,
         instance=instance,
         emit_persistent_events=emit_persistent_events,
+        event_loop=event_loop,
     )
     return EventGenerationManager(generator, ScopedResourcesBuilder)
 
@@ -121,6 +124,7 @@ def _core_resource_initialization_event_generator(
     resource_keys_to_init: Optional[AbstractSet[str]],
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
+    event_loop,
 ):
     job_name = ""  # Must be initialized to a string to satisfy typechecker
     contains_generator = False
@@ -166,6 +170,7 @@ def _core_resource_initialization_event_generator(
                     resources=resources,
                     instance=instance,
                     all_resource_defs=resource_defs,
+                    event_loop=event_loop,
                 )
                 manager = single_resource_generation_manager(
                     resource_context, resource_name, resource_def
@@ -217,6 +222,7 @@ def resource_initialization_event_generator(
     resource_keys_to_init: Optional[AbstractSet[str]],
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
+    event_loop: Optional[AbstractEventLoop],
 ):
     check.inst_param(log_manager, "log_manager", DagsterLogManager)
     resource_keys_to_init = check.opt_set_param(
@@ -251,6 +257,7 @@ def resource_initialization_event_generator(
             resource_keys_to_init=resource_keys_to_init,
             instance=instance,
             emit_persistent_events=emit_persistent_events,
+            event_loop=event_loop,
         )
     except GeneratorExit:
         # Shouldn't happen, but avoid runtime-exception in case this generator gets GC-ed

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from asyncio import new_event_loop
 from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -93,6 +94,7 @@ def create_test_pipeline_execution_context(
         ),
         log_manager=log_manager,
         output_capture=None,
+        event_loop=new_event_loop(),
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_init.py
@@ -96,6 +96,7 @@ def test_clean_event_generator_exit():
         resource_keys_to_init={"a"},
         instance=instance,
         emit_persistent_events=True,
+        event_loop=None,
     )
     next(generator)
     generator.close()

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
@@ -1,8 +1,13 @@
 import asyncio
+from contextlib import asynccontextmanager
 
-from dagster import Output, asset, materialize
+import pytest
+from dagster import ConfigurableResource, Output, asset, materialize
 from dagster._core.definitions.decorators import op
+from dagster._core.errors import DagsterError
+from dagster._core.execution.context.invocation import build_asset_context, build_op_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
+from pydantic import PrivateAttr
 
 
 def test_aio_op():
@@ -33,3 +38,66 @@ def test_aio_gen_op():
 
     result = wrap_op_in_graph_and_execute(aio_gen)
     assert result.output_value() == "done"
+
+
+def test_can_run_in_async():
+    @op
+    def emit():
+        return 1
+
+    async def _go():
+        result = wrap_op_in_graph_and_execute(emit)
+        assert result.output_value() == 1
+
+    asyncio.run(_go())
+
+
+def test_aio_resource():
+    class AioResource(ConfigurableResource):
+        _loop = PrivateAttr()
+
+        @property
+        def loop(self):
+            return self._loop
+
+        @asynccontextmanager
+        async def yield_for_execution(self, context):
+            await asyncio.sleep(0)
+            self._loop = asyncio.get_running_loop()
+            yield self
+
+    @op
+    async def aio_op(aio_resource: AioResource):
+        await asyncio.sleep(0)
+        assert aio_resource.loop is asyncio.get_running_loop()
+        return "done"
+
+    result = wrap_op_in_graph_and_execute(aio_op, {"aio_resource": AioResource()})
+    assert result.output_value() == "done"
+
+    with pytest.raises(
+        DagsterError, match="Unable to handle resource with async def yield_for_execution"
+    ):
+        build_op_context({"aio_resource": AioResource()})
+
+    loop = asyncio.new_event_loop()
+    with build_op_context({"aio_resource": AioResource()}, event_loop=loop) as ctx:
+        assert loop.run_until_complete(aio_op(ctx)) == "done"
+
+    @asset
+    async def aio_asset(aio_resource: AioResource):
+        await asyncio.sleep(0)
+        assert aio_resource.loop is asyncio.get_running_loop()
+        return "done"
+
+    result = materialize([aio_asset], resources={"aio_resource": AioResource()})
+    assert result.output_for_node("aio_asset") == "done"
+
+    with pytest.raises(
+        DagsterError, match="Unable to handle resource with async def yield_for_execution"
+    ):
+        build_op_context({"aio_resource": AioResource()})
+
+    loop = asyncio.new_event_loop()
+    with build_asset_context({"aio_resource": AioResource()}, event_loop=loop) as ctx:
+        assert loop.run_until_complete(aio_asset(ctx)) == "done"  # type: ignore

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 
@@ -525,21 +524,17 @@ def test_partitioned_materialization(dlt_pipeline: Pipeline) -> None:
         month = context.partition_key[:-3]
         yield from dlt_pipeline_resource.run(context=context, dlt_source=pipeline(month))
 
-    async def run_partition(year: str):
+    def run_partition(year: str):
         return materialize(
             [example_pipeline_assets],
             resources={"dlt_pipeline_resource": DagsterDltResource()},
             partition_key=year,
         )
 
-    async def main():
-        [res1, res2] = await asyncio.gather(
-            run_partition("2022-09-01"), run_partition("2022-10-01")
-        )
-        assert res1.success
-        assert res2.success
-
-    asyncio.run(main())
+    res1 = run_partition("2022-09-01")
+    res2 = run_partition("2022-10-01")
+    assert res1.success
+    assert res2.success
 
 
 def test_with_asset_key_replacements(dlt_pipeline: Pipeline) -> None:

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import uuid
+from asyncio import AbstractEventLoop
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, AbstractSet, Any, Optional, cast  # noqa: UP035
 
@@ -85,6 +86,7 @@ class Manager:
         resource_keys_to_init: Optional[AbstractSet[str]],
         instance: Optional[DagsterInstance],
         emit_persistent_events: Optional[bool],
+        event_loop: Optional[AbstractEventLoop],
     ):
         """Drop-in replacement for
         `dagster._core.execution.resources_init.resource_initialization_manager`.  It uses a
@@ -99,6 +101,7 @@ class Manager:
             resource_keys_to_init=resource_keys_to_init,
             instance=instance,
             emit_persistent_events=emit_persistent_events,
+            event_loop=event_loop,
         )
         self.resource_manager = DagstermillResourceEventGenerationManager(
             generator, ScopedResourcesBuilder


### PR DESCRIPTION
Add support for async context manager backed resources by passing the same event loop to resource init and core execution. 

The biggest bit of awkwardness here is that to ensure the same event loop is used for both resource init and execution in the direct execution case you have to manually pass the loop in to context creation and then use it to execute your asset/op. This is demonstrated in the test. 

resolves https://github.com/dagster-io/dagster/issues/27974

## How I Tested These Changes

added tests

## Changelog

* `async def yield_for_execution`  is now supported on `ConfigurableResource`. An `event_loop` argument has been added to context builders to support direct execution. 
