### PR TITLE
[Asset Graph] Show an indeterminate loading bar instead of un-rendering graph and showing spinner.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -148,13 +148,14 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
 export function indexedDBAsyncMemoize<R, U extends (...args: any[]) => Promise<R>>(
   fn: U,
   hashFn?: (...args: Parameters<U>) => any,
+  key?: string,
 ): U & {
   isCached: (...args: Parameters<U>) => Promise<boolean>;
 } {
   let lru: ReturnType<typeof cache<R>> | undefined;
   try {
     lru = cache<R>({
-      dbName: 'indexDBAsyncMemoizeDB',
+      dbName: `indexDBAsyncMemoizeDB${key}`,
       maxCount: 50,
     });
   } catch {}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -3,6 +3,7 @@ import LRU from 'lru-cache';
 
 import {timeByParts} from './timeByParts';
 import {cache} from '../util/idb-lru-cache';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 function twoDigit(v: number) {
   return `${v < 10 ? '0' : ''}${v}`;
@@ -144,11 +145,11 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
   }) as any;
 }
 
-export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise<R>>(
+export function indexedDBAsyncMemoize<T extends any[], R, U extends (...args: T) => Promise<R>>(
   fn: U,
-  hashFn?: (arg: T, ...rest: any[]) => any,
+  hashFn?: (...args: any[]) => any,
 ): U & {
-  isCached: (arg: T, ...rest: any[]) => Promise<boolean>;
+  isCached: (...args: any[]) => Promise<boolean>;
 } {
   let lru: ReturnType<typeof cache<R>> | undefined;
   try {
@@ -160,8 +161,8 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
 
   const hashToPromise: Record<string, Promise<R>> = {};
 
-  async function genHashKey(arg: T, ...rest: any[]) {
-    const hash = hashFn ? hashFn(arg, ...rest) : arg;
+  const genHashKey = weakMapMemoize(async (...args: T) => {
+    const hash = hashFn ? hashFn(...args) : args;
 
     const encoder = new TextEncoder();
     // Crypto.subtle isn't defined in insecure contexts... fallback to using the full string as a key
@@ -173,11 +174,11 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
       return hashArray.map((b) => b.toString(16).padStart(2, '0')).join(''); // convert bytes to hex string
     }
     return hash.toString();
-  }
+  });
 
-  const ret = (async (arg: T, ...rest: any[]) => {
+  const ret = (async (...args: T) => {
     return new Promise<R>(async (resolve, reject) => {
-      const hashKey = await genHashKey(arg, ...rest);
+      const hashKey = await genHashKey(...args);
       if (lru && (await lru.has(hashKey))) {
         const entry = await lru.get(hashKey);
         const value = entry?.value;
@@ -189,7 +190,7 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
         return;
       } else if (!hashToPromise[hashKey]) {
         hashToPromise[hashKey] = new Promise(async (res) => {
-          const result = await fn(arg, ...rest);
+          const result = await fn(...args);
           // Resolve the promise before storing the result in IndexedDB
           res(result);
           if (lru) {
@@ -201,34 +202,14 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
       resolve(await hashToPromise[hashKey]!);
     });
   }) as any;
-  ret.isCached = async (arg: T, ...rest: any) => {
-    const hashKey = await genHashKey(arg, ...rest);
+  ret.isCached = async (...args: T) => {
+    const hashKey = await genHashKey(...args);
     if (!lru) {
       return false;
     }
     return await lru.has(hashKey);
   };
   return ret;
-}
-
-// Simple memoization function for methods that take a single object argument.
-// Returns a memoized copy of the provided function which retrieves the result
-// from a cache after the first invocation with a given object.
-//
-// Uses WeakMap to tie the lifecycle of the cache to the lifecycle of the
-// object argument.
-export function weakmapMemoize<T extends object, R>(
-  fn: (arg: T, ...rest: any[]) => R,
-): (arg: T, ...rest: any[]) => R {
-  const cache = new WeakMap();
-  return (arg: T, ...rest: any[]) => {
-    if (cache.has(arg)) {
-      return cache.get(arg);
-    }
-    const r = fn(arg, ...rest);
-    cache.set(arg, r);
-    return r;
-  };
 }
 
 export function assertUnreachable(value: never): never {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -15,7 +15,7 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import * as React from 'react';
-import {useCallback, useLayoutEffect, useMemo, useState} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {AssetGraphAssetSelectionInput} from 'shared/asset-graph/AssetGraphAssetSelectionInput.oss';
 import {useAssetGraphExplorerFilters} from 'shared/asset-graph/useAssetGraphExplorerFilters.oss';
@@ -60,10 +60,10 @@ import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
 import {DEFAULT_MAX_ZOOM} from '../graph/SVGConsts';
 import {SVGViewport, SVGViewportRef} from '../graph/SVGViewport';
-import {SVGViewportProvider} from '../graph/SVGViewportContext';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
 import {AssetGroupSelector} from '../graphql/types';
+import {usePreviousDistinctValue} from '../hooks/usePrevious';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {
@@ -80,7 +80,8 @@ import {
 } from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
-import {Loading, LoadingSpinner} from '../ui/Loading';
+import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
+import {LoadingSpinner} from '../ui/Loading';
 
 type AssetNode = AssetNodeForGraphQueryFragment;
 
@@ -105,16 +106,19 @@ export const GROUPS_ONLY_SCALE = 0.15;
 
 const DEFAULT_SET_HIDE_NODES_MATCH = (_node: AssetNodeForGraphQueryFragment) => true;
 
-export const AssetGraphExplorer = (props: Props) => {
-  const {fullAssetGraphData} = useFullAssetGraphData(props.fetchOptions);
+export const AssetGraphExplorer = React.memo((props: Props) => {
+  const {fullAssetGraphData: currentFullAssetGraphData} = useFullAssetGraphData(props.fetchOptions);
+  const previousFullAssetGraphData = usePreviousDistinctValue(currentFullAssetGraphData);
+
+  const fullAssetGraphData = currentFullAssetGraphData ?? previousFullAssetGraphData;
   const [hideNodesMatching, setHideNodesMatching] = useState(() => DEFAULT_SET_HIDE_NODES_MATCH);
 
   const {
     loading: graphDataLoading,
     fetchResult,
-    assetGraphData,
-    graphQueryItems,
-    allAssetKeys,
+    assetGraphData: currentAssetGraphData,
+    graphQueryItems: currentGraphQueryItems,
+    allAssetKeys: currentAllAssetKeys,
   } = useAssetGraphData(
     props.explorerPath.opsQuery,
     useMemo(
@@ -154,48 +158,47 @@ export const AssetGraphExplorer = (props: Props) => {
     setHideNodesMatching(() => (node: AssetNodeForGraphQueryFragment) => !filterFn(node));
   }, [filterFn]);
 
+  const previousAssetGraphData = usePreviousDistinctValue(currentAssetGraphData);
+  const previousGraphQueryItems = usePreviousDistinctValue(currentGraphQueryItems);
+  const previousAllAssetKeys = usePreviousDistinctValue(currentAllAssetKeys);
+
+  const assetGraphData = currentAssetGraphData ?? previousAssetGraphData;
+  const graphQueryItems = currentGraphQueryItems ?? previousGraphQueryItems;
+  const allAssetKeys = currentAllAssetKeys ?? previousAllAssetKeys;
+
+  if (
+    (fetchResult.loading || graphDataLoading || filteredAssetsLoading) &&
+    (!assetGraphData || !allAssetKeys)
+  ) {
+    return <LoadingSpinner purpose="page" />;
+  }
+
+  if (!assetGraphData || !allAssetKeys) {
+    return <NonIdealState icon="error" title="Query Error" />;
+  }
+
+  const hasCycles = graphHasCycles(assetGraphData);
+
+  if (hasCycles) {
+    return <NonIdealState icon="error" title="Cycle detected" />;
+  }
+
   return (
-    <SVGViewportProvider>
-      <Loading allowStaleData queryResult={fetchResult}>
-        {() => {
-          if (graphDataLoading || filteredAssetsLoading) {
-            return <LoadingSpinner purpose="page" />;
-          }
-          if (!assetGraphData || !allAssetKeys) {
-            return <NonIdealState icon="error" title="Query Error" />;
-          }
-
-          const hasCycles = graphHasCycles(assetGraphData);
-
-          if (hasCycles) {
-            return (
-              <NonIdealState
-                icon="error"
-                title="Cycle detected"
-                description="Assets dependencies form a cycle"
-              />
-            );
-          }
-          return (
-            <AssetGraphExplorerWithData
-              key={props.explorerPath.pipelineName}
-              assetGraphData={assetGraphData}
-              fullAssetGraphData={fullAssetGraphData ?? assetGraphData}
-              allAssetKeys={allAssetKeys}
-              graphQueryItems={graphQueryItems}
-              filterBar={filterBar}
-              filterButton={button}
-              kindFilter={kindFilter}
-              groupsFilter={groupsFilter}
-              loading={filteredAssetsLoading || graphDataLoading}
-              {...props}
-            />
-          );
-        }}
-      </Loading>
-    </SVGViewportProvider>
+    <AssetGraphExplorerWithData
+      key={props.explorerPath.pipelineName}
+      assetGraphData={assetGraphData}
+      fullAssetGraphData={fullAssetGraphData ?? assetGraphData}
+      allAssetKeys={allAssetKeys}
+      graphQueryItems={graphQueryItems}
+      filterBar={filterBar}
+      filterButton={button}
+      kindFilter={kindFilter}
+      groupsFilter={groupsFilter}
+      loading={filteredAssetsLoading || graphDataLoading || fetchResult.loading}
+      {...props}
+    />
   );
-};
+});
 
 type WithDataProps = Props & {
   allAssetKeys: AssetKey[];
@@ -688,7 +691,12 @@ const AssetGraphExplorerWithData = ({
     </SVGViewport>
   ) : null;
 
-  const loading = layoutLoading || dataLoading;
+  const nextLayoutLoading = layoutLoading || dataLoading;
+  const isInitialLayout = useRef(true);
+  if (!nextLayoutLoading && isInitialLayout.current) {
+    isInitialLayout.current = false;
+  }
+  const loading = (layoutLoading || dataLoading) && isInitialLayout.current;
 
   const explorer = (
     <SplitPanelContainer
@@ -705,12 +713,12 @@ const AssetGraphExplorerWithData = ({
           </LoadingContainer>
         ) : (
           <ErrorBoundary region="graph">
-            {graphQueryItems.length === 0 ? (
+            {!loading && graphQueryItems.length === 0 ? (
               <EmptyDAGNotice nodeType="asset" isGraph />
-            ) : Object.keys(assetGraphData.nodes).length === 0 ? (
+            ) : !loading && Object.keys(assetGraphData.nodes).length === 0 ? (
               <EntirelyFilteredDAGNotice nodeType="asset" />
             ) : undefined}
-            {loading || !layout ? (
+            {loading && !layout ? (
               <LoadingNotice async={async} nodeType="asset" />
             ) : (
               <AssetGraphBackgroundContextMenu
@@ -797,6 +805,15 @@ const AssetGraphExplorerWithData = ({
                   />
                 </Box>
                 {featureEnabled(FeatureFlag.flagSelectionSyntax) ? null : filterBar}
+                <IndeterminateLoadingBar
+                  $loading={nextLayoutLoading}
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    right: 0,
+                    bottom: -2,
+                  }}
+                />
               </Box>
             </TopbarWrapper>
           </ErrorBoundary>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -226,13 +226,12 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 
 type AssetNode = AssetNodeForGraphQueryFragment;
 
-const computeGraphData = indexedDBAsyncMemoize<
-  Omit<ComputeGraphDataMessageType, 'id' | 'type'>,
-  GraphDataState,
-  typeof computeGraphDataWrapper
->(computeGraphDataWrapper, (props) => {
-  return JSON.stringify(props);
-});
+const computeGraphData = indexedDBAsyncMemoize<GraphDataState, typeof computeGraphDataWrapper>(
+  computeGraphDataWrapper,
+  (props) => {
+    return JSON.stringify(props);
+  },
+);
 
 const buildGraphQueryItems = (nodes: AssetNode[]) => {
   const items: {[name: string]: AssetGraphQueryItem} = {};
@@ -391,13 +390,12 @@ async function computeGraphDataWrapper(
   return computeGraphDataImpl(props);
 }
 
-const buildGraphData = indexedDBAsyncMemoize<
-  BuildGraphDataMessageType,
-  GraphData,
-  typeof buildGraphDataWrapper
->(buildGraphDataWrapper, (props) => {
-  return JSON.stringify(props);
-});
+const buildGraphData = indexedDBAsyncMemoize<GraphData, typeof buildGraphDataWrapper>(
+  buildGraphDataWrapper,
+  (props) => {
+    return JSON.stringify(props);
+  },
+);
 
 async function buildGraphDataWrapper(
   props: Omit<BuildGraphDataMessageType, 'id' | 'type'>,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -16,7 +16,6 @@ import {AssetGraphSettingsButton, useLayoutDirectionState} from '../asset-graph/
 import {GraphData, GraphNode, groupIdForNode, toGraphId} from '../asset-graph/Utils';
 import {DEFAULT_MAX_ZOOM} from '../graph/SVGConsts';
 import {SVGViewport, SVGViewportRef} from '../graph/SVGViewport';
-import {SVGViewportProvider} from '../graph/SVGViewportContext';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {isNodeOffscreen} from '../graph/common';
 import {AssetKeyInput} from '../graphql/types';
@@ -28,11 +27,7 @@ export type AssetNodeLineageGraphProps = {
 };
 
 export const AssetNodeLineageGraph = (props: AssetNodeLineageGraphProps) => {
-  return (
-    <SVGViewportProvider>
-      <AssetNodeLineageGraphInner {...props} />
-    </SVGViewportProvider>
-  );
+  return <AssetNodeLineageGraphInner {...props} />;
 };
 
 const AssetNodeLineageGraphInner = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpEdges.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import {OpGraphLayout, OpLayout, OpLayoutEdge} from './asyncGraphLayout';
 import {OpLayoutEdgeSide, OpLayoutIO} from './layout';
 import {OpGraphOpFragment} from './types/OpGraph.types';
-import {weakmapMemoize} from '../app/Util';
 import {buildSVGPathVertical} from '../asset-graph/Utils';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 export type Edge = {a: string; b: string};
 
@@ -17,7 +17,7 @@ type Path = {
   to: OpLayoutEdgeSide;
 };
 
-const buildSVGPaths = weakmapMemoize((edges: OpLayoutEdge[], nodes: {[name: string]: OpLayout}) =>
+const buildSVGPaths = weakMapMemoize((edges: OpLayoutEdge[], nodes: {[name: string]: OpLayout}) =>
   edges
     .map(({from, to}) => {
       const source = nodes[from.opName]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -125,7 +125,7 @@ type Action =
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'loading':
-      return {loading: true, layout: null, cacheKey: ''};
+      return {loading: true, layout: state.layout, cacheKey: state.cacheKey};
     case 'layout':
       return {
         loading: false,
@@ -195,6 +195,7 @@ export function useAssetLayout(
   _graphData: GraphData,
   expandedGroups: string[],
   opts: LayoutAssetGraphOptions,
+  dataLoading?: boolean,
 ) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const flags = useFeatureFlags();
@@ -206,6 +207,9 @@ export function useAssetLayout(
   const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
   useLayoutEffect(() => {
+    if (dataLoading) {
+      return;
+    }
     let canceled = false;
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
@@ -231,7 +235,7 @@ export function useAssetLayout(
     return () => {
       canceled = true;
     };
-  }, [cacheKey, graphData, runAsync, flags, opts]);
+  }, [cacheKey, graphData, runAsync, flags, opts, dataLoading]);
 
   const uid = useRef(0);
   useDangerousRenderEffect(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
@@ -18,7 +18,7 @@ const getDifferences = <T extends Record<any, any>>(
   obj2: T | undefined,
 ): Partial<Record<keyof T, Difference<any>>> => {
   const diffs: Partial<Record<keyof T, Difference<any>>> = {};
-  Object.keys({...obj1, ...obj2}).forEach((key) => {
+  Object.keys({...(obj1 || {}), ...(obj2 || {})}).forEach((key) => {
     if (!isEqual(obj1?.[key], obj2?.[key])) {
       diffs[key as keyof T] = {previous: obj1?.[key], current: obj2?.[key]};
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
@@ -14,13 +14,13 @@ type Changes<T> = {
 };
 
 const getDifferences = <T extends Record<any, any>>(
-  obj1: T,
-  obj2: T,
+  obj1: T | undefined,
+  obj2: T | undefined,
 ): Partial<Record<keyof T, Difference<any>>> => {
   const diffs: Partial<Record<keyof T, Difference<any>>> = {};
   Object.keys({...obj1, ...obj2}).forEach((key) => {
-    if (!isEqual(obj1[key], obj2[key])) {
-      diffs[key as keyof T] = {previous: obj1[key], current: obj2[key]};
+    if (!isEqual(obj1?.[key], obj2?.[key])) {
+      diffs[key as keyof T] = {previous: obj1?.[key], current: obj2?.[key]};
     }
   });
   return diffs;

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/usePrevious.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/usePrevious.tsx
@@ -7,3 +7,16 @@ export const usePrevious = <T,>(value: T): T | undefined => {
   }, [value]);
   return ref.current;
 };
+
+export const usePreviousDistinctValue = <T,>(value: T): T | undefined => {
+  const ref = useRef<T>();
+  const prev = useRef<T>();
+
+  useEffect(() => {
+    if (ref.current !== value) {
+      prev.current = ref.current;
+      ref.current = value;
+    }
+  }, [value]);
+  return prev.current;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
@@ -2,8 +2,8 @@ import {LogFilter, LogsProviderLogs} from './LogsProvider';
 import {eventTypeToDisplayType} from './getRunFilterProviders';
 import {logNodeLevel} from './logNodeLevel';
 import {LogNode} from './types';
-import {weakmapMemoize} from '../app/Util';
 import {flattenOneLevel} from '../util/flattenOneLevel';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
   const filteredNodes = flattenOneLevel(logs.allNodeChunks).filter((node) => {
@@ -61,7 +61,7 @@ export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStep
 // different top-level keys, such as "intValue", "mdStr" and "tableSchema", and
 // the searchable text is the value of these keys.
 //
-const metadataEntryKeyValueStrings = weakmapMemoize((node: LogNode) => {
+const metadataEntryKeyValueStrings = weakMapMemoize((node: LogNode) => {
   if (!('metadataEntries' in node)) {
     return [];
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -8,6 +8,7 @@ import {
   OperationVariables,
   useApolloClient,
 } from '../apollo-client';
+import {usePreviousDistinctValue} from '../hooks/usePrevious';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {CompletionType, useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {cache} from '../util/idb-lru-cache';
@@ -161,8 +162,11 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
     }
   }, [error, dep]);
 
+  const previousData = usePreviousDistinctValue(data);
+
   return {
     data,
+    previousData,
     called: true, // Add called for compatibility with useBlockTraceOnQueryResult
     error,
     loading,


### PR DESCRIPTION
## Summary & Motivation

Currently when you change filters in the asset graph it immediately shows a spinner while it calculates the new graph. One unintended side effect of this is that in the filter menu if you check a filter we immediately show the spinner and effectively only allow you to select 1 filter at a time. To remedy this, instead of showing the spinner, lets just add an indeterminate loading bar and keep the previous graph rendered until the new one is ready. This allows users to move fast while filtering without waiting for potentially slow layout re-rendering.

## How I Tested These Changes

locally

https://github.com/user-attachments/assets/39a9147a-6a43-403d-a683-1160b42fb9b3

