### PR TITLE
[defs validate] hide frames for all dagster libraries

### DIFF
--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -244,8 +244,9 @@ def serializable_error_info_from_exc_info(
 
 
 DAGSTER_FRAMEWORK_SUBSTRINGS = [
-    "/site-packages/dagster/",
-    "/python_modules/dagster/dagster/",
+    "/site-packages/dagster",
+    "/python_modules/dagster",
+    "/python_modules/libraries/dagster",
 ]
 
 IMPORT_MACHINERY_SUBSTRINGS = [

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -416,4 +416,3 @@ def test_dagster_dev_command_verbose(verbose: bool) -> None:
                     )
                     == 1
                 ), contents
-                assert contents.count("dagster system frames hidden") == 2, contents

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -129,7 +129,7 @@ def test_invalid_project_truncated_properly(verbose):
                 )
                 == 1
             )
-            assert result.output.count("dagster system frames hidden") == 2
+            assert result.output.count("dagster system frames hidden") >= 1
 
 
 def test_env_var(monkeypatch):


### PR DESCRIPTION
Treat all of our code as "system frames" instead of just `dagster` module specifically

motivation was turning
https://gist.github.com/alangenfeld/73d62dce1c0b0699bcfaea33ee0113af
in to 
https://gist.github.com/alangenfeld/2f4bf5b1ba1215dd58b3854afb853ec9

## How I Tested These Changes

manual, can add test

