### PR TITLE
[SerializableErrorInfo] respect __surpress_context__

### DIFF
--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -78,7 +78,9 @@ def _serializable_error_info_from_tb(tb: traceback.TracebackException) -> Serial
         tb.stack.format(),
         tb.exc_type.__name__ if tb.exc_type is not None else None,
         _serializable_error_info_from_tb(tb.__cause__) if tb.__cause__ else None,
-        _serializable_error_info_from_tb(tb.__context__) if tb.__context__ else None,
+        _serializable_error_info_from_tb(tb.__context__)
+        if tb.__context__ and not tb.__suppress_context__
+        else None,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_errors.py
@@ -25,3 +25,33 @@ foo = bar
 SyntaxError: invalid syntax
 """
     )
+
+
+def test_from_none():
+    def _raise():
+        raise Exception("yaho")
+
+    def _wrap(from_none):
+        try:
+            _raise()
+        except:
+            if from_none:
+                raise Exception("wrapped") from None
+            else:
+                raise Exception("wrapped")
+
+    try:
+        _wrap(from_none=False)
+    except:
+        err = serializable_error_info_from_exc_info(sys.exc_info())
+
+    assert err
+    assert err.context
+
+    try:
+        _wrap(from_none=True)
+    except:
+        err = serializable_error_info_from_exc_info(sys.exc_info())
+
+    assert err
+    assert err.context is None


### PR DESCRIPTION
I figured out why `raise ... from None` was not working as expected when we went through serializable errors - we were not respecting the flag that gets set.

https://docs.python.org/3/library/exceptions.html

## How I Tested These Changes

added test

