### PR TITLE
Ignore *.ambr files in diffs, just like uv.lock files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.py diff=python
 **/uv.lock linguist-generated
+**/*.ambr linguist-generated


### PR DESCRIPTION
## Summary & Motivation

As https://app.graphite.dev/github/pr/dagster-io/internal/14067 demonstrates we should ignore .ambr files 

## How I Tested These Changes

Read file

## Changelog

NOCHANGELOG

