### PR TITLE
[dagster-sling] allow streaming option for SlingResource replicate function.

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -240,10 +240,10 @@ class SlingResource(ConfigurableResource):
         tmp = None
         tmp_metadata = {}
         end_time = time.time()
-        target_type = re.findall(r"writing to target ([\w\s]*) ", metadata_string)[0]
-        if target_type == "database":
+        target_type = re.findall(r"writing to target ([\w\s]*) ", metadata_string)
+        if target_type and target_type[0] == "database":
             tmp = re.findall(r"inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)", metadata_string)
-        elif target_type == "file system":
+        elif target_type and target_type[0] == "file system":
             tmp = re.findall(r"wrote ([0-9]*) rows .*to ([\w.:/;-_\"\'{}]*)", metadata_string)
         else:
             tmp = re.findall(r"inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)", metadata_string)

--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -216,10 +216,10 @@ class SlingResource(ConfigurableResource):
         return d
     
     def _query_metadata(self, metadata_string: str, start_time: float, base_metadata: Union[list,None] = None):
-        """Metadata quering using regular expression from standard sling log
+        """Metadata quering using regular expression from standard sling log.
         
         Args:
-            metadata_string (string): raw log string containing log/metadata from sling cli run
+            metadata_string (str): raw log string containing log/metadata from sling cli run
             start_time (float): start time that will be assign to calculate elapse
             base_metadata (list, Null): list of metadata to be query from string
 
@@ -264,9 +264,9 @@ class SlingResource(ConfigurableResource):
         return ANSI_ESCAPE.sub("", line).replace("INF", "")
     
     def _clean_timestamp_log(self, line: str):
-        """Remove timestamp from log gather from sling cli to reduce redundency in dagster log
+        """Remove timestamp from log gather from sling cli to reduce redundency in dagster log.
         
-        Args: 
+        Args:
             line (str): line of log gather from cli to be cleaned
         
         Returns:
@@ -435,7 +435,7 @@ class SlingResource(ConfigurableResource):
 
             ##### Old method use _run which is not streamable #####
 
-            if stream != True: 
+            if not stream: 
                 results = sling._run(  # noqa
                     cmd=cmd,
                     temp_file=temp_file,
@@ -483,7 +483,7 @@ class SlingResource(ConfigurableResource):
                 metadata_text = []
                 metadata = {}
 
-                for line in sling._exec_cmd(cmd, env=env):
+                for line in sling._exec_cmd(cmd, env=env): #noqa
                     if line == "": # if empty line -- skipped
                         continue
                     text = self._clean_timestamp_log(line) # else clean timestamp
@@ -505,7 +505,7 @@ class SlingResource(ConfigurableResource):
                         # Else search for single replication format
                         else:
                             # If found, extract stream name, stream config, asset key
-                            matched = re.findall("Sling Replication [|] .* [|] (\S*)$", text)
+                            matched = re.findall(r"Sling Replication [|] .* [|] (\S*)$", text)
                             if matched:
                                 current_stream = matched[0]
                                 current_config = replication_config.get("streams", {}).get(current_stream,{})

--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -249,9 +249,9 @@ class SlingResource(ConfigurableResource):
             tmp = re.findall(r"inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)", metadata_string)
 
         if tmp:
-            if target_type == "database":
+            if target_type and target_type[0] == "database":
                 tmp_metadata["destination_table"] = re.sub(r"[^\w\s.]", "", tmp[0][1])
-            if target_type == "file system":
+            if target_type and target_type[0] == "file system":
                 tmp_metadata["destination_file"] = re.sub(r"[^\w\s.]", "", tmp[0][1])
             tmp_metadata["elapsed_time"] = end_time - start_time
             tmp_metadata["row_count"] = tmp[0][0]
@@ -599,7 +599,8 @@ class SlingResource(ConfigurableResource):
                             logger.debug(asset_key)
                     # Else log that no stream found. This is normal for a few line. But if multiple line come up, further evaluate might be needed for other pattern
                     else:
-                        logger.debug("no match stream name")
+                        if debug:
+                            logger.debug("no match stream name")
             # If current stream is already choose
             else:
                 # Search whether the current stream ended
@@ -610,9 +611,7 @@ class SlingResource(ConfigurableResource):
                     metadata = self._query_metadata("\n".join(metadata_text), start_time=start_time)
                     start_time = time.time()
                     metadata["stream_name"] = current_stream
-                    if debug:
-                        logger.debug(metadata)
-                        logger.debug(metadata_text)
+                    logger.debug(metadata)
                     if context.has_assets_def:
                         yield MaterializeResult(asset_key=asset_key, metadata=metadata)
                     else:

--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -232,13 +232,13 @@ class SlingResource(ConfigurableResource):
         tmp = None
         tmp_metadata = {}
         end_time = time.time()
-        target_type = re.findall('writing to target ([\w\s]*) ',metadata_string)[0]
+        target_type = re.findall(r'writing to target ([\w\s]*) ',metadata_string)[0]
         if target_type == "database":
-            tmp = re.findall('inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)',metadata_string)
+            tmp = re.findall(r'inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)',metadata_string)
         elif target_type == "file system": 
-            tmp = re.findall('wrote ([0-9]*) rows .*to ([\w.:/;-_\"\'{}]*)',metadata_string)
+            tmp = re.findall(r'wrote ([0-9]*) rows .*to ([\w.:/;-_\"\'{}]*)',metadata_string)
         else: 
-            tmp = re.findall('inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)',metadata_string)
+            tmp = re.findall(r'inserted ([0-9]*) rows .*into ([\w.:/;-_\"\'{}]*)',metadata_string)
             
         if tmp:
             

--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -250,9 +250,9 @@ class SlingResource(ConfigurableResource):
 
         if tmp:
             if target_type == "database":
-                tmp_metadata["destination_table"] = tmp[0][1]
+                tmp_metadata["destination_table"] = re.sub(r"[^\w\s.]","",tmp[0][1])
             if target_type == "file system":
-                tmp_metadata["destination_file"] = tmp[0][1]
+                tmp_metadata["destination_file"] = re.sub(r"[^\w\s.]","",tmp[0][1])
             tmp_metadata["elapsed_time"] = end_time - start_time
             tmp_metadata["row_count"] = tmp[0][0]
 
@@ -437,7 +437,6 @@ class SlingResource(ConfigurableResource):
                     debug=debug,
                 )
             
-
             else:
                 #### New method use sling _exec_cmd to stream log from sling to dagster log
                 generator = self._stream_sling_replicate(
@@ -496,7 +495,6 @@ class SlingResource(ConfigurableResource):
                 )
 
         end_time = time.time()
-        os.remove(temp_file)
 
         for row in results.split("\n"):
             clean_line = self._clean_line(row)

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
@@ -1,0 +1,166 @@
+import os
+import sqlite3
+from unittest import mock
+
+from dagster import AssetExecutionContext, AssetKey, file_relative_path
+from dagster._core.definitions.materialize import materialize
+
+from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
+
+from dagster_sling import SlingReplicationParam, sling_assets
+
+
+def test_default_sling_replicate(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    from dagster_sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.orders").fetchone()[0]
+    assert counts == 4
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.employees").fetchone()[0]
+    assert counts == 4
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
+    assert counts == 4
+
+def test_streams_sling_replicate(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    from dagster_sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context, stream=True)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+        selection=[AssetKey(["target", "main", "orders"])],
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 1
+    found_asset_keys = {
+        mat.event_specific_data.materialization.asset_key  # pyright: ignore
+        for mat in asset_materializations
+    }
+    assert found_asset_keys == {AssetKey(["target", "main", "orders"])}
+
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+        selection=[
+            AssetKey(["target", "main", "employees"]),
+            AssetKey(["target", "main", "products"]),
+        ],
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 2
+    found_asset_keys = {
+        mat.event_specific_data.materialization.asset_key  # pyright: ignore
+        for mat in asset_materializations
+    }
+    assert found_asset_keys == {
+        AssetKey(["target", "main", "employees"]),
+        AssetKey(["target", "main", "products"]),
+    }
+
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.orders").fetchone()[0]
+    assert counts == 4
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.employees").fetchone()[0]
+    assert counts == 4
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
+    assert counts == 4
+
+def test_stream_sling_replicate_metadata(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    from dagster_sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context, stream=True)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+
+    assert all(["stream_name" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["elapsed_time" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["row_count" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["destination_table" in metadata for metadata in metadatas]), str(metadatas)
+
+    products_key = AssetKey(["target", "main", "products"])
+    products_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    product_name_path = os.path.join(path_name,"Products.csv")
+
+    assert products_metadata["stream_name"].value == f"file://{product_name_path}"
+    assert products_metadata["row_count"].value == '4'
+    assert products_metadata["destination_table"].value == "main.products"

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
@@ -1,12 +1,8 @@
 import os
 import sqlite3
-from unittest import mock
 
 from dagster import AssetExecutionContext, AssetKey, file_relative_path
 from dagster._core.definitions.materialize import materialize
-
-from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
-
 from dagster_sling import SlingReplicationParam, sling_assets
 
 
@@ -46,6 +42,7 @@ def test_default_sling_replicate(
     assert counts == 4
     counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
     assert counts == 4
+
 
 def test_streams_sling_replicate(
     csv_to_sqlite_dataworks_replication: SlingReplicationParam,
@@ -111,6 +108,7 @@ def test_streams_sling_replicate(
     counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
     assert counts == 4
 
+
 def test_stream_sling_replicate_metadata(
     csv_to_sqlite_dataworks_replication: SlingReplicationParam,
     path_to_temp_sqlite_db: str,
@@ -159,8 +157,8 @@ def test_stream_sling_replicate_metadata(
     path_name = os.path.abspath(
         file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
     )
-    product_name_path = os.path.join(path_name,"Products.csv")
+    product_name_path = os.path.join(path_name, "Products.csv")
 
     assert products_metadata["stream_name"].value == f"file://{product_name_path}"
-    assert products_metadata["row_count"].value == '4'
+    assert products_metadata["row_count"].value == "4"
     assert products_metadata["destination_table"].value == "main.products"


### PR DESCRIPTION
## Summary & Motivation

This pull request add streaming option for SlingResource Replicate function 

motivation:
Old dagster sling method doesn't support streaming sling log to dagster log and push that information only after sling complete. This makes it hard to track pipelines process in real time.  Furthermore, asset materialization only happens after sling complete all streams. This might make it vulnerable to longer jobs that fail after some pipeline complete causing differentiated between asset metadata and real data in the database (only possibility not sure if real problem observed yet.) 

New streaming option was developed with these two limitations in mind. Optional streaming offers a possibility to stream output to log in real time solving first problem. Also, the method is developed so that asset materialized as soon as sling execution succeeded for each stream. Metadata for each materialization is extract from sling log using regular expression. Multiple scenarios were test during the development. Nevertheless, I believe that some problem may arise in specific situation, thus further testing should be performed before it is set to be default method.

By default, this optional flag is set to False. So, the previous method is used unless specify to prevent breaking change.

## How I Tested These Changes

First, I test it by trying default flag on my personal pipeline project to prevent any breaking changes.
Next, streaming was set to true for some pipelines to test its capability in various pipeline types.
Types of pipelines used during testing including File (s3) to File (local), File (s3) to DB (duckdb), DB (mysql) to File (local), DB (mysql) to DB (duckdb).
Scenerio used to run including manual trigger of single and combined multiple streams in one run.
Also pytest was run before and after the change to confirm that there is not any increased error due to implement.
Finally, ruff was used to check and fix a problem regarding code format. 

## Changelog

- Add streaming optional parameter for SlingResource Replicate
- Defualt parameter to False for stability reason.
- Add support for streaming in replicate and _replicate utilizing sling._exec_cmd method.
- The new method stream log from sling cli, preprocess and output to dagster log in realtime.
- The new method also support sequentially materialize an asset as soon as the sling complete execution without depending on other stream.