### PR TITLE
[components] Add `dg list defs`

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -105,15 +105,25 @@ def list_definitions_command(ctx: click.Context, **other_opts: object) -> None:
                 group=node.group_name,
                 kinds=sorted(list(node.kinds)),
                 description=node.description,
+                automation_condition=node.automation_condition.__name__
+                if node.automation_condition
+                else None,
             )
         )
     for job in repo_def.get_all_jobs():
         if not is_reserved_asset_job_name(job.name):
             all_defs.append(DgJobMetadata(type="job", name=job.name))
     for schedule in repo_def.schedule_defs:
+        schedule_str = (
+            schedule.cron_schedule
+            if isinstance(schedule.cron_schedule, str)
+            else ", ".join(schedule.cron_schedule)
+        )
         all_defs.append(
             DgScheduleMetadata(
-                type="schedule", name=schedule.name, cron_schedule=schedule.cron_schedule
+                type="schedule",
+                name=schedule.name,
+                cron_schedule=schedule_str,
             )
         )
     for sensor in repo_def.sensor_defs:

--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -2,6 +2,14 @@ import json
 from typing import Any, Literal, Union
 
 import click
+from dagster._cli.utils import assert_no_remaining_opts
+from dagster._cli.workspace.cli_target import (
+    PythonPointerOpts,
+    get_repository_python_origin_from_cli_opts,
+    python_pointer_options,
+)
+from dagster._core.definitions.asset_job import is_reserved_asset_job_name
+from dagster._utils.hosted_user_process import recon_repository_from_origin
 from pydantic import ConfigDict, TypeAdapter, create_model
 
 from dagster_components.core.component import (
@@ -11,6 +19,13 @@ from dagster_components.core.component import (
     discover_entry_point_component_types,
 )
 from dagster_components.core.component_key import ComponentKey
+from dagster_components.core.defs import (
+    DgAssetMetadata,
+    DgDefinitionMetadata,
+    DgJobMetadata,
+    DgScheduleMetadata,
+    DgSensorMetadata,
+)
 
 
 @click.group(name="list")
@@ -63,6 +78,48 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
             )
     union_type = Union[tuple(schemas)]  # type: ignore
     click.echo(json.dumps(TypeAdapter(union_type).json_schema()))
+
+
+@list_cli.command(name="definitions")
+@python_pointer_options
+@click.pass_context
+def list_definitions_command(ctx: click.Context, **other_opts: object) -> None:
+    """List registered Dagster components."""
+    python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
+    assert_no_remaining_opts(other_opts)
+
+    repository_origin = get_repository_python_origin_from_cli_opts(python_pointer_opts)
+    recon_repo = recon_repository_from_origin(repository_origin)
+    repo_def = recon_repo.get_definition()
+
+    all_defs: list[DgDefinitionMetadata] = []
+
+    asset_graph = repo_def.asset_graph
+    for key in sorted(list(asset_graph.get_all_asset_keys()), key=lambda key: key.to_user_string()):
+        node = asset_graph.get(key)
+        all_defs.append(
+            DgAssetMetadata(
+                type="asset",
+                key=key.to_user_string(),
+                deps=sorted([k.to_user_string() for k in node.parent_keys]),
+                group=node.group_name,
+                kinds=sorted(list(node.kinds)),
+                description=node.description,
+            )
+        )
+    for job in repo_def.get_all_jobs():
+        if not is_reserved_asset_job_name(job.name):
+            all_defs.append(DgJobMetadata(type="job", name=job.name))
+    for schedule in repo_def.schedule_defs:
+        all_defs.append(
+            DgScheduleMetadata(
+                type="schedule", name=schedule.name, cron_schedule=schedule.cron_schedule
+            )
+        )
+    for sensor in repo_def.sensor_defs:
+        all_defs.append(DgSensorMetadata(type="sensor", name=sensor.name))
+
+    click.echo(json.dumps(all_defs))
 
 
 # ########################

--- a/python_modules/libraries/dagster-components/dagster_components/core/defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/defs.py
@@ -1,0 +1,33 @@
+from typing import Literal, Optional, TypedDict, Union
+
+from typing_extensions import TypeAlias
+
+DgDefinitionMetadata: TypeAlias = Union[
+    "DgAssetMetadata", "DgSensorMetadata", "DgScheduleMetadata", "DgJobMetadata"
+]
+
+
+class DgAssetMetadata(TypedDict):
+    type: Literal["asset"]
+    key: str
+    deps: list[str]
+    kinds: list[str]
+    group: Optional[str]
+    description: Optional[str]
+    automation_condition: Optional[str]
+
+
+class DgSensorMetadata(TypedDict):
+    type: Literal["sensor"]
+    name: str
+
+
+class DgScheduleMetadata(TypedDict):
+    type: Literal["schedule"]
+    name: str
+    cron_schedule: str
+
+
+class DgJobMetadata(TypedDict):
+    type: Literal["job"]
+    name: str

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -1,5 +1,7 @@
 import json
+from dataclasses import asdict
 from pathlib import Path
+from typing import Any
 
 import click
 from rich.console import Console
@@ -9,6 +11,14 @@ from dagster_dg.cli.shared_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
+from dagster_dg.defs import (
+    DgAssetMetadata,
+    DgDefinitionMetadata,
+    DgJobMetadata,
+    DgScheduleMetadata,
+    DgSensorMetadata,
+)
+from dagster_dg.error import DgError
 from dagster_dg.utils import DgClickCommand, DgClickGroup
 
 
@@ -93,3 +103,107 @@ def component_type_list(output_json: bool, **global_options: object) -> None:
             table.add_row(key.to_typename(), registry.get(key).summary)
         console = Console()
         console.print(table)
+
+
+# ########################
+# ##### DEFS
+# ########################
+
+
+@list_group.command(name="defs", cls=DgClickCommand)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON instead of a table.",
+)
+@dg_global_options
+def list_defs_command(output_json: bool, **global_options: object) -> None:
+    """List registered Dagster components in the current project environment."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+
+    result = dg_context.external_components_command(
+        ["list", "definitions", "-m", dg_context.code_location_target_module_name]
+    )
+    definitions = [_resolve_definition(x) for x in json.loads(result)]
+
+    # JSON
+    if output_json:  # pass it straight through
+        json_output = [asdict(defn) for defn in definitions]
+        click.echo(json.dumps(json_output, indent=4))
+
+    # TABLE
+    else:
+        assets = [item for item in definitions if isinstance(item, DgAssetMetadata)]
+        jobs = [item for item in definitions if isinstance(item, DgJobMetadata)]
+        schedules = [item for item in definitions if isinstance(item, DgScheduleMetadata)]
+        sensors = [item for item in definitions if isinstance(item, DgSensorMetadata)]
+
+        if len(definitions) == 0:
+            click.echo("No definitions are defined for this project.")
+
+        console = Console()
+        if assets:
+            click.echo("Assets")
+            table = Table(border_style="dim")
+            table.add_column("Key")
+            table.add_column("Group")
+            table.add_column("Deps")
+            table.add_column("Kinds")
+            table.add_column("Description")
+
+            for asset in sorted(assets, key=lambda x: x.key):
+                table.add_row(
+                    asset.key,
+                    asset.group,
+                    "\n".join(asset.deps),
+                    "\n".join(asset.kinds),
+                    asset.description,
+                )
+            console.print(table)
+            click.echo("")
+
+        if jobs:
+            click.echo("Jobs")
+            table = Table(border_style="dim")
+            table.add_column("Name")
+
+            for schedule in schedules:
+                table.add_row(schedule.name)
+            console.print(table)
+            click.echo("")
+
+        if schedules:
+            click.echo("Schedules")
+            table = Table(border_style="dim")
+            table.add_column("Name")
+            table.add_column("Cron schedule")
+
+            for schedule in schedules:
+                table.add_row(schedule.name, schedule.cron_schedule)
+            console.print(table)
+            click.echo("")
+
+        if sensors:
+            click.echo("Sensors")
+            table = Table(border_style="dim")
+            table.add_column("Name")
+
+            for schedule in schedules:
+                table.add_row(schedule.name)
+            console.print(table)
+
+
+def _resolve_definition(item: dict[str, Any]) -> DgDefinitionMetadata:
+    if item["type"] == "asset":
+        return DgAssetMetadata(**item)
+    elif item["type"] == "job":
+        return DgJobMetadata(**item)
+    elif item["type"] == "schedule":
+        return DgScheduleMetadata(**item)
+    elif item["type"] == "sensor":
+        return DgSensorMetadata(**item)
+    else:
+        raise DgError(f"Unexpected item type: {item['type']}")

--- a/python_modules/libraries/dagster-dg/dagster_dg/defs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/defs.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Literal, Optional, Union
+
+from typing_extensions import TypeAlias
+
+DgDefinitionMetadata: TypeAlias = Union[
+    "DgAssetMetadata", "DgSensorMetadata", "DgScheduleMetadata", "DgJobMetadata"
+]
+
+
+@dataclass
+class DgAssetMetadata:
+    type: Literal["asset"]
+    key: str
+    group: Optional[str]
+    deps: list[str]
+    kinds: list[str]
+    description: Optional[str]
+    automation_condition: Optional[str] = None
+
+
+@dataclass
+class DgSensorMetadata:
+    type: Literal["sensor"]
+    name: str
+
+
+@dataclass
+class DgScheduleMetadata:
+    type: Literal["schedule"]
+    name: str
+    cron_schedule: str
+
+
+@dataclass
+class DgJobMetadata:
+    type: Literal["job"]
+    name: str

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -56,6 +56,7 @@ PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("utils", "configure-editor"), "vscode"),
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
+    CommandSpec(("list", "defs")),
     CommandSpec(("scaffold", "component"), DEFAULT_COMPONENT_TYPE, "foot"),
 ]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -1,6 +1,9 @@
+import inspect
 import shutil
 import textwrap
+from pathlib import Path
 
+import pytest
 from dagster_components.utils import format_error_message
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
@@ -151,3 +154,196 @@ def test_list_component_type_bad_entry_point_fails(capfd):
 
         captured = capfd.readouterr()
         assert "Error loading entry point `foo_bar` in group `dagster.components`." in captured.err
+
+
+# ########################
+# ##### DEFS
+# ########################
+
+_EXPECTED_DEFS = textwrap.dedent("""
+    Assets
+    ┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┓
+    ┃ Key        ┃ Group   ┃ Deps ┃ Kinds ┃ Description ┃
+    ┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━┩
+    │ my_asset_1 │ default │      │       │             │
+    │ my_asset_2 │ default │      │       │             │
+    └────────────┴─────────┴──────┴───────┴─────────────┘
+
+    Jobs
+    ┏━━━━━━━━━━━━━┓
+    ┃ Name        ┃
+    ┡━━━━━━━━━━━━━┩
+    │ my_schedule │
+    └─────────────┘
+
+    Schedules
+    ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+    ┃ Name        ┃ Cron schedule ┃
+    ┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+    │ my_schedule │ @daily        │
+    └─────────────┴───────────────┘
+
+    Sensors
+    ┏━━━━━━━━━━━━━┓
+    ┃ Name        ┃
+    ┡━━━━━━━━━━━━━┩
+    │ my_schedule │
+    └─────────────┘
+""").strip()
+
+_EXPECTED_DEFS_JSON = textwrap.dedent("""
+    [
+        {
+            "type": "asset",
+            "key": "my_asset_1",
+            "group": "default",
+            "deps": [],
+            "kinds": [],
+            "description": null,
+            "automation_condition": null
+        },
+        {
+            "type": "asset",
+            "key": "my_asset_2",
+            "group": "default",
+            "deps": [],
+            "kinds": [],
+            "description": null,
+            "automation_condition": null
+        },
+        {
+            "type": "job",
+            "name": "my_job"
+        },
+        {
+            "type": "schedule",
+            "name": "my_schedule",
+            "cron_schedule": "@daily"
+        },
+        {
+            "type": "sensor",
+            "name": "my_sensor"
+        }
+    ]
+""").strip()
+
+
+@pytest.mark.parametrize("use_json", [True, False])
+def test_list_defs_succeeds(use_json: bool):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        result = runner.invoke(
+            "scaffold",
+            "component",
+            "dagster_components.dagster.DefinitionsComponent",
+            "mydefs",
+        )
+        assert_runner_result(result)
+
+        with Path("foo_bar/defs/mydefs/definitions.py").open("w") as f:
+            defs_source = textwrap.dedent(inspect.getsource(_sample_defs).split("\n", 1)[1])
+            f.write(defs_source)
+
+        if use_json:
+            result = runner.invoke("list", "defs", "--json")
+            assert_runner_result(result)
+            output = "\n".join(result.output.split("\n")[1:])
+            assert output.strip() == _EXPECTED_DEFS_JSON
+        else:
+            result = runner.invoke("list", "defs")
+            assert_runner_result(result)
+            output = "\n".join(result.output.split("\n")[1:])
+            match_terminal_box_output(output.strip(), _EXPECTED_DEFS)
+
+
+def _sample_defs():
+    from dagster import Definitions, asset, job, schedule, sensor
+
+    @asset
+    def my_asset_1(): ...
+
+    @asset
+    def my_asset_2(): ...
+
+    @schedule(cron_schedule="@daily", target=[my_asset_1])
+    def my_schedule(): ...
+
+    @sensor(target=[my_asset_2])
+    def my_sensor(): ...
+
+    @job
+    def my_job(): ...
+
+    defs = Definitions(  # noqa: F841
+        assets=[my_asset_1, my_asset_2],
+        schedules=[my_schedule],
+        sensors=[my_sensor],
+    )
+
+
+_EXPECTED_COMPLEX_ASSET_DEFS = textwrap.dedent("""
+    Assets
+    ┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+    ┃ Key     ┃ Group   ┃ Deps  ┃ Kinds ┃ Description      ┃
+    ┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+    │ alpha   │ group_1 │       │ sling │                  │
+    │ beta    │ group_2 │       │ dbt   │ This is beta.    │
+    │ delta   │ group_2 │ alpha │ dbt   │                  │
+    │         │         │ beta  │       │                  │
+    │ epsilon │ group_2 │ delta │ dbt   │ This is epsilon. │
+    └─────────┴─────────┴───────┴───────┴──────────────────┘
+""").strip()
+
+
+def test_list_defs_complex_assets_succeeds():
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        result = runner.invoke(
+            "scaffold",
+            "component",
+            "dagster_components.dagster.DefinitionsComponent",
+            "mydefs",
+        )
+        assert_runner_result(result)
+
+        with Path("foo_bar/defs/mydefs/definitions.py").open("w") as f:
+            defs_source = textwrap.dedent(
+                inspect.getsource(_sample_complex_asset_defs).split("\n", 1)[1]
+            )
+            f.write(defs_source)
+
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
+        output = "\n".join(result.output.split("\n")[1:])
+        match_terminal_box_output(output.strip(), _EXPECTED_COMPLEX_ASSET_DEFS)
+
+
+def _sample_complex_asset_defs():
+    from dagster import asset
+
+    @asset(kinds={"sling"}, group_name="group_1")
+    def alpha():
+        pass
+
+    @asset(
+        kinds={"dbt"},
+        group_name="group_2",
+        description="This is beta.",
+    )
+    def beta():
+        pass
+
+    @asset(
+        kinds={"dbt"},
+        group_name="group_2",
+    )
+    def delta(alpha, beta):
+        pass
+
+    @asset(kinds={"dbt"}, group_name="group_2", description="This is epsilon.")
+    def epsilon(delta):
+        pass


### PR DESCRIPTION
## Summary & Motivation

Basic implementation of `dg list defs`. This is a project-scoped command that outputs tables showing the definitions defined by the target project. It currently lists assets, schedules, sensors, and jobs. It puts each type of definition in a separate table.

More thought is going to need to go in to how exactly to present all the metadata associated with various definition types. In this PR, only assets show a significant amount of metadata. Example output:

```
$ dg list defs

Assets
┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Key     ┃ Group   ┃ Deps  ┃ Kinds ┃ Description      ┃
┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ alpha   │ group_1 │       │ sling │                  │
│ beta    │ group_2 │       │ dbt   │ This is beta.    │
│ delta   │ group_2 │ alpha │ dbt   │                  │
│         │         │ beta  │       │                  │
│ epsilon │ group_2 │ delta │ dbt   │ This is epsilon. │
└─────────┴─────────┴───────┴───────┴──────────────────┘
```

We'll want to add tags, metadata, automation condition and maybe more in the near future. We'll also want the ability to target a particular defs submodule (e.g. a component instance) to get just the defs from that submodule.

## How I Tested These Changes

New unit tests.