### PR TITLE
[dg] Allow for non-components to be loaded and listed as library-objects

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -1,11 +1,14 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 from dagster import _check as check
 from dagster._record import record
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from dagster_components.core.component import ScaffolderMetadata
 
 # Type variable for generic class handling
 T = TypeVar("T")
@@ -79,6 +82,11 @@ class Scaffolder:
     @classmethod
     def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
         return None
+
+    @classmethod
+    def get_metadata(cls) -> "ScaffolderMetadata":
+        params_schema = cls.get_scaffold_params()
+        return {"schema": params_schema.model_json_schema() if params_schema else None}
 
     @abstractmethod
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -1,5 +1,5 @@
 """Sample local components for testing validation. Paired with test cases
-in integration_tests/components/validation.
+in integration_tests/integration_test_defs/validation.
 """
 
 from collections.abc import Mapping

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -46,22 +46,21 @@ def test_list_library_objects_from_module():
     ]
 
     assert result["dagster_test.components.SimpleAssetComponent"] == {
-        "objtype": "component-type",
-        "schema": {
-            "additionalProperties": False,
-            "properties": {
-                "asset_key": {"title": "Asset Key", "type": "string"},
-                "value": {"title": "Value", "type": "string"},
+        "component_type": {
+            "schema": {
+                "additionalProperties": False,
+                "properties": {
+                    "asset_key": {"title": "Asset Key", "type": "string"},
+                    "value": {"title": "Value", "type": "string"},
+                },
+                "required": ["asset_key", "value"],
+                "title": "SimpleAssetComponentModel",
+                "type": "object",
             },
-            "required": ["asset_key", "value"],
-            "title": "SimpleAssetComponentModel",
-            "type": "object",
+            "description": "A simple asset that returns a constant string value.",
+            "summary": "A simple asset that returns a constant string value.",
         },
-        "description": "A simple asset that returns a constant string value.",
-        "name": "SimpleAssetComponent",
-        "namespace": "dagster_test.components",
-        "scaffolder": None,
-        "summary": "A simple asset that returns a constant string value.",
+        "scaffolder": {"schema": None},
     }
 
     pipes_script_params_schema = {
@@ -75,13 +74,12 @@ def test_list_library_objects_from_module():
     }
 
     assert result["dagster_test.components.SimplePipesScriptComponent"] == {
-        "objtype": "component-type",
-        "name": "SimplePipesScriptComponent",
-        "namespace": "dagster_test.components",
-        "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
-        "description": "A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
+        "component_type": {
+            "schema": pipes_script_params_schema,
+            "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
+            "description": "A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
+        },
         "scaffolder": {"schema": pipes_script_params_schema},
-        "schema": pipes_script_params_schema,
     }
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -356,7 +356,7 @@ def _create_component_scaffold_subcommand(
         json_params: Mapping[str, Any],
         **key_value_params: Any,
     ) -> None:
-        f"""Scaffold of a {component_type.name} component.
+        f"""Scaffold of a {component_key.name} component.
 
         This command must be run inside a Dagster project directory. The component scaffold will be
         placed in submodule `<project_name>.components.<COMPONENT_NAME>`.

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -22,8 +22,6 @@ class RemoteScaffolder:
 
 @dataclass
 class RemoteLibraryObject:
-    name: str
-    namespace: str
     scaffolder: Optional[RemoteScaffolder]
 
     @property
@@ -33,12 +31,12 @@ class RemoteLibraryObject:
     @staticmethod
     def from_json(json: dict[str, Any]) -> "RemoteLibraryObject":
         scaffolder = RemoteScaffolder.from_json(json.pop("scaffolder", None))
+        component_type = json.pop("component_type", None)
 
-        objtype = json.pop("objtype")
-        if objtype == "component-type":
-            return RemoteComponentType(scaffolder=scaffolder, **json)
+        if component_type:
+            return RemoteComponentType(scaffolder=scaffolder, **component_type)
         else:
-            raise ValueError(f"Unknown object type: {objtype}")
+            return RemoteLibraryObject(scaffolder=scaffolder, **json)
 
 
 @dataclass


### PR DESCRIPTION
## Summary & Motivation

This lets non-component-types get discovered within a given project. Instead of just checking for subclasses of Components, we now check for objects with `__dg_library_object__` set.

## How I Tested These Changes

## Changelog

NOCHANGELOG
