### PR TITLE
[components] Allow for implicit defs loading

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -24,16 +24,31 @@ class DefinitionsComponent(Component, ResolvableModel):
         None, description="Relative path to a file containing Dagster definitions."
     )
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        defs_path = Path(self.definitions_path) if self.definitions_path else Path("definitions.py")
+    def _build_defs_for_path(self, context: ComponentLoadContext, defs_path: Path) -> Definitions:
         defs_module = context.load_component_relative_python_module(defs_path)
         defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
-        if len(defs_attrs) > 1:
+
+        if defs_attrs and self.definitions_path is None:
             raise ValueError(
-                f"Found multiple Definitions objects in {defs_path}. "
-                "At most one Definitions object may be specified when using the DefinitionsComponent."
+                f"Found a Definitions object in {defs_path}, which is not supported when implicitly loading definitions. "
+                "You may need to add an explicit `component.yaml` file to specify a DefinitionsComponent."
+            )
+        elif len(defs_attrs) > 1:
+            raise ValueError(
+                f"Found multiple Definitions objects in {defs_path}. At most one Definitions object "
+                "may be specified when using the DefinitionsComponent."
             )
         elif len(defs_attrs) == 1:
             return defs_attrs[0]
         else:
             return load_definitions_from_module(defs_module)
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        defs_paths = (
+            [Path(self.definitions_path)]
+            if self.definitions_path
+            else list(context.path.rglob("*.py"))
+        )
+        return Definitions.merge(
+            *(self._build_defs_for_path(context, defs_path) for defs_path in defs_paths)
+        )

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -245,11 +245,15 @@ class ComponentLoadContext:
     @property
     def path(self) -> Path:
         from dagster_components.core.component_decl_builder import (
+            ImplicitDefinitionsComponentDecl,
             PythonComponentDecl,
             YamlComponentDecl,
         )
 
-        if not isinstance(self.decl_node, (YamlComponentDecl, PythonComponentDecl)):
+        if not isinstance(
+            self.decl_node,
+            (YamlComponentDecl, PythonComponentDecl, ImplicitDefinitionsComponentDecl),
+        ):
             check.failed(f"Unsupported decl_node type {type(self.decl_node)}")
 
         return self.decl_node.path

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -35,6 +35,41 @@ class ComponentFileModel(BaseModel):
 T = TypeVar("T", bound=BaseModel)
 
 
+def has_python_files(folder_path: Path) -> bool:
+    """Check if a folder contains any Python files excluding __init__.py.
+
+    Args:
+        folder_path (Path): Path object representing the folder to check
+    Returns:
+        bool: True if folder contains .py files (except __init__.py), False otherwise
+    """
+    if not folder_path.is_dir():
+        return False
+    return any(folder_path.glob("*.py"))
+
+
+@record
+class ImplicitDefinitionsComponentDecl(ComponentDeclNode):
+    path: Path
+
+    @staticmethod
+    def exists_at(path: Path) -> bool:
+        if YamlComponentDecl.exists_at(path):
+            return False
+        if PythonComponentDecl.exists_at(path):
+            return False
+        return has_python_files(path)
+
+    @staticmethod
+    def from_path(path: Path) -> "ImplicitDefinitionsComponentDecl":
+        return ImplicitDefinitionsComponentDecl(path=path)
+
+    def load(self, context) -> Sequence[Component]:
+        from dagster_components.dagster import DefinitionsComponent
+
+        return [DefinitionsComponent(definitions_path=None)]
+
+
 @record
 class PythonComponentDecl(ComponentDeclNode):
     path: Path
@@ -156,6 +191,8 @@ def path_to_decl_node(path: Path) -> Optional[ComponentDeclNode]:
         return YamlComponentDecl.from_path(path)
     elif PythonComponentDecl.exists_at(path):
         return PythonComponentDecl.from_path(path)
+    elif ImplicitDefinitionsComponentDecl.exists_at(path):
+        return ImplicitDefinitionsComponentDecl.from_path(path)
 
     subs = []
     for subpath in path.iterdir():

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/my_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/my_defs.py
@@ -1,0 +1,11 @@
+from dagster import Definitions, asset
+
+from .other_file import asset_in_other_file  # noqa: TID252
+from .some_file import asset_in_some_file  # noqa: TID252
+
+
+@asset
+def an_asset_that_is_not_included() -> None: ...
+
+
+defs = Definitions(assets=[asset_in_some_file, asset_in_other_file])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/other_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/other_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_other_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/some_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/definitions_object_relative_imports/some_file.py
@@ -1,0 +1,9 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_file() -> None: ...
+
+
+@asset
+def asset_that_isnt_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/multiple_files/other_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/multiple_files/other_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_other_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/multiple_files/some_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/multiple_files/some_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/single_file/some_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions_implicit/single_file/some_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def an_asset() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component_implicit.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component_implicit.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pytest
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._utils import pushd
+
+from dagster_components_tests.integration_tests.component_loader import load_test_component_defs
+
+
+@pytest.fixture(autouse=True)
+def chdir():
+    with pushd(str(Path(__file__).parent.parent)):
+        sys.path.append(str(Path(__file__).parent))
+        yield
+
+
+def test_definitions_component_with_single_file() -> None:
+    defs = load_test_component_defs("definitions_implicit/single_file")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("an_asset")}
+
+
+def test_definitions_component_with_multiple_files() -> None:
+    defs = load_test_component_defs("definitions_implicit/multiple_files")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {
+        AssetKey("asset_in_some_file"),
+        AssetKey("asset_in_other_file"),
+    }
+
+
+def test_definitions_component_with_definitions_object() -> None:
+    with pytest.raises(ValueError, match="Found a Definitions object"):
+        load_test_component_defs("definitions_implicit/definitions_object_relative_imports")


### PR DESCRIPTION
## Summary & Motivation

This changes the default behavior of the Definitions component to scan the entire directory for python files if no path is defined.

It then allows for the Definitions component to be used in cases where there is no `component.yaml` or `component.py` file available.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
