### PR TITLE
[dg] Change naming conventions around scaffolding parameterization from schema to params

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
@@ -33,7 +33,7 @@ class ShellCommandScaffolder(Scaffolder):
                 ],
             },
         )
-        script_path = Path(request.component_instance_root_path) / "script.sh"
+        script_path = Path(request.target_path) / "script.sh"
         script_path.write_text("#!/bin/bash\n\necho 'Hello, world!'")
         os.chmod(script_path, 0o755)
 

--- a/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
@@ -14,19 +14,19 @@ from pydantic import BaseModel
 
 
 # Same schema used for file generation and defs generation
-class SimplePipesScriptSchema(BaseModel):
+class SimplePipesScaffoldParams(BaseModel):
     asset_key: str
     filename: str
 
 
 class SimplePipesScriptScaffolder(Scaffolder):
     @classmethod
-    def get_schema(cls):
-        return SimplePipesScriptSchema
+    def get_scaffold_params(cls):
+        return SimplePipesScaffoldParams
 
-    def scaffold(self, request: ScaffoldRequest, params: SimplePipesScriptSchema) -> None:
+    def scaffold(self, request: ScaffoldRequest, params: SimplePipesScaffoldParams) -> None:
         scaffold_component_yaml(request, params.model_dump())
-        Path(request.component_instance_root_path, params.filename).write_text(
+        Path(request.target_path, params.filename).write_text(
             _SCRIPT_TEMPLATE.format(asset_key=params.asset_key)
         )
 
@@ -50,7 +50,7 @@ class SimplePipesScriptComponent(Component):
 
     @classmethod
     def get_schema(cls):
-        return SimplePipesScriptSchema
+        return SimplePipesScaffoldParams
 
     def __init__(self, asset_key: AssetKey, script_path: Path):
         self._asset_key = asset_key

--- a/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
@@ -14,17 +14,17 @@ from pydantic import BaseModel
 
 
 # Same schema used for file generation and defs generation
-class SimplePipesScaffoldParams(BaseModel):
+class SimplePipesScriptScaffoldParams(BaseModel):
     asset_key: str
     filename: str
 
 
 class SimplePipesScriptScaffolder(Scaffolder):
     @classmethod
-    def get_scaffold_params(cls):
-        return SimplePipesScaffoldParams
+    def get_params(cls):
+        return SimplePipesScriptScaffoldParams
 
-    def scaffold(self, request: ScaffoldRequest, params: SimplePipesScaffoldParams) -> None:
+    def scaffold(self, request: ScaffoldRequest, params: SimplePipesScriptScaffoldParams) -> None:
         scaffold_component_yaml(request, params.model_dump())
         Path(request.target_path, params.filename).write_text(
             _SCRIPT_TEMPLATE.format(asset_key=params.asset_key)
@@ -50,7 +50,7 @@ class SimplePipesScriptComponent(Component):
 
     @classmethod
     def get_schema(cls):
-        return SimplePipesScaffoldParams
+        return SimplePipesScriptScaffoldParams
 
     def __init__(self, asset_key: AssetKey, script_path: Path):
         self._asset_key = asset_key

--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -33,7 +33,7 @@ def scaffold_component_command(
             raise Exception(
                 f"Component type {component_type} does not have a scaffolder. Reason: {scaffolder.message}."
             )
-        scaffold_params = TypeAdapter(scaffolder.get_scaffold_params()).validate_json(json_params)
+        scaffold_params = TypeAdapter(scaffolder.get_params()).validate_json(json_params)
     else:
         scaffold_params = {}
 

--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -33,7 +33,7 @@ def scaffold_component_command(
             raise Exception(
                 f"Component type {component_type} does not have a scaffolder. Reason: {scaffolder.message}."
             )
-        scaffold_params = TypeAdapter(scaffolder.get_schema()).validate_json(json_params)
+        scaffold_params = TypeAdapter(scaffolder.get_scaffold_params()).validate_json(json_params)
     else:
         scaffold_params = {}
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
@@ -17,7 +17,7 @@ class DbtScaffoldParams(BaseModel):
 
 class DbtProjectComponentScaffolder(Scaffolder):
     @classmethod
-    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+    def get_params(cls) -> Optional[type[BaseModel]]:
         return DbtScaffoldParams
 
     def scaffold(self, request: ScaffoldRequest, params: DbtScaffoldParams) -> None:

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
@@ -10,17 +10,17 @@ from dagster_components.core.component_scaffolder import Scaffolder, ScaffoldReq
 from dagster_components.scaffold import scaffold_component_yaml
 
 
-class DbtScaffoldSchema(BaseModel):
+class DbtScaffoldParams(BaseModel):
     init: bool = Field(default=False)
     project_path: Optional[str] = None
 
 
 class DbtProjectComponentScaffolder(Scaffolder):
     @classmethod
-    def get_schema(cls) -> Optional[type[BaseModel]]:
-        return DbtScaffoldSchema
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+        return DbtScaffoldParams
 
-    def scaffold(self, request: ScaffoldRequest, params: DbtScaffoldSchema) -> None:
+    def scaffold(self, request: ScaffoldRequest, params: DbtScaffoldParams) -> None:
         cwd = os.getcwd()
         if params.project_path:
             # NOTE: CWD is not set "correctly" above so we prepend "../../.." as a temporary hack to

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
@@ -9,21 +9,21 @@ from dagster_components.core.component_scaffolder import ScaffoldRequest
 from dagster_components.scaffold import scaffold_component_yaml
 
 
-class DefinitionsScaffoldSchema(BaseModel):
+class DefinitionsScaffoldParams(BaseModel):
     definitions_path: Optional[str] = None
 
 
 class DefinitionsComponentScaffolder(Scaffolder):
     @classmethod
-    def get_schema(cls):
-        return DefinitionsScaffoldSchema
+    def get_scaffold_params(cls):
+        return DefinitionsScaffoldParams
 
-    def scaffold(self, request: ScaffoldRequest, params: DefinitionsScaffoldSchema) -> None:
+    def scaffold(self, request: ScaffoldRequest, params: DefinitionsScaffoldParams) -> None:
         scaffold_params = (
-            params if isinstance(params, DefinitionsScaffoldSchema) else DefinitionsScaffoldSchema()
+            params if isinstance(params, DefinitionsScaffoldParams) else DefinitionsScaffoldParams()
         )
 
-        with pushd(str(request.component_instance_root_path)):
+        with pushd(str(request.target_path)):
             Path(
                 scaffold_params.definitions_path
                 if scaffold_params.definitions_path

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
@@ -15,7 +15,7 @@ class DefinitionsScaffoldParams(BaseModel):
 
 class DefinitionsComponentScaffolder(Scaffolder):
     @classmethod
-    def get_scaffold_params(cls):
+    def get_params(cls):
         return DefinitionsScaffoldParams
 
     def scaffold(self, request: ScaffoldRequest, params: DefinitionsScaffoldParams) -> None:

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/scaffolder.py
@@ -9,6 +9,6 @@ from dagster_components.scaffold import scaffold_component_yaml
 class SlingReplicationComponentScaffolder(Scaffolder):
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None:
         scaffold_component_yaml(request, {"replications": [{"path": "replication.yaml"}]})
-        replication_path = request.component_instance_root_path / "replication.yaml"
+        replication_path = request.target_path / "replication.yaml"
         with open(replication_path, "w") as f:
             yaml.dump({"source": {}, "target": {}, "streams": {}}, f)

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -79,7 +79,7 @@ class Component(ABC):
             )
 
         component_schema = cls.get_schema()
-        scaffold_params = scaffolder.get_schema()
+        scaffold_params = scaffolder.get_scaffold_params()
         return {
             "summary": clean_docstring.split("\n\n")[0] if clean_docstring else None,
             "description": clean_docstring if clean_docstring else None,

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -79,7 +79,7 @@ class Component(ABC):
             )
 
         component_schema = cls.get_schema()
-        scaffold_params = scaffolder.get_scaffold_params()
+        scaffold_params = scaffolder.get_params()
         return {
             "summary": clean_docstring.split("\n\n")[0] if clean_docstring else None,
             "description": clean_docstring if clean_docstring else None,

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -20,8 +20,8 @@ class ComponentDumper(yaml.Dumper):
 def scaffold_component_yaml(
     request: ScaffoldRequest, attributes: Optional[Mapping[str, Any]]
 ) -> None:
-    with open(request.component_instance_root_path / "component.yaml", "w") as f:
-        component_data = {"type": request.component_type_name, "attributes": attributes or {}}
+    with open(request.target_path / "component.yaml", "w") as f:
+        component_data = {"type": request.type_name, "attributes": attributes or {}}
         yaml.dump(
             component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
         )
@@ -46,8 +46,8 @@ def scaffold_component_instance(
 
     scaffolder.scaffold(
         ScaffoldRequest(
-            component_type_name=component_type_name,
-            component_instance_root_path=path,
+            type_name=component_type_name,
+            target_path=path,
         ),
         scaffold_params,
     )

--- a/python_modules/libraries/dagster-components/dagster_components/scaffoldable/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffoldable/scaffolder.py
@@ -22,7 +22,7 @@ class ScaffoldRequest:
 
 class Scaffolder:
     @classmethod
-    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+    def get_params(cls) -> Optional[type[BaseModel]]:
         return None
 
     @abstractmethod

--- a/python_modules/libraries/dagster-components/dagster_components/scaffoldable/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffoldable/scaffolder.py
@@ -14,13 +14,15 @@ class ScaffolderUnavailableReason:
 
 @record
 class ScaffoldRequest:
-    component_type_name: str
-    component_instance_root_path: Path
+    # fully qualified class name of the scaffolded class
+    type_name: str
+    # target path for the scaffold request. Typically used to construct absolute paths
+    target_path: Path
 
 
 class Scaffolder:
     @classmethod
-    def get_schema(cls) -> Optional[type[BaseModel]]:
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
         return None
 
     @abstractmethod

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -69,7 +69,7 @@ def test_list_components_types_from_module():
             "filename": {"title": "Filename", "type": "string"},
         },
         "required": ["asset_key", "filename"],
-        "title": "SimplePipesScaffoldParams",
+        "title": "SimplePipesScriptScaffoldParams",
         "type": "object",
     }
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -69,7 +69,7 @@ def test_list_components_types_from_module():
             "filename": {"title": "Filename", "type": "string"},
         },
         "required": ["asset_key", "filename"],
-        "title": "SimplePipesScriptSchema",
+        "title": "SimplePipesScaffoldParams",
         "type": "object",
     }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -36,7 +36,7 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
             "asset_key",
             "filename"
         ],
-        "title": "SimplePipesScriptSchema",
+        "title": "SimplePipesScaffoldParams",
         "type": "object"
     }
 
@@ -57,7 +57,7 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
             "asset_key",
             "filename"
         ],
-        "title": "SimplePipesScriptSchema",
+        "title": "SimplePipesScaffoldParams",
         "type": "object"
     }
 """).strip()
@@ -130,7 +130,7 @@ def test_inspect_component_type_flag_fields_success():
                         "asset_key",
                         "filename"
                     ],
-                    "title": "SimplePipesScriptSchema",
+                    "title": "SimplePipesScaffoldParams",
                     "type": "object"
                 }
             """).strip()
@@ -160,7 +160,7 @@ def test_inspect_component_type_flag_fields_success():
                         "asset_key",
                         "filename"
                     ],
-                    "title": "SimplePipesScriptSchema",
+                    "title": "SimplePipesScaffoldParams",
                     "type": "object"
                 }
             """).strip()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_info_commands.py
@@ -36,7 +36,7 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
             "asset_key",
             "filename"
         ],
-        "title": "SimplePipesScaffoldParams",
+        "title": "SimplePipesScriptScaffoldParams",
         "type": "object"
     }
 
@@ -57,7 +57,7 @@ _EXPECTED_INSPECT_COMPONENT_TYPE_FULL = textwrap.dedent("""
             "asset_key",
             "filename"
         ],
-        "title": "SimplePipesScaffoldParams",
+        "title": "SimplePipesScriptScaffoldParams",
         "type": "object"
     }
 """).strip()
@@ -130,7 +130,7 @@ def test_inspect_component_type_flag_fields_success():
                         "asset_key",
                         "filename"
                     ],
-                    "title": "SimplePipesScaffoldParams",
+                    "title": "SimplePipesScriptScaffoldParams",
                     "type": "object"
                 }
             """).strip()
@@ -160,7 +160,7 @@ def test_inspect_component_type_flag_fields_success():
                         "asset_key",
                         "filename"
                     ],
-                    "title": "SimplePipesScaffoldParams",
+                    "title": "SimplePipesScriptScaffoldParams",
                     "type": "object"
                 }
             """).strip()


### PR DESCRIPTION
## Summary & Motivation

This was already halfway done, but this is an opportunity to complete it. This PR adopts "params" terminology for scaffolding rather than "schema" which 1) makes more sense given how it is exposed to users (CLI) and 2) clearly disambiguates from component yaml schema.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG