### PR TITLE
[dg] Eliminate scaffolder_from_component_type

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -6,7 +6,8 @@ from pydantic import TypeAdapter
 
 from dagster_components.core.component import load_component_type
 from dagster_components.core.component_key import ComponentKey
-from dagster_components.scaffold import scaffold_component_instance, scaffolder_from_component_type
+from dagster_components.scaffold import scaffold_component_instance
+from dagster_components.scaffoldable.decorator import get_scaffolder
 from dagster_components.scaffoldable.scaffolder import ScaffolderUnavailableReason
 
 
@@ -28,7 +29,7 @@ def scaffold_component_command(
     component_type_cls = load_component_type(key)
 
     if json_params:
-        scaffolder = scaffolder_from_component_type(component_type_cls)
+        scaffolder = get_scaffolder(component_type_cls)
         if isinstance(scaffolder, ScaffolderUnavailableReason):
             raise Exception(
                 f"Component type {component_type} does not have a scaffolder. Reason: {scaffolder.message}."

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
@@ -4,9 +4,9 @@ from typing import Optional
 from dagster._utils import pushd
 from pydantic import BaseModel
 
-from dagster_components.core.component import Scaffolder
 from dagster_components.core.component_scaffolder import ScaffoldRequest
 from dagster_components.scaffold import scaffold_component_yaml
+from dagster_components.scaffoldable.scaffolder import Scaffolder
 
 
 class DefinitionsScaffoldParams(BaseModel):

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -5,7 +5,8 @@ from typing import Any, Optional
 import click
 import yaml
 
-from dagster_components.core.component import Component, scaffolder_from_component_type
+from dagster_components.core.component import Component
+from dagster_components.scaffoldable.decorator import get_scaffolder
 from dagster_components.scaffoldable.scaffolder import ScaffolderUnavailableReason, ScaffoldRequest
 
 
@@ -37,7 +38,7 @@ def scaffold_component_instance(
     click.echo(f"Creating a Dagster component instance folder at {path}.")
     if not path.exists():
         path.mkdir()
-    scaffolder = scaffolder_from_component_type(component_type)
+    scaffolder = get_scaffolder(component_type)
 
     if isinstance(scaffolder, ScaffolderUnavailableReason):
         raise Exception(

--- a/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, TypeVar, Union
+from typing import Callable, TypeVar, Union
 
 from dagster import _check as check
 
@@ -11,8 +11,7 @@ T = TypeVar("T")
 SCAFFOLDER_ATTRIBUTE = "__scaffolder_class__"
 
 
-if TYPE_CHECKING:
-    from dagster_components.scaffoldable.scaffolder import Scaffolder, ScaffolderUnavailableReason
+from dagster_components.scaffoldable.scaffolder import Scaffolder, ScaffolderUnavailableReason
 
 
 def scaffoldable(
@@ -49,7 +48,7 @@ def is_scaffoldable_class(cls: type) -> bool:
 
 def get_scaffolder(
     cls: type,
-) -> Union[type["Scaffolder"], "ScaffolderUnavailableReason"]:
+) -> Union["Scaffolder", "ScaffolderUnavailableReason"]:
     """Retrieves the scaffolder class attached to the decorated class.
 
     Args:
@@ -61,4 +60,5 @@ def get_scaffolder(
     check.param_invariant(
         is_scaffoldable_class(cls), "cls", "Class must be decorated with @scaffoldable"
     )
-    return getattr(cls, SCAFFOLDER_ATTRIBUTE)
+    attr = getattr(cls, SCAFFOLDER_ATTRIBUTE)
+    return attr if isinstance(attr, ScaffolderUnavailableReason) else attr()

--- a/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffoldable/decorator.py
@@ -11,7 +11,7 @@ T = TypeVar("T")
 SCAFFOLDER_ATTRIBUTE = "__scaffolder_class__"
 
 
-from dagster_components.scaffoldable.scaffolder import Scaffolder, ScaffolderUnavailableReason
+from dagster_components.scaffoldable.scaffolder import ScaffolderUnavailableReason
 
 
 def scaffoldable(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/scaffoldable_tests/test_decorator.py
@@ -26,7 +26,7 @@ def test_basic_usage() -> None:
     # Test the functions
     assert is_scaffoldable_class(MyClass) is True
     assert is_scaffoldable_class(RegularClass) is False
-    assert get_scaffolder(MyClass) is MyScaffolder
+    assert isinstance(get_scaffolder(MyClass), MyScaffolder)
     with pytest.raises(CheckError):
         get_scaffolder(RegularClass)
 
@@ -43,7 +43,7 @@ def test_inheritance() -> None:
     class ClassTwo(ClassOne): ...
 
     assert is_scaffoldable_class(ClassOne) is True
-    assert get_scaffolder(ClassOne) is ScaffoldableOne
+    assert isinstance(get_scaffolder(ClassOne), ScaffoldableOne)
 
     assert is_scaffoldable_class(ClassTwo) is True
-    assert get_scaffolder(ClassTwo) is ScaffoldableTwo
+    assert isinstance(get_scaffolder(ClassTwo), ScaffoldableTwo)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_with_optional_scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_with_optional_scaffolder.py
@@ -1,5 +1,5 @@
 from dagster_components import Component
-from dagster_components.core.component import scaffolder_from_component_type
+from dagster_components.scaffold import get_scaffolder
 from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.scaffoldable.scaffolder import ScaffolderUnavailableReason
 
@@ -14,6 +14,6 @@ class ComponentWithOptionalScaffolder(Component): ...
 
 def test_component_with_optional_scaffolder() -> None:
     assert isinstance(
-        scaffolder_from_component_type(ComponentWithOptionalScaffolder),
+        get_scaffolder(ComponentWithOptionalScaffolder),
         ScaffolderUnavailableReason,
     )


### PR DESCRIPTION
## Summary & Motivation

Completely eliminate `scaffolder_from_component_type` and just use vanilla `get_scaffolder` function.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG