### PR TITLE
Remove spammy log line on each initial 'dagster dev' invocation

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -524,12 +524,13 @@ class AssetDaemon(DagsterDaemon):
                 if not get_has_migrated_sensor_names(instance):
                     # Do a one-time migration to copy state from sensors with the legacy default
                     # name to the new default name
-                    self._logger.info(
-                        "Renaming any states corresponding to the legacy default name"
-                    )
-                    all_sensor_states = self._copy_default_auto_materialize_sensor_states(
-                        instance, all_sensor_states
-                    )
+                    if all_sensor_states:
+                        self._logger.info(
+                            "Renaming any states corresponding to the legacy default name"
+                        )
+                        all_sensor_states = self._copy_default_auto_materialize_sensor_states(
+                            instance, all_sensor_states
+                        )
                     set_has_migrated_sensor_names(instance)
 
                 self._checked_migrations = True


### PR DESCRIPTION
## Summary & Motivation
This is usually no longer relevant, but logs on every fresh dagster dev spinup for a new instance. Only log if it actually does any work.

## How I Tested These Changes
BK, run dagster dev locally on a fresh instance

## Changelog
NOCHANGELOG
