### PR TITLE
[dagster dev] By default, collapse and deduplicate stack traces

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -66,7 +66,11 @@ def definitions_cli():
     """,
 )
 def definitions_validate_command(
-    log_level: str, log_format: str, load_with_grpc: bool, verbose: bool, **other_opts: object
+    log_level: str,
+    log_format: str,
+    load_with_grpc: bool,
+    verbose_stack_traces: bool,
+    **other_opts: object,
 ):
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
     assert_no_remaining_opts(other_opts)

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -105,7 +105,7 @@ def definitions_validate_command(
             ]
             for code_location, entry in workspace.get_code_location_entries().items():
                 if entry.load_error:
-                    if verbose:
+                    if verbose_stack_traces:
                         underlying_error = entry.load_error
                     else:
                         underlying_error = remove_system_frames_from_error(

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -43,11 +43,11 @@ def definitions_cli():
     help="Load the code locations using a gRPC server, instead of in-process.",
 )
 @click.option(
-    "--verbose",
+    "--verbose-stack-traces",
     "-v",
     flag_value=True,
     default=False,
-    help="Show verbose error messages, including system frames in stack traces.",
+    help="Show verbose stack traces, including system frames in stack traces.",
 )
 @definitions_cli.command(
     name="validate",
@@ -78,7 +78,7 @@ def definitions_validate_command(
 
     removed_system_frame_hint = (
         lambda is_first_hidden_frame,
-        i: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
+        i: f"  [{i} dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace]\n"
         if is_first_hidden_frame
         else f"  [{i} dagster system frames hidden]\n"
     )

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -43,7 +43,7 @@ def definitions_cli():
     help="Load the code locations using a gRPC server, instead of in-process.",
 )
 @click.option(
-    "--verbose-stack-traces",
+    "--verbose",
     "-v",
     flag_value=True,
     default=False,
@@ -69,7 +69,7 @@ def definitions_validate_command(
     log_level: str,
     log_format: str,
     load_with_grpc: bool,
-    verbose_stack_traces: bool,
+    verbose: bool,
     **other_opts: object,
 ):
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -82,7 +82,7 @@ def definitions_validate_command(
 
     removed_system_frame_hint = (
         lambda is_first_hidden_frame,
-        i: f"  [{i} dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace]\n"
+        i: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
         if is_first_hidden_frame
         else f"  [{i} dagster system frames hidden]\n"
     )
@@ -105,7 +105,7 @@ def definitions_validate_command(
             ]
             for code_location, entry in workspace.get_code_location_entries().items():
                 if entry.load_error:
-                    if verbose_stack_traces:
+                    if verbose:
                         underlying_error = entry.load_error
                     else:
                         underlying_error = remove_system_frames_from_error(

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -100,7 +100,7 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     help="Internal use only. Pass a readable pipe file descriptor to the dev process that will be monitored for a shutdown signal.",
 )
 @click.option(
-    "--verbose-stack-traces",
+    "--verbose",
     "-v",
     is_flag=True,
     default=False,
@@ -119,7 +119,7 @@ def dev_command(
     live_data_poll_rate: Optional[str],
     use_legacy_code_server_behavior: bool,
     shutdown_pipe: Optional[int],
-    verbose_stack_traces: bool,
+    verbose: bool,
     **other_opts: object,
 ) -> None:
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -136,7 +136,7 @@ def dev_command(
         )
 
     os.environ["DAGSTER_IS_DEV_CLI"] = "1"
-    os.environ["DAGSTER_VERBOSE_STACK_TRACES"] = "1" if verbose_stack_traces else ""
+    os.environ["DAGSTER_verbose"] = "1" if verbose else ""
 
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -99,6 +99,13 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     hidden=True,
     help="Internal use only. Pass a readable pipe file descriptor to the dev process that will be monitored for a shutdown signal.",
 )
+@click.option(
+    "--verbose-stack-traces",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show verbose stack traces for errors in the code server.",
+)
 @workspace_options
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
@@ -112,6 +119,7 @@ def dev_command(
     live_data_poll_rate: Optional[str],
     use_legacy_code_server_behavior: bool,
     shutdown_pipe: Optional[int],
+    verbose_stack_traces: bool,
     **other_opts: object,
 ) -> None:
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -128,6 +136,7 @@ def dev_command(
         )
 
     os.environ["DAGSTER_IS_DEV_CLI"] = "1"
+    os.environ["DAGSTER_VERBOSE_STACK_TRACES"] = "1" if verbose_stack_traces else ""
 
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -71,6 +71,7 @@ from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCo
 from dagster._time import get_current_timestamp
 from dagster._utils.aiodataloader import DataLoader
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+from dagster._utils.env import using_dagster_dev
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
@@ -640,7 +641,6 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         grpc_server_registry: Optional[GrpcServerRegistry] = None,
         code_server_log_level: str = "INFO",
         server_command: GrpcServerCommand = GrpcServerCommand.API_GRPC,
-        verbose_stack_traces: bool = True,
     ):
         self._stack = ExitStack()
 
@@ -665,8 +665,6 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         self._state_subscriber_id_iter = count()
         self._state_subscribers: dict[int, LocationStateSubscriber] = {}
         self.add_state_subscriber(LocationStateSubscriber(self._location_state_events_handler))
-
-        self._verbose_stack_traces = verbose_stack_traces
 
         if grpc_server_registry:
             self._grpc_server_registry: GrpcServerRegistry = check.inst_param(
@@ -826,7 +824,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             error = serializable_error_info_from_exc_info(sys.exc_info())
             # In dagster dev, the code server process already logs the error, so we don't need to log it again from
             # the workspace process context
-            if self._verbose_stack_traces:
+            if using_dagster_dev():
                 warnings.warn(f"Error loading repository location {location_name}")
             else:
                 warnings.warn(

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -103,7 +103,7 @@ from dagster._utils.container import (
     ContainerUtilizationMetrics,
     retrieve_containerized_utilization_metrics,
 )
-from dagster._utils.env import use_verbose_stack_traces, using_dagster_dev
+from dagster._utils.env import use_verbose, using_dagster_dev
 from dagster._utils.error import (
     remove_system_frames_from_error,
     serializable_error_info_from_exc_info,
@@ -433,10 +433,10 @@ class DagsterApiServer(DagsterApiServicer):
                 raise
             self._loaded_repositories = None
             self._serializable_load_error = serializable_error_info_from_exc_info(sys.exc_info())
-            if using_dagster_dev() and not use_verbose_stack_traces():
+            if using_dagster_dev() and not use_verbose():
                 removed_system_frame_hint = (
                     lambda is_first_hidden_frame,
-                    i: f"  [{i} dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace]\n"
+                    i: f"  [{i} dagster system frames hidden, run with --verbose to see the full stack trace]\n"
                     if is_first_hidden_frame
                     else f"  [{i} dagster system frames hidden]\n"
                 )

--- a/python_modules/dagster/dagster/_utils/env.py
+++ b/python_modules/dagster/dagster/_utils/env.py
@@ -24,3 +24,11 @@ def environ(env: Mapping[str, str]) -> Iterator[None]:
                     del os.environ[key]
             else:
                 os.environ[key] = value
+
+
+def using_dagster_dev() -> bool:
+    return bool(os.getenv("DAGSTER_IS_DEV_CLI"))
+
+
+def use_verbose_stack_traces() -> bool:
+    return bool(os.getenv("DAGSTER_VERBOSE_STACK_TRACES", "1"))

--- a/python_modules/dagster/dagster/_utils/env.py
+++ b/python_modules/dagster/dagster/_utils/env.py
@@ -30,5 +30,5 @@ def using_dagster_dev() -> bool:
     return bool(os.getenv("DAGSTER_IS_DEV_CLI"))
 
 
-def use_verbose_stack_traces() -> bool:
-    return bool(os.getenv("DAGSTER_VERBOSE_STACK_TRACES", "1"))
+def use_verbose() -> bool:
+    return bool(os.getenv("DAGSTER_verbose", "1"))

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -6,8 +6,10 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Optional, TextIO
 
 import psutil
+import pytest
 import requests
 import yaml
 from dagster._cli.utils import TMP_DAGSTER_HOME_PREFIX
@@ -24,6 +26,10 @@ from dagster._serdes.ipc import (
 )
 from dagster._utils import find_free_port, pushd
 from dagster_graphql import DagsterGraphQLClient
+
+from dagster_tests.cli_tests.command_tests.test_definitions_validate_command import (
+    INVALID_PROJECT_PATH_WITH_EXCEPTION,
+)
 
 
 def test_dagster_dev_command_workspace():
@@ -212,13 +218,16 @@ def test_dagster_dev_command_legacy_code_server_behavior():
 
 @contextmanager
 def _launch_dev_command(
-    options: list[str], capture_output: bool = False
+    options: list[str],
+    capture_output: bool = False,
+    stdout_file: Optional[TextIO] = None,
+    stderr_file: Optional[TextIO] = None,
 ) -> Iterator[subprocess.Popen]:
     read_fd, write_fd = get_ipc_shutdown_pipe()
     proc = open_ipc_subprocess(
         ["dagster", "dev", *options, "--shutdown-pipe", str(read_fd)],
-        stdout=subprocess.PIPE if capture_output else None,
-        stderr=subprocess.PIPE if capture_output else None,
+        stdout=stdout_file if stdout_file else (subprocess.PIPE if capture_output else None),
+        stderr=stderr_file if stderr_file else (subprocess.PIPE if capture_output else None),
         cwd=os.getcwd(),
         pass_fds=[read_fd],
     )
@@ -374,3 +383,38 @@ def _get_cmdline(proc: psutil.Process) -> str:
         return str(proc.cmdline())
     except psutil.NoSuchProcess:
         return "CMDLINE IRRETRIEVABLE"
+
+
+@pytest.mark.parametrize("verbose", [True, False])
+def test_dagster_dev_command_verbose_stack_traces(verbose: bool) -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        stdout_filepath = str(Path(tempdir) / "stdout.txt")
+
+        with pushd(INVALID_PROJECT_PATH_WITH_EXCEPTION):
+            webserver_port = find_free_port()
+            stdout_file = open(stdout_filepath, "w")
+            with _launch_dev_command(
+                options=["--port", str(webserver_port)]
+                + (["--verbose-stack-traces"] if verbose else []),
+                capture_output=True,
+                stdout_file=stdout_file,
+            ):
+                _wait_for_webserver_running(webserver_port)
+
+        stdout_file.close()
+        with open(stdout_filepath, encoding="utf-8") as f:
+            contents = f.read()
+
+            assert "is not a valid name in Dagster" in contents, contents
+
+            if verbose:
+                assert "importlib" in contents, contents
+            else:
+                assert "importlib" not in contents, contents
+                assert (
+                    contents.count(
+                        "dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace"
+                    )
+                    == 1
+                ), contents
+                assert contents.count("dagster system frames hidden") == 2, contents

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -386,7 +386,7 @@ def _get_cmdline(proc: psutil.Process) -> str:
 
 
 @pytest.mark.parametrize("verbose", [True, False])
-def test_dagster_dev_command_verbose_stack_traces(verbose: bool) -> None:
+def test_dagster_dev_command_verbose(verbose: bool) -> None:
     with tempfile.TemporaryDirectory() as tempdir:
         stdout_filepath = str(Path(tempdir) / "stdout.txt")
 
@@ -394,8 +394,7 @@ def test_dagster_dev_command_verbose_stack_traces(verbose: bool) -> None:
             webserver_port = find_free_port()
             stdout_file = open(stdout_filepath, "w")
             with _launch_dev_command(
-                options=["--port", str(webserver_port)]
-                + (["--verbose-stack-traces"] if verbose else []),
+                options=["--port", str(webserver_port)] + (["--verbose"] if verbose else []),
                 capture_output=True,
                 stdout_file=stdout_file,
             ):
@@ -413,7 +412,7 @@ def test_dagster_dev_command_verbose_stack_traces(verbose: bool) -> None:
                 assert "importlib" not in contents, contents
                 assert (
                     contents.count(
-                        "dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace"
+                        "dagster system frames hidden, run with --verbose to see the full stack trace"
                     )
                     == 1
                 ), contents

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -110,7 +110,7 @@ def test_invalid_project(options, monkeypatch):
 @pytest.mark.parametrize("verbose", [True, False])
 def test_invalid_project_truncated_properly(verbose):
     with pushd(INVALID_PROJECT_PATH_WITH_EXCEPTION):
-        result = invoke_validate(options=["--verbose"] if verbose else [])
+        result = invoke_validate(options=["--verbose-stack-traces"] if verbose else [])
         assert result.exit_code == 1
         assert "Validation failed" in result.output
         assert "is not a valid name in Dagster" in result.output, result.output
@@ -125,7 +125,7 @@ def test_invalid_project_truncated_properly(verbose):
             # (after user code)
             assert (
                 result.output.count(
-                    "dagster system frames hidden, run with --verbose to see the full stack trace"
+                    "dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace"
                 )
                 == 1
             )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -110,7 +110,7 @@ def test_invalid_project(options, monkeypatch):
 @pytest.mark.parametrize("verbose", [True, False])
 def test_invalid_project_truncated_properly(verbose):
     with pushd(INVALID_PROJECT_PATH_WITH_EXCEPTION):
-        result = invoke_validate(options=["--verbose-stack-traces"] if verbose else [])
+        result = invoke_validate(options=["--verbose"] if verbose else [])
         assert result.exit_code == 1
         assert "Validation failed" in result.output
         assert "is not a valid name in Dagster" in result.output, result.output
@@ -125,7 +125,7 @@ def test_invalid_project_truncated_properly(verbose):
             # (after user code)
             assert (
                 result.output.count(
-                    "dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace"
+                    "dagster system frames hidden, run with --verbose to see the full stack trace"
                 )
                 == 1
             )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -70,7 +70,7 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     required=False,
 )
 @click.option(
-    "--verbose-stack-traces",
+    "--verbose",
     "-v",
     flag_value=True,
     default=False,
@@ -84,7 +84,7 @@ def dev_command(
     port: Optional[int],
     host: Optional[str],
     live_data_poll_rate: int,
-    verbose_stack_traces: bool,
+    verbose: bool,
     **global_options: Mapping[str, object],
 ) -> None:
     """Start a local instance of Dagster.
@@ -102,7 +102,7 @@ def dev_command(
         *format_forwarded_option("--port", port),
         *format_forwarded_option("--host", host),
         *format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
-        ["--verbose-stack-traces"] if verbose_stack_traces else [],
+        *(["--verbose"] if verbose else []),
     ]
 
     # In a project context, we can just run `dagster dev` directly, using `dagster` from the

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -69,6 +69,13 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     show_default=True,
     required=False,
 )
+@click.option(
+    "--verbose-stack-traces",
+    "-v",
+    flag_value=True,
+    default=False,
+    help="Show verbose stack traces, including system frames in stack traces.",
+)
 @dg_global_options
 def dev_command(
     code_server_log_level: str,
@@ -77,6 +84,7 @@ def dev_command(
     port: Optional[int],
     host: Optional[str],
     live_data_poll_rate: int,
+    verbose_stack_traces: bool,
     **global_options: Mapping[str, object],
 ) -> None:
     """Start a local instance of Dagster.
@@ -94,6 +102,7 @@ def dev_command(
         *format_forwarded_option("--port", port),
         *format_forwarded_option("--host", host),
         *format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
+        ["--verbose-stack-traces"] if verbose_stack_traces else [],
     ]
 
     # In a project context, we can just run `dagster dev` directly, using `dagster` from the


### PR DESCRIPTION
## Summary

Defaults similar behavior to `dagster definitions validate` for `dagster dev`, `dg dev`.

Before:

```python
2025-03-06 11:50:35 -0800 - dagster - INFO - Using temporary directory /Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/.tmp_dagster_home_cn04zjkx for storage. This will be removed when dagster dev exits.
2025-03-06 11:50:35 -0800 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2025-03-06 11:50:35 -0800 - dagster.code_server - INFO - Starting Dagster code proxy server for file definitions.py in process 80665
2025-03-06 11:50:36 -0800 - dagster.code_server - INFO - Starting Dagster code server for file definitions.py in process 80669
2025-03-06 11:50:36 -0800 - dagster.code_server - ERROR - Error while importing code
Traceback (most recent call last):
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 420, in __init__
    self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
                                                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 253, in __init__
    loadable_targets = get_loadable_targets(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/utils.py", line 41, in get_loadable_targets
    else loadable_targets_from_python_file(python_file, working_directory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/autodiscovery.py", line 24, in loadable_targets_from_python_file
    loaded_module = load_python_file(python_file, working_directory)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/code_pointer.py", line 84, in load_python_file
    return import_module_from_path(module_name, python_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_seven/__init__.py", line 47, in import_module_from_path
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py", line 123, in __call__
    op_def = OpDefinition.dagster_internal_init(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 201, in dagster_internal_init
    return OpDefinition(
           ^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/decorator_utils.py", line 195, in wrapped_with_pre_call_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 177, in __init__
    super().__init__(
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/node_definition.py", line 44, in __init__
    self._name = check_valid_name(name)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 82, in check_valid_name
    check_valid_chars(name)
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 90, in check_valid_chars
    raise DagsterInvalidDefinitionError(
dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.
2025-03-06 11:50:36 -0800 - dagster.code_server - INFO - Started Dagster code server for file definitions.py in process 80669
2025-03-06 11:50:36 -0800 - dagster.code_server - INFO - Started Dagster code proxy server for file definitions.py in process 80665
2025-03-06 11:50:36 -0800 - dagster - WARNING - /Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/context.py:824: UserWarning: Error loading repository location definitions.py:dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 420, in __init__
    self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
                                                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 253, in __init__
    loadable_targets = get_loadable_targets(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/utils.py", line 41, in get_loadable_targets
    else loadable_targets_from_python_file(python_file, working_directory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/autodiscovery.py", line 24, in loadable_targets_from_python_file
    loaded_module = load_python_file(python_file, working_directory)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/code_pointer.py", line 84, in load_python_file
    return import_module_from_path(module_name, python_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_seven/__init__.py", line 47, in import_module_from_path
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py", line 123, in __call__
    op_def = OpDefinition.dagster_internal_init(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 201, in dagster_internal_init
    return OpDefinition(
           ^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/decorator_utils.py", line 195, in wrapped_with_pre_call_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 177, in __init__
    super().__init__(
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/node_definition.py", line 44, in __init__
    self._name = check_valid_name(name)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 82, in check_valid_name
    check_valid_chars(name)
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 90, in check_valid_chars
    raise DagsterInvalidDefinitionError(

  warnings.warn(f"Error loading repository location {location_name}:{error.to_string()}")

2025-03-06 11:50:36 -0800 - dagster - INFO - Launching Dagster services...
/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/context.py:824: UserWarning: Error loading repository location definitions.py:dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 420, in __init__
    self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
                                                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 253, in __init__
    loadable_targets = get_loadable_targets(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/utils.py", line 41, in get_loadable_targets
    else loadable_targets_from_python_file(python_file, working_directory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/autodiscovery.py", line 24, in loadable_targets_from_python_file
    loaded_module = load_python_file(python_file, working_directory)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/code_pointer.py", line 84, in load_python_file
    return import_module_from_path(module_name, python_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_seven/__init__.py", line 47, in import_module_from_path
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py", line 123, in __call__
    op_def = OpDefinition.dagster_internal_init(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 201, in dagster_internal_init
    return OpDefinition(
           ^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/decorator_utils.py", line 195, in wrapped_with_pre_call_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 177, in __init__
    super().__init__(
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/node_definition.py", line 44, in __init__
    self._name = check_valid_name(name)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 82, in check_valid_name
    check_valid_chars(name)
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 90, in check_valid_chars
    raise DagsterInvalidDefinitionError(

  warnings.warn(f"Error loading repository location {location_name}:{error.to_string()}")
2025-03-06 11:50:37 -0800 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'QueuedRunCoordinatorDaemon', 'SchedulerDaemon', 'SensorDaemon']
2025-03-06 11:50:37 -0800 - dagster - WARNING - /Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/context.py:824: UserWarning: Error loading repository location definitions.py:dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 420, in __init__
    self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
                                                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/server.py", line 253, in __init__
    loadable_targets = get_loadable_targets(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_grpc/utils.py", line 41, in get_loadable_targets
    else loadable_targets_from_python_file(python_file, working_directory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/autodiscovery.py", line 24, in loadable_targets_from_python_file
    loaded_module = load_python_file(python_file, working_directory)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/code_pointer.py", line 84, in load_python_file
    return import_module_from_path(module_name, python_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_seven/__init__.py", line 47, in import_module_from_path
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py", line 123, in __call__
    op_def = OpDefinition.dagster_internal_init(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 201, in dagster_internal_init
    return OpDefinition(
           ^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/decorator_utils.py", line 195, in wrapped_with_pre_call_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/op_definition.py", line 177, in __init__
    super().__init__(
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/node_definition.py", line 44, in __init__
    self._name = check_valid_name(name)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 82, in check_valid_name
    check_valid_chars(name)
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_core/definitions/utils.py", line 90, in check_valid_chars
    raise DagsterInvalidDefinitionError(

  warnings.warn(f"Error loading repository location {location_name}:{error.to_string()}")

2025-03-06 11:50:37 -0800 - dagster-webserver - INFO - Serving dagster-webserver on http://127.0.0.1:3000 in process 80674
```

After:

```python
2025-03-06 11:50:10 -0800 - dagster - INFO - Using temporary directory /Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/.tmp_dagster_home_mi8u9lq7 for storage. This will be removed when dagster dev exits.
2025-03-06 11:50:10 -0800 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2025-03-06 11:50:11 -0800 - dagster.code_server - INFO - Starting Dagster code proxy server for file definitions.py in process 80310
2025-03-06 11:50:11 -0800 - dagster.code_server - INFO - Starting Dagster code server for file definitions.py in process 80314
2025-03-06 11:50:11 -0800 - dagster.code_server - ERROR - dagster._core.errors.DagsterInvalidDefinitionError: "invalid!op/name" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  [8 dagster system frames hidden, run with --verbose-stack-traces to see the full stack trace]
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_project_exc/invalid_project_exc/definitions.py", line 4, in <module>
    @dg.op(name="invalid!op/name")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [7 dagster system frames hidden]

2025-03-06 11:50:11 -0800 - dagster.code_server - INFO - Started Dagster code server for file definitions.py in process 80314
2025-03-06 11:50:11 -0800 - dagster.code_server - INFO - Started Dagster code proxy server for file definitions.py in process 80310
2025-03-06 11:50:12 -0800 - dagster - WARNING - /Users/ben/repos/dagster/python_modules/dagster/dagster/_core/workspace/context.py:830: UserWarning: Error loading repository location definitions.py
  warnings.warn(f"Error loading repository location {location_name}")
```
## Test Plan

New unit test.

## Changelog

> `dagster dev` deduplicates stacktraces when code locations fail to load, and will by default truncate them to highlight only user code frames.