### PR TITLE
Migration fix (backfill_end_timestamp)

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -441,4 +441,4 @@ def get_end_timestamp_for_backfill(run_storage: RunStorage, backfill: PartitionB
         # reconstruct the time the backfill actually moved to a terminal state, so use the start
         # time as an estimation
         return backfill.backfill_timestamp
-    return max([record.end_time or 0 for record in run_records])
+    return max([record.end_time or 0.0 for record in run_records])


### PR DESCRIPTION
```
Running migration:
Updating run storage...
Skipping already applied data migration: run_partitions
Skipping already applied data migration: run_repo_label_tags
Skipping already applied data migration: bulk_action_types
Starting data migration: run_backfill_id
Querying run storage.
Finished data migration: run_backfill_id
Starting data migration: backfill_job_name_and_tags
Querying run storage.
100%|██████████| 6/6 [00:00<00:00, 22.32it/s]
Finished data migration: backfill_job_name_and_tags
Starting data migration: backfill_end_timestamp
Querying run storage.
  0%|          | 0/6 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/.venv/bin/dagster", line 8, in <module>
    sys.exit(main())
  File "/.venv/lib/python3.9/site-packages/dagster/_cli/__init__.py", line 50, in main
    cli(auto_envvar_prefix=ENV_PREFIX)
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/.venv/lib/python3.9/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/.venv/lib/python3.9/site-packages/dagster/_cli/instance.py", line 67, in migrate_command
    instance.upgrade(click.echo)
  File "/.venv/lib/python3.9/site-packages/dagster/_core/instance/__init__.py", line 996, in upgrade
    self._run_storage.migrate(print_fn)
  File "/.venv/lib/python3.9/site-packages/dagster/_core/storage/runs/sql_run_storage.py", line 737, in migrate
    self._execute_data_migrations(REQUIRED_DATA_MIGRATIONS, print_fn, force_rebuild_all)
  File "/.venv/lib/python3.9/site-packages/dagster/_core/storage/runs/sql_run_storage.py", line 731, in ecute_data_migrations
    migration_fn()(self, print_fn)
  File "/.venv/lib/python3.9/site-packages/dagster/_core/storage/runs/migration.py", line 435, in migrate_backfill_end_timestamp
    updated_backfill = backfill.with_end_timestamp(end_time)
  File "/.venv/lib/python3.9/site-packages/dagster/_core/execution/backfill.py", line 408, in with_end_timestamp
    check.float_param(end_timestamp, "end_timestamp")
  File "/.venv/lib/python3.9/site-packages/dagster/_check/functions.py", line 433, in float_param
    raise _param_type_mismatch_exception(obj, float, param_name, additional_message)
dagster._check.functions.ParameterCheckError: Param "end_timestamp" is not a float. Got 0 which is type <class 'int'>.
```