### PR TITLE
[components] Add __init__.py to scaffolded project defs folder

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/10-tree-jaffle-platform.txt
@@ -4,10 +4,11 @@ jaffle_platform
 ├── __init__.py
 ├── definitions.py
 ├── defs
+│   ├── __init__.py
 │   └── ingest_files
 │       ├── component.yaml
 │       └── replication.yaml
 └── lib
     └── __init__.py
 
-4 directories, 5 files
+4 directories, 6 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/3-tree.txt
@@ -5,6 +5,7 @@ cd jaffle-platform && tree
 │   ├── __init__.py
 │   ├── definitions.py
 │   ├── defs
+│   │   └── __init__.py
 │   └── lib
 │       └── __init__.py
 ├── jaffle_platform.egg-info
@@ -19,4 +20,4 @@ cd jaffle-platform && tree
 ├── pyproject.toml
 └── uv.lock
 
-6 directories, 12 files
+6 directories, 13 files

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/2-tree.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/workspace/2-tree.txt
@@ -8,6 +8,7 @@ cd dagster-workspace && tree
 │       │   ├── __init__.py
 │       │   ├── definitions.py
 │       │   ├── defs
+│       │   │   └── __init__.py
 │       │   └── lib
 │       │       └── __init__.py
 │       ├── project_1_tests

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -100,7 +100,7 @@ def build_component_defs(
     component_types = component_types or discover_entry_point_component_types()
 
     all_defs: list[Definitions] = []
-    for component_path in components_root.iterdir():
+    for component_path in [item for item in components_root.iterdir() if item.is_dir()]:
         defs = build_defs_from_component_path(
             components_root=components_root,
             path=component_path,

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -316,7 +316,7 @@ class DgContext:
         return self.get_path_for_local_module(self.defs_module_name)
 
     def get_component_instance_names(self) -> Iterable[str]:
-        return [str(instance_path.name) for instance_path in self.defs_path.iterdir()]
+        return [str(p.name) for p in self.defs_path.iterdir() if p.is_dir()]
 
     def get_component_instance_module_name(self, name: str) -> str:
         return f"{self.defs_module_name}.{name}"


### PR DESCRIPTION
## Summary & Motivation

We should include `defs/__init__.py` to communicate to people this is just a python package.