### PR TITLE
Revert "Kill repository location state observer (#27777)"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -91,6 +91,7 @@
   "JobMetadataQuery": "489183f897f5a30e8c9883a6b96fcaa6141734c79613e5979baa3e5a15050efd",
   "LatestRunTagQuery": "6b18755e69bb01ee63d4ef02333c219a8c935b087e938b5da89ca99b95824e60",
   "InstigationStatesQuery": "98c41676dfb3c489e46455a3c2716e375050c9bed2d73e74c765453f2c63d0da",
+  "LocationStateChangeSubscription": "d6cb6b73be1c484a2f592e60be15fb89b344e385f703ce2c92516e2779df8217",
   "VersionNumberQuery": "1947790817d11313027a8addb9ceb992f0c79e96f3aa6b99cbece967e3458c40",
   "RepositoryLocationStatusQuery": "7129557ca993e0638a147e30c6fe3bdff04a929d4e6775c3e4e5dc9fa3c88d94",
   "ReloadWorkspaceMutation": "763808cb236e2d60a426cd891a4f60efd6851a755345d4a3ef019549f35e0a5e",

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
@@ -3,6 +3,7 @@ import {memo, useContext} from 'react';
 import styled from 'styled-components';
 
 import {RepoNavItem} from './RepoNavItem';
+import {RepositoryLocationStateObserver} from './RepositoryLocationStateObserver';
 import {SectionedLeftNav} from '../ui/SectionedLeftNav';
 import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
 import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
@@ -50,6 +51,7 @@ const LoadedRepositorySection = ({
   return (
     <Container>
       <ListContainer>{listContent()}</ListContainer>
+      <RepositoryLocationStateObserver />
       <RepoNavItem allRepos={allRepos} selected={visibleRepos} onToggle={toggleVisible} />
     </Container>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLocationStateObserver.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLocationStateObserver.tsx
@@ -1,0 +1,96 @@
+import {ButtonLink, Caption, Colors, Group, Icon} from '@dagster-io/ui-components';
+import {useContext, useState} from 'react';
+
+import {gql, useApolloClient, useSubscription} from '../apollo-client';
+import {
+  LocationStateChangeSubscription,
+  LocationStateChangeSubscriptionVariables,
+} from './types/RepositoryLocationStateObserver.types';
+import {LocationStateChangeEventType} from '../graphql/types';
+import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
+
+const LOCATION_STATE_CHANGE_SUBSCRIPTION = gql`
+  subscription LocationStateChangeSubscription {
+    locationStateChangeEvents {
+      event {
+        message
+        locationName
+        eventType
+        serverId
+      }
+    }
+  }
+`;
+
+export const RepositoryLocationStateObserver = () => {
+  const client = useApolloClient();
+  const {locationEntries, refetch} = useContext(WorkspaceContext);
+  const [updatedLocations, setUpdatedLocations] = useState<string[]>([]);
+  const totalMessages = updatedLocations.length;
+
+  useSubscription<LocationStateChangeSubscription, LocationStateChangeSubscriptionVariables>(
+    LOCATION_STATE_CHANGE_SUBSCRIPTION,
+    {
+      fetchPolicy: 'no-cache',
+      onSubscriptionData: ({subscriptionData}) => {
+        const changeEvents = subscriptionData.data?.locationStateChangeEvents;
+        if (!changeEvents) {
+          return;
+        }
+
+        const {locationName, eventType, serverId} = changeEvents.event;
+
+        switch (eventType) {
+          case LocationStateChangeEventType.LOCATION_ERROR:
+            refetch();
+            setUpdatedLocations((s) => s.filter((name) => name !== locationName));
+            return;
+          case LocationStateChangeEventType.LOCATION_UPDATED:
+            const matchingRepositoryLocation = locationEntries.find((n) => n.name === locationName);
+            if (
+              matchingRepositoryLocation &&
+              matchingRepositoryLocation.locationOrLoadError?.__typename === 'RepositoryLocation' &&
+              matchingRepositoryLocation.locationOrLoadError?.serverId !== serverId
+            ) {
+              setUpdatedLocations((s) => [...s, locationName]);
+            }
+            return;
+        }
+      },
+    },
+  );
+
+  if (!totalMessages) {
+    return null;
+  }
+
+  return (
+    <Group background={Colors.backgroundLight()} direction="column" spacing={0}>
+      {updatedLocations.length > 0 ? (
+        <Group padding={{vertical: 8, horizontal: 12}} direction="row" spacing={8}>
+          <Icon name="warning" color={Colors.accentGray()} />
+          <Caption color={Colors.textLight()}>
+            {updatedLocations.length === 1
+              ? `Code location ${updatedLocations[0]} has been updated,` // Be specific when there's only one code location updated
+              : 'One or more code locations have been updated,'}
+            {' and new data is available. '}
+            <ButtonLink
+              color={{
+                link: Colors.textLight(),
+                hover: Colors.textLighter(),
+                active: Colors.textLighter(),
+              }}
+              underline="always"
+              onClick={() => {
+                setUpdatedLocations([]);
+                client.refetchQueries({include: 'active'});
+              }}
+            >
+              Update data
+            </ButtonLink>
+          </Caption>
+        </Group>
+      ) : null}
+    </Group>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -20,6 +20,10 @@ import {
   buildWorkspaceQueryWithZeroLocations,
 } from '../__fixtures__/LeftNavRepositorySection.fixtures';
 
+jest.mock('../RepositoryLocationStateObserver', () => ({
+  RepositoryLocationStateObserver: () => <div />,
+}));
+
 describe('Repository options', () => {
   const locationOne = 'ipsum';
   const repoOne = 'lorem';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/RepositoryLocationStateObserver.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/RepositoryLocationStateObserver.types.ts
@@ -1,0 +1,21 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type LocationStateChangeSubscriptionVariables = Types.Exact<{[key: string]: never}>;
+
+export type LocationStateChangeSubscription = {
+  __typename: 'Subscription';
+  locationStateChangeEvents: {
+    __typename: 'LocationStateChangeSubscription';
+    event: {
+      __typename: 'LocationStateChangeEvent';
+      message: string;
+      locationName: string;
+      eventType: Types.LocationStateChangeEventType;
+      serverId: string | null;
+    };
+  };
+};
+
+export const LocationStateChangeSubscriptionVersion = 'd6cb6b73be1c484a2f592e60be15fb89b344e385f703ce2c92516e2779df8217';


### PR DESCRIPTION
This reverts commit 1f1372d7d19ce5c82839a95983fd8f175a44a24c. Turns out this is actually pretty useful to support hot reloading. Was there a particular bug or error case I should watch out for when bringing it back?

Considering removing the underlying UI though and making it just trigger the reload when the underlying condition is triggered.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
