### PR TITLE
[dagster-components] Add get_passed_asset_defs util

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -16,7 +16,7 @@ from dagster_components.core.component_blueprint import (
 )
 from dagster_components.core.component_defs_builder import (
     build_component_defs as build_component_defs,
-    get_passed_assets_defs as get_passed_assets_defs,
+    get_all_passed_assets_as_assets_defs as get_all_passed_assets_as_assets_defs,
     load_defs as load_defs,
 )
 from dagster_components.resolved.context import ResolutionContext as ResolutionContext

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -124,7 +124,7 @@ def load_defs(
     return Definitions.merge(*all_defs)
 
 
-def get_passed_assets_defs(defs: Definitions) -> Sequence[AssetsDefinition]:
+def get_all_passed_assets_as_assets_defs(defs: Definitions) -> Sequence[AssetsDefinition]:
     """Returns all AssetsDefinitions associated with the Definitions object. Does not support
     CacheableAssetsDefinitions.
     """
@@ -132,7 +132,7 @@ def get_passed_assets_defs(defs: Definitions) -> Sequence[AssetsDefinition]:
         not any(
             isinstance(asset_def, CacheableAssetsDefinition) for asset_def in (defs.assets or [])
         ),
-        "Cannot call get_passed_assets_defs on a Definitions object that contains CacheableAssetsDefinitions",
+        "Cannot call get_all_passed_assets_as_assets_defs on a Definitions object that contains CacheableAssetsDefinitions",
     )
 
     return [

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_get_all_passed_assets_as_assets_defs.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_get_all_passed_assets_as_assets_defs.py
@@ -6,26 +6,26 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
-from dagster_components import get_passed_assets_defs
+from dagster_components import get_all_passed_assets_as_assets_defs
 
 
-def test_get_passed_asset_defs_all_assets_defs():
+def test_get_all_passed_assets_as_assets_defs_all_assets_defs():
     @dg.asset
     def my_asset():
         pass
 
     defs = dg.Definitions(assets=[my_asset])
-    assert get_passed_assets_defs(defs) == [my_asset]
+    assert get_all_passed_assets_as_assets_defs(defs) == [my_asset]
 
 
-def test_get_passed_asset_defs_all_asset_specs():
+def test_get_all_passed_assets_as_assets_defs_all_asset_specs():
     my_spec = dg.AssetSpec(key="my_asset")
     defs = dg.Definitions(assets=[my_spec])
-    assert len(get_passed_assets_defs(defs)) == 1
-    assert get_passed_assets_defs(defs)[0].key == my_spec.key
+    assert len(get_all_passed_assets_as_assets_defs(defs)) == 1
+    assert get_all_passed_assets_as_assets_defs(defs)[0].key == my_spec.key
 
 
-def test_get_passed_asset_defs_cacheable_assets_defs():
+def test_get_all_passed_assets_as_assets_defs_cacheable_assets_defs():
     class MyCacheableAssets(CacheableAssetsDefinition):
         def compute_cacheable_data(self):
             return [
@@ -52,19 +52,19 @@ def test_get_passed_asset_defs_cacheable_assets_defs():
     defs = dg.Definitions(assets=[MyCacheableAssets("a"), MyCacheableAssets("b")])
     with pytest.raises(
         CheckError,
-        match="Cannot call get_passed_assets_defs on a Definitions object that contains CacheableAssetsDefinitions",
+        match="Cannot call get_all_passed_assets_as_assets_defs on a Definitions object that contains CacheableAssetsDefinitions",
     ):
-        get_passed_assets_defs(defs)
+        get_all_passed_assets_as_assets_defs(defs)
 
 
-def get_passed_asset_defs_mixed():
+def get_all_passed_assets_as_assets_defs_mixed():
     @dg.asset
     def my_asset():
         pass
 
     my_spec = dg.AssetSpec(key="my_asset")
     defs = dg.Definitions(assets=[my_asset, my_spec])
-    assert {asset.key for asset in get_passed_assets_defs(defs)} == {
+    assert {asset.key for asset in get_all_passed_assets_as_assets_defs(defs)} == {
         my_asset.key,
         my_spec.key,
     }

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/_events.json
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/_events.json
@@ -1,0 +1,1 @@
+[{"eventName":"NEXT_CLI_SESSION_STOPPED","payload":{"nextVersion":"15.2.1","nodeVersion":"v21.7.3","cliCommand":"dev","durationMilliseconds":26336880,"turboFlag":false,"pagesDir":false,"appDir":true}}]

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/trace
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/trace
@@ -1,0 +1,1 @@
+[{"name":"next-dev","duration":26336943576,"timestamp":7794930815685,"id":1,"tags":{},"startTime":1741649036140,"traceId":"6ac29230950cfdac"}]


### PR DESCRIPTION
## Summary

Adds lightweight util which gets the passed list of asset defs to a `Definitions` object, ignoring any directly-passed specs, cacheable assets etc.

Lets us avoid painful casts, e.g.

```
defs = cast(Sequence[dg.AssetsDefinitions, defs.assets)
```

## Test Plan

New set of unit tests.
