### PR TITLE
[Asset graph] Hide "show upstream/downstream" options in Asset lineage page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -107,14 +107,14 @@ export const useAssetNodeMenu = ({
             }}
           />
         ) : null}
-        {upstream.length || !graphData ? (
+        {(upstream.length || !graphData) && onChangeExplorerPath ? (
           <MenuItem
             text="Show upstream graph"
             icon="arrow_back"
             onClick={() => showGraph(upstreamGraphQuery(node.assetKey))}
           />
         ) : null}
-        {downstream.length || !graphData ? (
+        {(downstream.length || !graphData) && onChangeExplorerPath ? (
           <MenuItem
             text="Show downstream graph"
             icon="arrow_forward"


### PR DESCRIPTION
## Summary & Motivation

On the lineage page for an asset we don't show the asset selection syntax input (this seems to be intentional, but maybe we should revisit this decision at some point?). Currently the "Show upstream/downstream" options relies on the asset selection syntax input to work. Since this input doesn't exist on this page the options don't actually end up doing anything. So lets just not show them in this context.

## How I Tested These Changes

manual testing:
<img width="1728" alt="Screenshot 2025-03-10 at 2 39 33 PM" src="https://github.com/user-attachments/assets/ca62cadb-5fec-4882-b67c-af92337dac1d" />
