### PR TITLE
[5/n][dagster-dbt] Implement load_dbt_cloud_asset_specs and load_dbt_cloud_check_specs

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -726,8 +726,13 @@ DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
 DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
 
 
+<<<<<<< HEAD
 def get_dagster_adhoc_job_name(project_id: int, environment_id: int) -> str:
     return f"{DAGSTER_ADHOC_PREFIX}{project_id}__{environment_id}"
+=======
+def get_job_name(environment_id: int, project_id: int) -> str:
+    return f"{DAGSTER_ADHOC_PREFIX}{project_id}__{environment_id}_4"
+>>>>>>> f954d5eb97 (Fix unique id)
 
 
 @preview
@@ -765,6 +770,10 @@ class DbtCloudWorkspace(ConfigurableResource):
         default=15,
         description="Time (in seconds) after which the requests to dbt Cloud are declared timed out.",
     )
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self.project_id}-{self.environment_id}"
 
     @cached_method
     def get_client(self) -> DbtCloudWorkspaceClient:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -726,13 +726,8 @@ DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
 DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
 
 
-<<<<<<< HEAD
 def get_dagster_adhoc_job_name(project_id: int, environment_id: int) -> str:
     return f"{DAGSTER_ADHOC_PREFIX}{project_id}__{environment_id}"
-=======
-def get_job_name(environment_id: int, project_id: int) -> str:
-    return f"{DAGSTER_ADHOC_PREFIX}{project_id}__{environment_id}_4"
->>>>>>> f954d5eb97 (Fix unique id)
 
 
 @preview

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -853,7 +853,7 @@ class DbtCloudWorkspace(ConfigurableResource):
             asset_check_specs = check.is_list(
                 [
                     check_spec
-                    for asset_def in defs.asset_checks
+                    for asset_def in defs.asset_checks or []
                     for check_spec in asset_def.check_specs
                 ],
                 AssetCheckSpec,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -4,12 +4,16 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Any, NamedTuple, Optional, cast
+from functools import lru_cache
+from typing import Any, NamedTuple, Optional, Union, cast
 from urllib.parse import urlencode, urljoin
 
 import requests
 from dagster import (
+    AssetCheckSpec,
+    AssetSpec,
     ConfigurableResource,
+    Definitions,
     Failure,
     IAttachDifferentObjectToOpContext,
     MetadataValue,
@@ -20,15 +24,19 @@ from dagster import (
 )
 from dagster._annotations import beta, preview
 from dagster._config.pythonic_config.resource import ResourceDependency
+from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
+from dagster._record import record
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 from requests.exceptions import RequestException
 
+from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.cloud.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud.run_handler import DbtCloudJobRunHandler
 from dagster_dbt.cloud.types import DbtCloudJob, DbtCloudOutput, DbtCloudWorkspaceData
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 DBT_DEFAULT_HOST = "https://cloud.getdbt.com/"
 DBT_API_V2_PATH = "api/v2/accounts/"
@@ -714,7 +722,7 @@ def dbt_cloud_resource(context) -> DbtCloudResource:
 # ------------------
 
 DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
-LIST_JOBS_INDIVIDUAL_REQUEST_LIMIT = 100
+DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
 
 
 def get_dagster_adhoc_job_name(project_id: int, environment_id: int) -> str:
@@ -815,3 +823,82 @@ class DbtCloudWorkspace(ConfigurableResource):
             job_id=job.id,
             manifest=run_handler.get_manifest(),
         )
+
+    # Cache spec retrieval for a specific translator class.
+    @lru_cache(maxsize=1)
+    def load_specs(
+        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+    ) -> Sequence[Union[AssetSpec, AssetCheckSpec]]:
+        dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
+
+        with self.process_config_and_initialize_cm() as initialized_workspace:
+            defs = DbtCloudWorkspaceDefsLoader(
+                workspace=initialized_workspace,
+                translator=dagster_dbt_translator,
+            ).build_defs()
+            asset_specs = check.is_list(
+                defs.assets,
+                AssetSpec,
+            )
+            asset_check_specs = check.is_list(
+                defs.asset_checks,
+                AssetCheckSpec,
+            )
+            return [*asset_specs, *asset_check_specs]
+
+    def load_asset_specs(
+        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+    ) -> Sequence[AssetSpec]:
+        return [
+            spec
+            for spec in self.get_specs(dagster_dbt_translator=dagster_dbt_translator)
+            if isinstance(spec, AssetSpec)
+        ]
+
+    def load_check_specs(
+        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+    ) -> Sequence[AssetCheckSpec]:
+        return [
+            spec
+            for spec in self.get_specs(dagster_dbt_translator=dagster_dbt_translator)
+            if isinstance(spec, AssetCheckSpec)
+        ]
+
+
+@preview
+def load_dbt_cloud_asset_specs(
+    workspace: DbtCloudWorkspace, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+) -> Sequence[AssetSpec]:
+    return workspace.load_asset_specs(dagster_dbt_translator=dagster_dbt_translator)
+
+
+@preview
+def load_dbt_cloud_check_specs(
+    workspace: DbtCloudWorkspace, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+) -> Sequence[AssetCheckSpec]:
+    return workspace.load_check_specs(dagster_dbt_translator=dagster_dbt_translator)
+
+
+@preview
+@record
+class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspaceData]):
+    workspace: DbtCloudWorkspace
+    translator: DagsterDbtTranslator
+
+    @property
+    def defs_key(self) -> str:
+        return f"{DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX}.{self.workspace.unique_id}"
+
+    def fetch_state(self) -> DbtCloudWorkspaceData:
+        return self.workspace.fetch_workspace_data()
+
+    def defs_from_state(self, state: DbtCloudWorkspaceData) -> Definitions:
+        all_asset_specs, all_check_specs = build_dbt_specs(
+            manifest=state.manifest,
+            translator=self.translator,
+            select="fqn:*",
+            exclude="",
+            io_manager_key=None,
+            project=None,
+        )
+        return Definitions(assets=all_asset_specs, asset_checks=all_check_specs)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -916,7 +916,7 @@ class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspace
             project=None,
         )
 
-        # External facing checks are not support yet
+        # External facing checks are not supported yet
         # https://linear.app/dagster-labs/issue/AD-915/support-external-asset-checks-in-dbt-cloud-v2
         @multi_asset_check(specs=all_check_specs)
         def _all_asset_checks(): ...

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -768,6 +768,11 @@ class DbtCloudWorkspace(ConfigurableResource):
 
     @property
     def unique_id(self) -> str:
+        """Unique ID for this dbt Cloud workspace, which is composed of the project ID and environment ID.
+
+        Returns:
+            str: the unique ID for this dbt Cloud workspace.
+        """
         return f"{self.project_id}-{self.environment_id}"
 
     @cached_method
@@ -911,6 +916,8 @@ class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspace
             project=None,
         )
 
+        # External facing checks are not support yet
+        # https://linear.app/dagster-labs/issue/AD-915/support-external-asset-checks-in-dbt-cloud-v2
         @multi_asset_check(specs=all_check_specs)
         def _all_asset_checks(): ...
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -20,6 +20,7 @@ from dagster import (
     __version__,
     _check as check,
     get_dagster_logger,
+    multi_asset_check,
     resource,
 )
 from dagster._annotations import beta, preview
@@ -841,7 +842,11 @@ class DbtCloudWorkspace(ConfigurableResource):
                 AssetSpec,
             )
             asset_check_specs = check.is_list(
-                defs.asset_checks,
+                [
+                    check_spec
+                    for asset_def in defs.asset_checks
+                    for check_spec in asset_def.check_specs
+                ],
                 AssetCheckSpec,
             )
             return [*asset_specs, *asset_check_specs]
@@ -851,7 +856,7 @@ class DbtCloudWorkspace(ConfigurableResource):
     ) -> Sequence[AssetSpec]:
         return [
             spec
-            for spec in self.get_specs(dagster_dbt_translator=dagster_dbt_translator)
+            for spec in self.load_specs(dagster_dbt_translator=dagster_dbt_translator)
             if isinstance(spec, AssetSpec)
         ]
 
@@ -860,7 +865,7 @@ class DbtCloudWorkspace(ConfigurableResource):
     ) -> Sequence[AssetCheckSpec]:
         return [
             spec
-            for spec in self.get_specs(dagster_dbt_translator=dagster_dbt_translator)
+            for spec in self.load_specs(dagster_dbt_translator=dagster_dbt_translator)
             if isinstance(spec, AssetCheckSpec)
         ]
 
@@ -901,4 +906,8 @@ class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspace
             io_manager_key=None,
             project=None,
         )
-        return Definitions(assets=all_asset_specs, asset_checks=all_check_specs)
+
+        @multi_asset_check(specs=all_check_specs)
+        def _all_asset_checks(): ...
+
+        return Definitions(assets=all_asset_specs, asset_checks=[_all_asset_checks])

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/preview/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/preview/test_specs.py
@@ -35,6 +35,9 @@ def test_load_asset_specs(
     first_asset_key = next(key for key in sorted(all_assets_keys))
     assert first_asset_key.path == ["customers"]
 
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()
+
 
 def test_load_check_specs(
     workspace: DbtCloudWorkspace,
@@ -51,3 +54,6 @@ def test_load_check_specs(
     first_check_key = next(key for key in sorted(all_checks_keys))
     assert first_check_key.name == "not_null_customers_customer_id"
     assert first_check_key.asset_key.path == ["customers"]
+
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/preview/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/preview/test_specs.py
@@ -18,3 +18,36 @@ def test_fetch_dbt_cloud_workspace_data(
     assert workspace_data.environment_id == TEST_ENVIRONMENT_ID
     assert workspace_data.job_id == TEST_JOB_ID
     assert workspace_data.manifest == get_sample_manifest_json()
+
+
+def test_load_asset_specs(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_assets = workspace.load_asset_specs()
+    all_assets_keys = [asset.key for asset in all_assets]
+
+    # 8 dbt models
+    assert len(all_assets) == 8
+    assert len(all_assets_keys) == 8
+
+    # Sanity check outputs
+    first_asset_key = next(key for key in sorted(all_assets_keys))
+    assert first_asset_key.path == ["customers"]
+
+
+def test_load_check_specs(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_checks = workspace.load_check_specs()
+    all_checks_keys = [check.key for check in all_checks]
+
+    # 8 dbt models
+    assert len(all_checks) == 20
+    assert len(all_checks_keys) == 20
+
+    # Sanity check outputs
+    first_check_key = next(key for key in sorted(all_checks_keys))
+    assert first_check_key.name == "not_null_customers_customer_id"
+    assert first_check_key.asset_key.path == ["customers"]


### PR DESCRIPTION
## Summary & Motivation

This PR adds the `load_dbt_cloud_asset_specs` and `load_dbt_cloud_check_specs` methods.

These methods leverages state-backed definitions. The state loader uses `build_dbt_specs` to create both asset and check specs - this function is used in dbt Core to load specs. This function takes a manifest file, which we fetch from dbt Cloud using `DbtCloudWorkspace.fetch_workspace_data`, and a `DagsterDbtTranslator`.

The goal here is to make sure that:
- assets for dbt Core and dbt Cloud are both loaded using the manifest file
- the same translator can be used with dbt Core or dbt Cloud.

```python
import dagster as dg
from dagster_dbt.cloud.resources import (
    DbtCloudCredentials,
    DbtCloudWorkspace,
    load_dbt_cloud_asset_specs,
    load_dbt_cloud_check_specs,
)

creds = DbtCloudCredentials(
    account_id=dg.EnvVar("DBT_CLOUD_ACCOUNT_ID"),
    access_url=dg.EnvVar("DBT_CLOUD_ACCESS_URL"),
    token=dg.EnvVar("DBT_CLOUD_TOKEN"),
)

workspace = DbtCloudWorkspace(
    credentials=creds,
    project_id=dg.EnvVar("DBT_CLOUD_PROJECT_ID"),
    environment_id=dg.EnvVar("DBT_CLOUD_ENVIRONMENT_ID"),
)

assets = load_dbt_cloud_asset_specs(workspace=workspace)
checks = load_dbt_cloud_checks_specs(workspace=workspace)
```

## How I Tested These Changes

Additional tests with BK.