### PR TITLE
[dg] Make implementing get_schema unnecesseary when inheriting from ResolvableFromSchema

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -12,7 +12,6 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
-from typing_extensions import Self
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
@@ -29,7 +28,6 @@ from dagster_components.core.schema.objects import (
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     ResolvableFromSchema,
-    resolve_schema_to_resolvable,
 )
 from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
@@ -84,18 +82,9 @@ class DbtProjectComponent(Component, ResolvableFromSchema[DbtProjectSchema]):
     select: str = "fqn:*"
     exclude: Optional[str] = None
 
-    @classmethod
-    def load(cls, attributes: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
-        assert isinstance(attributes, DbtProjectSchema)
-        return resolve_schema_to_resolvable(attributes, cls, context.resolution_context)
-
     @cached_property
     def project(self) -> DbtProject:
         return DbtProject(self.dbt.project_dir)
-
-    @classmethod
-    def get_schema(cls) -> type[DbtProjectSchema]:
-        return DbtProjectSchema
 
     def get_asset_selection(
         self, select: str, exclude: Optional[str] = None

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -10,7 +10,7 @@ from dagster_sling import DagsterSlingTranslator, SlingResource, sling_assets
 from dagster_sling.resources import AssetExecutionContext
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass
-from typing_extensions import Self, TypeAlias
+from typing_extensions import TypeAlias
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.sling_replication_collection.scaffolder import (
@@ -29,7 +29,6 @@ from dagster_components.core.schema.objects import (
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     ResolvableFromSchema,
-    resolve_schema_to_resolvable,
 )
 from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
@@ -126,15 +125,6 @@ class SlingReplicationCollectionComponent(
         default=None,
         description="Post-processors to apply to the asset definitions produced by this component.",
     )
-
-    @classmethod
-    def load(cls, attributes: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
-        assert isinstance(attributes, SlingReplicationCollectionSchema)
-        return resolve_schema_to_resolvable(attributes, cls, context.resolution_context)
-
-    @classmethod
-    def get_schema(cls) -> type[SlingReplicationCollectionSchema]:
-        return SlingReplicationCollectionSchema
 
     def build_asset(
         self, context: ComponentLoadContext, replication_spec: SlingReplicationSpec

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Optional, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict, TypeVar
 
 from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
@@ -21,9 +21,16 @@ from dagster_components.core.component_key import ComponentKey
 from dagster_components.core.component_scaffolder import DefaultComponentScaffolder
 from dagster_components.core.schema.base import ResolvableSchema, resolve_as
 from dagster_components.core.schema.context import ResolutionContext
+from dagster_components.core.schema.resolvable_from_schema import (
+    ResolvableFromSchema,
+    resolve_schema_to_resolvable,
+)
 from dagster_components.scaffoldable.decorator import get_scaffolder, scaffoldable
 from dagster_components.scaffoldable.scaffolder import ScaffolderUnavailableReason
 from dagster_components.utils import format_error_message
+
+if TYPE_CHECKING:
+    from dagster_components.core.schema.resolvable_from_schema import EitherSchema
 
 
 class ComponentsEntryPointLoadError(DagsterError):
@@ -38,7 +45,14 @@ class ComponentDeclNode(ABC):
 @scaffoldable(scaffolder=DefaultComponentScaffolder)
 class Component(ABC):
     @classmethod
-    def get_schema(cls) -> Optional[type[ResolvableSchema]]:
+    def get_schema(cls) -> Optional[type["EitherSchema"]]:
+        from dagster_components.core.schema.resolvable_from_schema import (
+            ResolvableFromSchema,
+            get_schema_type,
+        )
+
+        if issubclass(cls, ResolvableFromSchema):
+            return get_schema_type(cls)
         return None
 
     @classmethod
@@ -49,8 +63,16 @@ class Component(ABC):
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...
 
     @classmethod
-    def load(cls, attributes: Optional[ResolvableSchema], context: "ComponentLoadContext") -> Self:
-        return resolve_as(attributes, cls, context.resolution_context) if attributes else cls()
+    def load(cls, attributes: Optional["EitherSchema"], context: "ComponentLoadContext") -> Self:
+        if issubclass(cls, ResolvableFromSchema):
+            return (
+                resolve_schema_to_resolvable(attributes, cls, context.resolution_context)
+                if attributes
+                else cls()
+            )
+        else:
+            assert isinstance(attributes, ResolvableSchema)
+            return resolve_as(attributes, cls, context.resolution_context) if attributes else cls()
 
     @classmethod
     def get_metadata(cls) -> "ComponentTypeInternalMetadata":

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -11,7 +11,10 @@ from dagster import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
-from dagster_components.components.dbt_project.component import DbtProjectComponent
+from dagster_components.components.dbt_project.component import (
+    DbtProjectComponent,
+    DbtProjectSchema,
+)
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -73,7 +76,7 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
             },
         ),
     )
-    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    attributes = decl_node.get_attributes(DbtProjectSchema)
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
@@ -139,7 +142,8 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
         DebugDbtProjectComponent.get_additional_scope()
     )
     component = DebugDbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DebugDbtProjectComponent.get_schema()), context=context
+        attributes=decl_node.get_attributes(DebugDbtProjectComponent.get_schema()),  # type: ignore
+        context=context,
     )
     defs = component.build_defs(script_load_context())
     assets_def: AssetsDefinition = defs.get_assets_def(AssetKey("stg_customers"))
@@ -216,7 +220,7 @@ def test_asset_attributes(
         )
         context = script_load_context(decl_node)
         component = DbtProjectComponent.load(
-            attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
+            attributes=decl_node.get_attributes(DbtProjectSchema), context=context
         )
         assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
         defs = component.build_defs(script_load_context())
@@ -238,7 +242,7 @@ def test_subselection(dbt_path: Path) -> None:
     )
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
+        attributes=decl_node.get_attributes(DbtProjectSchema), context=context
     )
     assert get_asset_keys(component) == {AssetKey("raw_customers")}
 
@@ -256,6 +260,6 @@ def test_exclude(dbt_path: Path) -> None:
     )
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()), context=context
+        attributes=decl_node.get_attributes(DbtProjectSchema), context=context
     )
     assert get_asset_keys(component) == set(JAFFLE_SHOP_KEYS) - {AssetKey("customers")}

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -19,6 +19,7 @@ from dagster._utils.env import environ
 from dagster_components.cli import cli
 from dagster_components.components.sling_replication_collection.component import (
     SlingReplicationCollectionComponent,
+    SlingReplicationCollectionSchema,
 )
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import YamlComponentDecl, build_component_defs
@@ -75,7 +76,7 @@ def temp_sling_component_instance(
 def test_python_attributes() -> None:
     with temp_sling_component_instance([{"path": "./replication.yaml"}]) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        attributes = decl_node.get_attributes(SlingReplicationCollectionSchema)
         component = SlingReplicationCollectionComponent.load(attributes, context)
 
         replications = component.replications
@@ -99,7 +100,7 @@ def test_python_attributes_op_name() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        attributes = decl_node.get_attributes(SlingReplicationCollectionSchema)
         component = SlingReplicationCollectionComponent.load(attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -121,7 +122,7 @@ def test_python_attributes_op_tags() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        attributes = decl_node.get_attributes(SlingReplicationCollectionSchema)
         component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -139,7 +140,7 @@ def test_python_params_include_metadata() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        attributes = decl_node.get_attributes(SlingReplicationCollectionSchema)
         component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -195,7 +196,7 @@ def test_sling_subclass() -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(DebugSlingReplicationComponent.get_schema())
+    attributes = decl_node.get_attributes(SlingReplicationCollectionSchema)
     component_inst = DebugSlingReplicationComponent.load(attributes=attributes, context=context)
     assert component_inst.build_defs(context).get_asset_graph().get_all_asset_keys() == {
         AssetKey("input_csv"),
@@ -259,7 +260,7 @@ def test_asset_attributes(
         ) as decl_node,
     ):
         context = script_load_context(decl_node)
-        attrs = decl_node.get_attributes(SlingReplicationCollectionComponent.get_schema())
+        attrs = decl_node.get_attributes(SlingReplicationCollectionSchema)
         component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
         defs = component.build_defs(context)
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING
 import pytest
 from dagster import AssetKey
 from dagster._utils.env import environ
-from dagster_components.components.dbt_project.component import DbtProjectComponent
+from dagster_components.components.dbt_project.component import (
+    DbtProjectComponent,
+    DbtProjectSchema,
+)
 from dagster_components.core.component_decl_builder import ComponentFileModel
 from dagster_components.core.component_defs_builder import (
     YamlComponentDecl,
@@ -75,7 +78,7 @@ def test_python_attributes_node_rename(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    attributes = decl_node.get_attributes(DbtProjectSchema)
     component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS_WITH_PREFIX
 
@@ -94,7 +97,7 @@ def test_python_attributes_group(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+    attributes = decl_node.get_attributes(DbtProjectSchema)
     comp = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
     defs: Definitions = comp.build_defs(script_load_context(None))
@@ -133,7 +136,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+        attributes = decl_node.get_attributes(DbtProjectSchema)
         comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
         defs: Definitions = comp.build_defs(script_load_context())

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -159,6 +159,6 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(DbtProjectComponent.get_schema())
+        attributes = decl_node.get_attributes(DbtProjectSchema)
         comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS_WITH_PREFIX


### PR DESCRIPTION
## Summary & Motivation

If we inherit from `ResolvableFromSchema` we shouldn't have to implement `get_schema`. This does that.

We also implement the need to override `load` in converted components.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG