### PR TITLE
[dagster-components] Alternate `ctx.build_defs_from_component_module`

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -288,6 +288,10 @@ class ComponentLoadContext:
     def normalize_component_type_str(self, type_str: str) -> str:
         return f"{self.module_name}{type_str}" if type_str.startswith(".") else type_str
 
+    def build_defs_from_component_module(self, module: ModuleType) -> Definitions:
+        component_path = self.path.parent.parent.parent / Path(*module.__name__.split("."))
+        return self.module_cache.build_defs_from_component_path(component_path)
+
     def build_defs_from_component_path(self, path: Path) -> Definitions:
         return self.module_cache.build_defs_from_component_path(path)
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -1,18 +1,16 @@
 from collections.abc import Sequence
-from pathlib import Path
 from typing import cast
 
 import dagster as dg
+from component_component_deps.defs import my_python_defs
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster_components.core.component import ComponentLoadContext
-
-MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 ctx = ComponentLoadContext.current()
 
 assets_from_my_python_defs = cast(
     Sequence[AssetsDefinition],
-    ctx.build_defs_from_component_path(MY_PYTHON_DEFS_COMPONENT_PATH).assets,
+    ctx.build_defs_from_component_module(my_python_defs).assets,
 )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -11,9 +11,11 @@ MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 class MyCustomComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
+        from component_component_deps_custom_component.defs import my_python_defs
+
         assets_from_my_python_defs = cast(
             Sequence[dg.AssetsDefinition],
-            context.build_defs_from_component_path(MY_PYTHON_DEFS_COMPONENT_PATH).assets,
+            context.build_defs_from_component_module(my_python_defs).assets,
         )
 
         @dg.asset(deps=assets_from_my_python_defs)


### PR DESCRIPTION
## Summary

Adds an alternate version of `ctx.build_defs_from_component_path` (from #28133) which takes a module instead. Can foreground this method/clean up a bit if we prefer this approach.


```python
from component_component_deps.defs import my_python_defs

ctx = ComponentLoadContext.current()

assets_from_my_python_defs = cast(
    Sequence[AssetsDefinition],
    ctx.build_defs_from_component_module(my_python_defs).assets,
)


@dg.asset(deps=assets_from_my_python_defs)
def downstream_of_all_my_python_defs():
    pass
```

## How I Tested These Changes

Update tests.

