### PR TITLE
[dg docs] Iteration on JSONSchema

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
@@ -20,16 +20,16 @@ export default function ComponentDetails({config}: Props) {
         <a href="#scaffolding">#</a>
       </div>
       <ComponentScaffolding componentName={config.name} />
-      <div className={styles.sectionHeader} id="example">
-        <h2>Example YAML</h2>
-        <a href="#example">#</a>
-      </div>
-      <ComponentExample yaml={config.example} />
       <div className={styles.sectionHeader} id="schema">
         <h2>Schema</h2>
         <a href="#schema">#</a>
       </div>
       <ComponentSchema schema={config.schema} />
+      <div className={styles.sectionHeader} id="example">
+        <h2>Example YAML</h2>
+        <a href="#example">#</a>
+      </div>
+      <ComponentExample yaml={config.example} />
     </div>
   );
 }

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/css/ComponentSchema.module.css
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/css/ComponentSchema.module.css
@@ -27,6 +27,8 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .expandButton {
@@ -67,6 +69,7 @@
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .propertyName {
@@ -130,6 +133,11 @@
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+}
+
+.anyOfLabel {
+  white-space: nowrap;
 }
 
 .expansion {

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/ArrayTag.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/ArrayTag.tsx
@@ -4,12 +4,10 @@ import styles from './css/ArrayTag.module.css';
 interface Props {
   items: JSONSchema7['items'];
   defs: Record<string, JSONSchema7Definition> | undefined;
-  onClick: (item: JSONSchema7Definition) => void;
 }
 
 export default function ArrayTag({items, defs}: Props) {
   const itemName = getItemName(items, defs);
-
   return <div className={styles.tag}>Array&lt;{itemName}&gt;</div>;
 }
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/TypeTag.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/TypeTag.tsx
@@ -1,14 +1,28 @@
 import clsx from 'clsx';
 import styles from './css/TypeTag.module.css';
+import {JSONSchema7TypeName} from 'json-schema';
+
+const basicTypes = new Set<JSONSchema7TypeName>([
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'array',
+  'null',
+]);
 
 interface Props {
   name: string;
-  onClick?: () => void;
 }
 
-export default function TypeTag({name, onClick}: Props) {
+export default function TypeTag({name}: Props) {
   return (
-    <button className={clsx(styles.tag, onClick ? styles.clickable : null)} onClick={onClick}>
+    <button
+      className={clsx(
+        styles.tag,
+        !basicTypes.has(name as JSONSchema7TypeName) ? styles.objectType : null,
+      )}
+    >
       {name}
     </button>
   );

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/css/TypeTag.module.css
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/schema/css/TypeTag.module.css
@@ -9,13 +9,7 @@
   color: var(--color-text-light);
 }
 
-.clickable {
+.objectType {
   background-color: var(--color-background-cyan);
   color: var(--color-text-cyan);
-  transition: background-color 0.1s linear;
-  cursor: pointer;
-}
-
-.clickable:hover {
-  background-color: var(--color-background-gray-hover);
 }


### PR DESCRIPTION
## Summary & Motivation

Some tweaks to the nested JSONSchema display, including:

- Move the schema back above the example
- Better determination of expandability
- Fix overflow and wrapping for smaller viewports

Still a little concerned about pathological nesting cases here and various flavors of schema that this might not handle fully yet, but it seems decent for the current test case.

https://github.com/user-attachments/assets/581802ec-c685-4c08-a69b-3d56fb01eaed


Would like to try this on more examples.

## How I Tested These Changes

dg docs, do some expanding/collapsing on the schema view.