### PR TITLE
[dg] Backwards compatability layer for existing Components to allow incremental adoption of scaffoldable

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -9,6 +9,7 @@ from dagster_components.core.component_key import ComponentKey
 from dagster_components.scaffold import (
     ComponentScaffolderUnavailableReason,
     scaffold_component_instance,
+    scaffolder_from_component_type,
 )
 
 
@@ -30,7 +31,7 @@ def scaffold_component_command(
     component_type_cls = load_component_type(key)
 
     if json_params:
-        scaffolder = component_type_cls.get_scaffolder()
+        scaffolder = scaffolder_from_component_type(component_type_cls)
         if isinstance(scaffolder, ComponentScaffolderUnavailableReason):
             raise Exception(
                 f"Component type {component_type} does not have a scaffolder. Reason: {scaffolder.message}."

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -12,6 +12,7 @@ from dagster_components import Component, ComponentLoadContext, ResolvableSchema
 from dagster_components.components.definitions_component.scaffolder import (
     DefinitionsComponentScaffolder,
 )
+from dagster_components.scaffoldable.decorator import scaffoldable
 
 
 class DefinitionsParamSchema(ResolvableSchema):
@@ -19,6 +20,7 @@ class DefinitionsParamSchema(ResolvableSchema):
 
 
 @dataclass
+@scaffoldable(scaffolder=DefinitionsComponentScaffolder)
 class DefinitionsComponent(Component):
     """Wraps an arbitrary set of Dagster definitions."""
 
@@ -28,7 +30,7 @@ class DefinitionsComponent(Component):
 
     @classmethod
     def get_scaffolder(cls) -> DefinitionsComponentScaffolder:
-        return DefinitionsComponentScaffolder()
+        raise Exception("Using decorator instead of classmethod")
 
     @classmethod
     def get_schema(cls) -> type[DefinitionsParamSchema]:

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import click
 import yaml
 
-from dagster_components.core.component import Component
+from dagster_components.core.component import Component, scaffolder_from_component_type
 from dagster_components.core.component_scaffolder import (
     ComponentScaffolderUnavailableReason,
     ComponentScaffoldRequest,
@@ -40,7 +40,7 @@ def scaffold_component_instance(
     click.echo(f"Creating a Dagster component instance folder at {path}.")
     if not path.exists():
         path.mkdir()
-    scaffolder = component_type.get_scaffolder()
+    scaffolder = scaffolder_from_component_type(component_type)
 
     if isinstance(scaffolder, ComponentScaffolderUnavailableReason):
         raise Exception(

--- a/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar, Union
 
 from dagster import _check as check
 
@@ -10,8 +10,14 @@ T = TypeVar("T")
 # Constant for scaffolder attribute name
 SCAFFOLDER_ATTRIBUTE = "__scaffolder_class__"
 
+if TYPE_CHECKING:
+    from dagster_components.core.component_scaffolder import ComponentScaffolderUnavailableReason
+    from dagster_components.scaffoldable.scaffolder import ComponentScaffolder
 
-def scaffoldable(scaffolder: type[ComponentScaffolder]) -> Callable[[type[T]], type[T]]:
+
+def scaffoldable(
+    scaffolder: Union[type["ComponentScaffolder"], "ComponentScaffolderUnavailableReason"],
+) -> Callable[[type[T]], type[T]]:
     """A decorator that attaches a scaffolder class to the decorated class.
 
     Args:
@@ -41,7 +47,9 @@ def is_scaffoldable_class(cls: type) -> bool:
     return hasattr(cls, SCAFFOLDER_ATTRIBUTE)
 
 
-def get_scaffolder(cls: type) -> type[ComponentScaffolder]:
+def get_scaffolder(
+    cls: type,
+) -> Union[type["ComponentScaffolder"], "ComponentScaffolderUnavailableReason"]:
     """Retrieves the scaffolder class attached to the decorated class.
 
     Args:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
@@ -1,11 +1,11 @@
 import pytest
 from dagster._check.functions import CheckError
 from dagster_components.scaffoldable.decorator import (
-    ComponentScaffolder,
     get_scaffolder,
     is_scaffoldable_class,
     scaffoldable,
 )
+from dagster_components.scaffoldable.scaffolder import ComponentScaffolder
 
 
 # Example usage:


### PR DESCRIPTION
## Summary & Motivation

Here we add a backwards compatibility layer where an existing `Component` class can use the decorator and make the `get_scaffolder` automatically fail if called. This allows us to add `scaffoldable` decorators incrementally, which we do so to `DefinitionsComponent`

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG