### PR TITLE
[components] Switch dagster-dg tests to explicitly opt in to fixed test components

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -175,7 +175,10 @@ def test_sub_command_with_option_help_message():
 
 
 def test_dynamic_subcommand_help_message():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         with fixed_panel_width(width=120):
             result = runner.invoke(
                 "scaffold",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
@@ -10,7 +10,10 @@ from dagster_dg_tests.utils import ProxyRunner, assert_runner_result, isolated_c
 
 
 def test_docs_component_type_success():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "docs", "component-type", "dagster_test.components.SimpleAssetComponent"
         )
@@ -26,7 +29,10 @@ def _includes_ignore_indent(text: str, substr: str) -> bool:
 
 
 def test_docs_component_type_success_output_console():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "docs",
             "component-type",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -134,7 +134,10 @@ def test_no_local_venv_failure(spec: CommandSpec) -> None:
     ids=lambda spec: "-".join(spec.command),
 )
 def test_no_local_dagster_components_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         _uninstall_dagster_components_from_local_venv(Path.cwd())
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
@@ -154,7 +157,7 @@ def test_no_local_dagster_components_failure(spec: CommandSpec) -> None:
     ids=lambda spec: "-".join(spec.command),
 )
 def test_no_ambient_dagster_components_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+    with ProxyRunner.test(use_fixed_test_components=True) as runner, runner.isolated_filesystem():
         cli_args = _add_global_cli_options(spec.to_cli_args(), "--no-require-local-venv")
         # Set $PATH to /dev/null to ensure that the `dagster-components` executable is not found
         result = runner.invoke(*cli_args, "--no-require-local-venv", env={"PATH": "/dev/null"})
@@ -164,7 +167,10 @@ def test_no_ambient_dagster_components_failure(spec: CommandSpec) -> None:
 
 @pytest.mark.parametrize("spec", PROJECT_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command))
 def test_no_project_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster project directory" in result.output
@@ -174,7 +180,10 @@ def test_no_project_failure(spec: CommandSpec) -> None:
     "spec", COMPONENT_LIBRARY_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command)
 )
 def test_no_component_library_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster component library directory" in result.output
@@ -184,7 +193,10 @@ def test_no_component_library_failure(spec: CommandSpec) -> None:
     "spec", WORKSPACE_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command)
 )
 def test_no_workspace_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster workspace directory" in result.output
@@ -194,7 +206,10 @@ def test_no_workspace_failure(spec: CommandSpec) -> None:
     "spec", WORKSPACE_OR_PROJECT_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command)
 )
 def test_no_workspace_or_project_failure(spec: CommandSpec) -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster workspace or project directory" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -64,7 +64,10 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
 
 
 def test_inspect_component_type_all_metadata_success():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "utils",
             "inspect-component-type",
@@ -75,7 +78,10 @@ def test_inspect_component_type_all_metadata_success():
 
 
 def test_inspect_component_type_all_metadata_empty_success():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "utils",
             "inspect-component-type",
@@ -90,7 +96,10 @@ def test_inspect_component_type_all_metadata_empty_success():
 
 
 def test_inspect_component_type_flag_fields_success():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "utils",
             "inspect-component-type",
@@ -168,7 +177,10 @@ def test_inspect_component_type_flag_fields_success():
 
 
 def test_inspect_component_type_multiple_flags_fails() -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "utils",
             "inspect-component-type",
@@ -184,7 +196,10 @@ def test_inspect_component_type_multiple_flags_fails() -> None:
 
 
 def test_inspect_component_type_undefined_component_type_fails() -> None:
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke(
             "utils",
             "inspect-component-type",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -16,11 +16,9 @@ ensure_dagster_dg_tests_import()
 
 from dagster_dg_tests.utils import ProxyRunner, assert_runner_result
 
-runner_opts = {"use_entry_points": True}
-
 
 def test_dg_init_command_success(monkeypatch) -> None:
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", input="\nhelloworld\n")
         assert_runner_result(result)
         assert Path("dagster-workspace").exists()
@@ -34,7 +32,7 @@ def test_dg_init_command_success(monkeypatch) -> None:
 
 
 def test_dg_init_command_no_project(monkeypatch) -> None:
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", input="\n\n")
         assert_runner_result(result)
         assert Path("dagster-workspace").exists()
@@ -44,7 +42,7 @@ def test_dg_init_command_no_project(monkeypatch) -> None:
 
 
 def test_dg_init_override_workspace_name(monkeypatch) -> None:
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", input="my-workspace\ngoodbyeworld\n")
         assert_runner_result(result)
         assert Path("my-workspace").exists()
@@ -61,7 +59,7 @@ def test_dg_init_workspace_already_exists_failure(monkeypatch) -> None:
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         os.mkdir("dagster-workspace")
         result = runner.invoke("init", "--use-editable-dagster", input="\nhelloworld\n")
         assert_runner_result(result, exit_0=False)
@@ -80,7 +78,7 @@ def test_dg_init_use_editable_dagster(
     else:
         editable_args = [option, str(dagster_git_repo_dir)]
 
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", *editable_args, input="\nhelloworld\n")
         assert_runner_result(result)
 
@@ -97,7 +95,7 @@ def test_dg_init_project_editable_dagster_no_env_var_no_value_fails(
     option: EditableOption, monkeypatch
 ) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", "")
-    with ProxyRunner.test(**runner_opts) as runner, runner.isolated_filesystem():
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", option, input="\nhelloworld\n")
         assert_runner_result(result, exit_0=False)
         assert "require the `DAGSTER_GIT_REPO_DIR`" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -43,7 +43,10 @@ def test_list_project_success():
 
 
 def test_list_components_succeeds():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner, in_workspace=False):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
         result = runner.invoke(
             "scaffold",
             "component",
@@ -101,7 +104,10 @@ _EXPECTED_COMPONENT_TYPES_JSON = textwrap.dedent("""
 
 
 def test_list_component_types_success():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         with fixed_panel_width(width=120):
             result = runner.invoke("list", "component-type")
             assert_runner_result(result)
@@ -111,7 +117,10 @@ def test_list_component_types_success():
 
 
 def test_list_component_type_json_succeeds():
-    with ProxyRunner.test() as runner, isolated_components_venv(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_components_venv(runner),
+    ):
         result = runner.invoke("list", "component-type", "--json")
         assert_runner_result(result)
         # strip the first line of logging output
@@ -124,7 +133,7 @@ def test_list_component_type_json_succeeds():
 # not work.
 def test_list_component_type_bad_entry_point_fails(capfd):
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner),
     ):
         # Delete the component lib package referenced by the entry point

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -302,7 +302,10 @@ def test_scaffold_project_already_exists_fails() -> None:
 
 
 def test_scaffold_component_dynamic_subcommand_generation() -> None:
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         result = runner.invoke("scaffold", "component", "--help")
         assert_runner_result(result)
 
@@ -321,7 +324,7 @@ def test_scaffold_component_dynamic_subcommand_generation() -> None:
 @pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
@@ -343,7 +346,7 @@ def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
 @pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
@@ -368,7 +371,7 @@ def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
 @pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_component_key_value_params_success(in_workspace: bool) -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
@@ -391,7 +394,10 @@ def test_scaffold_component_key_value_params_success(in_workspace: bool) -> None
 
 
 def test_scaffold_component_json_params_and_key_value_params_fails() -> None:
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         result = runner.invoke(
             "scaffold",
             "component",
@@ -415,7 +421,10 @@ def test_scaffold_component_undefined_component_type_fails() -> None:
 
 
 def test_scaffold_component_command_with_non_matching_module_name():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         #  move the module from foo_bar to module_not_same_as_project
         python_module = Path("foo_bar")
         python_module.rename("module_not_same_as_project")
@@ -433,7 +442,7 @@ def test_scaffold_component_command_with_non_matching_module_name():
 @pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_component_already_exists_fails(in_workspace: bool) -> None:
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
@@ -454,7 +463,10 @@ def test_scaffold_component_already_exists_fails(in_workspace: bool) -> None:
 
 
 def test_scaffold_component_succeeds_non_default_component_package() -> None:
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         alt_lib_path = Path("foo_bar/_defs")
         alt_lib_path.mkdir(parents=True)
         with modify_pyproject_toml() as toml:
@@ -476,7 +488,10 @@ def test_scaffold_component_succeeds_non_default_component_package() -> None:
 
 
 def test_scaffold_component_fails_components_package_does_not_exist() -> None:
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
         with modify_pyproject_toml() as toml:
             set_toml_value(toml, ("tool", "dg", "project", "components_module"), "foo_bar._defs")
         result = runner.invoke(
@@ -491,7 +506,7 @@ def test_scaffold_component_fails_components_package_does_not_exist() -> None:
 
 def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
         result = runner.invoke("scaffold", "component-type", "Baz")
@@ -521,7 +536,7 @@ dbt_project_path = Path("../stub_projects/dbt_project_location/defs/jaffle_shop"
 )
 def test_scaffold_dbt_project_instance(params) -> None:
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
         # We need to add dagster-dbt also because we are using editable installs. Only
@@ -569,7 +584,7 @@ def test_scaffold_component_type_success() -> None:
 
 def test_scaffold_component_type_already_exists_fails() -> None:
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner),
     ):
         result = runner.invoke("scaffold", "component-type", "Baz")
@@ -581,7 +596,7 @@ def test_scaffold_component_type_already_exists_fails() -> None:
 
 def test_scaffold_component_type_succeeds_non_default_component_lib_package() -> None:
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner, lib_module_name="foo_bar._lib"),
     ):
         result = runner.invoke(
@@ -598,7 +613,7 @@ def test_scaffold_component_type_succeeds_non_default_component_lib_package() ->
 
 def test_scaffold_component_type_fails_components_lib_package_does_not_exist(capfd) -> None:
     with (
-        ProxyRunner.test(use_entry_points=True) as runner,
+        ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner, lib_module_name="foo_bar.fake"),
     ):
         # Delete the entry point module

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -11,7 +11,7 @@ from dagster_dg_tests.utils import (
 # For all cache tests, avoid setting up venv in example project so we do not prepopulate the
 # cache (which is part of the venv setup routine).
 example_project = partial(isolated_example_project_foo_bar, populate_cache=False)
-cache_runner_args = {"use_entry_points": True, "verbose": True}
+cache_runner_args = {"verbose": True}
 
 
 def test_load_from_cache():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -340,11 +340,9 @@ def normalize_windows_path(path: str) -> str:
 # ########################
 
 
-# NOTE: This class sets up a runner that by default targets only the `dagster_test.components`
-# components in the remote environment. This is to provide stability against the set of components
-# we are testing against. Tests that are testing against scaffolded components need to set
-# `use_entry_points=True` in order to detect scaffolded components (since they aren't part of
-# `dagster_test.components`).
+# NOTE: Pass use_fixed_test_components=True to use the dagster_test.components module instead of
+# components loaded from entry points. This should be done whenever we want to test against a fixed
+# set of known component types (as in inspect or list commands).
 @dataclass
 class ProxyRunner:
     original: CliRunner
@@ -355,7 +353,7 @@ class ProxyRunner:
     @contextmanager
     def test(
         cls,
-        use_entry_points: bool = False,
+        use_fixed_test_components: bool = False,
         verbose: bool = False,
         disable_cache: bool = False,
         console_width: int = DG_CLI_MAX_OUTPUT_WIDTH,
@@ -364,7 +362,9 @@ class ProxyRunner:
         # We set the `COLUMNS` environment variable because this determines the width of output from
         # `rich`, which we use for generating tables etc.
         use_component_modules_args = (
-            [] if use_entry_points else ["--use-component-module", STANDARD_TEST_COMPONENT_MODULE]
+            ["--use-component-module", STANDARD_TEST_COMPONENT_MODULE]
+            if use_fixed_test_components
+            else []
         )
         with TemporaryDirectory() as cache_dir, set_env_var("COLUMNS", str(console_width)):
             append_opts = [


### PR DESCRIPTION
## Summary & Motivation

Now that the test components live in `dagster-test` instead of `dagster-components`, we don't want to target them by default in tests since the `dagster-test` package is not installed in non-editable scaffolded projects. This was leading to confusing error messages about `dagster-test` not being installed in new tests.

## How I Tested These Changes

Existing test suite.