### PR TITLE
Remove components only editable flag

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -23,7 +23,6 @@ _DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
 @dg_global_options
 def init_command(
     use_editable_dagster: Optional[str],
-    use_editable_components_package_only: Optional[str],
     **global_options: object,
 ):
     """Initialize a new Dagster workspace and a first project within that workspace.
@@ -50,7 +49,6 @@ def init_command(
     workspace_config = DgRawWorkspaceConfig(
         scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
             use_editable_dagster,
-            use_editable_components_package_only,
         )
     )
 
@@ -82,7 +80,6 @@ def init_command(
             project_path,
             workspace_dg_context,
             use_editable_dagster=use_editable_dagster,
-            use_editable_components_package_only=use_editable_components_package_only,
             skip_venv=False,
             populate_cache=True,
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -61,7 +61,6 @@ def scaffold_group():
 def scaffold_workspace_command(
     name: str,
     use_editable_dagster: Optional[str],
-    use_editable_components_package_only: Optional[str],
     **global_options: object,
 ):
     """Initialize a new Dagster workspace.
@@ -80,7 +79,6 @@ def scaffold_workspace_command(
     workspace_config = DgRawWorkspaceConfig(
         scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
             use_editable_dagster,
-            use_editable_components_package_only,
         )
     )
     scaffold_workspace(name, workspace_config)
@@ -113,7 +111,6 @@ def scaffold_project_command(
     skip_venv: bool,
     populate_cache: bool,
     use_editable_dagster: Optional[str],
-    use_editable_components_package_only: Optional[str],
     **global_options: object,
 ) -> None:
     """Scaffold a Dagster project file structure and a uv-managed virtual environment scoped
@@ -152,7 +149,6 @@ def scaffold_project_command(
         abs_path,
         dg_context,
         use_editable_dagster=use_editable_dagster,
-        use_editable_components_package_only=use_editable_components_package_only,
         skip_venv=skip_venv,
         populate_cache=populate_cache,
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/shared_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/shared_options.py
@@ -135,22 +135,6 @@ EDITABLE_DAGSTER_OPTIONS = {
                 " the location of the local Dagster clone will be read from the `DAGSTER_GIT_REPO_DIR` environment variable."
             ),
         ),
-        click.Option(
-            ["--use-editable-components-package-only"],
-            type=str,
-            flag_value="TRUE",
-            is_flag=False,
-            default=None,
-            hidden=True,
-            help=(
-                "Install the `dagster-components` dependency from a local Dagster clone. Accepts a path to local Dagster clone root or"
-                " may be set as a flag (no value is passed). If set as a flag,"
-                " the location of the local Dagster clone will be read from the `DAGSTER_GIT_REPO_DIR` environment variable."
-                " The reason this flag exists is to mimic the environment into which `dagster-components` and `dagster-dg` are released."
-                " They are released on a separate cadence from the main Dagster package, so in the wild they will always use the latest published Dagster version."
-                " `dagster-dg` unit tests should use environments constructed with this option."
-            ),
-        ),
     ]
 }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -285,17 +285,12 @@ class DgRawWorkspaceProjectSpec(TypedDict, total=False):
 @dataclass
 class DgWorkspaceScaffoldProjectOptions:
     use_editable_dagster: Union[str, bool] = False
-    use_editable_components_package_only: Union[str, bool] = False
 
     @classmethod
     def from_raw(cls, raw: "DgRawWorkspaceNewProjectOptions") -> Self:
         return cls(
             use_editable_dagster=raw.get(
                 "use_editable_dagster", DgWorkspaceScaffoldProjectOptions.use_editable_dagster
-            ),
-            use_editable_components_package_only=raw.get(
-                "use_editable_components_package_only",
-                DgWorkspaceScaffoldProjectOptions.use_editable_components_package_only,
             ),
         )
 
@@ -305,25 +300,17 @@ class DgWorkspaceScaffoldProjectOptions:
     def get_raw_from_cli(
         cls,
         use_editable_dagster: Optional[str],
-        use_editable_components_package_only: Optional[str],
     ) -> "DgRawWorkspaceNewProjectOptions":
         raw_scaffold_project_options: DgRawWorkspaceNewProjectOptions = {}
         if use_editable_dagster:
             raw_scaffold_project_options["use_editable_dagster"] = (
                 True if use_editable_dagster == "TRUE" else use_editable_dagster
             )
-        if use_editable_components_package_only:
-            raw_scaffold_project_options["use_editable_components_package_only"] = (
-                True
-                if use_editable_components_package_only == "TRUE"
-                else use_editable_components_package_only
-            )
         return raw_scaffold_project_options
 
 
 class DgRawWorkspaceNewProjectOptions(TypedDict, total=False):
     use_editable_dagster: Union[str, bool]
-    use_editable_components_package_only: Union[str, bool]
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -72,15 +72,12 @@ def scaffold_project(
     path: Path,
     dg_context: DgContext,
     use_editable_dagster: Optional[str],
-    use_editable_components_package_only: Optional[str],
     skip_venv: bool = False,
     populate_cache: bool = True,
 ) -> None:
     click.echo(f"Creating a Dagster project at {path}.")
 
-    cli_options = DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
-        use_editable_dagster, use_editable_components_package_only
-    )
+    cli_options = DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(use_editable_dagster)
     workspace_options = (
         dg_context.config.workspace.scaffold_project_options
         if dg_context.config.workspace
@@ -91,16 +88,8 @@ def scaffold_project(
         "use_editable_dagster",
         workspace_options.use_editable_dagster if workspace_options else None,
     )
-    final_use_editable_components_package_only = cli_options.get(
-        "use_editable_components_package_only",
-        workspace_options.use_editable_components_package_only if workspace_options else None,
-    )
 
-    if final_use_editable_dagster and final_use_editable_components_package_only:
-        exit_with_error(
-            "Cannot specify both --use-editable-dagster and --use-editable-components-package-only."
-        )
-    elif final_use_editable_dagster:
+    if final_use_editable_dagster:
         editable_dagster_root = (
             _get_editable_dagster_from_env()
             if final_use_editable_dagster is True
@@ -109,19 +98,7 @@ def scaffold_project(
         deps = EDITABLE_DAGSTER_DEPENDENCIES
         dev_deps = EDITABLE_DAGSTER_DEV_DEPENDENCIES
         sources = _gather_dagster_packages(Path(editable_dagster_root))
-    elif final_use_editable_components_package_only:
-        editable_dagster_root = (
-            _get_editable_dagster_from_env()
-            if final_use_editable_components_package_only is True
-            else final_use_editable_components_package_only
-        )
-        deps = EDITABLE_COMPONENTS_ONLY_DEPENDENCIES
-        dev_deps = EDITABLE_COMPONENTS_ONLY_DEV_DEPENDENCIES
-        sources = [
-            x
-            for x in _gather_dagster_packages(Path(editable_dagster_root))
-            if x.name in ("dagster-components", "dagster-test")
-        ]
+
     else:
         editable_dagster_root = None
         deps = PYPI_DAGSTER_DEPENDENCIES
@@ -188,9 +165,7 @@ EDITABLE_DAGSTER_DEPENDENCIES = (
     "dagster-components",
     "dagster-test[components]",  # we include dagster-test for testing purposes
 )
-EDITABLE_COMPONENTS_ONLY_DEPENDENCIES = ("dagster-components", "dagster-test[components]")
 EDITABLE_DAGSTER_DEV_DEPENDENCIES = ("dagster-webserver", "dagster-graphql")
-EDITABLE_COMPONENTS_ONLY_DEV_DEPENDENCIES = ("dagster-webserver",)
 PYPI_DAGSTER_DEPENDENCIES = ("dagster-components",)
 PYPI_DAGSTER_DEV_DEPENDENCIES = ("dagster-webserver",)
 
@@ -198,8 +173,8 @@ PYPI_DAGSTER_DEV_DEPENDENCIES = ("dagster-webserver",)
 def _get_editable_dagster_from_env() -> str:
     if not os.environ.get("DAGSTER_GIT_REPO_DIR"):
         exit_with_error(
-            "The `--use-editable-dagster` and `--use-editable-components-package-only` options, when used as flags,"
-            " require the `DAGSTER_GIT_REPO_DIR` environment variable to be set."
+            "The `--use-editable-dagster` option "
+            "requires the `DAGSTER_GIT_REPO_DIR` environment variable to be set."
         )
     return os.environ["DAGSTER_GIT_REPO_DIR"]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_defs_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_check_defs_command.py
@@ -22,7 +22,7 @@ def test_check_defs_workspace_context_success():
         result = runner.invoke(
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             "projects/project-1",
         )
@@ -30,7 +30,7 @@ def test_check_defs_workspace_context_success():
         result = runner.invoke(
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             "projects/project-2",
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -35,7 +35,7 @@ def test_dev_workspace_context_success(monkeypatch):
         result = runner.invoke(
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             "project-1",
         )
@@ -43,7 +43,7 @@ def test_dev_workspace_context_success(monkeypatch):
         result = runner.invoke(
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             "project-2",
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -118,4 +118,4 @@ def test_init_project_editable_dagster_no_env_var_no_value_fails(
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke("init", option, input="\nhelloworld\n")
         assert_runner_result(result, exit_0=False)
-        assert "require the `DAGSTER_GIT_REPO_DIR`" in result.output
+        assert "requires the `DAGSTER_GIT_REPO_DIR`" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -121,7 +121,7 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         # with open("projects/bar/pyproject.toml") as f:
         #     toml = tomlkit.parse(f.read())
         #
-        #     # No tool.uv.sources added without --use-editable-components-package-only
+        #     # No tool.uv.sources added without --use-editable-dagster
         #     assert "uv" not in toml["tool"]
 
         # Check cache was populated
@@ -148,7 +148,7 @@ def test_scaffold_project_inside_workspace_applies_scaffold_project_options(monk
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
     with (
         ProxyRunner.test() as runner,
-        isolated_example_workspace(runner, use_editable_components_package_only=False),
+        isolated_example_workspace(runner, use_editable_dagster=False),
     ):
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             create_toml_node(
@@ -174,9 +174,7 @@ def test_scaffold_project_outside_workspace_success(monkeypatch) -> None:
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
 
     with ProxyRunner.test() as runner, runner.isolated_filesystem(), clear_module_from_cache("bar"):
-        result = runner.invoke(
-            "scaffold", "project", "foo-bar", "--use-editable-components-package-only"
-        )
+        result = runner.invoke("scaffold", "project", "foo-bar", "--use-editable-dagster")
         assert_runner_result(result)
         assert Path("foo-bar").exists()
         assert Path("foo-bar/foo_bar").exists()
@@ -190,9 +188,7 @@ def test_scaffold_project_outside_workspace_success(monkeypatch) -> None:
         assert Path("foo-bar/uv.lock").exists()
 
 
-EditableOption: TypeAlias = Literal[
-    "--use-editable-dagster", "--use-editable-components-package-only"
-]
+EditableOption: TypeAlias = Literal["--use-editable-dagster"]
 
 
 @pytest.mark.parametrize("option", get_args(EditableOption))
@@ -208,7 +204,7 @@ def test_scaffold_project_editable_dagster_success(
         editable_args = [option, str(dagster_git_repo_dir)]
     with (
         ProxyRunner.test() as runner,
-        isolated_example_workspace(runner, use_editable_components_package_only=False),
+        isolated_example_workspace(runner, use_editable_dagster=False),
     ):
         result = runner.invoke("scaffold", "project", *editable_args, "projects/foo-bar")
         assert_runner_result(result)
@@ -296,7 +292,7 @@ def test_scaffold_project_no_populate_cache_success(monkeypatch) -> None:
             "project",
             "--no-populate-cache",
             "foo-bar",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
         )
         assert_runner_result(result)
         assert Path("foo-bar").exists()
@@ -325,7 +321,7 @@ def test_scaffold_project_no_use_dg_managed_environment_success(monkeypatch) -> 
             "project",
             "--no-use-dg-managed-environment",
             "foo-bar",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
         )
         assert_runner_result(result)
         assert Path("foo-bar").exists()
@@ -347,11 +343,11 @@ def test_scaffold_project_editable_dagster_no_env_var_no_value_fails(
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", "")
     with (
         ProxyRunner.test() as runner,
-        isolated_example_workspace(runner, use_editable_components_package_only=False),
+        isolated_example_workspace(runner, use_editable_dagster=False),
     ):
         result = runner.invoke("scaffold", "project", option, "--", "bar")
         assert_runner_result(result, exit_0=False)
-        assert "require the `DAGSTER_GIT_REPO_DIR`" in result.output
+        assert "requires the `DAGSTER_GIT_REPO_DIR`" in result.output
 
 
 def test_scaffold_project_already_exists_fails() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -141,11 +141,6 @@ def test_invalid_config_workspace():
                 Union[bool, str],
                 1,
             ],
-            [
-                "tool.dg.workspace.scaffold_project_options.use_editable_components_package_only",
-                Union[bool, str],
-                1,
-            ],
         ]
         for path, expected_type, val in cases:
             with _reset_pyproject_toml():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -64,7 +64,7 @@ def isolated_example_workspace(
     runner: Union[CliRunner, "ProxyRunner"],
     project_name: Optional[str] = None,
     create_venv: bool = False,
-    use_editable_components_package_only: bool = True,
+    use_editable_dagster: bool = True,
 ) -> Iterator[None]:
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
@@ -75,11 +75,7 @@ def isolated_example_workspace(
     ):
         result = runner.invoke(
             "init",
-            *(
-                ["--use-editable-components-package-only", dagster_git_repo_dir]
-                if use_editable_components_package_only
-                else []
-            ),
+            *(["--use-editable-dagster", dagster_git_repo_dir] if use_editable_dagster else []),
             input=f"\n{project_name or ''}\n",
         )
         assert_runner_result(result)
@@ -123,7 +119,7 @@ def isolated_example_project_foo_bar(
         args = [
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             *(["--no-use-dg-managed-environment"] if skip_venv else []),
             *(["--no-populate-cache"] if not populate_cache else []),
@@ -161,7 +157,7 @@ def isolated_example_component_library_foo_bar(
         result = runner.invoke(
             "scaffold",
             "project",
-            "--use-editable-components-package-only",
+            "--use-editable-dagster",
             dagster_git_repo_dir,
             "--skip-venv",
             "foo-bar",


### PR DESCRIPTION
Summary:
Once we are releasing components and dg in parallel with dagster, we don't need this anymore (and adding dagster-shard is not playing nicely with it). So remove the flag altogether and install everything editably.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
