### PR TITLE
[dg] Convert all existing Component use to scaffoldable

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -19,10 +19,6 @@ class ShellCommand(Component):
     def get_schema(cls):
         return ShellCommandSchema
 
-    @classmethod
-    def get_scaffolder(cls) -> DefaultComponentScaffolder:
-        return DefaultComponentScaffolder()
-
     def build_defs(self, load_context: ComponentLoadContext) -> Definitions:
         # Add definition construction logic here.
         return Definitions()

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
@@ -14,6 +14,7 @@ from dagster_components import (
     ResolvableSchema,
     scaffold_component_yaml,
 )
+from dagster_components.scaffoldable.decorator import scaffoldable
 
 import dagster as dg
 
@@ -45,6 +46,9 @@ class ShellScriptSchema(ResolvableSchema):
     asset_specs: Sequence[AssetSpecSchema]
 
 
+# highlight-start
+@scaffoldable(scaffolder=ShellCommandScaffolder)
+# highlight-end
 @dataclass
 class ShellCommand(Component):
     """Models a shell script as a Dagster asset."""
@@ -67,11 +71,3 @@ class ShellCommand(Component):
 
     def execute(self, resolved_script_path: Path, context: dg.AssetExecutionContext):
         return subprocess.run(["sh", str(resolved_script_path)], check=True)
-
-    # highlight-start
-    @classmethod
-    def get_scaffolder(cls) -> ComponentScaffolder:
-        return ShellCommandScaffolder()
-
-
-# highlight-end

--- a/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
@@ -2,14 +2,9 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
 
 
 class AllMetadataEmptyComponent(Component):
-    @classmethod
-    def get_scaffolder(cls) -> DefaultComponentScaffolder:
-        return DefaultComponentScaffolder()
-
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         @asset
         def hardcoded_asset(context: AssetExecutionContext):

--- a/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
@@ -5,7 +5,6 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
 from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
 from dagster_components.core.schema.objects import (
@@ -36,10 +35,6 @@ class ComplexAssetComponent(Component):
     @classmethod
     def get_schema(cls):
         return ComplexAssetSchema
-
-    @classmethod
-    def get_scaffolder(cls) -> DefaultComponentScaffolder:
-        return DefaultComponentScaffolder()
 
     def __init__(
         self,

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -3,10 +3,6 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.core.component_scaffolder import (
-    ComponentScaffolder,
-    DefaultComponentScaffolder,
-)
 from pydantic import BaseModel
 
 
@@ -21,10 +17,6 @@ class SimpleAssetComponent(Component):
     @classmethod
     def get_schema(cls):
         return SimpleAssetSchema
-
-    @classmethod
-    def get_scaffolder(cls) -> ComponentScaffolder:
-        return DefaultComponentScaffolder()
 
     def __init__(self, asset_key: AssetKey, value: str):
         self._asset_key = asset_key

--- a/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
@@ -12,6 +12,7 @@ from dagster_components.core.component_scaffolder import (
     ComponentScaffoldRequest,
 )
 from dagster_components.scaffold import scaffold_component_yaml
+from dagster_components.scaffoldable.decorator import scaffoldable
 from pydantic import BaseModel
 
 
@@ -43,15 +44,12 @@ context.report_asset_materialization(asset_key="{asset_key}")
 """
 
 
+@scaffoldable(scaffolder=SimplePipesScriptScaffolder)
 class SimplePipesScriptComponent(Component):
     """A simple asset that runs a Python script with the Pipes subprocess client.
 
     Because it is a pipes asset, no value is returned.
     """
-
-    @classmethod
-    def get_scaffolder(cls) -> ComponentScaffolder:
-        return SimplePipesScriptScaffolder()
 
     @classmethod
     def get_schema(cls):

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -25,6 +25,7 @@ from dagster_components.core.schema.objects import (
     PostProcessorFn,
     ResolutionContext,
 )
+from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
@@ -57,6 +58,7 @@ def resolve_translator(
     )
 
 
+@scaffoldable(scaffolder=DbtProjectComponentScaffolder)
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))  # omits translator prop from schema
 class DbtProjectComponent(Component):
     """Expose a DBT project to Dagster as a set of assets."""
@@ -82,10 +84,6 @@ class DbtProjectComponent(Component):
     @property
     def project(self) -> DbtProject:
         return DbtProject(self.dbt.project_dir)
-
-    @classmethod
-    def get_scaffolder(cls) -> "DbtProjectComponentScaffolder":
-        return DbtProjectComponentScaffolder()
 
     @classmethod
     def get_schema(cls) -> type[DbtProjectSchema]:

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -29,10 +29,6 @@ class DefinitionsComponent(Component):
     )
 
     @classmethod
-    def get_scaffolder(cls) -> DefinitionsComponentScaffolder:
-        raise Exception("Using decorator instead of classmethod")
-
-    @classmethod
     def get_schema(cls) -> type[DefinitionsParamSchema]:
         return DefinitionsParamSchema
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -13,7 +13,9 @@ from pydantic.dataclasses import dataclass
 from typing_extensions import TypeAlias
 
 from dagster_components import Component, ComponentLoadContext, FieldResolver
-from dagster_components.core.component_scaffolder import ComponentScaffolder
+from dagster_components.components.sling_replication_collection.scaffolder import (
+    SlingReplicationComponentScaffolder,
+)
 from dagster_components.core.schema.base import ResolvableSchema
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.metadata import ResolvableFieldInfo
@@ -24,6 +26,7 @@ from dagster_components.core.schema.objects import (
     OpSpecSchema,
     PostProcessorFn,
 )
+from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
@@ -92,6 +95,7 @@ def resolve_resource(
     )
 
 
+@scaffoldable(scaffolder=SlingReplicationComponentScaffolder)
 @dataclass
 class SlingReplicationCollectionComponent(Component):
     """Expose one or more Sling replications to Dagster as assets."""
@@ -106,14 +110,6 @@ class SlingReplicationCollectionComponent(Component):
         default=None,
         description="Post-processors to apply to the asset definitions produced by this component.",
     )
-
-    @classmethod
-    def get_scaffolder(cls) -> ComponentScaffolder:
-        from dagster_components.components.sling_replication_collection.scaffolder import (
-            SlingReplicationComponentScaffolder,
-        )
-
-        return SlingReplicationComponentScaffolder()
 
     @classmethod
     def get_schema(cls) -> type[SlingReplicationCollectionSchema]:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
@@ -29,3 +29,21 @@ def test_basic_usage() -> None:
     assert get_scaffolder(MyClass) is MyScaffolder
     with pytest.raises(CheckError):
         get_scaffolder(RegularClass)
+
+
+def test_inheritance() -> None:
+    class ScaffoldableOne(ComponentScaffolder): ...
+
+    class ScaffoldableTwo(ComponentScaffolder): ...
+
+    @scaffoldable(ScaffoldableOne)
+    class ClassOne: ...
+
+    @scaffoldable(ScaffoldableTwo)
+    class ClassTwo(ClassOne): ...
+
+    assert is_scaffoldable_class(ClassOne) is True
+    assert get_scaffolder(ClassOne) is ScaffoldableOne
+
+    assert is_scaffoldable_class(ClassTwo) is True
+    assert get_scaffolder(ClassTwo) is ScaffoldableTwo

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_with_optional_scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_with_optional_scaffolder.py
@@ -1,23 +1,21 @@
-from typing import Union
-
 from dagster_components import Component
 from dagster_components.core.component import (
-    ComponentScaffolder,
     ComponentScaffolderUnavailableReason,
+    scaffolder_from_component_type,
 )
+from dagster_components.scaffoldable.decorator import scaffoldable
 
 
-class ComponentWithOptionalScaffolder(Component):
-    @classmethod
-    def get_scaffolder(cls) -> Union[ComponentScaffolder, ComponentScaffolderUnavailableReason]:
-        # Check for some installed dependency
-        # _has_dagster_dbt = importlib.util.find_spec("dagster_dbt") is not None
-        return ComponentScaffolderUnavailableReason(
-            "In order to scaffold this component you must install dagster_foobar with the [dev] extra. E.g. `uv add dagster-foobar[dev]` or `pip install dagster-foobar[dev]`"
-        )
+@scaffoldable(
+    scaffolder=ComponentScaffolderUnavailableReason(
+        "In order to scaffold this component you must install dagster_foobar with the [dev] extra. E.g. `uv add dagster-foobar[dev]` or `pip install dagster-foobar[dev]`"
+    )
+)
+class ComponentWithOptionalScaffolder(Component): ...
 
 
 def test_component_with_optional_scaffolder() -> None:
     assert isinstance(
-        ComponentWithOptionalScaffolder.get_scaffolder(), ComponentScaffolderUnavailableReason
+        scaffolder_from_component_type(ComponentWithOptionalScaffolder),
+        ComponentScaffolderUnavailableReason,
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -19,10 +19,6 @@ class {{ name }}(Component):
     def get_schema(cls):
         return {{ name }}Schema
 
-    @classmethod
-    def get_scaffolder(cls) -> DefaultComponentScaffolder:
-        return DefaultComponentScaffolder()
-
     def build_defs(self, load_context: ComponentLoadContext) -> Definitions:
         # Add definition construction logic here.
         return Definitions()


### PR DESCRIPTION
## Summary & Motivation

This PR converts all existing components to use `scaffoldable`, setting us up to delete scaffoldling from the `Component` base class.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG