### PR TITLE
[Selection syntax auto-complete] Make tag autocomplete replace entire value excluding any space afterwards.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
@@ -195,7 +195,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     const parentContext = ctx.parent;
     if (parentContext instanceof AttributeExpressionContext) {
       this.startReplacementIndex = parentContext.colonToken().start.startIndex + 1;
-      this.stopReplacementIndex = parentContext.stop!.stopIndex + 1;
+      this.stopReplacementIndex = parentContext.postAttributeValueWhitespace().start!.startIndex;
     }
 
     const parentChildren = ctx.parent?.children ?? [];

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
@@ -1107,7 +1107,7 @@ describe('createAssetSelectionHint', () => {
   });
 
   it('value suggestions should replace entire key=value segment in tag:key=value', () => {
-    expect(testAutocomplete('tag:k|ey=value')).toEqual({
+    expect(testAutocomplete('tag:k|ey=value or key:"test"')).toEqual({
       from: 4,
       list: [
         expect.objectContaining({text: '"key=value1"'}),
@@ -1116,7 +1116,7 @@ describe('createAssetSelectionHint', () => {
       to: 13,
     });
 
-    expect(testAutocomplete('tag:key|=value')).toEqual({
+    expect(testAutocomplete('tag:key|=value or key:"test"')).toEqual({
       from: 4,
       list: [
         expect.objectContaining({text: '"key=value1"'}),
@@ -1125,7 +1125,7 @@ describe('createAssetSelectionHint', () => {
       to: 13,
     });
 
-    expect(testAutocomplete('tag:key=|value')).toEqual({
+    expect(testAutocomplete('tag:key=|value or key:"test"')).toEqual({
       from: 4,
       list: [
         expect.objectContaining({text: '"key=value1"'}),
@@ -1133,7 +1133,7 @@ describe('createAssetSelectionHint', () => {
       ],
       to: 13,
     });
-    expect(testAutocomplete('tag:key=val|ue')).toEqual({
+    expect(testAutocomplete('tag:key=val|ue or key:"test"')).toEqual({
       from: 4,
       list: [
         expect.objectContaining({text: '"key=value1"'}),


### PR DESCRIPTION
## Summary & Motivation
as titled.

## How I Tested These Changes

jest