### PR TITLE
[dg] Make DbtProject resolvers explicit

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -167,7 +167,7 @@ class AssetPostProcessorSchema(ResolvableSchema):
     attributes: AssetAttributesSchema
 
     def resolve(self, context: ResolutionContext) -> Callable[[Definitions], Definitions]:
-        return resolve_schema_to_transform(context, self)
+        return resolve_schema_to_post_processor(context, self)
 
 
 def apply_post_processor_to_spec(
@@ -208,7 +208,7 @@ def apply_post_processor_to_defs(
     return replace(defs, assets=assets)
 
 
-def resolve_schema_to_transform(
+def resolve_schema_to_post_processor(
     context, schema: AssetPostProcessorSchema
 ) -> Callable[[Definitions], Definitions]:
     return lambda defs: apply_post_processor_to_defs(schema, defs, context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -74,9 +74,6 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
         ),
     )
     attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
-    # import code
-
-    # code.interact(local=locals())
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -73,10 +73,12 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
             },
         ),
     )
+    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    # import code
+
+    # code.interact(local=locals())
     context = script_load_context(decl_node)
-    component = DbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
-    )
+    component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
     defs = component.build_defs(script_load_context())
     assets_def: AssetsDefinition = defs.get_assets_def("stg_customers")


### PR DESCRIPTION
## Summary & Motivation

Refactoring the `DbtProjectComponent` to use explicit resolvers in all cases. This is part of the process to remove all instances that rely on the `ResolvableSchema` indirection magic so we can eliminate and build up mappings in the other direction.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG