### PR TITLE
[dg docs] Truncate description with markdown

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentDetails.tsx
@@ -14,7 +14,7 @@ interface Props {
 export default function ComponentDetails({config}: Props) {
   return (
     <div>
-      <ComponentHeader config={config} descriptionStyle="markdown" />
+      <ComponentHeader config={config} descriptionStyle="full" />
       <div className={styles.sectionHeader} id="scaffolding">
         <h2>Scaffolding</h2>
         <a href="#scaffolding">#</a>

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentHeader.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/ComponentHeader.tsx
@@ -2,27 +2,36 @@ import {ComponentType} from '@/util/types';
 
 import styles from './css/ComponentHeader.module.css';
 import ComponentTags from '@/app/components/ComponentTags';
-import Markdown from 'react-markdown';
+import Markdown, {Components} from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import stripMarkdown from 'strip-markdown';
+import {HTMLProps} from 'react';
 
 interface Props {
   config: ComponentType;
-  descriptionStyle: 'plaintext' | 'markdown';
+  descriptionStyle: 'truncated' | 'full';
 }
 
 export default function ComponentHeader({config, descriptionStyle}: Props) {
+  const {description, name} = config;
+
+  // For truncated display, use only the first line in the description.
+  const displayedDescription =
+    descriptionStyle === 'truncated'
+      ? (description.split('\n').find((str) => str.trim().length > 0) ?? '')
+      : description;
+
   return (
     <div className={styles.container}>
       <div className={styles.heading}>
         <div className={styles.icon} />
         <div className={styles.headingContent}>
-          <h1>{config.name}</h1>
+          <h1>{name}</h1>
           <div className={styles.description}>
             <Markdown
-              remarkPlugins={descriptionStyle === 'markdown' ? [remarkGfm] : [stripMarkdown]}
+              remarkPlugins={[remarkGfm]}
+              components={descriptionStyle === 'truncated' ? componentsMinusLinks : undefined}
             >
-              {config.description}
+              {displayedDescription}
             </Markdown>
           </div>
         </div>
@@ -31,3 +40,7 @@ export default function ComponentHeader({config, descriptionStyle}: Props) {
     </div>
   );
 }
+
+const componentsMinusLinks: Components = {
+  a: ({children}: HTMLProps<HTMLAnchorElement>) => <span>{children}</span>,
+};

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/PackageDetails.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/components/PackageDetails.tsx
@@ -17,7 +17,7 @@ export default function PackageDetails({pkg}: Props) {
           key={component.name}
           className={styles.componentItem}
         >
-          <ComponentHeader config={component} descriptionStyle="plaintext" />
+          <ComponentHeader config={component} descriptionStyle="truncated" />
         </Link>
       ))}
     </div>

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/app/page.tsx
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/app/page.tsx
@@ -27,7 +27,7 @@ export default async function Home() {
           key={component.name}
           className={styles.componentItem}
         >
-          <ComponentHeader config={component} descriptionStyle="plaintext" />
+          <ComponentHeader config={component} descriptionStyle="truncated" />
         </Link>
       ))}
     </div>

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/package.json
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/package.json
@@ -17,8 +17,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
-    "strip-markdown": "^6.0.0"
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/yarn.lock
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/yarn.lock
@@ -1234,7 +1234,6 @@ __metadata:
     react-dom: "npm:^19.0.0"
     react-markdown: "npm:^10.1.0"
     remark-gfm: "npm:^4.0.1"
-    strip-markdown: "npm:^6.0.0"
     typescript: "npm:^5"
   languageName: unknown
   linkType: soft
@@ -4115,15 +4114,6 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
-  languageName: node
-  linkType: hard
-
-"strip-markdown@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "strip-markdown@npm:6.0.0"
-  dependencies:
-    "@types/mdast": "npm:^4.0.0"
-  checksum: 10c0/209b3fa4f6a0c655124143c40e7a7cf7e764cf339a1429649f8b0cb905ee165d77aff58456753edb24e02c05f1e0881aca7d775e3a162d804ea5d4b69a09a0ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Some description tweaks:

- In the package list view, truncate the config description to its first line. Use regular markdown formatting, minus anchors, since these are linked items and we want to avoid nesting an anchor within an anchor.
- In the component view, render the full markdown.

<img width="1075" alt="Screenshot 2025-03-13 at 10 30 16" src="https://github.com/user-attachments/assets/cb56d9f8-d7ba-4cda-9e4c-82b11fb99ad0" />
<img width="766" alt="Screenshot 2025-03-13 at 10 30 21" src="https://github.com/user-attachments/assets/12238254-c8b6-420d-be6b-ce0a2cd2637b" />

## How I Tested These Changes

TS, lint. Test dev and build versions to verify correct rendering, and that there are no errors due to invalid DOM.