### PR TITLE
[dg] Add ResolutionSpec

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
@@ -64,7 +64,7 @@ class ResolutionSpec(Generic[TSchema]): ...
 class ResolvableFromSchema(ResolutionSpec[TSchema]):
     @classmethod
     def from_schema(cls, context: "ResolutionContext", schema: TSchema) -> Self:
-        return resolve_schema_to_resolvable(schema=schema, resolution_spec=cls, context=context)
+        return resolve_schema_to_resolvable(schema=schema, resolvable_type=cls, context=context)
 
     @classmethod
     def from_optional(
@@ -179,10 +179,21 @@ T = TypeVar("T")
 
 def resolve_schema_to_resolvable(
     schema: EitherSchema,
+    resolvable_type: type[TResolvableFromSchema],
+    context: "ResolutionContext",
+) -> TResolvableFromSchema:
+    return resolve_schema_with_transform(
+        schema=schema,
+        resolution_spec=resolvable_type,
+        context=context,
+        target_type=resolvable_type,
+    )
+
+
+def resolve_schema_with_transform(
+    schema: EitherSchema,
     resolution_spec: type[TResolutionSpec],
     context: "ResolutionContext",
-    type_to_create: Optional[type[T]] = None,  # defaults to type[TResolutionSpec]
+    target_type: type[T],
 ) -> T:
-    type_to_create = type_to_create if type_to_create else resolution_spec  # type: ignore
-    assert type_to_create
-    return type_to_create(**resolve_fields(schema, resolution_spec, context))
+    return target_type(**resolve_fields(schema, resolution_spec, context))

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
@@ -58,17 +58,6 @@ def get_schema_type(resolvable_from_schema_type: type["ResolvableFromSchema"]) -
     raise ValueError("No generic type arguments found in ResolvableFromSchema subclass")
 
 
-from typing import TypeVar
-
-# def from_schema(context: "ResolutionContext", schema: EitherSchema, target_type: type[T]) -> T:
-#     return resolve_schema_with_transform(
-#         schema=schema,
-#         resolution_spec=ResolutionSpec,  # Adjust as needed
-#         context=context,
-#         target_type=target_type,
-#     )
-
-
 class ResolutionSpec(Generic[TSchema]): ...
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/resolvable_from_schema.py
@@ -58,6 +58,17 @@ def get_schema_type(resolvable_from_schema_type: type["ResolvableFromSchema"]) -
     raise ValueError("No generic type arguments found in ResolvableFromSchema subclass")
 
 
+from typing import TypeVar
+
+# def from_schema(context: "ResolutionContext", schema: EitherSchema, target_type: type[T]) -> T:
+#     return resolve_schema_with_transform(
+#         schema=schema,
+#         resolution_spec=ResolutionSpec,  # Adjust as needed
+#         context=context,
+#         target_type=target_type,
+#     )
+
+
 class ResolutionSpec(Generic[TSchema]): ...
 
 
@@ -105,6 +116,17 @@ class DSLFieldResolver:
     @staticmethod
     def from_parent(fn: Callable[["ResolutionContext", Any], Any]):
         return DSLFieldResolver(ParentFn(fn))
+
+    @staticmethod
+    def from_spec(spec: type[ResolutionSpec], target_type: type):
+        return DSLFieldResolver.from_parent(
+            lambda context, schema: resolve_schema_using_spec(
+                schema=schema,
+                resolution_spec=spec,
+                context=context,
+                target_type=target_type,
+            )
+        )
 
     @staticmethod
     def from_annotation(annotation: Any, field_name: str) -> "DSLFieldResolver":
@@ -182,7 +204,7 @@ def resolve_schema_to_resolvable(
     resolvable_type: type[TResolvableFromSchema],
     context: "ResolutionContext",
 ) -> TResolvableFromSchema:
-    return resolve_schema_with_transform(
+    return resolve_schema_using_spec(
         schema=schema,
         resolution_spec=resolvable_type,
         context=context,
@@ -190,7 +212,7 @@ def resolve_schema_to_resolvable(
     )
 
 
-def resolve_schema_with_transform(
+def resolve_schema_using_spec(
     schema: EitherSchema,
     resolution_spec: type[TResolutionSpec],
     context: "ResolutionContext",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Annotated
+
+from dagster_components.core.schema.context import ResolutionContext
+from dagster_components.core.schema.resolvable_from_schema import (
+    DSLFieldResolver,
+    DSLSchema,
+    ResolutionSpec,
+    resolve_fields,
+    resolve_schema_to_resolvable,
+)
+
+
+def test_resolve_fields_on_transform() -> None:
+    fields = resolve_fields(
+        schema=ExistingBusinessObjectSchema(value="1"),
+        resolution_spec=TransformToExistingBusinessObject,
+        context=ResolutionContext.default(),
+    )
+    assert fields == {"value": 1}
+
+
+def test_use_transform_to_build_business_object():
+    schema = ExistingBusinessObjectSchema(value="1")
+    business_object = resolve_schema_to_resolvable(
+        schema,
+        TransformToExistingBusinessObject,
+        ResolutionContext.default(),
+        ExistingBusinessObject,
+    )
+    assert business_object.value == 1
+
+
+@dataclass
+class ExistingBusinessObject:
+    value: int
+
+
+class ExistingBusinessObjectSchema(DSLSchema):
+    value: str
+
+
+# TODO remove the need for this
+# @dataclass
+class TransformToExistingBusinessObject(ResolutionSpec[ExistingBusinessObjectSchema]):
+    value: Annotated[int, DSLFieldResolver(lambda context, val: int(val))]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -1,36 +1,21 @@
 from dataclasses import dataclass
 from typing import Annotated
 
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component, ComponentLoadContext
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     DSLSchema,
     ResolutionSpec,
+    ResolvableFromSchema,
     resolve_fields,
-    resolve_schema_to_resolvable,
+    resolve_schema_using_spec,
 )
+from typing_extensions import TypeAlias
 
 
-def test_resolve_fields_on_transform() -> None:
-    fields = resolve_fields(
-        schema=ExistingBusinessObjectSchema(value="1"),
-        resolution_spec=TransformToExistingBusinessObject,
-        context=ResolutionContext.default(),
-    )
-    assert fields == {"value": 1}
-
-
-def test_use_transform_to_build_business_object():
-    schema = ExistingBusinessObjectSchema(value="1")
-    business_object = resolve_schema_to_resolvable(
-        schema,
-        TransformToExistingBusinessObject,
-        ResolutionContext.default(),
-        ExistingBusinessObject,
-    )
-    assert business_object.value == 1
-
-
+# Not allow to modified this. Example is AssetSpec
 @dataclass
 class ExistingBusinessObject:
     value: int
@@ -40,7 +25,94 @@ class ExistingBusinessObjectSchema(DSLSchema):
     value: str
 
 
-# TODO remove the need for this
-# @dataclass
-class TransformToExistingBusinessObject(ResolutionSpec[ExistingBusinessObjectSchema]):
+class ExistingBusinessObjectResolutionSpec(ResolutionSpec[ExistingBusinessObjectSchema]):
     value: Annotated[int, DSLFieldResolver(lambda context, val: int(val))]
+
+
+def test_resolve_fields_on_transform() -> None:
+    fields = resolve_fields(
+        schema=ExistingBusinessObjectSchema(value="1"),
+        resolution_spec=ExistingBusinessObjectResolutionSpec,
+        context=ResolutionContext.default(),
+    )
+    assert fields == {"value": 1}
+
+
+def test_use_transform_to_build_business_object():
+    schema = ExistingBusinessObjectSchema(value="1")
+    business_object = resolve_schema_using_spec(
+        schema=schema,
+        resolution_spec=ExistingBusinessObjectResolutionSpec,
+        context=ResolutionContext.default(),
+        target_type=ExistingBusinessObject,
+    )
+    assert business_object.value == 1
+
+
+def test_with_resolution_spec_on_component():
+    class ComponentWithExistingBusinessObjectSchema(DSLSchema):
+        business_object: ExistingBusinessObjectSchema
+
+    @dataclass
+    class ComponentWithExistingBusinessObject(
+        Component, ResolvableFromSchema[ComponentWithExistingBusinessObjectSchema]
+    ):
+        business_object: Annotated[
+            ExistingBusinessObject,
+            DSLFieldResolver.from_spec(
+                ExistingBusinessObjectResolutionSpec, ExistingBusinessObject
+            ),
+        ]
+
+        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+
+    comp_instance = ComponentWithExistingBusinessObject.load(
+        attributes=ExistingBusinessObjectSchema(value="1"), context=ComponentLoadContext.for_test()
+    )
+
+    assert isinstance(comp_instance, ComponentWithExistingBusinessObject)
+    assert comp_instance.business_object.value == 1
+
+
+ExistingBusinessObjectField: TypeAlias = Annotated[
+    ExistingBusinessObject,
+    DSLFieldResolver.from_spec(ExistingBusinessObjectResolutionSpec, ExistingBusinessObject),
+]
+
+
+def test_reuse_across_components():
+    class ComponentWithExistingBusinessObjectSchemaOne(DSLSchema):
+        business_object: ExistingBusinessObjectSchema
+
+    @dataclass
+    class ComponentWithExistingBusinessObjectOne(
+        Component, ResolvableFromSchema[ComponentWithExistingBusinessObjectSchemaOne]
+    ):
+        business_object: ExistingBusinessObjectField
+
+        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+
+    class ComponentWithExistingBusinessObjectSchemaTwo(DSLSchema):
+        business_object: ExistingBusinessObjectSchema
+
+    @dataclass
+    class ComponentWithExistingBusinessObjectTwo(
+        Component, ResolvableFromSchema[ComponentWithExistingBusinessObjectSchemaTwo]
+    ):
+        business_object: ExistingBusinessObjectField
+
+        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+
+    comp_instance_one = ComponentWithExistingBusinessObjectOne.load(
+        attributes=ExistingBusinessObjectSchema(value="1"), context=ComponentLoadContext.for_test()
+    )
+
+    assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectOne)
+    assert comp_instance_one.business_object.value == 1
+
+    comp_instance_one = ComponentWithExistingBusinessObjectTwo.load(
+        attributes=ExistingBusinessObjectSchema(value="2"), context=ComponentLoadContext.for_test()
+    )
+
+    assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectTwo)
+    assert comp_instance_one.business_object.value == 2


### PR DESCRIPTION
## Summary & Motivation

Sometimes you have existing business objects you do not want to modify (e.g. `AssetSpec`) that you want to apply resolution logic on. This leaves an unfortunate situation where one would need to add a separate class that users would have to instantiate in order a reasonable reuse story. This PR proposes an approach which solves that problem.

The core insight is that `ResolvableFromSchema` is actually the composition of two concepts:

1. A _specification_ of how to perform the resolution process
2. The target type that you want to instantiate

This PR formally encodes that composability by adding a more
generic function

```python
def resolve_schema_using_spec(
    schema: EitherSchema,
    resolution_spec: type[TResolutionSpec],
    context: "ResolutionContext",
    target_type: type[T],
) -> T:
```
Which allow you specify the "spec" (which contains the field resolvers) and target type separately.

See the test case for a simple version of this in practice:

```python
# Not allow to modified this. Example is AssetSpec
@dataclass
class ExistingBusinessObject:
    value: int

class ExistingBusinessObjectSchema(DSLSchema):
    value: str

class ExistingBusinessObjectResolutionSpec(ResolutionSpec[ExistingBusinessObjectSchema]):
    value: Annotated[int, DSLFieldResolver(lambda context, val: int(val))]
```

These declarations would exist in reusable library code. One would reuse this via a pre-defined TypeAlias. E.g.

```python
ExistingBusinessObjectField: TypeAlias = Annotated[
    ExistingBusinessObject,
    DSLFieldResolver.from_spec(ExistingBusinessObjectResolutionSpec, ExistingBusinessObject),
]
```

e.g.

```python
class ComponentWithExistingBusinessObjectSchemaOne(DSLSchema):
    business_object: ExistingBusinessObjectSchema

@dataclass
class ComponentWithExistingBusinessObjectOne(
    Component, ResolvableFromSchema[ComponentWithExistingBusinessObjectSchemaOne]
):
    business_object: ExistingBusinessObjectField
    def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...

class ComponentWithExistingBusinessObjectSchemaTwo(DSLSchema):
    business_object: ExistingBusinessObjectSchema

@dataclass
class ComponentWithExistingBusinessObjectTwo(
    Component, ResolvableFromSchema[ComponentWithExistingBusinessObjectSchemaTwo]
):
    business_object: ExistingBusinessObjectField
    def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
```

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
