### PR TITLE
[components] Include .gitignore with "!lib" in scaffolded projects

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/.gitignore.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/.gitignore.jinja
@@ -1,0 +1,4 @@
+# Ignore any upstream gitignore pattern for "lib". This is included because "lib" is an important
+# folder in scaffolded `dg` projects, but "lib" is also present in Github's default gitignore file
+# for Python projects.
+!lib

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -100,6 +100,7 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert Path("projects/foo-bar/foo_bar/defs").exists()
         assert Path("projects/foo-bar/foo_bar_tests").exists()
         assert Path("projects/foo-bar/pyproject.toml").exists()
+        assert Path("projects/foo-bar/.gitignore").exists()
 
         # Check project TOML content
         toml = tomlkit.parse(Path("projects/foo-bar/pyproject.toml").read_text())


### PR DESCRIPTION
## Summary & Motivation

Include `.gitignore` with "!lib" in scaffolded projects. This will override upstream ignores of "lib", which Github's default Python gitignore includes.

## How I Tested These Changes

Tweaked unit test and also manually tested that this actually works to override upstream ignores.