### PR TITLE
[dg] RFC: @udf decorator

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -39,6 +39,9 @@ class ComponentDeclNode(ABC):
     def get_source_position_tree(self) -> Optional[SourcePositionTree]: ...
 
 
+from dagster_components.core.udf import get_udf_methods
+
+
 @scaffoldable(scaffolder=DefaultComponentScaffolder)
 class Component(ABC):
     @classmethod
@@ -54,7 +57,7 @@ class Component(ABC):
 
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:
-        return {}
+        return get_udf_methods(cls)
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...

--- a/python_modules/libraries/dagster-components/dagster_components/core/udf.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/udf.py
@@ -1,0 +1,39 @@
+import inspect
+from functools import wraps
+from typing import Callable
+
+
+# Decorator definition
+def udf(func: Callable) -> Callable:
+    """Decorator that validates a function is a staticmethod and marks it as a udf."""
+    # Mark the function as a udf by adding an attribute
+    setattr(func, "__is_udf__", True)
+
+    # Get the original function and preserve its metadata
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return staticmethod(wrapper)  # type:ignore something about staticmethod
+
+
+# Function to collect udf-decorated static methods
+def get_udf_methods(cls: type) -> dict[str, Callable]:
+    """Returns a dictionary of udf-decorated static methods from a class.
+    Key is the function name, value is the function itself.
+    """
+    udf_methods = {}
+
+    members = inspect.getmembers(cls)
+
+    # Iterate through all class attributes
+    for name, attr in members:
+        # Check if it's a staticmethod
+        # Get the original function using __get__ to access the underlying function
+        if isinstance(attr, staticmethod):
+            func = attr.__get__(None, cls)
+            # Check if it has our udf marker
+            if getattr(func, "__is_udf__", False):
+                udf_methods[name] = func
+
+    return udf_methods

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -18,6 +18,7 @@ from dagster_components.core.component_defs_builder import (
     build_components_from_component_folder,
     defs_from_components,
 )
+from dagster_components.core.udf import udf
 from dagster_dbt import DbtProject
 
 from dagster_components_tests.utils import assert_assets, get_asset_keys, script_load_context
@@ -121,9 +122,10 @@ def test_load_from_path(dbt_path: Path) -> None:
 def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     @dataclass
     class DebugDbtProjectComponent(DbtProjectComponent):
-        @classmethod
-        def get_additional_scope(cls) -> Mapping[str, Any]:
-            return {"get_tags_for_node": lambda node: {"model_id": node["name"].replace("_", "-")}}
+        @staticmethod
+        @udf
+        def get_tags_for_node(node: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {"model_id": node["name"].replace("_", "-")}
 
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,


### PR DESCRIPTION
## Summary & Motivation

Instead of having to override `get_additional_scope` I think Resolved should have a `udf` decorator. It is easy to implement and much more clear.

Right now I have it stashed as staticmethod. However I am very open to the possibility of having it be a freestanding function and then having the autoloading pick it up, rather than attaching it to the class. This would allow you to define them globally:

```python

@udf
def some_udf(): ...

class SomeComponent(Component): ...
```

This opens up possibility of having the user be able to define udfs _without_ defining a custom class, which would be very nice.

Name just a co-located file next to component.yaml whose contents are:

```python

@udf
def some_udf(): ...
```


## How I Tested These Changes

BK

## Changelog

NOCHANGELOG