### PR TITLE
[dg] Demonstrate pattern for how we can support sequences generically

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
@@ -10,10 +10,9 @@ from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
-# from pydantic import BaseModel, ConfigDict, Field from pydantic.dataclasses import dataclass
 from dagster_components.core.component import Component, ComponentLoadContext
 from dagster_components.core.schema.context import ResolutionContext
-from dagster_components.core.schema.objects import AssetSpecSchema
+from dagster_components.core.schema.objects import AssetSpecSchema, AssetSpecSequenceField
 from dagster_components.core.schema.resolvable_from_schema import (
     DSLFieldResolver,
     DSLSchema,
@@ -32,7 +31,7 @@ class PipesSubprocessScriptSchema(DSLSchema):
 @dataclass
 class PipesSubprocessScriptSpec(ResolvableFromSchema[PipesSubprocessScriptSchema]):
     path: str
-    assets: Sequence[AssetSpec]
+    assets: AssetSpecSequenceField
 
 
 class PipesSubprocessScriptCollectionSchema(DSLSchema):

--- a/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/schema/objects.py
@@ -155,6 +155,12 @@ class AssetSpecResolutionSpec(ResolutionSpec):
     automation_condition: Optional[AutomationCondition]
 
 
+AssetSpecSequenceField: TypeAlias = Annotated[
+    Sequence[AssetSpec],
+    DSLFieldResolver(AssetSpecResolutionSpec.resolver_fn(AssetSpec).from_seq),
+]
+
+
 class AssetAttributesSchema(_ResolvableAssetAttributesMixin, ResolvableSchema):
     """Resolves into a dictionary of asset attributes. This is similar to AssetSpecSchema, but
     does not require a key. This is useful in contexts where you want to modify attributes of


### PR DESCRIPTION
## Summary & Motivation

This is not perfect yet, but provides a fairly condense syntax for dealing with collection types.

What we really need is a more dynamic engine that knows how to descend over the built-in `typing` types.

So that 

```python
    @dataclass
    class SomeObject(ResolvableFromSchema[SomeObjectSchema]):
        specs: Annotated[
            Sequence[AssetSpec],
            DSLFieldResolver(AssetSpecResolutionSpec.resolver_fn(AssetSpec).from_seq),
        ]
```

Can become

```python

ResolvedAssetSpec: TypeAlias = Annotated[AssetSpec, DSLFieldResolver(...)]     # exact syntax tbd

    @dataclass
    class SomeObject(ResolvableFromSchema[SomeObjectSchema]):
        specs:  Sequence[ResolvedAssetSpec]
```

but we can do that as a followup

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG