### PR TITLE
[components] Read project code location name/target from `tool.dagster`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -158,6 +158,21 @@ def test_invalid_config_project():
                 _set_and_detect_missing_required_key(path, expected_type)
 
 
+def test_tool_dg_config():
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+        context = DgContext.for_project_environment(Path.cwd(), {})
+        assert context.code_location_target_module_name == "foo_bar.definitions"
+        assert context.code_location_name == "foo-bar"
+
+        with modify_pyproject_toml() as toml:
+            set_toml_value(toml, ("tool", "dagster", "module_name"), "foo_bar._definitions")
+            set_toml_value(toml, ("tool", "dagster", "code_location_name"), "my-code_location")
+
+        context = DgContext.for_project_environment(Path.cwd(), {})
+        assert context.code_location_target_module_name == "foo_bar._definitions"
+        assert context.code_location_name == "my-code_location"
+
+
 # ########################
 # ##### HELPERS
 # ########################


### PR DESCRIPTION
## Summary & Motivation

There was a discrepancy where the `code_location_load_target_module_name` was hardcoded to `<root_module>/definitions.py` instead of being read from `tool.dagster`. This changes it to read from `tool.dagster`. This is an intermediate step to the elimination of `tool.dagster` from projects.

## How I Tested These Changes

New unit test.