### PR TITLE
[dg] "dg scaffold defs" as alias for "dg scaffold component"

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -432,10 +432,6 @@ def component_type_scaffold_command(
     This command must be run inside a Dagster project directory. The component type scaffold
     will be placed in submodule `<project_name>.lib.<name>`.
     """
-    do_type_scaffold(context, name, global_options)
-
-
-def do_type_scaffold(context, name, global_options):
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
     registry = RemoteComponentRegistry.from_dg_context(dg_context)
@@ -448,12 +444,3 @@ def do_type_scaffold(context, name, global_options):
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
     scaffold_component_type(dg_context, name, module_name)
-
-
-@scaffold_group.command(name="type", cls=DgClickCommand)
-@click.argument("name", type=str)
-@dg_global_options
-@click.pass_context
-def type_scaffold_command(context: click.Context, name: str, **global_options: object) -> None:
-    """Scaffold of a scaffoldable Dagster type."""
-    return do_type_scaffold(context, name, global_options)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -245,7 +245,10 @@ def component_scaffold_group(context: click.Context, help_: bool, **global_optio
 def handle_component_scaffold_group(
     context: click.Context, help_: bool, **global_options: object
 ) -> None:
-    """Handle the component scaffold group command."""
+    # Click attempts to resolve subcommands BEFORE it invokes this callback.
+    # Therefore we need to manually invoke this callback during subcommand generation to make sure
+    # it runs first. It will be invoked again later by Click. We make it idempotent to deal with
+    # that.
     if not has_config_on_cli_context(context):
         cli_config = normalize_cli_config(global_options, context)
         set_config_on_cli_context(context, cli_config)


### PR DESCRIPTION
## Summary & Motivation

This enables an alias: `dg scaffold component` can now work as `dg scaffold defs`. 

(Note: grok and chatgpt suggested there is an aliasing feature but I could not get it to work so did this more hacky version)

## How I Tested These Changes

```
(dagster-dev-3.11.11-2024-12-08) ➜  dagster git:(schrockn/create-aliases) dg scaffold -h

 Usage: dg scaffold [OPTIONS] COMMAND [ARGS]...

 Commands for scaffolding Dagster code.

╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help  -h        Show this message and exit.                                                                                                                                                                                                                                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ asset            Scaffold of a definition.                                                                                                                                                                                                                                   │
│ component        Scaffold of a Dagster component.                                                                                                                                                                                                                            │
│ component-type   Scaffold of a custom Dagster component type.                                                                                                                                                                                                                │
│ defs             Scaffold a Dagster defs module.                                                                                                                                                                                                                             │
│ project          Scaffold a Dagster project file structure and a uv-managed virtual environment scoped                                                                                                                                                                       │
│                  to the project.                                                                                                                                                                                                                                             │
│ schedule         Scaffold of a definition.                                                                                                                                                                                                                                   │
│ sensor           Scaffold of a definition.                                                                                                                                                                                                                                   │
│ workspace        Initialize a new Dagster workspace.                                                                                                                                                                                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

(dagster-dev-3.11.11-2024-12-08) ➜  dagster git:(schrockn/create-aliases) ✗ dg scaffold defs -h

 Usage: dg scaffold defs [OPTIONS] COMMAND [ARGS]...

 Scaffold a Dagster defs module.

╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help  -h        Show this message and exit.                                                                                                                                                                                                                                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --require-local-venv            --no-require-local-venv                  Require use of a local virtual environment (`.venv` found in ancestors of the working directory).                                                                                                   │
│ --use-dg-managed-environment    --no-use-dg-managed-environment          Enable management of the virtual environment with uv.                                                                                                                                               │
│ --verbose                                                                Enable verbose output for debugging.                                                                                                                                                                │
│ --disable-cache                                                          Disable the cache..                                                                                                                                                                                 │
│ --cache-dir                                                        TEXT  Specify a directory to use for the cache.                                                                                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```


## Changelog

NOCHANGELOG