### PR TITLE
[dg] Rename core concepts in Resolved

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -3,13 +3,13 @@ from dagster_components import (
     Component,
     ComponentLoadContext,
     DefaultComponentScaffolder,
-    DSLSchema,
+    ResolvableModel,
 )
 
-class ShellCommandSchema(DSLSchema):
+class ShellCommandSchema(ResolvableModel):
     ...
 
-class ShellCommand(Component, DSLSchema):
+class ShellCommand(Component, ResolvableModel):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -6,9 +6,6 @@ from dagster_components import (
     ResolvableModel,
 )
 
-class ShellCommandSchema(ResolvableModel):
-    ...
-
 class ShellCommand(Component, ResolvableModel):
     """COMPONENT SUMMARY HERE.
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
@@ -5,7 +5,6 @@ from dagster_components import (
     Component,
     ComponentLoadContext,
     FieldResolver,
-    ResolavableModel,
     ResolutionContext,
     ResolvableModel,
     ResolvedFrom,

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
@@ -4,10 +4,11 @@ from typing import Annotated
 from dagster_components import (
     Component,
     ComponentLoadContext,
-    DSLFieldResolver,
-    DSLSchema,
+    FieldResolver,
+    ResolavableModel,
     ResolutionContext,
-    ResolvableFromSchema,
+    ResolvableModel,
+    ResolvedFrom,
 )
 
 import dagster as dg
@@ -17,7 +18,7 @@ class MyApiClient:
     def __init__(self, api_key: str): ...
 
 
-class MyComponentSchema(DSLSchema):
+class MyComponentSchema(ResolvableModel):
     api_key: str
 
 
@@ -28,9 +29,9 @@ def resolve_api_key(
 
 
 @dataclass
-class MyComponent(Component, ResolvableFromSchema[MyComponentSchema]):
+class MyComponent(Component, ResolvedFrom[MyComponentSchema]):
     # FieldResolver specifies a function used to map input matching the schema
     # to a value for this field
-    api_client: Annotated[MyApiClient, DSLFieldResolver(resolve_api_key)]
+    api_client: Annotated[MyApiClient, FieldResolver(resolve_api_key)]
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
@@ -1,8 +1,8 @@
-from dagster_components import Component, ComponentLoadContext, DSLSchema
+from dagster_components import Component, ComponentLoadContext, ResolvableModel
 from pydantic import BaseModel
 
 import dagster as dg
 
 
-class ShellCommand(Component, DSLSchema):
+class ShellCommand(Component, ResolvableModel):
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/resolving-resolvable-field.py
@@ -1,8 +1,8 @@
 from collections.abc import Sequence
 
-from dagster_components import AssetSpecSchema, Component, DSLSchema
+from dagster_components import AssetSpecSchema, Component, ResolvableModel
 
 
-class ShellCommand(Component, DSLSchema):
+class ShellCommand(Component, ResolvableModel):
     path: str
     asset_specs: Sequence[AssetSpecSchema]

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -7,21 +7,21 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    DSLSchema,
-    ResolvableFromSchema,
+    ResolvableModel,
+    ResolvedFrom,
 )
 from dagster_components.core.schema.objects import AssetSpecSequenceField
 
 import dagster as dg
 
 
-class ShellScriptSchema(DSLSchema):
+class ShellScriptSchema(ResolvableModel):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
 
 
 @dataclass
-class ShellCommand(Component, ResolvableFromSchema[ShellScriptSchema]):
+class ShellCommand(Component, ResolvedFrom[ShellScriptSchema]):
     """Models a shell script as a Dagster asset."""
 
     script_path: str

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
@@ -5,21 +5,21 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    DSLSchema,
-    ResolvableFromSchema,
+    ResolvableModel,
+    ResolvedFrom,
 )
 from dagster_components.core.schema.objects import AssetSpecSequenceField
 
 import dagster as dg
 
 
-class ShellScriptSchema(DSLSchema):
+class ShellScriptSchema(ResolvableModel):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
 
 
 @dataclass
-class ShellCommand(Component, ResolvableFromSchema[ShellScriptSchema]):
+class ShellCommand(Component, ResolvedFrom[ShellScriptSchema]):
     script_path: str
     asset_specs: AssetSpecSequenceField
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
@@ -4,13 +4,13 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    DSLSchema,
+    ResolvableModel,
 )
 
 import dagster as dg
 
 
-class ShellCommand(Component, DSLSchema):
+class ShellCommand(Component, ResolvableModel):
     """Models a shell script as a Dagster asset."""
 
     script_path: str

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
@@ -8,21 +8,21 @@ from dagster_components import (
     AssetSpecSchema,
     Component,
     ComponentLoadContext,
-    DSLSchema,
-    ResolvableFromSchema,
+    ResolvableModel,
+    ResolvedFrom,
 )
 from dagster_components.core.schema.objects import AssetSpecSequenceField
 
 import dagster as dg
 
 
-class ShellScriptSchema(DSLSchema):
+class ShellScriptSchema(ResolvableModel):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
 
 
 @dataclass
-class ShellCommand(Component, ResolvableFromSchema[ShellScriptSchema]):
+class ShellCommand(Component, ResolvedFrom[ShellScriptSchema]):
     script_path: str
     asset_specs: AssetSpecSequenceField
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
@@ -15,8 +15,8 @@ from dagster_components import (
 )
 from dagster_components.core.schema.objects import AssetSpecSequenceField
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLSchema,
-    ResolvableFromSchema,
+    ResolvableModel,
+    ResolvedFrom,
 )
 from dagster_components.scaffoldable.decorator import scaffoldable
 
@@ -45,7 +45,7 @@ class ShellCommandScaffolder(Scaffolder):
 # highlight-end
 
 
-class ShellScriptSchema(DSLSchema):
+class ShellScriptSchema(ResolvableModel):
     script_path: str
     asset_specs: Sequence[AssetSpecSchema]
 
@@ -54,7 +54,7 @@ class ShellScriptSchema(DSLSchema):
 @scaffoldable(scaffolder=ShellCommandScaffolder)
 # highlight-end
 @dataclass
-class ShellCommand(Component, ResolvableFromSchema[ShellScriptSchema]):
+class ShellCommand(Component, ResolvedFrom[ShellScriptSchema]):
     """Models a shell script as a Dagster asset."""
 
     script_path: str

--- a/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
@@ -13,11 +13,11 @@ from dagster_components.core.schema.objects import (
     AssetPostProcessorSchema,
     OpSpecSchema,
 )
-from dagster_components.core.schema.resolvable_from_schema import DSLSchema, ResolvableFromSchema
+from dagster_components.core.schema.resolvable_from_schema import ResolvableModel, ResolvedFrom
 from pydantic import Field
 
 
-class ComplexAssetSchema(DSLSchema):
+class ComplexAssetSchema(ResolvableModel):
     value: str = Field(..., examples=["example_for_value"])
     list_value: list[str] = Field(
         ..., examples=[["example_for_list_value_1", "example_for_list_value_2"]]
@@ -31,7 +31,7 @@ class ComplexAssetSchema(DSLSchema):
 
 
 @dataclass
-class ComplexAssetComponent(Component, ResolvableFromSchema[ComplexAssetSchema]):
+class ComplexAssetComponent(Component, ResolvedFrom[ComplexAssetSchema]):
     """An asset that has a complex schema."""
 
     value: str

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -18,10 +18,10 @@ from dagster_components.core.schema.objects import (
     OpSpecSchema as OpSpecSchema,
 )
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLFieldResolver as DSLFieldResolver,
-    DSLSchema as DSLSchema,
-    ResolutionSpec as ResolutionSpec,
-    ResolvableFromSchema as ResolvableFromSchema,
+    FieldResolver as FieldResolver,
+    ResolvableModel as ResolvableModel,
+    ResolvedFrom as ResolvedFrom,
+    ResolvedKwargs as ResolvedKwargs,
 )
 from dagster_components.scaffold import scaffold_component_yaml as scaffold_component_yaml
 from dagster_components.scaffoldable.scaffolder import (

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -25,15 +25,15 @@ from dagster_components.core.schema.objects import (
     ResolutionContext,
 )
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLFieldResolver,
-    DSLSchema,
-    ResolvableFromSchema,
+    FieldResolver,
+    ResolvableModel,
+    ResolvedFrom,
 )
 from dagster_components.scaffoldable.decorator import scaffoldable
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
-class DbtProjectSchema(DSLSchema):
+class DbtProjectSchema(ResolvableModel):
     dbt: DbtCliResource
     op: Optional[OpSpecSchema] = None
     asset_attributes: Annotated[
@@ -64,18 +64,18 @@ def resolve_dbt(context: ResolutionContext, dbt: DbtCliResource) -> DbtCliResour
 
 @scaffoldable(scaffolder=DbtProjectComponentScaffolder)
 @dataclass
-class DbtProjectComponent(Component, ResolvableFromSchema[DbtProjectSchema]):
+class DbtProjectComponent(Component, ResolvedFrom[DbtProjectSchema]):
     """Expose a DBT project to Dagster as a set of assets."""
 
-    dbt: Annotated[DbtCliResource, DSLFieldResolver(resolve_dbt)]
-    op: Annotated[Optional[OpSpec], DSLFieldResolver(OpSpec.from_optional)] = None
+    dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
+    op: Annotated[Optional[OpSpec], FieldResolver(OpSpec.from_optional)] = None
     # This requires from_parent because it access asset_attributes in the schema
-    translator: Annotated[
-        DagsterDbtTranslator, DSLFieldResolver.from_parent(resolve_translator)
-    ] = field(default_factory=DagsterDbtTranslator)
+    translator: Annotated[DagsterDbtTranslator, FieldResolver.from_model(resolve_translator)] = (
+        field(default_factory=DagsterDbtTranslator)
+    )
     asset_post_processors: Annotated[
         Optional[Sequence[AssetPostProcessor]],
-        DSLFieldResolver(AssetPostProcessor.from_optional_seq),
+        FieldResolver(AssetPostProcessor.from_optional_seq),
     ] = None
     select: str = "fqn:*"
     exclude: Optional[str] = None

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -11,12 +11,12 @@ from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.definitions_component.scaffolder import (
     DefinitionsComponentScaffolder,
 )
-from dagster_components.core.schema.resolvable_from_schema import DSLSchema
+from dagster_components.core.schema.resolvable_from_schema import ResolvableModel
 from dagster_components.scaffoldable.decorator import scaffoldable
 
 
 @scaffoldable(scaffolder=DefinitionsComponentScaffolder)
-class DefinitionsComponent(Component, DSLSchema):
+class DefinitionsComponent(Component, ResolvableModel):
     """Wraps an arbitrary set of Dagster definitions."""
 
     definitions_path: Optional[str] = Field(

--- a/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
@@ -14,33 +14,33 @@ from dagster_components.core.component import Component, ComponentLoadContext
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.objects import AssetSpecSchema, AssetSpecSequenceField
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLFieldResolver,
-    DSLSchema,
-    ResolvableFromSchema,
+    FieldResolver,
+    ResolvableModel,
+    ResolvedFrom,
 )
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
 
 
-class PipesSubprocessScriptSchema(DSLSchema):
+class PipesSubprocessScriptSchema(ResolvableModel):
     path: str
     assets: Sequence[AssetSpecSchema]
 
 
 @dataclass
-class PipesSubprocessScriptSpec(ResolvableFromSchema[PipesSubprocessScriptSchema]):
+class PipesSubprocessScriptSpec(ResolvedFrom[PipesSubprocessScriptSchema]):
     path: str
     assets: AssetSpecSequenceField
 
 
-class PipesSubprocessScriptCollectionSchema(DSLSchema):
+class PipesSubprocessScriptCollectionSchema(ResolvableModel):
     scripts: Sequence[PipesSubprocessScriptSchema]
 
 
 @dataclass
 class PipesSubprocessScriptCollectionComponent(
-    Component, ResolvableFromSchema[PipesSubprocessScriptCollectionSchema]
+    Component, ResolvedFrom[PipesSubprocessScriptCollectionSchema]
 ):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
 
@@ -55,7 +55,7 @@ class PipesSubprocessScriptCollectionComponent(
         }
 
     specs_by_path: Annotated[
-        Mapping[str, Sequence[AssetSpec]], DSLFieldResolver.from_parent(resolve_specs_by_path)
+        Mapping[str, Sequence[AssetSpec]], FieldResolver.from_model(resolve_specs_by_path)
     ] = ...
 
     @staticmethod

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -9,7 +9,7 @@ from typing import Any
 from dagster._core.definitions.definitions_class import Definitions
 from pydantic import BaseModel, ConfigDict
 
-from dagster_components import Component, DSLSchema, ResolvableFromSchema
+from dagster_components import Component, ResolvableModel, ResolvedFrom
 from dagster_components.core.component import ComponentLoadContext
 
 
@@ -21,13 +21,13 @@ def _error():
     _inner_error()
 
 
-class MyComponentSchema(DSLSchema):
+class MyComponentModel(ResolvableModel):
     a_string: str
     an_int: int
 
 
 @dataclass
-class MyComponent(Component, ResolvableFromSchema[MyComponentSchema]):
+class MyComponent(Component, ResolvedFrom[MyComponentModel]):
     a_string: str
     an_int: int
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/components/definitions/local_component_sample/__init__.py
@@ -1,9 +1,9 @@
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, DSLSchema
+from dagster_components import Component, ResolvableModel
 from dagster_components.core.component import ComponentLoadContext
 
 
-class MyComponentSchema(DSLSchema):
+class MyComponentSchema(ResolvableModel):
     a_string: str
     an_int: int
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
@@ -5,7 +5,7 @@ from typing import Any
 from dagster import AssetSpec, AutomationCondition, Definitions
 from dagster_components import AssetAttributesSchema, Component, ComponentLoadContext
 from dagster_components.core.schema.objects import ResolvedAssetAttributes
-from dagster_components.core.schema.resolvable_from_schema import DSLSchema, ResolvableFromSchema
+from dagster_components.core.schema.resolvable_from_schema import ResolvableModel, ResolvedFrom
 
 
 def my_custom_fn(a: str, b: str) -> str:
@@ -16,12 +16,12 @@ def my_custom_automation_condition(cron_schedule: str) -> AutomationCondition:
     return AutomationCondition.cron_tick_passed(cron_schedule) & ~AutomationCondition.in_progress()
 
 
-class CustomScopeSchema(DSLSchema):
+class CustomScopeSchema(ResolvableModel):
     asset_attributes: AssetAttributesSchema
 
 
 @dataclass
-class HasCustomScope(Component, ResolvableFromSchema[CustomScopeSchema]):
+class HasCustomScope(Component, ResolvedFrom[CustomScopeSchema]):
     asset_attributes: ResolvedAssetAttributes
 
     @classmethod

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
@@ -1,16 +1,16 @@
 from dataclasses import dataclass
 from typing import Annotated
 
-from dagster_components.components.pipes_subprocess_script_collection import DSLFieldResolver
 from dagster_components.core.schema.resolvable_from_schema import (
-    ResolutionSpec,
+    FieldResolver,
+    ResolvedKwargs,
     get_annotation_field_resolvers,
 )
 from pydantic import BaseModel
 
 
 def test_inheritance_vanilla() -> None:
-    class Base(ResolutionSpec):
+    class Base(ResolvedKwargs):
         base_field: int
 
     class Derived(Base):
@@ -23,7 +23,7 @@ def test_inheritance_vanilla() -> None:
 
 def test_inheritance_dataclass() -> None:
     @dataclass
-    class Base(ResolutionSpec):
+    class Base(ResolvedKwargs):
         base_field: int
 
     @dataclass
@@ -36,7 +36,7 @@ def test_inheritance_dataclass() -> None:
 
 
 def test_inheritance_pydantic() -> None:
-    class Base(BaseModel, ResolutionSpec):
+    class Base(BaseModel, ResolvedKwargs):
         base_field: int
 
     class Derived(Base):
@@ -48,10 +48,10 @@ def test_inheritance_pydantic() -> None:
 
 
 def test_override_vanilla() -> None:
-    class Base(ResolutionSpec):
+    class Base(ResolvedKwargs):
         value: int
 
-    class CustomResolver(DSLFieldResolver): ...
+    class CustomResolver(FieldResolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]
@@ -63,10 +63,10 @@ def test_override_vanilla() -> None:
 
 def test_override_dataclass() -> None:
     @dataclass
-    class Base(ResolutionSpec):
+    class Base(ResolvedKwargs):
         value: int
 
-    class CustomResolver(DSLFieldResolver): ...
+    class CustomResolver(FieldResolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]
@@ -77,10 +77,10 @@ def test_override_dataclass() -> None:
 
 
 def test_override_pydantic() -> None:
-    class Base(BaseModel, ResolutionSpec):
+    class Base(BaseModel, ResolvedKwargs):
         value: int
 
-    class CustomResolver(DSLFieldResolver): ...
+    class CustomResolver(FieldResolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -2,24 +2,22 @@ from typing import Annotated
 
 from dagster_components.core.schema.context import ResolutionContext
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLFieldResolver,
-    DSLSchema,
-    ResolvableFromSchema,
+    FieldResolver,
+    ResolvableModel,
+    ResolvedFrom,
     resolve_schema_to_resolvable,
 )
 
 
 def test_simple_dataclass_resolveable_from_schema():
-    class HelloSchema(DSLSchema):
+    class HelloSchema(ResolvableModel):
         hello: str
 
     from dataclasses import dataclass
 
     @dataclass
-    class Hello(ResolvableFromSchema[HelloSchema]):
-        hello: Annotated[
-            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
-        ]
+    class Hello(ResolvedFrom[HelloSchema]):
+        hello: Annotated[int, FieldResolver.from_model(lambda context, schema: int(schema.hello))]
 
     hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
 
@@ -28,15 +26,13 @@ def test_simple_dataclass_resolveable_from_schema():
 
 
 def test_simple_pydantic_resolveable_from_schema():
-    class HelloSchema(DSLSchema):
+    class HelloSchema(ResolvableModel):
         hello: str
 
     from pydantic import BaseModel
 
-    class Hello(BaseModel, ResolvableFromSchema[HelloSchema]):
-        hello: Annotated[
-            int, DSLFieldResolver.from_parent(lambda context, schema: int(schema.hello))
-        ]
+    class Hello(BaseModel, ResolvedFrom[HelloSchema]):
+        hello: Annotated[int, FieldResolver.from_model(lambda context, schema: int(schema.hello))]
 
     hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
 
@@ -45,14 +41,14 @@ def test_simple_pydantic_resolveable_from_schema():
 
 
 def test_simple_dataclass_resolveable_from_schema_with_condense_syntax():
-    class HelloSchema(DSLSchema):
+    class HelloSchema(ResolvableModel):
         hello: str
 
     from dataclasses import dataclass
 
     @dataclass
-    class Hello(ResolvableFromSchema[HelloSchema]):
-        hello: Annotated[int, DSLFieldResolver(lambda context, val: int(val))]
+    class Hello(ResolvedFrom[HelloSchema]):
+        hello: Annotated[int, FieldResolver(lambda context, val: int(val))]
 
     hello = resolve_schema_to_resolvable(HelloSchema(hello="1"), Hello, ResolutionContext.default())
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -3,9 +3,9 @@ from typing import Annotated, Optional
 
 from dagster_components import ResolutionContext
 from dagster_components.core.schema.resolvable_from_schema import (
-    DSLFieldResolver,
-    DSLSchema,
-    ResolvableFromSchema,
+    FieldResolver,
+    ResolvableModel,
+    ResolvedFrom,
     resolve_schema_to_resolvable,
 )
 from pydantic import BaseModel
@@ -15,26 +15,24 @@ def resolve_val1(context: ResolutionContext, schema: "InnerSchema") -> int:
     return context.resolve_value(schema.val1, as_type=int) + 20
 
 
-class InnerObject(BaseModel, ResolvableFromSchema["InnerSchema"]):
-    val1_renamed: Annotated[int, DSLFieldResolver.from_parent(resolve_val1)]
+class InnerObject(BaseModel, ResolvedFrom["InnerSchema"]):
+    val1_renamed: Annotated[int, FieldResolver.from_model(resolve_val1)]
     val2: Optional[str]
 
 
-class TargetObject(BaseModel, ResolvableFromSchema["TargetSchema"]):
+class TargetObject(BaseModel, ResolvedFrom["TargetSchema"]):
     int_val: int
     str_val: str
-    inners: Annotated[
-        Optional[Sequence[InnerObject]], DSLFieldResolver(InnerObject.from_optional_seq)
-    ]
+    inners: Annotated[Optional[Sequence[InnerObject]], FieldResolver(InnerObject.from_optional_seq)]
 
 
-class InnerSchema(DSLSchema):
+class InnerSchema(ResolvableModel):
     val1: str
     val2: Optional[str]
     val3: str = "val3"
 
 
-class TargetSchema(DSLSchema):
+class TargetSchema(ResolvableModel):
     int_val: str
     str_val: str
     inners: Optional[Sequence[InnerSchema]]

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -3,13 +3,10 @@ from dagster_components import (
     Component,
     ComponentLoadContext,
     DefaultComponentScaffolder,
-    DSLSchema,
+    ResolvableModel,
 )
 
-class {{ name }}Schema(DSLSchema):
-    ...
-
-class {{ name }}(Component, DSLSchema):
+class {{ name }}(Component, ResolvableModel):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -1,17 +1,16 @@
 from collections.abc import Sequence
 from typing import Annotated
 
-from dagster_components import ResolvableFieldInfo
+from dagster_components import ResolvableFieldInfo, ResolvableModel
 from dagster_dg.docs import generate_sample_yaml
-from pydantic import BaseModel
 
 
-class SampleSubSchema(BaseModel):
+class SampleSubSchema(ResolvableModel):
     str_field: str
     int_field: int
 
 
-class SampleSchema(BaseModel):
+class SampleSchema(ResolvableModel):
     sub_scoped: Annotated[SampleSubSchema, ResolvableFieldInfo(required_scope={"outer_scope"})]
     sub_optional: SampleSubSchema
     sub_list: Sequence[SampleSubSchema]


### PR DESCRIPTION
## Summary & Motivation

Per discussion yesterday, we are going to refer to this system as `Resolved`.

Core renames:

- Schema —> Model. ResolveableModel
- ResolveableFromSchema —> ResolvedFrom
- ResolutionSpec → ResolvedKwargs
- FieldResolver.from_parent —> FieldResolver.from_model

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG