### PR TITLE
[dg] create shims classes for a selection of dagster definitions

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/asset.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from dagster._utils import pushd
+
+from dagster_components import Scaffolder, ScaffoldRequest
+from dagster_components.components.shim_components.base import ShimComponent
+from dagster_components.scaffoldable.decorator import scaffoldable
+
+
+class AssetScaffolder(Scaffolder):
+    def scaffold(self, request: ScaffoldRequest, params: None) -> None:
+        with pushd(str(request.target_path)):
+            Path("definitions.py").write_text("""
+# import dagster as dg
+# 
+# @dg.asset
+# def my_asset(context: dg.AssetExecutionContext) -> dg.MaterializeResult: ...
+""")
+
+
+@scaffoldable(AssetScaffolder)
+class RawAssetComponent(ShimComponent):
+    """Asset definition component."""

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/base.py
@@ -1,0 +1,12 @@
+from dagster_components import Component
+
+
+class ShimComponent(Component):
+    """A component that will never be loaded independently. This exists purely as a vessel
+    for the @scaffoldable decorator so that the dagster-dg CLI can know about and invoke
+    commands against it. In the near future, we'll improve the CLI such that it can handle
+    arbitrary scaffoldable objects so that this hack is no longer necessary.
+    """
+
+    def build_defs(self, context):
+        raise NotImplementedError("Shim components should never be loaded.")

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/schedule.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/schedule.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from dagster._utils import pushd
+
+from dagster_components import Scaffolder, ScaffoldRequest
+from dagster_components.components.shim_components.base import ShimComponent
+from dagster_components.scaffoldable.decorator import scaffoldable
+
+
+class ScheduleScaffolder(Scaffolder):
+    def scaffold(self, request: ScaffoldRequest, params: None) -> None:
+        with pushd(str(request.target_path)):
+            Path("definitions.py").write_text("""
+# import dagster as dg
+# 
+# @dg.schedule(cron_schedule=..., target=...)
+# def my_schedule(context: dg.ScheduleEvaluationContext): ...
+
+""")
+
+
+@scaffoldable(ScheduleScaffolder)
+class RawScheduleComponent(ShimComponent):
+    """Schedule component."""

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/sensor.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/sensor.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from dagster._utils import pushd
+
+from dagster_components import Scaffolder, ScaffoldRequest
+from dagster_components.components.shim_components.base import ShimComponent
+from dagster_components.scaffoldable.decorator import scaffoldable
+
+
+class SensorScaffolder(Scaffolder):
+    def scaffold(self, request: ScaffoldRequest, params: None) -> None:
+        with pushd(str(request.target_path)):
+            Path("definitions.py").write_text("""
+# import dagster as dg
+# 
+# @dg.sensor(target=...)
+# def my_sensor(context: dg.SensorEvaluationContext): ...
+""")
+
+
+@scaffoldable(SensorScaffolder)
+class RawSensorComponent(ShimComponent):
+    """Sensor component."""

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -64,6 +64,9 @@ class ImplicitDefinitionsComponentDecl(ComponentDeclNode):
     def from_path(path: Path) -> "ImplicitDefinitionsComponentDecl":
         return ImplicitDefinitionsComponentDecl(path=path)
 
+    def get_source_position_tree(self) -> Optional[SourcePositionTree]:
+        return None
+
     def load(self, context) -> Sequence[Component]:
         from dagster_components.dagster import DefinitionsComponent
 

--- a/python_modules/libraries/dagster-components/dagster_components/dagster.py
+++ b/python_modules/libraries/dagster-components/dagster_components/dagster.py
@@ -4,3 +4,12 @@ from dagster_components.components.definitions_component.component import (
 from dagster_components.components.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionComponent as PipesSubprocessScriptCollectionComponent,
 )
+from dagster_components.components.shim_components.asset import (
+    RawAssetComponent as RawAssetComponent,
+)
+from dagster_components.components.shim_components.schedule import (
+    RawScheduleComponent as RawScheduleComponent,
+)
+from dagster_components.components.shim_components.sensor import (
+    RawSensorComponent as RawSensorComponent,
+)

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -35,6 +35,8 @@ def scaffold_component_instance(
     component_type_name: str,
     scaffold_params: Mapping[str, Any],
 ) -> None:
+    from dagster_components.components.shim_components.base import ShimComponent
+
     click.echo(f"Creating a Dagster component instance folder at {path}.")
     if not path.exists():
         path.mkdir()
@@ -53,8 +55,9 @@ def scaffold_component_instance(
         scaffold_params,
     )
 
-    component_yaml_path = path / "component.yaml"
-    if not component_yaml_path.exists():
-        raise Exception(
-            f"Currently all components require a component.yaml file. Please ensure your implementation of scaffold writes this file at {component_yaml_path}."
-        )
+    if not issubclass(component_type, ShimComponent):
+        component_yaml_path = path / "component.yaml"
+        if not component_yaml_path.exists():
+            raise Exception(
+                f"Currently all components require a component.yaml file. Please ensure your implementation of scaffold writes this file at {component_yaml_path}."
+            )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -7,6 +7,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from dagster_dg.cli.scaffold import SHIM_COMPONENTS
 from dagster_dg.cli.shared_options import dg_global_options
 from dagster_dg.component import RemoteComponentRegistry
 from dagster_dg.config import normalize_cli_config
@@ -79,7 +80,7 @@ def component_type_list(output_json: bool, **global_options: object) -> None:
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
 
-    sorted_keys = sorted(registry.keys(), key=lambda k: k.to_typename())
+    sorted_keys = sorted(registry.keys() - SHIM_COMPONENTS.keys(), key=lambda k: k.to_typename())
 
     # JSON
     if output_json:
@@ -99,7 +100,7 @@ def component_type_list(output_json: bool, **global_options: object) -> None:
         table = Table(border_style="dim")
         table.add_column("Component Type", style="bold cyan", no_wrap=True)
         table.add_column("Summary")
-        for key in sorted(registry.keys(), key=lambda k: k.to_typename()):
+        for key in sorted_keys:
             table.add_row(key.to_typename(), registry.get(key).summary)
         console = Console()
         console.print(table)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -15,6 +15,7 @@ from dagster_dg.cli.shared_options import (
 from dagster_dg.component import RemoteComponentRegistry, RemoteComponentType
 from dagster_dg.component_key import ComponentKey
 from dagster_dg.config import (
+    DgRawCliConfig,
     get_config_from_cli_context,
     has_config_on_cli_context,
     normalize_cli_config,
@@ -250,6 +251,74 @@ def component_scaffold_group(context: click.Context, help_: bool, **global_optio
         context.exit(0)
 
 
+def _core_scaffold(
+    cli_context: click.Context,
+    cli_config: DgRawCliConfig,
+    component_key: ComponentKey,
+    instance_name: str,
+    key_value_params,
+    json_params,
+) -> None:
+    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    registry = RemoteComponentRegistry.from_dg_context(dg_context)
+    if not registry.has(component_key):
+        exit_with_error(f"Component type `{component_key.to_typename()}` not found.")
+    elif dg_context.has_component_instance(instance_name):
+        exit_with_error(f"A component instance named `{instance_name}` already exists.")
+
+    # Specified key-value params will be passed to this function with their default value of
+    # `None` even if the user did not set them. Filter down to just the ones that were set by
+    # the user.
+    user_provided_key_value_params = {
+        k: v
+        for k, v in key_value_params.items()
+        if cli_context.get_parameter_source(k) == ParameterSource.COMMANDLINE
+    }
+    if json_params is not None and user_provided_key_value_params:
+        exit_with_error(
+            "Detected params passed as both --json-params and individual options. These are mutually exclusive means of passing"
+            " component generation parameters. Use only one.",
+        )
+    elif json_params:
+        scaffold_params = json_params
+    elif user_provided_key_value_params:
+        scaffold_params = user_provided_key_value_params
+    else:
+        scaffold_params = None
+
+    scaffold_component_instance(
+        Path(dg_context.defs_path) / instance_name,
+        component_key.to_typename(),
+        scaffold_params,
+        dg_context,
+    )
+
+
+def _create_component_shim_scaffold_subcommand(
+    component_key: ComponentKey, command_name: str
+) -> DgClickCommand:
+    # We need to "reset" the help option names to the default ones because we inherit the parent
+    # value of context settings from the parent group, which has been customized.
+    @click.command(
+        name=command_name,
+        cls=ComponentScaffoldSubCommand,
+        context_settings={"help_option_names": ["-h", "--help"]},
+    )
+    @click.argument("instance_name", type=str)
+    @dg_global_options
+    @click.pass_context
+    def scaffold_component_shim_command(
+        cli_context: click.Context,
+        instance_name: str,
+        **global_options: object,
+    ) -> None:
+        """Scaffold of a definition."""
+        cli_config = normalize_cli_config(global_options, cli_context)
+        _core_scaffold(cli_context, cli_config, component_key, instance_name, {}, {})
+
+    return scaffold_component_shim_command
+
+
 def _create_component_scaffold_subcommand(
     component_key: ComponentKey, component_type: RemoteComponentType
 ) -> DgClickCommand:
@@ -293,41 +362,13 @@ def _create_component_scaffold_subcommand(
         It is an error to pass both --json-params and key-value pairs as options.
         """
         cli_config = get_config_from_cli_context(cli_context)
-        dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
-
-        registry = RemoteComponentRegistry.from_dg_context(dg_context)
-        if not registry.has(component_key):
-            exit_with_error(f"Component type `{component_key.to_typename()}` not found.")
-        elif dg_context.has_component_instance(component_instance_name):
-            exit_with_error(
-                f"A component instance named `{component_instance_name}` already exists."
-            )
-
-        # Specified key-value params will be passed to this function with their default value of
-        # `None` even if the user did not set them. Filter down to just the ones that were set by
-        # the user.
-        user_provided_key_value_params = {
-            k: v
-            for k, v in key_value_params.items()
-            if cli_context.get_parameter_source(k) == ParameterSource.COMMANDLINE
-        }
-        if json_params is not None and user_provided_key_value_params:
-            exit_with_error(
-                "Detected params passed as both --json-params and individual options. These are mutually exclusive means of passing"
-                " component generation parameters. Use only one.",
-            )
-        elif json_params:
-            scaffold_params = json_params
-        elif user_provided_key_value_params:
-            scaffold_params = user_provided_key_value_params
-        else:
-            scaffold_params = None
-
-        scaffold_component_instance(
-            Path(dg_context.defs_path) / component_instance_name,
-            component_key.to_typename(),
-            scaffold_params,
-            dg_context,
+        _core_scaffold(
+            cli_context,
+            cli_config,
+            component_key,
+            component_instance_name,
+            key_value_params,
+            json_params,
         )
 
     # If there are defined scaffold params, add them to the command
@@ -341,6 +382,21 @@ def _create_component_scaffold_subcommand(
 
     return scaffold_component_command
 
+
+# ########################
+# ##### COMPONENT SHIMS
+# ########################
+
+SHIM_COMPONENTS = {
+    ComponentKey("dagster_components.dagster", "RawAssetComponent"): "asset",
+    ComponentKey("dagster_components.dagster", "RawSensorComponent"): "sensor",
+    ComponentKey("dagster_components.dagster", "RawScheduleComponent"): "schedule",
+}
+
+for key, command_name in SHIM_COMPONENTS.items():
+    scaffold_group.add_command(
+        _create_component_shim_scaffold_subcommand(key, command_name),
+    )
 
 # ########################
 # ##### COMPONENT TYPE

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -37,6 +37,9 @@ NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "project"), "foo"),
     CommandSpec(("init",), "foo"),
     CommandSpec(("scaffold", "workspace"), "foo"),
+    CommandSpec(("scaffold", "asset"), "foo"),
+    CommandSpec(("scaffold", "schedule"), "foo"),
+    CommandSpec(("scaffold", "sensor"), "foo"),
 ]
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -518,6 +518,36 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
         assert "type: foo_bar.lib.Baz" in component_yaml_path.read_text()
 
 
+# ##### SHIMS
+
+
+def test_scaffold_asset() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke("scaffold", "asset", "assets/foo")
+        assert_runner_result(result)
+        assert Path("foo_bar/defs/assets/foo/definitions.py").exists()
+        assert not Path("foo_bar/defs/assets/foo/component.yaml").exists()
+
+        result = runner.invoke("scaffold", "asset", "assets/bar")
+        assert_runner_result(result)
+        assert Path("foo_bar/defs/assets/bar/definitions.py").exists()
+        assert not Path("foo_bar/defs/assets/bar/component.yaml").exists()
+
+
+def test_scaffold_sensor() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke("scaffold", "sensor", "my_sensor")
+        assert_runner_result(result)
+        assert Path("foo_bar/defs/my_sensor/definitions.py").exists()
+        assert not Path("foo_bar/defs/my_sensor/component.yaml").exists()
+
+
 # ##### REAL COMPONENTS
 
 


### PR DESCRIPTION
## Summary & Motivation

This is a bit of a hack, which creates Components that represent raw definitions of assets, schedules, and sensors.

This lets you do stuff like:

```
dg scaffold asset some/path

dg scaffold schedule some/path
```

I needed to create components here so metadata about the scaffolder could make its way through to the dg CLI, but obviously the "correct" solution here is to separate out a command that forwards scaffolder-specific information.

## How I Tested These Changes

## Changelog

NOCHANGELOG
