### PR TITLE
[components] Clean up TOML

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -31,9 +31,9 @@ from dagster_dg.utils import (
     exit_with_error,
     generate_missing_dagster_components_in_local_venv_error_message,
     generate_tool_dg_cli_in_project_in_workspace_error_message,
-    get_toml_value,
+    get_toml_node,
     get_venv_executable,
-    has_toml_value,
+    has_toml_node,
     pushd,
     resolve_local_venv,
     strip_activated_venv_from_env_vars,
@@ -378,10 +378,10 @@ class DgContext:
         if not self.pyproject_toml_path.exists():
             return {}
         toml = tomlkit.parse(self.pyproject_toml_path.read_text())
-        if not has_toml_value(toml, ("project", "entry-points", "dagster.components")):
+        if not has_toml_node(toml, ("project", "entry-points", "dagster.components")):
             return {}
         else:
-            return get_toml_value(
+            return get_toml_node(
                 toml,
                 ("project", "entry-points", "dagster.components"),
                 (tomlkit.items.Table, tomlkit.items.InlineTable),

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -6,10 +6,10 @@ import re
 import subprocess
 import sys
 import textwrap
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Literal, Optional, TypeVar, Union, overload
 
 import click
 import jinja2
@@ -233,6 +233,28 @@ def _should_skip_file(path: str, excludes: list[str] = DEFAULT_FILE_EXCLUDE_PATT
     return False
 
 
+@contextlib.contextmanager
+def modify_toml(path: Path) -> Iterator[tomlkit.TOMLDocument]:
+    toml = tomlkit.parse(path.read_text())
+    yield toml
+    path.write_text(tomlkit.dumps(toml))
+
+
+@contextlib.contextmanager
+def modify_toml_as_dict(path: Path) -> Iterator[dict[str, Any]]:  # unwrap gets the dict
+    """Modify a TOML file as a plain python dict, destroying any comments or formatting.
+
+    This is a destructive means of modifying TOML. We convert the parsed TOML document into a plain
+    python object, modify it, and then write it back to the file. This will destroy comments and
+    styling. It is useful mostly in a testing context where we want to e.g. set arbitrary invalid
+    values in the file without worrying about the details of the TOML syntax (it has multiple kinds of
+    dict-like objects, for instance).
+    """
+    toml_dict = tomlkit.parse(path.read_text()).unwrap()
+    yield toml_dict
+    path.write_text(tomlkit.dumps(toml_dict))
+
+
 def ensure_dagster_dg_tests_import() -> None:
     from dagster_dg import __file__ as dagster_dg_init_py
 
@@ -440,64 +462,185 @@ def parse_json_option(context: click.Context, param: click.Option, value: str):
 # ##### TOML MANIPULATION
 # ########################
 
+TomlPath: TypeAlias = tuple[Union[str, int], ...]
+TomlDoc: TypeAlias = Union[tomlkit.TOMLDocument, dict[str, Any]]
 
-def get_toml_value(
-    doc: tomlkit.TOMLDocument,
-    path: Iterable[str],
+
+def get_toml_node(
+    doc: TomlDoc,
+    path: TomlPath,
     expected_type: Union[type[T], tuple[type[T], ...]],
 ) -> T:
     """Given a tomlkit-parsed document/table (`doc`),retrieve the nested value at `path` and ensure
     it is of type `expected_type`. Returns the value if so, or raises a KeyError / TypeError if not.
     """
-    current: Any = doc
-    for key in path:
-        # If current is not a table/dict or doesn't have the key, error out
-        if not isinstance(current, dict) or key not in current:
-            raise KeyError(f"Key '{key}' not found in path: {'.'.join(path)}")
-        current = current[key]
-
-    # Finally, ensure the found value is of the expected type
-    if not isinstance(current, expected_type):
+    value = _gather_toml_nodes(doc, path)[-1]
+    if not isinstance(value, expected_type):
         expected_types = expected_type if isinstance(expected_type, tuple) else (expected_type,)
         type_str = " or ".join(t.__name__ for t in expected_types)
         raise TypeError(
-            f"Expected '{'.'.join(path)}' to be {type_str}, "
-            f"but got {type(current).__name__} instead."
+            f"Expected '{toml_path_to_str(path)}' to be {type_str}, "
+            f"but got {type(value).__name__} instead."
         )
-    return current
+    return value
 
 
-def has_toml_value(doc: tomlkit.TOMLDocument, path: Sequence[str]) -> bool:
+def has_toml_node(doc: TomlDoc, path: TomlPath) -> bool:
     """Given a tomlkit-parsed document/table (`doc`), return whether a value is defined at `path`."""
-    leading_path, key = path[:-1], path[-1]
-    current = doc
-    for leading_key in leading_path:
-        if not isinstance(current, dict) or leading_key not in current:
-            return False
-        current = current[leading_key]
-    return isinstance(current, dict) and key in current
+    result = _gather_toml_nodes(doc, path, error_on_missing=False)
+    return False if result is None else True
 
 
-def delete_toml_value(doc: tomlkit.TOMLDocument, path: Sequence[str]) -> None:
+def delete_toml_node(doc: TomlDoc, path: TomlPath) -> None:
     """Given a tomlkit-parsed document/table (`doc`), delete the nested value at `path`. Raises
-    an error if the leading keys do not already lead to a dictionary.
+    an error if the leading keys do not already lead to a TOML container node.
     """
-    dct = get_toml_value(doc, path[:-1], dict) if len(path) > 1 else doc
-    del dct[path[-1]]
+    nodes = _gather_toml_nodes(doc, path)
+    container = nodes[-2]
+    key_or_index = path[-1]
+    if isinstance(container, dict):
+        del container[path[-1]]
+    elif isinstance(container, list):
+        assert isinstance(key_or_index, int)  # We already know this from _traverse_toml_path
+        container.pop(key_or_index)
+    else:
+        raise Exception("Unreachable.")
 
 
-def set_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], value: object) -> None:
+def set_toml_node(doc: TomlDoc, path: TomlPath, value: object) -> None:
     """Given a tomlkit-parsed document/table (`doc`),set a nested value at `path` to `value`. Raises
-    an error if the leading keys do not already lead to a dictionary.
+    an error if the leading keys do not already lead to a TOML container node.
     """
-    path_list = list(path)
+    container = _gather_toml_nodes(doc, path[:-1])[-1]
+    key_or_index = path[-1]
+    if isinstance(container, dict):
+        if not isinstance(key_or_index, str):
+            raise TypeError(f"Expected key to be a string, but got {type(key_or_index).__name__}")
+        container[key_or_index] = value
+    elif isinstance(container, list):
+        if not isinstance(key_or_index, int):
+            raise TypeError(f"Expected key to be an integer, but got {type(key_or_index).__name__}")
+        container[key_or_index] = value
+    else:
+        raise Exception("Unreachable.")
+
+
+@overload
+def _gather_toml_nodes(
+    doc: TomlDoc, path: TomlPath, error_on_missing: Literal[True] = ...
+) -> list[Any]: ...
+
+
+@overload
+def _gather_toml_nodes(
+    doc: TomlDoc, path: TomlPath, error_on_missing: Literal[False] = ...
+) -> Optional[list[Any]]: ...
+
+
+def _gather_toml_nodes(
+    doc: TomlDoc, path: TomlPath, error_on_missing: bool = True
+) -> Optional[list[Any]]:
+    nodes: list[Any] = []
     current: Any = doc
-    for key in path_list[:-1]:
-        if key not in current:
-            current[key] = {}
-        elif not isinstance(current[key], dict):
+    for key in path:
+        if isinstance(key, str):
+            if not isinstance(current, dict) or key not in current:
+                if error_on_missing:
+                    raise KeyError(f"Key '{key}' not found in path: {toml_path_to_str(path)}")
+                return None
+            current = current[key]
+        elif isinstance(key, int):
+            if not isinstance(current, list) or key < 0 or key >= len(current):
+                if error_on_missing:
+                    raise KeyError(f"Index '{key}' not found in path: {toml_path_to_str(path)}")
+                return None
+            current = current[key]
+        else:
+            raise TypeError(f"Expected key to be a string or integer, but got {type(key)}")
+        nodes.append(current)
+
+    return nodes
+
+
+def toml_path_to_str(path: TomlPath) -> str:
+    first, rest = path[0], path[1:]
+    if not isinstance(first, str):
+        raise TypeError(f"Expected first element of path to be a string, but got {type(first)}")
+    str_path = first
+    for item in rest:
+        if isinstance(item, int):
+            str_path += f"[{item}]"
+        elif isinstance(item, str):
+            str_path += f".{item}"
+        else:
             raise TypeError(
-                f"Expected '{key}' to be a table, but got {type(current[key]).__name__}."
+                f"Expected path elements to be strings or integers, but got {type(item)}"
             )
-        current = current[key]
-    current[path_list[-1]] = value
+    return str_path
+
+
+def toml_path_from_str(path: str) -> TomlPath:
+    tokens = []
+    for segment in path.split("."):
+        # Split each segment by bracketed chunks, e.g. "key[1]" -> ["key", "[1]"]
+        parts = re.split(r"(\[\d+\])", segment)
+        for p in parts:
+            if not p:  # Skip empty strings
+                continue
+            if p.startswith("[") and p.endswith("]"):
+                tokens.append(int(p[1:-1]))  # Convert "[1]" to integer 1
+            else:
+                tokens.append(p)
+    return tuple(tokens)
+
+
+def create_toml_node(
+    doc: dict[str, Any],
+    path: tuple[Union[str, int], ...],
+    value: object,
+) -> None:
+    """Set a toml node at a path that consists of a sequence of keys and integer indices.
+    Intermediate containers that don't yet exist will be created along the way based on the types of
+    the keys. Note that this does not support TOMLDocument objects, only plain dictionaries. The
+    reason is that the correct type of container to insert at intermediate nodes is ambiguous for
+    TOMLDocmuent objects.
+    """
+    if isinstance(doc, tomlkit.TOMLDocument):
+        raise TypeError(
+            "`create_toml_node` only works on the plain dictionary representation of a TOML document."
+        )
+    current: Any = doc
+    for i, key in enumerate(path):
+        is_final_key = i == len(path) - 1
+        if isinstance(key, str):
+            if not isinstance(current, dict):
+                raise KeyError(f"Key '{key}' not found in path: {toml_path_to_str(path)}")
+            elif is_final_key:
+                current[key] = value
+            elif key not in current:
+                current[key] = _get_new_container_node(path[i + 1])
+            current = current[key]
+        elif isinstance(key, int):
+            if not isinstance(current, list):
+                raise KeyError(f"Index '{key}' not found in path: {toml_path_to_str(path)}")
+            is_key_in_range = key >= 0 and key < len(current)
+            is_append_key = key == len(current)
+            if is_final_key and is_key_in_range:
+                current[key] = value
+            elif is_final_key and is_append_key:
+                current.append(value)
+            elif is_key_in_range:
+                current = current[key]
+            elif is_append_key:
+                current.append(_get_new_container_node(path[i + 1]))
+                current = current[key]
+            else:
+                raise KeyError(f"Key '{key}' not found in path: {toml_path_to_str(path)}")
+        else:
+            raise TypeError(f"Expected key to be a string or integer, but got {type(key)}")
+
+
+def _get_new_container_node(
+    representative_key: Union[int, str],
+) -> Union[dict[str, Any], list[Any]]:
+    return [] if isinstance(representative_key, int) else {}

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -15,14 +15,18 @@ from dagster_components.test.test_cases import (
     ComponentValidationTestCase,
     msg_includes_all_of,
 )
-from dagster_dg.utils import ensure_dagster_dg_tests_import, pushd, set_toml_value
+from dagster_dg.utils import (
+    create_toml_node,
+    ensure_dagster_dg_tests_import,
+    modify_toml_as_dict,
+    pushd,
+)
 
 ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import (
     ProxyRunner,
     assert_runner_result,
     isolated_example_project_foo_bar,
-    modify_pyproject_toml,
 )
 
 COMPONENT_INTEGRATION_TEST_DIR = (
@@ -75,8 +79,8 @@ def create_project_from_components(
 
 def test_check_component_succeeds_non_default_defs_module() -> None:
     with ProxyRunner.test() as runner, create_project_from_components(runner):
-        with modify_pyproject_toml() as toml:
-            set_toml_value(toml, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+            create_toml_node(toml_dict, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
 
         # We need to do all of this copying here rather than relying on the project setup
         # fixture because that fixture assumes a default component package.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -8,14 +8,21 @@ import pytest
 from dagster_dg.config import DgFileConfigDirectoryType, get_type_str
 from dagster_dg.context import DgContext
 from dagster_dg.error import DgError
-from dagster_dg.utils import delete_toml_value, pushd, set_toml_value
+from dagster_dg.utils import (
+    TomlPath,
+    create_toml_node,
+    delete_toml_node,
+    modify_toml_as_dict,
+    pushd,
+    toml_path_from_str,
+    toml_path_to_str,
+)
 
 from dagster_dg_tests.utils import (
     ProxyRunner,
     isolated_components_venv,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
-    modify_pyproject_toml,
 )
 
 
@@ -29,8 +36,8 @@ def test_context_in_workspace():
         assert context.workspace_root_path == Path.cwd()
 
         # Test config properly set
-        with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+            create_toml_node(toml_dict, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_workspace_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
@@ -47,14 +54,14 @@ def test_context_in_project_in_workspace():
         assert context.config.cli.verbose is False  # default
 
         # Test config inheritance from workspace
-        with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+            create_toml_node(toml_dict, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
         # Test cli config in project is ignored and generates warning
-        with pushd(project_path), modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), False)
+        with pushd(project_path), modify_toml_as_dict(Path("pyproject.toml")) as pyproject_toml:
+            create_toml_node(pyproject_toml, ("tool", "dg", "cli", "verbose"), False)
         with pytest.warns(match="`tool.dg.cli` section detected in project"):
             context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
@@ -68,12 +75,12 @@ def test_context_in_project_outside_workspace():
 
         context = DgContext.for_project_environment(path_arg, {})
         assert context.root_path == project_path
-        assert context.workspace_root_path is None
+        assert context.is_workspace is False
         assert context.config.cli.verbose is False
 
         # Test CLI setting is used in project outside of workspace
-        with modify_pyproject_toml() as pyproject_toml:
-            set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
+        with modify_toml_as_dict(Path("pyproject.toml")) as pyproject_toml:
+            create_toml_node(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
@@ -82,7 +89,7 @@ def test_context_outside_project_or_workspace():
     with ProxyRunner.test() as runner, isolated_components_venv(runner):
         context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
         assert context.root_path == Path.cwd()
-        assert context.workspace_root_path is None
+        assert context.is_workspace is False
         assert context.config.cli.verbose is False
 
 
@@ -98,33 +105,31 @@ def test_invalid_config_type():
     with ProxyRunner.test() as runner, isolated_example_workspace(runner):
         with _reset_pyproject_toml():
             _set_and_detect_missing_required_key(
-                ("tool", "dg", "directory_type"), DgFileConfigDirectoryType
+                ("tool.dg.directory_type"), DgFileConfigDirectoryType
             )
         with _reset_pyproject_toml():
-            _set_and_detect_mistyped_value(
-                ("tool", "dg", "directory_type"), DgFileConfigDirectoryType, 1
-            )
+            _set_and_detect_mistyped_value(("tool.dg.directory_type"), DgFileConfigDirectoryType, 1)
 
 
 def test_invalid_config_workspace():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner, "foo-bar"):
-        paths = [
-            ("tool", "dg", "invalid_key"),
-            ("tool", "dg", "project"),
-            ("tool", "dg", "library"),
-            ("tool", "dg", "cli", "invalid_key"),
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, project_name="foo-bar"):
+        cases = [
+            "tool.dg.invalid_key",
+            "tool.dg.project",
+            "tool.dg.cli.invalid_key",
+            "tool.dg.workspace.invalid_key",
         ]
-        for case in paths:
+        for path in cases:
             with _reset_pyproject_toml():
-                _set_and_detect_invalid_key(case)
+                _set_and_detect_invalid_key(path)
 
         cases = [
-            [("tool", "dg", "cli", "disable_cache"), bool, 1],
-            [("tool", "dg", "cli", "cache_dir"), str, 1],
-            [("tool", "dg", "cli", "verbose"), bool, 1],
-            [("tool", "dg", "cli", "use_component_modules"), Sequence[str], 1],
-            [("tool", "dg", "cli", "use_dg_managed_environment"), bool, 1],
-            [("tool", "dg", "cli", "require_local_venv"), bool, 1],
+            ["tool.dg.cli.disable_cache", bool, 1],
+            ["tool.dg.cli.cache_dir", str, 1],
+            ["tool.dg.cli.verbose", bool, 1],
+            ["tool.dg.cli.use_dg_managed_environment", bool, 1],
+            ["tool.dg.cli.use_component_modules", Sequence[str], 1],
+            ["tool.dg.cli.require_local_venv", bool, 1],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():
@@ -134,28 +139,27 @@ def test_invalid_config_workspace():
 def test_invalid_config_project():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         paths = [
-            ("tool", "dg", "invalid_key"),
-            ("tool", "dg", "project", "invalid_key"),
-            ("tool", "dg", "library"),
-            ("tool", "dg", "cli", "invalid_key"),
+            "tool.dg.invalid_key",
+            "tool.dg.project.invalid_key",
+            "tool.dg.cli.invalid_key",
         ]
         for case in paths:
             with _reset_pyproject_toml():
                 _set_and_detect_invalid_key(case)
 
         cases = [
-            [("tool", "dg", "cli", "verbose"), bool, 1],
-            [("tool", "dg", "project", "root_module"), str, 1],
-            [("tool", "dg", "project", "defs_module"), str, 1],
-            [("tool", "dg", "project", "code_location_name"), str, 1],
-            [("tool", "dg", "project", "code_location_target_module"), str, 1],
+            [("tool.dg.cli.verbose"), bool, 1],
+            [("tool.dg.project.root_module"), str, 1],
+            [("tool.dg.project.defs_module"), str, 1],
+            [("tool.dg.project.code_location_name"), str, 1],
+            [("tool.dg.project.code_location_target_module"), str, 1],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():
                 _set_and_detect_mistyped_value(path, expected_type, val)
 
         cases = [
-            [("tool", "dg", "project", "root_module"), str],
+            ["tool.dg.project.root_module", str],
         ]
         for path, expected_type in cases:
             with _reset_pyproject_toml():
@@ -168,13 +172,13 @@ def test_code_location_config():
         assert context.code_location_target_module_name == "foo_bar.definitions"
         assert context.code_location_name == "foo-bar"
 
-        with modify_pyproject_toml() as toml:
-            set_toml_value(
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+            create_toml_node(
                 toml,
                 ("tool", "dg", "project", "code_location_target_module"),
                 "foo_bar._definitions",
             )
-            set_toml_value(
+            create_toml_node(
                 toml, ("tool", "dg", "project", "code_location_name"), "my-code_location"
             )
 
@@ -195,32 +199,36 @@ def _reset_pyproject_toml():
     Path("pyproject.toml").write_text(original)
 
 
-def _set_and_detect_error(path: tuple[str, ...], config_value: object, error_message: str):
-    with modify_pyproject_toml() as toml:
-        set_toml_value(toml, path, config_value)
+def _set_and_detect_error(path: TomlPath, config_value: object, error_message: str):
+    with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+        create_toml_node(toml, path, config_value)
     with pytest.raises(DgError, match=re.escape(error_message)):
         DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
 
 
-def _set_and_detect_invalid_key(path: tuple[str, ...], config_value: object = True):
-    leading_path, key = ".".join(path[:-1]), path[-1]
-    error_message = rf"Unrecognized fields in `{leading_path}`: ['{key}']"
+def _set_and_detect_invalid_key(str_path: str, config_value: object = True):
+    path = toml_path_from_str(str_path)
+    leading_str_path, key = toml_path_to_str(path[:-1]), path[-1]
+    error_message = rf"Unrecognized fields in `{leading_str_path}`: ['{key}']"
     _set_and_detect_error(path, config_value, error_message)
 
 
 # expected_type Any to handle typing constructs (`Literal` etc)
-def _set_and_detect_mistyped_value(path: tuple[str, ...], expected_type: Any, config_value: object):
-    key = ".".join(path)
+def _set_and_detect_mistyped_value(str_path: str, expected_type: Any, config_value: object):
+    path = toml_path_from_str(str_path)
     expected_str = get_type_str(expected_type)
-    error_message = rf"Invalid value for `{key}`. Expected {expected_str}, got `{config_value}`"
+    error_message = (
+        rf"Invalid value for `{str_path}`. Expected {expected_str}, got `{config_value}`"
+    )
     _set_and_detect_error(path, config_value, error_message)
 
 
-def _set_and_detect_missing_required_key(path: tuple[str, ...], expected_type: Any) -> None:
-    key = ".".join(path)
+# expected_type Any to handle typing constructs (`Literal` etc)
+def _set_and_detect_missing_required_key(str_path: str, expected_type: Any):
+    path = toml_path_from_str(str_path)
     expected_str = get_type_str(expected_type)
-    error_message = rf"Missing required value for `{key}`. Expected {expected_str}"
-    with modify_pyproject_toml() as toml:
-        delete_toml_value(toml, path)
-    with pytest.raises(DgError, match=error_message):
+    error_message = rf"Missing required value for `{str_path}`. Expected {expected_str}"
+    with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+        delete_toml_node(toml, path)
+    with pytest.raises(DgError, match=re.escape(error_message)):
         DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})


### PR DESCRIPTION
## Summary & Motivation

Cleanup/enhancement of some of the TOML utilities we use for validation and modification of TOML files. The enhancements are needed upstack when we start adding `[[tool.dg.workspace.projects]]` entries.

- Change utility method `modify_pyproject.toml` to more general `modify_toml`
- Add `modify_toml_as_dict` to get a plain dict instead of a TOML document object. This is useful in config testing where it's fine to nuke styling and write the modified dict back as new TOML. Modifying the `TOMLDocument` object is more involved.
- Allow TOML paths used for TOML accessors to include array indices

This entire TOML util section will leave `dg` and become a part of a factored out utility package when we do that (if we cannot find a well-maintained library that supports this stuff, which I was unable to find-- we need `tomlkit` for style/comment preservation when we modify TOML files but it's pretty low level).

## How I Tested These Changes

Existing test suite.