### PR TITLE
[dagster-fivetran] Remove default group_name in build_fivetran_assets_definitions

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -834,7 +834,6 @@ def build_fivetran_assets_definitions(
             connector_id=connector_id,
             workspace=workspace,
             name=connector_id,
-            group_name=connector_id,
             dagster_fivetran_translator=dagster_fivetran_translator,
             connector_selector_fn=connector_selector_fn,
         )


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-913.

Setting a default group name on multi assets in `build_fivetran_assets_definitions` prevents users from customizing their group names later.

## How I Tested These Changes

Additional test to cover this specific use case, BK

