### PR TITLE
[DOC-923] Change most temporay redirects to permanent

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -489,7 +489,7 @@
     },
     {
       "source": "/_apidocs/libraries/dagster-airflow",
-      "destination": "/api/python-api/libraries/dagster-airlift",
+      "destination": "/api/python-api/libraries/dagster-airlift"
     },
     {
       "source": "/integrations/great-expectations",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -42,47 +42,40 @@
     },
     {
       "source": "/dagster-cloud/:path*",
-      "destination": "/dagster-plus/:path*",
-      "permanent": false
+      "destination": "/dagster-plus/:path*"
     },
     {
       "source": "/guides/dagster-pipes/:path*",
-      "destination": "/guides/build/external-pipelines/",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/"
     },
     {
       "source": "/_apidocs/:path*",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/_apidocs/:path*/",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/sections/api/apidocs/:path*/",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/sections/api/apidocs/:path*",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/docs/apidocs/:path*",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/master/_apidocs/:path*",
-      "destination": "/api/python-api/:path*",
-      "permanent": false
+      "destination": "/api/python-api/:path*"
     },
     {
       "source": "/api/libraries/:path*",
-      "destination": "/api/python-api/libraries/:path*"
+      "destination": "/api/python-api/libraries/:path*",
+      "permanent": false
     },
     {
       "source": "/api/asset-checks",
@@ -191,133 +184,107 @@
     },
     {
       "source": "/deploying/celery",
-      "destination": "/guides/deploy/deployment-options/kubernetes/kubernetes-and-celery",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/kubernetes-and-celery"
     },
     {
       "source": "/deploying/dask",
-      "destination": "/guides/deploy/execution/dask",
-      "permanent": false
+      "destination": "/guides/deploy/execution/dask"
     },
     {
       "source": "/deploying/airflow",
-      "destination": "/integrations/libraries/airlift/",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/"
     },
     {
       "source": "/troubleshooting/schedules",
-      "destination": "/guides/automate/schedules/troubleshooting-schedules",
-      "permanent": false
+      "destination": "/guides/automate/schedules/troubleshooting-schedules"
     },
     {
       "source": "/troubleshooting/run-queue",
-      "destination": "/guides/deploy/execution/customizing-run-queue-priority",
-      "permanent": false
+      "destination": "/guides/deploy/execution/customizing-run-queue-priority"
     },
     {
       "source": "/examples/airflow_ingest",
-      "destination": "/integrations/libraries/airlift/",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/"
     },
     {
       "source": "/examples/materializations",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/examples/conditional_execution",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/examples/config_mapping",
-      "destination": "/guides/operate/configuration/run-configuration",
-      "permanent": false
+      "destination": "/guides/operate/configuration/run-configuration"
     },
     {
       "source": "/examples/dbt_example",
-      "destination": "/integrations/libraries/dbt/",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/"
     },
     {
       "source": "/examples/dep_dsl",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/examples/deploy_docker",
-      "destination": "/guides/deploy/deployment-options/docker",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/docker"
     },
     {
       "source": "/examples/emr_pyspark",
-      "destination": "/integrations/libraries/spark",
-      "permanent": false
+      "destination": "/integrations/libraries/spark"
     },
     {
       "source": "/examples/fan_in_pipeline",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/examples/ge_example",
-      "destination": "https://dagster.io/blog/ensuring-data-quality-with-dagster-and-great-expectations",
-      "permanent": false
+      "destination": "https://dagster.io/blog/ensuring-data-quality-with-dagster-and-great-expectations"
     },
     {
       "source": "/examples/hooks",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/examples/multi_location",
-      "destination": "/guides/deploy/code-locations/workspace-yaml",
-      "permanent": false
+      "destination": "/guides/deploy/code-locations/workspace-yaml"
     },
     {
       "source": "/examples/nothing",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/examples/pipeline_tags",
-      "destination": "/guides/build/assets/metadata-and-tags/tags",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/tags"
     },
     {
       "source": "/examples/basic_pyspark",
-      "destination": "/integrations/libraries/spark",
-      "permanent": false
+      "destination": "/integrations/libraries/spark"
     },
     {
       "source": "/examples/dynamic_graph",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/examples/memoized_development",
-      "destination": "/",
-      "permanent": false
+      "destination": "/"
     },
     {
       "source": "/deployment/custom-infra/celery",
-      "destination": "/guides/deploy/deployment-options/kubernetes/kubernetes-and-celery",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/kubernetes-and-celery"
     },
     {
       "source": "/deployment/custom-infra/dask",
-      "destination": "/guides/deploy/execution/dask",
-      "permanent": false
+      "destination": "/guides/deploy/execution/dask"
     },
     {
       "source": "/deployment/custom-infra/airflow",
-      "destination": "/guides/deploy/deployment-options/",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/"
     },
     {
       "source": "/concepts/executors",
-      "destination": "/guides/operate/run-executors",
-      "permanent": false
+      "destination": "/guides/operate/run-executors"
     },
     {
       "source": "/integrations/pyspark",
@@ -326,128 +293,103 @@
     },
     {
       "source": "/deployment/guides/airflow",
-      "destination": "/integrations/libraries/airlift/",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/"
     },
     {
       "source": "/tutorial/introduction",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/single-op-job",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/single-solid-pipeline",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/connecting-ops",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/connecting-solids",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/testable",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/intro-tutorial/configuring-solids",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/configuring-solids",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/configuring-ops",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/pipelines",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/types",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/resources",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/repositories",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/scheduling",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/tutorial/advanced-tutorial/materializations",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/concepts/solids-pipelines/solids",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/solids-pipelines/pipelines",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/ops-jobs-graphs/jobs-graphs",
-      "destination": "/guides/build/graphs",
-      "permanent": false
+      "destination": "/guides/build/graphs"
     },
     {
       "source": "/concepts/solids-pipelines/pipeline-execution",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/solids-pipelines/composite-solids",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/solids-pipelines/solid-events",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/solids-pipelines/solid-hooks",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/concepts/modes-resources",
-      "destination": "/guides/build/external-resources/",
-      "permanent": false
+      "destination": "/guides/build/external-resources/"
     },
     {
       "source": "/deployment/guides/ecs",
-      "destination": "/guides/deploy/deployment-options/aws",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/aws"
     },
     {
       "source": "/integrations/dbt_cloud",
@@ -456,98 +398,79 @@
     },
     {
       "source": "/tutorial/assets",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/tutorial/ops-jobs/connecting-ops",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/tutorial/ops-jobs/single-op-job",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/tutorial/ops-jobs/testable",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/guides/dagster/scheduling-assets",
-      "destination": "/guides/automate/",
-      "permanent": false
+      "destination": "/guides/automate/"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/part-one",
-      "destination": "/integrations/libraries/dbt/transform-dbt",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/transform-dbt"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/part-two",
-      "destination": "/integrations/libraries/dbt/transform-dbt",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/transform-dbt"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/part-three",
-      "destination": "/integrations/libraries/dbt/transform-dbt",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/transform-dbt"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/part-four",
-      "destination": "/integrations/libraries/dbt/transform-dbt",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/transform-dbt"
     },
     {
       "source": "/guides/dagster/non-argument-deps",
-      "destination": "/guides/build/assets/defining-assets-with-asset-dependencies",
-      "permanent": false
+      "destination": "/guides/build/assets/defining-assets-with-asset-dependencies"
     },
     {
       "source": "/tutorial/managing-your-own-io",
-      "destination": "/guides/build/io-managers/",
-      "permanent": false
+      "destination": "/guides/build/io-managers/"
     },
     {
       "source": "/concepts/assets/asset-materializations",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/getting-started/releases",
-      "destination": "/about/releases",
-      "permanent": false
+      "destination": "/about/releases"
     },
     {
       "source": "/getting-started/telemetry",
-      "destination": "/about/telemetry",
-      "permanent": false
+      "destination": "/about/telemetry"
     },
     {
       "source": "/getting-started/hello-dagster",
-      "destination": "/",
-      "permanent": false
+      "destination": "/"
     },
     {
       "source": "/concepts/ops-jobs-graphs/metadata-tags",
-      "destination": "/guides/build/assets/metadata-and-tags/",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/"
     },
     {
       "source": "/dagster-plus/managing-deployments/setting-up-alerts",
-      "destination": "/dagster-plus/features/alerts/",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/"
     },
     {
       "source": "/dagster-plus/managing-deployments/dagster-cloud-cli",
-      "destination": "/dagster-plus/deployment/management/dagster-cloud-cli/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/dagster-cloud-cli/"
     },
     {
       "source": "/dagster-plus/developing-testing/code-locations",
-      "destination": "/dagster-plus/deployment/code-locations/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/code-locations/"
     },
     {
       "source": "/integrations/airflow/migrating-to-dagster",
@@ -567,7 +490,6 @@
     {
       "source": "/_apidocs/libraries/dagster-airflow",
       "destination": "/api/python-api/libraries/dagster-airlift",
-      "permanent": false
     },
     {
       "source": "/integrations/great-expectations",
@@ -591,8 +513,7 @@
     },
     {
       "source": "/getting-started/what-why-dagster",
-      "destination": "/",
-      "permanent": false
+      "destination": "/"
     },
     {
       "source": "/getting-started/install",
@@ -621,728 +542,583 @@
     },
     {
       "source": "/concepts",
-      "destination": "/getting-started/concepts",
-      "permanent": false
+      "destination": "/getting-started/concepts"
     },
     {
       "source": "/concepts/assets/software-defined-assets",
-      "destination": "/guides/build/assets/defining-assets",
-      "permanent": false
+      "destination": "/guides/build/assets/defining-assets"
     },
     {
       "source": "/concepts/assets/graph-backed-assets",
-      "destination": "/guides/build/assets/defining-assets#graph-asset",
-      "permanent": false
+      "destination": "/guides/build/assets/defining-assets#graph-asset"
     },
     {
       "source": "/concepts/assets/multi-assets",
-      "destination": "/guides/build/assets/defining-assets#multi-asset",
-      "permanent": false
+      "destination": "/guides/build/assets/defining-assets#multi-asset"
     },
     {
       "source": "/concepts/assets/asset-jobs",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/concepts/assets/asset-observations",
-      "destination": "/guides/build/assets/metadata-and-tags/asset-observations",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/asset-observations"
     },
     {
       "source": "/concepts/assets/asset-selection-syntax",
-      "destination": "/guides/build/assets/asset-selection-syntax",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-selection-syntax"
     },
     {
       "source": "/concepts/assets/asset-checks",
-      "destination": "/guides/test/asset-checks",
-      "permanent": false
+      "destination": "/guides/test/asset-checks"
     },
     {
       "source": "/concepts/assets/asset-checks/define-execute-asset-checks",
-      "destination": "/guides/test/asset-checks",
-      "permanent": false
+      "destination": "/guides/test/asset-checks"
     },
     {
       "source": "/concepts/assets/asset-checks/subsetting-asset-checks",
-      "destination": "/guides/test/running-a-subset-of-asset-checks",
-      "permanent": false
+      "destination": "/guides/test/running-a-subset-of-asset-checks"
     },
     {
       "source": "/concepts/assets/asset-checks/checking-for-data-freshness",
-      "destination": "/guides/test/data-freshness-testing",
-      "permanent": false
+      "destination": "/guides/test/data-freshness-testing"
     },
     {
       "source": "/concepts/assets/external-assets",
-      "destination": "/guides/build/assets/external-assets",
-      "permanent": false
+      "destination": "/guides/build/assets/external-assets"
     },
     {
       "source": "/concepts/automation",
-      "destination": "/guides/automate/",
-      "permanent": false
+      "destination": "/guides/automate/"
     },
     {
       "source": "/concepts/automation/schedules",
-      "destination": "/guides/automate/schedules/",
-      "permanent": false
+      "destination": "/guides/automate/schedules/"
     },
     {
       "source": "/concepts/automation/schedules/automating-assets-schedules-jobs",
-      "destination": "/guides/automate/schedules/",
-      "permanent": false
+      "destination": "/guides/automate/schedules/"
     },
     {
       "source": "/concepts/automation/schedules/automating-ops-schedules-jobs",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/concepts/automation/schedules/examples",
-      "destination": "/guides/automate/schedules/",
-      "permanent": false
+      "destination": "/guides/automate/schedules/"
     },
     {
       "source": "/concepts/automation/schedules/partitioned-schedules",
-      "destination": "/guides/automate/schedules/constructing-schedules-for-partitioned-assets-and-jobs",
-      "permanent": false
+      "destination": "/guides/automate/schedules/constructing-schedules-for-partitioned-assets-and-jobs"
     },
     {
       "source": "/concepts/automation/schedules/customizing-executing-timezones",
-      "destination": "/guides/automate/schedules/customizing-execution-timezone",
-      "permanent": false
+      "destination": "/guides/automate/schedules/customizing-execution-timezone"
     },
     {
       "source": "/concepts/automation/schedules/testing",
-      "destination": "/guides/automate/schedules/testing-schedules",
-      "permanent": false
+      "destination": "/guides/automate/schedules/testing-schedules"
     },
     {
       "source": "/concepts/automation/schedules/troubleshooting",
-      "destination": "/guides/automate/schedules/troubleshooting-schedules",
-      "permanent": false
+      "destination": "/guides/automate/schedules/troubleshooting-schedules"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/sensors",
-      "destination": "/guides/automate/sensors/",
-      "permanent": false
+      "destination": "/guides/automate/sensors/"
     },
     {
       "source": "/concepts/automation/declarative-automation",
-      "destination": "/guides/automate/declarative-automation",
-      "permanent": false
+      "destination": "/guides/automate/declarative-automation"
     },
     {
       "source": "/concepts/automation/declarative-automation/customizing-automation-conditions",
-      "destination": "/guides/automate/declarative-automation/customizing-automation-conditions",
-      "permanent": false
+      "destination": "/guides/automate/declarative-automation/customizing-automation-conditions"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/asset-sensors",
-      "destination": "/guides/automate/asset-sensors",
-      "permanent": false
+      "destination": "/guides/automate/asset-sensors"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/partitions",
-      "destination": "/guides/build/partitions-and-backfills/",
-      "permanent": false
+      "destination": "/guides/build/partitions-and-backfills/"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/partitioning-assets",
-      "destination": "/guides/build/partitions-and-backfills/partitioning-assets",
-      "permanent": false
+      "destination": "/guides/build/partitions-and-backfills/partitioning-assets"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/partitioning-ops",
-      "destination": "/guides/build/partitions-and-backfills/partitioning-assets",
-      "permanent": false
+      "destination": "/guides/build/partitions-and-backfills/partitioning-assets"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/testing-partitions",
-      "destination": "/guides/test/testing-partitioned-config-and-jobs",
-      "permanent": false
+      "destination": "/guides/test/testing-partitioned-config-and-jobs"
     },
     {
       "source": "/concepts/partitions-schedules-sensors/backfills",
-      "destination": "/guides/build/partitions-and-backfills/backfilling-data",
-      "permanent": false
+      "destination": "/guides/build/partitions-and-backfills/backfilling-data"
     },
     {
       "source": "/concepts/resources",
-      "destination": "/guides/build/external-resources/",
-      "permanent": false
+      "destination": "/guides/build/external-resources/"
     },
     {
       "source": "/concepts/configuration/config-schema",
-      "destination": "/guides/operate/configuration/run-configuration",
-      "permanent": false
+      "destination": "/guides/operate/configuration/run-configuration"
     },
     {
       "source": "/concepts/configuration/advanced-config-types",
-      "destination": "/guides/operate/configuration/advanced-config-types",
-      "permanent": false
+      "destination": "/guides/operate/configuration/advanced-config-types"
     },
     {
       "source": "/concepts/code-locations",
-      "destination": "/guides/deploy/code-locations/managing-code-locations-with-definitions",
-      "permanent": false
+      "destination": "/guides/deploy/code-locations/managing-code-locations-with-definitions"
     },
     {
       "source": "/concepts/code-locations/workspace-files",
-      "destination": "/guides/deploy/code-locations/workspace-yaml",
-      "permanent": false
+      "destination": "/guides/deploy/code-locations/workspace-yaml"
     },
     {
       "source": "/concepts/webserver/ui-user-settings",
-      "destination": "/guides/operate/ui-user-settings",
-      "permanent": false
+      "destination": "/guides/operate/ui-user-settings"
     },
     {
       "source": "/concepts/logging",
-      "destination": "/guides/monitor/logging/",
-      "permanent": false
+      "destination": "/guides/monitor/logging/"
     },
     {
       "source": "/concepts/logging/loggers",
-      "destination": "/guides/monitor/logging/",
-      "permanent": false
+      "destination": "/guides/monitor/logging/"
     },
     {
       "source": "/concepts/logging/python-logging",
-      "destination": "/guides/monitor/logging/python-logging",
-      "permanent": false
+      "destination": "/guides/monitor/logging/python-logging"
     },
     {
       "source": "/concepts/testing",
-      "destination": "/guides/test/",
-      "permanent": false
+      "destination": "/guides/test/"
     },
     {
       "source": "/concepts/ops-jobs-graphs/ops",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/concepts/ops-jobs-graphs/op-events",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/concepts/ops-jobs-graphs/op-hooks",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/concepts/ops-jobs-graphs/op-retries",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/concepts/ops-jobs-graphs/graphs",
-      "destination": "/guides/build/graphs",
-      "permanent": false
+      "destination": "/guides/build/graphs"
     },
     {
       "source": "/concepts/ops-jobs-graphs/nesting-graphs",
-      "destination": "/guides/build/graphs",
-      "permanent": false
+      "destination": "/guides/build/graphs"
     },
     {
       "source": "/concepts/ops-jobs-graphs/dynamic-graphs",
-      "destination": "/guides/build/graphs",
-      "permanent": false
+      "destination": "/guides/build/graphs"
     },
     {
       "source": "/concepts/ops-jobs-graphs/jobs",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/concepts/ops-jobs-graphs/op-jobs",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/concepts/ops-jobs-graphs/job-execution",
-      "destination": "/guides/build/assets/asset-jobs",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-jobs"
     },
     {
       "source": "/concepts/metadata-tags/asset-metadata",
-      "destination": "/guides/build/assets/metadata-and-tags/",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/"
     },
     {
       "source": "/concepts/metadata-tags/asset-metadata/column-level-lineage",
-      "destination": "/guides/build/assets/metadata-and-tags/",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/"
     },
     {
       "source": "/concepts/metadata-tags/kind-tags",
-      "destination": "/guides/build/assets/metadata-and-tags/kind-tags",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/kind-tags"
     },
     {
       "source": "/concepts/metadata-tags/op-job-metadata",
-      "destination": "/guides/build/assets/metadata-and-tags/",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/"
     },
     {
       "source": "/concepts/metadata-tags/tags",
-      "destination": "/guides/build/assets/metadata-and-tags/tags",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/tags"
     },
     {
       "source": "/concepts/dagster-pipes/subprocess",
-      "destination": "/guides/build/external-pipelines/using-dagster-pipes/",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/using-dagster-pipes/"
     },
     {
       "source": "/concepts/dagster-pipes/subprocess/create-subprocess-asset",
-      "destination": "/guides/build/external-pipelines/using-dagster-pipes/create-subprocess-asset",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/using-dagster-pipes/create-subprocess-asset"
     },
     {
       "source": "/concepts/dagster-pipes/subprocess/modify-external-code",
-      "destination": "/guides/build/external-pipelines/using-dagster-pipes/modify-external-code",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/using-dagster-pipes/modify-external-code"
     },
     {
       "source": "/concepts/dagster-pipes/subprocess/reference",
-      "destination": "/guides/build/external-pipelines/using-dagster-pipes/reference",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/using-dagster-pipes/reference"
     },
     {
       "source": "/concepts/dagster-pipes/aws-ecs",
-      "destination": "/guides/build/external-pipelines/aws/aws-ecs-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-ecs-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/aws-glue",
-      "destination": "/guides/build/external-pipelines/aws/aws-glue-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-glue-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/aws-emr",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/aws-emr-containers",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/aws-emr-serverless",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-serverless-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-serverless-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/aws-lambda",
-      "destination": "/guides/build/external-pipelines/aws/aws-lambda-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-lambda-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-ecs-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-ecs-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-ecs-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-glue-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-glue-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-glue-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-emr-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-emr-serverless-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-serverless-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-serverless-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-lambda-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-lambda-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/aws/aws-lambda-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/kubernetes",
-      "destination": "/guides/build/external-pipelines/kubernetes-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/kubernetes-pipeline"
     },
     {
       "source": "/concepts/dagster-pipes/dagster-pipes-details-and-customization",
-      "destination": "/guides/build/external-pipelines/dagster-pipes-details-and-customization",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/dagster-pipes-details-and-customization"
     },
     {
       "source": "/guides/migrations/from-step-launchers-to-pipes",
-      "destination": "/guides/build/external-pipelines/migrating-from-step-launchers-to-pipes",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/migrating-from-step-launchers-to-pipes"
     },
     {
       "source": "/concepts/io-management/io-managers",
-      "destination": "guides/build/io-managers/",
-      "permanent": false
+      "destination": "guides/build/io-managers/"
     },
     {
       "source": "/concepts/io-management/unconnected-inputs",
-      "destination": "/guides/build/io-managers/",
-      "permanent": false
+      "destination": "/guides/build/io-managers/"
     },
     {
       "source": "/concepts/types",
-      "destination": "/api/python-api/types",
-      "permanent": false
+      "destination": "/api/python-api/types"
     },
     {
       "source": "/concepts/logging/custom-loggers",
-      "destination": "/guides/monitor/logging/custom-logging",
-      "permanent": false
+      "destination": "/guides/monitor/logging/custom-logging"
     },
     {
       "source": "/concepts/webserver/graphql",
-      "destination": "/guides/operate/graphql/",
-      "permanent": false
+      "destination": "/guides/operate/graphql/"
     },
     {
       "source": "/concepts/webserver/graphql-client",
-      "destination": "/guides/operate/graphql/graphql-client",
-      "permanent": false
+      "destination": "/guides/operate/graphql/graphql-client"
     },
     {
       "source": "/dagster-plus/deployment",
-      "destination": "/dagster-plus/deployment/deployment-types/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/"
     },
     {
       "source": "/dagster-plus/deployment/serverless",
-      "destination": "/dagster-plus/deployment/deployment-types/serverless/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/serverless/"
     },
     {
       "source": "/dagster-plus/deployment/hybrid",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/"
     },
     {
       "source": "/dagster-plus/deployment/agents",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs/creating-ecs-agent-new-vpc",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/new-vpc",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/new-vpc"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs/creating-ecs-agent-existing-vpc",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/existing-vpc",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/existing-vpc"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs/manually-provisioning-ecs-agent",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/manual-provision",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/manual-provision"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs/configuration-reference",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/configuration-reference",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/configuration-reference"
     },
     {
       "source": "/dagster-plus/deployment/agents/amazon-ecs/upgrading-cloudformation-template",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/upgrading-cloudformation",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/amazon-ecs/upgrading-cloudformation"
     },
     {
       "source": "/dagster-plus/deployment/agents/docker",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/"
     },
     {
       "source": "/dagster-plus/deployment/agents/docker/configuring-running-docker-agent",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/setup",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/setup"
     },
     {
       "source": "/dagster-plus/deployment/agents/docker/configuration-reference",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/configuration",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/docker/configuration"
     },
     {
       "source": "/dagster-plus/deployment/agents/kubernetes",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/"
     },
     {
       "source": "/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/setup",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/setup"
     },
     {
       "source": "/dagster-plus/deployment/agents/kubernetes/configuration-reference",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/configuration",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/kubernetes/configuration"
     },
     {
       "source": "/dagster-plus/deployment/agents/local",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/local",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/local"
     },
     {
       "source": "/dagster-plus/deployment/agents/customizing-configuration",
-      "destination": "/dagster-plus/deployment/management/settings/customizing-agent-settings",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/settings/customizing-agent-settings"
     },
     {
       "source": "/dagster-plus/deployment/agents/running-multiple-agents",
-      "destination": "/dagster-plus/deployment/deployment-types/hybrid/multiple",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/deployment-types/hybrid/multiple"
     },
     {
       "source": "/dagster-plus/account",
-      "destination": "/dagster-plus/deployment/management/tokens/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/tokens/"
     },
     {
       "source": "/dagster-plus/account/managing-user-agent-tokens",
-      "destination": "/dagster-plus/deployment/management/tokens/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/tokens/"
     },
     {
       "source": "/dagster-plus/account/authentication",
-      "destination": "/dagster-plus/features/authentication-and-access-control/",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/"
     },
     {
       "source": "/dagster-plus/account/managing-users",
-      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/users",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/users"
     },
     {
       "source": "/dagster-plus/account/managing-users/managing-teams",
-      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/teams",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/teams"
     },
     {
       "source": "/dagster-plus/account/managing-users/managing-user-roles-permissions",
-      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions"
     },
     {
       "source": "/dagster-plus/account/authentication/utilizing-scim-provisioning",
-      "destination": "/dagster-plus/features/authentication-and-access-control/scim/enabling-scim-provisioning",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/scim/enabling-scim-provisioning"
     },
     {
       "source": "/dagster-plus/account/authentication/setting-up-azure-ad-saml-sso",
-      "destination": "/dagster-plus/features/authentication-and-access-control/sso/azure-ad-sso",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/sso/azure-ad-sso"
     },
     {
       "source": "/dagster-plus/account/authentication/setting-up-google-workspace-saml-sso",
-      "destination": "/dagster-plus/features/authentication-and-access-control/sso/google-workspace-sso",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/sso/google-workspace-sso"
     },
     {
       "source": "/dagster-plus/account/authentication/okta/saml-sso",
-      "destination": "/dagster-plus/features/authentication-and-access-control/sso/okta-sso",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/sso/okta-sso"
     },
     {
       "source": "/dagster-plus/account/authentication/okta/scim-provisioning",
-      "destination": "/dagster-plus/features/authentication-and-access-control/scim/enabling-scim-provisioning",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/scim/enabling-scim-provisioning"
     },
     {
       "source": "/dagster-plus/account/authentication/setting-up-onelogin-saml-sso",
-      "destination": "/dagster-plus/features/authentication-and-access-control/sso/onelogin-sso",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/sso/onelogin-sso"
     },
     {
       "source": "/dagster-plus/account/authentication/setting-up-pingone-saml-sso",
-      "destination": "/dagster-plus/features/authentication-and-access-control/sso/pingone-sso",
-      "permanent": false
+      "destination": "/dagster-plus/features/authentication-and-access-control/sso/pingone-sso"
     },
     {
       "source": "/dagster-plus/managing-deployments",
-      "destination": "/dagster-plus/deployment/management/deployments/managing-deployments",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/deployments/managing-deployments"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts",
-      "destination": "/dagster-plus/features/alerts/",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui",
-      "destination": "/dagster-plus/features/alerts/creating-alerts",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/creating-alerts"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/managing-alerts-cli",
-      "destination": "/dagster-plus/features/alerts/creating-alerts",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/creating-alerts"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/email",
-      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/microsoft-teams",
-      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/slack",
-      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service"
     },
     {
       "source": "/dagster-plus/managing-deployments/alerts/pagerduty",
-      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service",
-      "permanent": false
+      "destination": "/dagster-plus/features/alerts/configuring-an-alert-notification-service"
     },
     {
       "source": "/dagster-plus/managing-deployments/environment-variables-and-secrets",
-      "destination": "/dagster-plus/deployment/management/environment-variables/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/environment-variables/"
     },
     {
       "source": "/dagster-plus/managing-deployments/setting-environment-variables-agents",
-      "destination": "/dagster-plus/deployment/management/environment-variables/agent-config",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/environment-variables/agent-config"
     },
     {
       "source": "/dagster-plus/managing-deployments/reserved-environment-variables",
-      "destination": "/dagster-plus/deployment/management/environment-variables/built-in",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/environment-variables/built-in"
     },
     {
       "source": "/dagster-plus/managing-deployments/deployment-settings-reference",
-      "destination": "/dagster-plus/deployment/management/deployments/deployment-settings-reference",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/deployments/deployment-settings-reference"
     },
     {
       "source": "/dagster-plus/managing-deployments/code-locations",
-      "destination": "/dagster-plus/deployment/code-locations/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/code-locations/"
     },
     {
       "source": "/dagster-plus/managing-deployments/branch-deployments",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/"
     },
     {
       "source": "/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-github",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/setting-up-branch-deployments",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/setting-up-branch-deployments"
     },
     {
       "source": "/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/setting-up-branch-deployments",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/setting-up-branch-deployments"
     },
     {
       "source": "/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/using-branch-deployments-with-the-cli",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/using-branch-deployments-with-the-cli"
     },
     {
       "source": "/dagster-plus/managing-deployments/branch-deployments/change-tracking",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/change-tracking",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/change-tracking"
     },
     {
       "source": "/dagster-plus/managing-deployments/controlling-logs",
-      "destination": "/dagster-plus/deployment/management/managing-compute-logs-and-error-messages",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/managing-compute-logs-and-error-messages"
     },
     {
       "source": "/dagster-plus/best-practices",
-      "destination": "/dagster-plus/deployment/management/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/"
     },
     {
       "source": "/dagster-plus/best-practices/managing-multiple-projects-and-teams",
-      "destination": "/dagster-plus/deployment/management/managing-multiple-projects-and-teams",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/managing-multiple-projects-and-teams"
     },
     {
       "source": "/dagster-plus/insights",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/asset-metadata",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/integrating-external-metrics",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/integrating-bigquery",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/integrating-bigquery-and-dbt",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/integrating-snowflake",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/integrating-snowflake-and-dbt",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/insights/exporting-insights-metrics",
-      "destination": "/dagster-plus/features/insights/",
-      "permanent": false
+      "destination": "/dagster-plus/features/insights/"
     },
     {
       "source": "/dagster-plus/managing-deployments/dagster-plus-cli",
-      "destination": "/dagster-plus/deployment/management/dagster-cloud-cli/",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/dagster-cloud-cli/"
     },
     {
       "source": "/dagster-plus/references/ci-cd-file-reference",
-      "destination": "/dagster-plus/features/ci-cd/ci-cd-file-reference",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/ci-cd-file-reference"
     },
     {
       "source": "/dagster-plus/managing-deployments/dagster-cloud-yaml",
-      "destination": "/dagster-plus/deployment/code-locations/dagster-cloud-yaml",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/code-locations/dagster-cloud-yaml"
     },
     {
       "source": "/dagster-plus/references/limits",
-      "destination": "/dagster-plus/deployment/management/rate-limits",
-      "permanent": false
+      "destination": "/dagster-plus/deployment/management/rate-limits"
     },
     {
       "source": "/deployment",
@@ -1356,193 +1132,155 @@
     },
     {
       "source": "/deployment/concepts",
-      "destination": "/guides/deploy/",
-      "permanent": false
+      "destination": "/guides/deploy/"
     },
     {
       "source": "/deployment/dagster-instance",
-      "destination": "/guides/deploy/dagster-instance-configuration",
-      "permanent": false
+      "destination": "/guides/deploy/dagster-instance-configuration"
     },
     {
       "source": "/deployment/dagster-daemon",
-      "destination": "/guides/deploy/execution/dagster-daemon",
-      "permanent": false
+      "destination": "/guides/deploy/execution/dagster-daemon"
     },
     {
       "source": "/deployment/run-launcher",
-      "destination": "/guides/deploy/execution/run-launchers",
-      "permanent": false
+      "destination": "/guides/deploy/execution/run-launchers"
     },
     {
       "source": "/deployment/executors",
-      "destination": "/guides/operate/run-executors",
-      "permanent": false
+      "destination": "/guides/operate/run-executors"
     },
     {
       "source": "/deployment/run-coordinator",
-      "destination": "/guides/deploy/execution/run-coordinators",
-      "permanent": false
+      "destination": "/guides/deploy/execution/run-coordinators"
     },
     {
       "source": "/deployment/run-monitoring",
-      "destination": "/guides/deploy/execution/run-monitoring",
-      "permanent": false
+      "destination": "/guides/deploy/execution/run-monitoring"
     },
     {
       "source": "/deployment/run-retries",
-      "destination": "/guides/deploy/execution/run-retries",
-      "permanent": false
+      "destination": "/guides/deploy/execution/run-retries"
     },
     {
       "source": "/deployment/guides",
-      "destination": "/guides/deploy/deployment-options/",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/"
     },
     {
       "source": "/deployment/guides/service",
-      "destination": "/guides/deploy/deployment-options/deploying-dagster-as-a-service",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/deploying-dagster-as-a-service"
     },
     {
       "source": "/deployment/guides/kubernetes",
-      "destination": "/guides/deploy/deployment-options/kubernetes/",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/"
     },
     {
       "source": "/deployment/guides/kubernetes/deploying-with-helm",
-      "destination": "/guides/deploy/deployment-options/kubernetes/deploying-to-kubernetes",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/deploying-to-kubernetes"
     },
     {
       "source": "/deployment/guides/kubernetes/deploying-with-helm-advanced",
-      "destination": "/guides/deploy/deployment-options/kubernetes/",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/"
     },
     {
       "source": "/deployment/guides/kubernetes/customizing-your-deployment",
-      "destination": "/guides/deploy/deployment-options/kubernetes/customizing-your-deployment",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/customizing-your-deployment"
     },
     {
       "source": "/deployment/guides/kubernetes/how-to-migrate-your-instance",
-      "destination": "/guides/deploy/deployment-options/kubernetes/migrating-while-upgrading",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/kubernetes/migrating-while-upgrading"
     },
     {
       "source": "/deployment/guides/docker",
-      "destination": "/guides/deploy/deployment-options/docker",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/docker"
     },
     {
       "source": "/deployment/guides/aws",
-      "destination": "/guides/deploy/deployment-options/aws",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/aws"
     },
     {
       "source": "/deployment/guides/gcp",
-      "destination": "/guides/deploy/deployment-options/gcp",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/gcp"
     },
     {
       "source": "/deployment/guides/celery",
-      "destination": "/guides/deploy/execution/celery",
-      "permanent": false
+      "destination": "/guides/deploy/execution/celery"
     },
     {
       "source": "/deployment/guides/dask",
-      "destination": "/guides/deploy/execution/dask",
-      "permanent": false
+      "destination": "/guides/deploy/execution/dask"
     },
     {
       "source": "/guides/understanding-dagster-project-files",
-      "destination": "/guides/build/projects/dagster-project-file-reference",
-      "permanent": false
+      "destination": "/guides/build/projects/dagster-project-file-reference"
     },
     {
       "source": "/guides/running-dagster-locally",
-      "destination": "/guides/deploy/deployment-options/running-dagster-locally",
-      "permanent": false
+      "destination": "/guides/deploy/deployment-options/running-dagster-locally"
     },
     {
       "source": "/guides/dagster/using-environment-variables-and-secrets",
-      "destination": "/guides/deploy/using-environment-variables-and-secrets",
-      "permanent": false
+      "destination": "/guides/deploy/using-environment-variables-and-secrets"
     },
     {
       "source": "/guides/dagster/transitioning-data-pipelines-from-development-to-production",
-      "destination": "/guides/deploy/dev-to-prod",
-      "permanent": false
+      "destination": "/guides/deploy/dev-to-prod"
     },
     {
       "source": "/guides/dagster/branch_deployments",
-      "destination": "/dagster-plus/features/ci-cd/branch-deployments/testing",
-      "permanent": false
+      "destination": "/dagster-plus/features/ci-cd/branch-deployments/testing"
     },
     {
       "source": "/guides/integration/approaches-to-writing-integrations",
-      "destination": "/integrations/guides/integration-approaches",
-      "permanent": false
+      "destination": "/integrations/guides/integration-approaches"
     },
     {
       "source": "/guides/integrations/writing-a-multi-asset-decorator-integration",
-      "destination": "/integrations/guides/multi-asset-integration",
-      "permanent": false
+      "destination": "/integrations/guides/multi-asset-integration"
     },
     {
       "source": "/guides/dagster/how-assets-relate-to-ops-and-graphs",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/guides/dagster/enriching-with-software-defined-assets",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/guides/dagster/software-defined-assets",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/guides/dagster/testing-assets",
-      "destination": "/guides/test/unit-testing-assets-and-ops",
-      "permanent": false
+      "destination": "/guides/test/unit-testing-assets-and-ops"
     },
     {
       "source": "/guides/dagster/migrating-to-pythonic-resources-and-config",
-      "destination": "/guides/operate/configuration/run-configuration",
-      "permanent": false
+      "destination": "/guides/operate/configuration/run-configuration"
     },
     {
       "source": "/guides/dagster/intro-to-ops-jobs",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/guides/dagster/intro-to-ops-jobs/single-op-job",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/guides/dagster/intro-to-ops-jobs/testable",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/guides/dagster/intro-to-ops-jobs/connecting-ops",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/0.15.7/guides/dagster/graph_job/op",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/guides/dagster/re-execution",
-      "destination": "/guides/build/ops",
-      "permanent": false
+      "destination": "/guides/build/ops"
     },
     {
       "source": "/migration",
@@ -1551,68 +1289,55 @@
     },
     {
       "source": "/guides/migrations",
-      "destination": "/guides/migrate/",
-      "permanent": false
+      "destination": "/guides/migrate/"
     },
     {
       "source": "/integrations/airflow/from-airflow-to-dagster",
-      "destination": "/integrations/libraries/airlift/airflow-to-dagster/",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/airflow-to-dagster/"
     },
     {
       "source": "/guides/migrations/observe-your-airflow-pipelines-with-dagster",
-      "destination": "/integrations/libraries/airlift/",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/"
     },
     {
       "source": "/guides/dagster/recommended-project-structure",
-      "destination": "/guides/build/projects/structuring-your-dagster-project",
-      "permanent": false
+      "destination": "/guides/build/projects/structuring-your-dagster-project"
     },
     {
       "source": "/guides/dagster/ml-pipeline",
-      "destination": "/guides/build/ml-pipelines/managing-ml",
-      "permanent": false
+      "destination": "/guides/build/ml-pipelines/managing-ml"
     },
     {
       "source": "/guides/dagster/managing-ml",
-      "destination": "/guides/build/ml-pipelines/managing-ml",
-      "permanent": false
+      "destination": "/guides/build/ml-pipelines/managing-ml"
     },
     {
       "source": "/guides/dagster/example_project",
-      "destination": "/etl-pipeline-tutorial/",
-      "permanent": false
+      "destination": "/etl-pipeline-tutorial/"
     },
     {
       "source": "/guides/experimental-features",
-      "destination": "/",
-      "permanent": false
+      "destination": "/"
     },
     {
       "source": "/guides/limiting-concurrency-in-data-pipelines",
-      "destination": "/guides/operate/managing-concurrency",
-      "permanent": false
+      "destination": "/guides/operate/managing-concurrency"
     },
     {
       "source": "/guides/customizing-run-queue-priority",
-      "destination": "/guides/deploy/execution/customizing-run-queue-priority",
-      "permanent": false
+      "destination": "/guides/deploy/execution/customizing-run-queue-priority"
     },
     {
       "source": "/guides/dagster/dagster_type_factories",
-      "destination": "/guides/build/assets/",
-      "permanent": false
+      "destination": "/guides/build/assets/"
     },
     {
       "source": "/guides/dagster/asset-versioning-and-caching",
-      "destination": "/guides/build/assets/asset-versioning-and-caching",
-      "permanent": false
+      "destination": "/guides/build/assets/asset-versioning-and-caching"
     },
     {
       "source": "/guides/dagster/code-references",
-      "destination": "/guides/build/assets/metadata-and-tags/",
-      "permanent": false
+      "destination": "/guides/build/assets/metadata-and-tags/"
     },
     {
       "source": "/integrations",
@@ -1636,8 +1361,7 @@
     },
     {
       "source": "/concepts/dagster-pipes/databricks",
-      "destination": "/guides/build/external-pipelines/databricks-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/databricks-pipeline"
     },
     {
       "source": "/integrations/dbt",
@@ -1646,53 +1370,43 @@
     },
     {
       "source": "/integrations/dbt/quickstart",
-      "destination": "/integrations/libraries/dbt/transform-dbt",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/transform-dbt"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/set-up-dbt-project",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/set-up-dbt-project"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/load-dbt-models",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/load-dbt-models",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/load-dbt-models"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/upstream-assets",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/upstream-assets",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/upstream-assets"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster/downstream-assets",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/downstream-assets",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster/downstream-assets"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster-plus",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster-plus/serverless",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/serverless",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/serverless"
     },
     {
       "source": "/integrations/dbt/using-dbt-with-dagster-plus/hybrid",
-      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/hybrid",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/using-dbt-with-dagster-plus/hybrid"
     },
     {
       "source": "/integrations/dbt/reference",
-      "destination": "/integrations/libraries/dbt/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/dbt/reference"
     },
     {
       "source": "/integrations/dbt-cloud",
@@ -1706,13 +1420,11 @@
     },
     {
       "source": "/integrations/deltalake/using-deltalake-with-dagster",
-      "destination": "/integrations/libraries/deltalake/using-deltalake-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/deltalake/using-deltalake-with-dagster"
     },
     {
       "source": "/integrations/deltalake/reference",
-      "destination": "/integrations/libraries/deltalake/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/deltalake/reference"
     },
     {
       "source": "/integrations/duckdb",
@@ -1721,13 +1433,11 @@
     },
     {
       "source": "/integrations/duckdb/using-duckdb-with-dagster",
-      "destination": "/integrations/libraries/duckdb/using-duckdb-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/duckdb/using-duckdb-with-dagster"
     },
     {
       "source": "/integrations/duckdb/reference",
-      "destination": "/integrations/libraries/duckdb/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/duckdb/reference"
     },
     {
       "source": "/integrations/embedded-elt",
@@ -1736,13 +1446,11 @@
     },
     {
       "source": "/integrations/embedded-elt/dlt",
-      "destination": "/integrations/libraries/dlt/",
-      "permanent": false
+      "destination": "/integrations/libraries/dlt/"
     },
     {
       "source": "/integrations/embedded-elt/sling",
-      "destination": "/integrations/libraries/sling",
-      "permanent": false
+      "destination": "/integrations/libraries/sling"
     },
     {
       "source": "/integrations/fivetran",
@@ -1756,13 +1464,11 @@
     },
     {
       "source": "/integrations/bigquery/using-bigquery-with-dagster",
-      "destination": "/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster"
     },
     {
       "source": "/integrations/bigquery/reference",
-      "destination": "/integrations/libraries/gcp/bigquery/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/gcp/bigquery/reference"
     },
     {
       "source": "/integrations/dagstermill",
@@ -1771,13 +1477,11 @@
     },
     {
       "source": "/integrations/dagstermill/using-notebooks-with-dagster",
-      "destination": "/integrations/libraries/jupyter/using-notebooks-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/jupyter/using-notebooks-with-dagster"
     },
     {
       "source": "/integrations/dagstermill/reference",
-      "destination": "/integrations/libraries/jupyter/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/jupyter/reference"
     },
     {
       "source": "/integrations/looker",
@@ -1821,18 +1525,15 @@
     },
     {
       "source": "/integrations/snowflake/using-snowflake-with-dagster",
-      "destination": "/integrations/libraries/snowflake/using-snowflake-with-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/snowflake/using-snowflake-with-dagster"
     },
     {
       "source": "/integrations/snowflake/using-snowflake-with-dagster-io-managers",
-      "destination": "/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers",
-      "permanent": false
+      "destination": "/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers"
     },
     {
       "source": "/integrations/snowflake/reference",
-      "destination": "/integrations/libraries/snowflake/reference",
-      "permanent": false
+      "destination": "/integrations/libraries/snowflake/reference"
     },
     {
       "source": "/integrations/tableau",
@@ -1841,33 +1542,23 @@
     },
     {
       "source": "/concepts/dagster-pipes",
-      "destination": "/guides/build/external-pipelines",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines"
     },
     {
       "source": "/dagster-pipes/pyspark",
-      "destination": "/guides/build/external-pipelines/pyspark-pipeline",
-      "permanent": false
+      "destination": "/guides/build/external-pipelines/pyspark-pipeline"
     },
     {
       "source": "/community/contributing/",
-      "destination": "/about/contributing",
-      "permanent": false
-    },
-    {
-      "source": "/community/contributing",
-      "destination": "/about/contributing",
-      "permanent": false
+      "destination": "/about/contributing"
     },
     {
       "source": "/integrations/airlift/tutorial/overview",
-      "destination": "/integrations/libraries/airlift",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift"
     },
     {
       "source": "/integrations/airlift/airflow-1-migration",
-      "destination": "/integrations/libraries/airlift",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift"
     },
     {
       "source": "/integrations/airlift",
@@ -1876,18 +1567,15 @@
     },
     {
       "source": "/next/guides/build/components",
-      "destination": "/guides/labs/components/",
-      "permanent": false
+      "destination": "/guides/labs/components/"
     },
     {
       "source": "/next/guides/build/components/",
-      "destination": "/guides/labs/components/",
-      "permanent": false
+      "destination": "/guides/labs/components/"
     },
     {
       "source": "/next/guides/build/components/:path",
-      "destination": "/guides/labs/components/:path",
-      "permanent": false
+      "destination": "/guides/labs/components/:path"
     },
     {
       "source": "/guides/build/components",
@@ -1916,53 +1604,43 @@
     },
     {
       "source": "/integrations/airlift/tutorial/migrate",
-      "destination": "/integrations/libraries/airlift/airflow-to-dagster",
-      "permanent": false
+      "destination": "/integrations/libraries/airlift/airflow-to-dagster"
     },
     {
       "source": "/guides/labs/components/building-pipelines-with-components/creating-a-code-location-with-components",
-      "destination": "/guides/labs/components/building-pipelines-with-components/creating-a-project-with-components",
-      "permanent": false
+      "destination": "/guides/labs/components/building-pipelines-with-components/creating-a-project-with-components"
     },
     {
       "source": "/guides/labs/components/creating-a-component",
-      "destination": "/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type",
-      "permanent": false
+      "destination": "/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type"
     },
     {
       "source": "/guides/labs/components/existing-code-location",
-      "destination": "/guides/labs/components/incrementally-adopting-components/existing-project",
-      "permanent": false
+      "destination": "/guides/labs/components/incrementally-adopting-components/existing-project"
     },
     {
       "source": "/guides/labs/components/migrating-definitions",
-      "destination": "/guides/labs/components/incrementally-adopting-components/existing-definitions",
-      "permanent": false
+      "destination": "/guides/labs/components/incrementally-adopting-components/existing-definitions"
     },
     {
       "source": "/guides/labs/components/setting-up-a-deployment",
-      "destination": "/guides/labs/components/managing-multiple-projects",
-      "permanent": false
+      "destination": "/guides/labs/components/managing-multiple-projects"
     },
     {
       "source": "/guides/labs/components/using-a-component",
-      "destination": "/guides/labs/components/building-pipelines-with-components/adding-components",
-      "permanent": false
+      "destination": "/guides/labs/components/building-pipelines-with-components/adding-components"
     },
     {
       "source": "/guides/labs/components/using-a-component-python",
-      "destination": "/guides/labs/components/building-pipelines-with-components/adding-components-python",
-      "permanent": false
+      "destination": "/guides/labs/components/building-pipelines-with-components/adding-components-python"
     },
     {
       "source": "/guides/labs/components/incrementally-adopting-components/existing-code-location",
-      "destination": "/guides/labs/components/incrementally-adopting-components/existing-project",
-      "permanent": false
+      "destination": "/guides/labs/components/incrementally-adopting-components/existing-project"
     },
     {
       "source": "/guides/labs/components/managing-multiple-code-locations",
-      "destination": "/guides/labs/components/managing-multiple-projects",
-      "permanent": false
+      "destination": "/guides/labs/components/managing-multiple-projects"
     },
     {
       "source": "/guides/preview/",


### PR DESCRIPTION
## Summary & Motivation

Changes most temporary redirects (307) to permanent redirects (308). I did leave some temporary redirects in place because it is possible we will want to use those source paths again, but I can change those as well if we don't want to deal with the minor SEO hit.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
