### PR TITLE
Fix issue with cycle resolution when using additional_deps

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -36,8 +36,10 @@ from dagster import (
 from dagster._config import StringSource
 from dagster._core.definitions import AssetIn, SourceAsset, asset
 from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
@@ -2673,6 +2675,45 @@ def test_subset_cycle_resolution_basic():
         AssetKey("a_prime"),
         AssetKey("b_prime"),
     }
+
+
+def test_subset_cycle_resolution_with_checks():
+    """Ops:
+        foo produces: a, b
+        foo_prime produces: a', b'
+    Assets:
+        s -> a -> a' -> b -> b'.
+    """
+
+    @multi_asset(
+        specs=[
+            AssetSpec("a", deps=["s"], skippable=True),
+            AssetSpec("b", deps=["a_prime"], skippable=True),
+        ],
+        can_subset=True,
+    )
+    def foo(context): ...
+
+    @multi_asset(
+        specs=[
+            AssetSpec("a_prime", deps=["a"], skippable=True),
+            AssetSpec("b_prime", deps=["b"], skippable=True),
+        ],
+        check_specs=[
+            AssetCheckSpec("a_prime_is_good", asset="a_prime", additional_deps=["b"]),
+        ],
+        can_subset=True,
+    )
+    def foo_prime(context): ...
+
+    defs = Definitions(assets=[foo, foo_prime])
+
+    Definitions.validate_loadable(defs)
+
+    job = defs.get_implicit_global_asset_job_def()
+
+    # should produce a job with foo -> foo_prime -> foo_2 -> foo_prime_2
+    assert len(list(job.graph.iterate_op_defs())) == 4
 
 
 @ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")


### PR DESCRIPTION
## Summary & Motivation

The key issue here is that we were using `keys_by_input_name` as a way to determine which execution dependencies we cared about, when we actually have a kinda nuanced system for determining this, which depends on if the node contains only asset checks or not.

The code here is fairly verbose, but I wanted to factor it in a way that maximized explainability, given how weird this stuff is.

## How I Tested These Changes

## Changelog

Fixed a bug that could cause invalid circular dependency errors when using asset checks with additional dependencies.