### PR TITLE
Add `push` behavior to `useQueryPersistedState`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionState.oss.tsx
@@ -4,5 +4,6 @@ export function useAssetSelectionState() {
   return useQueryPersistedState<string>({
     queryKey: 'asset-selection',
     defaults: {['asset-selection']: ''},
+    behavior: 'push',
   });
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
@@ -125,7 +125,7 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
         }
       }
     },
-    [history, encode, options],
+    [encode, options.defaults, behavior, history],
   );
 
   if (!isEqual(valueRef.current, qsDecoded)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
@@ -114,14 +114,11 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
       // the `replace` so that we surface any unwanted loops during development.
       if (process.env.NODE_ENV !== 'production' || !areQueriesEqual(currentQueryString, next)) {
         currentQueryString = next;
+        const nextPath = `${history.location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`;
         if (behavior === 'replace') {
-          history.replace(
-            `${history.location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`,
-          );
+          history.replace(nextPath);
         } else {
-          history.push(
-            `${history.location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`,
-          );
+          history.push(nextPath);
         }
       }
     },


### PR DESCRIPTION
## Summary & Motivation

Add push behavior so that we can use this for selection syntax to allow *back* to go to the previous syntax.

## How I Tested These Changes
jest + local testing