### PR TITLE
[Selection input autocomplete] Rename exact match -> `key` / `name`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
@@ -237,15 +237,8 @@ export const createProvider = <
   }) {
     const displayText = `${attribute as string}:`;
     const icon: IconName = attributeToIcon[attribute];
-    let label;
-    switch (attribute) {
-      case primaryAttributeKey as string:
-        label = 'Exact match';
-        break;
-      default:
-        label = (attribute as string).replace(/_/g, ' ');
-        label = label[0]!.toUpperCase() + label.slice(1);
-    }
+    let label = (attribute as string).replace(/_/g, ' ');
+    label = label[0]!.toUpperCase() + label.slice(1);
     return {
       text,
       jsx: (


### PR DESCRIPTION
Renaming from Exact match because we allow wild cards here and the exact match label suggests otherwise.


<img width="1073" alt="Screenshot 2025-03-06 at 4 14 31 PM" src="https://github.com/user-attachments/assets/71f2c81d-37c0-46e1-b25b-96424e66ba8f" />
<img width="557" alt="Screenshot 2025-03-06 at 4 16 58 PM" src="https://github.com/user-attachments/assets/55b50bfb-8532-48cc-99d1-31de1bf41e8b" />
