### PR TITLE
[dg] Update dg project scaffold description to remove component-specific language

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -136,9 +136,9 @@ def scaffold_project_command(
     │   └── __init__.py
     └── pyproject.toml
 
-    The `<name>.components` directory holds components (which can be created with `dg scaffold
-    component`).  The `<name>.lib` directory holds custom component types scoped to the project
-    (which can be created with `dg scaffold component-type`).
+    The `<name>.lib` directory holds Python objects that can be targeted by the `dg scaffold` command or
+    have dg-inspectable metadata. Custom component types in the project live `<name>.lib. This types
+    which can be created with `dg scaffold component-type`.
     """  # noqa: D301
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)


### PR DESCRIPTION
## Summary & Motivation

The long description of this command was too component-specific

## How I Tested These Changes

```
(dagster-dev-3.11.11-2024-12-08) ➜  new_project dg scaffold project -h

 Usage: dg scaffold project [OPTIONS] PATH

 Scaffold a Dagster project file structure and a uv-managed virtual environment scoped to the project.
 This command can be run inside or outside of a workspace directory. If run inside a workspace,
 the project will be created within the workspace directory's project directory.

 The project file structure defines a Python package with some pre-existing internal
 structure:


 ├── <name>
 │   ├── __init__.py
 │   ├── defs
 │   ├── definitions.py
 │   └── lib
 │       └── __init__.py
 ├── <name>_tests
 │   └── __init__.py
 └── pyproject.toml

 The `<name>.lib` directory holds Python objects that can be targeted by the `dg scaffold` command or
 have dg-inspectable metadata. Custom component types in the project live `<name>.lib. This types
 which can be created with `dg scaffold component-type`.
```

## Changelog

NOCHANGELOG

