### PR TITLE
[ui] Fix whacky rendering of multi-dimension partition headers

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -6,7 +6,6 @@ import {
   MenuItem,
   Popover,
   Spinner,
-  Subheading,
   TextInput,
   Tooltip,
 } from '@dagster-io/ui-components';
@@ -270,107 +269,101 @@ export const AssetPartitions = ({
               data-testid={testId(`partitions-${selection.dimension.name}`)}
             >
               <Box
-                flex={{
-                  direction: 'row',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  gap: 8,
-                }}
-                background={Colors.backgroundDefault()}
                 border="bottom"
-                padding={{horizontal: 24, vertical: 8}}
+                background={Colors.backgroundDefault()}
+                padding={{right: 16, vertical: 8, left: idx === 0 ? 24 : 16}}
               >
-                <Box style={{display: 'flex', flex: 1}}>
-                  <TextInput
-                    fill
-                    icon="search"
-                    value={searchValues[idx] || ''}
-                    onChange={(e) => updateSearchValue(idx, e.target.value)}
-                    placeholder="Filter by name…"
-                    data-testid={testId(`search-${idx}`)}
-                  />
-                </Box>
-                <div>
-                  {selection.dimension.name !== 'default' && (
-                    <Box flex={{gap: 8, alignItems: 'center'}}>
-                      <Icon name="partition" />
-                      <Subheading>{selection.dimension.name}</Subheading>
-                    </Box>
-                  )}
-                </div>
-                <Popover
-                  content={
-                    <Menu>
-                      <MenuItem
-                        text={
-                          <Tooltip content="The order in which partitions were created">
-                            <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                              <span>Creation sort</span>
-                              <Icon name="info" />
-                            </Box>
-                          </Tooltip>
-                        }
-                        active={SortType.CREATION === sortType}
-                        onClick={() => {
-                          setSortTypes((sorts) => {
-                            const copy = [...sorts];
-                            copy[idx] = SortType.CREATION;
-                            return copy;
-                          });
-                        }}
-                        data-testid={testId('sort-creation')}
-                      />
-                      <MenuItem
-                        text={
-                          <Tooltip content="The order in which partitions were created, reversed">
-                            <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                              <span>Reverse creation sort</span>
-                              <Icon name="info" />
-                            </Box>
-                          </Tooltip>
-                        }
-                        active={SortType.REVERSE_CREATION === sortType}
-                        onClick={() => {
-                          setSortTypes((sorts) => {
-                            const copy = [...sorts];
-                            copy[idx] = SortType.REVERSE_CREATION;
-                            return copy;
-                          });
-                        }}
-                        data-testid={testId('sort-reverse-creation')}
-                      />
-                      <MenuItem
-                        text="Alphabetical sort"
-                        active={SortType.ALPHABETICAL === sortType}
-                        onClick={() => {
-                          setSortTypes((sorts) => {
-                            const copy = [...sorts];
-                            copy[idx] = SortType.ALPHABETICAL;
-                            return copy;
-                          });
-                        }}
-                        data-testid={testId('sort-alphabetical')}
-                      />
-                      <MenuItem
-                        text="Reverse alphabetical sort"
-                        active={SortType.REVERSE_ALPHABETICAL === sortType}
-                        onClick={() => {
-                          setSortTypes((sorts) => {
-                            const copy = [...sorts];
-                            copy[idx] = SortType.REVERSE_ALPHABETICAL;
-                            return [...copy];
-                          });
-                        }}
-                        data-testid={testId('sort-reverse-alphabetical')}
-                      />
-                    </Menu>
+                <TextInput
+                  icon="search"
+                  fill
+                  style={{width: `100%`}}
+                  value={searchValues[idx] || ''}
+                  onChange={(e) => updateSearchValue(idx, e.target.value)}
+                  placeholder={
+                    selection.dimension.name !== 'default'
+                      ? `Filter by ${selection.dimension.name}…`
+                      : 'Filter by name…'
                   }
-                  position="bottom-left"
-                >
-                  <SortButton data-testid={`sort-${idx}`}>
-                    <Icon name="sort_by_alpha" color={Colors.accentGray()} />
-                  </SortButton>
-                </Popover>
+                  data-testid={testId(`search-${idx}`)}
+                  rightElement={
+                    <Popover
+                      content={
+                        <Menu>
+                          <MenuItem
+                            text={
+                              <Tooltip content="The order in which partitions were created">
+                                <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                                  <span>Creation sort</span>
+                                  <Icon name="info" />
+                                </Box>
+                              </Tooltip>
+                            }
+                            active={SortType.CREATION === sortType}
+                            onClick={() => {
+                              setSortTypes((sorts) => {
+                                const copy = [...sorts];
+                                copy[idx] = SortType.CREATION;
+                                return copy;
+                              });
+                            }}
+                            data-testid={testId('sort-creation')}
+                          />
+                          <MenuItem
+                            text={
+                              <Tooltip content="The order in which partitions were created, reversed">
+                                <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                                  <span>Reverse creation sort</span>
+                                  <Icon name="info" />
+                                </Box>
+                              </Tooltip>
+                            }
+                            active={SortType.REVERSE_CREATION === sortType}
+                            onClick={() => {
+                              setSortTypes((sorts) => {
+                                const copy = [...sorts];
+                                copy[idx] = SortType.REVERSE_CREATION;
+                                return copy;
+                              });
+                            }}
+                            data-testid={testId('sort-reverse-creation')}
+                          />
+                          <MenuItem
+                            text="Alphabetical sort"
+                            active={SortType.ALPHABETICAL === sortType}
+                            onClick={() => {
+                              setSortTypes((sorts) => {
+                                const copy = [...sorts];
+                                copy[idx] = SortType.ALPHABETICAL;
+                                return copy;
+                              });
+                            }}
+                            data-testid={testId('sort-alphabetical')}
+                          />
+                          <MenuItem
+                            text="Reverse alphabetical sort"
+                            active={SortType.REVERSE_ALPHABETICAL === sortType}
+                            onClick={() => {
+                              setSortTypes((sorts) => {
+                                const copy = [...sorts];
+                                copy[idx] = SortType.REVERSE_ALPHABETICAL;
+                                return [...copy];
+                              });
+                            }}
+                            data-testid={testId('sort-reverse-alphabetical')}
+                          />
+                        </Menu>
+                      }
+                      position="bottom-left"
+                    >
+                      <SortButton
+                        data-testid={`sort-${idx}`}
+                        style={{margin: 0, marginRight: -4, borderRadius: 6}}
+                      >
+                        <Icon name="sort_by_alpha" color={Colors.accentGray()} />
+                      </SortButton>
+                    </Popover>
+                  }
+                />
               </Box>
 
               {!assetHealth ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Colors,
   Icon,
-  IconWrapper,
   Menu,
   MenuDivider,
   MenuItem,
@@ -403,9 +402,7 @@ export const SortButton = styled.button`
     outline: none;
   }
   :hover {
-    ${IconWrapper} {
-      background-color: ${Colors.backgroundLight()};
-    }
+    background-color: ${Colors.backgroundLight()};
   }
 `;
 


### PR DESCRIPTION
## Summary & Motivation

This is just a drive-by, noticed this was busted when I was fixing the overview page issue.  I think the original intention was for the sort button to appear to the right of the input, and for the dimension name to appear below (maybe?)

- I made the sort indicator the right-hand element of the input
- I made the dimension name part of the placeholder text, which simplifies the header a bit

Before:

<img width="780" alt="image" src="https://github.com/user-attachments/assets/8db8b967-f82a-4d17-94b2-5422f0868e1c" />

<img width="453" alt="image" src="https://github.com/user-attachments/assets/6955c46e-81c7-4f8b-861e-cbb3b6a501f0" />


After:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/0a286879-2804-4822-9490-f7ac890e3201" />
<img width="614" alt="image" src="https://github.com/user-attachments/assets/39e3cc82-abb5-43ff-9d04-31d91e04a3a8" />


## How I Tested These Changes

Tested on single- and multi- dimensional assets. Also checked that you can still fill in the input and change the A/Z order

