### PR TITLE
[dagster-polars, chore]: update to deltalake 0.25.0

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -197,7 +197,8 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
                         f"Found: `{partition_by}`"
                     )
 
-                if (engine := delta_write_options.get("engine", "pyarrow")) == "rust":
+                # rust is the default engine in newer versions of deltalake
+                if (engine := delta_write_options.get("engine", "rust")) == "rust":
                     delta_write_options["predicate"] = self.get_predicate(context)
 
                 elif engine == "pyarrow":

--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -42,14 +42,15 @@ setup(
         "universal_pathlib>=0.1.4",
     ],
     extras_require={
-        "deltalake": ["deltalake>=0.15.0"],
+        "deltalake": ["deltalake>=0.25.0"],
         "gcp": ["dagster-gcp>=0.19.5"],
         "test": [
+            "polars>=1.24.0",
             "pytest>=8",
             "hypothesis[zoneinfo]>=6.89.0",
             "deepdiff>=6.3.0",
             "pytest-cases>=3.6.14",
-            "pyarrow<19.0.0",  # temporary pin until https://github.com/apache/arrow/issues/45283 is fixed
+            "pytest_mock"
         ],
     },
     zip_safe=False,

--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -50,7 +50,7 @@ setup(
             "hypothesis[zoneinfo]>=6.89.0",
             "deepdiff>=6.3.0",
             "pytest-cases>=3.6.14",
-            "pytest_mock"
+            "pytest_mock",
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

the deltalake IOManager is broken on never versions of `deltalake`: 

```python
ValueError: Partition filters can only be used with PyArrow engine, use predicate instead. PyArrow engine will be deprecated in 1.0
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/execution/plan/utils.py", line 56, in op_execution_error_boundary
    yield
  File "/usr/local/lib/python3.11/site-packages/dagster/_utils/__init__.py", line 480, in iterate_with_context
    next_output = next(iterator)
                  ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/execution/plan/execute_step.py", line 767, in _gen_fn
    gen_output = output_manager.handle_output(output_context, output.value)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/python/anam-dagster/src/anam_dagster/io_managers/branching.py", line 121, in handle_output
    self.branch.handle_output(context, obj)
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/storage/upath_io_manager.py", line 448, in handle_output
    self.dump_to_path(context=context, obj=obj, path=path)
  File "/usr/local/lib/python3.11/site-packages/dagster_polars/io_managers/base.py", line 138, in dump_to_path
    type_router.dump(obj, path, dump_fn)
  File "/usr/local/lib/python3.11/site-packages/dagster_polars/io_managers/type_routers.py", line 58, in dump
    dump_fn(cast(OutputContext, self.context), obj, path)
  File "/usr/local/lib/python3.11/site-packages/dagster_polars/io_managers/delta.py", line 218, in write_df_to_path
    df.write_delta(
  File "/usr/local/lib/python3.11/site-packages/polars/dataframe/frame.py", line 4616, in write_delta
    write_deltalake(
  File "/usr/local/lib/python3.11/site-packages/deltalake/writer.py", line 310, in write_deltalake
    raise ValueError(
```

This is because the default engine has switched from `pyarrow` to `rust`, but the IOManager code still assumes `pyarrow` by default. 

This PR bumps the `deltalake` pin and changes the code to assume `rust` instead. 

Minor deps fixes:
- noticed `pytest_mock` was missing from deps
- removed the pyarrow pin
- bumped `polars` version in tests
## How I Tested These Changes
Existing test suite

## Changelog

[dagster-polars] minimal compatible `deltalake` version bumped to `0.25.0`; the `PolarsDeltaIOManager` is now using the `rust` engine for writing DeltaLake tables by default.