### PR TITLE
Correct the description of assets in the quickstart tutorial

### DIFF
--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -14,7 +14,7 @@ Welcome to Dagster! In this guide, you'll use Dagster to create a basic pipeline
 ## What you'll learn
 
 - How to set up a basic Dagster project
-- How to create a Dagster asset for each step of the Extract, Transform, and Load (ETL) process
+- How to create a single Dagster asset that encapsulates the entire Extract, Transform, and Load (ETL) process
 - How to use Dagster's UI to monitor and execute your pipeline
 
 ## Prerequisites


### PR DESCRIPTION
## Summary & Motivation

There is a bullet in the Quickstart that implies we're creating multiple assets in this tutorial when in fact we're creating only one.