### PR TITLE
patch: fallback to `data` dbt log properties when creating asset event

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -343,7 +343,6 @@ class DbtCliEventMessage:
 
         node_resource_type: str = event_node_info["resource_type"]
         # if model materialization is incremental microbatch, node_status property is "None", hence fall back to status
-        print(f'raw_event.data.status: {self.raw_event["data"]["status"]}, event_node_info.node_status: {event_node_info["node_status"]}')
         node_status: str = self.raw_event["data"]["status"].lower() if event_node_info["node_status"] == "None" else event_node_info["node_status"]
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -341,6 +341,7 @@ class DbtCliEventMessage:
 
         node_resource_type: str = event_node_info["resource_type"]
         # if model materialization is incremental microbatch, node_status property is "None", hence fall back to status
+        print(f'raw_event.data.status: {self.raw_event["data"]["status"]}, event_node_info.node_status: {event_node_info["node_status"]}')
         node_status: str = self.raw_event["data"]["status"].lower() if event_node_info["node_status"] == "None" else event_node_info["node_status"]
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -332,18 +332,24 @@ class DbtCliEventMessage:
             "invocation_id": invocation_id,
         }
 
-        if event_node_info.get("node_started_at") and event_node_info.get("node_finished_at"):
+        if event_node_info.get("node_started_at") == "" and event_node_info.get("node_finished_at") == "":
+            # if model materialization is incremental microbatch, node_started_at and node_finished_at are empty strings
+            # and require fallback to data.execution_time
+            default_metadata["Execution Duration"] = self.raw_event["data"]["execution_time"]
+        elif event_node_info.get("node_started_at") and event_node_info.get("node_finished_at"):
             started_at = dateutil.parser.isoparse(event_node_info["node_started_at"])
             finished_at = dateutil.parser.isoparse(event_node_info["node_finished_at"])
             default_metadata["Execution Duration"] = (finished_at - started_at).total_seconds()
-        else:
-            default_metadata["Execution Duration"] = self.raw_event["data"]["execution_time"]
 
         has_asset_def: bool = bool(context and context.has_assets_def)
 
         node_resource_type: str = event_node_info["resource_type"]
         # if model materialization is incremental microbatch, node_status property is "None", hence fall back to status
-        node_status: str = self.raw_event["data"]["status"].lower() if event_node_info["node_status"] == "None" else event_node_info["node_status"]
+        node_status: str = (
+            self.raw_event["data"]["status"].lower()
+            if event_node_info["node_status"] == "None"
+            else event_node_info["node_status"]
+        )
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 
         is_node_ephemeral = node_materialization == "ephemeral"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -332,7 +332,10 @@ class DbtCliEventMessage:
             "invocation_id": invocation_id,
         }
 
-        if event_node_info.get("node_started_at") == "" and event_node_info.get("node_finished_at") == "":
+        if (
+                event_node_info.get("node_started_at") in ["", "None", None] and
+                event_node_info.get("node_finished_at") in ["", "None", None]
+        ):
             # if model materialization is incremental microbatch, node_started_at and node_finished_at are empty strings
             # and require fallback to data.execution_time
             default_metadata["Execution Duration"] = self.raw_event["data"]["execution_time"]
@@ -347,7 +350,7 @@ class DbtCliEventMessage:
         # if model materialization is incremental microbatch, node_status property is "None", hence fall back to status
         node_status: str = (
             self.raw_event["data"]["status"].lower()
-            if event_node_info["node_status"] == "None"
+            if event_node_info["node_status"] in ["", "None", None]
             else event_node_info["node_status"]
         )
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -336,6 +336,8 @@ class DbtCliEventMessage:
             started_at = dateutil.parser.isoparse(event_node_info["node_started_at"])
             finished_at = dateutil.parser.isoparse(event_node_info["node_finished_at"])
             default_metadata["Execution Duration"] = (finished_at - started_at).total_seconds()
+        else:
+            default_metadata["Execution Duration"] = self.raw_event["data"]["execution_time"]
 
         has_asset_def: bool = bool(context and context.has_assets_def)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -340,8 +340,8 @@ class DbtCliEventMessage:
         has_asset_def: bool = bool(context and context.has_assets_def)
 
         node_resource_type: str = event_node_info["resource_type"]
-        # if model materialization is incremental microbatch, node_status property is None, hence fall back to status
-        node_status: str = event_node_info["node_status"] or self.raw_event["data"]["status"].lower()
+        # if model materialization is incremental microbatch, node_status property is "None", hence fall back to status
+        node_status: str = self.raw_event["data"]["status"].lower() if event_node_info["node_status"] == "None" else event_node_info["node_status"]
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 
         is_node_ephemeral = node_materialization == "ephemeral"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -332,10 +332,9 @@ class DbtCliEventMessage:
             "invocation_id": invocation_id,
         }
 
-        if (
-                event_node_info.get("node_started_at") in ["", "None", None] and
-                event_node_info.get("node_finished_at") in ["", "None", None]
-        ):
+        if event_node_info.get("node_started_at") in ["", "None", None] and event_node_info.get(
+            "node_finished_at"
+        ) in ["", "None", None]:
             # if model materialization is incremental microbatch, node_started_at and node_finished_at are empty strings
             # and require fallback to data.execution_time
             default_metadata["Execution Duration"] = self.raw_event["data"]["execution_time"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -340,7 +340,8 @@ class DbtCliEventMessage:
         has_asset_def: bool = bool(context and context.has_assets_def)
 
         node_resource_type: str = event_node_info["resource_type"]
-        node_status: str = event_node_info["node_status"]
+        # if model materialization is incremental microbatch, node_status property is None, hence fall back to status
+        node_status: str = event_node_info["node_status"] or self.raw_event["data"]["status"].lower()
         node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 
         is_node_ephemeral = node_materialization == "ephemeral"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
@@ -1,0 +1,196 @@
+from datetime import datetime
+
+from dagster import FloatMetadataValue
+from dagster_dbt.core.dbt_cli_event import DbtCliEventMessage
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+
+def test_microbatch_log_model_result_to_asset():
+    """Microbatch models do not produce reliable data.node_info.node_started_at, data.node_info.node_finished_at and
+    data.node_info.node_status, so we need to fall back to data.execution_time and data.status.
+
+    Below is an example of LogModelResult produced by an actual dbt==1.9.1 executed against Snowflake.
+    """
+    microbatch_log_model_result = {
+        "data": {
+            "description": "sql microbatch model public.orders",
+            "execution_time": 10.905523,
+            "index": 1,
+            "node_info": {
+                "materialized": "incremental",
+                "node_finished_at": "",
+                "node_name": "public__orders",
+                "node_path": "mart/public__orders.sql",
+                "node_relation": {
+                    "alias": "order_history",
+                    "database": "dev",
+                    "relation_name": "dev.public.order_history",
+                    "schema": "public",
+                },
+                "node_started_at": "",
+                "node_status": "None",
+                "resource_type": "model",
+                "unique_id": "model.pytest_dwh.public__orders",
+            },
+            "status": "SUCCESS",
+            "total": 1,
+        },
+        "info": {
+            "category": "",
+            "code": "Q012",
+            "extra": {},
+            "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+            "level": "info",
+            "msg": "1 of 1 OK created sql microbatch model public.orders  [\u001b[32mSUCCESS\u001b[0m in 10.91s]",
+            "name": "LogModelResult",
+            "pid": 14277,
+            "thread": "MainThread",
+            "ts": "2025-03-10T12:54:41.369662Z",
+        },
+    }
+
+    microbatch_event_history_metadata = {
+        "metadata": {
+            "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+            "generated_at": "2025-03-10T12:54:41.369662Z",
+            "env": {},
+        },
+        "logs": [],
+    }
+
+    event_message = DbtCliEventMessage(
+        raw_event=microbatch_log_model_result,
+        event_history_metadata=microbatch_event_history_metadata,
+    )
+
+    dagster_dbt_translator = DagsterDbtTranslator()
+
+    manifest = {
+        "metadata": {
+            "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+            "generated_at": "2025-03-10T12:54:41.369662Z",
+        },
+        "nodes": {
+            "model.pytest_dwh.public__orders": {
+                "unique_id": "model.pytest_dwh.public__orders",
+                "name": "public__orders",
+                "resource_type": "model",
+                "materialized": "incremental",
+                "database": "dev",
+                "schema": "public",
+                "alias": "order_history",
+                "path": "mart/public__orders.sql",
+                "config": {"schema": "public"},
+            }
+        },
+    }
+
+    asset_materialization_event = next(
+        event_message.to_default_asset_events(manifest, dagster_dbt_translator)
+    )
+
+    assert asset_materialization_event.metadata.get("Execution Duration") == FloatMetadataValue(
+        value=10.905523
+    )
+
+
+def test_incremental_log_model_result_to_asset():
+    """Incremental models produce logs with reliable data.node_info.node_started_at, data.node_info.node_finished_at and
+    data.node_info.node_status, so there's no need for a patch -- we expect Execution Duration to be calculated as
+    (node_finished_at - node_started_at) instead of sourcing it from data.execution_time.
+
+    Below is an example of LogModelResult produced by an actual dbt==1.9.1 executed against Snowflake.
+    """
+    incremental_log_model_result = {
+        "data": {
+            "description": "sql incremental model public.orders",
+            "execution_time": 11.995666,
+            "index": 1,
+            "node_info": {
+                "materialized": "incremental",
+                "node_finished_at": "2025-03-10T12:53:48.818126",
+                "node_name": "public__orders",
+                "node_path": "mart/public__orders.sql",
+                "node_relation": {
+                    "alias": "order_history",
+                    "database": "dev",
+                    "relation_name": "dev.public.order_history",
+                    "schema": "public",
+                },
+                "node_started_at": "2025-03-10T12:53:36.820592",
+                "node_status": "success",
+                "resource_type": "model",
+                "unique_id": "model.pytest_dwh.public__orders",
+            },
+            "status": "SUCCESS 0",
+            "total": 1,
+        },
+        "info": {
+            "category": "",
+            "code": "Q012",
+            "extra": {},
+            "invocation_id": "3f0b2ff3-e708-4a86-a81d-eb348f7d2faa",
+            "level": "info",
+            "msg": "1 of 1 OK created sql incremental model public.orders .......... [\u001b[32mSUCCESS 0\u001b[0m in 12.00s]",
+            "name": "LogModelResult",
+            "pid": 14251,
+            "thread": "Thread-1 (worker)",
+            "ts": "2025-03-10T12:53:48.825332Z",
+        },
+    }
+
+    incremental_event_history_metadata = {
+        "metadata": {
+            "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+            "generated_at": "2025-03-10T12:54:41.369662Z",
+            "env": {},
+        },
+        "logs": [],
+    }
+
+    event_message = DbtCliEventMessage(
+        raw_event=incremental_log_model_result,
+        event_history_metadata=incremental_event_history_metadata,
+    )
+
+    dagster_dbt_translator = DagsterDbtTranslator()
+
+    manifest = {
+        "metadata": {
+            "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+            "generated_at": "2025-03-10T12:54:41.369662Z",
+        },
+        "nodes": {
+            "model.pytest_dwh.public__orders": {
+                "unique_id": "model.pytest_dwh.public__orders",
+                "name": "public__orders",
+                "resource_type": "model",
+                "materialized": "incremental",
+                "database": "dev",
+                "schema": "public",
+                "alias": "order_history",
+                "path": "mart/public__orders.sql",
+                "config": {"schema": "public"},
+            }
+        },
+    }
+
+    asset_materialization_event = next(
+        event_message.to_default_asset_events(manifest, dagster_dbt_translator)
+    )
+
+    node_started_at = incremental_log_model_result["data"]["node_info"]["node_started_at"]
+    node_finished_at = incremental_log_model_result["data"]["node_info"]["node_finished_at"]
+    timestamp_format = "%Y-%m-%dT%H:%M:%S.%f"
+    started_at = datetime.strptime(node_started_at, timestamp_format)
+    finished_at = datetime.strptime(node_finished_at, timestamp_format)
+    execution_duration_seconds = (finished_at - started_at).total_seconds()
+
+    # this test only makes sense it data.execution_time differs from (node_finished_at - node_started_at)
+    assert incremental_log_model_result["data"]["execution_time"] != execution_duration_seconds
+
+    # we expect AssetMaterialization to source Execution Duration from (node_finished_at - node_started_at) instead of
+    # data.execution_time
+    assert asset_materialization_event.metadata.get("Execution Duration") == FloatMetadataValue(
+        value=execution_duration_seconds
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
@@ -186,7 +186,7 @@ def test_incremental_log_model_result_to_asset():
     finished_at = datetime.strptime(node_finished_at, timestamp_format)
     execution_duration_seconds = (finished_at - started_at).total_seconds()
 
-    # this test only makes sense it data.execution_time differs from (node_finished_at - node_started_at)
+    # this test only makes sense if data.execution_time differs from (node_finished_at - node_started_at)
     assert incremental_log_model_result["data"]["execution_time"] != execution_duration_seconds
 
     # we expect AssetMaterialization to source Execution Duration from (node_finished_at - node_started_at) instead of


### PR DESCRIPTION
## Summary & Motivation

There is a problem with `LogModelResult` log messages, if a model is incremental-microbatch: such logs lack `node_finished_at` and `node_status` properties. These properties are required for the freshness metrics and the fact that they are missing makes [dagster-dbt/.../dbt_cli_event.py](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py#L351) skip such logs is why they never get transformed into asset events consumed by Datadog.

## How I Tested These Changes

Tested e2e after importing this version of `dagster-dbt` into Dagster cloud, executing `dbt build` for an incremental-microbatch model in Snowflake --> I observed `ASSET_MATERIALIZATION` event being emitted.

## Changelog

> Insert changelog entry or delete this section.
