### PR TITLE
Fix issue where code that took more than 45 seconds to load was failing the initial code server heartbeat when using dagster dev

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/slow_grpc_repo.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/slow_grpc_repo.py
@@ -1,0 +1,12 @@
+import time
+
+from dagster import asset
+
+print("WAITING 10 seconds")  # noqa
+time.sleep(10)
+print("DONE WAITING")  # noqa
+
+
+@asset
+def my_asset():
+    pass

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -567,7 +567,7 @@ def test_load_timeout():
 def test_server_heartbeat_timeout_code_server_cli() -> None:
     """Test that without a heartbeat from the calling process, the server will eventually time out."""
     port = find_free_port()
-    python_file = file_relative_path(__file__, "grpc_repo.py")
+    python_file = file_relative_path(__file__, "slow_grpc_repo.py")
 
     subprocess_args = [
         "dagster",


### PR DESCRIPTION
## Summary & Motivation
Before, we started the heartbeat clock right away, then started loading up the subprocess and loading code. If the latter took a while, the server would immediatley heartbeat fail as soon as the import finished.

## How I Tested These Changes
New test that was failing before

## Changelog
Fixed an issue where `dagster dev` would fail to load code that took more than 45 seconds to import unless the `--use-legacy-code-server-behavior` flag was used.