### PR TITLE
[dg] move staticmethod resolvers back to functions

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -45,36 +45,34 @@ class DbtProjectSchema(DSLSchema):
     exclude: Optional[str] = None
 
 
+def resolve_dbt(context: ResolutionContext, dbt: DbtCliResource) -> DbtCliResource:
+    return DbtCliResource(**context.resolve_value(dbt.model_dump()))
+
+
+def resolve_translator(
+    context: ResolutionContext, schema: DbtProjectSchema
+) -> DagsterDbtTranslator:
+    if schema.asset_attributes and schema.asset_attributes.deps:
+        # TODO: Consider supporting alerting deps in the future
+        raise ValueError("deps are not supported for dbt_project component")
+    return get_wrapped_translator_class(DagsterDbtTranslator)(
+        resolving_info=TranslatorResolvingInfo(
+            "node", schema.asset_attributes or AssetAttributesSchema(), context
+        )
+    )
+
+
 @scaffoldable(scaffolder=DbtProjectComponentScaffolder)
 @dataclass
 class DbtProjectComponent(Component, ResolvableFromSchema[DbtProjectSchema]):
     """Expose a DBT project to Dagster as a set of assets."""
 
-    @staticmethod
-    def resolve_dbt(context: ResolutionContext, dbt: DbtCliResource) -> DbtCliResource:
-        return DbtCliResource(**context.resolve_value(dbt.model_dump()))
-
     dbt: Annotated[DbtCliResource, DSLFieldResolver(resolve_dbt)]
     op: Annotated[Optional[OpSpec], DSLFieldResolver(OpSpec.from_optional)] = None
-
-    @staticmethod
-    def resolve_translator(
-        context: ResolutionContext, schema: DbtProjectSchema
-    ) -> DagsterDbtTranslator:
-        if schema.asset_attributes and schema.asset_attributes.deps:
-            # TODO: Consider supporting alerting deps in the future
-            raise ValueError("deps are not supported for dbt_project component")
-        return get_wrapped_translator_class(DagsterDbtTranslator)(
-            resolving_info=TranslatorResolvingInfo(
-                "node", schema.asset_attributes or AssetAttributesSchema(), context
-            )
-        )
-
     # This requires from_parent because it access asset_attributes in the schema
     translator: Annotated[
         DagsterDbtTranslator, DSLFieldResolver.from_parent(resolve_translator)
     ] = field(default_factory=DagsterDbtTranslator)
-
     asset_post_processors: Annotated[
         Optional[Sequence[AssetPostProcessor]],
         DSLFieldResolver(AssetPostProcessor.from_optional_seq),

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -36,29 +36,26 @@ from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_transl
 SlingMetadataAddons: TypeAlias = Literal["column_metadata", "row_count"]
 
 
+def resolve_translator(
+    context: ResolutionContext, schema: "SlingReplicationSchema"
+) -> DagsterSlingTranslator:
+    # TODO: Consider supporting owners and code_version in the future
+    if schema.asset_attributes and schema.asset_attributes.owners:
+        raise ValueError("owners are not supported for sling_replication_collection component")
+    if schema.asset_attributes and schema.asset_attributes.code_version:
+        raise ValueError("code_version is not supported for sling_replication_collection component")
+    return get_wrapped_translator_class(DagsterSlingTranslator)(
+        resolving_info=TranslatorResolvingInfo(
+            "stream_definition",
+            schema.asset_attributes or AssetAttributesSchema(),
+            context,
+        )
+    )
+
+
 class SlingReplicationSpec(BaseModel, ResolvableFromSchema["SlingReplicationSchema"]):
     path: str
     op: Annotated[Optional[OpSpec], DSLFieldResolver(OpSpec.from_optional)]
-
-    @staticmethod
-    def resolve_translator(
-        context: ResolutionContext, schema: "SlingReplicationSchema"
-    ) -> DagsterSlingTranslator:
-        # TODO: Consider supporting owners and code_version in the future
-        if schema.asset_attributes and schema.asset_attributes.owners:
-            raise ValueError("owners are not supported for sling_replication_collection component")
-        if schema.asset_attributes and schema.asset_attributes.code_version:
-            raise ValueError(
-                "code_version is not supported for sling_replication_collection component"
-            )
-        return get_wrapped_translator_class(DagsterSlingTranslator)(
-            resolving_info=TranslatorResolvingInfo(
-                "stream_definition",
-                schema.asset_attributes or AssetAttributesSchema(),
-                context,
-            )
-        )
-
     translator: Annotated[
         Optional[DagsterSlingTranslator], DSLFieldResolver.from_parent(resolve_translator)
     ]
@@ -93,6 +90,16 @@ class SlingReplicationCollectionSchema(DSLSchema):
     asset_post_processors: Optional[Sequence[AssetPostProcessorSchema]] = None
 
 
+def resolve_resource(
+    context: ResolutionContext, schema: SlingReplicationCollectionSchema
+) -> SlingResource:
+    return (
+        SlingResource(**context.resolve_value(schema.sling.model_dump()))
+        if schema.sling
+        else SlingResource()
+    )
+
+
 @scaffoldable(scaffolder=SlingReplicationComponentScaffolder)
 @dataclass
 class SlingReplicationCollectionComponent(
@@ -100,24 +107,12 @@ class SlingReplicationCollectionComponent(
 ):
     """Expose one or more Sling replications to Dagster as assets."""
 
-    @staticmethod
-    def resolve_resource(
-        context: ResolutionContext, schema: SlingReplicationCollectionSchema
-    ) -> SlingResource:
-        return (
-            SlingResource(**context.resolve_value(schema.sling.model_dump()))
-            if schema.sling
-            else SlingResource()
-        )
-
     resource: Annotated[SlingResource, DSLFieldResolver.from_parent(resolve_resource)] = Field(
         ..., description="Customizations to Sling execution."
     )
-
     replications: Annotated[
         Sequence[SlingReplicationSpec], DSLFieldResolver(SlingReplicationSpec.from_seq)
     ] = Field(..., description="A set of Sling replications to expose as assets.")
-
     asset_post_processors: Annotated[
         Optional[Sequence[AssetPostProcessor]],
         DSLFieldResolver(AssetPostProcessor.from_optional_seq),


### PR DESCRIPTION
this is capturing references to the unbound methods which doesn't work at runtime on 3.9 

## How I Tested These Changes

run tests on py3.9
