### PR TITLE
Fix return type of the `get_table_name()` function

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -65,7 +65,7 @@ class DbClient(Generic[T]):
     def get_select_statement(table_slice: TableSlice) -> str: ...
 
     @staticmethod
-    def get_table_name(table_slice: TableSlice) -> Optional[str]:
+    def get_table_name(table_slice: TableSlice) -> str:
         """Returns a string which is set as the dagster/table_name metadata value for an
         emitted asset. This value should be the fully qualified name of the table, including the
         schema and database, if applicable.


### PR DESCRIPTION
## Summary & Motivation

Causes Pyright violations in my code, because it doesn't make sense for a table name to come back `None` from this.
