### PR TITLE
[dagster-components] Make "spec" available in scope for asset_attributes

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -91,7 +91,7 @@ def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> Da
                 )
                 self._specs_map[id(stream_definition)] = self.resolving_info.get_asset_spec(
                     base_spec,
-                    {self.resolving_info.obj_name: stream_definition},
+                    {self.resolving_info.obj_name: stream_definition, "spec": base_spec},
                 )
             return self._specs_map[id(stream_definition)]
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -61,7 +61,7 @@ class ComponentsDagsterSlingTranslator(DagsterSlingTranslator):
         base_spec = super().get_asset_spec(obj)
         return self.resolving_info.get_asset_spec(
             base_spec,
-            {self.resolving_info.obj_name: obj},
+            {self.resolving_info.obj_name: obj, "spec": base_spec},
         )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -311,3 +311,26 @@ def test_dependency_on_dbt_project():
     assert set(downstream_of_customers_def.asset_deps[AssetKey("downstream_of_customers")]) == {
         AssetKey("customers")
     }
+
+
+def test_spec_is_available_in_scope(dbt_path: Path) -> None:
+    decl_node = YamlComponentDecl(
+        path=dbt_path / COMPONENT_RELPATH,
+        component_file_model=ComponentFileModel(
+            type="  ",
+            attributes={
+                "dbt": {"project_dir": "jaffle_shop"},
+                "asset_attributes": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
+            },
+        ),
+    )
+    context = script_load_context(decl_node)
+    component = DbtProjectComponent.load(
+        attributes=decl_node.get_attributes(DbtProjectComponent.get_schema()),  # type: ignore
+        context=context,
+    )
+    defs = component.build_defs(script_load_context())
+    assets_def: AssetsDefinition = defs.get_assets_def(AssetKey("stg_customers"))
+    assert assets_def.get_asset_spec(AssetKey("stg_customers")).metadata["asset_key"] == [
+        "stg_customers"
+    ]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -319,3 +319,23 @@ def test_scaffold_sling():
         assert result.exit_code == 0
         assert Path("bar/components/qux/replication.yaml").exists()
         assert Path("bar/components/qux/component.yaml").exists()
+
+
+def test_spec_is_available_in_scope() -> None:
+    with temp_sling_component_instance(
+        [
+            {
+                "path": "./replication.yaml",
+                "asset_attributes": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
+            }
+        ]
+    ) as decl_node:
+        context = script_load_context(decl_node)
+        attrs = decl_node.get_attributes(SlingReplicationCollectionModel)
+        component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
+        defs = component.build_defs(context)
+
+        assets_def: AssetsDefinition = defs.get_assets_def("input_duckdb")
+        assert assets_def.get_asset_spec(AssetKey("input_duckdb")).metadata["asset_key"] == [
+            "input_duckdb"
+        ]


### PR DESCRIPTION
## Summary

Rehash of #28334 which depends on #28438 to do the heavy lifting. Now it's just a one-liner!

Makes the base `AssetSpec` generated by the underlying default Dagster translator available as scope for dbt & Sling.

## Test Plan

New unit tests.

