### PR TITLE
[dg][BUILD-769] Ensure uv sync run before dagster dev

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -120,6 +120,7 @@ def check_definitions_command(
     ]
 
     if dg_context.use_dg_managed_environment:
+        dg_context.ensure_uv_sync()
         run_cmds = ["uv", "run", "dagster", "definitions", "validate"]
     elif dg_context.is_project:
         run_cmds = ["dagster", "definitions", "validate"]

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -118,6 +118,8 @@ def dev_command(
         os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
             {dg_context.code_location_name: str(dg_context.root_path)}
         )
+        if dg_context.use_dg_managed_environment:
+            dg_context.ensure_uv_sync()
 
     # In a project context, we can just run `dagster dev` directly, using `dagster` from the
     # code location's environment.

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Final, Optional, Union
 
+import click
 import tomlkit
 import tomlkit.items
 from dagster_shared.utils.config import does_dg_config_file_exist
@@ -482,6 +483,7 @@ class DgContext:
         path = path or self.root_path
         with pushd(path):
             if not (path / "uv.lock").exists():
+                click.echo("Syncing uv project")
                 subprocess.run(
                     ["uv", "sync"], check=True, env=strip_activated_venv_from_env_vars(os.environ)
                 )

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -475,6 +475,11 @@ class DgContext:
 
     def ensure_uv_lock(self, path: Optional[Path] = None) -> None:
         path = path or self.root_path
+        if not (path / "uv.lock").exists():
+            self.ensure_uv_sync(path)
+
+    def ensure_uv_sync(self, path: Optional[Path] = None) -> None:
+        path = path or self.root_path
         with pushd(path):
             if not (path / "uv.lock").exists():
                 subprocess.run(

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from pathlib import Path
 from typing import Final, Optional, Union
 
-import click
 import tomlkit
 import tomlkit.items
 from dagster_shared.utils.config import does_dg_config_file_exist
@@ -483,7 +482,6 @@ class DgContext:
         path = path or self.root_path
         with pushd(path):
             if not (path / "uv.lock").exists():
-                click.echo("Syncing uv project")
                 subprocess.run(
                     ["uv", "sync"], check=True, env=strip_activated_venv_from_env_vars(os.environ)
                 )

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -482,8 +482,9 @@ class DgContext:
         path = path or self.root_path
         with pushd(path):
             if not (path / "uv.lock").exists():
-                subprocess.run(
-                    ["uv", "sync"], check=True, env=strip_activated_venv_from_env_vars(os.environ)
+                subprocess.check_output(
+                    ["uv", "sync"],
+                    env=strip_activated_venv_from_env_vars(os.environ),
                 )
 
     @property

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import signal
 import subprocess
 import tempfile
@@ -179,6 +181,16 @@ defs = dg.Definitions()
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
 def test_dev_project_context_success():
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+        port = find_free_port()
+        dev_process = _launch_dev_command(["--port", str(port)])
+        _assert_projects_loaded_and_exit({"foo-bar"}, port, dev_process)
+
+
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
+def test_dev_command_project_context_success_no_uv_sync():
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+        shutil.rmtree(Path.cwd() / ".venv")
+        os.remove(Path.cwd() / "uv.lock")
         port = find_free_port()
         dev_process = _launch_dev_command(["--port", str(port)])
         _assert_projects_loaded_and_exit({"foo-bar"}, port, dev_process)


### PR DESCRIPTION
## Summary

Ensures that uv venv matches expected env before running `dg dev`

## Test Plan

prev. failing test