### PR TITLE
[ui] Replace references with data-testId => data-testid

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -287,7 +287,7 @@ export const AssetPartitions = ({
                     value={searchValues[idx] || ''}
                     onChange={(e) => updateSearchValue(idx, e.target.value)}
                     placeholder="Filter by name…"
-                    data-testId={testId(`search-${idx}`)}
+                    data-testid={testId(`search-${idx}`)}
                   />
                 </Box>
                 <div>
@@ -318,7 +318,7 @@ export const AssetPartitions = ({
                             return copy;
                           });
                         }}
-                        data-testId={testId('sort-creation')}
+                        data-testid={testId('sort-creation')}
                       />
                       <MenuItem
                         text={
@@ -337,7 +337,7 @@ export const AssetPartitions = ({
                             return copy;
                           });
                         }}
-                        data-testId={testId('sort-reverse-creation')}
+                        data-testid={testId('sort-reverse-creation')}
                       />
                       <MenuItem
                         text="Alphabetical sort"
@@ -349,7 +349,7 @@ export const AssetPartitions = ({
                             return copy;
                           });
                         }}
-                        data-testId={testId('sort-alphabetical')}
+                        data-testid={testId('sort-alphabetical')}
                       />
                       <MenuItem
                         text="Reverse alphabetical sort"
@@ -361,7 +361,7 @@ export const AssetPartitions = ({
                             return [...copy];
                           });
                         }}
-                        data-testId={testId('sort-reverse-alphabetical')}
+                        data-testid={testId('sort-reverse-alphabetical')}
                       />
                     </Menu>
                   }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -192,7 +192,7 @@ export const BackfillActionsMenu = ({
       }
     >
       <Button
-        data-testId={testId('backfill_actions_dropdown_toggle')}
+        data-testid={testId('backfill_actions_dropdown_toggle')}
         icon={<Icon name="expand_more" />}
       />
     </Popover>


### PR DESCRIPTION
These are interchangeable in the tests (they both work), but at some point React started printing errors about data-testId in the console:

```Warning: React does not recognize the `data-testId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-testid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.```