### PR TITLE
[components] Remove tool.dagster from scaffolded projects

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/4-pyproject.toml
@@ -1,8 +1,4 @@
 ...
-[tool.dagster]
-module_name = "jaffle_platform.definitions"
-code_location_name = "jaffle-platform"
-
 [tool.dg]
 directory_type = "project"
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/4-project-pyproject.toml
@@ -1,8 +1,4 @@
 ...
-[tool.dagster]
-module_name = "project_1.definitions"
-code_location_name = "project-1"
-
 [tool.dg]
 directory_type = "project"
 

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -76,7 +76,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
             COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-pyproject.toml",
             update_snippets=update_snippets,
             snippet_replace_regex=[
-                re_ignore_before("[tool.dagster]"),
+                re_ignore_before("[tool.dg]"),
                 re_ignore_after('root_module = "jaffle_platform"'),
             ],
         )

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_workspace.py
@@ -85,7 +85,7 @@ def test_components_docs_workspace(update_snippets: bool) -> None:
             / f"{get_next_snip_number()}-project-pyproject.toml",
             update_snippets=update_snippets,
             snippet_replace_regex=[
-                re_ignore_before("[tool.dagster]"),
+                re_ignore_before("[tool.dg]"),
                 re_ignore_after('root_module = "project_1"'),
             ],
         )

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -130,6 +130,19 @@ def get_origins_from_toml(
                         ).create_origins()
                     )
             return origins
+
+        # This allows `dagster dev` to work with projects scaffolded by the new `dg` CLI
+        # without the need to include a `tool.dagster` section.
+        dg_block = data.get("tool", {}).get("dg", {}).get("project", {})
+        if dg_block:
+            default_module_name = f"{dg_block['root_module']}.definitions"
+            module_name = dg_block.get("code_location_load_target_module", default_module_name)
+            return ModuleTarget(
+                module_name=module_name,
+                attribute=None,
+                working_directory=os.getcwd(),
+                location_name=dg_block.get("code_location_name"),
+            ).create_origins()
         else:
             return []
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -1,6 +1,5 @@
 import subprocess
 from collections.abc import Mapping, Sequence
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
@@ -216,10 +215,10 @@ def check_definitions_command(
 
     # In a code location context, we can just run `dagster definitions validate` directly, using `dagster` from the
     # code location's environment.
+    temp_workspace_file_cm = temp_workspace_file(dg_context)
     if dg_context.is_project:
         cmd = ["uv", "run", "dagster", "definitions", "validate", *forward_options]
         cmd_location = dg_context.get_executable("dagster")
-        temp_workspace_file_cm = nullcontext()
 
     # In a deployment context, dg validate will construct a temporary
     # workspace file that points at all defined code locations and invoke:

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -213,18 +213,27 @@ class DgRawCliConfig(TypedDict, total=False):
 class DgProjectConfig:
     root_module: str
     defs_module: Optional[str] = None
+    code_location_target_module: Optional[str] = None
+    code_location_name: Optional[str] = None
 
     @classmethod
     def from_raw(cls, raw: "DgRawProjectConfig") -> Self:
         return cls(
             root_module=raw["root_module"],
             defs_module=raw.get("defs_module", DgProjectConfig.defs_module),
+            code_location_name=raw.get("code_location_name", DgProjectConfig.code_location_name),
+            code_location_target_module=raw.get(
+                "code_location_target_module",
+                DgProjectConfig.code_location_target_module,
+            ),
         )
 
 
 class DgRawProjectConfig(TypedDict):
     root_module: Required[str]
     defs_module: NotRequired[str]
+    code_location_target_module: NotRequired[str]
+    code_location_name: NotRequired[str]
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -316,13 +316,13 @@ class DgContext:
 
     @property
     def code_location_target_module_name(self) -> str:
-        if not self.is_project:
+        if not self.config.project:
             raise DgError(
                 "`code_location_target_module_name` is only available in a Dagster project context"
             )
-        return self._tool_dagster_config_section.get(
-            "module_name",
-            f"{self.root_module_name}.{_DEFAULT_PROJECT_CODE_LOCATION_TARGET_MODULE}",
+        return (
+            self.config.project.code_location_target_module
+            or f"{self.root_module_name}.{_DEFAULT_PROJECT_CODE_LOCATION_TARGET_MODULE}"
         )
 
     @cached_property
@@ -331,19 +331,9 @@ class DgContext:
 
     @property
     def code_location_name(self) -> str:
-        if not self.is_project:
+        if not self.config.project:
             raise DgError("`code_location_name` is only available in a Dagster project context")
-        return self._tool_dagster_config_section.get("code_location_name", self.project_name)
-
-    @cached_property
-    def _tool_dagster_config_section(self) -> dict[str, str]:
-        if not self.is_project:
-            raise DgError("`tool_dg_config_section` is only available in a Dagster project context")
-        with open(self.pyproject_toml_path) as f:
-            toml = tomlkit.parse(f.read())
-            if not has_toml_value(toml, ("tool", "dagster")):
-                return {}
-            return get_toml_value(toml, ("tool", "dagster"), dict)
+        return self.config.project.code_location_name or self.project_name
 
     # ########################
     # ##### COMPONENT LIBRARY METHODS

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -100,7 +100,6 @@ def scaffold_project(
         ),
         dependencies=dependencies_str,
         dev_dependencies=dev_dependencies_str,
-        code_location_name=path.name,
         uv_sources=uv_sources_str,
     )
     click.echo(f"Scaffolded files for Dagster project at {path}.")

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -14,10 +14,6 @@ version = "0.1.0"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.dagster]
-module_name = "{{ project_name }}.definitions"
-code_location_name = "{{ code_location_name }}"
-
 [tool.dg]
 directory_type = "project"
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -94,7 +94,7 @@ def test_dev_command_has_options_of_dagster_dev():
 # Modify this test with a new option whenever a new forwarded option is added to `dagster-dev`.
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_command_forwards_options_to_dagster_dev():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, "foo-bar"):
         port = _find_free_port()
         options = [
             "--code-server-log-level",
@@ -114,14 +114,7 @@ def test_dev_command_forwards_options_to_dagster_dev():
             dev_process = _launch_dev_command(options)
             time.sleep(0.5)
             child_process = _get_child_processes(dev_process.pid)[0]
-            expected_cmdline = [
-                "uv",
-                "run",
-                "dagster",
-                "dev",
-                *options,
-            ]
-            assert child_process.cmdline() == expected_cmdline
+            assert " ".join(options) in " ".join(child_process.cmdline())
         finally:
             dev_process.terminate()
             dev_process.communicate()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -99,10 +99,7 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
 
         # Check TOML content
         toml = tomlkit.parse(Path("projects/foo-bar/pyproject.toml").read_text())
-        assert (
-            get_toml_value(toml, ("tool", "dagster", "module_name"), str) == "foo_bar.definitions"
-        )
-        assert get_toml_value(toml, ("tool", "dagster", "code_location_name"), str) == "foo-bar"
+        assert get_toml_value(toml, ("tool", "dg", "project", "root_module"), str) == "foo_bar"
 
         # Check venv created
         assert Path("projects/foo-bar/.venv").exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_validate_command.py
@@ -42,7 +42,7 @@ def test_validate_command_deployment_context_success():
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
-def test_validate_command_code_location_context_success():
+def test_validate_command_project_context_success():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         result = runner.invoke("check", "defs")
         assert_runner_result(result)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -145,6 +145,8 @@ def test_invalid_config_project():
             [("tool", "dg", "cli", "verbose"), bool, 1],
             [("tool", "dg", "project", "root_module"), str, 1],
             [("tool", "dg", "project", "defs_module"), str, 1],
+            [("tool", "dg", "project", "code_location_name"), str, 1],
+            [("tool", "dg", "project", "code_location_target_module"), str, 1],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():
@@ -158,15 +160,21 @@ def test_invalid_config_project():
                 _set_and_detect_missing_required_key(path, expected_type)
 
 
-def test_tool_dg_config():
+def test_code_location_config():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         context = DgContext.for_project_environment(Path.cwd(), {})
         assert context.code_location_target_module_name == "foo_bar.definitions"
         assert context.code_location_name == "foo-bar"
 
         with modify_pyproject_toml() as toml:
-            set_toml_value(toml, ("tool", "dagster", "module_name"), "foo_bar._definitions")
-            set_toml_value(toml, ("tool", "dagster", "code_location_name"), "my-code_location")
+            set_toml_value(
+                toml,
+                ("tool", "dg", "project", "code_location_target_module"),
+                "foo_bar._definitions",
+            )
+            set_toml_value(
+                toml, ("tool", "dg", "project", "code_location_name"), "my-code_location"
+            )
 
         context = DgContext.for_project_environment(Path.cwd(), {})
         assert context.code_location_target_module_name == "foo_bar._definitions"


### PR DESCRIPTION
## Summary & Motivation

Eliminate all use of `tool.dagster` in scaffolded projects. Where previously scaffolded projects were created with a `tool.dagster.{module_name,code_location_name}`, we now omit the `tool.dagster` section. There are two new `tool.dg.project` settings to replace them:

- `tool.dg.project.code_location_load_target_module` (default to `<root_package>.definitions`)
- `tool.dg.project.code_location_name` (default to the project name)

It is rare that either of these should need to be set. `code_location_load_target_module` is a mouthful but calling it `definitions_module` would be very confusing now that there is `defs_module`.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
