### PR TITLE
[da] Fix bug with executed_with_root_target condition and self-dependent assets

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -704,6 +704,13 @@ class AssetGraphView(LoadingContext):
         from dagster._core.storage.dagster_run import RunRecord
         from dagster._core.storage.event_log.base import AssetRecord
 
+        if query_key == target_key:
+            # this happens when this is evaluated for a self-dependent asset. in these cases,
+            # it does not make sense to consider the asset as having been executed with itself
+            # as the partition key of the target is necessarily different than the partition
+            # key of the query key
+            return False
+
         asset_record = await AssetRecord.gen(self, query_key)
         if (
             asset_record

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from dagster import (
     AssetDep,
@@ -160,6 +162,63 @@ def test_eager_static_partitioned() -> None:
             defs=_get_defs(four_partitions), instance=instance, cursor=result.cursor
         )
         assert result.total_requested == 0
+
+
+def test_eager_self_dependency() -> None:
+    @asset
+    def root() -> None: ...
+
+    @asset(
+        deps=[
+            root,
+            AssetDep(
+                "A", partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+            ),
+        ],
+        automation_condition=AutomationCondition.eager(),
+        partitions_def=DailyPartitionsDefinition("2024-01-01"),
+    )
+    def A() -> None: ...
+
+    defs = Definitions(assets=[root, A])
+    instance = DagsterInstance.ephemeral()
+
+    # parent doesn't exist
+    evaluation_time = datetime.datetime(2024, 8, 16, 1, 1)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # now previous partition of A exists, so request
+    defs.get_implicit_global_asset_job_def().execute_in_process(
+        instance=instance, asset_selection=[root.key, A.key], partition_key="2024-08-14"
+    )
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 1
+
+    # don't keep requesting
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # now materialize the previous partition again, kick off again
+    defs.get_implicit_global_asset_job_def().execute_in_process(
+        instance=instance, asset_selection=[A.key], partition_key="2024-08-14"
+    )
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 1
+
+    # don't keep requesting
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
 
 
 def test_eager_multi_partitioned_self_dependency() -> None:


### PR DESCRIPTION
## Summary & Motivation

As title / changelog entry. Test that was added failed before and passes now. Basically updates to self-dependent assets would always be ignored.

## How I Tested These Changes

## Changelog

Fixed issue that would cause the `AutomationCondition.any_deps_updated()` condition to evaluate to `False` when evaluated on a self-dependency.
