### PR TITLE
[dg docs][ui] Move schema after example yaml

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
@@ -20,16 +20,16 @@ export default function ComponentDetails({config}: Props) {
         <a href="#scaffolding">#</a>
       </div>
       <ComponentScaffolding componentName={config.name} />
-      <div className={styles.sectionHeader} id="schema">
-        <h2>Schema</h2>
-        <a href="#schema">#</a>
-      </div>
-      <ComponentSchema schema={config.schema} />
       <div className={styles.sectionHeader} id="example">
         <h2>Example YAML</h2>
         <a href="#example">#</a>
       </div>
       <ComponentExample yaml={config.example} />
+      <div className={styles.sectionHeader} id="schema">
+        <h2>Schema</h2>
+        <a href="#schema">#</a>
+      </div>
+      <ComponentSchema schema={config.schema} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Move example up on the page, since schema is a huge unweildy json blob right now.
