### PR TITLE
[components] Scaffold project options

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/3-pyproject.toml
@@ -2,5 +2,7 @@
 directory_type = "workspace"
 
 [tool.dg.workspace]
+[tool.dg.workspace.scaffold_project_options]
+use_editable_dagster = true
 [[tool.dg.workspace.projects]]
 path = "projects/project-1"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -5,7 +5,11 @@ import click
 
 from dagster_dg.cli.scaffold import DEFAULT_WORKSPACE_NAME
 from dagster_dg.cli.shared_options import dg_editable_dagster_options, dg_global_options
-from dagster_dg.config import normalize_cli_config
+from dagster_dg.config import (
+    DgRawWorkspaceConfig,
+    DgWorkspaceScaffoldProjectOptions,
+    normalize_cli_config,
+)
 from dagster_dg.context import DgContext
 from dagster_dg.scaffold import scaffold_project, scaffold_workspace
 from dagster_dg.utils import DgClickCommand, exit_with_error
@@ -43,7 +47,14 @@ def init_command(
         default=DEFAULT_WORKSPACE_NAME,
     ).strip()
 
-    workspace_path = scaffold_workspace(workspace_name)
+    workspace_config = DgRawWorkspaceConfig(
+        scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
+            use_editable_dagster,
+            use_editable_components_package_only,
+        )
+    )
+
+    workspace_path = scaffold_workspace(workspace_name, workspace_config)
     workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
         workspace_path, cli_config
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -16,6 +16,8 @@ from dagster_dg.component import RemoteComponentRegistry, RemoteComponentType
 from dagster_dg.component_key import ComponentKey
 from dagster_dg.config import (
     DgRawCliConfig,
+    DgRawWorkspaceConfig,
+    DgWorkspaceScaffoldProjectOptions,
     get_config_from_cli_context,
     has_config_on_cli_context,
     normalize_cli_config,
@@ -54,9 +56,12 @@ def scaffold_group():
 
 @scaffold_group.command(name="workspace", cls=DgClickCommand)
 @click.argument("name", type=str, default=DEFAULT_WORKSPACE_NAME)
+@dg_editable_dagster_options
 @dg_global_options
 def workspace_scaffold_command(
     name: str,
+    use_editable_dagster: Optional[str],
+    use_editable_components_package_only: Optional[str],
     **global_options: object,
 ):
     """Initialize a new Dagster workspace.
@@ -72,7 +77,13 @@ def workspace_scaffold_command(
     │   └── pyproject.toml
 
     """  # noqa: D301
-    scaffold_workspace(name)
+    workspace_config = DgRawWorkspaceConfig(
+        scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
+            use_editable_dagster,
+            use_editable_components_package_only,
+        )
+    )
+    scaffold_workspace(name, workspace_config)
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -9,7 +9,11 @@ import tomlkit
 import tomlkit.items
 
 from dagster_dg.component import RemoteComponentRegistry
-from dagster_dg.config import discover_workspace_root
+from dagster_dg.config import (
+    DgRawWorkspaceConfig,
+    DgWorkspaceScaffoldProjectOptions,
+    discover_workspace_root,
+)
 from dagster_dg.context import DgContext
 from dagster_dg.utils import (
     exit_with_error,
@@ -27,6 +31,7 @@ from dagster_dg.utils import (
 
 def scaffold_workspace(
     workspace_name: str,
+    workspace_config: Optional[DgRawWorkspaceConfig] = None,
 ) -> Path:
     # Can't create a workspace that is a child of another workspace
     new_workspace_path = Path.cwd() / workspace_name
@@ -46,6 +51,14 @@ def scaffold_workspace(
         ),
         project_name=workspace_name,
     )
+
+    if workspace_config is not None:
+        with modify_toml(new_workspace_path / "pyproject.toml") as toml:
+            for k, v in workspace_config.items():
+                # Ignore empty collections and None, but not False
+                if v != {} and v != [] and v is not None:
+                    set_toml_node(toml, ("tool", "dg", "workspace", k), v)
+
     click.echo(f"Scaffolded files for Dagster workspace at {new_workspace_path}.")
     return new_workspace_path
 
@@ -65,24 +78,42 @@ def scaffold_project(
 ) -> None:
     click.echo(f"Creating a Dagster project at {path}.")
 
-    if use_editable_dagster and use_editable_components_package_only:
+    cli_options = DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
+        use_editable_dagster, use_editable_components_package_only
+    )
+    workspace_options = (
+        dg_context.config.workspace.scaffold_project_options
+        if dg_context.config.workspace
+        else None
+    )
+
+    final_use_editable_dagster = cli_options.get(
+        "use_editable_dagster",
+        workspace_options.use_editable_dagster if workspace_options else None,
+    )
+    final_use_editable_components_package_only = cli_options.get(
+        "use_editable_components_package_only",
+        workspace_options.use_editable_components_package_only if workspace_options else None,
+    )
+
+    if final_use_editable_dagster and final_use_editable_components_package_only:
         exit_with_error(
             "Cannot specify both --use-editable-dagster and --use-editable-components-package-only."
         )
-    elif use_editable_dagster:
+    elif final_use_editable_dagster:
         editable_dagster_root = (
             _get_editable_dagster_from_env()
-            if use_editable_dagster == "TRUE"
-            else use_editable_dagster
+            if final_use_editable_dagster is True
+            else final_use_editable_dagster
         )
         deps = EDITABLE_DAGSTER_DEPENDENCIES
         dev_deps = EDITABLE_DAGSTER_DEV_DEPENDENCIES
         sources = _gather_dagster_packages(Path(editable_dagster_root))
-    elif use_editable_components_package_only:
+    elif final_use_editable_components_package_only:
         editable_dagster_root = (
             _get_editable_dagster_from_env()
-            if use_editable_components_package_only == "TRUE"
-            else use_editable_components_package_only
+            if final_use_editable_components_package_only is True
+            else final_use_editable_components_package_only
         )
         deps = EDITABLE_COMPONENTS_ONLY_DEPENDENCIES
         dev_deps = EDITABLE_COMPONENTS_ONLY_DEV_DEPENDENCIES

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -90,9 +90,24 @@ def test_dg_init_use_editable_dagster(
         assert_runner_result(result)
 
         assert Path("dagster-workspace").exists()
-        pyproject_toml = Path("dagster-workspace/projects/helloworld/pyproject.toml")
-        assert pyproject_toml.exists()
-        with pyproject_toml.open() as f:
+
+        workspace_config = Path("dagster-workspace/pyproject.toml")
+        with workspace_config.open() as f:
+            toml = tomlkit.parse(f.read())
+            option_key = option[2:].replace("-", "_")
+            option_value = True if value_source == "env_var" else str(dagster_git_repo_dir)
+            assert (
+                get_toml_node(
+                    toml,
+                    ("tool", "dg", "workspace", "scaffold_project_options", option_key),
+                    (bool, str),
+                )
+                == option_value
+            )
+
+        project_config = Path("dagster-workspace/projects/helloworld/pyproject.toml")
+        assert project_config.exists()
+        with project_config.open() as f:
             toml = tomlkit.parse(f.read())
             validate_pyproject_toml_with_editable(toml, option, dagster_git_repo_dir)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -141,6 +141,31 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         )
 
 
+def test_scaffold_project_inside_workspace_applies_scaffold_project_options(monkeypatch):
+    dagster_git_repo_dir = discover_git_root(Path(__file__))
+    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(runner, use_editable_components_package_only=False),
+    ):
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+            create_toml_node(
+                toml_dict,
+                ("tool", "dg", "workspace", "scaffold_project_options", "use_editable_dagster"),
+                True,
+            )
+
+        result = runner.invoke(
+            "scaffold",
+            "project",
+            "projects/foo-bar",
+        )
+        assert_runner_result(result)
+        # Check that use_editable_dagster was applied
+        toml = tomlkit.parse(Path("projects/foo-bar/pyproject.toml").read_text())
+        assert has_toml_node(toml, ("tool", "uv", "sources", "dagster"))
+
+
 def test_scaffold_project_outside_workspace_success(monkeypatch) -> None:
     # Remove when we are able to test without editable install
     dagster_git_repo_dir = discover_git_root(Path(__file__))
@@ -181,7 +206,7 @@ def test_scaffold_project_editable_dagster_success(
         editable_args = [option, str(dagster_git_repo_dir)]
     with (
         ProxyRunner.test() as runner,
-        isolated_example_workspace(runner),
+        isolated_example_workspace(runner, use_editable_components_package_only=False),
     ):
         result = runner.invoke("scaffold", "project", *editable_args, "projects/foo-bar")
         assert_runner_result(result)
@@ -303,7 +328,10 @@ def test_scaffold_project_editable_dagster_no_env_var_no_value_fails(
     option: EditableOption, monkeypatch
 ) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", "")
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(runner, use_editable_components_package_only=False),
+    ):
         result = runner.invoke("scaffold", "project", option, "--", "bar")
         assert_runner_result(result, exit_0=False)
         assert "require the `DAGSTER_GIT_REPO_DIR`" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 import pytest
 from dagster_dg.config import DgFileConfigDirectoryType, get_type_str
@@ -119,6 +119,7 @@ def test_invalid_config_workspace():
             "tool.dg.cli.invalid_key",
             "tool.dg.workspace.invalid_key",
             "tool.dg.workspace.projects[0].invalid_key",
+            "tool.dg.workspace.scaffold_project_options.invalid_key",
         ]
         for path in cases:
             with _reset_pyproject_toml():
@@ -134,6 +135,17 @@ def test_invalid_config_workspace():
             ["tool.dg.workspace.projects", list, 1],
             ["tool.dg.workspace.projects[1]", dict, 1],
             ["tool.dg.workspace.projects[0].path", str, 1],
+            ["tool.dg.workspace.scaffold_project_options", dict, 1],
+            [
+                "tool.dg.workspace.scaffold_project_options.use_editable_dagster",
+                Union[bool, str],
+                1,
+            ],
+            [
+                "tool.dg.workspace.scaffold_project_options.use_editable_components_package_only",
+                Union[bool, str],
+                1,
+            ],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -62,6 +62,7 @@ def isolated_example_workspace(
     runner: Union[CliRunner, "ProxyRunner"],
     project_name: Optional[str] = None,
     create_venv: bool = False,
+    use_editable_components_package_only: bool = True,
 ) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
@@ -72,8 +73,11 @@ def isolated_example_workspace(
     ):
         result = runner.invoke(
             "init",
-            "--use-editable-components-package-only",
-            dagster_git_repo_dir,
+            *(
+                ["--use-editable-components-package-only", dagster_git_repo_dir]
+                if use_editable_components_package_only
+                else []
+            ),
             input=f"\n{project_name or ''}\n",
         )
         assert_runner_result(result)


### PR DESCRIPTION
## Summary & Motivation

Add `tool.dg.workspace.new_project_options`. Currently this can only take two options:

- `use_editable_dagster`
- `use_editable_components_package_only`

If you `dg init` with either option it will be set in the workspace `pyproject.toml`, ensuring new projects are created with the corresponding option.

Since these options are internal, this should be considered a private detail for now, we will likely change it in the future when we have a stronger project scaffolding customization story.

Relevant prior discussion/decision: https://www.notion.so/dagster/Outstanding-dg-API-ergonomics-questions-1a318b92e462807a855ff198b6d285ae?pvs=4#1a318b92e46280a8bebef5351bb44334

## How I Tested These Changes

New unit tests