### PR TITLE
[ui] Fix for extra padding on Materialize button

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -315,6 +315,9 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
         }
         right={
           <Box style={{margin: '-4px 0'}} flex={{direction: 'row', gap: 8}}>
+            {reportEvents.element}
+            {wipe.element}
+            {dynamicPartitionsDelete.element}
             {cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 ? (
               <LaunchAssetExecutionButton
                 scope={{all: [cachedOrLiveDefinition]}}
@@ -326,9 +329,6 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
                 ]}
               />
             ) : undefined}
-            {reportEvents.element}
-            {wipe.element}
-            {dynamicPartitionsDelete.element}
           </Box>
         }
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
@@ -40,7 +40,7 @@ export function useDeleteDynamicPartitionsDialog(
     !canSeeWipeMaterializationAction
   ) {
     return {
-      element: <span />,
+      element: undefined,
       dropdownOptions: [] as JSX.Element[],
     };
   }


### PR DESCRIPTION
The extra components provided by these three hooks are dialogs and are not rendering additional buttons, so I re-ordered them so that they don't contribute padding to the end of the flexbox. Also changed one element that was intended to be conditional from a `<span />` to undefined like the others.

Before:
<img width="83" alt="image" src="https://github.com/user-attachments/assets/81ee1c76-c95c-4c97-8682-184942a3489a" />

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/5c8f7221-a33f-4658-815b-5029253071d9" />

After:
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/e0be4ff0-c273-407e-b869-635d195e4ed3" />

