### PR TITLE
[selection input auto complete] Default to -1 index

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -82,7 +82,7 @@ export const SelectionAutoCompleteInput = ({
 
   const focusRef = useRef(false);
 
-  const [selectedIndexRef, setSelectedIndex] = useState({current: 0});
+  const [selectedIndexRef, setSelectedIndex] = useState({current: -1});
 
   // Memoize the stringified results to avoid resetting the selected index down below
   const resultsJson = useMemo(() => {
@@ -95,7 +95,7 @@ export const SelectionAutoCompleteInput = ({
   // Handle selection reset
   useDangerousRenderEffect(() => {
     if (prevAutoCompleteResults?.from !== autoCompleteResults?.from || prevJson !== resultsJson) {
-      selectedIndexRef.current = 0;
+      selectedIndexRef.current = -1;
     }
   }, [resultsJson, autoCompleteResults, prevAutoCompleteResults, prevJson, selectedIndexRef]);
 
@@ -217,7 +217,7 @@ export const SelectionAutoCompleteInput = ({
       setCursorPosition(cursor.ch);
       requestAnimationFrame(() => {
         // Reset selected index on value change
-        setSelectedIndex({current: 0});
+        setSelectedIndex({current: -1});
       });
     }
   }, [value]);
@@ -261,15 +261,17 @@ export const SelectionAutoCompleteInput = ({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Enter') {
-        e.stopPropagation();
-        e.preventDefault();
-        onSelectionChange(innerValueRef.current);
-        setShowResults({current: false});
-      }
-      if (!showResults.current) {
+        if (selectedIndexRef.current !== -1 && selectedItem) {
+          onSelect(selectedItem);
+        } else {
+          e.stopPropagation();
+          e.preventDefault();
+          onSelectionChange(innerValueRef.current);
+          setShowResults({current: false});
+        }
+      } else if (!showResults.current) {
         return;
-      }
-      if (e.key === 'ArrowDown' && !e.shiftKey && !e.ctrlKey) {
+      } else if (e.key === 'ArrowDown' && !e.shiftKey && !e.ctrlKey) {
         e.preventDefault();
         e.stopPropagation();
         setSelectedIndex((prev) => ({
@@ -296,11 +298,12 @@ export const SelectionAutoCompleteInput = ({
     },
     [
       showResults,
+      selectedIndexRef,
+      selectedItem,
       onSelectionChange,
       innerValueRef,
-      autoCompleteResults?.list.length,
-      selectedItem,
       onSelect,
+      autoCompleteResults?.list.length,
     ],
   );
 


### PR DESCRIPTION
## Summary & Motivation

Default to -1 index so that `enter` can continue to submit the query, but also so that it can select autocomplete entries if its not -1.

## How I Tested These Changes

locally.

You can see the first item is no longer immediately highlighted now
<img width="1269" alt="Screenshot 2025-03-04 at 6 27 03 PM" src="https://github.com/user-attachments/assets/7a9eda98-3fc3-4098-aefd-607f5368c683" />
