### PR TITLE
[docs tests] Add debug makefile entrypoint for docs tests

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,5 +38,8 @@ regenerate_cli_snippets_and_screenshots:
 regenerate_cli_snippets_and_test:
 	cd ../examples/docs_beta_snippets && tox -e docs_snapshot_update && tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!"
 
+regenerate_cli_snippets_and_test_debug:
+	cd ../examples/docs_beta_snippets && rm -rf /tmp/cli_snippets && mkdir -p /tmp/cli_snippets && (CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets tox -e docs_snapshot_update && CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets  tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!") || (echo "Snippet regeneration failed. Please check the logs for more information. Working directory: /tmp/cli_snippets" && exit 1)
+
 test_cli_snippets_simulate_bk:
 	docker run --platform linux/amd64 --rm -it  -v "$(DAGSTER_GIT_REPO_DIR):/dagster" --entrypoint /bin/sh dagster/buildkite-test:py3.9-2025-01-31T181043 -c 'cd /dagster/examples/docs_beta_snippets && tox -e docs_snapshot_test -- --pdb'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,7 +39,7 @@ regenerate_cli_snippets_and_test:
 	cd ../examples/docs_beta_snippets && tox -e docs_snapshot_update && tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!"
 
 regenerate_cli_snippets_and_test_debug:
-	cd ../examples/docs_beta_snippets && rm -rf /tmp/cli_snippets && mkdir -p /tmp/cli_snippets && (CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets tox -e docs_snapshot_update && CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets  tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!") || (echo "Snippet regeneration failed. Please check the logs for more information. Working directory: /tmp/cli_snippets" && exit 1)
+	cd ../examples/docs_beta_snippets && rm -rf /tmp/cli_snippets && mkdir -p /tmp/cli_snippets && (DAGSTER_CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets tox -e docs_snapshot_update && DAGSTER_CLI_SNIPPET_WORKING_DIR=/tmp/cli_snippets  tox -e docs_snapshot_test && echo "\nSnippets regenerated and tested!") || (echo "Snippet regeneration failed. Please check the logs for more information. Working directory: /tmp/cli_snippets" && exit 1)
 
 test_cli_snippets_simulate_bk:
 	docker run --platform linux/amd64 --rm -it  -v "$(DAGSTER_GIT_REPO_DIR):/dagster" --entrypoint /bin/sh dagster/buildkite-test:py3.9-2025-01-31T181043 -c 'cd /dagster/examples/docs_beta_snippets && tox -e docs_snapshot_test -- --pdb'

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -304,7 +304,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
                 """),
             )
             run_command_and_snippet_output(
-                cmd="dg check yaml",
+                cmd="dg check yzaml",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-check.txt",
                 update_snippets=update_snippets,

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -304,7 +304,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
                 """),
             )
             run_command_and_snippet_output(
-                cmd="dg check yzaml",
+                cmd="dg check yaml",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-component-check.txt",
                 update_snippets=update_snippets,

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/utils.py
@@ -44,13 +44,13 @@ SNIPPET_ENV = {
 
 @contextmanager
 def _get_snippet_working_dir() -> Iterator[str]:
-    """If CLI_SNIPPET_WORKING_DIR is set, use it as the working directory for all snippet tests.
+    """If DAGSTER_CLI_SNIPPET_WORKING_DIR is set, use it as the working directory for all snippet tests.
     This makes it easier to debug the state of the working directory when a test fails.
     Otherwise, create a temporary directory and use that.
     """
     test_file_name = inspect.stack()[4].filename
 
-    working_dir_from_env = os.getenv("CLI_SNIPPET_WORKING_DIR")
+    working_dir_from_env = os.getenv("DAGSTER_CLI_SNIPPET_WORKING_DIR")
     if working_dir_from_env:
         path = Path(working_dir_from_env) / Path(test_file_name).stem
         path.mkdir(parents=True, exist_ok=True)

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -9,6 +9,7 @@ passenv =
     POSTGRES_TEST_DB_HOST
     BUILDKITE*
     EXTRA_PARAMS
+    CLI_SNIPPET_WORKING_DIR
 install_command = uv pip install {opts} {packages}
 deps =
   duckdb

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -9,7 +9,7 @@ passenv =
     POSTGRES_TEST_DB_HOST
     BUILDKITE*
     EXTRA_PARAMS
-    CLI_SNIPPET_WORKING_DIR
+    DAGSTER_CLI_SNIPPET_WORKING_DIR
 install_command = uv pip install {opts} {packages}
 deps =
   duckdb


### PR DESCRIPTION
## Summary

When the docs integrations tests fail, the tempdirs are cleaned up and evidence of the project state at the time the test failed is erased. This PR adds a new makefile target `make regenerate_cli_snippets_and_test_debug` which runs tests in `/tmp/cli_snippets/{test_file_name}`, so that the results are preseved afterwards to inspect in the case of success or failure.

```sh
$ make regenerate_cli_snippets_and_test

...
============================================= short test summary info ==============================================
FAILED docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py::test_components_docs_index - subprocess.CalledProcessError: Command 'dg check yzaml && echo "PWD=$(pwd);"' returned non-zero exit status 2.

Snippet regeneration failed. Please check the logs for more information. Working directory: /tmp/cli_snippets
make: *** [regenerate_cli_snippets_and_test] Error 1
```

```sh
$ tree /tmp/cli_snippets/test_components_docs

/tmp/cli_snippets/test_components_docs
└── jaffle-platform
    ├── dbt
    │   └── jdbt
    │       ├── README.md
    │       ├── dbt_project.yml
    │       ├── models
    │       │   ├── customers.sql
    │       │   ├── orders.sql
    │       │   ├── sources.yml
    │       │   └── stg
    │       │       ├── stg_customers.sql
    │       │       ├── stg_orders.sql
    │       │       └── stg_payments.sql
    │       └── profiles.yml
    ├── jaffle_platform
    │   ├── __init__.py
    │   ├── definitions.py
    │   ├── defs
    │   │   ├── ingest_files
    │   │   │   ├── component.yaml
    │   │   │   └── replication.yaml
    │   │   └── jdbt
    │   │       └── component.yaml
    │   └── lib
    │       ├── __init__.py
    ├── jaffle_platform_tests
    │   └── __init__.py
    ├── pyproject.toml
    ├── raw_customers.csv
    ├── raw_orders.csv
    ├── raw_payments.csv
    └── uv.lock

```

## How I Tested These Changes

Tested locally.
