### PR TITLE
[dg docs] Left nav improvements

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/PackageTree.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/PackageTree.tsx
@@ -1,24 +1,7 @@
-import {Contents} from '@/util/types';
-
 import getContents from '@/util/getContents';
-import {Suspense} from 'react';
 import PackageTreeInner from '@/app/components/PackageTreeInner';
 
-interface Props {
-  contents: Contents | null;
-}
-
-export default function PackageTree({contents}: Props) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <PackageTreeInner contents={contents} />
-    </Suspense>
-  );
-}
-
-export async function getStaticProps() {
+export default async function PackageTree() {
   const contents = await getContents();
-  return {
-    props: {contents},
-  };
+  return <PackageTreeInner contents={contents} />;
 }

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/css/PackageTree.module.css
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/css/PackageTree.module.css
@@ -31,7 +31,8 @@
 }
 
 .search:focus {
-  box-shadow: var(--color-border-default) inset 0px 0px 0px 1px,
+  box-shadow:
+    var(--color-border-default) inset 0px 0px 0px 1px,
     var(--color-keyline-default) inset 2px 2px 1.5px,
     var(--color-focus-ring) 0 0 0 2px;
 }
@@ -39,6 +40,33 @@
 .treeContainer {
   padding: 12px;
   font-size: 14px;
+}
+
+.pkgItem {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  background-color: var(--color-background-default);
+  cursor: pointer;
+}
+
+.expandButton {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.expandButton .chevron {
+  transition: transform 0.1s ease-in-out;
+  transform: rotate(-90deg);
+}
+
+.expandButton.expanded .chevron {
+  transform: rotate(0deg);
 }
 
 .pkgLink {
@@ -71,17 +99,6 @@
   background-color: var(--color-background-blue);
 }
 
-.pkgLink .chevron {
-  height: 16px;
-  width: 16px;
-  transform: rotate(-90deg);
-  transition: transform 0.1s ease-in-out;
-}
-
-.expanded .chevron {
-  transform: rotate(0deg);
-}
-
 .componentList {
   display: flex;
   flex-direction: column;
@@ -94,8 +111,8 @@
   align-items: center;
   flex-direction: row;
   gap: 4px;
-  margin-left: 12px;
-  padding: 8px 12px;
+  margin-left: 20px;
+  padding: 8px 4px;
   border-radius: 8px;
   background-color: var(--color-background-default);
   user-select: none;

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/layout.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/layout.tsx
@@ -6,7 +6,6 @@ import './css/colors.css';
 import './css/globals.css';
 import styles from './css/layout.module.css';
 
-import getContents from '@/util/getContents';
 import PackageTree from '@/app/components/PackageTree';
 import Header from '@/app/components/Header';
 import clsx from 'clsx';
@@ -34,7 +33,6 @@ export default async function RootLayout({
 }: Readonly<{
   children: ReactNode;
 }>) {
-  const contents = await getContents();
   return (
     <html lang="en">
       <body className={clsx(geistSans.variable, geistMono.variable)}>
@@ -42,7 +40,7 @@ export default async function RootLayout({
           <Header />
           <div className={styles.contentContainer}>
             <div className={styles.sidebar}>
-              <PackageTree contents={contents} />
+              <PackageTree />
             </div>
             <div className={styles.main}>{children}</div>
           </div>


### PR DESCRIPTION
## Summary & Motivation

Some improvements to the dg docs left nav.

- Allow packages to be expanded/collapsed without actually navigating anywhere
- When loading a package or component page, automatically expand the left nav to show it in the package tree
- Use a different icon for the package

<img width="329" alt="Screenshot 2025-03-13 at 10 17 23" src="https://github.com/user-attachments/assets/f1f0cf9e-5eb7-4710-b02d-221edbe9916a" />


## How I Tested These Changes

TS, lint. Test left nav behavior as described, in both dev and build versions.