### PR TITLE
[dg] Use prefab helpers to eliminate boilerplate

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -75,8 +75,9 @@ class DbtProjectComponent(Component, ResolvableFromSchema[DbtProjectSchema]):
         DagsterDbtTranslator, DSLFieldResolver.from_parent(resolve_translator)
     ] = field(default_factory=DagsterDbtTranslator)
     asset_post_processors: Annotated[
-        Sequence[AssetPostProcessor], DSLFieldResolver(AssetPostProcessor.from_optional_seq)
-    ] = field(default_factory=list)
+        Optional[Sequence[AssetPostProcessor]],
+        DSLFieldResolver(AssetPostProcessor.from_optional_seq),
+    ] = None
     select: str = "fqn:*"
     exclude: Optional[str] = None
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -34,30 +34,32 @@ from dagster_components.core.schema.resolvable_from_schema import (
 from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
-
-def resolve_translator(
-    context: ResolutionContext, schema: "SlingReplicationSchema"
-) -> DagsterSlingTranslator:
-    # TODO: Consider supporting owners and code_version in the future
-    if schema.asset_attributes and schema.asset_attributes.owners:
-        raise ValueError("owners are not supported for sling_replication_collection component")
-    if schema.asset_attributes and schema.asset_attributes.code_version:
-        raise ValueError("code_version is not supported for sling_replication_collection component")
-    return get_wrapped_translator_class(DagsterSlingTranslator)(
-        resolving_info=TranslatorResolvingInfo(
-            "stream_definition",
-            schema.asset_attributes or AssetAttributesSchema(),
-            context,
-        )
-    )
-
-
 SlingMetadataAddons: TypeAlias = Literal["column_metadata", "row_count"]
 
 
 class SlingReplicationSpec(BaseModel, ResolvableFromSchema["SlingReplicationSchema"]):
     path: str
     op: Annotated[Optional[OpSpec], DSLFieldResolver(OpSpec.from_optional)]
+
+    @staticmethod
+    def resolve_translator(
+        context: ResolutionContext, schema: "SlingReplicationSchema"
+    ) -> DagsterSlingTranslator:
+        # TODO: Consider supporting owners and code_version in the future
+        if schema.asset_attributes and schema.asset_attributes.owners:
+            raise ValueError("owners are not supported for sling_replication_collection component")
+        if schema.asset_attributes and schema.asset_attributes.code_version:
+            raise ValueError(
+                "code_version is not supported for sling_replication_collection component"
+            )
+        return get_wrapped_translator_class(DagsterSlingTranslator)(
+            resolving_info=TranslatorResolvingInfo(
+                "stream_definition",
+                schema.asset_attributes or AssetAttributesSchema(),
+                context,
+            )
+        )
+
     translator: Annotated[
         Optional[DagsterSlingTranslator], DSLFieldResolver.from_parent(resolve_translator)
     ]
@@ -92,22 +94,22 @@ class SlingReplicationCollectionSchema(ResolvableSchema):
     asset_post_processors: Optional[Sequence[AssetPostProcessorSchema]] = None
 
 
-def resolve_resource(
-    context: ResolutionContext, schema: SlingReplicationCollectionSchema
-) -> SlingResource:
-    return (
-        SlingResource(**context.resolve_value(schema.sling.model_dump()))
-        if schema.sling
-        else SlingResource()
-    )
-
-
 @scaffoldable(scaffolder=SlingReplicationComponentScaffolder)
 @dataclass
 class SlingReplicationCollectionComponent(
     Component, ResolvableFromSchema[SlingReplicationCollectionSchema]
 ):
     """Expose one or more Sling replications to Dagster as assets."""
+
+    @staticmethod
+    def resolve_resource(
+        context: ResolutionContext, schema: SlingReplicationCollectionSchema
+    ) -> SlingResource:
+        return (
+            SlingResource(**context.resolve_value(schema.sling.model_dump()))
+            if schema.sling
+            else SlingResource()
+        )
 
     resource: Annotated[SlingResource, DSLFieldResolver.from_parent(resolve_resource)] = Field(
         ..., description="Customizations to Sling execution."

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -18,7 +18,6 @@ from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     ResolvableFromSchema,
-    resolve_schema_to_resolvable,
 )
 
 
@@ -66,18 +65,6 @@ class OpSpec(ResolvableFromSchema["OpSpecSchema"]):
     backfill_policy: Annotated[
         Optional[BackfillPolicy], DSLFieldResolver.from_parent(resolve_backfill_policy)
     ] = None
-
-    @classmethod
-    def from_schema(cls, context: ResolutionContext, schema: "OpSpecSchema") -> "OpSpec":
-        return resolve_schema_to_resolvable(
-            schema=schema, resolvable_from_schema_type=OpSpec, context=context
-        )
-
-    @classmethod
-    def from_optional(
-        cls, context: ResolutionContext, schema: Optional["OpSpecSchema"]
-    ) -> Optional["OpSpec"]:
-        return cls.from_schema(context, schema) if schema else None
 
 
 class OpSpecSchema(ResolvableSchema):

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -18,6 +18,7 @@ from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     ResolvableFromSchema,
+    resolve_schema_to_resolvable,
 )
 
 
@@ -65,6 +66,18 @@ class OpSpec(ResolvableFromSchema["OpSpecSchema"]):
     backfill_policy: Annotated[
         Optional[BackfillPolicy], DSLFieldResolver.from_parent(resolve_backfill_policy)
     ] = None
+
+    @classmethod
+    def from_schema(cls, context: ResolutionContext, schema: "OpSpecSchema") -> "OpSpec":
+        return resolve_schema_to_resolvable(
+            schema=schema, resolvable_from_schema_type=OpSpec, context=context
+        )
+
+    @classmethod
+    def from_optional(
+        cls, context: ResolutionContext, schema: Optional["OpSpecSchema"]
+    ) -> Optional["OpSpec"]:
+        return cls.from_schema(context, schema) if schema else None
 
 
 class OpSpecSchema(ResolvableSchema):

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -175,9 +175,6 @@ class AssetPostProcessorSchema(ResolvableSchema):
     operation: Literal["merge", "replace"] = "merge"
     attributes: AssetAttributesSchema
 
-    def resolve(self, context: ResolutionContext) -> Callable[[Definitions], Definitions]:
-        return resolve_schema_to_post_processor(context, self)
-
 
 def apply_post_processor_to_spec(
     schema: AssetPostProcessorSchema, spec: AssetSpec, context: ResolutionContext
@@ -221,3 +218,8 @@ def resolve_schema_to_post_processor(
     context, schema: AssetPostProcessorSchema
 ) -> Callable[[Definitions], Definitions]:
     return lambda defs: apply_post_processor_to_defs(schema, defs, context)
+
+
+@dataclass
+class AssetPostProcessor(ResolvableFromSchema[AssetPostProcessorSchema]):
+    fn: Annotated[PostProcessorFn, DSLFieldResolver.from_parent(resolve_schema_to_post_processor)]

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
@@ -50,6 +50,12 @@ class ResolvableFromSchema(Generic[TSchema]):
     def from_seq(cls, context: "ResolutionContext", schema: Sequence[TSchema]) -> Sequence[Self]:
         return [cls.from_schema(context, item) for item in schema]
 
+    @classmethod
+    def from_optional_seq(
+        cls, context: "ResolutionContext", schema: Optional[Sequence[TSchema]]
+    ) -> Optional[Sequence[Self]]:
+        return cls.from_seq(context, schema) if schema else None
+
 
 @dataclass
 class ParentFn:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -52,8 +52,7 @@ def test_simple_dataclass_resolveable_from_schema_with_condense_syntax():
 
     @dataclass
     class Hello(ResolvableFromSchema[HelloSchema]):
-        # int equivalent to lambda val: int(val)
-        hello: Annotated[int, DSLFieldResolver(int)]
+        hello: Annotated[int, DSLFieldResolver(lambda context, val: int(val))]
 
     hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
 


### PR DESCRIPTION
## Summary & Motivation

This begins to show the patterns we can use to reduce boilerplate, and I think we can go farther.

What this PR is implement these functions on `ResolvableFromSchema`:

```python
class ResolvableFromSchema(Generic[TSchema]):
    @classmethod
    def from_schema(cls, context: "ResolutionContext", schema: TSchema) -> Self:
        return resolve_schema_to_resolvable(
            schema=schema, resolvable_from_schema_type=cls, context=context
        )
    @classmethod
    def from_optional(
        cls, context: "ResolutionContext", schema: Optional[TSchema]
    ) -> Optional[Self]:
        return cls.from_schema(context, schema) if schema else None
    @classmethod
    def from_seq(cls, context: "ResolutionContext", schema: Sequence[TSchema]) -> Sequence[Self]:
        return [cls.from_schema(context, item) for item in schema]
    @classmethod
    def from_optional_seq(
        cls, context: "ResolutionContext", schema: Optional[Sequence[TSchema]]
    ) -> Optional[Sequence[Self]]:
        return cls.from_seq(context, schema) if schema else None
```

At which point you can write declarations like the following:

```python
    replications: Annotated[
        Sequence[SlingReplicationSpec], DSLFieldResolver(SlingReplicationSpec.from_seq)
    ] = Field(..., description="A set of Sling replications to expose as assets.")
```

Which is fairly obvious but less magical to someone inspecting code.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
