### PR TITLE
[dagster-components] Make "spec" available in scope for asset_attributes

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -1,8 +1,10 @@
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_dbt import (
@@ -12,6 +14,8 @@ from dagster_dbt import (
     DbtProject,
     dbt_assets,
 )
+from dagster_dbt.asset_utils import build_dbt_specs
+from dagster_dbt.dbt_manifest import validate_manifest
 
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
@@ -26,7 +30,11 @@ from dagster_components.resolved.core_models import (
 from dagster_components.resolved.metadata import ResolvableFieldInfo
 from dagster_components.resolved.model import FieldResolver, ResolvableModel, ResolvedFrom
 from dagster_components.scaffoldable.decorator import scaffoldable
-from dagster_components.utils import TranslatorResolvingInfo, get_wrapped_translator_class
+from dagster_components.utils import (
+    AssetSpecTranslator,
+    TranslatorResolvingInfo,
+    get_wrapped_translator_class,
+)
 
 
 class DbtProjectModel(ResolvableModel):
@@ -34,7 +42,7 @@ class DbtProjectModel(ResolvableModel):
     op: Optional[OpSpecModel] = None
     asset_attributes: Annotated[
         Optional[AssetAttributesModel],
-        ResolvableFieldInfo(required_scope={"node"}),
+        ResolvableFieldInfo(required_scope={"node", "spec"}),
     ] = None
     asset_post_processors: Optional[Sequence[AssetPostProcessorModel]] = None
     select: str = "fqn:*"
@@ -42,10 +50,39 @@ class DbtProjectModel(ResolvableModel):
 
 
 def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> DagsterDbtTranslator:
+    project = DbtProject(model.dbt.project_dir)
+    manifest = project.manifest_path
+
+    class DagsterDbtTranslatorWithSpecs(DagsterDbtTranslator, AssetSpecTranslator):
+        """dagster-dbt's asset specs are not wholly determined by the translator.
+        They're built externally, using build_dbt_specs. This class wraps the base
+        translator, while emulating a get_asset_spec method by reaching out to
+        build_dbt_specs and caching the result.
+        """
+
+        def __init__(self):
+            self._specs_map: Optional[Mapping[AssetKey, AssetSpec]] = None
+
+        def get_specs_by_key(self) -> Mapping[AssetKey, AssetSpec]:
+            if not self._specs_map:
+                specs, _ = build_dbt_specs(
+                    translator=self,
+                    manifest=validate_manifest(manifest),
+                    select=model.select,
+                    exclude=model.exclude or "",
+                    io_manager_key=None,
+                    project=project,
+                )
+                self._specs_map = {spec.key: spec for spec in specs}
+            return self._specs_map
+
+        def get_asset_spec(self, obj: Any) -> AssetSpec:
+            return self.get_specs_by_key()[self.get_asset_key(obj)]
+
     if model.asset_attributes and model.asset_attributes.deps:
         # TODO: Consider supporting alerting deps in the future
         raise ValueError("deps are not supported for dbt_project component")
-    return get_wrapped_translator_class(DagsterDbtTranslator)(
+    return get_wrapped_translator_class(DagsterDbtTranslatorWithSpecs)(
         resolving_info=TranslatorResolvingInfo(
             "node", model.asset_attributes or AssetAttributesModel(), context
         )

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -74,7 +74,7 @@ class SlingReplicationModel(ResolvableModel):
     )
     asset_attributes: Annotated[
         Optional[AssetAttributesModel],
-        ResolvableFieldInfo(required_scope={"stream_definition"}),
+        ResolvableFieldInfo(required_scope={"stream_definition", "spec"}),
     ] = Field(
         None,
         description="Customizations to the assets produced by the Sling replication.",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -285,3 +285,23 @@ def test_scaffold_sling():
         assert result.exit_code == 0
         assert Path("bar/components/qux/replication.yaml").exists()
         assert Path("bar/components/qux/component.yaml").exists()
+
+
+def test_spec_is_available_in_scope() -> None:
+    with temp_sling_component_instance(
+        [
+            {
+                "path": "./replication.yaml",
+                "asset_attributes": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
+            }
+        ]
+    ) as decl_node:
+        context = script_load_context(decl_node)
+        attrs = decl_node.get_attributes(SlingReplicationCollectionModel)
+        component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
+        defs = component.build_defs(context)
+
+        assets_def: AssetsDefinition = defs.get_assets_def("input_duckdb")
+        assert assets_def.get_asset_spec(AssetKey("input_duckdb")).metadata["asset_key"] == [
+            "input_duckdb"
+        ]


### PR DESCRIPTION
## Summary

Makes the base integration->Dagster translator spec available in components' `asset_attributes` as `spec`. This allows for user logic or udfs to reference the base spec when computing a property.

For Sling, this is quite straightforward - we just call `get_asset_spec` on the Sling translator and put the result in scope.
For dbt, things are a little sketchier - the dbt translator is not the source of truth for dbt asset specs, which are produced by the `build_dbt_specs` function. To mimic `get_asset_spec` on the translator, we subclass the base translator and implement `get_asset_spec` which calls `build_dbt_specs`.

## Test Plan

Unit tests for dbt and Sling.
