### PR TITLE
[dagster-airlift] remove beta annotations from in-airflow subpackage

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/base_asset_operator.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import requests
 from airflow.models import BaseOperator
-from dagster._annotations import beta
 from requests import Response
 
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY, TASK_ID_TAG_KEY
@@ -39,7 +38,6 @@ IMPLICIT_ASSET_JOB_PREFIX = "__ASSET_JOB"
 DEFAULT_DAGSTER_RUN_STATUS_POLL_INTERVAL = 1
 
 
-@beta
 class BaseDagsterAssetsOperator(BaseOperator, ABC):
     """Interface for an operator which materializes dagster assets.
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
@@ -6,13 +6,11 @@ from typing import Any
 
 import requests
 from airflow import DAG
-from dagster._annotations import beta
 
 from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
 from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator, Context
 
 
-@beta
 class BaseProxyDAGToDagsterOperator(BaseDagsterAssetsOperator):
     """An operator base class that proxies the entire DAG's execution to Dagster assets with
     metadata that map to the DAG id used by this task.
@@ -46,7 +44,6 @@ class BaseProxyDAGToDagsterOperator(BaseDagsterAssetsOperator):
         """Builds a proxy operator from the passed-in DAG."""
 
 
-@beta
 class DefaultProxyDAGToDagsterOperator(BaseProxyDAGToDagsterOperator):
     """The default task proxying operator - which opens a blank session and expects the dagster URL to be set in the environment.
     The dagster url is expected to be set in the environment as DAGSTER_URL.

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
@@ -3,10 +3,8 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 import yaml
-from dagster._annotations import beta
 
 
-@beta
 class TaskProxiedState(NamedTuple):
     """A class to store the proxied state of a task.
 
@@ -32,7 +30,6 @@ class TaskProxiedState(NamedTuple):
         return {"id": self.task_id, "proxied": self.proxied}
 
 
-@beta
 class DagProxiedState(NamedTuple):
     """A class to store the proxied state of tasks in a dag.
 
@@ -94,7 +91,6 @@ class DagProxiedState(NamedTuple):
         return self.proxied is not None
 
 
-@beta
 class AirflowProxiedState(NamedTuple):
     """A class to store the proxied state of dags and tasks in Airflow.
     Typically, this is constructed by :py:func:`load_proxied_state_from_yaml`.
@@ -155,7 +151,6 @@ class ProxiedStateParsingError(Exception):
     pass
 
 
-@beta
 def load_proxied_state_from_yaml(proxied_yaml_path: Path) -> AirflowProxiedState:
     """Loads the proxied state from a directory of yaml files.
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/proxying_fn.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/proxying_fn.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Optional
 
 from airflow import DAG
 from airflow.models import BaseOperator
-from dagster._annotations import beta
 
 from dagster_airlift.in_airflow.dag_proxy_operator import (
     BaseProxyDAGToDagsterOperator,
@@ -16,7 +15,6 @@ from dagster_airlift.in_airflow.task_proxy_operator import (
 )
 
 
-@beta
 def proxying_to_dagster(
     *,
     global_vars: dict[str, Any],

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
@@ -6,13 +6,11 @@ from typing import Any, Callable
 
 import requests
 from airflow.models import BaseOperator
-from dagster._annotations import beta
 
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator, Context
 
 
-@beta
 class BaseProxyTaskToDagsterOperator(BaseDagsterAssetsOperator):
     """An operator that proxies task execution to Dagster assets with metadata that map to this task's dag ID and task ID.
 
@@ -46,7 +44,6 @@ class BaseProxyTaskToDagsterOperator(BaseDagsterAssetsOperator):
         return build_dagster_task(task, cls)
 
 
-@beta
 class DefaultProxyTaskToDagsterOperator(BaseProxyTaskToDagsterOperator):
     """The default task proxying operator - which opens a blank session and expects the dagster URL to be set in the environment.
     The dagster url is expected to be set in the environment as DAGSTER_URL.

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/import_script.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/import_script.py
@@ -1,0 +1,16 @@
+import_failed = False
+try:
+    import dagster as dagster
+except ImportError:
+    import_failed = True
+if not import_failed:
+    raise Exception("Importing dagster did not fail")
+
+requires_airflow = False
+try:
+    from dagster_airlift.in_airflow import AirflowProxiedState as AirflowProxiedState
+except Exception as e:
+    if "Airflow is not installed" in str(e):
+        requires_airflow = True
+if not requires_airflow:
+    raise Exception("Importing dagster_airlift.in_airflow did not fail")

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/import_script_with_airflow.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/import_script_with_airflow.py
@@ -1,0 +1,9 @@
+import_failed = False
+try:
+    import dagster as dagster
+except ImportError:
+    import_failed = True
+if not import_failed:
+    raise Exception("Importing dagster did not fail")
+
+from dagster_airlift.in_airflow import AirflowProxiedState as AirflowProxiedState

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
@@ -1,0 +1,96 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def temp_venv():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_venv = Path(temp_dir) / "venv"
+        try:
+            # Check if uv is installed
+            subprocess.run(["uv", "--version"], check=True, capture_output=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            raise Exception("uv is not installed or not in PATH")
+
+        # Create a new virtual environment using uv
+        result = subprocess.run(
+            ["uv", "venv", temp_dir_venv, "--seed"], check=True, capture_output=True, text=True
+        )
+        assert result.returncode == 0, f"Failed to create virtual environment: {result.stderr}"
+
+        # Verify the environment was created by checking if python executable exists
+        python_executable = temp_dir_venv / "bin" / "python"
+        assert python_executable.exists(), f"Python executable not found at {python_executable}"
+        # Install uv
+        uv_install_output = subprocess.run(
+            [python_executable, "-m", "pip", "install", "uv"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert (
+            uv_install_output.returncode == 0
+        ), f"Failed to install uv: {uv_install_output.stderr}"
+        yield temp_dir_venv
+
+
+def test_in_airflow_package_implicit_requirements(temp_venv: Path):
+    """The dagster-airlift[in-airflow] package has an implicit dependency on Airflow, and should be able to work without dagster installed.
+    This test news up a fresh virtualenv, installs the dagster-airlift[in-airflow] package, and ensures the following:
+    - import dagster fails
+    - import dagster_airlift.in_airflow fails with an error message indicating that Airflow is not installed
+    Then, we install Airflow properly and run a separate import script to ensure that the package works as expected, and does not require dagster to be installed.
+    """
+    path_to_package = Path(__file__).parent.parent.parent.parent
+    # install package using uv pip install
+    python_executable = temp_venv / "bin" / "python"
+    uv_entrypoint = [python_executable, "-m", "uv"]
+    install_result = subprocess.run(
+        [*uv_entrypoint, "pip", "install", "-e", ".[in-airflow]"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=path_to_package,
+    )
+    assert (
+        install_result.returncode == 0
+    ), f"Failed to install package in virtual environment: {install_result.stderr}"
+
+    uv_pip_freeze_output = subprocess.run(
+        [*uv_entrypoint, "pip", "freeze"], check=True, capture_output=True, text=True
+    )
+    assert (
+        install_result.returncode == 0
+    ), f"Failed to get pip freeze output: {uv_pip_freeze_output.stderr}"
+    assert (
+        "dagster-airlift" in uv_pip_freeze_output.stdout
+    ), "dagster-airlift not found in pip freeze output"
+
+    # Run the import script
+    import_script_path = Path(__file__).parent / "import_script.py"
+    script_result = subprocess.run(
+        [python_executable, import_script_path], check=True, capture_output=True, text=True
+    )
+    assert script_result.returncode == 0, f"Script execution failed: {script_result.stderr}"
+
+    # Install Airflow
+    airflow_install_result = subprocess.run(
+        [*uv_entrypoint, "pip", "install", "apache-airflow"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        airflow_install_result.returncode == 0
+    ), f"Failed to install Airflow: {airflow_install_result.stderr}"
+
+    import_airflow_script_path = Path(__file__).parent / "import_script_with_airflow.py"
+    airflow_script_result = subprocess.run(
+        [python_executable, import_airflow_script_path], check=True, capture_output=True, text=True
+    )
+    assert (
+        airflow_script_result.returncode == 0
+    ), f"Script execution failed: {airflow_script_result.stderr}"


### PR DESCRIPTION
## Summary & Motivation
Beta annotations were creating an implicit dependency on dagster from within the `in-airflow` subpackage.

This is the second time this has happened unintentionally. To ensure it doesn't happen again, I've added a new test which news up a fresh uv venv, and ensures that the airflow-only install path works correctly.

## How I Tested These Changes
New unit test

## Changelog
- [dagster-airlift] APIs from within the `[in-airflow]` submodule have had the beta banner removed.
