### PR TITLE
[dagster-airbyte] Remove default group_name in build_airbyte_assets_definitions

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1128,7 +1128,6 @@ def build_airbyte_assets_definitions(
             connection_id=connection_id,
             workspace=workspace,
             name=clean_name(connection_name),
-            group_name=clean_name(connection_name),
             dagster_airbyte_translator=dagster_airbyte_translator,
         )
         def _asset_fn(context: AssetExecutionContext, airbyte: AirbyteCloudWorkspace):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
@@ -162,3 +162,30 @@ def test_translator_custom_metadata(
         assert asset_spec.key.path == ["test_connection", "test_prefix_test_stream"]
         assert has_kind(asset_spec.tags, "airbyte")
         assert has_kind(asset_spec.tags, TEST_DESTINATION_TYPE)
+
+
+class MyAssetFactoryCustomTranslator(DagsterAirbyteTranslator):
+    def get_asset_spec(self, data: AirbyteConnectionTableProps) -> AssetSpec:
+        default_spec = super().get_asset_spec(data)
+        return default_spec.replace_attributes(group_name="my_group_name")
+
+
+def test_translator_custom_group_name_with_asset_factory(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ(
+        {"AIRBYTE_CLIENT_ID": TEST_CLIENT_ID, "AIRBYTE_CLIENT_SECRET": TEST_CLIENT_SECRET}
+    ):
+        workspace = AirbyteCloudWorkspace(
+            workspace_id=TEST_WORKSPACE_ID,
+            client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+            client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
+        )
+
+        my_airbyte_assets = build_airbyte_assets_definitions(
+            workspace=workspace, dagster_airbyte_translator=MyAssetFactoryCustomTranslator()
+        )
+
+        first_assets_def = next(assets_def for assets_def in my_airbyte_assets)
+        first_asset_spec = next(asset_spec for asset_spec in first_assets_def.specs)
+        assert first_asset_spec.group_name == "my_group_name"


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-914.

Setting a default group name on multi assets in `build_airbyte_assets_definitions` prevents users from customizing their group names later.

## How I Tested These Changes

Additional test to cover this specific use case, BK