### PR TITLE
Fix reconstruction metadata routing through DefinitionsLoadContext

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reconstruction_metadata.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reconstruction_metadata.py
@@ -1,0 +1,84 @@
+import inspect
+import os
+import textwrap
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any, Callable
+
+from dagster._core.instance_for_test import instance_for_test
+from dagster_graphql.test.utils import define_out_of_process_context, materialize_assets
+
+_STATE_BACKED_DEFINITIONS_TEST_LOG_FILE_VAR = "DAGSTER_STATE_BACKED_DEFINITIONS_TEST_LOG_FILE"
+
+
+def test_state_backed_defs_loader(monkeypatch) -> None:
+    with NamedTemporaryFile(delete=False) as f:
+        log_file_path = f.name
+    try:
+        monkeypatch.setenv(_STATE_BACKED_DEFINITIONS_TEST_LOG_FILE_VAR, log_file_path)
+        with (
+            instance_for_test(synchronous_run_coordinator=True) as instance,
+            _temp_script(_state_backed_defs) as repo_path,
+        ):
+            with define_out_of_process_context(repo_path, None, instance) as context:
+                assert _get_num_calls(log_file_path) == 1
+                materialize_assets(context)
+                assert _get_num_calls(log_file_path) == 1
+    finally:
+        os.unlink(log_file_path)
+
+
+def _get_num_calls(log_file_path: str) -> int:
+    lines = Path(log_file_path).read_text().strip().split("\n")
+    return len(lines)
+
+
+@contextmanager
+def _temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
+    # drop the signature line
+    source = textwrap.dedent(inspect.getsource(script_fn).split("\n", 1)[1])
+    with NamedTemporaryFile(suffix=".py") as file:
+        file.write(source.encode())
+        file.flush()
+        yield file.name
+
+
+# This is written to a temporary file for the test. It is important that this is written to a
+# standalone file and not wrapped in @lazy_definitions, because we are specifically testing the
+# effects of executing this at import time.
+def _state_backed_defs() -> None:
+    import os
+
+    from dagster._core.definitions.decorators.asset_decorator import asset
+    from dagster._core.definitions.definitions_class import Definitions
+    from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
+    from dagster._record import record
+    from dagster._serdes.serdes import whitelist_for_serdes
+
+    @whitelist_for_serdes
+    @record
+    class ExampleDefState:
+        a_string: str
+
+    class ExampleStateBackedDefinitionsLoader(StateBackedDefinitionsLoader[ExampleDefState]):
+        @property
+        def defs_key(self) -> str:
+            return "test_key"
+
+        def fetch_state(self) -> ExampleDefState:
+            log_file = os.environ["DAGSTER_STATE_BACKED_DEFINITIONS_TEST_LOG_FILE"]
+            with open(log_file, "a") as f:
+                f.write("fetch_state\n")
+            return ExampleDefState(a_string="foo")
+
+        def defs_from_state(self, state: ExampleDefState) -> Definitions:
+            @asset(key=state.a_string)
+            def foo_asset(_):
+                return 1
+
+            return Definitions(assets=[foo_asset])
+
+    assets = ExampleStateBackedDefinitionsLoader().build_defs().assets
+    defs = Definitions(assets=assets)  # noqa: F841

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, cas
 
 from dagster._core.definitions.cacheable_assets import AssetsDefinitionCacheableData
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.metadata.metadata_value import (
+    CodeLocationReconstructionMetadataValue,
+)
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._serdes.serdes import PackableValue, deserialize_value, serialize_value
 
@@ -62,6 +65,11 @@ class DefinitionsLoadContext:
         """Get the current DefinitionsLoadContext."""
         cls._instance = instance
 
+    @classmethod
+    def is_set(cls) -> bool:
+        """bool: Whether the context has been set."""
+        return cls._instance is not None
+
     @property
     def load_type(self) -> DefinitionsLoadType:
         """DefinitionsLoadType: Classifier for scenario in which Definitions are being loaded."""
@@ -99,7 +107,10 @@ class DefinitionsLoadContext:
             )
         # Expose the wrapped metadata values so that users access exactly what they put in.
         return (
-            {k: v.data for k, v in self._repository_load_data.reconstruction_metadata.items()}
+            {
+                k: v.data if isinstance(v, CodeLocationReconstructionMetadataValue) else v
+                for k, v in self._repository_load_data.reconstruction_metadata.items()
+            }
             if self._repository_load_data
             else {}
         )

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -785,13 +785,38 @@ def reconstruct_repository_def_from_pointer(
         DefinitionsLoadContext,
         DefinitionsLoadType,
     )
-    from dagster._core.definitions.repository_definition import RepositoryDefinition
-
-    DefinitionsLoadContext.set(
-        DefinitionsLoadContext(
-            load_type=DefinitionsLoadType.RECONSTRUCTION, repository_load_data=repository_load_data
-        )
+    from dagster._core.definitions.repository_definition import (
+        RepositoryDefinition,
+        RepositoryLoadData,
     )
+
+    # This method is called when generating the RepositoryDefinition from a
+    # ReconstructableRepository. It is sometimes called in the initialization context, in which case
+    # we need to make sure that any data present on `pending_reconstruction_metadata` gets set as
+    # "plain" reconstruction metadata in the new context. The distinction between "pending" and
+    # "regular" reconstruction metadata on the same class is confusing and should be eliminated in a
+    # future refactor, but this is a working solution.
+    curr_context = DefinitionsLoadContext.get() if DefinitionsLoadContext.is_set() else None
+    if repository_load_data or not curr_context:
+        context = DefinitionsLoadContext(
+            load_type=DefinitionsLoadType.RECONSTRUCTION,
+            repository_load_data=repository_load_data,
+        )
+    elif curr_context.load_type == DefinitionsLoadType.INITIALIZATION:
+        curr_repo_load_data = curr_context._repository_load_data  # noqa: SLF001
+        context = DefinitionsLoadContext(
+            load_type=DefinitionsLoadType.RECONSTRUCTION,
+            repository_load_data=RepositoryLoadData(
+                cacheable_asset_data=curr_repo_load_data.cacheable_asset_data
+                if curr_repo_load_data
+                else {},
+                reconstruction_metadata=curr_context.get_pending_reconstruction_metadata(),
+            ),
+        )
+    else:
+        context = curr_context
+
+    DefinitionsLoadContext.set(context)
     target = def_from_pointer(pointer)
     repo_def = _repository_def_from_target_def_inner(
         target,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -24,6 +24,10 @@ from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 import dagster._check as check
 import dagster._seven as seven
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_load_context import (
+    DefinitionsLoadContext,
+    DefinitionsLoadType,
+)
 from dagster._core.definitions.reconstruct import ReconstructableRepository
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.errors import (
@@ -239,6 +243,13 @@ class LoadedRepositories:
         self._loadable_repository_symbols: list[LoadableRepositorySymbol] = []
 
         self._container_context = container_context
+
+        # Make sure we have a persistent load context before loading any repositories.
+        DefinitionsLoadContext.set(
+            DefinitionsLoadContext(
+                DefinitionsLoadType.INITIALIZATION,
+            )
+        )
 
         if not loadable_target_origin:
             # empty workspace

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -419,7 +419,7 @@ def test_execute_using_repository_data():
                 call_counts = instance.run_storage.get_cursor_values(
                     {"compute_cacheable_data_called", "get_definitions_called"}
                 )
-                assert call_counts.get("compute_cacheable_data_called") == "2"
+                assert call_counts.get("compute_cacheable_data_called") == "1"
 
                 assert call_counts.get("get_definitions_called") == "9"
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -168,8 +168,13 @@ def build_mapped_defs() -> Definitions:
     )
 
 
+# We need to use a different name for this instance because the reconstruction metadata key is
+# derived from the instance name, and we don't want the reconstruction metadata from the mapped defs
+# instance to clobber the reconstruction metadata from this.
+UNMAPPED_SPECS_INSTANCE_NAME = "unmapped_specs_instance"
+
 unmapped_specs = load_airflow_dag_asset_specs(
-    airflow_instance=local_airflow_instance(),
+    airflow_instance=local_airflow_instance(UNMAPPED_SPECS_INSTANCE_NAME),
     dag_selector_fn=lambda dag: dag.dag_id.startswith("unmapped"),
 )
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -285,9 +285,9 @@ def test_respect_airflow_retries(
     dagster_home: str,
 ) -> None:
     """Airflow doesn't actually have dag-level retries; only task-level retries. This test just ensures that we handle task-level retries gracefully."""
-    from kitchen_sink.dagster_defs.mapped_defs import materialize_dags
+    from kitchen_sink.dagster_defs.mapped_defs import UNMAPPED_SPECS_INSTANCE_NAME, materialize_dags
 
-    af_instance = local_airflow_instance()
+    af_instance = local_airflow_instance(UNMAPPED_SPECS_INSTANCE_NAME)
 
     dagster_instance = DagsterInstance.get()
     result = materialize(


### PR DESCRIPTION
## Summary & Motivation

Fix a longstanding regression in reconstruction metadata routing that was introduced in #25436. Prior to that PR, reconstruction metadata during initial repository load was stored on `Definitions` objects in the `metadata` field. Integrations that used the reconstruction metadata API were expected to return a `Definitions` object that would be merged into the final `Definitions` object for the code location. This final `Definitions` object would then contained the merged reconstruction metadata for any integrations using the API:

```
my_integration_resource = MyIntegrationResource(...)
integration_defs = build_my_integration_defs(my_integration_resource)

# final defs object merges together metadata from all passed in defs objects
defs = Definitions.merge(
  integration_defs,
  # ... other definitions
)
```

#25436 aimed to eliminate the restriction that integrations using reconstruction metadata needed to return `Definitions` objects, so that they could return e.g. `AssetSpecs` without any wrapper. It did this by switching the channel by which reconstruction metadata was routed from `Definitions.metadata` to `DefinitionsLoadContext`. New methods `DefinitionsLoadContext.{add,get}_pending_reconstruction_metadata` were added. The idea was that integrations would stash their reconstruction metadata on a process-scoped `DefinitionsLoadContext`. Then the final bundle of reconstruction metadata would be pulled off the global `DefinitionsLoadContext` where previously it had been pulled off the final `Definitions` object:

```
my_integration_resource = MyIntegrationResource(...)
# build_my_integration_assets modified globally available `DefinitionsLoadContext`
integration_assets = build_my_integration_assets(my_integration_resource)

# final defs object merges together metadata from all passed in defs objects
defs = Definitions.merge(
  assets=my_integration_assets,
  # ... other definitions
)
```

There was a problem-- the `DefinitionsLoadContext` object was not actually process-scoped. `DefinitionsLoadContext.get()` would return a process-scoped singleton IF `DefinitionsLoadContext.set()` had been called first. But `DefinitionsLoadContext.set()` was NOT being called as part of code server startup, because previously it didn't need to be, since we weren't persisting data on the `DefinitionsLoadContext` during the initialization phase. Consequently, `add_pending_reconstruction_metadata` was being called on a throwaway instance of `DefinitionsLoadContext`-- this silently defeated the entire purpose of the system, which is to retrieve reconstruction metadata once at code server startup and then reuse that metadata in spawned run/step processes.

The reason this wasn't caught was inadequate testing (which to be clear was the situation prior to #25436). It's not that we had _no_ test coverage, but rather than our test environment was not quite the same as the real environment. Testing that reconstruction metadata for an external integration is appropriately cached cross-process is tricky-- we need to check that an external API is only hit once across multiple processes. The tests we had in place did not do this. Instead the external API was mocked and we conducted a simulated in-process initialization and reconstruction of a repo and execution (see `test_state_derived_defs` in `dagster-powerbi` for an example).

Routing of reconstruction metadata worked on this codepath but not the real-world code path of code server -> run/step processes. This codepath continued to execute without crashing, but cached reconstruction metadata was not being passed, instead being silently refetched in each process.

A final wrinkle is that another PR from a separate author/workstream that manipulated the reconstruction metadata system, #24632, landed one day after #25436, without being aware of the changes made to metadata routing in the latter PR. But it actually worked because the old metadata routing system wasn't totally removed in 25436-- it was partially removed, but then part of it was added back in yet another PR, #25483.

The morals of this long and complicated story are to (a) not cut corners on real-life cross-process testing; (b) when replacing an old internal system with a new one, totally remove the old system.

A worthy followup would make `DefinitionsLoadContext.get()` return a singleton unless that singleton is explicitly erased. A problem with this is that during code server startup we actually use `ReconstructableRepository` after initial load (I don't fully understand why yet), leading to the need to construct a different `DefinitionsLoadContext` in "reconstruction" mode after the initialization phase of the code server process.

## How I Tested These Changes

Added a new test (in `dagster-graphql`) that spins up an actual real-life code server and run /step processes and ensures that reconstruction metadata is appropriately cached.

Also manually tested that the API is hit only once for `dagster-fivetran`, using the repro in this thread.

I did not adjust all of our integrations using reconstruction metadata to use a real-life code server cross-process test, because this would've required modifying those integrations to perform some kind of logging that could be detected cross-process. I think the test I added (which ensures reconstruction metadata gets communicated cross-process for a generic integration) coupled with the existing "simulated cross-process execution" tests for the real integrations are sufficient.

## Changelog

Fixed a bug with several integrations that caused data fetched from external APIs not to be properly cached during code server initialization, leading to unnecessary API calls in run and step worker processes. This affected: `dagster-airbyte`, `dagster-dlift`, `dagster-dbt`, `dagster-fivetran`, `dagster-looker`, `dagster-powerbi`, `dagster-sigma`, and `dagster-tableau`.
