### PR TITLE
[components] Ignore and warn about `tool.dg.cli` in project inside workspace

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -276,7 +276,7 @@ def not_none(value: Optional[T]) -> T:
 
 
 def exit_with_error(error_message: str) -> Never:
-    formatted_error_message = _format_error_message(error_message)
+    formatted_error_message = format_multiline_str(error_message)
     click.echo(click.style(formatted_error_message, fg="red"))
     sys.exit(1)
 
@@ -286,7 +286,7 @@ def exit_with_error(error_message: str) -> Never:
 # ########################
 
 
-def _format_error_message(message: str) -> str:
+def format_multiline_str(message: str) -> str:
     # width=10000 unwraps any hardwrapping
     dedented = textwrap.dedent(message).strip()
     paragraphs = [textwrap.fill(p, width=10000) for p in dedented.split("\n\n")]
@@ -350,6 +350,21 @@ you are using `dg` in a non-managed environment (either outside of a Dagster pro
 `--no-use-dg-managed-environment` flag), you need to independently ensure `dagster-components` is
 installed.
 """
+
+
+def generate_tool_dg_cli_in_project_in_workspace_error_message(
+    project_path: Path, workspace_path: Path
+) -> str:
+    return textwrap.dedent(f"""
+        `tool.dg.cli` section detected in project `pyproject.toml` file at:
+            {project_path}
+        This project is inside of a workspace at:
+            {workspace_path}
+        """).lstrip() + format_multiline_str("""
+        The `tool.dg.cli` section is ignored for project `pyproject.toml` files inside of a
+        workspace. Any `tool.dg.cli` settings should be placed in the workspace config file.
+        """)
+
 
 # ########################
 # ##### CUSTOM CLICK SUBCLASSES

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -52,11 +52,12 @@ def test_context_in_project_in_workspace():
         context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
-        # Test config from project overrides workspace
+        # Test cli config in project is ignored and generates warning
         with pushd(project_path), modify_pyproject_toml() as pyproject_toml:
             set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), False)
-        context = DgContext.for_project_environment(path_arg, {})
-        assert context.config.cli.verbose is False
+        with pytest.warns(match="`tool.dg.cli` section detected in project"):
+            context = DgContext.for_project_environment(path_arg, {})
+        assert context.config.cli.verbose is True
 
 
 def test_context_in_project_outside_workspace():
@@ -70,6 +71,7 @@ def test_context_in_project_outside_workspace():
         assert context.workspace_root_path is None
         assert context.config.cli.verbose is False
 
+        # Test CLI setting is used in project outside of workspace
         with modify_pyproject_toml() as pyproject_toml:
             set_toml_value(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})


### PR DESCRIPTION
## Summary & Motivation

We permit `tool.dg.cli` in standalone project configs, but when a project is inside a workspace we want to use only the `tool.dg.cli` section in the workspace config to avoid ambiguity about which section should apply when operating on a project from within a workspace. This PR emits a warning and ignores `tool.dg.cli` in a project config that is inside a workspace.

## How I Tested These Changes

New unit test.