### PR TITLE
[dagster definitions validate] Unwrap, truncate user code errors

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -11,6 +11,10 @@ from dagster._cli.workspace.cli_target import (
     get_workspace_from_cli_opts,
     workspace_options,
 )
+from dagster._utils.error import (
+    remove_non_user_code_lines_from_serializable_exc_info,
+    unwrap_user_code_error,
+)
 from dagster._utils.log import configure_loggers
 
 
@@ -86,9 +90,12 @@ def definitions_validate_command(
             ]
             for code_location, entry in workspace.get_code_location_entries().items():
                 if entry.load_error:
+                    underlying_error = remove_non_user_code_lines_from_serializable_exc_info(
+                        unwrap_user_code_error(entry.load_error)
+                    )
                     logger.error(
                         f"Validation failed for code location {code_location}:\n\n"
-                        f"{entry.load_error.to_string()}"
+                        f"{underlying_error.to_string()}"
                     )
                     pass
                 else:

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -11,10 +11,7 @@ from dagster._cli.workspace.cli_target import (
     get_workspace_from_cli_opts,
     workspace_options,
 )
-from dagster._utils.error import (
-    remove_non_user_code_lines_from_serializable_exc_info,
-    unwrap_user_code_error,
-)
+from dagster._utils.error import remove_system_frames_from_error, unwrap_user_code_error
 from dagster._utils.log import configure_loggers
 
 
@@ -90,7 +87,7 @@ def definitions_validate_command(
             ]
             for code_location, entry in workspace.get_code_location_entries().items():
                 if entry.load_error:
-                    underlying_error = remove_non_user_code_lines_from_serializable_exc_info(
+                    underlying_error = remove_system_frames_from_error(
                         unwrap_user_code_error(entry.load_error)
                     )
                     logger.error(

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -265,15 +265,15 @@ def remove_system_frames_from_error(
     """Remove system frames from a SerializableErrorInfo, including Dagster framework boilerplate
     and import machinery, which are generally not useful for users to debug their code.
     """
-    return remove_matching_lines_from_serializable_error_info(
+    return remove_matching_lines_from_error_info(
         error_info,
         DAGSTER_FRAMEWORK_SUBSTRINGS + IMPORT_MACHINERY_SUBSTRINGS,
     )
 
 
-def remove_matching_lines_from_serializable_error_info(
+def remove_matching_lines_from_error_info(
     error_info: SerializableErrorInfo,
-    matching_lines: Sequence[str],
+    match_substrs: Sequence[str],
 ):
     """Utility which truncates a stacktrace to drop lines which match the given strings.
     This is useful for e.g. removing Dagster framework lines from a stacktrace that
@@ -287,14 +287,14 @@ def remove_matching_lines_from_serializable_error_info(
         SerializableErrorInfo: A new error info with the stacktrace truncated
     """
     return error_info._replace(
-        stack=remove_matching_lines_from_stack_trace(error_info.stack, matching_lines),
+        stack=remove_matching_lines_from_stack_trace(error_info.stack, match_substrs),
         cause=(
-            remove_matching_lines_from_serializable_error_info(error_info.cause, matching_lines)
+            remove_matching_lines_from_error_info(error_info.cause, match_substrs)
             if error_info.cause
             else None
         ),
         context=(
-            remove_matching_lines_from_serializable_error_info(error_info.context, matching_lines)
+            remove_matching_lines_from_error_info(error_info.context, match_substrs)
             if error_info.context
             else None
         ),

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -259,16 +259,19 @@ def unwrap_user_code_error(error_info: SerializableErrorInfo) -> SerializableErr
     return error_info
 
 
-def remove_non_user_code_lines_from_serializable_exc_info(
+def remove_system_frames_from_error(
     error_info: SerializableErrorInfo,
 ):
-    return remove_matching_lines_from_serializable_exc_info(
+    """Remove system frames from a SerializableErrorInfo, including Dagster framework boilerplate
+    and import machinery, which are generally not useful for users to debug their code.
+    """
+    return remove_matching_lines_from_serializable_error_info(
         error_info,
         DAGSTER_FRAMEWORK_SUBSTRINGS + IMPORT_MACHINERY_SUBSTRINGS,
     )
 
 
-def remove_matching_lines_from_serializable_exc_info(
+def remove_matching_lines_from_serializable_error_info(
     error_info: SerializableErrorInfo,
     matching_lines: Sequence[str],
 ):
@@ -286,12 +289,12 @@ def remove_matching_lines_from_serializable_exc_info(
     return error_info._replace(
         stack=remove_matching_lines_from_stack_trace(error_info.stack, matching_lines),
         cause=(
-            remove_matching_lines_from_serializable_exc_info(error_info.cause, matching_lines)
+            remove_matching_lines_from_serializable_error_info(error_info.cause, matching_lines)
             if error_info.cause
             else None
         ),
         context=(
-            remove_matching_lines_from_serializable_exc_info(error_info.context, matching_lines)
+            remove_matching_lines_from_serializable_error_info(error_info.context, matching_lines)
             if error_info.context
             else None
         ),

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py
@@ -1,0 +1,1 @@
+raise Exception("This is a test exception")

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/pyproject.toml
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.dagster]
+module_name = "invalid_project_exc.definitions"

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -9,6 +9,9 @@ from dagster._utils import file_relative_path
 EMPTY_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/empty_project")
 VALID_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/valid_project")
 INVALID_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/invalid_project")
+INVALID_PROJECT_PATH_WITH_EXCEPTION = file_relative_path(
+    __file__, "definitions_command_projects/invalid_project_exc"
+)
 PROJECT_ALTERNATE_ENTRYPOINT_PATH = file_relative_path(
     __file__, "definitions_command_projects/alternate_entrypoint_project"
 )
@@ -102,6 +105,18 @@ def test_invalid_project(options, monkeypatch):
         assert result.exit_code == 1
         assert "Validation failed" in result.output
         assert "Duplicate asset key: AssetKey(['my_asset'])" in result.output
+
+
+def test_invalid_project_truncated_properly(monkeypatch):
+    with monkeypatch.context() as m:
+        m.chdir(INVALID_PROJECT_PATH_WITH_EXCEPTION)
+        result = invoke_validate(options=[])
+        assert result.exit_code == 1
+        assert "Validation failed" in result.output
+        assert "This is a test exception" in result.output
+        # Assert extraneous lines are removed
+        assert "importlib" not in result.output, result.output
+        assert "DagsterUserCodeLoadError" not in result.output, result.output
 
 
 def test_env_var(monkeypatch):


### PR DESCRIPTION
## Summary

Tries to make `dg check defs` error messages more relevant by stripping out the framework junk around a user code error.

Before:
```python
2025-03-04 15:06:30 -0800 - dagster - ERROR - Validation failed for code location dagster_open_platform:

dagster._core.errors.DagsterUserCodeLoadError: Error occurred during the loading of Dagster definitions in
module_name=dagster_open_platform.definitions, working_directory=/Users/ben/repos/internal/python_modules/dagster-open-platform

Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/context.py", line 819, in _load_location
    else origin.create_location(self.instance)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/remote_representation/origin.py", line 203, in create_location
    return InProcessCodeLocation(self, instance=instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/remote_representation/code_location.py", line 386, in __init__
    self._loaded_repositories = LoadedRepositories(
                                ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 242, in __init__
    with user_code_error_boundary(
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/errors.py", line 299, in user_code_error_boundary
    raise new_error from e

The above exception was caused by the following exception:
dlt.common.configuration.exceptions.ConfigFieldMissingException: Following fields are missing: ['thinkific_subdomain', 'thinkific_api_key'] in configuration with spec ThinkificConfiguration
	for field "thinkific_subdomain" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key THINKIFIC_SUBDOMAIN was not found.
	for field "thinkific_api_key" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC_API_KEY was not found.
		In Environment Variables key THINKIFIC_API_KEY was not found.
WARNING: dlt looks for .dlt folder in your current working directory and your cwd (/Users/ben/repos/internal/python_modules/dagster-open-platform) is different from directory of your pipeline script (/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/bin).
If you keep your secret files in the same folder as your pipeline script but run your script from some other folder, secrets/configs will not be found
Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information


Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/errors.py", line 289, in user_code_error_boundary
    yield
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 253, in __init__
    loadable_targets = get_loadable_targets(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/utils.py", line 51, in get_loadable_targets
    else loadable_targets_from_python_module(module_name, working_directory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/autodiscovery.py", line 33, in loadable_targets_from_python_module
    module = load_python_module(
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/code_pointer.py", line 135, in load_python_module
    return importlib.import_module(module_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/definitions.py", line 14, in <module>
    import dagster_open_platform.dlt.definitions as dlt_definitions
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/definitions.py", line 21, in <module>
    from dagster_open_platform.dlt import assets
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/assets.py", line 29, in <module>
    dlt_source=thinkific(),
               ^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 199, in __call__
    source = self._deco_f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 284, in _wrap
    rv = conf_f(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 255, in _wrap
    config = resolve_config(bound_args, accept_partial_=accept_partial)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 183, in resolve_config
    return resolve_configuration(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 67, in resolve_configuration
    return _resolve_configuration(config, sections, (), explicit_value, accept_partial)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 164, in _resolve_configuration
    _resolve_config_fields(
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 304, in _resolve_config_fields
    raise ConfigFieldMissingException(type(config).__name__, unresolved_fields)

2025-03-04 15:06:30 -0800 - dagster - ERROR - Validation for 1 code locations failed.
```

After:
```python
2025-03-04 15:06:50 -0800 - dagster - ERROR - Validation failed for code location dagster_open_platform:

dlt.common.configuration.exceptions.ConfigFieldMissingException: Following fields are missing: ['thinkific_subdomain', 'thinkific_api_key'] in configuration with spec ThinkificConfiguration
	for field "thinkific_subdomain" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key THINKIFIC_SUBDOMAIN was not found.
	for field "thinkific_api_key" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC_API_KEY was not found.
		In Environment Variables key THINKIFIC_API_KEY was not found.
WARNING: dlt looks for .dlt folder in your current working directory and your cwd (/Users/ben/repos/internal/python_modules/dagster-open-platform) is different from directory of your pipeline script (/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/bin).
If you keep your secret files in the same folder as your pipeline script but run your script from some other folder, secrets/configs will not be found
Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information


Stack Trace:
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/definitions.py", line 14, in <module>
    import dagster_open_platform.dlt.definitions as dlt_definitions
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/definitions.py", line 21, in <module>
    from dagster_open_platform.dlt import assets
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/assets.py", line 29, in <module>
    dlt_source=thinkific(),
               ^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 199, in __call__
    source = self._deco_f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 284, in _wrap
    rv = conf_f(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 255, in _wrap
    config = resolve_config(bound_args, accept_partial_=accept_partial)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 183, in resolve_config
    return resolve_configuration(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 67, in resolve_configuration
    return _resolve_configuration(config, sections, (), explicit_value, accept_partial)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 164, in _resolve_configuration
    _resolve_config_fields(
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 304, in _resolve_config_fields
    raise ConfigFieldMissingException(type(config).__name__, unresolved_fields)

2025-03-04 15:06:50 -0800 - dagster - ERROR - Validation for 1 code locations failed.

```

## Test Plan

Unit test.
