### PR TITLE
[dg] Introduce ResolvableFromSchema

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
@@ -1,0 +1,87 @@
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
+from typing import TYPE_CHECKING, Annotated, Any, Callable, Generic, TypeVar, get_args, get_origin
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from dagster_components.core.schema.context import ResolutionContext
+
+
+class DSLSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+TSchema = TypeVar("TSchema", bound=DSLSchema)
+
+
+class ResolvableFromSchema(Generic[TSchema]): ...
+
+
+class DSLFieldResolver:
+    """Contains information on how to resolve this field from a DSLSchema."""
+
+    def __init__(self, fn: Callable[["ResolutionContext", Any], Any]):
+        self.fn = fn
+        super().__init__()
+
+    @staticmethod
+    def from_parent(fn: Callable[["ResolutionContext", Any], Any]):
+        return DSLFieldResolver(fn)
+
+    @staticmethod
+    def from_annotation(annotation: Any, field_name: str) -> "DSLFieldResolver":
+        if get_origin(annotation) is Annotated:
+            args = get_args(annotation)
+            resolver = next((arg for arg in args if isinstance(arg, DSLFieldResolver)), None)
+            if resolver:
+                return resolver
+        return DSLFieldResolver(
+            lambda context, schema: context.resolve_value(getattr(schema, field_name))
+        )
+
+
+def get_annotation_field_resolvers(cls: type) -> dict[str, DSLFieldResolver]:
+    if issubclass(cls, BaseModel):
+        # neither pydantic's Field.annotation nor Field.rebuild_annotation() actually
+        # return the original annotation, so we have to walk the mro to get them
+        annotations = {}
+        for field_name in cls.model_fields:
+            for base in cls.__mro__:
+                if field_name in getattr(base, "__annotations__", {}):
+                    annotations[field_name] = base.__annotations__[field_name]
+                    break
+        return {
+            field_name: DSLFieldResolver.from_annotation(annotation, field_name)
+            for field_name, annotation in annotations.items()
+        }
+    elif is_dataclass(cls):
+        return {
+            field.name: DSLFieldResolver.from_annotation(field.type, field.name)
+            for field in fields(cls)
+        }
+    else:
+        return {}
+
+
+def resolve_fields(
+    schema: DSLSchema, target_type: type, context: "ResolutionContext"
+) -> Mapping[str, Any]:
+    """Returns a mapping of field names to resolved values for those fields."""
+    return {
+        field_name: resolver.fn(context, schema)
+        for field_name, resolver in get_annotation_field_resolvers(target_type).items()
+    }
+
+
+TResolvableFromSchema = TypeVar("TResolvableFromSchema", bound=ResolvableFromSchema)
+
+
+def resolve_schema_to_resolvable(
+    schema: DSLSchema,
+    resolvable_from_schema_type: type[TResolvableFromSchema],
+    context: "ResolutionContext",
+) -> TResolvableFromSchema:
+    return resolvable_from_schema_type(
+        **resolve_fields(schema, resolvable_from_schema_type, context)
+    )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -1,0 +1,44 @@
+from typing import Annotated
+
+from dagster_components.core.schema.context import ResolutionContext
+from dagster_components.core.schema.resolvable_from_schema import (
+    DSLFieldResolver,
+    DSLSchema,
+    ResolvableFromSchema,
+    resolve_schema_to_resolvable,
+)
+
+
+def test_simple_dataclass_resolveable_from_schema():
+    class HelloSchema(DSLSchema):
+        hello: str
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class Hello(ResolvableFromSchema[HelloSchema]):
+        hello: Annotated[
+            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
+        ]
+
+    hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
+
+    assert isinstance(hello, Hello)
+    assert hello.hello == 1
+
+
+def test_simple_pydantic_resolveable_from_schema():
+    class HelloSchema(DSLSchema):
+        hello: str
+
+    from pydantic import BaseModel
+
+    class Hello(BaseModel, ResolvableFromSchema[HelloSchema]):
+        hello: Annotated[
+            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
+        ]
+
+    hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
+
+    assert isinstance(hello, Hello)
+    assert hello.hello == 1


### PR DESCRIPTION
## Summary & Motivation

This introduces ResolvableFromSchema as a successor to ResolvableSchema. We think this is going to be a more sustainable path forward with better structure and a more obvious API.

This adds a minimal implementation that makes the following test case possible:

```python
def test_simple_resolveable_from_schema():
    class HelloSchema(DSLSchema):
        hello: str

    @dataclass
    class Hello(ResolvableFromSchema[HelloSchema]):
        hello: Annotated[
            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
        ]

    hello = resolve_as(HelloSchema(hello="1"), Hello, ResolutionContext.default())

    assert isinstance(hello, Hello)
    assert hello.hello == 1
```

This is largely forked from the existing implementation in the other direction in `base.py` (which will be deleted). However there are important differences:

* The FieldResolver no longer inherits from `pydantic.FieldInfo`. The system is agnostic as to whether it is pydantic or not.
* The constructor is `DSLFieldResolver.from_parent` as you can see, which will allow us to have the common case be the case where it operates on the property itself. e.g.:

```python
    @dataclass
    class Hello(ResolvableFromSchema[HelloSchema]):
        hello: Annotated[
            int, DSLFieldResolver(lambda context, hello: int(hello))
        ]
```










## From the original linear ticket:

As @ben authored new component types and @schrockn reviewed them, it became clear to both of us that this system is too magical and difficult to trace. While in the end state it has a minimal amount of code, understanding is just too hard. An example PR.

```python 
def resolve_backfill_policy(
    context: ResolutionContext, schema: "OpSpecSchema"
) -> Optional[BackfillPolicy]:
    if schema.backfill_policy is None:
        return None
    if schema.backfill_policy.type == "single_run":
        return BackfillPolicy.single_run()
    elif schema.backfill_policy.type == "multi_run":
        return BackfillPolicy.multi_run(
            max_partitions_per_run=schema.backfill_policy.max_partitions_per_run
        )
    raise ValueError(f"Invalid backfill policy: {schema.backfill_policy}")

@dataclass
class OpSpec:
    name: Optional[str] = None
    tags: Optional[dict[str, str]] = None
    backfill_policy: Annotated[Optional[BackfillPolicy], FieldResolver(resolve_backfill_policy)] = (
       None
    )

class OpSpecSchema(ResolvableSchema[OpSpec]):
    name: Optional[str] = Field(default=None, description="The name of the op.")
    tags: Optional[dict[str, str]] = Field(
        default=None, description="Arbitrary metadata for the op."
    )
    backfill_policy: Optional[
        Union[SingleRunBackfillPolicySchema, MultiRunBackfillPolicySchema]
    ] = Field(default=None, description="The backfill policy to use for the assets.")
```

For example Ben added backfill_policy in that PR. As a reviewer I:

First looked at backfill_policy in OpSpec

I had to understand that OpSpec is associated with OpSpecSchema by knowing that OpecSpecSchema inherits from ResolvableSchema[OpSpec]

I had to understand there there are actually two different ways resolvers get applied, either explicitly passing in via a FieldResolver or through the resolve method on ResolvableSchema if it inherits from that

I could also look at resolve_backfill_policy and note that the 2nd argument is OpSpecSchema, and understand that somehow the OpSpecSchema gets shuffled to there but still isn't clear.

In the end this is pretty brutal with a lot of magic and indirection.

Instead you should be able to, from one "resolver" declaration trivially understand the relationship between the schema type, the transformed type, and the transformation function. This probably involves some duplicative metadata, but I think that is the right tradeoff.

Additional having the top-level fields of a Component directly expressed as pydantic fields requires that component subclasses are pydantic base models or dataclasses, which I believe is unacceptable heavy for what are not value objects. Pydantic brings in a bunch of behavior which is not appropriate here.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG