### PR TITLE
[dagster-dlt] Add backfill policy to dlt_assets, defaulting to single-run

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 import dlt
 import duckdb
+import pytest
 from dagster import (
     AssetExecutionContext,
     AssetKey,
@@ -11,8 +12,12 @@ from dagster import (
     AutoMaterializePolicy,
     AutoMaterializeRule,
     AutomationCondition,
+    BackfillPolicy,
+    DailyPartitionsDefinition,
     Definitions,
     MonthlyPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import (
@@ -781,3 +786,51 @@ def test_pool(dlt_pipeline: Pipeline) -> None:
     def my_dlt_assets(): ...
 
     assert my_dlt_assets.op.pool == pool
+
+
+@pytest.mark.parametrize(
+    ["partitions_def", "backfill_policy", "expected_backfill_policy"],
+    [
+        (
+            DailyPartitionsDefinition(start_date="2023-01-01"),
+            BackfillPolicy.multi_run(),
+            BackfillPolicy.multi_run(),
+        ),
+        (
+            DailyPartitionsDefinition(start_date="2023-01-01"),
+            None,
+            BackfillPolicy.single_run(),
+        ),
+        (
+            StaticPartitionsDefinition(partition_keys=["A", "B"]),
+            None,
+            None,
+        ),
+        (
+            StaticPartitionsDefinition(partition_keys=["A", "B"]),
+            BackfillPolicy.single_run(),
+            BackfillPolicy.single_run(),
+        ),
+    ],
+    ids=[
+        "use explicit backfill policy for time window",
+        "time window defaults to single run",
+        "non time window has no default backfill policy",
+        "non time window backfill policy is respected",
+    ],
+)
+def test_backfill_policy(
+    dlt_pipeline: Pipeline,
+    partitions_def: PartitionsDefinition,
+    backfill_policy: BackfillPolicy,
+    expected_backfill_policy: BackfillPolicy,
+) -> None:
+    @dlt_assets(
+        dlt_source=pipeline(),
+        dlt_pipeline=dlt_pipeline,
+        partitions_def=partitions_def,
+        backfill_policy=backfill_policy,
+    )
+    def my_dlt_assets(): ...
+
+    assert my_dlt_assets.backfill_policy == expected_backfill_policy


### PR DESCRIPTION
## Summary & Motivation

Fixes
[#25720](https://github.com/dagster-io/dagster/issues/25720).

This PR should allow dlt pipelines to be able to backfill multiple partitions without the dreaded [concurrency bug](https://github.com/dlt-hub/dlt/issues/1102)

## How I Tested These Changes

Test suite and manual testing.
