### PR TITLE
[dg] Syntax for DSLFieldResolver that hoists field

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -42,3 +42,20 @@ def test_simple_pydantic_resolveable_from_schema():
 
     assert isinstance(hello, Hello)
     assert hello.hello == 1
+
+
+def test_simple_dataclass_resolveable_from_schema_with_condense_syntax():
+    class HelloSchema(DSLSchema):
+        hello: str
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class Hello(ResolvableFromSchema[HelloSchema]):
+        # int equivalent to lambda val: int(val)
+        hello: Annotated[int, DSLFieldResolver(int)]
+
+    hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
+
+    assert isinstance(hello, Hello)
+    assert hello.hello == 1


### PR DESCRIPTION
## Summary & Motivation

Makes the default resolver behavior operate on the field that matches the name field that the resolver is annotated on. 

## How I Tested These Changes

This allows you to write

```python
    @dataclass
    class Hello(ResolvableFromSchema[HelloSchema]):
        # int equivalent to lambda val: int(val)
        hello: Annotated[int, DSLFieldResolver(int)]
```

instead of

```python
    @dataclass
    class Hello(ResolvableFromSchema[HelloSchema]):
        hello: Annotated[
            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
        ]
```

## Changelog

NOCHANGELOG
