### PR TITLE
[dg] Better error message

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -73,7 +73,11 @@ class Component(ABC):
                 else cls()
             )
         else:
-            check.failed(f"Unsupported component type {cls}")
+            # Ideally we would detect this at class declaration time. A metaclass is difficult
+            # to do because the way our users can mixin other frameworks that themselves use metaclasses.
+            check.failed(
+                f"Unsupported component type {cls}. Must inherit from either ResolvableModel or ResolvedFrom."
+            )
 
     @classmethod
     def get_metadata(cls) -> "ComponentTypeInternalMetadata":

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_invariant_errors.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_invariant_errors.py
@@ -1,0 +1,13 @@
+import pytest
+from dagster._check.functions import CheckError
+from dagster_components import Component, ComponentLoadContext
+
+
+def test_component_does_not_implement():
+    class AComponent(Component):
+        pass
+
+    with pytest.raises(
+        CheckError, match="Must inherit from either ResolvableModel or ResolvedFrom"
+    ):
+        AComponent.load(attributes=None, context=ComponentLoadContext.for_test())


### PR DESCRIPTION
## Summary & Motivation

Components right now must inherit from either `ResolvableModel` or `ResolveFrom`. This checks that invariant at load time.

Ideally we would detect this at class declaration time. A metaclass is difficult to do because the way our users can mixin other frameworks that themselves use metaclasses.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG