### PR TITLE
[dg] For simple components with no resolution logic, do not require schema classes

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -6,28 +6,21 @@ from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
 )
 from pydantic import Field
-from pydantic.dataclasses import dataclass
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.definitions_component.scaffolder import (
     DefinitionsComponentScaffolder,
 )
-from dagster_components.core.component import ResolvableFromSchema
 from dagster_components.core.schema.resolvable_from_schema import DSLSchema
 from dagster_components.scaffoldable.decorator import scaffoldable
 
 
-class DefinitionsParamSchema(DSLSchema):
-    definitions_path: Optional[str] = None
-
-
-@dataclass
 @scaffoldable(scaffolder=DefinitionsComponentScaffolder)
-class DefinitionsComponent(Component, ResolvableFromSchema[DefinitionsParamSchema]):
+class DefinitionsComponent(Component, DSLSchema):
     """Wraps an arbitrary set of Dagster definitions."""
 
     definitions_path: Optional[str] = Field(
-        ..., description="Relative path to a file containing Dagster definitions."
+        None, description="Relative path to a file containing Dagster definitions."
     )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:


### PR DESCRIPTION
## Summary & Motivation

For simple components that do not require resolution logic, we current require the declaration of a redundant Schema class. This doesn't feel great. Here we allow components to declare themselves as schema directly.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG