### PR TITLE
[components] Allow Definitions component to pick up raw Definitions objects

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
 )
+from dagster._core.definitions.module_loaders.utils import find_objects_in_module_of_types
 from pydantic import Field
 
 from dagster_components import Component, ComponentLoadContext
@@ -24,8 +25,15 @@ class DefinitionsComponent(Component, ResolvableModel):
     )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        return load_definitions_from_module(
-            context.load_component_relative_python_module(
-                Path(self.definitions_path) if self.definitions_path else Path("definitions.py")
+        defs_path = Path(self.definitions_path) if self.definitions_path else Path("definitions.py")
+        defs_module = context.load_component_relative_python_module(defs_path)
+        defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
+        if len(defs_attrs) > 1:
+            raise ValueError(
+                f"Found multiple Definitions objects in {defs_path}. "
+                "At most one Definitions object may be specified when using the DefinitionsComponent."
             )
-        )
+        elif len(defs_attrs) == 1:
+            return defs_attrs[0]
+        else:
+            return load_definitions_from_module(defs_module)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/component.yaml
@@ -1,0 +1,4 @@
+type: dagster_components.dagster.DefinitionsComponent
+
+attributes:
+  definitions_path: my_defs.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/my_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/my_defs.py
@@ -1,0 +1,13 @@
+from dagster import Definitions, asset
+
+
+@asset
+def a() -> None: ...
+
+
+@asset
+def b() -> None: ...
+
+
+defs1 = Definitions(assets=[a])
+defs2 = Definitions(assets=[b])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/component.yaml
@@ -1,0 +1,4 @@
+type: dagster_components.dagster.DefinitionsComponent
+
+attributes:
+  definitions_path: my_defs.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/my_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/my_defs.py
@@ -1,0 +1,11 @@
+from dagster import Definitions, asset
+
+from .some_file import asset_in_some_file  # noqa: TID252
+from .some_other_file import asset_in_some_other_file  # noqa: TID252
+
+
+@asset
+def an_asset_that_is_not_included() -> None: ...
+
+
+defs = Definitions(assets=[asset_in_some_file, asset_in_some_other_file])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_file.py
@@ -1,0 +1,9 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_file() -> None: ...
+
+
+@asset
+def asset_that_isnt_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_other_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_other_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_other_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
@@ -55,3 +55,16 @@ def test_definitions_component_validation_error() -> None:
         load_test_component_defs("definitions/validation_error_file")
 
     assert "component.yaml:4" in str(e.value)
+
+
+def test_definitions_component_with_definitions_object() -> None:
+    defs = load_test_component_defs("definitions/definitions_object_relative_imports")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {
+        AssetKey("asset_in_some_file"),
+        AssetKey("asset_in_some_other_file"),
+    }
+
+
+def test_definitions_component_with_multiple_definitions_objects() -> None:
+    with pytest.raises(ValueError, match="Found multiple Definitions objects in my_defs.py"):
+        load_test_component_defs("definitions/definitions_object_multiple")


### PR DESCRIPTION
## Summary & Motivation

This changes the behavior of the DefinitionsComponent to explicitly handle cases where a `Definitions` object is defined. Previously, these objects would be ignored entirely.

## How I Tested These Changes

## Changelog

NOCHANGELOG
