### PR TITLE
[components] Allow `dg --clear-cache` to work anywhere (BUILD-733)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import click
 
+from dagster_dg.cache import DgCache
 from dagster_dg.cli.check import check_group
 from dagster_dg.cli.dev import dev_command
 from dagster_dg.cli.docs import docs_group
@@ -81,7 +82,11 @@ def create_dg_cli():
             dg_context = DgContext.from_file_discovery_and_command_line_config(
                 Path.cwd(), cli_config
             )
-            dg_context.cache.clear_all()
+            # Normally we would access the cache through the DgContext, but cache is currently
+            # disabled outside of a project context. When that restriction is lifted, we will change
+            # this to access the cache through the DgContext.
+            cache = DgCache.from_config(dg_context.config)
+            cache.clear_all()
             if context.invoked_subcommand is None:
                 context.exit(0)
         elif rebuild_component_registry:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -1,6 +1,10 @@
 import subprocess
+from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
+
+import pytest
+from dagster_dg.utils import pushd
 
 from dagster_dg_tests.utils import (
     ProxyRunner,
@@ -68,18 +72,20 @@ def test_cache_no_invalidation_modified_pkg():
         assert "CACHE [hit]" in result.output
 
 
-def test_clear_cache():
+@pytest.mark.parametrize("clear_outside_project", [True, False])
+def test_clear_cache(clear_outside_project: bool):
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
         result = runner.invoke("list", "component-type")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
-        result = runner.invoke("--clear-cache")
-        assert_runner_result(result)
-        assert "CACHE [clear-all]" in result.output
-        result = runner.invoke("list", "component-type")
+        with pushd("..") if clear_outside_project else nullcontext():
+            result = runner.invoke("--clear-cache")
+            assert_runner_result(result)
+            assert "CACHE [clear-all]" in result.output
 
+        result = runner.invoke("list", "component-type")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
 


### PR DESCRIPTION
## Summary & Motivation

`dg --clear-cache` would throw an ugly error if you tried to use it outside of a project context. This PR makes it work anywhere.

## How I Tested These Changes

New unit test.