### PR TITLE
update the UI synchronously when a locationStateChangeEvent comes in over the websocket, rather tnan prompting in the UI to update

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLocationStateObserver.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLocationStateObserver.tsx
@@ -1,13 +1,9 @@
-import {ButtonLink, Caption, Colors, Group, Icon} from '@dagster-io/ui-components';
-import {useContext, useState} from 'react';
-
 import {gql, useApolloClient, useSubscription} from '../apollo-client';
 import {
   LocationStateChangeSubscription,
   LocationStateChangeSubscriptionVariables,
 } from './types/RepositoryLocationStateObserver.types';
 import {LocationStateChangeEventType} from '../graphql/types';
-import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
 
 const LOCATION_STATE_CHANGE_SUBSCRIPTION = gql`
   subscription LocationStateChangeSubscription {
@@ -24,9 +20,6 @@ const LOCATION_STATE_CHANGE_SUBSCRIPTION = gql`
 
 export const RepositoryLocationStateObserver = () => {
   const client = useApolloClient();
-  const {locationEntries, refetch} = useContext(WorkspaceContext);
-  const [updatedLocations, setUpdatedLocations] = useState<string[]>([]);
-  const totalMessages = updatedLocations.length;
 
   useSubscription<LocationStateChangeSubscription, LocationStateChangeSubscriptionVariables>(
     LOCATION_STATE_CHANGE_SUBSCRIPTION,
@@ -38,59 +31,17 @@ export const RepositoryLocationStateObserver = () => {
           return;
         }
 
-        const {locationName, eventType, serverId} = changeEvents.event;
+        const {eventType} = changeEvents.event;
 
         switch (eventType) {
           case LocationStateChangeEventType.LOCATION_ERROR:
-            refetch();
-            setUpdatedLocations((s) => s.filter((name) => name !== locationName));
-            return;
           case LocationStateChangeEventType.LOCATION_UPDATED:
-            const matchingRepositoryLocation = locationEntries.find((n) => n.name === locationName);
-            if (
-              matchingRepositoryLocation &&
-              matchingRepositoryLocation.locationOrLoadError?.__typename === 'RepositoryLocation' &&
-              matchingRepositoryLocation.locationOrLoadError?.serverId !== serverId
-            ) {
-              setUpdatedLocations((s) => [...s, locationName]);
-            }
-            return;
+            console.log('refetching due to location update or error');
+            client.refetchQueries({include: 'active'});
         }
       },
     },
   );
 
-  if (!totalMessages) {
-    return null;
-  }
-
-  return (
-    <Group background={Colors.backgroundLight()} direction="column" spacing={0}>
-      {updatedLocations.length > 0 ? (
-        <Group padding={{vertical: 8, horizontal: 12}} direction="row" spacing={8}>
-          <Icon name="warning" color={Colors.accentGray()} />
-          <Caption color={Colors.textLight()}>
-            {updatedLocations.length === 1
-              ? `Code location ${updatedLocations[0]} has been updated,` // Be specific when there's only one code location updated
-              : 'One or more code locations have been updated,'}
-            {' and new data is available. '}
-            <ButtonLink
-              color={{
-                link: Colors.textLight(),
-                hover: Colors.textLighter(),
-                active: Colors.textLighter(),
-              }}
-              underline="always"
-              onClick={() => {
-                setUpdatedLocations([]);
-                client.refetchQueries({include: 'active'});
-              }}
-            >
-              Update data
-            </ButtonLink>
-          </Caption>
-        </Group>
-      ) : null}
-    </Group>
-  );
+  return null;
 };


### PR DESCRIPTION
Summary:
I think we originally added this prompt back when the experience of reloading code when you clicked on the link was more disruptive. Immediately refetching the underlying data makes it possible to implement features like hot reloading during local development.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
