### PR TITLE
[Asset Graph][perf] Prepare layout worker in advance + allow only a single worker at a time

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -1,5 +1,4 @@
 import keyBy from 'lodash/keyBy';
-import memoize from 'lodash/memoize';
 import reject from 'lodash/reject';
 import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
@@ -25,6 +24,7 @@ import {AssetKey} from '../assets/types';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {useIndexedDBCachedQuery} from '../search/useIndexedDBCachedQuery';
+import {workerSpawner} from '../workers/workerSpawner';
 
 export interface AssetGraphFetchScope {
   hideEdgesToNodesOutsideQuery?: boolean;
@@ -353,23 +353,20 @@ export const ASSET_GRAPH_QUERY = gql`
   ${ASSET_NODE_FRAGMENT}
 `;
 
-const getWorker = memoize(
-  (_key: 'computeGraphWorker' | 'buildGraphWorker') =>
-    new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
+const spawnComputeGraphDataWorker = workerSpawner(
+  () => new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
 );
 
-if (typeof jest === 'undefined') {
-  // Pre-warm workers
-  getWorker('computeGraphWorker');
-  getWorker('buildGraphWorker');
-}
+const spawnBuildGraphDataWorker = workerSpawner(
+  () => new Worker(new URL('./ComputeGraphData.worker', import.meta.url)),
+);
 
 let _id = 0;
 async function computeGraphDataWrapper(
   props: Omit<ComputeGraphDataMessageType, 'id' | 'type'>,
 ): Promise<GraphDataState> {
   if (featureEnabled(FeatureFlag.flagAssetSelectionWorker)) {
-    const worker = getWorker('computeGraphWorker');
+    const worker = spawnComputeGraphDataWorker();
     return new Promise<GraphDataState>((resolve) => {
       const id = ++_id;
       const removeMessageListener = worker.onMessage((event: MessageEvent) => {
@@ -401,7 +398,7 @@ async function buildGraphDataWrapper(
   props: Omit<BuildGraphDataMessageType, 'id' | 'type'>,
 ): Promise<GraphData> {
   if (featureEnabled(FeatureFlag.flagAssetSelectionWorker)) {
-    const worker = getWorker('buildGraphWorker');
+    const worker = spawnBuildGraphDataWorker();
     return new Promise<GraphData>((resolve) => {
       const id = ++_id;
       const removeMessageListener = worker.onMessage((event: MessageEvent) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -27,7 +27,7 @@ export const getFullOpLayout = memoize(layoutOpGraph, _opLayoutCacheKey);
 
 const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraphOptions) => {
   return new Promise<OpGraphLayout>((resolve) => {
-    const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+    const worker = spawnNewLayoutWorker();
     worker.onMessage((event) => {
       resolve(event.data);
       worker.terminate();
@@ -77,7 +77,7 @@ const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
-      const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+      const worker = spawnNewLayoutWorker();
       worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
@@ -91,7 +91,7 @@ export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
 const asyncGetFullAssetLayout = asyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
-      const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+      const worker = spawnNewLayoutWorker();
       worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
@@ -101,6 +101,16 @@ const asyncGetFullAssetLayout = asyncMemoize(
   },
   _assetLayoutCacheKey,
 );
+
+let layoutWorker: Worker | null = null;
+function spawnNewLayoutWorker() {
+  // Make sure we only have one worker at a time
+  if (layoutWorker) {
+    layoutWorker.terminate();
+  }
+  layoutWorker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+  return layoutWorker;
+}
 
 // Helper Hooks:
 // - Automatically switch between sync and async loading strategies

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -102,14 +102,19 @@ const asyncGetFullAssetLayout = asyncMemoize(
   _assetLayoutCacheKey,
 );
 
-let layoutWorker: Worker | null = null;
+// Have the next layout worker ready to go
+let nextLayoutWorker: Worker | null = new Worker(
+  new URL('../workers/dagre_layout.worker', import.meta.url),
+);
+let currentLayoutWorker: Worker | null = null;
 function spawnNewLayoutWorker() {
   // Make sure we only have one worker at a time
-  if (layoutWorker) {
-    layoutWorker.terminate();
+  if (currentLayoutWorker) {
+    currentLayoutWorker.terminate();
   }
-  layoutWorker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-  return layoutWorker;
+  currentLayoutWorker = nextLayoutWorker;
+  nextLayoutWorker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+  return currentLayoutWorker;
 }
 
 // Helper Hooks:

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -9,6 +9,7 @@ import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
 import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {workerSpawner} from '../workers/workerSpawner';
 
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
@@ -27,7 +28,7 @@ export const getFullOpLayout = memoize(layoutOpGraph, _opLayoutCacheKey);
 
 const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraphOptions) => {
   return new Promise<OpGraphLayout>((resolve) => {
-    const worker = spawnNewLayoutWorker();
+    const worker = spawnLayoutWorker();
     worker.onMessage((event) => {
       resolve(event.data);
       worker.terminate();
@@ -77,7 +78,7 @@ const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
-      const worker = spawnNewLayoutWorker();
+      const worker = spawnLayoutWorker();
       worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
@@ -91,7 +92,7 @@ export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
 const asyncGetFullAssetLayout = asyncMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return new Promise<AssetGraphLayout>((resolve) => {
-      const worker = spawnNewLayoutWorker();
+      const worker = spawnLayoutWorker();
       worker.onMessage((event) => {
         resolve(event.data);
         worker.terminate();
@@ -102,21 +103,9 @@ const asyncGetFullAssetLayout = asyncMemoize(
   _assetLayoutCacheKey,
 );
 
-// Have the next layout worker ready to go
-let nextLayoutWorker: Worker | null = new Worker(
-  new URL('../workers/dagre_layout.worker', import.meta.url),
+const spawnLayoutWorker = workerSpawner(
+  () => new Worker(new URL('../workers/dagre_layout.worker', import.meta.url)),
 );
-let currentLayoutWorker: Worker | null = null;
-function spawnNewLayoutWorker() {
-  // Make sure we only have one worker at a time
-  if (currentLayoutWorker) {
-    currentLayoutWorker.terminate();
-  }
-  currentLayoutWorker = nextLayoutWorker;
-  nextLayoutWorker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-  return currentLayoutWorker;
-}
-
 // Helper Hooks:
 // - Automatically switch between sync and async loading strategies
 // - Re-layout when the cache key function returns a different value

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/workerSpawner.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/workerSpawner.ts
@@ -1,0 +1,14 @@
+import {Worker} from 'shared/workers/Worker.oss';
+export function workerSpawner(createWorker: () => Worker) {
+  let nextWorker: Worker | null = createWorker();
+  let currentWorker: Worker | null = null;
+  return function spawnNewWorker() {
+    // Make sure we only have one worker at a time
+    if (currentWorker) {
+      currentWorker.terminate();
+    }
+    currentWorker = nextWorker;
+    nextWorker = createWorker();
+    return currentWorker;
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/workerSpawner.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/workerSpawner.ts
@@ -1,6 +1,6 @@
 import {Worker} from 'shared/workers/Worker.oss';
 export function workerSpawner(createWorker: () => Worker) {
-  let nextWorker: Worker | null = createWorker();
+  let nextWorker: Worker = createWorker();
   let currentWorker: Worker | null = null;
   return function spawnNewWorker() {
     // Make sure we only have one worker at a time


### PR DESCRIPTION
## Summary & Motivation

1. Have a layout worker sitting idly by to handle next layout request asap. Improves initial load a bit.
2. Noticed locally that I had 2 layout workers spinning because the layout props changed before the previous layout completed.  In this case just terminate the previous worker before spawning the new one.

## How I Tested These Changes

local testing
