### PR TITLE
Turn on asset selection syntax by default

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
@@ -5,9 +5,7 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
  */
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<Record<FeatureFlag, boolean>> = {
   [FeatureFlag.flagAssetSelectionWorker]: true,
-  [FeatureFlag.flagSelectionSyntax]: new URLSearchParams(global?.location?.search ?? '').has(
-    'new-asset-selection-syntax',
-  ),
+  [FeatureFlag.flagSelectionSyntax]: true,
 
   // Flags for tests
   [FeatureFlag.__TestFlagDefaultTrue]: true,


### PR DESCRIPTION
## Summary & Motivation

As titled


## Changelog

[ui] An updated asset selection syntax is now available in the asset graph, All assets, insights, and alerts. The new syntax  allows combining logical operators, lineage operators and attribute filters.