### PR TITLE
[components][wip] allow scaffolding of specific types of Definitions

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.module_loaders.load_defs_from_module import (
     load_definitions_from_module,
 )
+from dagster._core.definitions.module_loaders.utils import find_objects_in_module_of_types
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
@@ -33,8 +34,15 @@ class DefinitionsComponent(Component):
         return DefinitionsParamSchema
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        return load_definitions_from_module(
-            context.load_component_relative_python_module(
-                Path(self.definitions_path) if self.definitions_path else Path("definitions.py")
+        defs_path = Path(self.definitions_path) if self.definitions_path else Path("definitions.py")
+        defs_module = context.load_component_relative_python_module(defs_path)
+        defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
+        if len(defs_attrs) > 1:
+            raise ValueError(
+                f"Found multiple Definitions objects in {defs_path}. "
+                "At most one Definitions object may be specified when using the DefinitionsComponent."
             )
-        )
+        elif len(defs_attrs) == 1:
+            return defs_attrs[0]
+        else:
+            return load_definitions_from_module(defs_module)

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -8,9 +9,12 @@ from dagster_components.core.component_scaffolder import ScaffoldRequest
 from dagster_components.scaffold import scaffold_component_yaml
 from dagster_components.scaffoldable.scaffolder import Scaffolder
 
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+
 
 class DefinitionsScaffoldParams(BaseModel):
     definitions_path: Optional[str] = None
+    object_type: Optional[str] = None
 
 
 class DefinitionsComponentScaffolder(Scaffolder):
@@ -24,11 +28,14 @@ class DefinitionsComponentScaffolder(Scaffolder):
         )
 
         with pushd(str(request.target_path)):
-            Path(
+            path = Path(
                 scaffold_params.definitions_path
                 if scaffold_params.definitions_path
                 else "definitions.py"
-            ).touch(exist_ok=True)
+            )
+            path.touch(exist_ok=params.object_type is None)
+            if params.object_type:
+                shutil.copy(_TEMPLATE_DIR / f"{params.object_type}.py", path)
 
         scaffold_component_yaml(
             request,

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/templates/schedule.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/templates/schedule.py
@@ -1,0 +1,3 @@
+import dagster as dg
+
+dg.ScheduleDefinition(name=..., cron_schedule=..., target=...)

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/templates/sensor.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/templates/sensor.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.sensor(target=...)
+def sensor_name(context: dg.SensorEvaluationContext) -> dg.SensorResult: ...

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 import click
 import yaml
+from pydantic import TypeAdapter
 
 from dagster_components.core.component import Component
 from dagster_components.scaffoldable.decorator import get_scaffolder
@@ -33,7 +34,7 @@ def scaffold_component_instance(
     path: Path,
     component_type: type[Component],
     component_type_name: str,
-    scaffold_params: Mapping[str, Any],
+    scaffold_params: Any,
 ) -> None:
     click.echo(f"Creating a Dagster component instance folder at {path}.")
     if not path.exists():
@@ -50,7 +51,7 @@ def scaffold_component_instance(
             type_name=component_type_name,
             target_path=path,
         ),
-        scaffold_params,
+        TypeAdapter(scaffolder.get_params()).validate_python(scaffold_params),
     )
 
     component_yaml_path = path / "component.yaml"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/component.yaml
@@ -1,0 +1,4 @@
+type: dagster_components.dagster.DefinitionsComponent
+
+attributes:
+  definitions_path: my_defs.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/my_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_multiple/my_defs.py
@@ -1,0 +1,13 @@
+from dagster import Definitions, asset
+
+
+@asset
+def a() -> None: ...
+
+
+@asset
+def b() -> None: ...
+
+
+defs1 = Definitions(assets=[a])
+defs2 = Definitions(assets=[b])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/component.yaml
@@ -1,0 +1,4 @@
+type: dagster_components.dagster.DefinitionsComponent
+
+attributes:
+  definitions_path: my_defs.py

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/my_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/my_defs.py
@@ -1,0 +1,11 @@
+from dagster import Definitions, asset
+
+from .some_file import asset_in_some_file  # noqa: TID252
+from .some_other_file import asset_in_some_other_file  # noqa: TID252
+
+
+@asset
+def an_asset_that_is_not_included() -> None: ...
+
+
+defs = Definitions(assets=[asset_in_some_file, asset_in_some_other_file])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_file.py
@@ -1,0 +1,9 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_file() -> None: ...
+
+
+@asset
+def asset_that_isnt_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_other_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/definitions_object_relative_imports/some_other_file.py
@@ -1,0 +1,5 @@
+from dagster import asset
+
+
+@asset
+def asset_in_some_other_file() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component.py
@@ -55,3 +55,16 @@ def test_definitions_component_validation_error() -> None:
         load_test_component_defs("definitions/validation_error_file")
 
     assert "component.yaml:4" in str(e.value)
+
+
+def test_definitions_component_with_definitions_object() -> None:
+    defs = load_test_component_defs("definitions/definitions_object_relative_imports")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {
+        AssetKey("asset_in_some_file"),
+        AssetKey("asset_in_some_other_file"),
+    }
+
+
+def test_definitions_component_with_multiple_definitions_objects() -> None:
+    with pytest.raises(ValueError, match="Found multiple Definitions objects in my_defs.py"):
+        load_test_component_defs("definitions/definitions_object_multiple")


### PR DESCRIPTION
## Summary & Motivation

This allows us to run the following command:

`dg scaffold component dagster_components.dagster.DefinitionsComponent schedules/some_schedule --object-type schedule`

Because this hooks into the existing component scaffolding system, there are some issues with this approach:

1. it's very verbose -- we need to specify the 
2. it generates a `component.yaml` file even though this is not necessary anymore due to downstack changes
3. it's hard / impossible to make the command schema different for different definition types

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
