### PR TITLE
Pin dagster-components to dagster

### DIFF
--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -34,7 +34,10 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_components_tests*", "examples*"]),
-    install_requires=["dagster>=1.9.5", "typer"],
+    install_requires=[
+        f"dagster{pin}",
+        "typer",
+    ],
     zip_safe=False,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Summary:
Once dagster-components is being released weekly in lockstep with dagster, it should be pinned to dagster like all our other integrations.

Test Plan:
Do a dry run OSS release, check resulting pins in the release branch

