### PR TITLE
[dg] Exit properly upon not finding editor in PATH

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
@@ -29,11 +29,10 @@ def run_editor_cli_command(executable_name: str, args: list[str]) -> bytes:
 
 def recommend_yaml_extension(executable_name: str) -> None:
     if not has_editor_cli_command(executable_name):
-        click.echo(
+        raise click.ClickException(
             f"Could not find `{executable_name}` executable in PATH. In order to use the dagster-components-schema extension, "
             "please install the redhat.vscode-yaml extension manually."
         )
-        return
 
     extensions = (
         run_editor_cli_command(executable_name, ["--list-extensions"]).decode("utf-8").split("\n")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_configure_editor_commands.py
@@ -19,6 +19,7 @@ def test_utils_configure_editor(editor: str) -> None:
     with (
         ProxyRunner.test() as runner,
         TemporaryDirectory() as extension_dir,
+        mock.patch("dagster_dg.utils.editor.has_editor_cli_command", new=lambda x: True),
         mock.patch("dagster_dg.utils.editor.run_editor_cli_command", new=mock_vscode_cli_command),
         mock.patch(
             "dagster_dg.utils.editor.get_default_extension_dir",


### PR DESCRIPTION
## Summary

When the specified editor isn't found on the PATH, raises an exception rather than printing (and later failing on invocation of the command).

## Test Plan

Tested locally, verified early exit.