### PR TITLE
[dg] Rename get_additional_scope to get_udfs

### DIFF
--- a/docs/docs/guides/labs/components/building-pipelines-with-components/customizing-components.md
+++ b/docs/docs/guides/labs/components/building-pipelines-with-components/customizing-components.md
@@ -32,16 +32,16 @@ For example, we can create a subclass of the `SlingReplicationCollectionComponen
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/debug-mode.py" language="python" />
 
-## Adding component-level templating scope
+## Adding component-level udfs
 
-By default, the scopes available for use in the template are:
+By default, the functions available for use in the template are:
 
 - `env`: A function that allows you to access environment variables.
 - `automation_condition`: A scope allowing you to access all static constructors of the `AutomationCondition` class.
 
-However, it can be useful to add additional scope options to your component type. For example, you may have a custom automation condition that you'd like to use in your component.
+However, it can be useful to add user-defined functions (udfs) options to your component type. For example, you may have a custom automation condition that you'd like to use in your component.
 
-To do so, you can define a function that returns an `AutomationCondition` and define a `get_additional_scope` method on your subclass:
+To do so, you can define a function that returns an `AutomationCondition` and define a `get_defs` method on your subclass:
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py" language="python" />
 

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -141,7 +141,7 @@ attributes:
   script_path: script.sh
   asset_specs:
     - key: a
-      partitions_def: "{{ daily_partitions }}"
+      partitions_def: "{{ daily_partitions_def() }}"
 ```
 
 ## Next steps

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -128,11 +128,11 @@ For example, we might want to provide an API client to our component, which can 
 
 The components system supports a rich templating syntax that allows you to load arbitrary Python values based off of your `component.yaml` file. All string values in a `ResolvableModel` can be templated using the Jinja2 templating engine, and may be resolved into arbitrary Python types. This allows you to expose complex object types, such as `PartitionsDefinition` or `AutomationCondition` to users of your component, even if they're working in pure YAML.
 
-You can define custom values that will be made available to the templating engine by defining a `get_additional_scope` classmethod on your component. In our case, we can define a `"daily_partitions"` function which returns a `DailyPartitionsDefinition` object with a pre-defined start date:
+You can define custom values that will be made available to the templating engine by defining a `get_udfs` classmethod on your component. In our case, we can define a `"daily_partitions"` function which returns a `DailyPartitionsDefinition` object with a pre-defined start date:
 
-<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py" language="python" />
+<CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-udf.py" language="python" />
 
-When a user instantiates this component, they will be able to use this custom scope in their `component.yaml` file:
+When a user instantiates this component, they will be able to use this udf in their `component.yaml` file:
 
 ```yaml
 component_type: my_component

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/custom-subclass/custom-scope.py
@@ -7,7 +7,7 @@ import dagster as dg
 
 
 class SubclassWithScope(SlingReplicationCollectionComponent):
-    def get_additional_scope(self) -> Mapping[str, Any]:
+    def get_udfs(self) -> Mapping[str, Any]:
         def _custom_cron(cron_schedule: str) -> dg.AutomationCondition:
             return (
                 dg.AutomationCondition.on_cron(cron_schedule)

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-udf.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-udf.py
@@ -21,6 +21,10 @@ class ShellCommandModel(ResolvableModel):
     asset_specs: Sequence[AssetSpecModel]
 
 
+def daily_partitions_def_from_jan1_2024() -> dg.DailyPartitionsDefinition:
+    return dg.DailyPartitionsDefinition(start_date="2024-01-01")
+
+
 @dataclass
 class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
@@ -29,7 +33,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     @classmethod
     def get_udfs(cls) -> Mapping[str, Any]:
         return {
-            "daily_partitions": dg.DailyPartitionsDefinition(start_date="2024-01-01")
+            "daily_partitions_def_from_20240101": daily_partitions_def_from_jan1_2024()
         }
 
     def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-udf.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-udf.py
@@ -27,7 +27,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     asset_specs: AssetSpecSequenceField
 
     @classmethod
-    def get_additional_scope(cls) -> Mapping[str, Any]:
+    def get_udfs(cls) -> Mapping[str, Any]:
         return {
             "daily_partitions": dg.DailyPartitionsDefinition(start_date="2024-01-01")
         }

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -53,7 +53,7 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_additional_scope(cls) -> Mapping[str, Any]:
+    def get_udfs(cls) -> Mapping[str, Any]:
         return {}
 
     @abstractmethod

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_decl_builder.py
@@ -161,7 +161,7 @@ class YamlComponentDecl(ComponentDeclNode):
         key = ComponentKey.from_typename(type_str)
         component_type = load_component_type(key)
         component_schema = component_type.get_schema()
-        context = context.with_rendering_scope(component_type.get_additional_scope())
+        context = context.with_rendering_scope(component_type.get_udfs())
         attributes = self.get_attributes(component_schema) if component_schema else None
         return [component_type.load(attributes, context)]
 

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -73,10 +73,7 @@ def defs_from_components(
 
     return Definitions.merge(
         *[
-            *[
-                c.build_defs(context.with_rendering_scope(c.get_additional_scope()))
-                for c in components
-            ],
+            *[c.build_defs(context.with_rendering_scope(c.get_udfs())) for c in components],
             Definitions(resources=resources),
         ]
     )

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -35,7 +35,7 @@ class MyComponent(Component, ResolvedFrom[MyComponentModel]):
         return Definitions()
 
     @classmethod
-    def get_additional_scope(cls) -> Mapping[str, Any]:
+    def get_udfs(cls) -> Mapping[str, Any]:
         return {
             "error": _error,
         }

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -122,7 +122,7 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     @dataclass
     class DebugDbtProjectComponent(DbtProjectComponent):
         @classmethod
-        def get_additional_scope(cls) -> Mapping[str, Any]:
+        def get_udfs(cls) -> Mapping[str, Any]:
             return {"get_tags_for_node": lambda node: {"model_id": node["name"].replace("_", "-")}}
 
     decl_node = YamlComponentDecl(
@@ -136,7 +136,7 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node).with_rendering_scope(
-        DebugDbtProjectComponent.get_additional_scope()
+        DebugDbtProjectComponent.get_udfs()
     )
     component = DebugDbtProjectComponent.load(
         attributes=decl_node.get_attributes(DebugDbtProjectComponent.get_schema()),  # type: ignore

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
@@ -25,7 +25,7 @@ class HasCustomScope(Component, ResolvedFrom[CustomScopeModel]):
     asset_attributes: ResolvedAssetAttributes
 
     @classmethod
-    def get_additional_scope(cls) -> Mapping[str, Any]:
+    def get_udfs(cls) -> Mapping[str, Any]:
         return {
             "custom_str": "xyz",
             "custom_dict": {"a": "b"},


### PR DESCRIPTION
## Summary & Motivation

As an intermediate step until a more sophisticated solution such as this [PR](https://app.graphite.dev/github/pr/dagster-io/dagster/28319/%5Bdg%5D-RFC-%40udf-decorator) or the suggestions within that PR, let's rename `get_additional_scope` to `get_udfs` to make that transition more natural and the functionality more clear in the short term.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG