### PR TITLE
[pythonic resources][ez] Better error message when resolving env vars for resources

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -460,13 +460,20 @@ class ConfigurableResourceFactory(
         """
         from dagster._config.post_process import post_process_config
 
+        post_processed_config = post_process_config(
+            self._config_schema.config_type,  # pyright: ignore[reportArgumentType]
+            self._convert_to_config_dictionary(),
+        )
+
+        if not post_processed_config.success:
+            raise DagsterInvalidConfigError(
+                "Errors while initializing resource",
+                post_processed_config.errors,
+                post_processed_config,
+            )
+
         return self.from_resource_context(
-            build_init_resource_context(
-                config=post_process_config(
-                    self._config_schema.config_type,  # pyright: ignore[reportArgumentType]
-                    self._convert_to_config_dictionary(),  # pyright: ignore[reportArgumentType]
-                ).value,
-            ),
+            build_init_resource_context(config=post_processed_config.value),
             nested_resources=self.nested_resources,
         )
 
@@ -477,13 +484,20 @@ class ConfigurableResourceFactory(
         """
         from dagster._config.post_process import post_process_config
 
+        post_processed_config = post_process_config(
+            self._config_schema.config_type,  # pyright: ignore[reportArgumentType]
+            self._convert_to_config_dictionary(),
+        )
+
+        if not post_processed_config.success:
+            raise DagsterInvalidConfigError(
+                "Errors while initializing resource",
+                post_processed_config.errors,
+                post_processed_config,
+            )
+
         with self.from_resource_context_cm(
-            build_init_resource_context(
-                config=post_process_config(
-                    self._config_schema.config_type,  # pyright: ignore[reportArgumentType]
-                    self._convert_to_config_dictionary(),  # pyright: ignore[reportArgumentType]
-                ).value
-            ),
+            build_init_resource_context(config=post_processed_config.value),
             nested_resources=self.nested_resources,
         ) as out:
             yield out

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
@@ -267,3 +267,21 @@ def test_env_var_alongside_enum() -> None:
     assert result.success
     assert result.output_for_node("an_asset") == ("BAR", "foo")
     assert executed["yes"]
+
+
+def test_env_var_err_at_instantiation() -> None:
+    if "UNSET_ENV_VAR" in os.environ:
+        del os.environ["UNSET_ENV_VAR"]
+
+    class ResourceWithString(ConfigurableResource):
+        a_str: str
+
+    with pytest.raises(
+        DagsterInvalidConfigError,
+        match=(
+            'You have attempted to fetch the environment variable "UNSET_ENV_VAR" which is not set.'
+        ),
+    ):
+        ResourceWithString(
+            a_str=EnvVar("UNSET_ENV_VAR"),
+        ).process_config_and_initialize()


### PR DESCRIPTION
## Summary

Ran into a bad error message experience on DOP here where we just get a Pydantic error if an env var silently fails to load. This forwards the error to the user instead.

## Test Plan

Test

## Changelog

> Improved error message experience for resources expecting an env var which was not provided.
