### PR TITLE
[ui] When the recent updates timeline is empty, default to “last week”

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -80,13 +80,7 @@ export const RecentUpdatesTimeline = ({
     );
   }, [materializations, observations]);
 
-  const endTimestamp = parseInt(
-    sortedMaterializations[sortedMaterializations.length - 1]?.timestamp ?? '0',
-  );
-  const startTimestamp = Math.min(
-    parseInt(sortedMaterializations[0]?.timestamp ?? '0'),
-    endTimestamp - 100,
-  );
+  const [startTimestamp, endTimestamp] = getTimelineBounds(sortedMaterializations);
   const timeRange = endTimestamp - startTimestamp;
   const bucketTimeRange = timeRange / buckets;
 
@@ -331,3 +325,21 @@ const TickLines = styled.div`
     transparent 5% /* spacing between lines */
   );
 `;
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+function getTimelineBounds(sortedMaterializations: {timestamp: string}[]): [number, number] {
+  if (!sortedMaterializations.length) {
+    const nowUnix = Math.floor(Date.now());
+    return [nowUnix - 7 * ONE_DAY, nowUnix];
+  }
+
+  const endTimestamp = parseInt(
+    sortedMaterializations[sortedMaterializations.length - 1]!.timestamp,
+  );
+  const startTimestamp = Math.min(
+    parseInt(sortedMaterializations[0]!.timestamp),
+    endTimestamp - 100,
+  );
+  return [startTimestamp, endTimestamp];
+}


### PR DESCRIPTION
## Summary & Motivation

Moves the calculation of the date bounds to a convenience method so that we can add a better fallback than `?? 0`

Before:

<img width="977" alt="image" src="https://github.com/user-attachments/assets/df77d923-bd0e-4a2e-ac9e-e299e0c08f36" />

After:

<img width="977" alt="image" src="https://github.com/user-attachments/assets/23c7d2cf-be28-4d6f-9977-86f3bc65da74" />

