### PR TITLE
[Asset Selection] Make submitting an invalid query with only a single value convert to a key substring filter.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/isUnmatchedValueQuery.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/isUnmatchedValueQuery.test.ts
@@ -1,0 +1,9 @@
+import {isUnmatchedValueQuery} from '../isUnmatchedValueQuery';
+
+describe('isUnmatchedValueQuery', () => {
+  it('should return true for unmatched value queries', () => {
+    expect(isUnmatchedValueQuery('key:"value"')).toBe(false);
+    expect(isUnmatchedValueQuery('one two')).toBe(false);
+    expect(isUnmatchedValueQuery('one')).toBe(true);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
@@ -45,7 +45,7 @@ export const AssetSelectionInput = ({
   const onChange = useCallback(
     (value: string) => {
       if (parseAssetSelectionQuery([], value) instanceof Error && isUnmatchedValueQuery(value)) {
-        _onChange(`key:"${value}"`);
+        _onChange(`key:"*${value}*"`);
       } else {
         _onChange(value);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/AssetSelectionInput.oss.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import {useAssetSelectionAutoCompleteProvider as defaultUseAssetSelectionAutoCompleteProvider} from 'shared/asset-selection/input/useAssetSelectionAutoCompleteProvider.oss';
 
 import {assetSelectionSyntaxSupportedAttributes, unsupportedAttributeMessages} from './util';
@@ -8,6 +9,8 @@ import {SelectionAutoCompleteInput} from '../../selection/SelectionInput';
 import {createSelectionLinter} from '../../selection/createSelectionLinter';
 import {AssetSelectionLexer} from '../generated/AssetSelectionLexer';
 import {AssetSelectionParser} from '../generated/AssetSelectionParser';
+import {isUnmatchedValueQuery} from '../isUnmatchedValueQuery';
+import {parseAssetSelectionQuery} from '../parseAssetSelectionQuery';
 
 export interface AssetSelectionInputProps {
   assets: AssetGraphQueryItem[];
@@ -30,7 +33,7 @@ const defaultLinter = createSelectionLinter({
 
 export const AssetSelectionInput = ({
   value,
-  onChange,
+  onChange: _onChange,
   assets,
   linter = defaultLinter,
   useAssetSelectionAutoComplete = defaultUseAssetSelectionAutoCompleteProvider,
@@ -38,6 +41,17 @@ export const AssetSelectionInput = ({
   onErrorStateChange,
 }: AssetSelectionInputProps) => {
   const {useAutoComplete} = useAssetSelectionAutoComplete(assets);
+
+  const onChange = useCallback(
+    (value: string) => {
+      if (parseAssetSelectionQuery([], value) instanceof Error && isUnmatchedValueQuery(value)) {
+        _onChange(`key:"${value}"`);
+      } else {
+        _onChange(value);
+      }
+    },
+    [_onChange],
+  );
 
   return (
     <SelectionAutoCompleteInput

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/isUnmatchedValueQuery.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/isUnmatchedValueQuery.ts
@@ -1,0 +1,53 @@
+import {CharStreams, CommonTokenStream} from 'antlr4ts';
+import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
+
+import {AntlrInputErrorListener} from './parseAssetSelectionQuery';
+import {SelectionAutoCompleteLexer} from '../selection/generated/SelectionAutoCompleteLexer';
+import {
+  SelectionAutoCompleteParser,
+  UnmatchedValueContext,
+} from '../selection/generated/SelectionAutoCompleteParser';
+import {SelectionAutoCompleteVisitor} from '../selection/generated/SelectionAutoCompleteVisitor';
+
+class UnmatchedValueQueryVisitor
+  extends AbstractParseTreeVisitor<void>
+  implements SelectionAutoCompleteVisitor<void>
+{
+  public isUnmatchedValue: boolean;
+
+  defaultResult() {}
+
+  constructor(private query: string) {
+    super();
+    this.isUnmatchedValue = false;
+  }
+
+  visitUnmatchedValue(ctx: UnmatchedValueContext) {
+    if (ctx.start.startIndex === 0 && ctx.stop?.stopIndex === this.query.length - 1) {
+      // If a single attribute expression is the entire query, it's not a complex
+      this.isUnmatchedValue = true;
+    }
+  }
+}
+
+export const isUnmatchedValueQuery = (query: string) => {
+  try {
+    const lexer = new SelectionAutoCompleteLexer(CharStreams.fromString(query));
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(new AntlrInputErrorListener());
+
+    const tokenStream = new CommonTokenStream(lexer);
+
+    const parser = new SelectionAutoCompleteParser(tokenStream);
+    parser.removeErrorListeners();
+    parser.addErrorListener(new AntlrInputErrorListener());
+
+    const tree = parser.start();
+
+    const visitor = new UnmatchedValueQueryVisitor(query);
+    visitor.visit(tree);
+    return visitor.isUnmatchedValue;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary & Motivation

A lot of users are using their muscle memory and doing:
1. Type partial asset key
2. Hit enter
3. Error -> No results
4. Give up.

Lets just do the right thing for these users by automatically converting their invalid query into a valid one!

## How I Tested these changes

https://github.com/user-attachments/assets/f8533af6-81db-4b38-8e2e-ed2a6e18640e

