### PR TITLE
[ui] Make asset overview show metadata, schema of latest event, not “latest partition or null"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -44,7 +44,7 @@
   "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
-  "AssetOverviewMetadataEventsQuery": "ce504cf0820b50aab6cecee3fb4cb5e412af98beef75a80038c83c872d4fb0cd",
+  "AssetOverviewMetadataEventsQuery": "0188ef9d8f04f99e2f98e0f7c8755982259c8e65ded2647e72ddf008acc0b331",
   "PartitionHealthQuery": "4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af",
   "AssetJobPartitionSetsQuery": "43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7",
   "AssetEventsQuery": "327d2e3b45fa328309610c4b7c691b0b31a4d2f65da029767e2f9da1e458d113",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -44,7 +44,7 @@
   "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
-  "AssetOverviewMetadataEventsQuery": "0188ef9d8f04f99e2f98e0f7c8755982259c8e65ded2647e72ddf008acc0b331",
+  "AssetOverviewMetadataEventsQuery": "114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca",
   "PartitionHealthQuery": "4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af",
   "AssetJobPartitionSetsQuery": "43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7",
   "AssetEventsQuery": "327d2e3b45fa328309610c4b7c691b0b31a4d2f65da029767e2f9da1e458d113",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -38,6 +38,11 @@ type Props = {
   loading: boolean;
 };
 
+export const RecentUpdatesTimelineForAssetKey = (props: {assetKey: AssetKey}) => {
+  const data = useRecentAssetEvents(props.assetKey, {}, {assetHasDefinedPartitions: false});
+  return <RecentUpdatesTimeline assetKey={props.assetKey} {...data} />;
+};
+
 export const RecentUpdatesTimeline = ({
   assetKey,
   observations,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {Box, Caption, Colors, Tag} from '@dagster-io/ui-components';
 import React from 'react';
+import {Link} from 'react-router-dom';
 
 import {MaterializationTag} from './MaterializationTag';
 import {Timestamp} from '../app/time/Timestamp';
@@ -18,9 +19,11 @@ import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
 export const SimpleStakeholderAssetStatus = ({
   liveData,
   assetNode,
+  partition,
 }: {
   liveData: LiveDataForNode | undefined;
   assetNode: Pick<AssetViewDefinitionNodeFragment, 'assetKey' | 'isObservable'>;
+  partition: string | null;
 }) => {
   if (!liveData) {
     return <span />;
@@ -53,20 +56,34 @@ export const SimpleStakeholderAssetStatus = ({
       </Tag>
     );
   }
+  const partitionTag = partition ? (
+    <Tag intent="none">
+      <Link to={`?view=partitions&partition=${encodeURIComponent(partition)}`}>
+        <Caption color={Colors.textDefault()}>{partition}</Caption>
+      </Link>
+    </Tag>
+  ) : undefined;
+
   if (liveData.lastMaterialization) {
     return (
-      <MaterializationTag
-        assetKey={assetNode.assetKey}
-        event={liveData.lastMaterialization}
-        stepKey={liveData.stepKey}
-      />
+      <Box flex={{gap: 4}}>
+        <MaterializationTag
+          assetKey={assetNode.assetKey}
+          event={liveData.lastMaterialization}
+          stepKey={liveData.stepKey}
+        />
+        {partitionTag}
+      </Box>
     );
   }
   if (liveData.lastObservation && assetNode.isObservable) {
     return (
-      <Tag intent="none">
-        <Timestamp timestamp={{ms: Number(liveData.lastObservation.timestamp)}} />
-      </Tag>
+      <Box flex={{gap: 4}}>
+        <Tag intent="none">
+          <Timestamp timestamp={{ms: Number(liveData.lastObservation.timestamp)}} />
+        </Tag>
+        {partitionTag}
+      </Box>
     );
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
@@ -31,7 +31,7 @@ import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {LargeCollapsibleSection} from '../LargeCollapsibleSection';
 import {MaterializationTag} from '../MaterializationTag';
 import {OverdueTag} from '../OverdueTag';
-import {RecentUpdatesTimeline} from '../RecentUpdatesTimeline';
+import {RecentUpdatesTimelineForAssetKey} from '../RecentUpdatesTimeline';
 import {SimpleStakeholderAssetStatus} from '../SimpleStakeholderAssetStatus';
 import {AssetChecksStatusSummary} from '../asset-checks/AssetChecksStatusSummary';
 import {buildConsolidatedColumnSchema} from '../buildConsolidatedColumnSchema';
@@ -39,8 +39,7 @@ import {globalAssetGraphPathForAssetsAndDescendants} from '../globalAssetGraphPa
 import {AssetKey} from '../types';
 import {AssetTableDefinitionFragment} from '../types/AssetTableFragment.types';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
-import {useLatestPartitionEvents} from '../useLatestPartitionEvents';
-import {useRecentAssetEvents} from '../useRecentAssetEvents';
+import {useLatestEvents} from '../useLatestEvents';
 
 export const AssetNodeOverview = ({
   assetKey,
@@ -72,20 +71,10 @@ export const AssetNodeOverview = ({
 
   const assetNodeLoadTimestamp = location ? location.updatedTimestamp * 1000 : undefined;
 
-  const {materialization, observation, loading} = useLatestPartitionEvents(
+  const {materialization, observation, loading} = useLatestEvents(
     assetKey,
     assetNodeLoadTimestamp,
     liveData,
-  );
-
-  const {
-    materializations,
-    observations,
-    loading: materializationsLoading,
-  } = useRecentAssetEvents(
-    cachedOrLiveAssetNode?.partitionDefinition ? undefined : cachedOrLiveAssetNode?.assetKey,
-    {},
-    {assetHasDefinedPartitions: false},
   );
 
   // Start loading neighboring assets data immediately to avoid waterfall.
@@ -154,12 +143,7 @@ export const AssetNodeOverview = ({
         ) : undefined}
       </Box>
       {cachedOrLiveAssetNode.isPartitioned ? null : (
-        <RecentUpdatesTimeline
-          materializations={materializations}
-          observations={observations}
-          assetKey={cachedOrLiveAssetNode.assetKey}
-          loading={materializationsLoading}
-        />
+        <RecentUpdatesTimelineForAssetKey assetKey={cachedOrLiveAssetNode.assetKey} />
       )}
     </Box>
   );
@@ -305,12 +289,6 @@ export const AssetNodeOverviewNonSDA = ({
   assetKey: AssetKey;
   lastMaterialization: {timestamp: string; runId: string} | null | undefined;
 }) => {
-  const {materializations, observations, loading} = useRecentAssetEvents(
-    assetKey,
-    {},
-    {assetHasDefinedPartitions: false},
-  );
-
   return (
     <AssetNodeOverviewContainer
       left={
@@ -327,12 +305,7 @@ export const AssetNodeOverviewNonSDA = ({
                 <Caption color={Colors.textLighter()}>Never materialized</Caption>
               )}
             </div>
-            <RecentUpdatesTimeline
-              materializations={materializations}
-              observations={observations}
-              assetKey={assetKey}
-              loading={loading}
-            />
+            <RecentUpdatesTimelineForAssetKey assetKey={assetKey} />
           </Box>
         </LargeCollapsibleSection>
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
@@ -372,4 +372,4 @@ export type AssetOverviewMetadataEventsQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const AssetOverviewMetadataEventsQueryVersion = 'ce504cf0820b50aab6cecee3fb4cb5e412af98beef75a80038c83c872d4fb0cd';
+export const AssetOverviewMetadataEventsQueryVersion = '0188ef9d8f04f99e2f98e0f7c8755982259c8e65ded2647e72ddf008acc0b331';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
@@ -16,6 +16,7 @@ export type AssetOverviewMetadataEventsQuery = {
           __typename: 'MaterializationEvent';
           timestamp: string;
           runId: string;
+          partition: string | null;
           metadataEntries: Array<
             | {
                 __typename: 'AssetMetadataEntry';
@@ -194,6 +195,7 @@ export type AssetOverviewMetadataEventsQuery = {
           __typename: 'ObservationEvent';
           timestamp: string;
           runId: string;
+          partition: string | null;
           metadataEntries: Array<
             | {
                 __typename: 'AssetMetadataEntry';
@@ -372,4 +374,4 @@ export type AssetOverviewMetadataEventsQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const AssetOverviewMetadataEventsQueryVersion = '0188ef9d8f04f99e2f98e0f7c8755982259c8e65ded2647e72ddf008acc0b331';
+export const AssetOverviewMetadataEventsQueryVersion = '114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
@@ -69,6 +69,7 @@ export const ASSET_OVERVIEW_METADATA_EVENTS_QUERY = gql`
         assetMaterializations(limit: 1) {
           timestamp
           runId
+          partition
           metadataEntries {
             ...MetadataEntryFragment
           }
@@ -76,6 +77,7 @@ export const ASSET_OVERVIEW_METADATA_EVENTS_QUERY = gql`
         assetObservations(limit: 1) {
           timestamp
           runId
+          partition
           metadataEntries {
             ...MetadataEntryFragment
           }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
@@ -6,12 +6,12 @@ import {gql, useQuery} from '../apollo-client';
 import {
   AssetOverviewMetadataEventsQuery,
   AssetOverviewMetadataEventsQueryVariables,
-} from './types/useLatestPartitionEvents.types';
+} from './types/useLatestEvents.types';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {usePredicateChangeSignal} from '../hooks/usePredicateChangeSignal';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 
-export function useLatestPartitionEvents(
+export function useLatestEvents(
   assetKey: AssetKey,
   assetNodeLoadTimestamp: number | undefined,
   liveData: LiveDataForNode | undefined,
@@ -66,14 +66,14 @@ export const ASSET_OVERVIEW_METADATA_EVENTS_QUERY = gql`
     assetOrError(assetKey: $assetKey) {
       ... on Asset {
         id
-        assetMaterializations(limit: 1, partitionInLast: 1) {
+        assetMaterializations(limit: 1) {
           timestamp
           runId
           metadataEntries {
             ...MetadataEntryFragment
           }
         }
-        assetObservations(limit: 1, partitionInLast: 1) {
+        assetObservations(limit: 1) {
           timestamp
           runId
           metadataEntries {


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FE-589/metadata-plots-only-work-in-asset-catalog-when-most-recent-partition, https://github.com/dagster-io/dagster/issues/24600

![image](https://github.com/user-attachments/assets/fe35cfca-dd56-4123-8c9e-2db2a12d2a4a)

It was flagged by a user that the new Asset Overview page shows the metadata and schema for the most recent PARTITION, or empty states if that partition is not present. This is somewhat confusing because these sections can render empty while the tag at the top still shows the latest event. (Screenshot above)

I think at some point the tag at the top of the page was also restricted to showing the latest partition, so this made sense. However, it seems problematic because for any daily partitioned asset, it is missing for some portion of the day and all the information disappears for that period.

The fix in this PR is just to make the metadata + schema portions of the page use the latest event, even if it's not for a recent / today's partition. This could have slightly undesirable behavior during backfills (eg: showing you metadata for an older partition), but means that the materialization in the green pill and the materialization used for these sections is always the same.

## How I Tested These Changes

Tested with a manual repro

## Changelog

[ui] The asset overview tab for a partitioned asset now shows metadata and schema of the most recent materialization, not today's partition.