### PR TITLE
[dg docs] Change example header, lock TOC

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
@@ -26,7 +26,9 @@ export default function ComponentDetails({config}: Props) {
       </div>
       <ComponentSchema schema={config.schema} />
       <div className={styles.sectionHeader} id="example">
-        <h2>Example YAML</h2>
+        <h2>
+          Example <code>component.yaml</code>
+        </h2>
         <a href="#example">#</a>
       </div>
       <ComponentExample yaml={config.example} />

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/css/globals.css
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/css/globals.css
@@ -228,6 +228,10 @@ a {
   text-decoration: none;
 }
 
+code {
+  font-family: var(--font-geist-mono);
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/packages/[pkg]/[component]/ComponentPage.module.css
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/packages/[pkg]/[component]/ComponentPage.module.css
@@ -1,3 +1,9 @@
+.outer {
+  position: relative;
+  overflow: hidden;
+  height: 100%;
+}
+
 .container {
   display: flex;
   flex-direction: row;
@@ -5,6 +11,7 @@
   gap: 16px;
   height: 100%;
   overflow-y: auto;
+  padding-right: 300px;
 }
 
 .main {
@@ -14,11 +21,13 @@
 }
 
 .tableOfContents {
-  width: 200px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
   box-shadow: inset 1px 0 0 0 var(--color-keyline-default);
   margin-top: 24px;
   padding: 0 16px 0 16px;
-  overflow-y: auto;
 }
 
 .tableOfContents ol {

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/packages/[pkg]/[component]/page.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/packages/[pkg]/[component]/page.tsx
@@ -20,9 +20,11 @@ export default async function ComponentPage({params}: Props) {
   }
 
   return (
-    <div className={styles.container}>
-      <div className={styles.main}>
-        <ComponentDetails config={componentConfig} />
+    <div className={styles.outer}>
+      <div className={styles.container}>
+        <div className={styles.main}>
+          <ComponentDetails config={componentConfig} />
+        </div>
       </div>
       <div className={styles.tableOfContents}>
         <ol>
@@ -33,7 +35,9 @@ export default async function ComponentPage({params}: Props) {
             <a href="#schema">Schema</a>
           </li>
           <li>
-            <a href="#example">Example YAML</a>
+            <a href="#example">
+              Example <code>component.yaml</code>
+            </a>
           </li>
         </ol>
       </div>


### PR DESCRIPTION
## Summary & Motivation

- Example `component.yaml`
- Lock scrolling for TOC on the right

## How I Tested These Changes

dg docs