### PR TITLE
[dg check defs] Add hint about system frames being removed, --verbose flag

### DIFF
--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -6,7 +6,7 @@ import traceback
 import uuid
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, Callable, NamedTuple, Optional, Union
 
 from typing_extensions import TypeAlias
 
@@ -259,8 +259,12 @@ def unwrap_user_code_error(error_info: SerializableErrorInfo) -> SerializableErr
     return error_info
 
 
+NO_HINT = lambda _: None
+
+
 def remove_system_frames_from_error(
     error_info: SerializableErrorInfo,
+    build_system_frame_removed_hint: Callable[[int], Optional[str]] = NO_HINT,
 ):
     """Remove system frames from a SerializableErrorInfo, including Dagster framework boilerplate
     and import machinery, which are generally not useful for users to debug their code.
@@ -268,12 +272,14 @@ def remove_system_frames_from_error(
     return remove_matching_lines_from_error_info(
         error_info,
         DAGSTER_FRAMEWORK_SUBSTRINGS + IMPORT_MACHINERY_SUBSTRINGS,
+        build_system_frame_removed_hint,
     )
 
 
 def remove_matching_lines_from_error_info(
     error_info: SerializableErrorInfo,
     match_substrs: Sequence[str],
+    build_system_frame_removed_hint: Callable[[int], Optional[str]],
 ):
     """Utility which truncates a stacktrace to drop lines which match the given strings.
     This is useful for e.g. removing Dagster framework lines from a stacktrace that
@@ -287,14 +293,20 @@ def remove_matching_lines_from_error_info(
         SerializableErrorInfo: A new error info with the stacktrace truncated
     """
     return error_info._replace(
-        stack=remove_matching_lines_from_stack_trace(error_info.stack, match_substrs),
+        stack=remove_matching_lines_from_stack_trace(
+            error_info.stack, match_substrs, build_system_frame_removed_hint
+        ),
         cause=(
-            remove_matching_lines_from_error_info(error_info.cause, match_substrs)
+            remove_matching_lines_from_error_info(
+                error_info.cause, match_substrs, build_system_frame_removed_hint
+            )
             if error_info.cause
             else None
         ),
         context=(
-            remove_matching_lines_from_error_info(error_info.context, match_substrs)
+            remove_matching_lines_from_error_info(
+                error_info.context, match_substrs, build_system_frame_removed_hint
+            )
             if error_info.context
             else None
         ),
@@ -304,11 +316,16 @@ def remove_matching_lines_from_error_info(
 def remove_matching_lines_from_stack_trace(
     stack: Sequence[str],
     matching_lines: Sequence[str],
+    build_system_frame_removed_hint: Callable[[int], Optional[str]],
 ) -> Sequence[str]:
     # Remove lines until you find the first non-dagster framework line
 
     for i in range(len(stack)):
         if not _line_contains_matching_string(stack[i], matching_lines):
+            if i > 0:
+                hint = build_system_frame_removed_hint(i)
+                if hint:
+                    return [hint] + list(stack[i:])
             return stack[i:]
 
     # Return the full stack trace if its all Dagster framework lines,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pytest
 from click.testing import CliRunner
 from dagster._cli.definitions import definitions_validate_command
-from dagster._utils import file_relative_path
+from dagster._utils import file_relative_path, pushd
 
 EMPTY_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/empty_project")
 VALID_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/valid_project")
@@ -107,16 +107,25 @@ def test_invalid_project(options, monkeypatch):
         assert "Duplicate asset key: AssetKey(['my_asset'])" in result.output
 
 
-def test_invalid_project_truncated_properly(monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(INVALID_PROJECT_PATH_WITH_EXCEPTION)
-        result = invoke_validate(options=[])
+@pytest.mark.parametrize("verbose", [True, False])
+def test_invalid_project_truncated_properly(verbose):
+    with pushd(INVALID_PROJECT_PATH_WITH_EXCEPTION):
+        result = invoke_validate(options=["--verbose"] if verbose else [])
         assert result.exit_code == 1
         assert "Validation failed" in result.output
         assert "This is a test exception" in result.output
-        # Assert extraneous lines are removed
-        assert "importlib" not in result.output, result.output
-        assert "DagsterUserCodeLoadError" not in result.output, result.output
+
+        if verbose:
+            assert "importlib" in result.output, result.output
+            assert "DagsterUserCodeLoadError" in result.output, result.output
+        else:
+            # Assert extraneous lines are removed
+            assert "importlib" not in result.output, result.output
+            assert "DagsterUserCodeLoadError" not in result.output, result.output
+            assert (
+                "system frames removed, run with --verbose to see the full stack trace"
+                in result.output
+            )
 
 
 def test_env_var(monkeypatch):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -186,12 +186,20 @@ def check_yaml_command(
     default="colored",
     help="Format of the logs for dagster services",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    flag_value=True,
+    default=False,
+    help="Show verbose error messages, including system frames in stack traces.",
+)
 @dg_global_options
 @click.pass_context
 def check_definitions_command(
     context: click.Context,
     log_level: str,
     log_format: str,
+    verbose: bool,
     **global_options: Mapping[str, object],
 ) -> None:
     """Loads and validates your Dagster definitions using a Dagster instance.
@@ -212,6 +220,7 @@ def check_definitions_command(
     forward_options = [
         *format_forwarded_option("--log-level", log_level),
         *format_forwarded_option("--log-format", log_format),
+        *(["--verbose"] if verbose else []),
     ]
 
     # In a code location context, we can just run `dagster definitions validate` directly, using `dagster` from the


### PR DESCRIPTION
## Summary

When system frames are stripped out of `dg check defs`/`dagster definitions validate`, now notes that in the trace itself, and prompts the user to pass the new `--verbose` flag if they would like to see an unadulterated stacktrace.

```python
dlt.common.configuration.exceptions.ConfigFieldMissingException: Following fields are missing: ['thinkific_subdomain', 'thinkific_api_key'] in configuration with spec ThinkificConfiguration
	for field "thinkific_subdomain" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key SOURCES__THINKIFIC_SUBDOMAIN was not found.
		In Environment Variables key THINKIFIC_SUBDOMAIN was not found.
	for field "thinkific_api_key" config providers and keys were tried in following order:
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC__THINKIFIC_API_KEY was not found.
		In Environment Variables key SOURCES__THINKIFIC_API_KEY was not found.
		In Environment Variables key THINKIFIC_API_KEY was not found.
WARNING: dlt looks for .dlt folder in your current working directory and your cwd (/Users/ben/repos/internal/python_modules/dagster-open-platform) is different from directory of your pipeline script (/Users/ben/repos/dagster/python_modules/dagster/dagster).
If you keep your secret files in the same folder as your pipeline script but run your script from some other folder, secrets/configs will not be found
Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information


Stack Trace:
  [11 system frames removed, run with --verbose to see the full stack trace]
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/definitions.py", line 14, in <module>
    import dagster_open_platform.dlt.definitions as dlt_definitions
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/definitions.py", line 21, in <module>
    from dagster_open_platform.dlt import assets
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/dagster_open_platform/dlt/assets.py", line 29, in <module>
    dlt_source=thinkific(),
               ^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 199, in __call__
    source = self._deco_f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/extract/decorators.py", line 284, in _wrap
    rv = conf_f(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 255, in _wrap
    config = resolve_config(bound_args, accept_partial_=accept_partial)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/inject.py", line 183, in resolve_config
    return resolve_configuration(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 67, in resolve_configuration
    return _resolve_configuration(config, sections, (), explicit_value, accept_partial)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 164, in _resolve_configuration
    _resolve_config_fields(
  File "/Users/ben/repos/internal/python_modules/dagster-open-platform/.venv/lib/python3.12/site-packages/dlt/common/configuration/resolve.py", line 304, in _resolve_config_fields
    raise ConfigFieldMissingException(type(config).__name__, unresolved_fields)
```

## How I Tested These Changes

New unit tests.


