### PR TITLE
[docs] Specify vercel.json trailing slash behavior

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1815,5 +1815,6 @@
       ],
       "destination": "/about/changelog"
     }
-  ]
+  ],
+  "trailingSlash": false
 }


### PR DESCRIPTION
## Summary & Motivation

https://dagsterlabs.slack.com/archives/C03ATLSRZMF/p1741698330657639

It's not recommended to leave the behavior undefined, as per https://vercel.com/docs/project-configuration#trailingslash

Another example: https://docs.dagster.io/dagster-plus/deployment/hybrid/ will 404; https://docs.dagster.io/dagster-plus/deployment/hybrid will redirect

(In the end, #28387 fixed the architecture issue, but this should still be an improvement, given Vercel explicitly warns against leaving trailing slash behavior undefined.)

## Changelog

Defined the redirect behavior on the Dagster website with respect to trailing slashes to avoid broken links.