### PR TITLE
[Selection input] Use antlr error message

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/useSelectionInputLintingAndHighlighting.tsx
@@ -3,8 +3,6 @@ import {
   Box,
   Colors,
   Icon,
-  MiddleTruncate,
-  MonoSmall,
   PopoverContentStyle,
   PopoverWrapperStyle,
 } from '@dagster-io/ui-components';
@@ -88,18 +86,7 @@ export const useSelectionInputLintingAndHighlighting = ({
       if (symbol === '<EOF>') {
         return 'Selection is incomplete';
       }
-      return (
-        <Box flex={{direction: 'row', alignItems: 'center'}}>
-          Unexpected input
-          <div style={{width: 4}} />
-          <MonoSmall color={Colors.textRed()}>
-            <div style={{maxWidth: 200}}>
-              <MiddleTruncate text={error.error.offendingSymbol} />
-            </div>
-          </MonoSmall>
-          .
-        </Box>
-      );
+      return <Box flex={{direction: 'row', alignItems: 'center'}}>{error.error.message}</Box>;
     }
     if (error.error.message) {
       return error.error.message;


### PR DESCRIPTION
## Summary & Motivation

The error messages are not super human friendly but give more context that is useful than just saying "Unexpected input".

## How I Tested These Changes

locally

before:
![image](https://github.com/user-attachments/assets/1a45bfc0-4217-4814-b2e3-e17718e6d33b)



after:
<img width="1103" alt="Screenshot 2025-03-06 at 3 56 34 PM" src="https://github.com/user-attachments/assets/6c18c4cf-824f-4d86-8c84-198878664418" />
