### PR TITLE
[resolved] field resolution update

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
@@ -4,10 +4,10 @@ from typing import Annotated
 from dagster_components import (
     Component,
     ComponentLoadContext,
-    FieldResolver,
     ResolutionContext,
     ResolvableModel,
     ResolvedFrom,
+    Resolver,
 )
 
 import dagster as dg
@@ -31,6 +31,6 @@ def resolve_api_key(
 class MyComponent(Component, ResolvedFrom[MyComponentModel]):
     # FieldResolver specifies a function used to map input matching the schema
     # to a value for this field
-    api_client: Annotated[MyApiClient, FieldResolver(resolve_api_key)]
+    api_client: Annotated[MyApiClient, Resolver(resolve_api_key)]
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-blueprint.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-blueprint.py
@@ -14,7 +14,7 @@ from dagster_components import (
     scaffold_component_yaml,
 )
 from dagster_components.blueprint import scaffold_with
-from dagster_components.resolved.core_models import AssetSpecSequenceField
+from dagster_components.resolved.core_models import ResolvedAssetSpec
 from dagster_components.resolved.model import ResolvableModel, ResolvedFrom
 
 import dagster as dg
@@ -55,7 +55,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     """Models a shell script as a Dagster asset."""
 
     script_path: str
-    asset_specs: AssetSpecSequenceField
+    asset_specs: Sequence[ResolvedAssetSpec]
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
         resolved_script_path = Path(load_context.path, self.script_path).absolute()

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -10,7 +10,7 @@ from dagster_components import (
     ResolvableModel,
     ResolvedFrom,
 )
-from dagster_components.resolved.core_models import AssetSpecSequenceField
+from dagster_components.resolved.core_models import ResolvedAssetSpec
 
 import dagster as dg
 
@@ -25,7 +25,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     """Models a shell script as a Dagster asset."""
 
     script_path: str
-    asset_specs: AssetSpecSequenceField
+    asset_specs: Sequence[ResolvedAssetSpec]
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
         resolved_script_path = Path(load_context.path, self.script_path).absolute()

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
@@ -8,7 +8,7 @@ from dagster_components import (
     ResolvableModel,
     ResolvedFrom,
 )
-from dagster_components.resolved.core_models import AssetSpecSequenceField
+from dagster_components.resolved.core_models import ResolvedAssetSpec
 
 import dagster as dg
 
@@ -21,6 +21,6 @@ class ShellCommandModel(ResolvableModel):
 @dataclass
 class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
-    asset_specs: AssetSpecSequenceField
+    asset_specs: Sequence[ResolvedAssetSpec]
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
@@ -11,7 +11,7 @@ from dagster_components import (
     ResolvableModel,
     ResolvedFrom,
 )
-from dagster_components.resolved.core_models import AssetSpecSequenceField
+from dagster_components.resolved.core_models import ResolvedAssetSpec
 
 import dagster as dg
 
@@ -24,7 +24,7 @@ class ShellCommandModel(ResolvableModel):
 @dataclass
 class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
-    asset_specs: AssetSpecSequenceField
+    asset_specs: Sequence[ResolvedAssetSpec]
 
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:

--- a/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
@@ -13,7 +13,7 @@ from dagster_components.resolved.core_models import (
     OpSpecModel,
 )
 from dagster_components.resolved.metadata import ResolvableFieldInfo
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
 from pydantic import Field
 
 
@@ -40,7 +40,7 @@ class ComplexAssetComponent(Component, ResolvedFrom[ComplexAssetModel]):
     op: Optional[OpSpecModel] = None
     asset_attributes: Optional[AssetAttributesModel] = None
     asset_post_processors: Annotated[
-        Optional[Sequence[AssetPostProcessor]], AssetPostProcessor.from_optional_seq
+        Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -27,9 +27,9 @@ from dagster_components.resolved.core_models import (
 )
 from dagster_components.resolved.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.resolved.model import (
-    FieldResolver as FieldResolver,
     ResolvableModel as ResolvableModel,
     ResolvedFrom as ResolvedFrom,
     ResolvedKwargs as ResolvedKwargs,
+    Resolver as Resolver,
 )
 from dagster_components.version import __version__ as __version__

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -29,7 +29,7 @@ from dagster_components.resolved.core_models import (
     ResolutionContext,
 )
 from dagster_components.resolved.metadata import ResolvableFieldInfo
-from dagster_components.resolved.model import FieldResolver, ResolvableModel, ResolvedFrom
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 
@@ -65,15 +65,14 @@ def resolve_dbt(context: ResolutionContext, dbt: DbtCliResource) -> DbtCliResour
 class DbtProjectComponent(Component, ResolvedFrom[DbtProjectModel]):
     """Expose a DBT project to Dagster as a set of assets."""
 
-    dbt: Annotated[DbtCliResource, FieldResolver(resolve_dbt)]
-    op: Annotated[Optional[OpSpec], FieldResolver(OpSpec.from_optional)] = None
+    dbt: Annotated[DbtCliResource, Resolver(resolve_dbt)]
+    op: Annotated[Optional[OpSpec], Resolver.from_annotation()] = None
     # This requires from_parent because it access asset_attributes in the model
-    translator: Annotated[DagsterDbtTranslator, FieldResolver.from_model(resolve_translator)] = (
-        field(default_factory=DagsterDbtTranslator)
+    translator: Annotated[DagsterDbtTranslator, Resolver.from_model(resolve_translator)] = field(
+        default_factory=DagsterDbtTranslator
     )
     asset_post_processors: Annotated[
-        Optional[Sequence[AssetPostProcessor]],
-        FieldResolver(AssetPostProcessor.from_optional_seq),
+        Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
     select: str = "fqn:*"
     exclude: Optional[str] = None

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -30,7 +30,7 @@ from dagster_components.resolved.core_models import (
     OpSpecModel,
 )
 from dagster_components.resolved.metadata import ResolvableFieldInfo
-from dagster_components.resolved.model import FieldResolver, ResolvableModel, ResolvedFrom
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
 from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
 
 SlingMetadataAddons: TypeAlias = Literal["column_metadata", "row_count"]
@@ -72,10 +72,8 @@ def resolve_translator(
 @dataclass
 class SlingReplicationSpecModel(ResolvedFrom["SlingReplicationModel"]):
     path: str
-    op: Annotated[Optional[OpSpec], FieldResolver(OpSpec.from_optional)]
-    translator: Annotated[
-        Optional[DagsterSlingTranslator], FieldResolver.from_model(resolve_translator)
-    ]
+    op: Annotated[Optional[OpSpec], Resolver.from_annotation()]
+    translator: Annotated[Optional[DagsterSlingTranslator], Resolver.from_model(resolve_translator)]
     include_metadata: list[SlingMetadataAddons]
 
 
@@ -122,13 +120,10 @@ def resolve_resource(
 class SlingReplicationCollectionComponent(Component, ResolvedFrom[SlingReplicationCollectionModel]):
     """Expose one or more Sling replications to Dagster as assets."""
 
-    resource: Annotated[SlingResource, FieldResolver.from_model(resolve_resource)] = ...
-    replications: Annotated[
-        Sequence[SlingReplicationSpecModel], FieldResolver(SlingReplicationSpecModel.from_seq)
-    ] = ...
+    resource: Annotated[SlingResource, Resolver.from_model(resolve_resource)] = ...
+    replications: Annotated[Sequence[SlingReplicationSpecModel], Resolver.from_annotation()] = ...
     asset_post_processors: Annotated[
-        Optional[Sequence[AssetPostProcessor]],
-        FieldResolver(AssetPostProcessor.from_optional_seq),
+        Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
 
     def build_asset(

--- a/python_modules/libraries/dagster-components/dagster_components/resolved/model.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/model.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import (
@@ -6,6 +7,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Optional,
     TypeVar,
     Union,
@@ -15,7 +17,13 @@ from typing import (
 
 from dagster import _check as check
 from pydantic import BaseModel, ConfigDict
-from typing_extensions import Self
+from typing_extensions import TypeAlias
+
+try:
+    # this type only exists in python 3.10+
+    from types import UnionType  # type: ignore
+except ImportError:
+    UnionType = Union
 
 if TYPE_CHECKING:
     from dagster_components.resolved.context import ResolutionContext
@@ -31,7 +39,7 @@ TModel = TypeVar("TModel", bound=ResolvableModel)
 def get_model_type(
     resolved_from_type: type["ResolvedFrom"],
 ) -> type[ResolvableModel]:
-    """Returns the first generic type argument (TSchema) of the ResolvableFromSchema instance at runtime."""
+    """Returns the first generic type argument (TModel) of the ResolvedFrom subclass at runtime."""
     check.param_invariant(
         issubclass(resolved_from_type, ResolvedFrom),
         "resolvable_from_type",
@@ -41,40 +49,66 @@ def get_model_type(
         "resolvable_from_type",
     )
     for base in resolved_from_type.__orig_bases__:  # type: ignore
-        # Check if this base originates from ResolvableFromSchema
+        # Check if this base originates from ResolvedFrom
         origin = getattr(base, "__origin__", None)
         if origin is ResolvedFrom:
             type_args = get_args(base)
             if not type_args:
-                raise ValueError(
-                    "ResolvableFromSchema base found but no generic type arguments present"
-                )
+                raise ValueError("ResolvedFrom base found but no generic type arguments present")
             return type_args[0]
 
-    raise ValueError("No generic type arguments found in ResolvableFromSchema subclass")
+    raise ValueError("No generic type arguments found in ResolvedFrom subclass")
+
+
+def get_resolved_kwargs_target_type(resolved_kwargs_type: type["ResolvedKwargs"]):
+    """Returns the generic type arguments (TModel, TObject) of a ResolvedKwargs subclass at runtime."""
+    check.param_invariant(
+        issubclass(resolved_kwargs_type, ResolvedKwargs),
+        "resolved_kwargs_type",
+    )
+    check.param_invariant(
+        hasattr(resolved_kwargs_type, "__orig_bases__"),
+        "resolved_kwargs_type",
+    )
+    for base in resolved_kwargs_type.__orig_bases__:  # type: ignore
+        # Check if this base originates from ResolvedFrom
+        origin = getattr(base, "__origin__", None)
+        if origin is ResolvedKwargs:
+            type_args = get_args(base)
+            if not type_args:
+                raise ValueError("ResolvedKwargs base found but no generic type arguments present")
+            if len(type_args) != 2:
+                raise ValueError(
+                    f"ResolvedKwargs base found but has incorrect number of type arguments, expected 2 got {len(type_args)}"
+                )
+            return type_args[1]
+
+    raise ValueError("No generic type arguments found in ResolvedKwargs subclass")
 
 
 T = TypeVar("T")
 
 
-class ResolutionResolverFn(Generic[T]):
-    def __init__(self, target_type: type[T], spec_type: type["ResolvedKwargs"]):
-        self.target_type = target_type
-        self.spec_type = spec_type
+class ResolvedFrom(Generic[TModel], ABC):
+    """Class which defines a type that can be resolved from the associated ResolvableModel."""
 
-    def from_model(self, context: "ResolutionContext", model: ResolvableModel) -> T:
-        return resolve_model_using_kwargs_cls(
-            model=model,
-            kwargs_cls=self.spec_type,
-            context=context,
-            target_type=self.target_type,
-        )
+
+class ResolvedKwargs(Generic[TModel, T], ABC):
+    """For cases where you can not inherit from ResolvedFrom on the desired target type,
+    ResolvedKwargs allows you to define an object which will be resolved from its associated
+    ResolvableModel and then passed unpacked as kwargs to create the target type.
+    """
+
+
+class _ModelResolver(Generic[T], ABC):
+    @abstractmethod
+    def resolve_from_model(self, context: "ResolutionContext", model: ResolvableModel) -> T: ...
 
     def from_seq(self, context: "ResolutionContext", model: Sequence[TModel]) -> Sequence[T]:
-        return [self.from_model(context, item) for item in model]
+        return [self.resolve_from_model(context, item) for item in model]
 
     def from_optional(self, context: "ResolutionContext", model: Optional[TModel]) -> Optional[T]:
-        return self.from_model(context, model) if model else None
+        return self.resolve_from_model(context, model) if model else None
 
     def from_optional_seq(
         self, context: "ResolutionContext", model: Optional[Sequence[TModel]]
@@ -82,30 +116,32 @@ class ResolutionResolverFn(Generic[T]):
         return self.from_seq(context, model) if model else None
 
 
-class ResolvedKwargs(Generic[TModel]):
-    @classmethod
-    def resolver_fn(cls, target_type: type) -> ResolutionResolverFn:
-        return ResolutionResolverFn(target_type=target_type, spec_type=cls)
+@dataclass(frozen=True)
+class _KwargsResolver(_ModelResolver[T]):
+    target_type: type[T]
+    kwargs_type: type["ResolvedKwargs"]
+
+    def resolve_from_model(self, context: "ResolutionContext", model: ResolvableModel) -> T:
+        return resolve_model_using_kwargs_cls(
+            model=model,
+            kwargs_cls=self.kwargs_type,
+            context=context,
+            target_type=self.target_type,
+        )
 
 
-class ResolvedFrom(ResolvedKwargs[TModel]):
-    @classmethod
-    def from_model(cls, context: "ResolutionContext", model: TModel) -> Self:
-        return resolve_model(model=model, resolvable_type=cls, context=context)
+@dataclass(frozen=True)
+class _DirectResolver(_ModelResolver[ResolvedFrom]):
+    target_type: type[ResolvedFrom]
 
-    @classmethod
-    def from_optional(cls, context: "ResolutionContext", model: Optional[TModel]) -> Optional[Self]:
-        return cls.from_model(context, model) if model else None
-
-    @classmethod
-    def from_seq(cls, context: "ResolutionContext", model: Sequence[TModel]) -> Sequence[Self]:
-        return [cls.from_model(context.at_path(idx), item) for idx, item in enumerate(model)]
-
-    @classmethod
-    def from_optional_seq(
-        cls, context: "ResolutionContext", model: Optional[Sequence[TModel]]
-    ) -> Optional[Sequence[Self]]:
-        return cls.from_seq(context, model) if model else None
+    def resolve_from_model(
+        self, context: "ResolutionContext", model: ResolvableModel
+    ) -> ResolvedFrom:
+        return resolve_model(
+            model=model,
+            resolvable_type=self.target_type,
+            context=context,
+        )
 
 
 @dataclass
@@ -118,12 +154,125 @@ class AttrWithContextFn:
     callable: Callable[["ResolutionContext", Any], Any]
 
 
-class FieldResolver:
-    """Contains information on how to resolve this field from a DSLSchema."""
+@dataclass(frozen=True)
+class _AutoResolve:
+    via: Optional[type[ResolvedKwargs]] = None
+
+
+class _ExpectedInjection: ...
+
+
+def _is_scalar(annotation):
+    if annotation in (int, float, str, bool, Any, type(None)):
+        return True
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin in (Union, UnionType, list, Sequence, tuple, dict, Mapping) and all(
+        _is_scalar(arg) for arg in args
+    ):
+        return True
+
+    if origin is Annotated and any(isinstance(arg, _ExpectedInjection) for arg in args):
+        return True
+
+    if origin is Literal and all(_is_scalar(type(arg)) for arg in args):
+        return True
+
+    return False
+
+
+def _get_resolver(
+    annotation: type,
+    top_level_auto_resolve: Optional[_AutoResolve],
+) -> Optional[_ModelResolver]:
+    if top_level_auto_resolve and isinstance(annotation, type):
+        if top_level_auto_resolve.via and annotation is get_resolved_kwargs_target_type(
+            top_level_auto_resolve.via
+        ):
+            return _KwargsResolver(
+                kwargs_type=top_level_auto_resolve.via,
+                target_type=annotation,
+            )
+
+        if issubclass(annotation, ResolvedFrom):
+            return _DirectResolver(annotation)
+
+    origin = get_origin(annotation)
+    if origin is not Annotated:
+        return None
+
+    args = get_args(annotation)
+    auto_resolve = next((arg for arg in args if isinstance(arg, _AutoResolve)), None)
+    if not auto_resolve:
+        return None
+
+    if auto_resolve.via:
+        return _KwargsResolver(kwargs_type=auto_resolve.via, target_type=args[0])
+
+    resolved_from_cls = args[0]
+    if not issubclass(resolved_from_cls, ResolvedFrom):
+        check.failed("Can only annotate ResolvedFrom types with ResolveModel()")
+    return _DirectResolver(resolved_from_cls)
+
+
+def derive_field_resolver(annotation: Any, field_name: str) -> "Resolver":
+    if _is_scalar(annotation):
+        return Resolver.from_model(
+            lambda context, model: context.resolve_value(getattr(model, field_name))
+        )
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    top_level_auto_resolve = None
+    if origin is Annotated:
+        resolver = next((arg for arg in args if isinstance(arg, Resolver)), None)
+        if resolver:
+            return resolver
+
+        top_level_auto_resolve = next((arg for arg in args if isinstance(arg, _AutoResolve)), None)
+        resolver = _get_resolver(args[0], top_level_auto_resolve)
+        if resolver:
+            return Resolver(resolver.resolve_from_model)
+
+        origin = get_origin(args[0])
+        args = get_args(args[0])
+
+    if origin in (Union, UnionType) and len(args) == 2:
+        left_t, right_t = args
+        if right_t is type(None):
+            resolver = _get_resolver(left_t, top_level_auto_resolve)
+            if resolver:
+                return Resolver(resolver.from_optional)
+
+            elif get_origin(left_t) in (Sequence, tuple, list):
+                resolver = _get_resolver(get_args(left_t)[0], top_level_auto_resolve)
+                if resolver:
+                    return Resolver(resolver.from_optional_seq)
+
+    elif origin in (Sequence, tuple, list):
+        resolver = _get_resolver(args[0], top_level_auto_resolve)
+
+        if resolver:
+            return Resolver(resolver.from_seq)
+
+    check.failed(
+        f"Could not derive resolver for annotation {field_name}: {annotation}.\n"
+        "Field types are expected to either be simple serializable types such as "
+        "str, float, int, bool, list, etc or Annotated with an appropriate Resolver."
+    )
+
+
+class Resolver:
+    """Contains information on how to resolve a field from a ResolvableModel."""
 
     def __init__(
-        self, fn: Union[ParentFn, AttrWithContextFn, Callable[["ResolutionContext", Any], Any]]
+        self,
+        fn: Union[ParentFn, AttrWithContextFn, Callable[["ResolutionContext", Any], Any]],
     ):
+        """Resolve this field by invoking the function which will receive the corresponding field value from the parent ResolvableModel."""
         if not isinstance(fn, (ParentFn, AttrWithContextFn)):
             if not callable(fn):
                 check.param_invariant(
@@ -137,33 +286,24 @@ class FieldResolver:
         super().__init__()
 
     @staticmethod
+    def from_annotation():
+        """Resolve this field to the (potentially nested) ResolvedFrom type via its associated ResolvableModel."""
+        return _AutoResolve()
+
+    @staticmethod
+    def from_resolved_kwargs(kwargs_cls: type[ResolvedKwargs]):
+        """Resolve this field to the (potentially nested) target type of the ResolvedKwargs via its associated ResolvableModel."""
+        return _AutoResolve(via=kwargs_cls)
+
+    @staticmethod
+    def from_template_injection(via: Optional[type[ResolvedKwargs]] = None):
+        """The complex type at this field must be template injected using an appropriate scope."""
+        return _ExpectedInjection()
+
+    @staticmethod
     def from_model(fn: Callable[["ResolutionContext", Any], Any]):
-        return FieldResolver(ParentFn(fn))
-
-    @staticmethod
-    def from_spec(spec: type[ResolvedKwargs], target_type: type):
-        return FieldResolver.from_model(
-            lambda context, model: resolve_model_using_kwargs_cls(
-                model=model,
-                kwargs_cls=spec,
-                context=context,
-                target_type=target_type,
-            )
-        )
-
-    @staticmethod
-    def from_annotation(annotation: Any, field_name: str) -> "FieldResolver":
-        if get_origin(annotation) is Annotated:
-            args = get_args(annotation)
-            resolver = next((arg for arg in args if isinstance(arg, FieldResolver)), None)
-            if resolver:
-                return resolver
-
-            check.failed(f"Could not find resolver on annotation {field_name}")
-
-        return FieldResolver.from_model(
-            lambda context, model: context.resolve_value(getattr(model, field_name))
-        )
+        """Resolve this field by invoking the function which will receive the entire parent ResolvableModel."""
+        return Resolver(ParentFn(fn))
 
     def execute(self, context: "ResolutionContext", model: ResolvableModel, field_name: str) -> Any:
         if isinstance(self.fn, ParentFn):
@@ -175,10 +315,10 @@ class FieldResolver:
             raise ValueError(f"Unsupported DSLFieldResolver type: {self.fn}")
 
 
-TResolvedKwargs = TypeVar("TResolvedKwargs", bound=ResolvedKwargs)
+ResolvedType: TypeAlias = Union[type[ResolvedKwargs], type[ResolvedFrom]]
 
 
-def get_annotation_field_resolvers(kwargs_cls: type[TResolvedKwargs]) -> dict[str, FieldResolver]:
+def get_annotation_field_resolvers(kwargs_cls: ResolvedType) -> dict[str, Resolver]:
     # Collect annotations from all base classes in MRO
     annotations = {}
 
@@ -191,17 +331,14 @@ def get_annotation_field_resolvers(kwargs_cls: type[TResolvedKwargs]) -> dict[st
         annotations.update(base_annotations)
 
     return {
-        field_name: FieldResolver.from_annotation(annotation, field_name)
+        field_name: derive_field_resolver(annotation, field_name)
         for field_name, annotation in annotations.items()
     }
 
 
-TResolvedFrom = TypeVar("TResolvedFrom", bound=ResolvedFrom)
-
-
 def resolve_fields(
     model: ResolvableModel,
-    kwargs_cls: type[TResolvedKwargs],
+    kwargs_cls: Union[type[ResolvedFrom], type[ResolvedKwargs]],
     context: "ResolutionContext",
 ) -> Mapping[str, Any]:
     """Returns a mapping of field names to resolved values for those fields."""
@@ -213,7 +350,7 @@ def resolve_fields(
     }
 
 
-T = TypeVar("T")
+TResolvedFrom = TypeVar("TResolvedFrom", bound=ResolvedFrom)
 
 
 def resolve_model(
@@ -231,8 +368,15 @@ def resolve_model(
 
 def resolve_model_using_kwargs_cls(
     model: ResolvableModel,
-    kwargs_cls: type[TResolvedKwargs],
+    kwargs_cls: Union[type[ResolvedFrom], type[ResolvedKwargs]],
     context: "ResolutionContext",
     target_type: type[T],
 ) -> T:
+    # In the future we will do an explicit validation of alignment, but for now raise a marginally better error.
+    check.inst_param(
+        model,
+        "model",
+        ResolvableModel,
+        "Ensure ResolveFrom field type annotations align with the corresponding ResolvableModel.",
+    )
     return target_type(**resolve_fields(model, kwargs_cls, context))

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Annotated
 
 from dagster_components.resolved.model import (
-    FieldResolver,
     ResolvedKwargs,
+    Resolver,
     get_annotation_field_resolvers,
 )
 from pydantic import BaseModel
@@ -51,7 +51,7 @@ def test_override_vanilla() -> None:
     class Base(ResolvedKwargs):
         value: int
 
-    class CustomResolver(FieldResolver): ...
+    class CustomResolver(Resolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]
@@ -66,7 +66,7 @@ def test_override_dataclass() -> None:
     class Base(ResolvedKwargs):
         value: int
 
-    class CustomResolver(FieldResolver): ...
+    class CustomResolver(Resolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]
@@ -80,7 +80,7 @@ def test_override_pydantic() -> None:
     class Base(BaseModel, ResolvedKwargs):
         value: int
 
-    class CustomResolver(FieldResolver): ...
+    class CustomResolver(Resolver): ...
 
     class Derived(Base):
         value: Annotated[str, CustomResolver(lambda context, val: str(val))]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -1,12 +1,7 @@
 from typing import Annotated
 
 from dagster_components.resolved.context import ResolutionContext
-from dagster_components.resolved.model import (
-    FieldResolver,
-    ResolvableModel,
-    ResolvedFrom,
-    resolve_model,
-)
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
 
 
 def test_simple_dataclass_resolveable_from_schema():
@@ -17,7 +12,7 @@ def test_simple_dataclass_resolveable_from_schema():
 
     @dataclass
     class Hello(ResolvedFrom[HelloModel]):
-        hello: Annotated[int, FieldResolver.from_model(lambda context, schema: int(schema.hello))]
+        hello: Annotated[int, Resolver.from_model(lambda context, schema: int(schema.hello))]
 
     hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
 
@@ -32,7 +27,7 @@ def test_simple_pydantic_resolveable_from_schema():
     from pydantic import BaseModel
 
     class Hello(BaseModel, ResolvedFrom[HelloModel]):
-        hello: Annotated[int, FieldResolver.from_model(lambda context, schema: int(schema.hello))]
+        hello: Annotated[int, Resolver.from_model(lambda context, schema: int(schema.hello))]
 
     hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
 
@@ -48,7 +43,7 @@ def test_simple_dataclass_resolveable_from_schema_with_condense_syntax():
 
     @dataclass
     class Hello(ResolvedFrom[HelloModel]):
-        hello: Annotated[int, FieldResolver(lambda context, val: int(val))]
+        hello: Annotated[int, Resolver(lambda context, val: int(val))]
 
     hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -2,12 +2,7 @@ from collections.abc import Sequence
 from typing import Annotated, Optional
 
 from dagster_components import ResolutionContext
-from dagster_components.resolved.model import (
-    FieldResolver,
-    ResolvableModel,
-    ResolvedFrom,
-    resolve_model,
-)
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
 from pydantic import BaseModel
 
 
@@ -16,14 +11,14 @@ def resolve_val1(context: ResolutionContext, schema: "InnerModel") -> int:
 
 
 class InnerObject(BaseModel, ResolvedFrom["InnerModel"]):
-    val1_renamed: Annotated[int, FieldResolver.from_model(resolve_val1)]
+    val1_renamed: Annotated[int, Resolver.from_model(resolve_val1)]
     val2: Optional[str]
 
 
 class TargetObject(BaseModel, ResolvedFrom["TargetModel"]):
     int_val: int
     str_val: str
-    inners: Annotated[Optional[Sequence[InnerObject]], FieldResolver(InnerObject.from_optional_seq)]
+    inners: Annotated[Optional[Sequence[InnerObject]], Resolver.from_annotation()]
 
 
 class InnerModel(ResolvableModel):


### PR DESCRIPTION
This updates renames `FieldResolver` to `Resolver` and adds

* `Resolver.from_annotation()` takes care of resolving potentially nested `ResolvedFrom` types from their associated `ResolvableModel`
* `Resolver.from_resolved_kwargs(KwargsCls)` takes care of resolving potentially nested target type from the associated ResolvableModel type.
* `Resolver.from_template_injection()` marks fields that expect to be resolved via template injection. 

Additionally
* deriving field resolvers fails on unexpected types instead of assuming things will work.
* `ResolvedKwargs` is now generic over both its `TModel` source and its `T` target type to facilitate nested resolution.

## How I Tested These Changes

updated and existing tests
