### PR TITLE
[Selection input] Reset selected index when dialog is opened/closed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -81,12 +81,15 @@ export const SelectionAutoCompleteInput = ({
 
   const [selectedIndexRef, setSelectedIndex] = useState({current: -1});
   const [showResults, _setShowResults] = useState({current: false});
+  const showResultsRef = useUpdatingRef(showResults.current);
   const setShowResults = useCallback(
-    (showResults: {current: boolean}) => {
-      selectedIndexRef.current = -1;
-      _setShowResults(showResults);
+    (nextShowResults: {current: boolean}) => {
+      if (showResultsRef.current !== nextShowResults.current) {
+        selectedIndexRef.current = -1;
+      }
+      _setShowResults(nextShowResults);
     },
-    [_setShowResults, selectedIndexRef],
+    [_setShowResults, selectedIndexRef, showResultsRef],
   );
   const [cursorPosition, setCursorPosition] = useState<number>(0);
   const [innerValue, setInnerValue] = useState(value);
@@ -316,9 +319,10 @@ export const SelectionAutoCompleteInput = ({
       showResults,
       selectedIndexRef,
       selectedItem,
+      onSelect,
       onSelectionChange,
       innerValueRef,
-      onSelect,
+      setShowResults,
       autoCompleteResults?.list.length,
     ],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -79,7 +79,15 @@ export const SelectionAutoCompleteInput = ({
   const editorRef = useRef<HTMLDivElement>(null);
   const cmInstance = useRef<CodeMirror.Editor | null>(null);
 
-  const [showResults, setShowResults] = useState({current: false});
+  const [selectedIndexRef, setSelectedIndex] = useState({current: -1});
+  const [showResults, _setShowResults] = useState({current: false});
+  const setShowResults = useCallback(
+    (showResults: {current: boolean}) => {
+      selectedIndexRef.current = -1;
+      _setShowResults(showResults);
+    },
+    [_setShowResults, selectedIndexRef],
+  );
   const [cursorPosition, setCursorPosition] = useState<number>(0);
   const [innerValue, setInnerValue] = useState(value);
   const cursorPositionRef = useUpdatingRef(cursorPosition);
@@ -92,8 +100,6 @@ export const SelectionAutoCompleteInput = ({
   const hintContainerRef = useRef<HTMLDivElement | null>(null);
 
   const focusRef = useRef(false);
-
-  const [selectedIndexRef, setSelectedIndex] = useState({current: -1});
 
   // Memoize the stringified results to avoid resetting the selected index down below
   const resultsJson = useMemo(() => {


### PR DESCRIPTION
## Summary & Motivation

Reset selected index so that if you close the dropdown and hit enter we don't end up submitting the last option you had selected when the dropdown was open.

## How I Tested These Changes

manual testing