### PR TITLE
[dagster-fivetran] Add warning message for missing connector schemas in FivetranWorkspace

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -930,6 +930,12 @@ class FivetranWorkspace(ConfigurableResource):
                     # so connectors for which the schemas are missing are discarded.
                     or not schema_config.has_schemas
                 ):
+                    if not schema_config.has_schemas:
+                        self._log.warning(
+                            f"Ignoring connector `{connector.name}`. "
+                            f"Dagster requires connector schema information to represent this connector, "
+                            f"which is not available until this connector has been run for the first time."
+                        )
                     continue
 
                 connectors_by_id[connector.id] = connector


### PR DESCRIPTION
## Summary & Motivation

Add the message suggested [here](https://github.com/dagster-io/dagster/pull/28080#pullrequestreview-2654826757) to warn users when a Fivetran connector is discarded/when connector schemas are missing.