### PR TITLE
Nicer log output when dg check defs fails

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -37,6 +37,7 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ docs       Commands for generating docs from your Dagster code.                        │
 │ init       Initialize a new Dagster workspace and a first project within that          │
 │            workspace.                                                                  │
+│ launch     Commands for launching Dagster runs.                                        │
 │ list       Commands for listing Dagster entities.                                      │
 │ scaffold   Commands for scaffolding Dagster code.                                      │
 │ utils      Assorted utility commands.                                                  │

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -6,6 +6,7 @@ from dagster_dg.cli.check import check_group
 from dagster_dg.cli.dev import dev_command
 from dagster_dg.cli.docs import docs_group
 from dagster_dg.cli.init import init_command
+from dagster_dg.cli.launch import launch_group
 from dagster_dg.cli.list import list_group
 from dagster_dg.cli.scaffold import scaffold_group
 from dagster_dg.cli.shared_options import dg_global_options
@@ -26,6 +27,7 @@ def create_dg_cli():
             "check": check_group,
             "docs": docs_group,
             "utils": utils_group,
+            "launch": launch_group,
             "list": list_group,
             "scaffold": scaffold_group,
             "dev": dev_command,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -222,6 +222,11 @@ def check_definitions_command(
         *(["--verbose"] if verbose else []),
     ]
 
-    run_dagster_command_with_workspace(dg_context, ["definitions", "validate", *forward_options])
-
-    click.echo("All definitions loaded successfully.")
+    result = run_dagster_command_with_workspace(
+        dg_context, ["definitions", "validate", *forward_options]
+    )
+    if result.returncode != 0:
+        # underlying command logs error message
+        click.get_current_context().exit(result.returncode)
+    else:
+        click.echo("All definitions loaded successfully.")

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
@@ -1,0 +1,74 @@
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from dagster_dg.cli.dev import format_forwarded_option
+from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.config import normalize_cli_config
+from dagster_dg.context import DgContext
+from dagster_dg.utils import DgClickCommand, DgClickGroup
+
+
+@click.group(name="launch", cls=DgClickGroup)
+def launch_group():
+    """Commands for launching Dagster runs."""
+
+
+@launch_group.command(name="assets", cls=DgClickCommand)
+@click.option("--select", help="Comma-separated Asset selection to target", required=True)
+@click.option("--partition", help="Asset partition to target", required=False)
+@click.option(
+    "--partition-range",
+    help="Asset partition range to target i.e. <start>...<end>",
+    required=False,
+)
+@click.option(
+    "--config-json", type=click.STRING, help="JSON string of run config to use for the launched."
+)
+@dg_global_options
+def assets_command(
+    select: str,
+    partition: Optional[str],
+    partition_range: Optional[str],
+    config_json: Optional[str],
+    **global_options: Mapping[str, object],
+):
+    """Launch a Dagster asset materialization."""
+    forward_options = [
+        *format_forwarded_option("--select", select),
+        *format_forwarded_option("--partition", partition),
+        *format_forwarded_option("--partition-range", partition_range),
+        *format_forwarded_option("--config-json", config_json),
+    ]
+
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    # TODO - make this work in a workspace and/or cloud context instead of materializing the
+    # assets in process. It should use the instance's run launcher to launch a run (or backfill
+    # depending on the asset selection) and optionally stream logs from that run or backfill in
+    # the command line until it finishes. right now, it only works in a project context in local
+    # dev/OSS, and executes the selected assets in process using the "dagster asset materialize"
+    # command.
+    if not dg_context.is_project:
+        raise Exception("Must be run in a dg project context.")
+
+    cmd_location = dg_context.get_executable("dagster")
+    click.echo(f"Using {cmd_location}")
+
+    args = [
+        "--working-directory",
+        str(dg_context.root_path),
+        "--module-name",
+        str(dg_context.code_location_target_module_name),
+    ]
+
+    result = subprocess.run(
+        [cmd_location, "asset", "materialize", *args, *forward_options], check=False
+    )
+    if result.returncode != 0:
+        click.echo("Failed to launch assets.")
+        click.get_current_context().exit(result.returncode)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/cli.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/cli.py
@@ -1,0 +1,40 @@
+import subprocess
+from collections.abc import Sequence
+
+import click
+
+from dagster_dg.cli.dev import temp_workspace_file
+from dagster_dg.context import DgContext
+from dagster_dg.utils import exit_with_error, pushd
+
+
+def run_dagster_command_with_workspace(dg_context: DgContext, args: Sequence[str]):
+    temp_workspace_file_cm = temp_workspace_file(dg_context)
+
+    # In a project context, we can just run the command directly, using `dagster` from the
+    # project's environment.
+    if dg_context.is_project:
+        cmd_location = dg_context.get_executable("dagster")
+        if dg_context.use_dg_managed_environment:
+            cmd = ["uv", "run", "dagster", *args]
+        else:
+            cmd = [cmd_location, *args]
+
+    # In a workspace context, construct a temporary
+    # workspace file that points at all defined projects.
+    elif dg_context.is_workspace:
+        cmd = [
+            "uv",
+            "tool",
+            "run",
+            "dagster",
+            *args,
+        ]
+        cmd_location = "ephemeral dagster"
+    else:
+        exit_with_error("This command must be run inside a project or workspace directory.")
+    with pushd(dg_context.root_path), temp_workspace_file_cm as workspace_file:
+        click.echo(f"Using {cmd_location}")
+        if workspace_file:  # only non-None deployment context
+            cmd.extend(["--workspace", workspace_file])
+        subprocess.run(cmd, check=True)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/cli.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/cli.py
@@ -37,4 +37,4 @@ def run_dagster_command_with_workspace(dg_context: DgContext, args: Sequence[str
         click.echo(f"Using {cmd_location}")
         if workspace_file:  # only non-None deployment context
             cmd.extend(["--workspace", workspace_file])
-        subprocess.run(cmd, check=True)
+        return subprocess.run(cmd, check=False)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -56,6 +56,7 @@ REGISTRY_CONTEXT_COMMANDS = [
 
 
 PROJECT_CONTEXT_COMMANDS = [
+    CommandSpec(("launch", "assets")),
     CommandSpec(("utils", "configure-editor"), "vscode"),
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
@@ -1,0 +1,115 @@
+import inspect
+import textwrap
+from pathlib import Path
+
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    assert_runner_result,
+    isolated_example_project_foo_bar,
+)
+
+
+def _sample_defs():
+    from dagster import DailyPartitionsDefinition, asset, schedule, sensor
+
+    @asset
+    def my_asset_1(): ...
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
+    )
+    def my_asset_2(): ...
+
+    @asset(config_schema={"foo": int})
+    def my_asset_3(context):
+        context.log.info(f"CONFIG: {context.op_config['foo']}")
+
+    @schedule(cron_schedule="@daily", target=[my_asset_1])
+    def my_schedule(): ...
+
+    @sensor(target=[my_asset_2])
+    def my_sensor(): ...
+
+
+def test_launch_assets(capfd) -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        result = runner.invoke(
+            "scaffold",
+            "component",
+            "dagster_components.dagster.DefinitionsComponent",
+            "mydefs",
+        )
+        assert_runner_result(result)
+
+        with Path("foo_bar/defs/mydefs/definitions.py").open("w") as f:
+            defs_source = textwrap.dedent(inspect.getsource(_sample_defs).split("\n", 1)[1])
+            f.write(defs_source)
+
+        result = runner.invoke("launch", "assets", "--select", "my_asset_1")
+        assert_runner_result(result)
+
+        captured = capfd.readouterr()
+        print(str(captured.err))  # noqa
+
+        assert "Started execution of run for" in captured.err
+        assert "RUN_SUCCESS" in captured.err
+
+        result = runner.invoke(
+            "launch", "assets", "--select", "my_asset_2", "--partition", "2024-02-03"
+        )
+        assert_runner_result(result)
+
+        captured = capfd.readouterr()
+        print(str(captured.err))  # noqa
+        assert "Started execution of run for" in captured.err
+        assert "Materialized value my_asset_2" in captured.err
+
+        result = runner.invoke(
+            "launch",
+            "assets",
+            "--select",
+            "my_asset_2",
+            "--partition-range",
+            "2024-02-03...2024-02-03",
+        )
+        assert_runner_result(result)
+
+        captured = capfd.readouterr()
+        print(str(captured.err))  # noqa
+        assert "Started execution of run for" in captured.err
+        assert "Materialized value my_asset_2" in captured.err
+
+        assert "2024-02-03" in captured.err
+
+        result = runner.invoke(
+            "launch",
+            "assets",
+            "--select",
+            "my_asset_3",
+            "--config-json",
+            '{"ops": {"my_asset_3": {"config": {"foo": 7 } } } }',
+        )
+        assert_runner_result(result)
+
+        captured = capfd.readouterr()
+        print(str(captured.err))  # noqa
+        assert "CONFIG: 7" in captured.err
+
+        result = runner.invoke(
+            "launch",
+            "assets",
+            "--select",
+            "nonexistant",
+        )
+        assert_runner_result(result, exit_0=False)
+        captured = capfd.readouterr()
+        print(str(captured.err))  # noqa
+        assert "no AssetsDefinition objects supply these keys" in captured.err
+        assert "Failed to launch assets." in result.output


### PR DESCRIPTION
## Summary & Motivation
Remove the unsightly subprocess.run stack trace from the output and just log the output from the underlying command.

## How I Tested These Changes
BK covers existing command, view process output in console when command fails

## Changelog
NOCHANGELOG