### PR TITLE
[dagster definitions validate] Truncate all system frames

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -77,8 +77,8 @@ def definitions_validate_command(
     logging.captureWarnings(True)
 
     removed_system_frame_hint = (
-        lambda i,
-        is_first_hidden_frame: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
+        lambda is_first_hidden_frame,
+        i: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
         if is_first_hidden_frame
         else f"  [{i} dagster system frames hidden]\n"
     )

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -77,7 +77,7 @@ def definitions_validate_command(
     logging.captureWarnings(True)
 
     removed_system_frame_hint = (
-        lambda i: f"  [{i-1} system frames removed, run with --verbose to see the full stack trace]\n"
+        lambda i: f"  [{i-1} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
     )
 
     with get_possibly_temporary_instance_for_cli(

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -77,7 +77,10 @@ def definitions_validate_command(
     logging.captureWarnings(True)
 
     removed_system_frame_hint = (
-        lambda i: f"  [{i-1} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
+        lambda i,
+        is_first_hidden_frame: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
+        if is_first_hidden_frame
+        else f"  [{i} dagster system frames hidden]\n"
     )
 
     with get_possibly_temporary_instance_for_cli(

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -318,19 +318,26 @@ def remove_matching_lines_from_stack_trace(
     matching_lines: Sequence[str],
     build_system_frame_removed_hint: Callable[[int], Optional[str]],
 ) -> Sequence[str]:
-    # Remove lines until you find the first non-dagster framework line
+    ctr = 0
+    out = []
 
     for i in range(len(stack)):
         if not _line_contains_matching_string(stack[i], matching_lines):
-            if i > 0:
-                hint = build_system_frame_removed_hint(i)
+            if ctr > 0:
+                hint = build_system_frame_removed_hint(ctr)
                 if hint:
-                    return [hint] + list(stack[i:])
-            return stack[i:]
+                    out.append(hint)
+            ctr = 0
+            out.append(stack[i])
+        else:
+            ctr += 1
 
-    # Return the full stack trace if its all Dagster framework lines,
-    # to not be left with an empty stack trace
-    return stack
+    if ctr > 0:
+        hint = build_system_frame_removed_hint(ctr)
+        if hint:
+            out.append(hint)
+
+    return out
 
 
 def _line_contains_matching_string(line: str, matching_strings: Sequence[str]):

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -259,12 +259,12 @@ def unwrap_user_code_error(error_info: SerializableErrorInfo) -> SerializableErr
     return error_info
 
 
-NO_HINT = lambda _: None
+NO_HINT = lambda _, __: None
 
 
 def remove_system_frames_from_error(
     error_info: SerializableErrorInfo,
-    build_system_frame_removed_hint: Callable[[int], Optional[str]] = NO_HINT,
+    build_system_frame_removed_hint: Callable[[bool, int], Optional[str]] = NO_HINT,
 ):
     """Remove system frames from a SerializableErrorInfo, including Dagster framework boilerplate
     and import machinery, which are generally not useful for users to debug their code.
@@ -279,7 +279,7 @@ def remove_system_frames_from_error(
 def remove_matching_lines_from_error_info(
     error_info: SerializableErrorInfo,
     match_substrs: Sequence[str],
-    build_system_frame_removed_hint: Callable[[int], Optional[str]],
+    build_system_frame_removed_hint: Callable[[bool, int], Optional[str]],
 ):
     """Utility which truncates a stacktrace to drop lines which match the given strings.
     This is useful for e.g. removing Dagster framework lines from a stacktrace that
@@ -316,15 +316,17 @@ def remove_matching_lines_from_error_info(
 def remove_matching_lines_from_stack_trace(
     stack: Sequence[str],
     matching_lines: Sequence[str],
-    build_system_frame_removed_hint: Callable[[int], Optional[str]],
+    build_system_frame_removed_hint: Callable[[bool, int], Optional[str]],
 ) -> Sequence[str]:
     ctr = 0
     out = []
+    is_first_hidden_frame = True
 
     for i in range(len(stack)):
         if not _line_contains_matching_string(stack[i], matching_lines):
             if ctr > 0:
-                hint = build_system_frame_removed_hint(ctr)
+                hint = build_system_frame_removed_hint(is_first_hidden_frame, ctr)
+                is_first_hidden_frame = False
                 if hint:
                     out.append(hint)
             ctr = 0
@@ -333,7 +335,7 @@ def remove_matching_lines_from_stack_trace(
             ctr += 1
 
     if ctr > 0:
-        hint = build_system_frame_removed_hint(ctr)
+        hint = build_system_frame_removed_hint(is_first_hidden_frame, ctr)
         if hint:
             out.append(hint)
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py
@@ -1,1 +1,6 @@
-raise Exception("This is a test exception")
+import dagster as dg
+
+
+@dg.op(name="invalid!op/name")
+def invalid_op():
+    pass

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -127,8 +127,9 @@ def test_invalid_project_truncated_properly(verbose):
                 result.output.count(
                     "dagster system frames hidden, run with --verbose to see the full stack trace"
                 )
-                == 2
+                == 1
             )
+            assert result.output.count("dagster system frames hidden") == 2
 
 
 def test_env_var(monkeypatch):

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -113,18 +113,21 @@ def test_invalid_project_truncated_properly(verbose):
         result = invoke_validate(options=["--verbose"] if verbose else [])
         assert result.exit_code == 1
         assert "Validation failed" in result.output
-        assert "This is a test exception" in result.output
+        assert "is not a valid name in Dagster" in result.output, result.output
 
         if verbose:
             assert "importlib" in result.output, result.output
-            assert "DagsterUserCodeLoadError" in result.output, result.output
         else:
-            # Assert extraneous lines are removed
+            # Assert extraneous lines are removed in two blocs
             assert "importlib" not in result.output, result.output
-            assert "DagsterUserCodeLoadError" not in result.output, result.output
+            # Assert system frames hint is present in the output exactly twice,
+            # once for the load error (before user code) and one for the Dagster check validation
+            # (after user code)
             assert (
-                "system frames removed, run with --verbose to see the full stack trace"
-                in result.output
+                result.output.count(
+                    "dagster system frames hidden, run with --verbose to see the full stack trace"
+                )
+                == 2
             )
 
 


### PR DESCRIPTION
## Summary

When running `dg check defs`/`dagster definitions validate`, remove all dagster system frames, not just the ones before the user code error.

e.g.

```python
2025-03-06 10:25:57 -0800 - dagster - ERROR - Validation failed for code location definitions.py:

dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  [9 dagster system frames hidden, run with --verbose to see the full stack trace]
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [6 dagster system frames hidden]
```

## How I Tested These Changes

Update test

