### PR TITLE
Remove psutil dependency from dagster-dg

### DIFF
--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -38,7 +38,6 @@ setup(
         "typing_extensions>=4.4.0,<5",
         "markdown",
         "jsonschema",
-        "psutil",
         "PyYAML>=5.1",
         "rich",
         "watchdog",
@@ -57,6 +56,7 @@ setup(
         "test": [
             "click",
             "dagster-components",
+            "psutil",
             "pydantic",
             "pytest",
         ],


### PR DESCRIPTION
## Summary & Motivation
psutil is a heavy dependency, and SIGTERM seems to work just as well as SIGINT for terminating the dagster dev process.

## How I Tested These Changes
BK, run uv tool run dg dev and terminate it with a signal -15 from the command line

