### PR TITLE
[dg] Default dg check defs to warning and print success message

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -173,7 +173,7 @@ def check_yaml_command(
     "--log-level",
     help="Set the log level for dagster services.",
     show_default=True,
-    default="info",
+    default="warning",
     type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
@@ -244,3 +244,5 @@ def check_definitions_command(
             cmd.extend(["--workspace", workspace_file])
 
         subprocess.run(cmd, check=True)
+
+    click.echo("All definitions loaded successfully.")


### PR DESCRIPTION
## Summary & Motivation

By defaulting to `warning` instead of `info` and adding a success method we can make `dg check defs` feel better.

## How I Tested These Changes

```
➜  test-project dg check defs
Using /Users/schrockn/code/scratch/component_workspaces/dw-0305-0516/projects/test-project/.venv/bin/dagster
All definitions loaded successfully.
➜  test-project
```

## Changelog

NOCHANGELOG