### PR TITLE
[dg] Update implicit definitions loading to allow for explicit Definitions objects

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Optional
 
@@ -24,24 +25,34 @@ class DefinitionsComponent(Component, ResolvableModel):
         None, description="Relative path to a file containing Dagster definitions."
     )
 
-    def _build_defs_for_path(self, context: ComponentLoadContext, defs_path: Path) -> Definitions:
-        defs_module = context.load_component_relative_python_module(defs_path)
-        defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
+    def _build_defs_for_paths(
+        self, context: ComponentLoadContext, defs_paths: Sequence[Path]
+    ) -> Definitions:
+        explicit_defs: dict[Path, Definitions] = {}
+        loaded_defs: dict[Path, Definitions] = {}
+        for defs_path in defs_paths:
+            defs_module = context.load_component_relative_python_module(defs_path)
+            defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
 
-        if defs_attrs and self.definitions_path is None:
+            if len(defs_attrs) > 1:
+                raise ValueError(
+                    f"Found multiple Definitions objects in {defs_path}. At most one Definitions object "
+                    "may be specified when using the DefinitionsComponent."
+                )
+            elif len(defs_attrs) == 1:
+                explicit_defs[defs_path] = defs_attrs[0]
+            else:
+                loaded_defs[defs_path] = load_definitions_from_module(defs_module)
+
+        if len(explicit_defs) > 1:
             raise ValueError(
-                f"Found a Definitions object in {defs_path}, which is not supported when implicitly loading definitions. "
-                "You may need to add an explicit `component.yaml` file to specify a DefinitionsComponent."
+                f"Found multiple files ({', '.join(path.name for path in explicit_defs)}) with explicit Definitions objects. "
+                "At most one Definitions object may be defined in a given directory."
             )
-        elif len(defs_attrs) > 1:
-            raise ValueError(
-                f"Found multiple Definitions objects in {defs_path}. At most one Definitions object "
-                "may be specified when using the DefinitionsComponent."
-            )
-        elif len(defs_attrs) == 1:
-            return defs_attrs[0]
+        elif len(explicit_defs) == 1:
+            return next(iter(explicit_defs.values()))
         else:
-            return load_definitions_from_module(defs_module)
+            return Definitions.merge(*loaded_defs.values())
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         defs_paths = (
@@ -50,6 +61,4 @@ class DefinitionsComponent(Component, ResolvableModel):
             else list(context.path.rglob("*.py"))
         )
 
-        return Definitions.merge(
-            *(self._build_defs_for_path(context, defs_path) for defs_path in defs_paths)
-        )
+        return self._build_defs_for_paths(context, defs_paths)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_implicit/definitions_object_multiple/defs1.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_implicit/definitions_object_multiple/defs1.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+
+@dg.asset
+def a1() -> None: ...
+
+
+defs = dg.Definitions(assets=[a1])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_implicit/definitions_object_multiple/defs2.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_implicit/definitions_object_multiple/defs2.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+
+@dg.asset
+def a2() -> None: ...
+
+
+defs = dg.Definitions(assets=[a2])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component_implicit.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_definitions_component_implicit.py
@@ -34,5 +34,13 @@ def test_definitions_component_empty() -> None:
 
 
 def test_definitions_component_with_definitions_object() -> None:
-    with pytest.raises(ValueError, match="Found a Definitions object"):
-        load_test_component_defs("definitions_implicit/definitions_object_relative_imports")
+    defs = load_test_component_defs("definitions_implicit/definitions_object_relative_imports")
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {
+        AssetKey("asset_in_some_file"),
+        AssetKey("asset_in_other_file"),
+    }
+
+
+def test_definitions_component_with_mulitple_definitions_objects() -> None:
+    with pytest.raises(ValueError, match="Found multiple files "):
+        load_test_component_defs("definitions_implicit/definitions_object_multiple")


### PR DESCRIPTION
## Summary & Motivation

Previously, we would error if you had a directory laid out like:

```
defs/
  my_stuff/
    assets.py
    definitions.py
```

where `definitions.py` contained an explicit `Definitions` object. Now, we fork between the following situations:

1. If no explicit `Definitions` objects are found in any file, we just call `load_definitions_from_module` on each path we find and merge all definitions together (same as before)
2. If a single `Definitions` object is found across all files, we will just return that object (previously, we errored)
3. If multiple `Definitions` objects are found, then we error (same as before)

## How I Tested These Changes

## Changelog

NOCHANGELOG
