### PR TITLE
Fix automation of Spark and Dataproc configuration

### DIFF
--- a/python_modules/automation/Makefile
+++ b/python_modules/automation/Makefile
@@ -2,21 +2,16 @@ dataproc:
 	python -m automation.parse_dataproc_configs
 
 	# Clean up formatting
-	ruff format ../libraries/dagster-gcp/dagster_gcp/dataproc/ \
-		--line-length=100 \
-		--extend-exclude "build/|buck-out/|dist/|_build/|\.eggs/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|snapshots/" -N
+	ruff format --config ../../pyproject.toml ../libraries/dagster-gcp/dagster_gcp/dataproc/*.py
 
 	# Clean up imports
 	autoflake --in-place --remove-all-unused-imports ../libraries/dagster-gcp/dagster_gcp/dataproc/*.py
 
 spark_docs:
-	python -m automation.parse_spark_configs --output-file \
-		../libraries/dagster-spark/dagster_spark/configs_spark.py
+	python -m automation.parse_spark_configs
 
 	# Clean up formatting
-	ruff format ../libraries/dagster-spark/dagster_spark/configs_spark.py \
-		--line-length=100 \
-		--extend-exclude "build/|buck-out/|dist/|_build/|\.eggs/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|snapshots/" -N
+	ruff format --config ../../pyproject.toml ../libraries/dagster-spark/dagster_spark/configs_spark.py
 
 	# Clean up imports
 	autoflake --in-place --remove-all-unused-imports ../libraries/dagster-spark/dagster_spark/configs_spark.py

--- a/python_modules/automation/Makefile
+++ b/python_modules/automation/Makefile
@@ -2,6 +2,7 @@ dataproc:
 	python -m automation.parse_dataproc_configs
 
 	# Clean up formatting
+	ruff check --fix --config ../../pyproject.toml ../libraries/dagster-gcp/dagster_gcp/dataproc/*.py
 	ruff format --config ../../pyproject.toml ../libraries/dagster-gcp/dagster_gcp/dataproc/*.py
 
 	# Clean up imports
@@ -11,6 +12,8 @@ spark_docs:
 	python -m automation.parse_spark_configs
 
 	# Clean up formatting
+	ruff check --fix --config ../../pyproject.toml ../libraries/dagster-spark/dagster_spark/configs_spark.py
+	ruff check --fix --config ../../pyproject.toml ../libraries/dagster-aws/dagster_aws/emr/configs_spark.py
 	ruff format --config ../../pyproject.toml ../libraries/dagster-spark/dagster_spark/configs_spark.py
 	ruff format --config ../../pyproject.toml ../libraries/dagster-aws/dagster_aws/emr/configs_spark.py
 

--- a/python_modules/automation/Makefile
+++ b/python_modules/automation/Makefile
@@ -12,6 +12,8 @@ spark_docs:
 
 	# Clean up formatting
 	ruff format --config ../../pyproject.toml ../libraries/dagster-spark/dagster_spark/configs_spark.py
+	ruff format --config ../../pyproject.toml ../libraries/dagster-aws/dagster_aws/emr/configs_spark.py
 
 	# Clean up imports
 	autoflake --in-place --remove-all-unused-imports ../libraries/dagster-spark/dagster_spark/configs_spark.py
+	autoflake --in-place --remove-all-unused-imports ../libraries/dagster-aws/dagster_aws/emr/configs_spark.py

--- a/python_modules/automation/automation/parse_dataproc_configs.py
+++ b/python_modules/automation/automation/parse_dataproc_configs.py
@@ -226,12 +226,7 @@ class ConfigParser:
             raise Exception("unknown type: ", obj)
 
         description = obj.get("description")
-        is_required = None
-        if description is not None:
-            if description.startswith("Optional."):
-                is_required = False
-            elif description.startswith("Required."):
-                is_required = True
+        is_required = description is not None and description.startswith("Required.")
         return Field(fields, is_required=is_required, description=description)
 
     def extract_schema_for_object(self, object_name, name):

--- a/python_modules/automation/automation/parse_dataproc_configs.py
+++ b/python_modules/automation/automation/parse_dataproc_configs.py
@@ -225,7 +225,14 @@ class ConfigParser:
         else:
             raise Exception("unknown type: ", obj)
 
-        return Field(fields, is_required=None, description=obj.get("description"))
+        description = obj.get("description")
+        is_required = None
+        if description is not None:
+            if description.startswith("Optional."):
+                is_required = False
+            elif description.startswith("Required."):
+                is_required = True
+        return Field(fields, is_required=is_required, description=description)
 
     def extract_schema_for_object(self, object_name, name):
         # Reset enums for this object

--- a/python_modules/automation/automation/parse_dataproc_configs.py
+++ b/python_modules/automation/automation/parse_dataproc_configs.py
@@ -149,7 +149,9 @@ class ConfigParser:
             # Optionally write enum includes
             if self.all_enums:
                 printer.line(
-                    "from .types_{} import {}".format(suffix, ", ".join(self.all_enums.keys()))
+                    "from dagster_gcp.dataproc.types_{} import {}".format(
+                        suffix, ", ".join(self.all_enums.keys())
+                    )
                 )
                 printer.blank_line()
 

--- a/python_modules/automation/automation/parse_dataproc_configs.py
+++ b/python_modules/automation/automation/parse_dataproc_configs.py
@@ -27,9 +27,10 @@ class Enum:
         self.enum_descriptions = enum_descriptions
 
     def write(self, printer):
-        printer.line(self.name.title() + " = Enum(")
+        capitalized_name = self.name[0].upper() + self.name[1:]
+        printer.line(capitalized_name + " = Enum(")
         with printer.with_indent():
-            printer.line(f"name='{self.name.title()}',")
+            printer.line(f"name='{capitalized_name}',")
             printer.line("enum_values=[")
             with printer.with_indent():
                 if self.enum_descriptions:
@@ -148,11 +149,8 @@ class ConfigParser:
 
             # Optionally write enum includes
             if self.all_enums:
-                printer.line(
-                    "from dagster_gcp.dataproc.types_{} import {}".format(
-                        suffix, ", ".join(self.all_enums.keys())
-                    )
-                )
+                enums = ", ".join(self.all_enums.keys())
+                printer.line(f"from dagster_gcp.dataproc.types_{suffix} import {enums}")
                 printer.blank_line()
 
             printer.line(f"def define_{suffix}_config():")
@@ -194,6 +192,8 @@ class ConfigParser:
             # than they should be for type "Component" and the name isn't there
             if name is None:
                 name = "Component"
+            else:
+                name = name[0].upper() + name[1:]
 
             enum = Enum(name, obj["enum"], enum_descriptions or obj.get("enumDescriptions"))
             self.all_enums[name] = enum

--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -279,8 +279,8 @@ def run() -> None:
     serialized = serialize(result)
 
     output_files = [
-        "python_modules/libraries/dagster-spark/dagster_spark/configs_spark.py",
-        "python_modules/libraries/dagster-aws/dagster_aws/emr/configs_spark.py",
+        "../libraries/dagster-spark/dagster_spark/configs_spark.py",
+        "../libraries/dagster-aws/dagster_aws/emr/configs_spark.py",
     ]
     for output_file in output_files:
         with open(output_file, "wb") as f:

--- a/python_modules/automation/automation/printer.py
+++ b/python_modules/automation/automation/printer.py
@@ -35,13 +35,13 @@ class IndentingBufferPrinter(IndentingPrinter):
 
     def write_header(self) -> None:
         args = [os.path.basename(sys.argv[0])] + sys.argv[1:]
-        self.line("'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT")
+        self.line('"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.')
         self.blank_line()
         self.line("@generated")
         self.blank_line()
         self.line("Produced via:")
         self.line("\n\t".join(f"{s} \\" for s in args if s != "--snapshot-update"))
         self.blank_line()
-        self.line("'''")
+        self.line('"""')
         self.blank_line()
         self.blank_line()

--- a/python_modules/automation/automation_tests/test_parse_dataproc_configs.py
+++ b/python_modules/automation/automation_tests/test_parse_dataproc_configs.py
@@ -11,19 +11,19 @@ def test_config_parser_job():
 
     c = ConfigParser(json_schema)
     parsed = c.extract_schema_for_object("Job", "dataproc_job")
-    assert parsed.configs.startswith(b"'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT")
+    assert parsed.configs.startswith(b'"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.')
     assert b"def define_dataproc_job_config():" in parsed.configs
     assert b"'sparkJob': Field(" in parsed.configs
 
-    assert parsed.enums.startswith(b"'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT")
+    assert parsed.enums.startswith(b'"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.')
     assert b"State = Enum(" in parsed.enums
     assert b"Substate = Enum(" in parsed.enums
 
     c = ConfigParser(json_schema)
     parsed = c.extract_schema_for_object("ClusterConfig", "dataproc_cluster")
-    assert parsed.configs.startswith(b"'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT")
+    assert parsed.configs.startswith(b'"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.')
     assert b"def define_dataproc_cluster_config():" in parsed.configs
     assert b"'masterConfig': Field(" in parsed.configs
 
-    assert parsed.enums.startswith(b"'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT")
+    assert parsed.enums.startswith(b'"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.')
     assert b"Component = Enum(" in parsed.enums

--- a/python_modules/automation/automation_tests/test_parse_spark_configs.py
+++ b/python_modules/automation/automation_tests/test_parse_spark_configs.py
@@ -75,5 +75,5 @@ def test_serialize():
 
     serialized = serialize(result)
     assert b"def spark_config():" in serialized
-    assert b"'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT\n\n" in serialized
+    assert b'"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\n\n' in serialized
     assert b"Application Properties: The name of your application." in serialized

--- a/python_modules/automation/automation_tests/test_printer.py
+++ b/python_modules/automation/automation_tests/test_printer.py
@@ -7,11 +7,11 @@ def test_header():
         result = printer.read()
 
     assert result.startswith(
-        """'''NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT
+        '''"""NOTE: THIS FILE IS AUTO-GENERATED. DO NOT EDIT.
 
 @generated
 
-Produced via:"""
+Produced via:'''
     )
 
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
@@ -138,7 +138,7 @@ def define_dataproc_cluster_config():
                                 description="""The Compute Engine network tags to add to all
                                 instances (see Tagging instances
                                 (https://cloud.google.com/vpc/docs/add-remove-network-tags)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "metadata": Field(
                                 Permissive(),
@@ -172,7 +172,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Reservation Affinity for consuming Zonal
                                 reservation.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "nodeGroupAffinity": Field(
                                 Shape(
@@ -194,7 +194,7 @@ def define_dataproc_cluster_config():
                                 description="""Node Group Affinity for clusters using sole-tenant
                                 node groups. The Dataproc NodeGroupAffinity resource is not related
                                 to the Dataproc NodeGroup resource.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "shieldedInstanceConfig": Field(
                                 Shape(
@@ -222,7 +222,7 @@ def define_dataproc_cluster_config():
                                 description="""Shielded Instance Config for clusters using Compute
                                 Engine Shielded VMs
                                 (https://cloud.google.com/security/shielded-cloud/shielded-vm).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "confidentialInstanceConfig": Field(
                                 Shape(
@@ -238,7 +238,7 @@ def define_dataproc_cluster_config():
                                 description="""Confidential Instance Config for clusters using
                                 Confidential VMs
                                 (https://cloud.google.com/compute/confidential-vm/docs)""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "resourceManagerTags": Field(
                                 Permissive(),
@@ -252,7 +252,7 @@ def define_dataproc_cluster_config():
                     ),
                     description="""Common config settings for resources of Compute Engine cluster
                     instances, applicable to all instances in the cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "masterConfig": Field(
                     Shape(
@@ -356,7 +356,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the config of disk options for a group of
                                 VM instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "preemptibility": Field(
                                 Preemptibility,
@@ -372,7 +372,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the resources used to actively manage an
                                 instance group.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "accelerators": Field(
                                 [
@@ -391,13 +391,13 @@ def define_dataproc_cluster_config():
                                             (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                             feature, you must use the short name of the accelerator
                                             type resource, for example, nvidia-tesla-t4.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                             "acceleratorCount": Field(
                                                 Int,
                                                 description="""The number of the accelerator cards of
                                             this type exposed to this instance.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     )
@@ -469,7 +469,7 @@ def define_dataproc_cluster_config():
                                             ),
                                             description="""Defines how Dataproc should create VMs
                                             with a mixture of provisioning models.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "instanceSelectionList": Field(
                                             [
@@ -505,7 +505,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Instance flexibility Policy allowing a mixture of VM
                                 shapes and provisioning models.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "startupConfig": Field(
                                 Shape(
@@ -526,13 +526,13 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Configuration to handle the startup of instances
                                 during cluster create and update process.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""The config settings for Compute Engine resources in an instance
                     group, such as a master or worker group.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "workerConfig": Field(
                     Shape(
@@ -636,7 +636,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the config of disk options for a group of
                                 VM instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "preemptibility": Field(
                                 Preemptibility,
@@ -652,7 +652,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the resources used to actively manage an
                                 instance group.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "accelerators": Field(
                                 [
@@ -671,13 +671,13 @@ def define_dataproc_cluster_config():
                                             (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                             feature, you must use the short name of the accelerator
                                             type resource, for example, nvidia-tesla-t4.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                             "acceleratorCount": Field(
                                                 Int,
                                                 description="""The number of the accelerator cards of
                                             this type exposed to this instance.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     )
@@ -749,7 +749,7 @@ def define_dataproc_cluster_config():
                                             ),
                                             description="""Defines how Dataproc should create VMs
                                             with a mixture of provisioning models.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "instanceSelectionList": Field(
                                             [
@@ -785,7 +785,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Instance flexibility Policy allowing a mixture of VM
                                 shapes and provisioning models.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "startupConfig": Field(
                                 Shape(
@@ -806,13 +806,13 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Configuration to handle the startup of instances
                                 during cluster create and update process.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""The config settings for Compute Engine resources in an instance
                     group, such as a master or worker group.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "secondaryWorkerConfig": Field(
                     Shape(
@@ -916,7 +916,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the config of disk options for a group of
                                 VM instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "preemptibility": Field(
                                 Preemptibility,
@@ -932,7 +932,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Specifies the resources used to actively manage an
                                 instance group.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "accelerators": Field(
                                 [
@@ -951,13 +951,13 @@ def define_dataproc_cluster_config():
                                             (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                             feature, you must use the short name of the accelerator
                                             type resource, for example, nvidia-tesla-t4.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                             "acceleratorCount": Field(
                                                 Int,
                                                 description="""The number of the accelerator cards of
                                             this type exposed to this instance.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     )
@@ -1029,7 +1029,7 @@ def define_dataproc_cluster_config():
                                             ),
                                             description="""Defines how Dataproc should create VMs
                                             with a mixture of provisioning models.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "instanceSelectionList": Field(
                                             [
@@ -1065,7 +1065,7 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Instance flexibility Policy allowing a mixture of VM
                                 shapes and provisioning models.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "startupConfig": Field(
                                 Shape(
@@ -1086,13 +1086,13 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Configuration to handle the startup of instances
                                 during cluster create and update process.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""The config settings for Compute Engine resources in an instance
                     group, such as a master or worker group.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "softwareConfig": Field(
                     Shape(
@@ -1131,7 +1131,7 @@ def define_dataproc_cluster_config():
                     ),
                     description="""Specifies the selection and config of software inside the
                     cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "initializationActions": Field(
                     [
@@ -1209,7 +1209,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Encryption settings for the cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "autoscalingConfig": Field(
                     Shape(
@@ -1227,7 +1227,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Autoscaling Policy config associated with the cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "securityConfig": Field(
                     Shape(
@@ -1347,7 +1347,7 @@ def define_dataproc_cluster_config():
                                     },
                                 ),
                                 description="""Specifies Kerberos related configuration.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "identityConfig": Field(
                                 Shape(
@@ -1362,13 +1362,13 @@ def define_dataproc_cluster_config():
                                 ),
                                 description="""Identity related configuration, including service
                                 account based secure multi-tenancy user mappings.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""Security related configuration, including encryption, Kerberos,
                     etc.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "lifecycleConfig": Field(
                     Shape(
@@ -1401,7 +1401,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Specifies the cluster auto-delete schedule configuration.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "endpointConfig": Field(
                     Shape(
@@ -1415,7 +1415,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Endpoint config for this cluster""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "metastoreConfig": Field(
                     Shape(
@@ -1430,7 +1430,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Specifies a Metastore configuration.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "gkeClusterConfig": Field(
                     Shape(
@@ -1456,7 +1456,7 @@ def define_dataproc_cluster_config():
                                 description="""Deprecated. Used only for the deprecated beta. A
                                 full, namespace-isolated deployment target for an existing GKE
                                 cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "gkeClusterTarget": Field(
                                 String,
@@ -1537,7 +1537,7 @@ def define_dataproc_cluster_config():
                                                                                 accelerator cards
                                                                                 exposed to an
                                                                                 instance.""",
-                                                                                        is_required=True,
+                                                                                        is_required=False,
                                                                                     ),
                                                                                     "acceleratorType": Field(
                                                                                         String,
@@ -1546,7 +1546,7 @@ def define_dataproc_cluster_config():
                                                                                 resource namename
                                                                                 (see GPUs on Compute
                                                                                 Engine).""",
-                                                                                        is_required=True,
+                                                                                        is_required=False,
                                                                                     ),
                                                                                     "gpuPartitionSize": Field(
                                                                                         String,
@@ -1558,7 +1558,7 @@ def define_dataproc_cluster_config():
                                                                                 NVIDIA mig user
                                                                                 guide
                                                                                 (https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning).""",
-                                                                                        is_required=True,
+                                                                                        is_required=False,
                                                                                     ),
                                                                                 },
                                                                             )
@@ -1619,7 +1619,7 @@ def define_dataproc_cluster_config():
                                                             ),
                                                             description="""Parameters that describe
                                                         cluster nodes.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "locations": Field(
                                                             [String],
@@ -1646,7 +1646,7 @@ def define_dataproc_cluster_config():
                                                                     number of nodes in the node
                                                                     pool. Must be >= 0 and <=
                                                                     max_node_count.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "maxNodeCount": Field(
                                                                         Int,
@@ -1656,7 +1656,7 @@ def define_dataproc_cluster_config():
                                                                     and must be > 0. Note: Quota
                                                                     must be sufficient to scale up
                                                                     the cluster.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                 },
                                                             ),
@@ -1664,14 +1664,14 @@ def define_dataproc_cluster_config():
                                                         contains information the cluster autoscaler
                                                         needs to adjust the size of the node pool to
                                                         the current cluster usage.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                     },
                                                 ),
                                                 description="""The configuration of a GKE node pool used
                                             by a Dataproc-on-GKE cluster
                                             (https://cloud.google.com/dataproc/docs/concepts/jobs/dataproc-gke#create-a-dataproc-on-gke-cluster).""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     )
@@ -1687,7 +1687,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""The cluster\'s GKE config.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "dataprocMetricConfig": Field(
                     Shape(
@@ -1739,7 +1739,7 @@ def define_dataproc_cluster_config():
                         },
                     ),
                     description="""Dataproc metric config.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "auxiliaryNodeGroups": Field(
                     [
@@ -1752,7 +1752,7 @@ def define_dataproc_cluster_config():
                                                 String,
                                                 description="""The Node group resource name
                                             (https://aip.dev/122).""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                             "roles": Field(
                                                 [Component],
@@ -1888,7 +1888,7 @@ def define_dataproc_cluster_config():
                                                             ),
                                                             description="""Specifies the config of disk
                                                         options for a group of VM instances.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "preemptibility": Field(
                                                             Preemptibility,
@@ -1906,7 +1906,7 @@ def define_dataproc_cluster_config():
                                                             ),
                                                             description="""Specifies the resources used
                                                         to actively manage an instance group.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "accelerators": Field(
                                                             [
@@ -1930,14 +1930,14 @@ def define_dataproc_cluster_config():
                                                                     name of the accelerator type
                                                                     resource, for example,
                                                                     nvidia-tesla-t4.""",
-                                                                            is_required=True,
+                                                                            is_required=False,
                                                                         ),
                                                                         "acceleratorCount": Field(
                                                                             Int,
                                                                             description="""The number of the
                                                                     accelerator cards of this type
                                                                     exposed to this instance.""",
-                                                                            is_required=True,
+                                                                            is_required=False,
                                                                         ),
                                                                     },
                                                                 )
@@ -2044,7 +2044,7 @@ def define_dataproc_cluster_config():
                                                                     Dataproc should create VMs with
                                                                     a mixture of provisioning
                                                                     models.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "instanceSelectionList": Field(
                                                                         [
@@ -2094,7 +2094,7 @@ def define_dataproc_cluster_config():
                                                             description="""Instance flexibility Policy
                                                         allowing a mixture of VM shapes and
                                                         provisioning models.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "startupConfig": Field(
                                                             Shape(
@@ -2123,14 +2123,14 @@ def define_dataproc_cluster_config():
                                                             description="""Configuration to handle the
                                                         startup of instances during cluster create
                                                         and update process.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                     },
                                                 ),
                                                 description="""The config settings for Compute Engine
                                             resources in an instance group, such as a master or
                                             worker group.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                             "labels": Field(
                                                 Permissive(),
@@ -2147,7 +2147,7 @@ def define_dataproc_cluster_config():
                                     ),
                                     description="""Dataproc Node Group. The Dataproc NodeGroup resource
                                 is not related to the Dataproc NodeGroupAffinity resource.""",
-                                    is_required=True,
+                                    is_required=False,
                                 ),
                                 "nodeGroupId": Field(
                                     String,
@@ -2166,5 +2166,5 @@ def define_dataproc_cluster_config():
             },
         ),
         description="""The cluster config.""",
-        is_required=True,
+        is_required=False,
     )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
@@ -11,10 +11,10 @@ from dagster import Bool, Field, Int, Permissive, Shape, String
 
 from dagster_gcp.dataproc.types_dataproc_cluster import (
     Component,
-    consumeReservationType,
-    metricSource,
-    preemptibility,
-    privateIpv6GoogleAccess,
+    ConsumeReservationType,
+    MetricSource,
+    Preemptibility,
+    PrivateIpv6GoogleAccess,
 )
 
 
@@ -101,7 +101,7 @@ def define_dataproc_cluster_config():
                                 is_required=True,
                             ),
                             "privateIpv6GoogleAccess": Field(
-                                privateIpv6GoogleAccess,
+                                PrivateIpv6GoogleAccess,
                                 description="""Optional. The type of IPv6 access for a cluster.""",
                                 is_required=True,
                             ),
@@ -151,7 +151,7 @@ def define_dataproc_cluster_config():
                                 Shape(
                                     fields={
                                         "consumeReservationType": Field(
-                                            consumeReservationType,
+                                            ConsumeReservationType,
                                             description="""Optional. Type of reservation to
                                             consume""",
                                             is_required=True,
@@ -359,7 +359,7 @@ def define_dataproc_cluster_config():
                                 is_required=True,
                             ),
                             "preemptibility": Field(
-                                preemptibility,
+                                Preemptibility,
                                 description="""Optional. Specifies the preemptibility of the
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
@@ -639,7 +639,7 @@ def define_dataproc_cluster_config():
                                 is_required=True,
                             ),
                             "preemptibility": Field(
-                                preemptibility,
+                                Preemptibility,
                                 description="""Optional. Specifies the preemptibility of the
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
@@ -919,7 +919,7 @@ def define_dataproc_cluster_config():
                                 is_required=True,
                             ),
                             "preemptibility": Field(
-                                preemptibility,
+                                Preemptibility,
                                 description="""Optional. Specifies the preemptibility of the
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
@@ -1697,7 +1697,7 @@ def define_dataproc_cluster_config():
                                     Shape(
                                         fields={
                                             "metricSource": Field(
-                                                metricSource,
+                                                MetricSource,
                                                 description="""Required. A standard set of metrics is
                                             collected unless metricOverrides are specified for the
                                             metric source (see Custom metrics
@@ -1891,7 +1891,7 @@ def define_dataproc_cluster_config():
                                                             is_required=True,
                                                         ),
                                                         "preemptibility": Field(
-                                                            preemptibility,
+                                                            Preemptibility,
                                                             description="""Optional. Specifies the
                                                         preemptibility of the instance group.The
                                                         default value for master and worker groups

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
@@ -33,7 +33,7 @@ def define_dataproc_cluster_config():
                     (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
                     This field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud
                     Storage bucket.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "tempBucket": Field(
                     String,
@@ -47,7 +47,7 @@ def define_dataproc_cluster_config():
                     (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
                     This field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud
                     Storage bucket.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "gceClusterConfig": Field(
                     Shape(
@@ -61,7 +61,7 @@ def define_dataproc_cluster_config():
                                 Examples:
                                 https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]
                                 projects/[project_id]/zones/[zone] [zone]""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "networkUri": Field(
                                 String,
@@ -75,7 +75,7 @@ def define_dataproc_cluster_config():
                                 Examples:
                                 https://www.googleapis.com/compute/v1/projects/[project_id]/global/networks/default
                                 projects/[project_id]/global/networks/default default""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "subnetworkUri": Field(
                                 String,
@@ -84,7 +84,7 @@ def define_dataproc_cluster_config():
                                 full URL, partial URI, or short name are valid. Examples:
                                 https://www.googleapis.com/compute/v1/projects/[project_id]/regions/[region]/subnetworks/sub0
                                 projects/[project_id]/regions/[region]/subnetworks/sub0 sub0""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "internalIpOnly": Field(
                                 Bool,
@@ -98,12 +98,12 @@ def define_dataproc_cluster_config():
                                 addresses.When set to false: Cluster VMs are not restricted to
                                 internal IP addresses. Ephemeral external IP addresses are assigned
                                 to each cluster VM.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "privateIpv6GoogleAccess": Field(
                                 PrivateIpv6GoogleAccess,
                                 description="""Optional. The type of IPv6 access for a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "serviceAccount": Field(
                                 String,
@@ -116,7 +116,7 @@ def define_dataproc_cluster_config():
                                 service account
                                 (https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
                                 is used.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "serviceAccountScopes": Field(
                                 [String],
@@ -131,7 +131,7 @@ def define_dataproc_cluster_config():
                                 https://www.googleapis.com/auth/bigtable.admin.table
                                 https://www.googleapis.com/auth/bigtable.data
                                 https://www.googleapis.com/auth/devstorage.full_control""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "tags": Field(
                                 [String],
@@ -145,7 +145,7 @@ def define_dataproc_cluster_config():
                                 description="""Optional. The Compute Engine metadata entries to add
                                 to all instances (see Project and instance metadata
                                 (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "reservationAffinity": Field(
                                 Shape(
@@ -154,19 +154,19 @@ def define_dataproc_cluster_config():
                                             ConsumeReservationType,
                                             description="""Optional. Type of reservation to
                                             consume""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "key": Field(
                                             String,
                                             description="""Optional. Corresponds to the label key of
                                             reservation resource.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "values": Field(
                                             [String],
                                             description="""Optional. Corresponds to the label values
                                             of reservation resource.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -203,19 +203,19 @@ def define_dataproc_cluster_config():
                                             Bool,
                                             description="""Optional. Defines whether instances have
                                             Secure Boot enabled.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "enableVtpm": Field(
                                             Bool,
                                             description="""Optional. Defines whether instances have
                                             the vTPM enabled.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "enableIntegrityMonitoring": Field(
                                             Bool,
                                             description="""Optional. Defines whether instances have
                                             integrity monitoring enabled.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -231,7 +231,7 @@ def define_dataproc_cluster_config():
                                             Bool,
                                             description="""Optional. Defines whether the instance
                                             should have confidential compute enabled.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -246,7 +246,7 @@ def define_dataproc_cluster_config():
                                 (https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing)
                                 to add to all instances (see Use secure tags in Dataproc
                                 (https://cloud.google.com/dataproc/docs/guides/attach-secure-tags)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -262,7 +262,7 @@ def define_dataproc_cluster_config():
                                 description="""Optional. The number of VM instances in the instance
                                 group. For HA cluster master_config groups, must be set to 3. For
                                 standard cluster master_config groups, must be set to 1.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "imageUri": Field(
                                 String,
@@ -276,7 +276,7 @@ def define_dataproc_cluster_config():
                                 projects/[project_id]/global/images/family/[custom-image-family-name]If
                                 the URI is unspecified, it will be inferred from
                                 SoftwareConfig.image_version or the system default.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "machineTypeUri": Field(
                                 String,
@@ -290,7 +290,7 @@ def define_dataproc_cluster_config():
                                 (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                 feature, you must use the short name of the machine type resource,
                                 for example, n1-standard-2.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "diskConfig": Field(
                                 Shape(
@@ -303,13 +303,13 @@ def define_dataproc_cluster_config():
                                             (Persistent Disk Solid State Drive), or "pd-standard"
                                             (Persistent Disk Hard Disk Drive). See Disk types
                                             (https://cloud.google.com/compute/docs/disks#disk-types).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskSizeGb": Field(
                                             Int,
                                             description="""Optional. Size in GB of the boot disk
                                             (default is 500GB).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "numLocalSsds": Field(
                                             Int,
@@ -322,7 +322,7 @@ def define_dataproc_cluster_config():
                                             contains only basic config and installed binaries.Note:
                                             Local SSD options may vary by machine type and number of
                                             vCPUs selected.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "localSsdInterface": Field(
                                             String,
@@ -331,7 +331,7 @@ def define_dataproc_cluster_config():
                                             Computer System Interface), "nvme" (Non-Volatile Memory
                                             Express). See local SSD performance
                                             (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedIops": Field(
                                             String,
@@ -340,7 +340,7 @@ def define_dataproc_cluster_config():
                                             operations per second that the disk can handle. This
                                             field is supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedThroughput": Field(
                                             String,
@@ -350,7 +350,7 @@ def define_dataproc_cluster_config():
                                             Values must be greater than or equal to 1. This field is
                                             supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -364,7 +364,7 @@ def define_dataproc_cluster_config():
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
                                 for secondary instances is PREEMPTIBLE.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "managedGroupConfig": Field(
                                 Shape(
@@ -404,14 +404,14 @@ def define_dataproc_cluster_config():
                                 ],
                                 description="""Optional. The Compute Engine accelerator
                                 configuration for these instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minCpuPlatform": Field(
                                 String,
                                 description="""Optional. Specifies the minimum cpu platform for the
                                 Instance Group. See Dataproc -> Minimum CPU Platform
                                 (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minNumInstances": Field(
                                 Int,
@@ -424,7 +424,7 @@ def define_dataproc_cluster_config():
                                 cluster is resized to 4 instances and placed in a RUNNING state. If
                                 2 instances are created and 3 instances fail, the cluster in placed
                                 in an ERROR state. The failed VMs are not deleted.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "instanceFlexibilityPolicy": Field(
                                 Shape(
@@ -447,7 +447,7 @@ def define_dataproc_cluster_config():
                                                         create 5 standard VMs and then start mixing
                                                         spot and standard VMs for remaining 10
                                                         instances.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                     "standardCapacityPercentAboveBase": Field(
                                                         Int,
@@ -463,7 +463,7 @@ def define_dataproc_cluster_config():
                                                         start mixing spot and standard VMs for
                                                         remaining 10 instances. The mix will be 30%
                                                         standard and 70% spot.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                 },
                                             ),
@@ -479,7 +479,7 @@ def define_dataproc_cluster_config():
                                                             [String],
                                                             description="""Optional. Full machine-type
                                                         names, e.g. "n1-standard-16".""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "rank": Field(
                                                             Int,
@@ -491,7 +491,7 @@ def define_dataproc_cluster_config():
                                                         based on availability. Machine types and
                                                         instance selections with the same priority
                                                         have the same preference.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                     },
                                                 )
@@ -499,7 +499,7 @@ def define_dataproc_cluster_config():
                                             description="""Optional. List of instance selection
                                             options that the group will use when creating new
                                             VMs.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -520,7 +520,7 @@ def define_dataproc_cluster_config():
                                             required_registration_fraction of instances are not
                                             available. This will include instance creation, agent
                                             registration, and service registration (if enabled).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -542,7 +542,7 @@ def define_dataproc_cluster_config():
                                 description="""Optional. The number of VM instances in the instance
                                 group. For HA cluster master_config groups, must be set to 3. For
                                 standard cluster master_config groups, must be set to 1.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "imageUri": Field(
                                 String,
@@ -556,7 +556,7 @@ def define_dataproc_cluster_config():
                                 projects/[project_id]/global/images/family/[custom-image-family-name]If
                                 the URI is unspecified, it will be inferred from
                                 SoftwareConfig.image_version or the system default.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "machineTypeUri": Field(
                                 String,
@@ -570,7 +570,7 @@ def define_dataproc_cluster_config():
                                 (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                 feature, you must use the short name of the machine type resource,
                                 for example, n1-standard-2.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "diskConfig": Field(
                                 Shape(
@@ -583,13 +583,13 @@ def define_dataproc_cluster_config():
                                             (Persistent Disk Solid State Drive), or "pd-standard"
                                             (Persistent Disk Hard Disk Drive). See Disk types
                                             (https://cloud.google.com/compute/docs/disks#disk-types).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskSizeGb": Field(
                                             Int,
                                             description="""Optional. Size in GB of the boot disk
                                             (default is 500GB).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "numLocalSsds": Field(
                                             Int,
@@ -602,7 +602,7 @@ def define_dataproc_cluster_config():
                                             contains only basic config and installed binaries.Note:
                                             Local SSD options may vary by machine type and number of
                                             vCPUs selected.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "localSsdInterface": Field(
                                             String,
@@ -611,7 +611,7 @@ def define_dataproc_cluster_config():
                                             Computer System Interface), "nvme" (Non-Volatile Memory
                                             Express). See local SSD performance
                                             (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedIops": Field(
                                             String,
@@ -620,7 +620,7 @@ def define_dataproc_cluster_config():
                                             operations per second that the disk can handle. This
                                             field is supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedThroughput": Field(
                                             String,
@@ -630,7 +630,7 @@ def define_dataproc_cluster_config():
                                             Values must be greater than or equal to 1. This field is
                                             supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -644,7 +644,7 @@ def define_dataproc_cluster_config():
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
                                 for secondary instances is PREEMPTIBLE.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "managedGroupConfig": Field(
                                 Shape(
@@ -684,14 +684,14 @@ def define_dataproc_cluster_config():
                                 ],
                                 description="""Optional. The Compute Engine accelerator
                                 configuration for these instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minCpuPlatform": Field(
                                 String,
                                 description="""Optional. Specifies the minimum cpu platform for the
                                 Instance Group. See Dataproc -> Minimum CPU Platform
                                 (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minNumInstances": Field(
                                 Int,
@@ -704,7 +704,7 @@ def define_dataproc_cluster_config():
                                 cluster is resized to 4 instances and placed in a RUNNING state. If
                                 2 instances are created and 3 instances fail, the cluster in placed
                                 in an ERROR state. The failed VMs are not deleted.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "instanceFlexibilityPolicy": Field(
                                 Shape(
@@ -727,7 +727,7 @@ def define_dataproc_cluster_config():
                                                         create 5 standard VMs and then start mixing
                                                         spot and standard VMs for remaining 10
                                                         instances.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                     "standardCapacityPercentAboveBase": Field(
                                                         Int,
@@ -743,7 +743,7 @@ def define_dataproc_cluster_config():
                                                         start mixing spot and standard VMs for
                                                         remaining 10 instances. The mix will be 30%
                                                         standard and 70% spot.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                 },
                                             ),
@@ -759,7 +759,7 @@ def define_dataproc_cluster_config():
                                                             [String],
                                                             description="""Optional. Full machine-type
                                                         names, e.g. "n1-standard-16".""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "rank": Field(
                                                             Int,
@@ -771,7 +771,7 @@ def define_dataproc_cluster_config():
                                                         based on availability. Machine types and
                                                         instance selections with the same priority
                                                         have the same preference.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                     },
                                                 )
@@ -779,7 +779,7 @@ def define_dataproc_cluster_config():
                                             description="""Optional. List of instance selection
                                             options that the group will use when creating new
                                             VMs.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -800,7 +800,7 @@ def define_dataproc_cluster_config():
                                             required_registration_fraction of instances are not
                                             available. This will include instance creation, agent
                                             registration, and service registration (if enabled).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -822,7 +822,7 @@ def define_dataproc_cluster_config():
                                 description="""Optional. The number of VM instances in the instance
                                 group. For HA cluster master_config groups, must be set to 3. For
                                 standard cluster master_config groups, must be set to 1.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "imageUri": Field(
                                 String,
@@ -836,7 +836,7 @@ def define_dataproc_cluster_config():
                                 projects/[project_id]/global/images/family/[custom-image-family-name]If
                                 the URI is unspecified, it will be inferred from
                                 SoftwareConfig.image_version or the system default.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "machineTypeUri": Field(
                                 String,
@@ -850,7 +850,7 @@ def define_dataproc_cluster_config():
                                 (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
                                 feature, you must use the short name of the machine type resource,
                                 for example, n1-standard-2.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "diskConfig": Field(
                                 Shape(
@@ -863,13 +863,13 @@ def define_dataproc_cluster_config():
                                             (Persistent Disk Solid State Drive), or "pd-standard"
                                             (Persistent Disk Hard Disk Drive). See Disk types
                                             (https://cloud.google.com/compute/docs/disks#disk-types).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskSizeGb": Field(
                                             Int,
                                             description="""Optional. Size in GB of the boot disk
                                             (default is 500GB).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "numLocalSsds": Field(
                                             Int,
@@ -882,7 +882,7 @@ def define_dataproc_cluster_config():
                                             contains only basic config and installed binaries.Note:
                                             Local SSD options may vary by machine type and number of
                                             vCPUs selected.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "localSsdInterface": Field(
                                             String,
@@ -891,7 +891,7 @@ def define_dataproc_cluster_config():
                                             Computer System Interface), "nvme" (Non-Volatile Memory
                                             Express). See local SSD performance
                                             (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedIops": Field(
                                             String,
@@ -900,7 +900,7 @@ def define_dataproc_cluster_config():
                                             operations per second that the disk can handle. This
                                             field is supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "bootDiskProvisionedThroughput": Field(
                                             String,
@@ -910,7 +910,7 @@ def define_dataproc_cluster_config():
                                             Values must be greater than or equal to 1. This field is
                                             supported only if boot_disk_type is
                                             hyperdisk-balanced.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -924,7 +924,7 @@ def define_dataproc_cluster_config():
                                 instance group.The default value for master and worker groups is
                                 NON_PREEMPTIBLE. This default cannot be changed.The default value
                                 for secondary instances is PREEMPTIBLE.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "managedGroupConfig": Field(
                                 Shape(
@@ -964,14 +964,14 @@ def define_dataproc_cluster_config():
                                 ],
                                 description="""Optional. The Compute Engine accelerator
                                 configuration for these instances.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minCpuPlatform": Field(
                                 String,
                                 description="""Optional. Specifies the minimum cpu platform for the
                                 Instance Group. See Dataproc -> Minimum CPU Platform
                                 (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "minNumInstances": Field(
                                 Int,
@@ -984,7 +984,7 @@ def define_dataproc_cluster_config():
                                 cluster is resized to 4 instances and placed in a RUNNING state. If
                                 2 instances are created and 3 instances fail, the cluster in placed
                                 in an ERROR state. The failed VMs are not deleted.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "instanceFlexibilityPolicy": Field(
                                 Shape(
@@ -1007,7 +1007,7 @@ def define_dataproc_cluster_config():
                                                         create 5 standard VMs and then start mixing
                                                         spot and standard VMs for remaining 10
                                                         instances.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                     "standardCapacityPercentAboveBase": Field(
                                                         Int,
@@ -1023,7 +1023,7 @@ def define_dataproc_cluster_config():
                                                         start mixing spot and standard VMs for
                                                         remaining 10 instances. The mix will be 30%
                                                         standard and 70% spot.""",
-                                                        is_required=True,
+                                                        is_required=False,
                                                     ),
                                                 },
                                             ),
@@ -1039,7 +1039,7 @@ def define_dataproc_cluster_config():
                                                             [String],
                                                             description="""Optional. Full machine-type
                                                         names, e.g. "n1-standard-16".""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "rank": Field(
                                                             Int,
@@ -1051,7 +1051,7 @@ def define_dataproc_cluster_config():
                                                         based on availability. Machine types and
                                                         instance selections with the same priority
                                                         have the same preference.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                     },
                                                 )
@@ -1059,7 +1059,7 @@ def define_dataproc_cluster_config():
                                             description="""Optional. List of instance selection
                                             options that the group will use when creating new
                                             VMs.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -1080,7 +1080,7 @@ def define_dataproc_cluster_config():
                                             required_registration_fraction of instances are not
                                             available. This will include instance creation, agent
                                             registration, and service registration (if enabled).""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -1106,7 +1106,7 @@ def define_dataproc_cluster_config():
                                 the "preview" version
                                 (https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
                                 If unspecified, it defaults to the latest Debian version.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -1119,13 +1119,13 @@ def define_dataproc_cluster_config():
                                 spark-defaults.conf yarn: yarn-site.xmlFor more information, see
                                 Cluster properties
                                 (https://cloud.google.com/dataproc/docs/concepts/cluster-properties).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "optionalComponents": Field(
                                 [Component],
                                 description="""Optional. The set of components to activate on the
                                 cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1150,7 +1150,7 @@ def define_dataproc_cluster_config():
                                 creation fails with an explanatory error message (the name of the
                                 executable that caused the error and the exceeded timeout period) if
                                 the executable is not completed at end of the timeout period.""",
-                                    is_required=True,
+                                    is_required=False,
                                 ),
                             },
                         )
@@ -1163,7 +1163,7 @@ def define_dataproc_cluster_config():
                     http://metadata/computeMetadata/v1/instance/attributes/dataproc-role) if [[
                     "${ROLE}" == \'Master\' ]]; then ... master specific actions ... else ... worker
                     specific actions ... fi """,
-                    is_required=True,
+                    is_required=False,
                 ),
                 "encryptionConfig": Field(
                     Shape(
@@ -1175,7 +1175,7 @@ def define_dataproc_cluster_config():
                                 CMEK with cluster data
                                 (https://cloud.google.com//dataproc/docs/concepts/configuring-clusters/customer-managed-encryption#use_cmek_with_cluster_data)
                                 for more information.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "kmsKey": Field(
                                 String,
@@ -1204,7 +1204,7 @@ def define_dataproc_cluster_config():
                                 scriptVariables and queryList.queries PrestoJob
                                 (https://cloud.google.com/dataproc/docs/reference/rest/v1/PrestoJob)
                                 scriptVariables and queryList.queries""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1222,7 +1222,7 @@ def define_dataproc_cluster_config():
                                 https://www.googleapis.com/compute/v1/projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]
                                 projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]Note
                                 that the policy must be in the same project and Dataproc region.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1240,27 +1240,27 @@ def define_dataproc_cluster_config():
                                             description="""Optional. Flag to indicate whether to
                                             Kerberize the cluster (default: false). Set this field
                                             to true to enable Kerberos on a cluster.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "rootPrincipalPasswordUri": Field(
                                             String,
                                             description="""Optional. The Cloud Storage URI of a KMS
                                             encrypted file containing the root principal
                                             password.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "kmsKeyUri": Field(
                                             String,
                                             description="""Optional. The URI of the KMS key used to
                                             encrypt sensitive files.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "keystoreUri": Field(
                                             String,
                                             description="""Optional. The Cloud Storage URI of the
                                             keystore file used for SSL encryption. If not provided,
                                             Dataproc will provide a self-signed certificate.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "truststoreUri": Field(
                                             String,
@@ -1268,7 +1268,7 @@ def define_dataproc_cluster_config():
                                             truststore file used for SSL encryption. If not
                                             provided, Dataproc will provide a self-signed
                                             certificate.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "keystorePasswordUri": Field(
                                             String,
@@ -1276,7 +1276,7 @@ def define_dataproc_cluster_config():
                                             encrypted file containing the password to the user
                                             provided keystore. For the self-signed certificate, this
                                             password is generated by Dataproc.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "keyPasswordUri": Field(
                                             String,
@@ -1284,7 +1284,7 @@ def define_dataproc_cluster_config():
                                             encrypted file containing the password to the user
                                             provided key. For the self-signed certificate, this
                                             password is generated by Dataproc.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "truststorePasswordUri": Field(
                                             String,
@@ -1292,28 +1292,28 @@ def define_dataproc_cluster_config():
                                             encrypted file containing the password to the user
                                             provided truststore. For the self-signed certificate,
                                             this password is generated by Dataproc.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "crossRealmTrustRealm": Field(
                                             String,
                                             description="""Optional. The remote realm the Dataproc
                                             on-cluster KDC will trust, should the user enable cross
                                             realm trust.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "crossRealmTrustKdc": Field(
                                             String,
                                             description="""Optional. The KDC (IP or hostname) for
                                             the remote trusted realm in a cross realm trust
                                             relationship.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "crossRealmTrustAdminServer": Field(
                                             String,
                                             description="""Optional. The admin server (IP or
                                             hostname) for the remote trusted realm in a cross realm
                                             trust relationship.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "crossRealmTrustSharedPasswordUri": Field(
                                             String,
@@ -1321,28 +1321,28 @@ def define_dataproc_cluster_config():
                                             encrypted file containing the shared password between
                                             the on-cluster Kerberos realm and the remote trusted
                                             realm, in a cross realm trust relationship.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "kdcDbKeyUri": Field(
                                             String,
                                             description="""Optional. The Cloud Storage URI of a KMS
                                             encrypted file containing the master key of the KDC
                                             database.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "tgtLifetimeHours": Field(
                                             Int,
                                             description="""Optional. The lifetime of the ticket
                                             granting ticket, in hours. If not specified, or user
                                             specifies 0, then default value 10 will be used.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "realm": Field(
                                             String,
                                             description="""Optional. The name of the on-cluster
                                             Kerberos realm. If not specified, the uppercased domain
                                             of hostnames will be the realm.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -1380,14 +1380,14 @@ def define_dataproc_cluster_config():
                                 cause the cluster to be deleted. Minimum value is 5 minutes; maximum
                                 value is 14 days (see JSON representation of Duration
                                 (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "autoDeleteTime": Field(
                                 String,
                                 description="""Optional. The time when cluster will be auto-deleted
                                 (see JSON representation of Timestamp
                                 (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "autoDeleteTtl": Field(
                                 String,
@@ -1396,7 +1396,7 @@ def define_dataproc_cluster_config():
                                 value is 10 minutes; maximum value is 14 days (see JSON
                                 representation of Duration
                                 (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1410,7 +1410,7 @@ def define_dataproc_cluster_config():
                                 Bool,
                                 description="""Optional. If true, enable http access to specific
                                 ports on the cluster from external sources. Defaults to false.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1443,13 +1443,13 @@ def define_dataproc_cluster_config():
                                             description="""Optional. The target GKE cluster to
                                             deploy to. Format:
                                             \'projects/{project}/locations/{location}/clusters/{cluster_id}\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                         "clusterNamespace": Field(
                                             String,
                                             description="""Optional. A namespace within the GKE
                                             cluster to deploy into.""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
@@ -1464,7 +1464,7 @@ def define_dataproc_cluster_config():
                                 be in the same project and region as the Dataproc cluster (the GKE
                                 cluster can be zonal or regional). Format:
                                 \'projects/{project}/locations/{location}/clusters/{cluster_id}\'""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "nodePoolTarget": Field(
                                 [
@@ -1495,7 +1495,7 @@ def define_dataproc_cluster_config():
                                                                     name of a Compute Engine machine
                                                                     type
                                                                     (https://cloud.google.com/compute/docs/machine-types).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "localSsdCount": Field(
                                                                         Int,
@@ -1506,7 +1506,7 @@ def define_dataproc_cluster_config():
                                                                     disks allowable per zone (see
                                                                     Adding Local SSDs
                                                                     (https://cloud.google.com/compute/docs/disks/local-ssd)).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "preemptible": Field(
                                                                         Bool,
@@ -1524,7 +1524,7 @@ def define_dataproc_cluster_config():
                                                                     CONTROLLER role is not assigned
                                                                     (the DEFAULT node pool will
                                                                     assume the CONTROLLER role).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "accelerators": Field(
                                                                         [
@@ -1567,7 +1567,7 @@ def define_dataproc_cluster_config():
                                                                     of hardware accelerators
                                                                     (https://cloud.google.com/compute/docs/gpus)
                                                                     to attach to each node.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "minCpuPlatform": Field(
                                                                         String,
@@ -1581,7 +1581,7 @@ def define_dataproc_cluster_config():
                                                                     names of CPU platforms, such as
                                                                     "Intel Haswell"` or Intel Sandy
                                                                     Bridge".""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "bootDiskKmsKey": Field(
                                                                         String,
@@ -1594,7 +1594,7 @@ def define_dataproc_cluster_config():
                                                                     node pool. Specify the key using
                                                                     the following format:
                                                                     projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "spot": Field(
                                                                         Bool,
@@ -1613,7 +1613,7 @@ def define_dataproc_cluster_config():
                                                                     CONTROLLER role is not assigned
                                                                     (the DEFAULT node pool will
                                                                     assume the CONTROLLER role).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                 },
                                                             ),
@@ -1635,7 +1635,7 @@ def define_dataproc_cluster_config():
                                                         region.If a location is not specified during
                                                         node pool creation, Dataproc on GKE will
                                                         choose the zone.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "autoscaling": Field(
                                                             Shape(
@@ -1682,7 +1682,7 @@ def define_dataproc_cluster_config():
                                 Dataproc constructs a DEFAULT GkeNodePoolTarget. Each role can be
                                 given to only one GkeNodePoolTarget. All node pools must have the
                                 same location settings.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -1728,7 +1728,7 @@ def define_dataproc_cluster_config():
                                             unaffected. For example, if both SPARK and YARN metric
                                             sources are enabled, and overrides are provided for
                                             Spark metrics only, all YARN metrics are collected.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     )
@@ -1769,7 +1769,7 @@ def define_dataproc_cluster_config():
                                                         cluster master_config groups, must be set to
                                                         3. For standard cluster master_config
                                                         groups, must be set to 1.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "imageUri": Field(
                                                             String,
@@ -1786,7 +1786,7 @@ def define_dataproc_cluster_config():
                                                         the URI is unspecified, it will be inferred
                                                         from SoftwareConfig.image_version or the
                                                         system default.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "machineTypeUri": Field(
                                                             String,
@@ -1802,7 +1802,7 @@ def define_dataproc_cluster_config():
                                                         feature, you must use the short name of the
                                                         machine type resource, for example,
                                                         n1-standard-2.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "diskConfig": Field(
                                                             Shape(
@@ -1819,14 +1819,14 @@ def define_dataproc_cluster_config():
                                                                     (Persistent Disk Hard Disk
                                                                     Drive). See Disk types
                                                                     (https://cloud.google.com/compute/docs/disks#disk-types).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "bootDiskSizeGb": Field(
                                                                         Int,
                                                                         description="""Optional. Size in
                                                                     GB of the boot disk (default is
                                                                     500GB).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "numLocalSsds": Field(
                                                                         Int,
@@ -1844,7 +1844,7 @@ def define_dataproc_cluster_config():
                                                                     binaries.Note: Local SSD options
                                                                     may vary by machine type and
                                                                     number of vCPUs selected.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "localSsdInterface": Field(
                                                                         String,
@@ -1856,7 +1856,7 @@ def define_dataproc_cluster_config():
                                                                     (Non-Volatile Memory Express).
                                                                     See local SSD performance
                                                                     (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "bootDiskProvisionedIops": Field(
                                                                         String,
@@ -1868,7 +1868,7 @@ def define_dataproc_cluster_config():
                                                                     disk can handle. This field is
                                                                     supported only if boot_disk_type
                                                                     is hyperdisk-balanced.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                     "bootDiskProvisionedThroughput": Field(
                                                                         String,
@@ -1882,7 +1882,7 @@ def define_dataproc_cluster_config():
                                                                     is supported only if
                                                                     boot_disk_type is
                                                                     hyperdisk-balanced.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                 },
                                                             ),
@@ -1898,7 +1898,7 @@ def define_dataproc_cluster_config():
                                                         is NON_PREEMPTIBLE. This default cannot be
                                                         changed.The default value for secondary
                                                         instances is PREEMPTIBLE.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "managedGroupConfig": Field(
                                                             Shape(
@@ -1945,7 +1945,7 @@ def define_dataproc_cluster_config():
                                                             description="""Optional. The Compute Engine
                                                         accelerator configuration for these
                                                         instances.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "minCpuPlatform": Field(
                                                             String,
@@ -1953,7 +1953,7 @@ def define_dataproc_cluster_config():
                                                         minimum cpu platform for the Instance Group.
                                                         See Dataproc -> Minimum CPU Platform
                                                         (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "minNumInstances": Field(
                                                             Int,
@@ -1971,7 +1971,7 @@ def define_dataproc_cluster_config():
                                                         2 instances are created and 3 instances
                                                         fail, the cluster in placed in an ERROR
                                                         state. The failed VMs are not deleted.""",
-                                                            is_required=True,
+                                                            is_required=False,
                                                         ),
                                                         "instanceFlexibilityPolicy": Field(
                                                             Shape(
@@ -2007,7 +2007,7 @@ def define_dataproc_cluster_config():
                                                                                 standard VMs for
                                                                                 remaining 10
                                                                                 instances.""",
-                                                                                    is_required=True,
+                                                                                    is_required=False,
                                                                                 ),
                                                                                 "standardCapacityPercentAboveBase": Field(
                                                                                     Int,
@@ -2036,7 +2036,7 @@ def define_dataproc_cluster_config():
                                                                                 instances. The mix
                                                                                 will be 30% standard
                                                                                 and 70% spot.""",
-                                                                                    is_required=True,
+                                                                                    is_required=False,
                                                                                 ),
                                                                             },
                                                                         ),
@@ -2056,7 +2056,7 @@ def define_dataproc_cluster_config():
                                                                                 Full machine-type
                                                                                 names, e.g.
                                                                                 "n1-standard-16".""",
-                                                                                        is_required=True,
+                                                                                        is_required=False,
                                                                                     ),
                                                                                     "rank": Field(
                                                                                         Int,
@@ -2078,7 +2078,7 @@ def define_dataproc_cluster_config():
                                                                                 with the same
                                                                                 priority have the
                                                                                 same preference.""",
-                                                                                        is_required=True,
+                                                                                        is_required=False,
                                                                                     ),
                                                                                 },
                                                                             )
@@ -2087,7 +2087,7 @@ def define_dataproc_cluster_config():
                                                                     instance selection options that
                                                                     the group will use when creating
                                                                     new VMs.""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                 },
                                                             ),
@@ -2116,7 +2116,7 @@ def define_dataproc_cluster_config():
                                                                     creation, agent registration,
                                                                     and service registration (if
                                                                     enabled).""",
-                                                                        is_required=True,
+                                                                        is_required=False,
                                                                     ),
                                                                 },
                                                             ),
@@ -2141,7 +2141,7 @@ def define_dataproc_cluster_config():
                                             from 1 to 63 characters and conform to RFC 1035
                                             (https://www.ietf.org/rfc/rfc1035.txt). The node group
                                             must have no more than 32 labels.""",
-                                                is_required=True,
+                                                is_required=False,
                                             ),
                                         },
                                     ),
@@ -2155,13 +2155,13 @@ def define_dataproc_cluster_config():
                                 specified.The ID must contain only letters (a-z, A-Z), numbers
                                 (0-9), underscores (_), and hyphens (-). Cannot begin or end with
                                 underscore or hyphen. Must consist of from 3 to 33 characters.""",
-                                    is_required=True,
+                                    is_required=False,
                                 ),
                             },
                         )
                     ],
                     description="""Optional. The node group settings.""",
-                    is_required=True,
+                    is_required=False,
                 ),
             },
         ),

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_cluster.py
@@ -9,562 +9,114 @@ parse_dataproc_configs.py \
 
 from dagster import Bool, Field, Int, Permissive, Shape, String
 
-from dagster_gcp.dataproc.types_dataproc_cluster import Component
+from dagster_gcp.dataproc.types_dataproc_cluster import (
+    Component,
+    consumeReservationType,
+    metricSource,
+    preemptibility,
+    privateIpv6GoogleAccess,
+)
 
 
 def define_dataproc_cluster_config():
     return Field(
         Shape(
             fields={
-                "masterConfig": Field(
-                    Shape(
-                        fields={
-                            "accelerators": Field(
-                                [
-                                    Shape(
-                                        fields={
-                                            "acceleratorCount": Field(
-                                                Int,
-                                                description="""The number of the accelerator cards of
-                                            this type exposed to this instance.""",
-                                                is_required=False,
-                                            ),
-                                            "acceleratorTypeUri": Field(
-                                                String,
-                                                description="""Full URL, partial URI, or short name of
-                                            the accelerator type resource to expose to this
-                                            instance. See Compute Engine AcceleratorTypes.Examples:
-                                            https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            nvidia-tesla-k80Auto Zone Exception: If you are using
-                                            the Cloud Dataproc Auto Zone Placement feature, you must
-                                            use the short name of the accelerator type resource, for
-                                            example, nvidia-tesla-k80.""",
-                                                is_required=False,
-                                            ),
-                                        }
-                                    )
-                                ],
-                                description="""Optional. The Compute Engine accelerator
-                                configuration for these instances.Beta Feature: This feature is
-                                still under development. It may be changed before final release.""",
-                                is_required=False,
-                            ),
-                            "numInstances": Field(
-                                Int,
-                                description="""Optional. The number of VM instances in the instance
-                                group. For master instance groups, must be set to 1.""",
-                                is_required=False,
-                            ),
-                            "diskConfig": Field(
-                                Shape(
-                                    fields={
-                                        "numLocalSsds": Field(
-                                            Int,
-                                            description="""Optional. Number of attached SSDs, from 0
-                                            to 4 (default is 0). If SSDs are not attached, the boot
-                                            disk is used to store runtime logs and HDFS
-                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
-                                            data. If one or more SSDs are attached, this runtime
-                                            bulk data is spread across them, and the boot disk
-                                            contains only basic config and installed binaries.""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskSizeGb": Field(
-                                            Int,
-                                            description="""Optional. Size in GB of the boot disk
-                                            (default is 500GB).""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskType": Field(
-                                            String,
-                                            description="""Optional. Type of the boot disk (default
-                                            is "pd-standard"). Valid values: "pd-ssd" (Persistent
-                                            Disk Solid State Drive) or "pd-standard" (Persistent
-                                            Disk Hard Disk Drive).""",
-                                            is_required=False,
-                                        ),
-                                    }
-                                ),
-                                description="""Specifies the config of disk options for a group of
-                                VM instances.""",
-                                is_required=False,
-                            ),
-                            "managedGroupConfig": Field(
-                                Shape(fields={}),
-                                description="""Specifies the resources used to actively manage an
-                                instance group.""",
-                                is_required=False,
-                            ),
-                            "isPreemptible": Field(
-                                Bool,
-                                description="""Optional. Specifies that this instance group contains
-                                preemptible instances.""",
-                                is_required=False,
-                            ),
-                            "imageUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine image resource used for
-                                cluster instances. It can be specified or may be inferred from
-                                SoftwareConfig.image_version.""",
-                                is_required=False,
-                            ),
-                            "machineTypeUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine machine type used for
-                                cluster instances.A full URL, partial URI, or short name are valid.
-                                Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                n1-standard-2Auto Zone Exception: If you are using the Cloud
-                                Dataproc Auto Zone Placement feature, you must use the short name of
-                                the machine type resource, for example, n1-standard-2.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""Optional. The config settings for Compute Engine resources in an
-                    instance group, such as a master or worker group.""",
-                    is_required=False,
-                ),
-                "secondaryWorkerConfig": Field(
-                    Shape(
-                        fields={
-                            "accelerators": Field(
-                                [
-                                    Shape(
-                                        fields={
-                                            "acceleratorCount": Field(
-                                                Int,
-                                                description="""The number of the accelerator cards of
-                                            this type exposed to this instance.""",
-                                                is_required=False,
-                                            ),
-                                            "acceleratorTypeUri": Field(
-                                                String,
-                                                description="""Full URL, partial URI, or short name of
-                                            the accelerator type resource to expose to this
-                                            instance. See Compute Engine AcceleratorTypes.Examples:
-                                            https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            nvidia-tesla-k80Auto Zone Exception: If you are using
-                                            the Cloud Dataproc Auto Zone Placement feature, you must
-                                            use the short name of the accelerator type resource, for
-                                            example, nvidia-tesla-k80.""",
-                                                is_required=False,
-                                            ),
-                                        }
-                                    )
-                                ],
-                                description="""Optional. The Compute Engine accelerator
-                                configuration for these instances.Beta Feature: This feature is
-                                still under development. It may be changed before final release.""",
-                                is_required=False,
-                            ),
-                            "numInstances": Field(
-                                Int,
-                                description="""Optional. The number of VM instances in the instance
-                                group. For master instance groups, must be set to 1.""",
-                                is_required=False,
-                            ),
-                            "diskConfig": Field(
-                                Shape(
-                                    fields={
-                                        "numLocalSsds": Field(
-                                            Int,
-                                            description="""Optional. Number of attached SSDs, from 0
-                                            to 4 (default is 0). If SSDs are not attached, the boot
-                                            disk is used to store runtime logs and HDFS
-                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
-                                            data. If one or more SSDs are attached, this runtime
-                                            bulk data is spread across them, and the boot disk
-                                            contains only basic config and installed binaries.""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskSizeGb": Field(
-                                            Int,
-                                            description="""Optional. Size in GB of the boot disk
-                                            (default is 500GB).""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskType": Field(
-                                            String,
-                                            description="""Optional. Type of the boot disk (default
-                                            is "pd-standard"). Valid values: "pd-ssd" (Persistent
-                                            Disk Solid State Drive) or "pd-standard" (Persistent
-                                            Disk Hard Disk Drive).""",
-                                            is_required=False,
-                                        ),
-                                    }
-                                ),
-                                description="""Specifies the config of disk options for a group of
-                                VM instances.""",
-                                is_required=False,
-                            ),
-                            "managedGroupConfig": Field(
-                                Shape(fields={}),
-                                description="""Specifies the resources used to actively manage an
-                                instance group.""",
-                                is_required=False,
-                            ),
-                            "isPreemptible": Field(
-                                Bool,
-                                description="""Optional. Specifies that this instance group contains
-                                preemptible instances.""",
-                                is_required=False,
-                            ),
-                            "imageUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine image resource used for
-                                cluster instances. It can be specified or may be inferred from
-                                SoftwareConfig.image_version.""",
-                                is_required=False,
-                            ),
-                            "machineTypeUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine machine type used for
-                                cluster instances.A full URL, partial URI, or short name are valid.
-                                Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                n1-standard-2Auto Zone Exception: If you are using the Cloud
-                                Dataproc Auto Zone Placement feature, you must use the short name of
-                                the machine type resource, for example, n1-standard-2.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""Optional. The config settings for Compute Engine resources in an
-                    instance group, such as a master or worker group.""",
-                    is_required=False,
-                ),
-                "encryptionConfig": Field(
-                    Shape(
-                        fields={
-                            "gcePdKmsKeyName": Field(
-                                String,
-                                description="""Optional. The Cloud KMS key name to use for PD disk
-                                encryption for all instances in the cluster.""",
-                                is_required=False,
-                            )
-                        }
-                    ),
-                    description="""Encryption settings for the cluster.""",
-                    is_required=False,
-                ),
-                "securityConfig": Field(
-                    Shape(
-                        fields={
-                            "kerberosConfig": Field(
-                                Shape(
-                                    fields={
-                                        "truststorePasswordUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of a KMS
-                                            encrypted file containing the password to the user
-                                            provided truststore. For the self-signed certificate,
-                                            this password is generated by Dataproc.""",
-                                            is_required=False,
-                                        ),
-                                        "enableKerberos": Field(
-                                            Bool,
-                                            description="""Optional. Flag to indicate whether to
-                                            Kerberize the cluster.""",
-                                            is_required=False,
-                                        ),
-                                        "truststoreUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of the
-                                            truststore file used for SSL encryption. If not
-                                            provided, Dataproc will provide a self-signed
-                                            certificate.""",
-                                            is_required=False,
-                                        ),
-                                        "crossRealmTrustRealm": Field(
-                                            String,
-                                            description="""Optional. The remote realm the Dataproc
-                                            on-cluster KDC will trust, should the user enable cross
-                                            realm trust.""",
-                                            is_required=False,
-                                        ),
-                                        "rootPrincipalPasswordUri": Field(
-                                            String,
-                                            description="""Required. The Cloud Storage URI of a KMS
-                                            encrypted file containing the root principal
-                                            password.""",
-                                            is_required=False,
-                                        ),
-                                        "kmsKeyUri": Field(
-                                            String,
-                                            description="""Required. The uri of the KMS key used to
-                                            encrypt various sensitive files.""",
-                                            is_required=False,
-                                        ),
-                                        "crossRealmTrustKdc": Field(
-                                            String,
-                                            description="""Optional. The KDC (IP or hostname) for
-                                            the remote trusted realm in a cross realm trust
-                                            relationship.""",
-                                            is_required=False,
-                                        ),
-                                        "crossRealmTrustSharedPasswordUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of a KMS
-                                            encrypted file containing the shared password between
-                                            the on-cluster Kerberos realm and the remote trusted
-                                            realm, in a cross realm trust relationship.""",
-                                            is_required=False,
-                                        ),
-                                        "tgtLifetimeHours": Field(
-                                            Int,
-                                            description="""Optional. The lifetime of the ticket
-                                            granting ticket, in hours. If not specified, or user
-                                            specifies 0, then default value 10 will be used.""",
-                                            is_required=False,
-                                        ),
-                                        "keystoreUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of the
-                                            keystore file used for SSL encryption. If not provided,
-                                            Dataproc will provide a self-signed certificate.""",
-                                            is_required=False,
-                                        ),
-                                        "keyPasswordUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of a KMS
-                                            encrypted file containing the password to the user
-                                            provided key. For the self-signed certificate, this
-                                            password is generated by Dataproc.""",
-                                            is_required=False,
-                                        ),
-                                        "keystorePasswordUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of a KMS
-                                            encrypted file containing the password to the user
-                                            provided keystore. For the self-signed certificate, this
-                                            password is generated by Dataproc.""",
-                                            is_required=False,
-                                        ),
-                                        "crossRealmTrustAdminServer": Field(
-                                            String,
-                                            description="""Optional. The admin server (IP or
-                                            hostname) for the remote trusted realm in a cross realm
-                                            trust relationship.""",
-                                            is_required=False,
-                                        ),
-                                        "kdcDbKeyUri": Field(
-                                            String,
-                                            description="""Optional. The Cloud Storage URI of a KMS
-                                            encrypted file containing the master key of the KDC
-                                            database.""",
-                                            is_required=False,
-                                        ),
-                                    }
-                                ),
-                                description="""Specifies Kerberos related configuration.""",
-                                is_required=False,
-                            )
-                        }
-                    ),
-                    description="""Security related configuration, including Kerberos.""",
-                    is_required=False,
-                ),
-                "initializationActions": Field(
-                    [
-                        Shape(
-                            fields={
-                                "executionTimeout": Field(
-                                    String,
-                                    description="""Optional. Amount of time executable has to complete.
-                                Default is 10 minutes. Cluster creation fails with an explanatory
-                                error message (the name of the executable that caused the error and
-                                the exceeded timeout period) if the executable is not completed at
-                                end of the timeout period.""",
-                                    is_required=False,
-                                ),
-                                "executableFile": Field(
-                                    String,
-                                    description="""Required. Cloud Storage URI of executable file.""",
-                                    is_required=False,
-                                ),
-                            }
-                        )
-                    ],
-                    description="""Optional. Commands to execute on each node after config is
-                    completed. By default, executables are run on master and all worker nodes. You
-                    can test a node\'s role metadata to run an executable on a master or worker
-                    node, as shown below using curl (you can also use wget): ROLE=$(curl -H
-                    Metadata-Flavor:Google
-                    http://metadata/computeMetadata/v1/instance/attributes/dataproc-role) if [[
-                    "${ROLE}" == \'Master\' ]]; then   ... master specific actions ... else   ...
-                    worker specific actions ... fi """,
-                    is_required=False,
-                ),
                 "configBucket": Field(
                     String,
-                    description="""Optional. A Google Cloud Storage bucket used to stage job
-                    dependencies, config files, and job driver console output. If you do not specify
-                    a staging bucket, Cloud Dataproc will determine a Cloud Storage location (US,
-                    ASIA, or EU) for your cluster\'s staging bucket according to the Google Compute
-                    Engine zone where your cluster is deployed, and then create and manage this
-                    project-level, per-location bucket (see Cloud Dataproc staging bucket).""",
-                    is_required=False,
+                    description="""Optional. A Cloud Storage bucket used to stage job dependencies,
+                    config files, and job driver console output. If you do not specify a staging
+                    bucket, Cloud Dataproc will determine a Cloud Storage location (US, ASIA, or EU)
+                    for your cluster\'s staging bucket according to the Compute Engine zone where
+                    your cluster is deployed, and then create and manage this project-level,
+                    per-location bucket (see Dataproc staging and temp buckets
+                    (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
+                    This field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud
+                    Storage bucket.""",
+                    is_required=True,
                 ),
-                "workerConfig": Field(
-                    Shape(
-                        fields={
-                            "accelerators": Field(
-                                [
-                                    Shape(
-                                        fields={
-                                            "acceleratorCount": Field(
-                                                Int,
-                                                description="""The number of the accelerator cards of
-                                            this type exposed to this instance.""",
-                                                is_required=False,
-                                            ),
-                                            "acceleratorTypeUri": Field(
-                                                String,
-                                                description="""Full URL, partial URI, or short name of
-                                            the accelerator type resource to expose to this
-                                            instance. See Compute Engine AcceleratorTypes.Examples:
-                                            https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
-                                            nvidia-tesla-k80Auto Zone Exception: If you are using
-                                            the Cloud Dataproc Auto Zone Placement feature, you must
-                                            use the short name of the accelerator type resource, for
-                                            example, nvidia-tesla-k80.""",
-                                                is_required=False,
-                                            ),
-                                        }
-                                    )
-                                ],
-                                description="""Optional. The Compute Engine accelerator
-                                configuration for these instances.Beta Feature: This feature is
-                                still under development. It may be changed before final release.""",
-                                is_required=False,
-                            ),
-                            "numInstances": Field(
-                                Int,
-                                description="""Optional. The number of VM instances in the instance
-                                group. For master instance groups, must be set to 1.""",
-                                is_required=False,
-                            ),
-                            "diskConfig": Field(
-                                Shape(
-                                    fields={
-                                        "numLocalSsds": Field(
-                                            Int,
-                                            description="""Optional. Number of attached SSDs, from 0
-                                            to 4 (default is 0). If SSDs are not attached, the boot
-                                            disk is used to store runtime logs and HDFS
-                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
-                                            data. If one or more SSDs are attached, this runtime
-                                            bulk data is spread across them, and the boot disk
-                                            contains only basic config and installed binaries.""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskSizeGb": Field(
-                                            Int,
-                                            description="""Optional. Size in GB of the boot disk
-                                            (default is 500GB).""",
-                                            is_required=False,
-                                        ),
-                                        "bootDiskType": Field(
-                                            String,
-                                            description="""Optional. Type of the boot disk (default
-                                            is "pd-standard"). Valid values: "pd-ssd" (Persistent
-                                            Disk Solid State Drive) or "pd-standard" (Persistent
-                                            Disk Hard Disk Drive).""",
-                                            is_required=False,
-                                        ),
-                                    }
-                                ),
-                                description="""Specifies the config of disk options for a group of
-                                VM instances.""",
-                                is_required=False,
-                            ),
-                            "managedGroupConfig": Field(
-                                Shape(fields={}),
-                                description="""Specifies the resources used to actively manage an
-                                instance group.""",
-                                is_required=False,
-                            ),
-                            "isPreemptible": Field(
-                                Bool,
-                                description="""Optional. Specifies that this instance group contains
-                                preemptible instances.""",
-                                is_required=False,
-                            ),
-                            "imageUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine image resource used for
-                                cluster instances. It can be specified or may be inferred from
-                                SoftwareConfig.image_version.""",
-                                is_required=False,
-                            ),
-                            "machineTypeUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine machine type used for
-                                cluster instances.A full URL, partial URI, or short name are valid.
-                                Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2
-                                n1-standard-2Auto Zone Exception: If you are using the Cloud
-                                Dataproc Auto Zone Placement feature, you must use the short name of
-                                the machine type resource, for example, n1-standard-2.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""Optional. The config settings for Compute Engine resources in an
-                    instance group, such as a master or worker group.""",
-                    is_required=False,
+                "tempBucket": Field(
+                    String,
+                    description="""Optional. A Cloud Storage bucket used to store ephemeral cluster
+                    and jobs data, such as Spark and MapReduce history files. If you do not specify
+                    a temp bucket, Dataproc will determine a Cloud Storage location (US, ASIA, or
+                    EU) for your cluster\'s temp bucket according to the Compute Engine zone where
+                    your cluster is deployed, and then create and manage this project-level,
+                    per-location bucket. The default bucket has a TTL of 90 days, but you can use
+                    any TTL (or none) if you specify a bucket (see Dataproc staging and temp buckets
+                    (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
+                    This field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud
+                    Storage bucket.""",
+                    is_required=True,
                 ),
                 "gceClusterConfig": Field(
                     Shape(
                         fields={
+                            "zoneUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine zone where the Dataproc
+                                cluster will be located. If omitted, the service will pick a zone in
+                                the cluster\'s Compute Engine region. On a get request, zone will
+                                always be present.A full URL, partial URI, or short name are valid.
+                                Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]
+                                projects/[project_id]/zones/[zone] [zone]""",
+                                is_required=True,
+                            ),
                             "networkUri": Field(
                                 String,
                                 description="""Optional. The Compute Engine network to be used for
                                 machine communications. Cannot be specified with subnetwork_uri. If
                                 neither network_uri nor subnetwork_uri is specified, the "default"
                                 network of the project is used, if it exists. Cannot be a "Custom
-                                Subnet Network" (see Using Subnetworks for more information).A full
-                                URL, partial URI, or short name are valid. Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default
-                                projects/[project_id]/regions/global/default default""",
-                                is_required=False,
+                                Subnet Network" (see Using Subnetworks
+                                (https://cloud.google.com/compute/docs/subnetworks) for more
+                                information).A full URL, partial URI, or short name are valid.
+                                Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/networks/default
+                                projects/[project_id]/global/networks/default default""",
+                                is_required=True,
                             ),
-                            "zoneUri": Field(
+                            "subnetworkUri": Field(
                                 String,
-                                description="""Optional. The zone where the Compute Engine cluster
-                                will be located. On a create request, it is required in the "global"
-                                region. If omitted in a non-global Cloud Dataproc region, the
-                                service will pick a zone in the corresponding Compute Engine region.
-                                On a get request, zone will always be present.A full URL, partial
-                                URI, or short name are valid. Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]
-                                projects/[project_id]/zones/[zone] us-central1-f""",
-                                is_required=False,
-                            ),
-                            "metadata": Field(
-                                Permissive(),
-                                description="""The Compute Engine metadata entries to add to all
-                                instances (see Project and instance metadata
-                                (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).""",
-                                is_required=False,
+                                description="""Optional. The Compute Engine subnetwork to be used
+                                for machine communications. Cannot be specified with network_uri.A
+                                full URL, partial URI, or short name are valid. Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/regions/[region]/subnetworks/sub0
+                                projects/[project_id]/regions/[region]/subnetworks/sub0 sub0""",
+                                is_required=True,
                             ),
                             "internalIpOnly": Field(
                                 Bool,
-                                description="""Optional. If true, all instances in the cluster will
-                                only have internal IP addresses. By default, clusters are not
-                                restricted to internal IP addresses, and will have ephemeral
-                                external IP addresses assigned to each instance. This
-                                internal_ip_only restriction can only be enabled for subnetwork
-                                enabled networks, and all off-cluster dependencies must be
-                                configured to be accessible without external IP addresses.""",
-                                is_required=False,
+                                description="""Optional. This setting applies to subnetwork-enabled
+                                networks. It is set to true by default in clusters created with
+                                image versions 2.2.x.When set to true: All cluster VMs have internal
+                                IP addresses. Google Private Access
+                                (https://cloud.google.com/vpc/docs/private-google-access) must be
+                                enabled to access Dataproc and other Google Cloud APIs. Off-cluster
+                                dependencies must be configured to be accessible without external IP
+                                addresses.When set to false: Cluster VMs are not restricted to
+                                internal IP addresses. Ephemeral external IP addresses are assigned
+                                to each cluster VM.""",
+                                is_required=True,
+                            ),
+                            "privateIpv6GoogleAccess": Field(
+                                privateIpv6GoogleAccess,
+                                description="""Optional. The type of IPv6 access for a cluster.""",
+                                is_required=True,
+                            ),
+                            "serviceAccount": Field(
+                                String,
+                                description="""Optional. The Dataproc service account
+                                (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#service_accounts_in_dataproc)
+                                (also see VM Data Plane identity
+                                (https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#vm_service_account_data_plane_identity))
+                                used by Dataproc cluster VM instances to access Google Cloud
+                                Platform services.If not specified, the Compute Engine default
+                                service account
+                                (https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
+                                is used.""",
+                                is_required=True,
                             ),
                             "serviceAccountScopes": Field(
                                 [String],
@@ -579,43 +131,983 @@ def define_dataproc_cluster_config():
                                 https://www.googleapis.com/auth/bigtable.admin.table
                                 https://www.googleapis.com/auth/bigtable.data
                                 https://www.googleapis.com/auth/devstorage.full_control""",
-                                is_required=False,
+                                is_required=True,
                             ),
                             "tags": Field(
                                 [String],
-                                description="""The Compute Engine tags to add to all instances (see
-                                Tagging instances).""",
-                                is_required=False,
+                                description="""The Compute Engine network tags to add to all
+                                instances (see Tagging instances
+                                (https://cloud.google.com/vpc/docs/add-remove-network-tags)).""",
+                                is_required=True,
                             ),
-                            "serviceAccount": Field(
-                                String,
-                                description="""Optional. The service account of the instances.
-                                Defaults to the default Compute Engine service account. Custom
-                                service accounts need permissions equivalent to the following IAM
-                                roles: roles/logging.logWriter roles/storage.objectAdmin(see
-                                https://cloud.google.com/compute/docs/access/service-accounts#custom_service_accounts
-                                for more information). Example:
-                                [account_id]@[project_id].iam.gserviceaccount.com""",
-                                is_required=False,
+                            "metadata": Field(
+                                Permissive(),
+                                description="""Optional. The Compute Engine metadata entries to add
+                                to all instances (see Project and instance metadata
+                                (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).""",
+                                is_required=True,
                             ),
-                            "subnetworkUri": Field(
-                                String,
-                                description="""Optional. The Compute Engine subnetwork to be used
-                                for machine communications. Cannot be specified with network_uri.A
-                                full URL, partial URI, or short name are valid. Examples:
-                                https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/subnetworks/sub0
-                                projects/[project_id]/regions/us-east1/subnetworks/sub0 sub0""",
-                                is_required=False,
+                            "reservationAffinity": Field(
+                                Shape(
+                                    fields={
+                                        "consumeReservationType": Field(
+                                            consumeReservationType,
+                                            description="""Optional. Type of reservation to
+                                            consume""",
+                                            is_required=True,
+                                        ),
+                                        "key": Field(
+                                            String,
+                                            description="""Optional. Corresponds to the label key of
+                                            reservation resource.""",
+                                            is_required=True,
+                                        ),
+                                        "values": Field(
+                                            [String],
+                                            description="""Optional. Corresponds to the label values
+                                            of reservation resource.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Reservation Affinity for consuming Zonal
+                                reservation.""",
+                                is_required=True,
                             ),
-                        }
+                            "nodeGroupAffinity": Field(
+                                Shape(
+                                    fields={
+                                        "nodeGroupUri": Field(
+                                            String,
+                                            description="""Required. The URI of a sole-tenant node
+                                            group resource
+                                            (https://cloud.google.com/compute/docs/reference/rest/v1/nodeGroups)
+                                            that the cluster will be created on.A full URL, partial
+                                            URI, or node group name are valid. Examples:
+                                            https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/nodeGroups/node-group-1
+                                            projects/[project_id]/zones/[zone]/nodeGroups/node-group-1
+                                            node-group-1""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Node Group Affinity for clusters using sole-tenant
+                                node groups. The Dataproc NodeGroupAffinity resource is not related
+                                to the Dataproc NodeGroup resource.""",
+                                is_required=True,
+                            ),
+                            "shieldedInstanceConfig": Field(
+                                Shape(
+                                    fields={
+                                        "enableSecureBoot": Field(
+                                            Bool,
+                                            description="""Optional. Defines whether instances have
+                                            Secure Boot enabled.""",
+                                            is_required=True,
+                                        ),
+                                        "enableVtpm": Field(
+                                            Bool,
+                                            description="""Optional. Defines whether instances have
+                                            the vTPM enabled.""",
+                                            is_required=True,
+                                        ),
+                                        "enableIntegrityMonitoring": Field(
+                                            Bool,
+                                            description="""Optional. Defines whether instances have
+                                            integrity monitoring enabled.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Shielded Instance Config for clusters using Compute
+                                Engine Shielded VMs
+                                (https://cloud.google.com/security/shielded-cloud/shielded-vm).""",
+                                is_required=True,
+                            ),
+                            "confidentialInstanceConfig": Field(
+                                Shape(
+                                    fields={
+                                        "enableConfidentialCompute": Field(
+                                            Bool,
+                                            description="""Optional. Defines whether the instance
+                                            should have confidential compute enabled.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Confidential Instance Config for clusters using
+                                Confidential VMs
+                                (https://cloud.google.com/compute/confidential-vm/docs)""",
+                                is_required=True,
+                            ),
+                            "resourceManagerTags": Field(
+                                Permissive(),
+                                description="""Optional. Resource manager tags
+                                (https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing)
+                                to add to all instances (see Use secure tags in Dataproc
+                                (https://cloud.google.com/dataproc/docs/guides/attach-secure-tags)).""",
+                                is_required=True,
+                            ),
+                        },
                     ),
                     description="""Common config settings for resources of Compute Engine cluster
                     instances, applicable to all instances in the cluster.""",
-                    is_required=False,
+                    is_required=True,
+                ),
+                "masterConfig": Field(
+                    Shape(
+                        fields={
+                            "numInstances": Field(
+                                Int,
+                                description="""Optional. The number of VM instances in the instance
+                                group. For HA cluster master_config groups, must be set to 3. For
+                                standard cluster master_config groups, must be set to 1.""",
+                                is_required=True,
+                            ),
+                            "imageUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine image resource used for
+                                cluster instances.The URI can represent an image or image
+                                family.Image examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/[image-id]
+                                projects/[project_id]/global/images/[image-id] image-idImage family
+                                examples. Dataproc will use the most recent image from the family:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/family/[custom-image-family-name]
+                                projects/[project_id]/global/images/family/[custom-image-family-name]If
+                                the URI is unspecified, it will be inferred from
+                                SoftwareConfig.image_version or the system default.""",
+                                is_required=True,
+                            ),
+                            "machineTypeUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine machine type used for
+                                cluster instances.A full URL, partial URI, or short name are valid.
+                                Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                n1-standard-2Auto Zone Exception: If you are using the Dataproc Auto
+                                Zone Placement
+                                (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                feature, you must use the short name of the machine type resource,
+                                for example, n1-standard-2.""",
+                                is_required=True,
+                            ),
+                            "diskConfig": Field(
+                                Shape(
+                                    fields={
+                                        "bootDiskType": Field(
+                                            String,
+                                            description="""Optional. Type of the boot disk (default
+                                            is "pd-standard"). Valid values: "pd-balanced"
+                                            (Persistent Disk Balanced Solid State Drive), "pd-ssd"
+                                            (Persistent Disk Solid State Drive), or "pd-standard"
+                                            (Persistent Disk Hard Disk Drive). See Disk types
+                                            (https://cloud.google.com/compute/docs/disks#disk-types).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskSizeGb": Field(
+                                            Int,
+                                            description="""Optional. Size in GB of the boot disk
+                                            (default is 500GB).""",
+                                            is_required=True,
+                                        ),
+                                        "numLocalSsds": Field(
+                                            Int,
+                                            description="""Optional. Number of attached SSDs, from 0
+                                            to 8 (default is 0). If SSDs are not attached, the boot
+                                            disk is used to store runtime logs and HDFS
+                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                                            data. If one or more SSDs are attached, this runtime
+                                            bulk data is spread across them, and the boot disk
+                                            contains only basic config and installed binaries.Note:
+                                            Local SSD options may vary by machine type and number of
+                                            vCPUs selected.""",
+                                            is_required=True,
+                                        ),
+                                        "localSsdInterface": Field(
+                                            String,
+                                            description="""Optional. Interface type of local SSDs
+                                            (default is "scsi"). Valid values: "scsi" (Small
+                                            Computer System Interface), "nvme" (Non-Volatile Memory
+                                            Express). See local SSD performance
+                                            (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedIops": Field(
+                                            String,
+                                            description="""Optional. Indicates how many IOPS to
+                                            provision for the disk. This sets the number of I/O
+                                            operations per second that the disk can handle. This
+                                            field is supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedThroughput": Field(
+                                            String,
+                                            description="""Optional. Indicates how much throughput
+                                            to provision for the disk. This sets the number of
+                                            throughput mb per second that the disk can handle.
+                                            Values must be greater than or equal to 1. This field is
+                                            supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Specifies the config of disk options for a group of
+                                VM instances.""",
+                                is_required=True,
+                            ),
+                            "preemptibility": Field(
+                                preemptibility,
+                                description="""Optional. Specifies the preemptibility of the
+                                instance group.The default value for master and worker groups is
+                                NON_PREEMPTIBLE. This default cannot be changed.The default value
+                                for secondary instances is PREEMPTIBLE.""",
+                                is_required=True,
+                            ),
+                            "managedGroupConfig": Field(
+                                Shape(
+                                    fields={},
+                                ),
+                                description="""Specifies the resources used to actively manage an
+                                instance group.""",
+                                is_required=True,
+                            ),
+                            "accelerators": Field(
+                                [
+                                    Shape(
+                                        fields={
+                                            "acceleratorTypeUri": Field(
+                                                String,
+                                                description="""Full URL, partial URI, or short name of
+                                            the accelerator type resource to expose to this
+                                            instance. See Compute Engine AcceleratorTypes
+                                            (https://cloud.google.com/compute/docs/reference/v1/acceleratorTypes).Examples:
+                                            https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            nvidia-tesla-t4Auto Zone Exception: If you are using the
+                                            Dataproc Auto Zone Placement
+                                            (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                            feature, you must use the short name of the accelerator
+                                            type resource, for example, nvidia-tesla-t4.""",
+                                                is_required=True,
+                                            ),
+                                            "acceleratorCount": Field(
+                                                Int,
+                                                description="""The number of the accelerator cards of
+                                            this type exposed to this instance.""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    )
+                                ],
+                                description="""Optional. The Compute Engine accelerator
+                                configuration for these instances.""",
+                                is_required=True,
+                            ),
+                            "minCpuPlatform": Field(
+                                String,
+                                description="""Optional. Specifies the minimum cpu platform for the
+                                Instance Group. See Dataproc -> Minimum CPU Platform
+                                (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
+                                is_required=True,
+                            ),
+                            "minNumInstances": Field(
+                                Int,
+                                description="""Optional. The minimum number of primary worker
+                                instances to create. If min_num_instances is set, cluster creation
+                                will succeed if the number of primary workers created is at least
+                                equal to the min_num_instances number.Example: Cluster creation
+                                request with num_instances = 5 and min_num_instances = 3: If 4 VMs
+                                are created and 1 instance fails, the failed VM is deleted. The
+                                cluster is resized to 4 instances and placed in a RUNNING state. If
+                                2 instances are created and 3 instances fail, the cluster in placed
+                                in an ERROR state. The failed VMs are not deleted.""",
+                                is_required=True,
+                            ),
+                            "instanceFlexibilityPolicy": Field(
+                                Shape(
+                                    fields={
+                                        "provisioningModelMix": Field(
+                                            Shape(
+                                                fields={
+                                                    "standardCapacityBase": Field(
+                                                        Int,
+                                                        description="""Optional. The base capacity
+                                                        that will always use Standard VMs to avoid
+                                                        risk of more preemption than the minimum
+                                                        capacity you need. Dataproc will create only
+                                                        standard VMs until it reaches
+                                                        standard_capacity_base, then it will start
+                                                        using standard_capacity_percent_above_base
+                                                        to mix Spot with Standard VMs. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5, Dataproc will
+                                                        create 5 standard VMs and then start mixing
+                                                        spot and standard VMs for remaining 10
+                                                        instances.""",
+                                                        is_required=True,
+                                                    ),
+                                                    "standardCapacityPercentAboveBase": Field(
+                                                        Int,
+                                                        description="""Optional. The percentage of
+                                                        target capacity that should use Standard VM.
+                                                        The remaining percentage will use Spot VMs.
+                                                        The percentage applies only to the capacity
+                                                        above standard_capacity_base. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5 and
+                                                        standard_capacity_percent_above_base is 30,
+                                                        Dataproc will create 5 standard VMs and then
+                                                        start mixing spot and standard VMs for
+                                                        remaining 10 instances. The mix will be 30%
+                                                        standard and 70% spot.""",
+                                                        is_required=True,
+                                                    ),
+                                                },
+                                            ),
+                                            description="""Defines how Dataproc should create VMs
+                                            with a mixture of provisioning models.""",
+                                            is_required=True,
+                                        ),
+                                        "instanceSelectionList": Field(
+                                            [
+                                                Shape(
+                                                    fields={
+                                                        "machineTypes": Field(
+                                                            [String],
+                                                            description="""Optional. Full machine-type
+                                                        names, e.g. "n1-standard-16".""",
+                                                            is_required=True,
+                                                        ),
+                                                        "rank": Field(
+                                                            Int,
+                                                            description="""Optional. Preference of this
+                                                        instance selection. Lower number means
+                                                        higher preference. Dataproc will first try
+                                                        to create a VM based on the machine-type
+                                                        with priority rank and fallback to next rank
+                                                        based on availability. Machine types and
+                                                        instance selections with the same priority
+                                                        have the same preference.""",
+                                                            is_required=True,
+                                                        ),
+                                                    },
+                                                )
+                                            ],
+                                            description="""Optional. List of instance selection
+                                            options that the group will use when creating new
+                                            VMs.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Instance flexibility Policy allowing a mixture of VM
+                                shapes and provisioning models.""",
+                                is_required=True,
+                            ),
+                            "startupConfig": Field(
+                                Shape(
+                                    fields={
+                                        "requiredRegistrationFraction": Field(
+                                            Int,
+                                            description="""Optional. The config setting to enable
+                                            cluster creation/ updation to be successful only after
+                                            required_registration_fraction of instances are up and
+                                            running. This configuration is applicable to only
+                                            secondary workers for now. The cluster will fail if
+                                            required_registration_fraction of instances are not
+                                            available. This will include instance creation, agent
+                                            registration, and service registration (if enabled).""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Configuration to handle the startup of instances
+                                during cluster create and update process.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""The config settings for Compute Engine resources in an instance
+                    group, such as a master or worker group.""",
+                    is_required=True,
+                ),
+                "workerConfig": Field(
+                    Shape(
+                        fields={
+                            "numInstances": Field(
+                                Int,
+                                description="""Optional. The number of VM instances in the instance
+                                group. For HA cluster master_config groups, must be set to 3. For
+                                standard cluster master_config groups, must be set to 1.""",
+                                is_required=True,
+                            ),
+                            "imageUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine image resource used for
+                                cluster instances.The URI can represent an image or image
+                                family.Image examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/[image-id]
+                                projects/[project_id]/global/images/[image-id] image-idImage family
+                                examples. Dataproc will use the most recent image from the family:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/family/[custom-image-family-name]
+                                projects/[project_id]/global/images/family/[custom-image-family-name]If
+                                the URI is unspecified, it will be inferred from
+                                SoftwareConfig.image_version or the system default.""",
+                                is_required=True,
+                            ),
+                            "machineTypeUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine machine type used for
+                                cluster instances.A full URL, partial URI, or short name are valid.
+                                Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                n1-standard-2Auto Zone Exception: If you are using the Dataproc Auto
+                                Zone Placement
+                                (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                feature, you must use the short name of the machine type resource,
+                                for example, n1-standard-2.""",
+                                is_required=True,
+                            ),
+                            "diskConfig": Field(
+                                Shape(
+                                    fields={
+                                        "bootDiskType": Field(
+                                            String,
+                                            description="""Optional. Type of the boot disk (default
+                                            is "pd-standard"). Valid values: "pd-balanced"
+                                            (Persistent Disk Balanced Solid State Drive), "pd-ssd"
+                                            (Persistent Disk Solid State Drive), or "pd-standard"
+                                            (Persistent Disk Hard Disk Drive). See Disk types
+                                            (https://cloud.google.com/compute/docs/disks#disk-types).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskSizeGb": Field(
+                                            Int,
+                                            description="""Optional. Size in GB of the boot disk
+                                            (default is 500GB).""",
+                                            is_required=True,
+                                        ),
+                                        "numLocalSsds": Field(
+                                            Int,
+                                            description="""Optional. Number of attached SSDs, from 0
+                                            to 8 (default is 0). If SSDs are not attached, the boot
+                                            disk is used to store runtime logs and HDFS
+                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                                            data. If one or more SSDs are attached, this runtime
+                                            bulk data is spread across them, and the boot disk
+                                            contains only basic config and installed binaries.Note:
+                                            Local SSD options may vary by machine type and number of
+                                            vCPUs selected.""",
+                                            is_required=True,
+                                        ),
+                                        "localSsdInterface": Field(
+                                            String,
+                                            description="""Optional. Interface type of local SSDs
+                                            (default is "scsi"). Valid values: "scsi" (Small
+                                            Computer System Interface), "nvme" (Non-Volatile Memory
+                                            Express). See local SSD performance
+                                            (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedIops": Field(
+                                            String,
+                                            description="""Optional. Indicates how many IOPS to
+                                            provision for the disk. This sets the number of I/O
+                                            operations per second that the disk can handle. This
+                                            field is supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedThroughput": Field(
+                                            String,
+                                            description="""Optional. Indicates how much throughput
+                                            to provision for the disk. This sets the number of
+                                            throughput mb per second that the disk can handle.
+                                            Values must be greater than or equal to 1. This field is
+                                            supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Specifies the config of disk options for a group of
+                                VM instances.""",
+                                is_required=True,
+                            ),
+                            "preemptibility": Field(
+                                preemptibility,
+                                description="""Optional. Specifies the preemptibility of the
+                                instance group.The default value for master and worker groups is
+                                NON_PREEMPTIBLE. This default cannot be changed.The default value
+                                for secondary instances is PREEMPTIBLE.""",
+                                is_required=True,
+                            ),
+                            "managedGroupConfig": Field(
+                                Shape(
+                                    fields={},
+                                ),
+                                description="""Specifies the resources used to actively manage an
+                                instance group.""",
+                                is_required=True,
+                            ),
+                            "accelerators": Field(
+                                [
+                                    Shape(
+                                        fields={
+                                            "acceleratorTypeUri": Field(
+                                                String,
+                                                description="""Full URL, partial URI, or short name of
+                                            the accelerator type resource to expose to this
+                                            instance. See Compute Engine AcceleratorTypes
+                                            (https://cloud.google.com/compute/docs/reference/v1/acceleratorTypes).Examples:
+                                            https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            nvidia-tesla-t4Auto Zone Exception: If you are using the
+                                            Dataproc Auto Zone Placement
+                                            (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                            feature, you must use the short name of the accelerator
+                                            type resource, for example, nvidia-tesla-t4.""",
+                                                is_required=True,
+                                            ),
+                                            "acceleratorCount": Field(
+                                                Int,
+                                                description="""The number of the accelerator cards of
+                                            this type exposed to this instance.""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    )
+                                ],
+                                description="""Optional. The Compute Engine accelerator
+                                configuration for these instances.""",
+                                is_required=True,
+                            ),
+                            "minCpuPlatform": Field(
+                                String,
+                                description="""Optional. Specifies the minimum cpu platform for the
+                                Instance Group. See Dataproc -> Minimum CPU Platform
+                                (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
+                                is_required=True,
+                            ),
+                            "minNumInstances": Field(
+                                Int,
+                                description="""Optional. The minimum number of primary worker
+                                instances to create. If min_num_instances is set, cluster creation
+                                will succeed if the number of primary workers created is at least
+                                equal to the min_num_instances number.Example: Cluster creation
+                                request with num_instances = 5 and min_num_instances = 3: If 4 VMs
+                                are created and 1 instance fails, the failed VM is deleted. The
+                                cluster is resized to 4 instances and placed in a RUNNING state. If
+                                2 instances are created and 3 instances fail, the cluster in placed
+                                in an ERROR state. The failed VMs are not deleted.""",
+                                is_required=True,
+                            ),
+                            "instanceFlexibilityPolicy": Field(
+                                Shape(
+                                    fields={
+                                        "provisioningModelMix": Field(
+                                            Shape(
+                                                fields={
+                                                    "standardCapacityBase": Field(
+                                                        Int,
+                                                        description="""Optional. The base capacity
+                                                        that will always use Standard VMs to avoid
+                                                        risk of more preemption than the minimum
+                                                        capacity you need. Dataproc will create only
+                                                        standard VMs until it reaches
+                                                        standard_capacity_base, then it will start
+                                                        using standard_capacity_percent_above_base
+                                                        to mix Spot with Standard VMs. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5, Dataproc will
+                                                        create 5 standard VMs and then start mixing
+                                                        spot and standard VMs for remaining 10
+                                                        instances.""",
+                                                        is_required=True,
+                                                    ),
+                                                    "standardCapacityPercentAboveBase": Field(
+                                                        Int,
+                                                        description="""Optional. The percentage of
+                                                        target capacity that should use Standard VM.
+                                                        The remaining percentage will use Spot VMs.
+                                                        The percentage applies only to the capacity
+                                                        above standard_capacity_base. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5 and
+                                                        standard_capacity_percent_above_base is 30,
+                                                        Dataproc will create 5 standard VMs and then
+                                                        start mixing spot and standard VMs for
+                                                        remaining 10 instances. The mix will be 30%
+                                                        standard and 70% spot.""",
+                                                        is_required=True,
+                                                    ),
+                                                },
+                                            ),
+                                            description="""Defines how Dataproc should create VMs
+                                            with a mixture of provisioning models.""",
+                                            is_required=True,
+                                        ),
+                                        "instanceSelectionList": Field(
+                                            [
+                                                Shape(
+                                                    fields={
+                                                        "machineTypes": Field(
+                                                            [String],
+                                                            description="""Optional. Full machine-type
+                                                        names, e.g. "n1-standard-16".""",
+                                                            is_required=True,
+                                                        ),
+                                                        "rank": Field(
+                                                            Int,
+                                                            description="""Optional. Preference of this
+                                                        instance selection. Lower number means
+                                                        higher preference. Dataproc will first try
+                                                        to create a VM based on the machine-type
+                                                        with priority rank and fallback to next rank
+                                                        based on availability. Machine types and
+                                                        instance selections with the same priority
+                                                        have the same preference.""",
+                                                            is_required=True,
+                                                        ),
+                                                    },
+                                                )
+                                            ],
+                                            description="""Optional. List of instance selection
+                                            options that the group will use when creating new
+                                            VMs.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Instance flexibility Policy allowing a mixture of VM
+                                shapes and provisioning models.""",
+                                is_required=True,
+                            ),
+                            "startupConfig": Field(
+                                Shape(
+                                    fields={
+                                        "requiredRegistrationFraction": Field(
+                                            Int,
+                                            description="""Optional. The config setting to enable
+                                            cluster creation/ updation to be successful only after
+                                            required_registration_fraction of instances are up and
+                                            running. This configuration is applicable to only
+                                            secondary workers for now. The cluster will fail if
+                                            required_registration_fraction of instances are not
+                                            available. This will include instance creation, agent
+                                            registration, and service registration (if enabled).""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Configuration to handle the startup of instances
+                                during cluster create and update process.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""The config settings for Compute Engine resources in an instance
+                    group, such as a master or worker group.""",
+                    is_required=True,
+                ),
+                "secondaryWorkerConfig": Field(
+                    Shape(
+                        fields={
+                            "numInstances": Field(
+                                Int,
+                                description="""Optional. The number of VM instances in the instance
+                                group. For HA cluster master_config groups, must be set to 3. For
+                                standard cluster master_config groups, must be set to 1.""",
+                                is_required=True,
+                            ),
+                            "imageUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine image resource used for
+                                cluster instances.The URI can represent an image or image
+                                family.Image examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/[image-id]
+                                projects/[project_id]/global/images/[image-id] image-idImage family
+                                examples. Dataproc will use the most recent image from the family:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/family/[custom-image-family-name]
+                                projects/[project_id]/global/images/family/[custom-image-family-name]If
+                                the URI is unspecified, it will be inferred from
+                                SoftwareConfig.image_version or the system default.""",
+                                is_required=True,
+                            ),
+                            "machineTypeUri": Field(
+                                String,
+                                description="""Optional. The Compute Engine machine type used for
+                                cluster instances.A full URL, partial URI, or short name are valid.
+                                Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                n1-standard-2Auto Zone Exception: If you are using the Dataproc Auto
+                                Zone Placement
+                                (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                feature, you must use the short name of the machine type resource,
+                                for example, n1-standard-2.""",
+                                is_required=True,
+                            ),
+                            "diskConfig": Field(
+                                Shape(
+                                    fields={
+                                        "bootDiskType": Field(
+                                            String,
+                                            description="""Optional. Type of the boot disk (default
+                                            is "pd-standard"). Valid values: "pd-balanced"
+                                            (Persistent Disk Balanced Solid State Drive), "pd-ssd"
+                                            (Persistent Disk Solid State Drive), or "pd-standard"
+                                            (Persistent Disk Hard Disk Drive). See Disk types
+                                            (https://cloud.google.com/compute/docs/disks#disk-types).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskSizeGb": Field(
+                                            Int,
+                                            description="""Optional. Size in GB of the boot disk
+                                            (default is 500GB).""",
+                                            is_required=True,
+                                        ),
+                                        "numLocalSsds": Field(
+                                            Int,
+                                            description="""Optional. Number of attached SSDs, from 0
+                                            to 8 (default is 0). If SSDs are not attached, the boot
+                                            disk is used to store runtime logs and HDFS
+                                            (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                                            data. If one or more SSDs are attached, this runtime
+                                            bulk data is spread across them, and the boot disk
+                                            contains only basic config and installed binaries.Note:
+                                            Local SSD options may vary by machine type and number of
+                                            vCPUs selected.""",
+                                            is_required=True,
+                                        ),
+                                        "localSsdInterface": Field(
+                                            String,
+                                            description="""Optional. Interface type of local SSDs
+                                            (default is "scsi"). Valid values: "scsi" (Small
+                                            Computer System Interface), "nvme" (Non-Volatile Memory
+                                            Express). See local SSD performance
+                                            (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedIops": Field(
+                                            String,
+                                            description="""Optional. Indicates how many IOPS to
+                                            provision for the disk. This sets the number of I/O
+                                            operations per second that the disk can handle. This
+                                            field is supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                        "bootDiskProvisionedThroughput": Field(
+                                            String,
+                                            description="""Optional. Indicates how much throughput
+                                            to provision for the disk. This sets the number of
+                                            throughput mb per second that the disk can handle.
+                                            Values must be greater than or equal to 1. This field is
+                                            supported only if boot_disk_type is
+                                            hyperdisk-balanced.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Specifies the config of disk options for a group of
+                                VM instances.""",
+                                is_required=True,
+                            ),
+                            "preemptibility": Field(
+                                preemptibility,
+                                description="""Optional. Specifies the preemptibility of the
+                                instance group.The default value for master and worker groups is
+                                NON_PREEMPTIBLE. This default cannot be changed.The default value
+                                for secondary instances is PREEMPTIBLE.""",
+                                is_required=True,
+                            ),
+                            "managedGroupConfig": Field(
+                                Shape(
+                                    fields={},
+                                ),
+                                description="""Specifies the resources used to actively manage an
+                                instance group.""",
+                                is_required=True,
+                            ),
+                            "accelerators": Field(
+                                [
+                                    Shape(
+                                        fields={
+                                            "acceleratorTypeUri": Field(
+                                                String,
+                                                description="""Full URL, partial URI, or short name of
+                                            the accelerator type resource to expose to this
+                                            instance. See Compute Engine AcceleratorTypes
+                                            (https://cloud.google.com/compute/docs/reference/v1/acceleratorTypes).Examples:
+                                            https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                            nvidia-tesla-t4Auto Zone Exception: If you are using the
+                                            Dataproc Auto Zone Placement
+                                            (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                            feature, you must use the short name of the accelerator
+                                            type resource, for example, nvidia-tesla-t4.""",
+                                                is_required=True,
+                                            ),
+                                            "acceleratorCount": Field(
+                                                Int,
+                                                description="""The number of the accelerator cards of
+                                            this type exposed to this instance.""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    )
+                                ],
+                                description="""Optional. The Compute Engine accelerator
+                                configuration for these instances.""",
+                                is_required=True,
+                            ),
+                            "minCpuPlatform": Field(
+                                String,
+                                description="""Optional. Specifies the minimum cpu platform for the
+                                Instance Group. See Dataproc -> Minimum CPU Platform
+                                (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
+                                is_required=True,
+                            ),
+                            "minNumInstances": Field(
+                                Int,
+                                description="""Optional. The minimum number of primary worker
+                                instances to create. If min_num_instances is set, cluster creation
+                                will succeed if the number of primary workers created is at least
+                                equal to the min_num_instances number.Example: Cluster creation
+                                request with num_instances = 5 and min_num_instances = 3: If 4 VMs
+                                are created and 1 instance fails, the failed VM is deleted. The
+                                cluster is resized to 4 instances and placed in a RUNNING state. If
+                                2 instances are created and 3 instances fail, the cluster in placed
+                                in an ERROR state. The failed VMs are not deleted.""",
+                                is_required=True,
+                            ),
+                            "instanceFlexibilityPolicy": Field(
+                                Shape(
+                                    fields={
+                                        "provisioningModelMix": Field(
+                                            Shape(
+                                                fields={
+                                                    "standardCapacityBase": Field(
+                                                        Int,
+                                                        description="""Optional. The base capacity
+                                                        that will always use Standard VMs to avoid
+                                                        risk of more preemption than the minimum
+                                                        capacity you need. Dataproc will create only
+                                                        standard VMs until it reaches
+                                                        standard_capacity_base, then it will start
+                                                        using standard_capacity_percent_above_base
+                                                        to mix Spot with Standard VMs. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5, Dataproc will
+                                                        create 5 standard VMs and then start mixing
+                                                        spot and standard VMs for remaining 10
+                                                        instances.""",
+                                                        is_required=True,
+                                                    ),
+                                                    "standardCapacityPercentAboveBase": Field(
+                                                        Int,
+                                                        description="""Optional. The percentage of
+                                                        target capacity that should use Standard VM.
+                                                        The remaining percentage will use Spot VMs.
+                                                        The percentage applies only to the capacity
+                                                        above standard_capacity_base. eg. If 15
+                                                        instances are requested and
+                                                        standard_capacity_base is 5 and
+                                                        standard_capacity_percent_above_base is 30,
+                                                        Dataproc will create 5 standard VMs and then
+                                                        start mixing spot and standard VMs for
+                                                        remaining 10 instances. The mix will be 30%
+                                                        standard and 70% spot.""",
+                                                        is_required=True,
+                                                    ),
+                                                },
+                                            ),
+                                            description="""Defines how Dataproc should create VMs
+                                            with a mixture of provisioning models.""",
+                                            is_required=True,
+                                        ),
+                                        "instanceSelectionList": Field(
+                                            [
+                                                Shape(
+                                                    fields={
+                                                        "machineTypes": Field(
+                                                            [String],
+                                                            description="""Optional. Full machine-type
+                                                        names, e.g. "n1-standard-16".""",
+                                                            is_required=True,
+                                                        ),
+                                                        "rank": Field(
+                                                            Int,
+                                                            description="""Optional. Preference of this
+                                                        instance selection. Lower number means
+                                                        higher preference. Dataproc will first try
+                                                        to create a VM based on the machine-type
+                                                        with priority rank and fallback to next rank
+                                                        based on availability. Machine types and
+                                                        instance selections with the same priority
+                                                        have the same preference.""",
+                                                            is_required=True,
+                                                        ),
+                                                    },
+                                                )
+                                            ],
+                                            description="""Optional. List of instance selection
+                                            options that the group will use when creating new
+                                            VMs.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Instance flexibility Policy allowing a mixture of VM
+                                shapes and provisioning models.""",
+                                is_required=True,
+                            ),
+                            "startupConfig": Field(
+                                Shape(
+                                    fields={
+                                        "requiredRegistrationFraction": Field(
+                                            Int,
+                                            description="""Optional. The config setting to enable
+                                            cluster creation/ updation to be successful only after
+                                            required_registration_fraction of instances are up and
+                                            running. This configuration is applicable to only
+                                            secondary workers for now. The cluster will fail if
+                                            required_registration_fraction of instances are not
+                                            available. This will include instance creation, agent
+                                            registration, and service registration (if enabled).""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Configuration to handle the startup of instances
+                                during cluster create and update process.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""The config settings for Compute Engine resources in an instance
+                    group, such as a master or worker group.""",
+                    is_required=True,
                 ),
                 "softwareConfig": Field(
                     Shape(
                         fields={
+                            "imageVersion": Field(
+                                String,
+                                description="""Optional. The version of software inside the cluster.
+                                It must be one of the supported Dataproc Versions
+                                (https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#supported-dataproc-image-versions),
+                                such as "1.2" (including a subminor version, such as "1.2.29"), or
+                                the "preview" version
+                                (https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
+                                If unspecified, it defaults to the latest Debian version.""",
+                                is_required=True,
+                            ),
                             "properties": Field(
                                 Permissive(),
                                 description="""Optional. The properties to set on daemon config
@@ -625,32 +1117,1054 @@ def define_dataproc_cluster_config():
                                 core-site.xml distcp: distcp-default.xml hdfs: hdfs-site.xml hive:
                                 hive-site.xml mapred: mapred-site.xml pig: pig.properties spark:
                                 spark-defaults.conf yarn: yarn-site.xmlFor more information, see
-                                Cluster properties.""",
-                                is_required=False,
+                                Cluster properties
+                                (https://cloud.google.com/dataproc/docs/concepts/cluster-properties).""",
+                                is_required=True,
                             ),
                             "optionalComponents": Field(
                                 [Component],
-                                description="""The set of optional components to activate on the
+                                description="""Optional. The set of components to activate on the
                                 cluster.""",
-                                is_required=False,
+                                is_required=True,
                             ),
-                            "imageVersion": Field(
-                                String,
-                                description="""Optional. The version of software inside the cluster.
-                                It must be one of the supported Cloud Dataproc Versions, such as
-                                "1.2" (including a subminor version, such as "1.2.29"), or the
-                                "preview" version. If unspecified, it defaults to the latest Debian
-                                version.""",
-                                is_required=False,
-                            ),
-                        }
+                        },
                     ),
                     description="""Specifies the selection and config of software inside the
                     cluster.""",
-                    is_required=False,
+                    is_required=True,
                 ),
-            }
+                "initializationActions": Field(
+                    [
+                        Shape(
+                            fields={
+                                "executableFile": Field(
+                                    String,
+                                    description="""Required. Cloud Storage URI of executable file.""",
+                                    is_required=True,
+                                ),
+                                "executionTimeout": Field(
+                                    String,
+                                    description="""Optional. Amount of time executable has to complete.
+                                Default is 10 minutes (see JSON representation of Duration
+                                (https://developers.google.com/protocol-buffers/docs/proto3#json)).Cluster
+                                creation fails with an explanatory error message (the name of the
+                                executable that caused the error and the exceeded timeout period) if
+                                the executable is not completed at end of the timeout period.""",
+                                    is_required=True,
+                                ),
+                            },
+                        )
+                    ],
+                    description="""Optional. Commands to execute on each node after config is
+                    completed. By default, executables are run on master and all worker nodes. You
+                    can test a node\'s role metadata to run an executable on a master or worker
+                    node, as shown below using curl (you can also use wget): ROLE=$(curl -H
+                    Metadata-Flavor:Google
+                    http://metadata/computeMetadata/v1/instance/attributes/dataproc-role) if [[
+                    "${ROLE}" == \'Master\' ]]; then ... master specific actions ... else ... worker
+                    specific actions ... fi """,
+                    is_required=True,
+                ),
+                "encryptionConfig": Field(
+                    Shape(
+                        fields={
+                            "gcePdKmsKeyName": Field(
+                                String,
+                                description="""Optional. The Cloud KMS key resource name to use for
+                                persistent disk encryption for all instances in the cluster. See Use
+                                CMEK with cluster data
+                                (https://cloud.google.com//dataproc/docs/concepts/configuring-clusters/customer-managed-encryption#use_cmek_with_cluster_data)
+                                for more information.""",
+                                is_required=True,
+                            ),
+                            "kmsKey": Field(
+                                String,
+                                description="""Optional. The Cloud KMS key resource name to use for
+                                cluster persistent disk and job argument encryption. See Use CMEK
+                                with cluster data
+                                (https://cloud.google.com//dataproc/docs/concepts/configuring-clusters/customer-managed-encryption#use_cmek_with_cluster_data)
+                                for more information.When this key resource name is provided, the
+                                following job arguments of the following job types submitted to the
+                                cluster are encrypted using CMEK: FlinkJob args
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/FlinkJob)
+                                HadoopJob args
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/HadoopJob)
+                                SparkJob args
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/SparkJob)
+                                SparkRJob args
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/SparkRJob)
+                                PySparkJob args
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/PySparkJob)
+                                SparkSqlJob
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/SparkSqlJob)
+                                scriptVariables and queryList.queries HiveJob
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/HiveJob)
+                                scriptVariables and queryList.queries PigJob
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/PigJob)
+                                scriptVariables and queryList.queries PrestoJob
+                                (https://cloud.google.com/dataproc/docs/reference/rest/v1/PrestoJob)
+                                scriptVariables and queryList.queries""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Encryption settings for the cluster.""",
+                    is_required=True,
+                ),
+                "autoscalingConfig": Field(
+                    Shape(
+                        fields={
+                            "policyUri": Field(
+                                String,
+                                description="""Optional. The autoscaling policy used by the
+                                cluster.Only resource names including projectid and location
+                                (region) are valid. Examples:
+                                https://www.googleapis.com/compute/v1/projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]
+                                projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]Note
+                                that the policy must be in the same project and Dataproc region.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Autoscaling Policy config associated with the cluster.""",
+                    is_required=True,
+                ),
+                "securityConfig": Field(
+                    Shape(
+                        fields={
+                            "kerberosConfig": Field(
+                                Shape(
+                                    fields={
+                                        "enableKerberos": Field(
+                                            Bool,
+                                            description="""Optional. Flag to indicate whether to
+                                            Kerberize the cluster (default: false). Set this field
+                                            to true to enable Kerberos on a cluster.""",
+                                            is_required=True,
+                                        ),
+                                        "rootPrincipalPasswordUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the root principal
+                                            password.""",
+                                            is_required=True,
+                                        ),
+                                        "kmsKeyUri": Field(
+                                            String,
+                                            description="""Optional. The URI of the KMS key used to
+                                            encrypt sensitive files.""",
+                                            is_required=True,
+                                        ),
+                                        "keystoreUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of the
+                                            keystore file used for SSL encryption. If not provided,
+                                            Dataproc will provide a self-signed certificate.""",
+                                            is_required=True,
+                                        ),
+                                        "truststoreUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of the
+                                            truststore file used for SSL encryption. If not
+                                            provided, Dataproc will provide a self-signed
+                                            certificate.""",
+                                            is_required=True,
+                                        ),
+                                        "keystorePasswordUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the password to the user
+                                            provided keystore. For the self-signed certificate, this
+                                            password is generated by Dataproc.""",
+                                            is_required=True,
+                                        ),
+                                        "keyPasswordUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the password to the user
+                                            provided key. For the self-signed certificate, this
+                                            password is generated by Dataproc.""",
+                                            is_required=True,
+                                        ),
+                                        "truststorePasswordUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the password to the user
+                                            provided truststore. For the self-signed certificate,
+                                            this password is generated by Dataproc.""",
+                                            is_required=True,
+                                        ),
+                                        "crossRealmTrustRealm": Field(
+                                            String,
+                                            description="""Optional. The remote realm the Dataproc
+                                            on-cluster KDC will trust, should the user enable cross
+                                            realm trust.""",
+                                            is_required=True,
+                                        ),
+                                        "crossRealmTrustKdc": Field(
+                                            String,
+                                            description="""Optional. The KDC (IP or hostname) for
+                                            the remote trusted realm in a cross realm trust
+                                            relationship.""",
+                                            is_required=True,
+                                        ),
+                                        "crossRealmTrustAdminServer": Field(
+                                            String,
+                                            description="""Optional. The admin server (IP or
+                                            hostname) for the remote trusted realm in a cross realm
+                                            trust relationship.""",
+                                            is_required=True,
+                                        ),
+                                        "crossRealmTrustSharedPasswordUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the shared password between
+                                            the on-cluster Kerberos realm and the remote trusted
+                                            realm, in a cross realm trust relationship.""",
+                                            is_required=True,
+                                        ),
+                                        "kdcDbKeyUri": Field(
+                                            String,
+                                            description="""Optional. The Cloud Storage URI of a KMS
+                                            encrypted file containing the master key of the KDC
+                                            database.""",
+                                            is_required=True,
+                                        ),
+                                        "tgtLifetimeHours": Field(
+                                            Int,
+                                            description="""Optional. The lifetime of the ticket
+                                            granting ticket, in hours. If not specified, or user
+                                            specifies 0, then default value 10 will be used.""",
+                                            is_required=True,
+                                        ),
+                                        "realm": Field(
+                                            String,
+                                            description="""Optional. The name of the on-cluster
+                                            Kerberos realm. If not specified, the uppercased domain
+                                            of hostnames will be the realm.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Specifies Kerberos related configuration.""",
+                                is_required=True,
+                            ),
+                            "identityConfig": Field(
+                                Shape(
+                                    fields={
+                                        "userServiceAccountMapping": Field(
+                                            Permissive(),
+                                            description="""Required. Map of user to service
+                                            account.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Identity related configuration, including service
+                                account based secure multi-tenancy user mappings.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Security related configuration, including encryption, Kerberos,
+                    etc.""",
+                    is_required=True,
+                ),
+                "lifecycleConfig": Field(
+                    Shape(
+                        fields={
+                            "idleDeleteTtl": Field(
+                                String,
+                                description="""Optional. The duration to keep the cluster alive
+                                while idling (when no jobs are running). Passing this threshold will
+                                cause the cluster to be deleted. Minimum value is 5 minutes; maximum
+                                value is 14 days (see JSON representation of Duration
+                                (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
+                                is_required=True,
+                            ),
+                            "autoDeleteTime": Field(
+                                String,
+                                description="""Optional. The time when cluster will be auto-deleted
+                                (see JSON representation of Timestamp
+                                (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
+                                is_required=True,
+                            ),
+                            "autoDeleteTtl": Field(
+                                String,
+                                description="""Optional. The lifetime duration of cluster. The
+                                cluster will be auto-deleted at the end of this period. Minimum
+                                value is 10 minutes; maximum value is 14 days (see JSON
+                                representation of Duration
+                                (https://developers.google.com/protocol-buffers/docs/proto3#json)).""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Specifies the cluster auto-delete schedule configuration.""",
+                    is_required=True,
+                ),
+                "endpointConfig": Field(
+                    Shape(
+                        fields={
+                            "enableHttpPortAccess": Field(
+                                Bool,
+                                description="""Optional. If true, enable http access to specific
+                                ports on the cluster from external sources. Defaults to false.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Endpoint config for this cluster""",
+                    is_required=True,
+                ),
+                "metastoreConfig": Field(
+                    Shape(
+                        fields={
+                            "dataprocMetastoreService": Field(
+                                String,
+                                description="""Required. Resource name of an existing Dataproc
+                                Metastore service.Example:
+                                projects/[project_id]/locations/[dataproc_region]/services/[service-name]""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Specifies a Metastore configuration.""",
+                    is_required=True,
+                ),
+                "gkeClusterConfig": Field(
+                    Shape(
+                        fields={
+                            "namespacedGkeDeploymentTarget": Field(
+                                Shape(
+                                    fields={
+                                        "targetGkeCluster": Field(
+                                            String,
+                                            description="""Optional. The target GKE cluster to
+                                            deploy to. Format:
+                                            \'projects/{project}/locations/{location}/clusters/{cluster_id}\'""",
+                                            is_required=True,
+                                        ),
+                                        "clusterNamespace": Field(
+                                            String,
+                                            description="""Optional. A namespace within the GKE
+                                            cluster to deploy into.""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""Deprecated. Used only for the deprecated beta. A
+                                full, namespace-isolated deployment target for an existing GKE
+                                cluster.""",
+                                is_required=True,
+                            ),
+                            "gkeClusterTarget": Field(
+                                String,
+                                description="""Optional. A target GKE cluster to deploy to. It must
+                                be in the same project and region as the Dataproc cluster (the GKE
+                                cluster can be zonal or regional). Format:
+                                \'projects/{project}/locations/{location}/clusters/{cluster_id}\'""",
+                                is_required=True,
+                            ),
+                            "nodePoolTarget": Field(
+                                [
+                                    Shape(
+                                        fields={
+                                            "nodePool": Field(
+                                                String,
+                                                description="""Required. The target GKE node pool.
+                                            Format:
+                                            \'projects/{project}/locations/{location}/clusters/{cluster}/nodePools/{node_pool}\'""",
+                                                is_required=True,
+                                            ),
+                                            "roles": Field(
+                                                [Component],
+                                                description="""Required. The roles associated with the
+                                            GKE node pool.""",
+                                                is_required=True,
+                                            ),
+                                            "nodePoolConfig": Field(
+                                                Shape(
+                                                    fields={
+                                                        "config": Field(
+                                                            Shape(
+                                                                fields={
+                                                                    "machineType": Field(
+                                                                        String,
+                                                                        description="""Optional. The
+                                                                    name of a Compute Engine machine
+                                                                    type
+                                                                    (https://cloud.google.com/compute/docs/machine-types).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "localSsdCount": Field(
+                                                                        Int,
+                                                                        description="""Optional. The
+                                                                    number of local SSD disks to
+                                                                    attach to the node, which is
+                                                                    limited by the maximum number of
+                                                                    disks allowable per zone (see
+                                                                    Adding Local SSDs
+                                                                    (https://cloud.google.com/compute/docs/disks/local-ssd)).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "preemptible": Field(
+                                                                        Bool,
+                                                                        description="""Optional. Whether
+                                                                    the nodes are created as legacy
+                                                                    preemptible VM instances
+                                                                    (https://cloud.google.com/compute/docs/instances/preemptible).
+                                                                    Also see Spot VMs, preemptible
+                                                                    VM instances without a maximum
+                                                                    lifetime. Legacy and Spot
+                                                                    preemptible nodes cannot be used
+                                                                    in a node pool with the
+                                                                    CONTROLLER role or in the
+                                                                    DEFAULT node pool if the
+                                                                    CONTROLLER role is not assigned
+                                                                    (the DEFAULT node pool will
+                                                                    assume the CONTROLLER role).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "accelerators": Field(
+                                                                        [
+                                                                            Shape(
+                                                                                fields={
+                                                                                    "acceleratorCount": Field(
+                                                                                        String,
+                                                                                        description="""The
+                                                                                number of
+                                                                                accelerator cards
+                                                                                exposed to an
+                                                                                instance.""",
+                                                                                        is_required=True,
+                                                                                    ),
+                                                                                    "acceleratorType": Field(
+                                                                                        String,
+                                                                                        description="""The
+                                                                                accelerator type
+                                                                                resource namename
+                                                                                (see GPUs on Compute
+                                                                                Engine).""",
+                                                                                        is_required=True,
+                                                                                    ),
+                                                                                    "gpuPartitionSize": Field(
+                                                                                        String,
+                                                                                        description="""Size
+                                                                                of partitions to
+                                                                                create on the GPU.
+                                                                                Valid values are
+                                                                                described in the
+                                                                                NVIDIA mig user
+                                                                                guide
+                                                                                (https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning).""",
+                                                                                        is_required=True,
+                                                                                    ),
+                                                                                },
+                                                                            )
+                                                                        ],
+                                                                        description="""Optional. A list
+                                                                    of hardware accelerators
+                                                                    (https://cloud.google.com/compute/docs/gpus)
+                                                                    to attach to each node.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "minCpuPlatform": Field(
+                                                                        String,
+                                                                        description="""Optional. Minimum
+                                                                    CPU platform
+                                                                    (https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
+                                                                    to be used by this instance. The
+                                                                    instance may be scheduled on the
+                                                                    specified or a newer CPU
+                                                                    platform. Specify the friendly
+                                                                    names of CPU platforms, such as
+                                                                    "Intel Haswell"` or Intel Sandy
+                                                                    Bridge".""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "bootDiskKmsKey": Field(
+                                                                        String,
+                                                                        description="""Optional. The
+                                                                    Customer Managed Encryption Key
+                                                                    (CMEK)
+                                                                    (https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek)
+                                                                    used to encrypt the boot disk
+                                                                    attached to each node in the
+                                                                    node pool. Specify the key using
+                                                                    the following format:
+                                                                    projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "spot": Field(
+                                                                        Bool,
+                                                                        description="""Optional. Whether
+                                                                    the nodes are created as Spot VM
+                                                                    instances
+                                                                    (https://cloud.google.com/compute/docs/instances/spot).
+                                                                    Spot VMs are the latest update
+                                                                    to legacy preemptible VMs. Spot
+                                                                    VMs do not have a maximum
+                                                                    lifetime. Legacy and Spot
+                                                                    preemptible nodes cannot be used
+                                                                    in a node pool with the
+                                                                    CONTROLLER role or in the
+                                                                    DEFAULT node pool if the
+                                                                    CONTROLLER role is not assigned
+                                                                    (the DEFAULT node pool will
+                                                                    assume the CONTROLLER role).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            description="""Parameters that describe
+                                                        cluster nodes.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "locations": Field(
+                                                            [String],
+                                                            description="""Optional. The list of Compute
+                                                        Engine zones
+                                                        (https://cloud.google.com/compute/docs/zones#available)
+                                                        where node pool nodes associated with a
+                                                        Dataproc on GKE virtual cluster will be
+                                                        located.Note: All node pools associated with
+                                                        a virtual cluster must be located in the
+                                                        same region as the virtual cluster, and they
+                                                        must be located in the same zone within that
+                                                        region.If a location is not specified during
+                                                        node pool creation, Dataproc on GKE will
+                                                        choose the zone.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "autoscaling": Field(
+                                                            Shape(
+                                                                fields={
+                                                                    "minNodeCount": Field(
+                                                                        Int,
+                                                                        description="""The minimum
+                                                                    number of nodes in the node
+                                                                    pool. Must be >= 0 and <=
+                                                                    max_node_count.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "maxNodeCount": Field(
+                                                                        Int,
+                                                                        description="""The maximum
+                                                                    number of nodes in the node
+                                                                    pool. Must be >= min_node_count,
+                                                                    and must be > 0. Note: Quota
+                                                                    must be sufficient to scale up
+                                                                    the cluster.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            description="""GkeNodePoolAutoscaling
+                                                        contains information the cluster autoscaler
+                                                        needs to adjust the size of the node pool to
+                                                        the current cluster usage.""",
+                                                            is_required=True,
+                                                        ),
+                                                    },
+                                                ),
+                                                description="""The configuration of a GKE node pool used
+                                            by a Dataproc-on-GKE cluster
+                                            (https://cloud.google.com/dataproc/docs/concepts/jobs/dataproc-gke#create-a-dataproc-on-gke-cluster).""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    )
+                                ],
+                                description="""Optional. GKE node pools where workloads will be
+                                scheduled. At least one node pool must be assigned the DEFAULT
+                                GkeNodePoolTarget.Role. If a GkeNodePoolTarget is not specified,
+                                Dataproc constructs a DEFAULT GkeNodePoolTarget. Each role can be
+                                given to only one GkeNodePoolTarget. All node pools must have the
+                                same location settings.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""The cluster\'s GKE config.""",
+                    is_required=True,
+                ),
+                "dataprocMetricConfig": Field(
+                    Shape(
+                        fields={
+                            "metrics": Field(
+                                [
+                                    Shape(
+                                        fields={
+                                            "metricSource": Field(
+                                                metricSource,
+                                                description="""Required. A standard set of metrics is
+                                            collected unless metricOverrides are specified for the
+                                            metric source (see Custom metrics
+                                            (https://cloud.google.com/dataproc/docs/guides/dataproc-metrics#custom_metrics)
+                                            for more information).""",
+                                                is_required=True,
+                                            ),
+                                            "metricOverrides": Field(
+                                                [String],
+                                                description="""Optional. Specify one or more Custom
+                                            metrics
+                                            (https://cloud.google.com/dataproc/docs/guides/dataproc-metrics#custom_metrics)
+                                            to collect for the metric course (for the SPARK metric
+                                            source (any Spark metric
+                                            (https://spark.apache.org/docs/latest/monitoring.html#metrics)
+                                            can be specified).Provide metrics in the following
+                                            format: METRIC_SOURCE: INSTANCE:GROUP:METRIC Use
+                                            camelcase as appropriate.Examples:
+                                            yarn:ResourceManager:QueueMetrics:AppsCompleted
+                                            spark:driver:DAGScheduler:job.allJobs
+                                            sparkHistoryServer:JVM:Memory:NonHeapMemoryUsage.committed
+                                            hiveserver2:JVM:Memory:NonHeapMemoryUsage.used Notes:
+                                            Only the specified overridden metrics are collected for
+                                            the metric source. For example, if one or more
+                                            spark:executive metrics are listed as metric overrides,
+                                            other SPARK metrics are not collected. The collection of
+                                            the metrics for other enabled custom metric sources is
+                                            unaffected. For example, if both SPARK and YARN metric
+                                            sources are enabled, and overrides are provided for
+                                            Spark metrics only, all YARN metrics are collected.""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    )
+                                ],
+                                description="""Required. Metrics sources to enable.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Dataproc metric config.""",
+                    is_required=True,
+                ),
+                "auxiliaryNodeGroups": Field(
+                    [
+                        Shape(
+                            fields={
+                                "nodeGroup": Field(
+                                    Shape(
+                                        fields={
+                                            "name": Field(
+                                                String,
+                                                description="""The Node group resource name
+                                            (https://aip.dev/122).""",
+                                                is_required=True,
+                                            ),
+                                            "roles": Field(
+                                                [Component],
+                                                description="""Required. Node group roles.""",
+                                                is_required=True,
+                                            ),
+                                            "nodeGroupConfig": Field(
+                                                Shape(
+                                                    fields={
+                                                        "numInstances": Field(
+                                                            Int,
+                                                            description="""Optional. The number of VM
+                                                        instances in the instance group. For HA
+                                                        cluster master_config groups, must be set to
+                                                        3. For standard cluster master_config
+                                                        groups, must be set to 1.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "imageUri": Field(
+                                                            String,
+                                                            description="""Optional. The Compute Engine
+                                                        image resource used for cluster
+                                                        instances.The URI can represent an image or
+                                                        image family.Image examples:
+                                                        https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/[image-id]
+                                                        projects/[project_id]/global/images/[image-id]
+                                                        image-idImage family examples. Dataproc will
+                                                        use the most recent image from the family:
+                                                        https://www.googleapis.com/compute/v1/projects/[project_id]/global/images/family/[custom-image-family-name]
+                                                        projects/[project_id]/global/images/family/[custom-image-family-name]If
+                                                        the URI is unspecified, it will be inferred
+                                                        from SoftwareConfig.image_version or the
+                                                        system default.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "machineTypeUri": Field(
+                                                            String,
+                                                            description="""Optional. The Compute Engine
+                                                        machine type used for cluster instances.A
+                                                        full URL, partial URI, or short name are
+                                                        valid. Examples:
+                                                        https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                                        projects/[project_id]/zones/[zone]/machineTypes/n1-standard-2
+                                                        n1-standard-2Auto Zone Exception: If you are
+                                                        using the Dataproc Auto Zone Placement
+                                                        (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                                        feature, you must use the short name of the
+                                                        machine type resource, for example,
+                                                        n1-standard-2.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "diskConfig": Field(
+                                                            Shape(
+                                                                fields={
+                                                                    "bootDiskType": Field(
+                                                                        String,
+                                                                        description="""Optional. Type of
+                                                                    the boot disk (default is
+                                                                    "pd-standard"). Valid values:
+                                                                    "pd-balanced" (Persistent Disk
+                                                                    Balanced Solid State Drive),
+                                                                    "pd-ssd" (Persistent Disk Solid
+                                                                    State Drive), or "pd-standard"
+                                                                    (Persistent Disk Hard Disk
+                                                                    Drive). See Disk types
+                                                                    (https://cloud.google.com/compute/docs/disks#disk-types).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "bootDiskSizeGb": Field(
+                                                                        Int,
+                                                                        description="""Optional. Size in
+                                                                    GB of the boot disk (default is
+                                                                    500GB).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "numLocalSsds": Field(
+                                                                        Int,
+                                                                        description="""Optional. Number
+                                                                    of attached SSDs, from 0 to 8
+                                                                    (default is 0). If SSDs are not
+                                                                    attached, the boot disk is used
+                                                                    to store runtime logs and HDFS
+                                                                    (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html)
+                                                                    data. If one or more SSDs are
+                                                                    attached, this runtime bulk data
+                                                                    is spread across them, and the
+                                                                    boot disk contains only basic
+                                                                    config and installed
+                                                                    binaries.Note: Local SSD options
+                                                                    may vary by machine type and
+                                                                    number of vCPUs selected.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "localSsdInterface": Field(
+                                                                        String,
+                                                                        description="""Optional.
+                                                                    Interface type of local SSDs
+                                                                    (default is "scsi"). Valid
+                                                                    values: "scsi" (Small Computer
+                                                                    System Interface), "nvme"
+                                                                    (Non-Volatile Memory Express).
+                                                                    See local SSD performance
+                                                                    (https://cloud.google.com/compute/docs/disks/local-ssd#performance).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "bootDiskProvisionedIops": Field(
+                                                                        String,
+                                                                        description="""Optional.
+                                                                    Indicates how many IOPS to
+                                                                    provision for the disk. This
+                                                                    sets the number of I/O
+                                                                    operations per second that the
+                                                                    disk can handle. This field is
+                                                                    supported only if boot_disk_type
+                                                                    is hyperdisk-balanced.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "bootDiskProvisionedThroughput": Field(
+                                                                        String,
+                                                                        description="""Optional.
+                                                                    Indicates how much throughput to
+                                                                    provision for the disk. This
+                                                                    sets the number of throughput mb
+                                                                    per second that the disk can
+                                                                    handle. Values must be greater
+                                                                    than or equal to 1. This field
+                                                                    is supported only if
+                                                                    boot_disk_type is
+                                                                    hyperdisk-balanced.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            description="""Specifies the config of disk
+                                                        options for a group of VM instances.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "preemptibility": Field(
+                                                            preemptibility,
+                                                            description="""Optional. Specifies the
+                                                        preemptibility of the instance group.The
+                                                        default value for master and worker groups
+                                                        is NON_PREEMPTIBLE. This default cannot be
+                                                        changed.The default value for secondary
+                                                        instances is PREEMPTIBLE.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "managedGroupConfig": Field(
+                                                            Shape(
+                                                                fields={},
+                                                            ),
+                                                            description="""Specifies the resources used
+                                                        to actively manage an instance group.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "accelerators": Field(
+                                                            [
+                                                                Shape(
+                                                                    fields={
+                                                                        "acceleratorTypeUri": Field(
+                                                                            String,
+                                                                            description="""Full URL, partial
+                                                                    URI, or short name of the
+                                                                    accelerator type resource to
+                                                                    expose to this instance. See
+                                                                    Compute Engine AcceleratorTypes
+                                                                    (https://cloud.google.com/compute/docs/reference/v1/acceleratorTypes).Examples:
+                                                                    https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                                                    projects/[project_id]/zones/[zone]/acceleratorTypes/nvidia-tesla-t4
+                                                                    nvidia-tesla-t4Auto Zone
+                                                                    Exception: If you are using the
+                                                                    Dataproc Auto Zone Placement
+                                                                    (https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement)
+                                                                    feature, you must use the short
+                                                                    name of the accelerator type
+                                                                    resource, for example,
+                                                                    nvidia-tesla-t4.""",
+                                                                            is_required=True,
+                                                                        ),
+                                                                        "acceleratorCount": Field(
+                                                                            Int,
+                                                                            description="""The number of the
+                                                                    accelerator cards of this type
+                                                                    exposed to this instance.""",
+                                                                            is_required=True,
+                                                                        ),
+                                                                    },
+                                                                )
+                                                            ],
+                                                            description="""Optional. The Compute Engine
+                                                        accelerator configuration for these
+                                                        instances.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "minCpuPlatform": Field(
+                                                            String,
+                                                            description="""Optional. Specifies the
+                                                        minimum cpu platform for the Instance Group.
+                                                        See Dataproc -> Minimum CPU Platform
+                                                        (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).""",
+                                                            is_required=True,
+                                                        ),
+                                                        "minNumInstances": Field(
+                                                            Int,
+                                                            description="""Optional. The minimum number
+                                                        of primary worker instances to create. If
+                                                        min_num_instances is set, cluster creation
+                                                        will succeed if the number of primary
+                                                        workers created is at least equal to the
+                                                        min_num_instances number.Example: Cluster
+                                                        creation request with num_instances = 5 and
+                                                        min_num_instances = 3: If 4 VMs are created
+                                                        and 1 instance fails, the failed VM is
+                                                        deleted. The cluster is resized to 4
+                                                        instances and placed in a RUNNING state. If
+                                                        2 instances are created and 3 instances
+                                                        fail, the cluster in placed in an ERROR
+                                                        state. The failed VMs are not deleted.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "instanceFlexibilityPolicy": Field(
+                                                            Shape(
+                                                                fields={
+                                                                    "provisioningModelMix": Field(
+                                                                        Shape(
+                                                                            fields={
+                                                                                "standardCapacityBase": Field(
+                                                                                    Int,
+                                                                                    description="""Optional.
+                                                                                The base capacity
+                                                                                that will always use
+                                                                                Standard VMs to
+                                                                                avoid risk of more
+                                                                                preemption than the
+                                                                                minimum capacity you
+                                                                                need. Dataproc will
+                                                                                create only standard
+                                                                                VMs until it reaches
+                                                                                standard_capacity_base,
+                                                                                then it will start
+                                                                                using
+                                                                                standard_capacity_percent_above_base
+                                                                                to mix Spot with
+                                                                                Standard VMs. eg. If
+                                                                                15 instances are
+                                                                                requested and
+                                                                                standard_capacity_base
+                                                                                is 5, Dataproc will
+                                                                                create 5 standard
+                                                                                VMs and then start
+                                                                                mixing spot and
+                                                                                standard VMs for
+                                                                                remaining 10
+                                                                                instances.""",
+                                                                                    is_required=True,
+                                                                                ),
+                                                                                "standardCapacityPercentAboveBase": Field(
+                                                                                    Int,
+                                                                                    description="""Optional.
+                                                                                The percentage of
+                                                                                target capacity that
+                                                                                should use Standard
+                                                                                VM. The remaining
+                                                                                percentage will use
+                                                                                Spot VMs. The
+                                                                                percentage applies
+                                                                                only to the capacity
+                                                                                above
+                                                                                standard_capacity_base.
+                                                                                eg. If 15 instances
+                                                                                are requested and
+                                                                                standard_capacity_base
+                                                                                is 5 and
+                                                                                standard_capacity_percent_above_base
+                                                                                is 30, Dataproc will
+                                                                                create 5 standard
+                                                                                VMs and then start
+                                                                                mixing spot and
+                                                                                standard VMs for
+                                                                                remaining 10
+                                                                                instances. The mix
+                                                                                will be 30% standard
+                                                                                and 70% spot.""",
+                                                                                    is_required=True,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        description="""Defines how
+                                                                    Dataproc should create VMs with
+                                                                    a mixture of provisioning
+                                                                    models.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                    "instanceSelectionList": Field(
+                                                                        [
+                                                                            Shape(
+                                                                                fields={
+                                                                                    "machineTypes": Field(
+                                                                                        [String],
+                                                                                        description="""Optional.
+                                                                                Full machine-type
+                                                                                names, e.g.
+                                                                                "n1-standard-16".""",
+                                                                                        is_required=True,
+                                                                                    ),
+                                                                                    "rank": Field(
+                                                                                        Int,
+                                                                                        description="""Optional.
+                                                                                Preference of this
+                                                                                instance selection.
+                                                                                Lower number means
+                                                                                higher preference.
+                                                                                Dataproc will first
+                                                                                try to create a VM
+                                                                                based on the
+                                                                                machine-type with
+                                                                                priority rank and
+                                                                                fallback to next
+                                                                                rank based on
+                                                                                availability.
+                                                                                Machine types and
+                                                                                instance selections
+                                                                                with the same
+                                                                                priority have the
+                                                                                same preference.""",
+                                                                                        is_required=True,
+                                                                                    ),
+                                                                                },
+                                                                            )
+                                                                        ],
+                                                                        description="""Optional. List of
+                                                                    instance selection options that
+                                                                    the group will use when creating
+                                                                    new VMs.""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            description="""Instance flexibility Policy
+                                                        allowing a mixture of VM shapes and
+                                                        provisioning models.""",
+                                                            is_required=True,
+                                                        ),
+                                                        "startupConfig": Field(
+                                                            Shape(
+                                                                fields={
+                                                                    "requiredRegistrationFraction": Field(
+                                                                        Int,
+                                                                        description="""Optional. The
+                                                                    config setting to enable cluster
+                                                                    creation/ updation to be
+                                                                    successful only after
+                                                                    required_registration_fraction
+                                                                    of instances are up and running.
+                                                                    This configuration is applicable
+                                                                    to only secondary workers for
+                                                                    now. The cluster will fail if
+                                                                    required_registration_fraction
+                                                                    of instances are not available.
+                                                                    This will include instance
+                                                                    creation, agent registration,
+                                                                    and service registration (if
+                                                                    enabled).""",
+                                                                        is_required=True,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            description="""Configuration to handle the
+                                                        startup of instances during cluster create
+                                                        and update process.""",
+                                                            is_required=True,
+                                                        ),
+                                                    },
+                                                ),
+                                                description="""The config settings for Compute Engine
+                                            resources in an instance group, such as a master or
+                                            worker group.""",
+                                                is_required=True,
+                                            ),
+                                            "labels": Field(
+                                                Permissive(),
+                                                description="""Optional. Node group labels. Label keys
+                                            must consist of from 1 to 63 characters and conform to
+                                            RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label
+                                            values can be empty. If specified, they must consist of
+                                            from 1 to 63 characters and conform to RFC 1035
+                                            (https://www.ietf.org/rfc/rfc1035.txt). The node group
+                                            must have no more than 32 labels.""",
+                                                is_required=True,
+                                            ),
+                                        },
+                                    ),
+                                    description="""Dataproc Node Group. The Dataproc NodeGroup resource
+                                is not related to the Dataproc NodeGroupAffinity resource.""",
+                                    is_required=True,
+                                ),
+                                "nodeGroupId": Field(
+                                    String,
+                                    description="""Optional. A node group ID. Generated if not
+                                specified.The ID must contain only letters (a-z, A-Z), numbers
+                                (0-9), underscores (_), and hyphens (-). Cannot begin or end with
+                                underscore or hyphen. Must consist of from 3 to 33 characters.""",
+                                    is_required=True,
+                                ),
+                            },
+                        )
+                    ],
+                    description="""Optional. The node group settings.""",
+                    is_required=True,
+                ),
+            },
         ),
         description="""The cluster config.""",
-        is_required=False,
+        is_required=True,
     )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
@@ -14,423 +14,15 @@ def define_dataproc_job_config():
     return Field(
         Shape(
             fields={
-                "status": Field(
-                    Shape(fields={}),
-                    description="""Cloud Dataproc job status.""",
-                    is_required=False,
-                ),
-                "placement": Field(
-                    Shape(
-                        fields={
-                            "clusterName": Field(
-                                String,
-                                description="""Required. The name of the cluster where the job will
-                                be submitted.""",
-                                is_required=False,
-                            )
-                        }
-                    ),
-                    description="""Cloud Dataproc job config.""",
-                    is_required=False,
-                ),
-                "scheduling": Field(
-                    Shape(
-                        fields={
-                            "maxFailuresPerHour": Field(
-                                Int,
-                                description="""Optional. Maximum number of times per hour a driver
-                                may be restarted as a result of driver terminating with non-zero
-                                code before job is reported failed.A job may be reported as
-                                thrashing if driver exits with non-zero code 4 times within 10
-                                minute window.Maximum value is 10.""",
-                                is_required=False,
-                            )
-                        }
-                    ),
-                    description="""Job scheduling options.""",
-                    is_required=False,
-                ),
-                "pigJob": Field(
-                    Shape(
-                        fields={
-                            "queryFileUri": Field(
-                                String,
-                                description="""The HCFS URI of the script that contains the Pig
-                                queries.""",
-                                is_required=False,
-                            ),
-                            "queryList": Field(
-                                Shape(
-                                    fields={
-                                        "queries": Field(
-                                            [String],
-                                            description="""Required. The queries to execute. You do
-                                            not need to terminate a query with a semicolon. Multiple
-                                            queries can be specified in one string by separating
-                                            each with a semicolon. Here is an example of an Cloud
-                                            Dataproc API snippet that uses a QueryList to specify a
-                                            HiveJob: "hiveJob": {   "queryList": {     "queries": [
-                                            "query1",       "query2",       "query3;query4",     ]
-                                            } } """,
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""A list of queries to run on a cluster.""",
-                                is_required=False,
-                            ),
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of jar files to add to the
-                                CLASSPATH of the Pig Client and Hadoop MapReduce (MR) tasks. Can
-                                contain Pig UDFs.""",
-                                is_required=False,
-                            ),
-                            "scriptVariables": Field(
-                                Permissive(),
-                                description="""Optional. Mapping of query variable names to values
-                                (equivalent to the Pig command: name=[value]).""",
-                                is_required=False,
-                            ),
-                            "loggingConfig": Field(
-                                Shape(
-                                    fields={
-                                        "driverLogLevels": Field(
-                                            Permissive(),
-                                            description="""The per-package log levels for the
-                                            driver. This may include "root" package name to
-                                            configure rootLogger. Examples:  \'com.google = FATAL\',
-                                            \'root = INFO\', \'org.apache = DEBUG\'""",
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""The runtime logging config of the job.""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names to values, used
-                                to configure Pig. Properties that conflict with values set by the
-                                Cloud Dataproc API may be overwritten. Can include properties set in
-                                /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties, and
-                                classes in user code.""",
-                                is_required=False,
-                            ),
-                            "continueOnFailure": Field(
-                                Bool,
-                                description="""Optional. Whether to continue executing queries if a
-                                query fails. The default value is false. Setting to true can be
-                                useful when executing independent parallel queries.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""A Cloud Dataproc job for running Apache Pig
-                    (https://pig.apache.org/) queries on YARN.""",
-                    is_required=False,
-                ),
-                "hiveJob": Field(
-                    Shape(
-                        fields={
-                            "continueOnFailure": Field(
-                                Bool,
-                                description="""Optional. Whether to continue executing queries if a
-                                query fails. The default value is false. Setting to true can be
-                                useful when executing independent parallel queries.""",
-                                is_required=False,
-                            ),
-                            "queryFileUri": Field(
-                                String,
-                                description="""The HCFS URI of the script that contains Hive
-                                queries.""",
-                                is_required=False,
-                            ),
-                            "queryList": Field(
-                                Shape(
-                                    fields={
-                                        "queries": Field(
-                                            [String],
-                                            description="""Required. The queries to execute. You do
-                                            not need to terminate a query with a semicolon. Multiple
-                                            queries can be specified in one string by separating
-                                            each with a semicolon. Here is an example of an Cloud
-                                            Dataproc API snippet that uses a QueryList to specify a
-                                            HiveJob: "hiveJob": {   "queryList": {     "queries": [
-                                            "query1",       "query2",       "query3;query4",     ]
-                                            } } """,
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""A list of queries to run on a cluster.""",
-                                is_required=False,
-                            ),
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of jar files to add to the
-                                CLASSPATH of the Hive server and Hadoop MapReduce (MR) tasks. Can
-                                contain Hive SerDes and UDFs.""",
-                                is_required=False,
-                            ),
-                            "scriptVariables": Field(
-                                Permissive(),
-                                description="""Optional. Mapping of query variable names to values
-                                (equivalent to the Hive command: SET name="value";).""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names and values,
-                                used to configure Hive. Properties that conflict with values set by
-                                the Cloud Dataproc API may be overwritten. Can include properties
-                                set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml,
-                                and classes in user code.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""A Cloud Dataproc job for running Apache Hive
-                    (https://hive.apache.org/) queries on YARN.""",
-                    is_required=False,
-                ),
-                "labels": Field(
-                    Permissive(),
-                    description="""Optional. The labels to associate with this job. Label keys must
-                    contain 1 to 63 characters, and must conform to RFC 1035
-                    (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if
-                    present, must contain 1 to 63 characters, and must conform to RFC 1035
-                    (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated
-                    with a job.""",
-                    is_required=False,
-                ),
-                "sparkJob": Field(
-                    Shape(
-                        fields={
-                            "archiveUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of archives to be extracted in
-                                the working directory of Spark drivers and tasks. Supported file
-                                types: .jar, .tar, .tar.gz, .tgz, and .zip.""",
-                                is_required=False,
-                            ),
-                            "mainJarFileUri": Field(
-                                String,
-                                description="""The HCFS URI of the jar file that contains the main
-                                class.""",
-                                is_required=False,
-                            ),
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of jar files to add to the
-                                CLASSPATHs of the Spark driver and tasks.""",
-                                is_required=False,
-                            ),
-                            "loggingConfig": Field(
-                                Shape(
-                                    fields={
-                                        "driverLogLevels": Field(
-                                            Permissive(),
-                                            description="""The per-package log levels for the
-                                            driver. This may include "root" package name to
-                                            configure rootLogger. Examples:  \'com.google = FATAL\',
-                                            \'root = INFO\', \'org.apache = DEBUG\'""",
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""The runtime logging config of the job.""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names to values, used
-                                to configure Spark. Properties that conflict with values set by the
-                                Cloud Dataproc API may be overwritten. Can include properties set in
-                                /etc/spark/conf/spark-defaults.conf and classes in user code.""",
-                                is_required=False,
-                            ),
-                            "args": Field(
-                                [String],
-                                description="""Optional. The arguments to pass to the driver. Do not
-                                include arguments, such as --conf, that can be set as job
-                                properties, since a collision may occur that causes an incorrect job
-                                submission.""",
-                                is_required=False,
-                            ),
-                            "fileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of files to be copied to the
-                                working directory of Spark drivers and distributed tasks. Useful for
-                                naively parallel tasks.""",
-                                is_required=False,
-                            ),
-                            "mainClass": Field(
-                                String,
-                                description="""The name of the driver\'s main class. The jar file
-                                that contains the class must be in the default CLASSPATH or
-                                specified in jar_file_uris.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""A Cloud Dataproc job for running Apache Spark
-                    (http://spark.apache.org/) applications on YARN.""",
-                    is_required=False,
-                ),
-                "sparkSqlJob": Field(
-                    Shape(
-                        fields={
-                            "queryList": Field(
-                                Shape(
-                                    fields={
-                                        "queries": Field(
-                                            [String],
-                                            description="""Required. The queries to execute. You do
-                                            not need to terminate a query with a semicolon. Multiple
-                                            queries can be specified in one string by separating
-                                            each with a semicolon. Here is an example of an Cloud
-                                            Dataproc API snippet that uses a QueryList to specify a
-                                            HiveJob: "hiveJob": {   "queryList": {     "queries": [
-                                            "query1",       "query2",       "query3;query4",     ]
-                                            } } """,
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""A list of queries to run on a cluster.""",
-                                is_required=False,
-                            ),
-                            "queryFileUri": Field(
-                                String,
-                                description="""The HCFS URI of the script that contains SQL
-                                queries.""",
-                                is_required=False,
-                            ),
-                            "scriptVariables": Field(
-                                Permissive(),
-                                description="""Optional. Mapping of query variable names to values
-                                (equivalent to the Spark SQL command: SET name="value";).""",
-                                is_required=False,
-                            ),
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of jar files to be added to the
-                                Spark CLASSPATH.""",
-                                is_required=False,
-                            ),
-                            "loggingConfig": Field(
-                                Shape(
-                                    fields={
-                                        "driverLogLevels": Field(
-                                            Permissive(),
-                                            description="""The per-package log levels for the
-                                            driver. This may include "root" package name to
-                                            configure rootLogger. Examples:  \'com.google = FATAL\',
-                                            \'root = INFO\', \'org.apache = DEBUG\'""",
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""The runtime logging config of the job.""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names to values, used
-                                to configure Spark SQL\'s SparkConf. Properties that conflict with
-                                values set by the Cloud Dataproc API may be overwritten.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""A Cloud Dataproc job for running Apache Spark SQL
-                    (http://spark.apache.org/sql/) queries.""",
-                    is_required=False,
-                ),
-                "pysparkJob": Field(
-                    Shape(
-                        fields={
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of jar files to add to the
-                                CLASSPATHs of the Python driver and tasks.""",
-                                is_required=False,
-                            ),
-                            "loggingConfig": Field(
-                                Shape(
-                                    fields={
-                                        "driverLogLevels": Field(
-                                            Permissive(),
-                                            description="""The per-package log levels for the
-                                            driver. This may include "root" package name to
-                                            configure rootLogger. Examples:  \'com.google = FATAL\',
-                                            \'root = INFO\', \'org.apache = DEBUG\'""",
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""The runtime logging config of the job.""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names to values, used
-                                to configure PySpark. Properties that conflict with values set by
-                                the Cloud Dataproc API may be overwritten. Can include properties
-                                set in /etc/spark/conf/spark-defaults.conf and classes in user
-                                code.""",
-                                is_required=False,
-                            ),
-                            "args": Field(
-                                [String],
-                                description="""Optional. The arguments to pass to the driver. Do not
-                                include arguments, such as --conf, that can be set as job
-                                properties, since a collision may occur that causes an incorrect job
-                                submission.""",
-                                is_required=False,
-                            ),
-                            "fileUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of files to be copied to the
-                                working directory of Python drivers and distributed tasks. Useful
-                                for naively parallel tasks.""",
-                                is_required=False,
-                            ),
-                            "pythonFileUris": Field(
-                                [String],
-                                description="""Optional. HCFS file URIs of Python files to pass to
-                                the PySpark framework. Supported file types: .py, .egg, and
-                                .zip.""",
-                                is_required=False,
-                            ),
-                            "mainPythonFileUri": Field(
-                                String,
-                                description="""Required. The HCFS URI of the main Python file to use
-                                as the driver. Must be a .py file.""",
-                                is_required=False,
-                            ),
-                            "archiveUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of archives to be extracted in
-                                the working directory of .jar, .tar, .tar.gz, .tgz, and .zip.""",
-                                is_required=False,
-                            ),
-                        }
-                    ),
-                    description="""A Cloud Dataproc job for running Apache PySpark
-                    (https://spark.apache.org/docs/0.9.0/python-programming-guide.html) applications
-                    on YARN.""",
-                    is_required=False,
-                ),
                 "reference": Field(
                     Shape(
                         fields={
                             "projectId": Field(
                                 String,
-                                description="""Required. The ID of the Google Cloud Platform project
-                                that the job belongs to.""",
-                                is_required=False,
+                                description="""Optional. The ID of the Google Cloud Platform project
+                                that the job belongs to. If specified, must match the request
+                                project ID.""",
+                                is_required=True,
                             ),
                             "jobId": Field(
                                 String,
@@ -439,75 +31,36 @@ def define_dataproc_job_config():
                                 underscores (_), or hyphens (-). The maximum length is 100
                                 characters.If not specified by the caller, the job ID will be
                                 provided by the server.""",
-                                is_required=False,
+                                is_required=True,
                             ),
-                        }
+                        },
                     ),
                     description="""Encapsulates the full scoping used to reference a job.""",
-                    is_required=False,
+                    is_required=True,
+                ),
+                "placement": Field(
+                    Shape(
+                        fields={
+                            "clusterName": Field(
+                                String,
+                                description="""Required. The name of the cluster where the job will
+                                be submitted.""",
+                                is_required=True,
+                            ),
+                            "clusterLabels": Field(
+                                Permissive(),
+                                description="""Optional. Cluster labels to identify a cluster where
+                                the job will be submitted.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Dataproc job config.""",
+                    is_required=True,
                 ),
                 "hadoopJob": Field(
                     Shape(
                         fields={
-                            "jarFileUris": Field(
-                                [String],
-                                description="""Optional. Jar file URIs to add to the CLASSPATHs of
-                                the Hadoop driver and tasks.""",
-                                is_required=False,
-                            ),
-                            "loggingConfig": Field(
-                                Shape(
-                                    fields={
-                                        "driverLogLevels": Field(
-                                            Permissive(),
-                                            description="""The per-package log levels for the
-                                            driver. This may include "root" package name to
-                                            configure rootLogger. Examples:  \'com.google = FATAL\',
-                                            \'root = INFO\', \'org.apache = DEBUG\'""",
-                                            is_required=False,
-                                        )
-                                    }
-                                ),
-                                description="""The runtime logging config of the job.""",
-                                is_required=False,
-                            ),
-                            "properties": Field(
-                                Permissive(),
-                                description="""Optional. A mapping of property names to values, used
-                                to configure Hadoop. Properties that conflict with values set by the
-                                Cloud Dataproc API may be overwritten. Can include properties set in
-                                /etc/hadoop/conf/*-site and classes in user code.""",
-                                is_required=False,
-                            ),
-                            "args": Field(
-                                [String],
-                                description="""Optional. The arguments to pass to the driver. Do not
-                                include arguments, such as -libjars or -Dfoo=bar, that can be set as
-                                job properties, since a collision may occur that causes an incorrect
-                                job submission.""",
-                                is_required=False,
-                            ),
-                            "fileUris": Field(
-                                [String],
-                                description="""Optional. HCFS (Hadoop Compatible Filesystem) URIs of
-                                files to be copied to the working directory of Hadoop drivers and
-                                distributed tasks. Useful for naively parallel tasks.""",
-                                is_required=False,
-                            ),
-                            "mainClass": Field(
-                                String,
-                                description="""The name of the driver\'s main class. The jar file
-                                containing the class must be in the default CLASSPATH or specified
-                                in jar_file_uris.""",
-                                is_required=False,
-                            ),
-                            "archiveUris": Field(
-                                [String],
-                                description="""Optional. HCFS URIs of archives to be extracted in
-                                the working directory of Hadoop drivers and tasks. Supported file
-                                types: .jar, .tar, .tar.gz, .tgz, or .zip.""",
-                                is_required=False,
-                            ),
                             "mainJarFileUri": Field(
                                 String,
                                 description="""The HCFS URI of the jar file containing the main
@@ -515,18 +68,789 @@ def define_dataproc_job_config():
                                 \'gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar\'
                                 \'hdfs:/tmp/test-samples/custom-wordcount.jar\'
                                 \'file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar\'""",
-                                is_required=False,
+                                is_required=True,
                             ),
-                        }
+                            "mainClass": Field(
+                                String,
+                                description="""The name of the driver\'s main class. The jar file
+                                containing the class must be in the default CLASSPATH or specified
+                                in jar_file_uris.""",
+                                is_required=True,
+                            ),
+                            "args": Field(
+                                [String],
+                                description="""Optional. The arguments to pass to the driver. Do not
+                                include arguments, such as -libjars or -Dfoo=bar, that can be set as
+                                job properties, since a collision might occur that causes an
+                                incorrect job submission.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. Jar file URIs to add to the CLASSPATHs of
+                                the Hadoop driver and tasks.""",
+                                is_required=True,
+                            ),
+                            "fileUris": Field(
+                                [String],
+                                description="""Optional. HCFS (Hadoop Compatible Filesystem) URIs of
+                                files to be copied to the working directory of Hadoop drivers and
+                                distributed tasks. Useful for naively parallel tasks.""",
+                                is_required=True,
+                            ),
+                            "archiveUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of archives to be extracted in
+                                the working directory of Hadoop drivers and tasks. Supported file
+                                types: .jar, .tar, .tar.gz, .tgz, or .zip.""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure Hadoop. Properties that conflict with values set by the
+                                Dataproc API might be overwritten. Can include properties set in
+                                /etc/hadoop/conf/*-site and classes in user code.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
                     ),
-                    description="""A Cloud Dataproc job for running Apache Hadoop MapReduce
+                    description="""A Dataproc job for running Apache Hadoop MapReduce
                     (https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html)
                     jobs on Apache Hadoop YARN
                     (https://hadoop.apache.org/docs/r2.7.1/hadoop-yarn/hadoop-yarn-site/YARN.html).""",
-                    is_required=False,
+                    is_required=True,
                 ),
-            }
+                "sparkJob": Field(
+                    Shape(
+                        fields={
+                            "mainJarFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the jar file that contains the main
+                                class.""",
+                                is_required=True,
+                            ),
+                            "mainClass": Field(
+                                String,
+                                description="""The name of the driver\'s main class. The jar file
+                                that contains the class must be in the default CLASSPATH or
+                                specified in SparkJob.jar_file_uris.""",
+                                is_required=True,
+                            ),
+                            "args": Field(
+                                [String],
+                                description="""Optional. The arguments to pass to the driver. Do not
+                                include arguments, such as --conf, that can be set as job
+                                properties, since a collision may occur that causes an incorrect job
+                                submission.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to add to the
+                                CLASSPATHs of the Spark driver and tasks.""",
+                                is_required=True,
+                            ),
+                            "fileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of files to be placed in the
+                                working directory of each executor. Useful for naively parallel
+                                tasks.""",
+                                is_required=True,
+                            ),
+                            "archiveUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of archives to be extracted into
+                                the working directory of each executor. Supported file types: .jar,
+                                .tar, .tar.gz, .tgz, and .zip.""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure Spark. Properties that conflict with values set by the
+                                Dataproc API might be overwritten. Can include properties set in
+                                /etc/spark/conf/spark-defaults.conf and classes in user code.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache Spark
+                    (https://spark.apache.org/) applications on YARN.""",
+                    is_required=True,
+                ),
+                "pysparkJob": Field(
+                    Shape(
+                        fields={
+                            "mainPythonFileUri": Field(
+                                String,
+                                description="""Required. The HCFS URI of the main Python file to use
+                                as the driver. Must be a .py file.""",
+                                is_required=True,
+                            ),
+                            "args": Field(
+                                [String],
+                                description="""Optional. The arguments to pass to the driver. Do not
+                                include arguments, such as --conf, that can be set as job
+                                properties, since a collision may occur that causes an incorrect job
+                                submission.""",
+                                is_required=True,
+                            ),
+                            "pythonFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS file URIs of Python files to pass to
+                                the PySpark framework. Supported file types: .py, .egg, and
+                                .zip.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to add to the
+                                CLASSPATHs of the Python driver and tasks.""",
+                                is_required=True,
+                            ),
+                            "fileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of files to be placed in the
+                                working directory of each executor. Useful for naively parallel
+                                tasks.""",
+                                is_required=True,
+                            ),
+                            "archiveUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of archives to be extracted into
+                                the working directory of each executor. Supported file types: .jar,
+                                .tar, .tar.gz, .tgz, and .zip.""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure PySpark. Properties that conflict with values set by
+                                the Dataproc API might be overwritten. Can include properties set in
+                                /etc/spark/conf/spark-defaults.conf and classes in user code.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache PySpark
+                    (https://spark.apache.org/docs/latest/api/python/index.html#pyspark-overview)
+                    applications on YARN.""",
+                    is_required=True,
+                ),
+                "hiveJob": Field(
+                    Shape(
+                        fields={
+                            "queryFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the script that contains Hive
+                                queries.""",
+                                is_required=True,
+                            ),
+                            "queryList": Field(
+                                Shape(
+                                    fields={
+                                        "queries": Field(
+                                            [String],
+                                            description="""Required. The queries to execute. You do
+                                            not need to end a query expression with a semicolon.
+                                            Multiple queries can be specified in one string by
+                                            separating each with a semicolon. Here is an example of
+                                            a Dataproc API snippet that uses a QueryList to specify
+                                            a HiveJob: "hiveJob": { "queryList": { "queries": [
+                                            "query1", "query2", "query3;query4", ] } } """,
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""A list of queries to run on a cluster.""",
+                                is_required=True,
+                            ),
+                            "continueOnFailure": Field(
+                                Bool,
+                                description="""Optional. Whether to continue executing queries if a
+                                query fails. The default value is false. Setting to true can be
+                                useful when executing independent parallel queries.""",
+                                is_required=True,
+                            ),
+                            "scriptVariables": Field(
+                                Permissive(),
+                                description="""Optional. Mapping of query variable names to values
+                                (equivalent to the Hive command: SET name="value";).""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names and values,
+                                used to configure Hive. Properties that conflict with values set by
+                                the Dataproc API might be overwritten. Can include properties set in
+                                /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml, and
+                                classes in user code.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to add to the
+                                CLASSPATH of the Hive server and Hadoop MapReduce (MR) tasks. Can
+                                contain Hive SerDes and UDFs.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache Hive (https://hive.apache.org/)
+                    queries on YARN.""",
+                    is_required=True,
+                ),
+                "pigJob": Field(
+                    Shape(
+                        fields={
+                            "queryFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the script that contains the Pig
+                                queries.""",
+                                is_required=True,
+                            ),
+                            "queryList": Field(
+                                Shape(
+                                    fields={
+                                        "queries": Field(
+                                            [String],
+                                            description="""Required. The queries to execute. You do
+                                            not need to end a query expression with a semicolon.
+                                            Multiple queries can be specified in one string by
+                                            separating each with a semicolon. Here is an example of
+                                            a Dataproc API snippet that uses a QueryList to specify
+                                            a HiveJob: "hiveJob": { "queryList": { "queries": [
+                                            "query1", "query2", "query3;query4", ] } } """,
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""A list of queries to run on a cluster.""",
+                                is_required=True,
+                            ),
+                            "continueOnFailure": Field(
+                                Bool,
+                                description="""Optional. Whether to continue executing queries if a
+                                query fails. The default value is false. Setting to true can be
+                                useful when executing independent parallel queries.""",
+                                is_required=True,
+                            ),
+                            "scriptVariables": Field(
+                                Permissive(),
+                                description="""Optional. Mapping of query variable names to values
+                                (equivalent to the Pig command: name=[value]).""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure Pig. Properties that conflict with values set by the
+                                Dataproc API might be overwritten. Can include properties set in
+                                /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties, and
+                                classes in user code.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to add to the
+                                CLASSPATH of the Pig Client and Hadoop MapReduce (MR) tasks. Can
+                                contain Pig UDFs.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache Pig (https://pig.apache.org/)
+                    queries on YARN.""",
+                    is_required=True,
+                ),
+                "sparkRJob": Field(
+                    Shape(
+                        fields={
+                            "mainRFileUri": Field(
+                                String,
+                                description="""Required. The HCFS URI of the main R file to use as
+                                the driver. Must be a .R file.""",
+                                is_required=True,
+                            ),
+                            "args": Field(
+                                [String],
+                                description="""Optional. The arguments to pass to the driver. Do not
+                                include arguments, such as --conf, that can be set as job
+                                properties, since a collision may occur that causes an incorrect job
+                                submission.""",
+                                is_required=True,
+                            ),
+                            "fileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of files to be placed in the
+                                working directory of each executor. Useful for naively parallel
+                                tasks.""",
+                                is_required=True,
+                            ),
+                            "archiveUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of archives to be extracted into
+                                the working directory of each executor. Supported file types: .jar,
+                                .tar, .tar.gz, .tgz, and .zip.""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure SparkR. Properties that conflict with values set by the
+                                Dataproc API might be overwritten. Can include properties set in
+                                /etc/spark/conf/spark-defaults.conf and classes in user code.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache SparkR
+                    (https://spark.apache.org/docs/latest/sparkr.html) applications on YARN.""",
+                    is_required=True,
+                ),
+                "sparkSqlJob": Field(
+                    Shape(
+                        fields={
+                            "queryFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the script that contains SQL
+                                queries.""",
+                                is_required=True,
+                            ),
+                            "queryList": Field(
+                                Shape(
+                                    fields={
+                                        "queries": Field(
+                                            [String],
+                                            description="""Required. The queries to execute. You do
+                                            not need to end a query expression with a semicolon.
+                                            Multiple queries can be specified in one string by
+                                            separating each with a semicolon. Here is an example of
+                                            a Dataproc API snippet that uses a QueryList to specify
+                                            a HiveJob: "hiveJob": { "queryList": { "queries": [
+                                            "query1", "query2", "query3;query4", ] } } """,
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""A list of queries to run on a cluster.""",
+                                is_required=True,
+                            ),
+                            "scriptVariables": Field(
+                                Permissive(),
+                                description="""Optional. Mapping of query variable names to values
+                                (equivalent to the Spark SQL command: SET name="value";).""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure Spark SQL\'s SparkConf. Properties that conflict with
+                                values set by the Dataproc API might be overwritten.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to be added to the
+                                Spark CLASSPATH.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache Spark SQL
+                    (https://spark.apache.org/sql/) queries.""",
+                    is_required=True,
+                ),
+                "prestoJob": Field(
+                    Shape(
+                        fields={
+                            "queryFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the script that contains SQL
+                                queries.""",
+                                is_required=True,
+                            ),
+                            "queryList": Field(
+                                Shape(
+                                    fields={
+                                        "queries": Field(
+                                            [String],
+                                            description="""Required. The queries to execute. You do
+                                            not need to end a query expression with a semicolon.
+                                            Multiple queries can be specified in one string by
+                                            separating each with a semicolon. Here is an example of
+                                            a Dataproc API snippet that uses a QueryList to specify
+                                            a HiveJob: "hiveJob": { "queryList": { "queries": [
+                                            "query1", "query2", "query3;query4", ] } } """,
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""A list of queries to run on a cluster.""",
+                                is_required=True,
+                            ),
+                            "continueOnFailure": Field(
+                                Bool,
+                                description="""Optional. Whether to continue executing queries if a
+                                query fails. The default value is false. Setting to true can be
+                                useful when executing independent parallel queries.""",
+                                is_required=True,
+                            ),
+                            "outputFormat": Field(
+                                String,
+                                description="""Optional. The format in which query output will be
+                                displayed. See the Presto documentation for supported output
+                                formats""",
+                                is_required=True,
+                            ),
+                            "clientTags": Field(
+                                [String],
+                                description="""Optional. Presto client tags to attach to this
+                                query""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values. Used
+                                to set Presto session properties
+                                (https://prestodb.io/docs/current/sql/set-session.html) Equivalent
+                                to using the --session flag in the Presto CLI""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Presto (https://prestosql.io/)
+                    queries. IMPORTANT: The Dataproc Presto Optional Component
+                    (https://cloud.google.com/dataproc/docs/concepts/components/presto) must be
+                    enabled when the cluster is created to submit a Presto job to the cluster.""",
+                    is_required=True,
+                ),
+                "trinoJob": Field(
+                    Shape(
+                        fields={
+                            "queryFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the script that contains SQL
+                                queries.""",
+                                is_required=True,
+                            ),
+                            "queryList": Field(
+                                Shape(
+                                    fields={
+                                        "queries": Field(
+                                            [String],
+                                            description="""Required. The queries to execute. You do
+                                            not need to end a query expression with a semicolon.
+                                            Multiple queries can be specified in one string by
+                                            separating each with a semicolon. Here is an example of
+                                            a Dataproc API snippet that uses a QueryList to specify
+                                            a HiveJob: "hiveJob": { "queryList": { "queries": [
+                                            "query1", "query2", "query3;query4", ] } } """,
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""A list of queries to run on a cluster.""",
+                                is_required=True,
+                            ),
+                            "continueOnFailure": Field(
+                                Bool,
+                                description="""Optional. Whether to continue executing queries if a
+                                query fails. The default value is false. Setting to true can be
+                                useful when executing independent parallel queries.""",
+                                is_required=True,
+                            ),
+                            "outputFormat": Field(
+                                String,
+                                description="""Optional. The format in which query output will be
+                                displayed. See the Trino documentation for supported output
+                                formats""",
+                                is_required=True,
+                            ),
+                            "clientTags": Field(
+                                [String],
+                                description="""Optional. Trino client tags to attach to this
+                                query""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values. Used
+                                to set Trino session properties
+                                (https://trino.io/docs/current/sql/set-session.html) Equivalent to
+                                using the --session flag in the Trino CLI""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Trino (https://trino.io/) queries.
+                    IMPORTANT: The Dataproc Trino Optional Component
+                    (https://cloud.google.com/dataproc/docs/concepts/components/trino) must be
+                    enabled when the cluster is created to submit a Trino job to the cluster.""",
+                    is_required=True,
+                ),
+                "flinkJob": Field(
+                    Shape(
+                        fields={
+                            "mainJarFileUri": Field(
+                                String,
+                                description="""The HCFS URI of the jar file that contains the main
+                                class.""",
+                                is_required=True,
+                            ),
+                            "mainClass": Field(
+                                String,
+                                description="""The name of the driver\'s main class. The jar file
+                                that contains the class must be in the default CLASSPATH or
+                                specified in jarFileUris.""",
+                                is_required=True,
+                            ),
+                            "args": Field(
+                                [String],
+                                description="""Optional. The arguments to pass to the driver. Do not
+                                include arguments, such as --conf, that can be set as job
+                                properties, since a collision might occur that causes an incorrect
+                                job submission.""",
+                                is_required=True,
+                            ),
+                            "jarFileUris": Field(
+                                [String],
+                                description="""Optional. HCFS URIs of jar files to add to the
+                                CLASSPATHs of the Flink driver and tasks.""",
+                                is_required=True,
+                            ),
+                            "savepointUri": Field(
+                                String,
+                                description="""Optional. HCFS URI of the savepoint, which contains
+                                the last saved progress for starting the current job.""",
+                                is_required=True,
+                            ),
+                            "properties": Field(
+                                Permissive(),
+                                description="""Optional. A mapping of property names to values, used
+                                to configure Flink. Properties that conflict with values set by the
+                                Dataproc API might be overwritten. Can include properties set in
+                                /etc/flink/conf/flink-defaults.conf and classes in user code.""",
+                                is_required=True,
+                            ),
+                            "loggingConfig": Field(
+                                Shape(
+                                    fields={
+                                        "driverLogLevels": Field(
+                                            Permissive(),
+                                            description="""The per-package log levels for the
+                                            driver. This can include "root" package name to
+                                            configure rootLogger. Examples: - \'com.google = FATAL\'
+                                            - \'root = INFO\' - \'org.apache = DEBUG\'""",
+                                            is_required=True,
+                                        ),
+                                    },
+                                ),
+                                description="""The runtime logging config of the job.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""A Dataproc job for running Apache Flink applications on YARN.""",
+                    is_required=True,
+                ),
+                "status": Field(
+                    Shape(
+                        fields={},
+                    ),
+                    description="""Dataproc job status.""",
+                    is_required=True,
+                ),
+                "labels": Field(
+                    Permissive(),
+                    description="""Optional. The labels to associate with this job. Label keys must
+                    contain 1 to 63 characters, and must conform to RFC 1035
+                    (https://www.ietf.org/rfc/rfc1035.txt). Label values can be empty, but, if
+                    present, must contain 1 to 63 characters, and must conform to RFC 1035
+                    (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated
+                    with a job.""",
+                    is_required=True,
+                ),
+                "scheduling": Field(
+                    Shape(
+                        fields={
+                            "maxFailuresPerHour": Field(
+                                Int,
+                                description="""Optional. Maximum number of times per hour a driver
+                                can be restarted as a result of driver exiting with non-zero code
+                                before job is reported failed.A job might be reported as thrashing
+                                if the driver exits with a non-zero code four times within a
+                                10-minute window.Maximum value is 10.Note: This restartable job
+                                option is not supported in Dataproc workflow templates
+                                (https://cloud.google.com/dataproc/docs/concepts/workflows/using-workflows#adding_jobs_to_a_template).""",
+                                is_required=True,
+                            ),
+                            "maxFailuresTotal": Field(
+                                Int,
+                                description="""Optional. Maximum total number of times a driver can
+                                be restarted as a result of the driver exiting with a non-zero code.
+                                After the maximum number is reached, the job will be reported as
+                                failed.Maximum value is 240.Note: Currently, this restartable job
+                                option is not supported in Dataproc workflow templates
+                                (https://cloud.google.com/dataproc/docs/concepts/workflows/using-workflows#adding_jobs_to_a_template).""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Job scheduling options.""",
+                    is_required=True,
+                ),
+                "driverSchedulingConfig": Field(
+                    Shape(
+                        fields={
+                            "memoryMb": Field(
+                                Int,
+                                description="""Required. The amount of memory in MB the driver is
+                                requesting.""",
+                                is_required=True,
+                            ),
+                            "vcores": Field(
+                                Int,
+                                description="""Required. The number of vCPUs the driver is
+                                requesting.""",
+                                is_required=True,
+                            ),
+                        },
+                    ),
+                    description="""Driver scheduling configuration.""",
+                    is_required=True,
+                ),
+            },
         ),
-        description="""A Cloud Dataproc job resource.""",
-        is_required=False,
+        description="""A Dataproc job resource.""",
+        is_required=True,
     )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
@@ -22,7 +22,7 @@ def define_dataproc_job_config():
                                 description="""Optional. The ID of the Google Cloud Platform project
                                 that the job belongs to. If specified, must match the request
                                 project ID.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jobId": Field(
                                 String,
@@ -31,7 +31,7 @@ def define_dataproc_job_config():
                                 underscores (_), or hyphens (-). The maximum length is 100
                                 characters.If not specified by the caller, the job ID will be
                                 provided by the server.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -51,7 +51,7 @@ def define_dataproc_job_config():
                                 Permissive(),
                                 description="""Optional. Cluster labels to identify a cluster where
                                 the job will be submitted.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -83,27 +83,27 @@ def define_dataproc_job_config():
                                 include arguments, such as -libjars or -Dfoo=bar, that can be set as
                                 job properties, since a collision might occur that causes an
                                 incorrect job submission.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. Jar file URIs to add to the CLASSPATHs of
                                 the Hadoop driver and tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "fileUris": Field(
                                 [String],
                                 description="""Optional. HCFS (Hadoop Compatible Filesystem) URIs of
                                 files to be copied to the working directory of Hadoop drivers and
                                 distributed tasks. Useful for naively parallel tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "archiveUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of archives to be extracted in
                                 the working directory of Hadoop drivers and tasks. Supported file
                                 types: .jar, .tar, .tar.gz, .tgz, or .zip.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -111,7 +111,7 @@ def define_dataproc_job_config():
                                 to configure Hadoop. Properties that conflict with values set by the
                                 Dataproc API might be overwritten. Can include properties set in
                                 /etc/hadoop/conf/*-site and classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -159,27 +159,27 @@ def define_dataproc_job_config():
                                 include arguments, such as --conf, that can be set as job
                                 properties, since a collision may occur that causes an incorrect job
                                 submission.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to add to the
                                 CLASSPATHs of the Spark driver and tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "fileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of files to be placed in the
                                 working directory of each executor. Useful for naively parallel
                                 tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "archiveUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of archives to be extracted into
                                 the working directory of each executor. Supported file types: .jar,
                                 .tar, .tar.gz, .tgz, and .zip.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -187,7 +187,7 @@ def define_dataproc_job_config():
                                 to configure Spark. Properties that conflict with values set by the
                                 Dataproc API might be overwritten. Can include properties set in
                                 /etc/spark/conf/spark-defaults.conf and classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -226,34 +226,34 @@ def define_dataproc_job_config():
                                 include arguments, such as --conf, that can be set as job
                                 properties, since a collision may occur that causes an incorrect job
                                 submission.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "pythonFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS file URIs of Python files to pass to
                                 the PySpark framework. Supported file types: .py, .egg, and
                                 .zip.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to add to the
                                 CLASSPATHs of the Python driver and tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "fileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of files to be placed in the
                                 working directory of each executor. Useful for naively parallel
                                 tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "archiveUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of archives to be extracted into
                                 the working directory of each executor. Supported file types: .jar,
                                 .tar, .tar.gz, .tgz, and .zip.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -261,7 +261,7 @@ def define_dataproc_job_config():
                                 to configure PySpark. Properties that conflict with values set by
                                 the Dataproc API might be overwritten. Can include properties set in
                                 /etc/spark/conf/spark-defaults.conf and classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -319,13 +319,13 @@ def define_dataproc_job_config():
                                 description="""Optional. Whether to continue executing queries if a
                                 query fails. The default value is false. Setting to true can be
                                 useful when executing independent parallel queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "scriptVariables": Field(
                                 Permissive(),
                                 description="""Optional. Mapping of query variable names to values
                                 (equivalent to the Hive command: SET name="value";).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -334,14 +334,14 @@ def define_dataproc_job_config():
                                 the Dataproc API might be overwritten. Can include properties set in
                                 /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml, and
                                 classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to add to the
                                 CLASSPATH of the Hive server and Hadoop MapReduce (MR) tasks. Can
                                 contain Hive SerDes and UDFs.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -382,13 +382,13 @@ def define_dataproc_job_config():
                                 description="""Optional. Whether to continue executing queries if a
                                 query fails. The default value is false. Setting to true can be
                                 useful when executing independent parallel queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "scriptVariables": Field(
                                 Permissive(),
                                 description="""Optional. Mapping of query variable names to values
                                 (equivalent to the Pig command: name=[value]).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -397,14 +397,14 @@ def define_dataproc_job_config():
                                 Dataproc API might be overwritten. Can include properties set in
                                 /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties, and
                                 classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to add to the
                                 CLASSPATH of the Pig Client and Hadoop MapReduce (MR) tasks. Can
                                 contain Pig UDFs.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -443,21 +443,21 @@ def define_dataproc_job_config():
                                 include arguments, such as --conf, that can be set as job
                                 properties, since a collision may occur that causes an incorrect job
                                 submission.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "fileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of files to be placed in the
                                 working directory of each executor. Useful for naively parallel
                                 tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "archiveUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of archives to be extracted into
                                 the working directory of each executor. Supported file types: .jar,
                                 .tar, .tar.gz, .tgz, and .zip.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -465,7 +465,7 @@ def define_dataproc_job_config():
                                 to configure SparkR. Properties that conflict with values set by the
                                 Dataproc API might be overwritten. Can include properties set in
                                 /etc/spark/conf/spark-defaults.conf and classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -521,20 +521,20 @@ def define_dataproc_job_config():
                                 Permissive(),
                                 description="""Optional. Mapping of query variable names to values
                                 (equivalent to the Spark SQL command: SET name="value";).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
                                 description="""Optional. A mapping of property names to values, used
                                 to configure Spark SQL\'s SparkConf. Properties that conflict with
                                 values set by the Dataproc API might be overwritten.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to be added to the
                                 Spark CLASSPATH.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -591,20 +591,20 @@ def define_dataproc_job_config():
                                 description="""Optional. Whether to continue executing queries if a
                                 query fails. The default value is false. Setting to true can be
                                 useful when executing independent parallel queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "outputFormat": Field(
                                 String,
                                 description="""Optional. The format in which query output will be
                                 displayed. See the Presto documentation for supported output
                                 formats""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "clientTags": Field(
                                 [String],
                                 description="""Optional. Presto client tags to attach to this
                                 query""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -612,7 +612,7 @@ def define_dataproc_job_config():
                                 to set Presto session properties
                                 (https://prestodb.io/docs/current/sql/set-session.html) Equivalent
                                 to using the --session flag in the Presto CLI""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -671,20 +671,20 @@ def define_dataproc_job_config():
                                 description="""Optional. Whether to continue executing queries if a
                                 query fails. The default value is false. Setting to true can be
                                 useful when executing independent parallel queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "outputFormat": Field(
                                 String,
                                 description="""Optional. The format in which query output will be
                                 displayed. See the Trino documentation for supported output
                                 formats""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "clientTags": Field(
                                 [String],
                                 description="""Optional. Trino client tags to attach to this
                                 query""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -692,7 +692,7 @@ def define_dataproc_job_config():
                                 to set Trino session properties
                                 (https://trino.io/docs/current/sql/set-session.html) Equivalent to
                                 using the --session flag in the Trino CLI""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -740,19 +740,19 @@ def define_dataproc_job_config():
                                 include arguments, such as --conf, that can be set as job
                                 properties, since a collision might occur that causes an incorrect
                                 job submission.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "jarFileUris": Field(
                                 [String],
                                 description="""Optional. HCFS URIs of jar files to add to the
                                 CLASSPATHs of the Flink driver and tasks.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "savepointUri": Field(
                                 String,
                                 description="""Optional. HCFS URI of the savepoint, which contains
                                 the last saved progress for starting the current job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "properties": Field(
                                 Permissive(),
@@ -760,7 +760,7 @@ def define_dataproc_job_config():
                                 to configure Flink. Properties that conflict with values set by the
                                 Dataproc API might be overwritten. Can include properties set in
                                 /etc/flink/conf/flink-defaults.conf and classes in user code.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "loggingConfig": Field(
                                 Shape(
@@ -798,7 +798,7 @@ def define_dataproc_job_config():
                     present, must contain 1 to 63 characters, and must conform to RFC 1035
                     (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated
                     with a job.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "scheduling": Field(
                     Shape(
@@ -812,7 +812,7 @@ def define_dataproc_job_config():
                                 10-minute window.Maximum value is 10.Note: This restartable job
                                 option is not supported in Dataproc workflow templates
                                 (https://cloud.google.com/dataproc/docs/concepts/workflows/using-workflows#adding_jobs_to_a_template).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "maxFailuresTotal": Field(
                                 Int,
@@ -822,7 +822,7 @@ def define_dataproc_job_config():
                                 failed.Maximum value is 240.Note: Currently, this restartable job
                                 option is not supported in Dataproc workflow templates
                                 (https://cloud.google.com/dataproc/docs/concepts/workflows/using-workflows#adding_jobs_to_a_template).""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/configs_dataproc_job.py
@@ -36,7 +36,7 @@ def define_dataproc_job_config():
                         },
                     ),
                     description="""Encapsulates the full scoping used to reference a job.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "placement": Field(
                     Shape(
@@ -56,7 +56,7 @@ def define_dataproc_job_config():
                         },
                     ),
                     description="""Dataproc job config.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "hadoopJob": Field(
                     Shape(
@@ -68,14 +68,14 @@ def define_dataproc_job_config():
                                 \'gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar\'
                                 \'hdfs:/tmp/test-samples/custom-wordcount.jar\'
                                 \'file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar\'""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "mainClass": Field(
                                 String,
                                 description="""The name of the driver\'s main class. The jar file
                                 containing the class must be in the default CLASSPATH or specified
                                 in jar_file_uris.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "args": Field(
                                 [String],
@@ -122,12 +122,12 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -135,7 +135,7 @@ def define_dataproc_job_config():
                     (https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html)
                     jobs on Apache Hadoop YARN
                     (https://hadoop.apache.org/docs/r2.7.1/hadoop-yarn/hadoop-yarn-site/YARN.html).""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "sparkJob": Field(
                     Shape(
@@ -144,14 +144,14 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the jar file that contains the main
                                 class.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "mainClass": Field(
                                 String,
                                 description="""The name of the driver\'s main class. The jar file
                                 that contains the class must be in the default CLASSPATH or
                                 specified in SparkJob.jar_file_uris.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "args": Field(
                                 [String],
@@ -198,18 +198,18 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache Spark
                     (https://spark.apache.org/) applications on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "pysparkJob": Field(
                     Shape(
@@ -272,19 +272,19 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache PySpark
                     (https://spark.apache.org/docs/latest/api/python/index.html#pyspark-overview)
                     applications on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "hiveJob": Field(
                     Shape(
@@ -293,7 +293,7 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the script that contains Hive
                                 queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "queryList": Field(
                                 Shape(
@@ -312,7 +312,7 @@ def define_dataproc_job_config():
                                     },
                                 ),
                                 description="""A list of queries to run on a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "continueOnFailure": Field(
                                 Bool,
@@ -347,7 +347,7 @@ def define_dataproc_job_config():
                     ),
                     description="""A Dataproc job for running Apache Hive (https://hive.apache.org/)
                     queries on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "pigJob": Field(
                     Shape(
@@ -356,7 +356,7 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the script that contains the Pig
                                 queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "queryList": Field(
                                 Shape(
@@ -375,7 +375,7 @@ def define_dataproc_job_config():
                                     },
                                 ),
                                 description="""A list of queries to run on a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "continueOnFailure": Field(
                                 Bool,
@@ -415,18 +415,18 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache Pig (https://pig.apache.org/)
                     queries on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "sparkRJob": Field(
                     Shape(
@@ -476,18 +476,18 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache SparkR
                     (https://spark.apache.org/docs/latest/sparkr.html) applications on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "sparkSqlJob": Field(
                     Shape(
@@ -496,7 +496,7 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the script that contains SQL
                                 queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "queryList": Field(
                                 Shape(
@@ -515,7 +515,7 @@ def define_dataproc_job_config():
                                     },
                                 ),
                                 description="""A list of queries to run on a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "scriptVariables": Field(
                                 Permissive(),
@@ -545,18 +545,18 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache Spark SQL
                     (https://spark.apache.org/sql/) queries.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "prestoJob": Field(
                     Shape(
@@ -565,7 +565,7 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the script that contains SQL
                                 queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "queryList": Field(
                                 Shape(
@@ -584,7 +584,7 @@ def define_dataproc_job_config():
                                     },
                                 ),
                                 description="""A list of queries to run on a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "continueOnFailure": Field(
                                 Bool,
@@ -623,12 +623,12 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -636,7 +636,7 @@ def define_dataproc_job_config():
                     queries. IMPORTANT: The Dataproc Presto Optional Component
                     (https://cloud.google.com/dataproc/docs/concepts/components/presto) must be
                     enabled when the cluster is created to submit a Presto job to the cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "trinoJob": Field(
                     Shape(
@@ -645,7 +645,7 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the script that contains SQL
                                 queries.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "queryList": Field(
                                 Shape(
@@ -664,7 +664,7 @@ def define_dataproc_job_config():
                                     },
                                 ),
                                 description="""A list of queries to run on a cluster.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "continueOnFailure": Field(
                                 Bool,
@@ -703,12 +703,12 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
@@ -716,7 +716,7 @@ def define_dataproc_job_config():
                     IMPORTANT: The Dataproc Trino Optional Component
                     (https://cloud.google.com/dataproc/docs/concepts/components/trino) must be
                     enabled when the cluster is created to submit a Trino job to the cluster.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "flinkJob": Field(
                     Shape(
@@ -725,14 +725,14 @@ def define_dataproc_job_config():
                                 String,
                                 description="""The HCFS URI of the jar file that contains the main
                                 class.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "mainClass": Field(
                                 String,
                                 description="""The name of the driver\'s main class. The jar file
                                 that contains the class must be in the default CLASSPATH or
                                 specified in jarFileUris.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                             "args": Field(
                                 [String],
@@ -771,24 +771,24 @@ def define_dataproc_job_config():
                                             driver. This can include "root" package name to
                                             configure rootLogger. Examples: - \'com.google = FATAL\'
                                             - \'root = INFO\' - \'org.apache = DEBUG\'""",
-                                            is_required=True,
+                                            is_required=False,
                                         ),
                                     },
                                 ),
                                 description="""The runtime logging config of the job.""",
-                                is_required=True,
+                                is_required=False,
                             ),
                         },
                     ),
                     description="""A Dataproc job for running Apache Flink applications on YARN.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "status": Field(
                     Shape(
                         fields={},
                     ),
                     description="""Dataproc job status.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "labels": Field(
                     Permissive(),
@@ -827,7 +827,7 @@ def define_dataproc_job_config():
                         },
                     ),
                     description="""Job scheduling options.""",
-                    is_required=True,
+                    is_required=False,
                 ),
                 "driverSchedulingConfig": Field(
                     Shape(
@@ -847,10 +847,10 @@ def define_dataproc_job_config():
                         },
                     ),
                     description="""Driver scheduling configuration.""",
-                    is_required=True,
+                    is_required=False,
                 ),
             },
         ),
         description="""A Dataproc job resource.""",
-        is_required=True,
+        is_required=False,
     )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_cluster.py
@@ -9,8 +9,8 @@ parse_dataproc_configs.py \
 
 from dagster import Enum, EnumValue
 
-Privateipv6Googleaccess = Enum(
-    name="Privateipv6Googleaccess",
+PrivateIpv6GoogleAccess = Enum(
+    name="PrivateIpv6GoogleAccess",
     enum_values=[
         EnumValue(
             "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED",
@@ -36,8 +36,8 @@ Privateipv6Googleaccess = Enum(
     ],
 )
 
-Consumereservationtype = Enum(
-    name="Consumereservationtype",
+ConsumeReservationType = Enum(
+    name="ConsumeReservationType",
     enum_values=[
         EnumValue("TYPE_UNSPECIFIED", description=""""""),
         EnumValue("NO_RESERVATION", description="""Do not consume from any allocated capacity."""),
@@ -91,8 +91,8 @@ Component = Enum(
     ],
 )
 
-Metricsource = Enum(
-    name="Metricsource",
+MetricSource = Enum(
+    name="MetricSource",
     enum_values=[
         EnumValue(
             "METRIC_SOURCE_UNSPECIFIED",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_cluster.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_cluster.py
@@ -9,17 +9,108 @@ parse_dataproc_configs.py \
 
 from dagster import Enum, EnumValue
 
+Privateipv6Googleaccess = Enum(
+    name="Privateipv6Googleaccess",
+    enum_values=[
+        EnumValue(
+            "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED",
+            description="""If unspecified, Compute
+        Engine default behavior will apply, which is the same as INHERIT_FROM_SUBNETWORK.""",
+        ),
+        EnumValue(
+            "INHERIT_FROM_SUBNETWORK",
+            description="""Private access to and from Google
+        Services configuration inherited from the subnetwork configuration. This is the default
+        Compute Engine behavior.""",
+        ),
+        EnumValue(
+            "OUTBOUND",
+            description="""Enables outbound private IPv6 access to Google Services
+        from the Dataproc cluster.""",
+        ),
+        EnumValue(
+            "BIDIRECTIONAL",
+            description="""Enables bidirectional private IPv6 access between
+        Google Services and the Dataproc cluster.""",
+        ),
+    ],
+)
+
+Consumereservationtype = Enum(
+    name="Consumereservationtype",
+    enum_values=[
+        EnumValue("TYPE_UNSPECIFIED", description=""""""),
+        EnumValue("NO_RESERVATION", description="""Do not consume from any allocated capacity."""),
+        EnumValue("ANY_RESERVATION", description="""Consume any reservation available."""),
+        EnumValue(
+            "SPECIFIC_RESERVATION",
+            description="""Must consume from a specific reservation.
+        Must specify key value fields for specifying the reservations.""",
+        ),
+    ],
+)
+
+Preemptibility = Enum(
+    name="Preemptibility",
+    enum_values=[
+        EnumValue(
+            "PREEMPTIBILITY_UNSPECIFIED",
+            description="""Preemptibility is unspecified, the
+        system will choose the appropriate setting for each instance group.""",
+        ),
+        EnumValue(
+            "NON_PREEMPTIBLE",
+            description="""Instances are non-preemptible.This option is
+        allowed for all instance groups and is the only valid value for Master and Worker instance
+        groups.""",
+        ),
+        EnumValue(
+            "PREEMPTIBLE",
+            description="""Instances are preemptible
+        (https://cloud.google.com/compute/docs/instances/preemptible).This option is allowed only
+        for secondary worker (https://cloud.google.com/dataproc/docs/concepts/compute/secondary-vms)
+        groups.""",
+        ),
+        EnumValue(
+            "SPOT",
+            description="""Instances are Spot VMs
+        (https://cloud.google.com/compute/docs/instances/spot).This option is allowed only for
+        secondary worker (https://cloud.google.com/dataproc/docs/concepts/compute/secondary-vms)
+        groups. Spot VMs are the latest version of preemptible VMs
+        (https://cloud.google.com/compute/docs/instances/preemptible), and provide additional
+        features.""",
+        ),
+    ],
+)
+
 Component = Enum(
     name="Component",
     enum_values=[
-        EnumValue("COMPONENT_UNSPECIFIED", description="""Unspecified component."""),
-        EnumValue("ANACONDA", description="""The Anaconda python distribution."""),
+        EnumValue("ROLE_UNSPECIFIED", description="""Required unspecified role."""),
+        EnumValue("DRIVER", description="""Job drivers run on the node pool."""),
+    ],
+)
+
+Metricsource = Enum(
+    name="Metricsource",
+    enum_values=[
         EnumValue(
-            "HIVE_WEBHCAT",
-            description="""The Hive Web HCatalog (the REST service for
-        accessing HCatalog).""",
+            "METRIC_SOURCE_UNSPECIFIED",
+            description="""Required unspecified metric
+        source.""",
         ),
-        EnumValue("JUPYTER", description="""The Jupyter Notebook."""),
-        EnumValue("ZEPPELIN", description="""The Zeppelin notebook."""),
+        EnumValue(
+            "MONITORING_AGENT_DEFAULTS",
+            description="""Monitoring agent metrics. If this
+        source is enabled, Dataproc enables the monitoring agent in Compute Engine, and collects
+        monitoring agent metrics, which are published with an agent.googleapis.com prefix.""",
+        ),
+        EnumValue("HDFS", description="""HDFS metric source."""),
+        EnumValue("SPARK", description="""Spark metric source."""),
+        EnumValue("YARN", description="""YARN metric source."""),
+        EnumValue("SPARK_HISTORY_SERVER", description="""Spark History Server metric source."""),
+        EnumValue("HIVESERVER2", description="""Hiveserver2 metric source."""),
+        EnumValue("HIVEMETASTORE", description="""hivemetastore metric source"""),
+        EnumValue("FLINK", description="""flink metric source"""),
     ],
 )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_job.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/types_dataproc_job.py
@@ -9,30 +9,6 @@ parse_dataproc_configs.py \
 
 from dagster import Enum, EnumValue
 
-Substate = Enum(
-    name="Substate",
-    enum_values=[
-        EnumValue("UNSPECIFIED", description="""The job substate is unknown."""),
-        EnumValue(
-            "SUBMITTED",
-            description="""The Job is submitted to the agent.Applies to RUNNING
-        state.""",
-        ),
-        EnumValue(
-            "QUEUED",
-            description="""The Job has been received and is awaiting execution (it
-        may be waiting for a condition to be met). See the "details" field for the reason for the
-        delay.Applies to RUNNING state.""",
-        ),
-        EnumValue(
-            "STALE_STATUS",
-            description="""The agent-reported status is out of date, which may
-        be caused by a loss of communication between the agent and Cloud Dataproc. If the agent does
-        not send a timely update, the job will fail.Applies to RUNNING state.""",
-        ),
-    ],
-)
-
 State = Enum(
     name="State",
     enum_values=[
@@ -45,5 +21,29 @@ State = Enum(
         EnumValue("FINISHED", description="""Status is FINISHED."""),
         EnumValue("FAILED", description="""Status is FAILED."""),
         EnumValue("KILLED", description="""Status is KILLED."""),
+    ],
+)
+
+Substate = Enum(
+    name="Substate",
+    enum_values=[
+        EnumValue("UNSPECIFIED", description="""The job substate is unknown."""),
+        EnumValue(
+            "SUBMITTED",
+            description="""The Job is submitted to the agent.Applies to RUNNING
+        state.""",
+        ),
+        EnumValue(
+            "QUEUED",
+            description="""The Job has been received and is awaiting execution (it
+        might be waiting for a condition to be met). See the "details" field for the reason for the
+        delay.Applies to RUNNING state.""",
+        ),
+        EnumValue(
+            "STALE_STATUS",
+            description="""The agent-reported status is out of date, which can
+        be caused by a loss of communication between the agent and Dataproc. If the agent does not
+        send a timely update, the job will fail.Applies to RUNNING state.""",
+        ),
     ],
 )


### PR DESCRIPTION
## Summary & Motivation

In order to update the Spark configuration, I needed to be able to get the automation working.

## How I Tested These Changes

Local runs and BK.

### `define_dataproc_job_config()` Diff

Only additions:

```diff
(dagster) deepyaman@Deepyamans-MacBook-Pro dagster % diff <(python dataproc_job_config_before.py) <(python dataproc_job_config_after.py)
0a1,7
> ('driverSchedulingConfig_memoryMb', 'Int')
> ('driverSchedulingConfig_vcores', 'Int')
> ('flinkJob_args', 'Array')
> ('flinkJob_jarFileUris', 'Array')
> ('flinkJob_mainClass', 'String')
> ('flinkJob_mainJarFileUri', 'String')
> ('flinkJob_savepointUri', 'String')
15a23,27
> ('prestoJob_clientTags', 'Array')
> ('prestoJob_continueOnFailure', 'Bool')
> ('prestoJob_outputFormat', 'String')
> ('prestoJob_queryFileUri', 'String')
> ('prestoJob_queryList_queries', 'Array')
24a37
> ('scheduling_maxFailuresTotal', 'Int')
30a44,47
> ('sparkRJob_archiveUris', 'Array')
> ('sparkRJob_args', 'Array')
> ('sparkRJob_fileUris', 'Array')
> ('sparkRJob_mainRFileUri', 'String')
33a51,55
> ('trinoJob_clientTags', 'Array')
> ('trinoJob_continueOnFailure', 'Bool')
> ('trinoJob_outputFormat', 'String')
> ('trinoJob_queryFileUri', 'String')
> ('trinoJob_queryList_queries', 'Array')
```

### `define_dataproc_cluster_config()` Diff

Only non-additive change is `isPreemptible` bool -> `preemptibility` enum:

```diff
(dagster) deepyaman@Deepyamans-MacBook-Pro dagster % diff <(python dataproc_cluster_config_before.py) <(python dataproc_cluster_config_after.py)
0a1,2
> ('autoscalingConfig_policyUri', 'String')
> ('auxiliaryNodeGroups', 'Array')
1a4
> ('dataprocMetricConfig_metrics', 'Array')
2a6,8
> ('encryptionConfig_kmsKey', 'String')
> ('endpointConfig_enableHttpPortAccess', 'Bool')
> ('gceClusterConfig_confidentialInstanceConfig_enableConfidentialCompute', 'Bool')
4a11,15
> ('gceClusterConfig_nodeGroupAffinity_nodeGroupUri', 'String')
> ('gceClusterConfig_privateIpv6GoogleAccess', 'Enum')
> ('gceClusterConfig_reservationAffinity_consumeReservationType', 'Enum')
> ('gceClusterConfig_reservationAffinity_key', 'String')
> ('gceClusterConfig_reservationAffinity_values', 'Array')
6a18,20
> ('gceClusterConfig_shieldedInstanceConfig_enableIntegrityMonitoring', 'Bool')
> ('gceClusterConfig_shieldedInstanceConfig_enableSecureBoot', 'Bool')
> ('gceClusterConfig_shieldedInstanceConfig_enableVtpm', 'Bool')
9a24,27
> ('gkeClusterConfig_gkeClusterTarget', 'String')
> ('gkeClusterConfig_namespacedGkeDeploymentTarget_clusterNamespace', 'String')
> ('gkeClusterConfig_namespacedGkeDeploymentTarget_targetGkeCluster', 'String')
> ('gkeClusterConfig_nodePoolTarget', 'Array')
10a29,31
> ('lifecycleConfig_autoDeleteTime', 'String')
> ('lifecycleConfig_autoDeleteTtl', 'String')
> ('lifecycleConfig_idleDeleteTtl', 'String')
11a33,34
> ('masterConfig_diskConfig_bootDiskProvisionedIops', 'String')
> ('masterConfig_diskConfig_bootDiskProvisionedThroughput', 'String')
13a37
> ('masterConfig_diskConfig_localSsdInterface', 'String')
16c40,42
< ('masterConfig_isPreemptible', 'Bool')
---
> ('masterConfig_instanceFlexibilityPolicy_instanceSelectionList', 'Array')
> ('masterConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityBase', 'Int')
> ('masterConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityPercentAboveBase', 'Int')
17a44,45
> ('masterConfig_minCpuPlatform', 'String')
> ('masterConfig_minNumInstances', 'Int')
18a47,49
> ('masterConfig_preemptibility', 'Enum')
> ('masterConfig_startupConfig_requiredRegistrationFraction', 'Int')
> ('metastoreConfig_dataprocMetastoreService', 'String')
19a51,52
> ('secondaryWorkerConfig_diskConfig_bootDiskProvisionedIops', 'String')
> ('secondaryWorkerConfig_diskConfig_bootDiskProvisionedThroughput', 'String')
21a55
> ('secondaryWorkerConfig_diskConfig_localSsdInterface', 'String')
24c58,60
< ('secondaryWorkerConfig_isPreemptible', 'Bool')
---
> ('secondaryWorkerConfig_instanceFlexibilityPolicy_instanceSelectionList', 'Array')
> ('secondaryWorkerConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityBase', 'Int')
> ('secondaryWorkerConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityPercentAboveBase', 'Int')
25a62,63
> ('secondaryWorkerConfig_minCpuPlatform', 'String')
> ('secondaryWorkerConfig_minNumInstances', 'Int')
26a65,66
> ('secondaryWorkerConfig_preemptibility', 'Enum')
> ('secondaryWorkerConfig_startupConfig_requiredRegistrationFraction', 'Int')
36a77
> ('securityConfig_kerberosConfig_realm', 'String')
42a84
> ('tempBucket', 'String')
43a86,87
> ('workerConfig_diskConfig_bootDiskProvisionedIops', 'String')
> ('workerConfig_diskConfig_bootDiskProvisionedThroughput', 'String')
45a90
> ('workerConfig_diskConfig_localSsdInterface', 'String')
48c93,95
< ('workerConfig_isPreemptible', 'Bool')
---
> ('workerConfig_instanceFlexibilityPolicy_instanceSelectionList', 'Array')
> ('workerConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityBase', 'Int')
> ('workerConfig_instanceFlexibilityPolicy_provisioningModelMix_standardCapacityPercentAboveBase', 'Int')
49a97,98
> ('workerConfig_minCpuPlatform', 'String')
> ('workerConfig_minNumInstances', 'Int')
50a100,101
> ('workerConfig_preemptibility', 'Enum')
> ('workerConfig_startupConfig_requiredRegistrationFraction', 'Int')
```

### Other changes

There are some changes to types (more notably, cluster-related enum definitions) that can be visually inspected.

## Changelog

[dagster-gcp] Updated Dataproc configuration to the latest version. If necessary, consider pinning your `dagster-gcp` version while you migrate config. Please see the full list of changed fields below.

### Dataproc job config

```diff
0a1,7
> driverSchedulingConfig.memoryMb
> driverSchedulingConfig.vcores
> flinkJob.args
> flinkJob.jarFileUris
> flinkJob.mainClass
> flinkJob.mainJarFileUri
> flinkJob.savepointUri
15a23,27
> prestoJob.clientTags
> prestoJob.continueOnFailure
> prestoJob.outputFormat
> prestoJob.queryFileUri
> prestoJob.queryList.queries
24a37
> scheduling.maxFailuresTotal
30a44,47
> sparkRJob.archiveUris
> sparkRJob.args
> sparkRJob.fileUris
> sparkRJob.mainRFileUri
33a51,55
> trinoJob.clientTags
> trinoJob.continueOnFailure
> trinoJob.outputFormat
> trinoJob.queryFileUri
> trinoJob.queryList.queries
```

### Dataproc cluster config

```diff
0a1,2
> autoscalingConfig.policyUri
> auxiliaryNodeGroups
1a4
> dataprocMetricConfig.metrics
2a6,8
> encryptionConfig.kmsKey
> endpointConfig.enableHttpPortAccess
> gceClusterConfig.confidentialInstanceConfig.enableConfidentialCompute
4a11,15
> gceClusterConfig.nodeGroupAffinity.nodeGroupUri
> gceClusterConfig.privateIpv6GoogleAccess
> gceClusterConfig.reservationAffinity.consumeReservationType
> gceClusterConfig.reservationAffinity.key
> gceClusterConfig.reservationAffinity.values
6a18,20
> gceClusterConfig.shieldedInstanceConfig.enableIntegrityMonitoring
> gceClusterConfig.shieldedInstanceConfig.enableSecureBoot
> gceClusterConfig.shieldedInstanceConfig.enableVtpm
9a24,27
> gkeClusterConfig.gkeClusterTarget
> gkeClusterConfig.namespacedGkeDeploymentTarget.clusterNamespace
> gkeClusterConfig.namespacedGkeDeploymentTarget.targetGkeCluster
> gkeClusterConfig.nodePoolTarget
10a29,31
> lifecycleConfig.autoDeleteTime
> lifecycleConfig.autoDeleteTtl
> lifecycleConfig.idleDeleteTtl
11a33,34
> masterConfig.diskConfig.bootDiskProvisionedIops
> masterConfig.diskConfig.bootDiskProvisionedThroughput
13a37
> masterConfig.diskConfig.localSsdInterface
16c40,42
< masterConfig.isPreemptible
---
> masterConfig.instanceFlexibilityPolicy.instanceSelectionList
> masterConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityBase
> masterConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityPercentAboveBase
17a44,45
> masterConfig.minCpuPlatform
> masterConfig.minNumInstances
18a47,49
> masterConfig.preemptibility
> masterConfig.startupConfig.requiredRegistrationFraction
> metastoreConfig.dataprocMetastoreService
19a51,52
> secondaryWorkerConfig.diskConfig.bootDiskProvisionedIops
> secondaryWorkerConfig.diskConfig.bootDiskProvisionedThroughput
21a55
> secondaryWorkerConfig.diskConfig.localSsdInterface
24c58,60
< secondaryWorkerConfig.isPreemptible
---
> secondaryWorkerConfig.instanceFlexibilityPolicy.instanceSelectionList
> secondaryWorkerConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityBase
> secondaryWorkerConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityPercentAboveBase
25a62,63
> secondaryWorkerConfig.minCpuPlatform
> secondaryWorkerConfig.minNumInstances
26a65,66
> secondaryWorkerConfig.preemptibility
> secondaryWorkerConfig.startupConfig.requiredRegistrationFraction
36a77
> securityConfig.kerberosConfig.realm
42a84
> tempBucket
43a86,87
> workerConfig.diskConfig.bootDiskProvisionedIops
> workerConfig.diskConfig.bootDiskProvisionedThroughput
45a90
> workerConfig.diskConfig.localSsdInterface
48c93,95
< workerConfig.isPreemptible
---
> workerConfig.instanceFlexibilityPolicy.instanceSelectionList
> workerConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityBase
> workerConfig.instanceFlexibilityPolicy.provisioningModelMix.standardCapacityPercentAboveBase
49a97,98
> workerConfig.minCpuPlatform
> workerConfig.minNumInstances
50a100,101
> workerConfig.preemptibility
> workerConfig.startupConfig.requiredRegistrationFraction
```