### PR TITLE
[components] Rename tool.dg.project.components_module -> defs_module and internal property renames

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/2-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/existing-project/2-pyproject.toml
@@ -4,7 +4,7 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "my_existing_project"
-components_module = "my_existing_project.defs"
+defs_module = "my_existing_project.defs"
 
 [tool.dagster]
 module_name = "my_existing_project.definitions"

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_existing_project/test_existing_code_location.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_existing_project/test_existing_code_location.py
@@ -50,7 +50,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
             [tool.dg.project]
             root_module = "my_existing_project"
-            components_module = "my_existing_project.defs"
+            defs_module = "my_existing_project.defs"
         """)
         pyproject_contents = pyproject_contents.replace(
             "[tool.dagster]", f"{tool_dg_section}\n\n[tool.dagster]"

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/my-existing-project/pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_migrating_definitions/my-existing-project/pyproject.toml
@@ -24,7 +24,7 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "my_existing_project"
-components_module = "my_existing_project.defs"
+defs_module = "my_existing_project.defs"
 
 [tool.dagster]
 module_name = "my_existing_project.definitions"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -82,7 +82,7 @@ def check_yaml_command(
 
     component_contents_by_key: dict[ComponentKey, Any] = {}
     modules_to_fetch = set()
-    for component_dir in dg_context.components_path.iterdir():
+    for component_dir in dg_context.defs_path.iterdir():
         if resolved_paths and not any(
             path == component_dir or path in component_dir.parents for path in resolved_paths
         ):
@@ -121,7 +121,9 @@ def check_yaml_command(
                 continue
 
             raw_key = component_doc_tree.value.get("type")
-            component_instance_module = dg_context.get_component_instance_module(component_dir.name)
+            component_instance_module = dg_context.get_component_instance_module_name(
+                component_dir.name
+            )
             qualified_key = (
                 f"{component_instance_module}{raw_key}" if raw_key.startswith(".") else raw_key
             )
@@ -130,7 +132,7 @@ def check_yaml_command(
 
             # We need to fetch components from any modules local to the project because these are
             # not cached with the components from the general environment.
-            if key.namespace.startswith(dg_context.components_module_name):
+            if key.namespace.startswith(dg_context.defs_module_name):
                 modules_to_fetch.add(key.namespace)
 
     # Fetch the local component types, if we need any local components

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -172,7 +172,7 @@ def temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
             project_context: DgContext = dg_context.with_root_path(project_root)
             entry = {
                 "working_directory": str(dg_context.workspace_root_path),
-                "relative_path": str(project_context.definitions_path),
+                "relative_path": str(project_context.code_location_target_path),
                 "location_name": project_context.project_name,
             }
             if project_context.use_dg_managed_environment:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -96,9 +96,7 @@ def workspace_scaffold_command(
 )
 @dg_editable_dagster_options
 @dg_global_options
-@click.pass_context
 def project_scaffold_command(
-    context: click.Context,
     name: str,
     skip_venv: bool,
     populate_cache: bool,
@@ -118,7 +116,7 @@ def project_scaffold_command(
     \b
     ├── <name>
     │   ├── __init__.py
-    │   ├── components
+    │   ├── defs
     │   ├── definitions.py
     │   └── lib
     │       └── __init__.py
@@ -130,7 +128,7 @@ def project_scaffold_command(
     component`).  The `<name>.lib` directory holds custom component types scoped to the project
     (which can be created with `dg scaffold component-type`).
     """  # noqa: D301
-    cli_config = normalize_cli_config(global_options, context)
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
     if dg_context.is_workspace:
         if dg_context.has_project(name):
@@ -326,7 +324,7 @@ def _create_component_scaffold_subcommand(
             scaffold_params = None
 
         scaffold_component_instance(
-            Path(dg_context.components_path) / component_instance_name,
+            Path(dg_context.defs_path) / component_instance_name,
             component_key.to_typename(),
             scaffold_params,
             dg_context,
@@ -366,7 +364,9 @@ def component_type_scaffold_command(
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)
-    component_key = ComponentKey(name=name, namespace=dg_context.default_components_library_module)
+    component_key = ComponentKey(
+        name=name, namespace=dg_context.default_component_library_module_name
+    )
     if registry.has(component_key):
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -212,19 +212,19 @@ class DgRawCliConfig(TypedDict, total=False):
 @dataclass
 class DgProjectConfig:
     root_module: str
-    components_module: Optional[str] = None
+    defs_module: Optional[str] = None
 
     @classmethod
     def from_raw(cls, raw: "DgRawProjectConfig") -> Self:
         return cls(
             root_module=raw["root_module"],
-            components_module=raw.get("components_module", DgProjectConfig.components_module),
+            defs_module=raw.get("defs_module", DgProjectConfig.defs_module),
         )
 
 
 class DgRawProjectConfig(TypedDict):
     root_module: Required[str]
-    components_module: NotRequired[str]
+    defs_module: NotRequired[str]
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -186,7 +186,7 @@ def _gather_dagster_packages(editable_dagster_root: Path) -> list[Path]:
 
 
 def scaffold_component_type(dg_context: DgContext, class_name: str, module_name: str) -> None:
-    root_path = Path(dg_context.default_components_library_path)
+    root_path = Path(dg_context.default_component_library_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{module_name}.py.")
 
     scaffold_subtree(
@@ -199,7 +199,7 @@ def scaffold_component_type(dg_context: DgContext, class_name: str, module_name:
 
     with open(root_path / "__init__.py", "a") as f:
         f.write(
-            f"from {dg_context.default_components_library_module}.{module_name} import {class_name}\n"
+            f"from {dg_context.default_component_library_module_name}.{module_name} import {class_name}\n"
         )
 
     click.echo(f"Scaffolded files for Dagster component type at {root_path}/{module_name}.py.")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_commands.py
@@ -73,27 +73,20 @@ def create_project_from_components(
         yield Path.cwd()
 
 
-def test_check_component_succeeds_non_default_component_package() -> None:
-    with (
-        ProxyRunner.test() as runner,
-        create_project_from_components(
-            runner,
-        ),
-    ):
+def test_check_component_succeeds_non_default_defs_module() -> None:
+    with ProxyRunner.test() as runner, create_project_from_components(runner):
         with modify_pyproject_toml() as toml:
-            set_toml_value(
-                toml, ("tool", "dg", "project", "components_module"), "foo_bar._components"
-            )
+            set_toml_value(toml, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
 
         # We need to do all of this copying here rather than relying on the project setup
         # fixture because that fixture assumes a default component package.
         component_src_path = COMPONENT_INTEGRATION_TEST_DIR / BASIC_VALID_VALUE.component_path
         component_name = component_src_path.name
-        components_dir = Path.cwd() / "foo_bar" / "_components" / component_name
-        components_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(component_src_path, components_dir, dirs_exist_ok=True)
+        defs_dir = Path.cwd() / "foo_bar" / "_defs" / component_name
+        defs_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(component_src_path, defs_dir, dirs_exist_ok=True)
         assert BASIC_VALID_VALUE.component_type_filepath
-        shutil.copy(BASIC_VALID_VALUE.component_type_filepath, components_dir / "__init__.py")
+        shutil.copy(BASIC_VALID_VALUE.component_type_filepath, defs_dir / "__init__.py")
 
         result = runner.invoke("check", "yaml")
         assert_runner_result(result, exit_0=True)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -462,7 +462,7 @@ def test_scaffold_component_already_exists_fails(in_workspace: bool) -> None:
         assert "already exists" in result.output
 
 
-def test_scaffold_component_succeeds_non_default_component_package() -> None:
+def test_scaffold_component_succeeds_non_default_defs_module() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
@@ -470,7 +470,7 @@ def test_scaffold_component_succeeds_non_default_component_package() -> None:
         alt_lib_path = Path("foo_bar/_defs")
         alt_lib_path.mkdir(parents=True)
         with modify_pyproject_toml() as toml:
-            set_toml_value(toml, ("tool", "dg", "project", "components_module"), "foo_bar._defs")
+            set_toml_value(toml, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
             "scaffold",
             "component",
@@ -487,13 +487,13 @@ def test_scaffold_component_succeeds_non_default_component_package() -> None:
         )
 
 
-def test_scaffold_component_fails_components_package_does_not_exist() -> None:
+def test_scaffold_component_fails_defs_module_does_not_exist() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
         with modify_pyproject_toml() as toml:
-            set_toml_value(toml, ("tool", "dg", "project", "components_module"), "foo_bar._defs")
+            set_toml_value(toml, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
             "scaffold",
             "component",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -144,7 +144,7 @@ def test_invalid_config_project():
         cases = [
             [("tool", "dg", "cli", "verbose"), bool, 1],
             [("tool", "dg", "project", "root_module"), str, 1],
-            [("tool", "dg", "project", "components_module"), str, 1],
+            [("tool", "dg", "project", "defs_module"), str, 1],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():


### PR DESCRIPTION
## Summary & Motivation

- `tool.dg.project.components_module` config setting -> `defs_module`
- `DgContext.components_module_name` -> `defs_module_name`
- `DgContext.definitions_module_name` -> `code_location_load_target_module_name`
- `*components_library` -> `*component_library` (internally-facing only)
- `*module` -> `*module_name` (internally facing only, config settings are just "module" since it is clear in that context it is a name and not an actual module ref)

## How I Tested These Changes

Existing test suite.