### PR TITLE
[dg] Polish for scaffolding traditional dagster definitions

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/dagster-definitions/1-scaffold.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/dagster-definitions/1-scaffold.txt
@@ -1,4 +1,4 @@
-dg scaffold asset assets/my_asset.py
+dg scaffold dagster.asset assets/my_asset.py
 
 Using /.../my-project/.venv/bin/dagster-components
 Creating a Dagster component instance folder at /.../my-project/my_project/defs/assets/my_asset.py.

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
@@ -42,7 +42,7 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
         )
 
         run_command_and_snippet_output(
-            cmd="dg scaffold asset assets/my_asset.py",
+            cmd="dg scaffold dagster.asset assets/my_asset.py",
             snippet_path=SNIPPETS_DIR / f"{get_next_snip_number()}-scaffold.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[MASK_MY_PROJECT],

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/asset.py
@@ -3,12 +3,13 @@ from dagster_components.scaffold import scaffold_with
 
 
 class AssetScaffolder(ShimScaffolder):
-    def get_text(self) -> str:
-        return """# import dagster as dg
+    def get_text(self, filename: str) -> str:
+        return f"""# import dagster as dg
 # 
 #
 # @dg.asset
-# def my_asset(context: dg.AssetExecutionContext) -> dg.MaterializeResult: ...
+# def {filename}(context: dg.AssetExecutionContext) -> dg.MaterializeResult: ...
+
 """
 
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/base.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/base.py
@@ -5,14 +5,14 @@ from dagster_components import Component, Scaffolder, ScaffoldRequest
 
 class ShimScaffolder(Scaffolder):
     @abstractmethod
-    def get_text(self) -> str: ...
+    def get_text(self, filename: str) -> str: ...
     def scaffold(self, request: ScaffoldRequest, params: None) -> None:
         if request.target_path.suffix != ".py":
             raise ValueError("Invalid target path suffix. Expected a path ending in `.py`.")
         # temporary hack as currently all scaffold requests target directories
         # that are auto-created
         request.target_path.rmdir()
-        request.target_path.write_text(self.get_text())
+        request.target_path.write_text(self.get_text(request.target_path.stem))
 
 
 class ShimComponent(Component):

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/schedule.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/schedule.py
@@ -3,12 +3,12 @@ from dagster_components.scaffold import scaffold_with
 
 
 class ScheduleScaffolder(ShimScaffolder):
-    def get_text(self) -> str:
-        return """# import dagster as dg
+    def get_text(self, filename: str) -> str:
+        return f"""# import dagster as dg
 # 
 #
 # @dg.schedule(cron_schedule=..., target=...)
-# def my_schedule(context: dg.ScheduleEvaluationContext): ...
+# def {filename}(context: dg.ScheduleEvaluationContext): ...
 
 """
 

--- a/python_modules/libraries/dagster-components/dagster_components/components/shim_components/sensor.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/shim_components/sensor.py
@@ -3,12 +3,13 @@ from dagster_components.scaffold import scaffold_with
 
 
 class SensorScaffolder(ShimScaffolder):
-    def get_text(self) -> str:
-        return """# import dagster as dg
+    def get_text(self, filename: str) -> str:
+        return f"""# import dagster as dg
 # 
 #
 # @dg.sensor(target=...)
-# def my_sensor(context: dg.SensorEvaluationContext): ...
+# def {filename}(context: dg.SensorEvaluationContext): ...
+
 """
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -319,6 +319,8 @@ def _create_component_shim_scaffold_subcommand(
         **global_options: object,
     ) -> None:
         """Scaffold of a definition."""
+        if not instance_name.endswith(".py"):
+            raise click.ClickException("Definition instance names must end with '.py'. ")
         cli_config = normalize_cli_config(global_options, cli_context)
         _core_scaffold(cli_context, cli_config, component_key, instance_name, {}, {})
 
@@ -394,9 +396,9 @@ def _create_component_scaffold_subcommand(
 # ########################
 
 SHIM_COMPONENTS = {
-    ComponentKey("dagster_components.dagster", "RawAssetComponent"): "asset",
-    ComponentKey("dagster_components.dagster", "RawSensorComponent"): "sensor",
-    ComponentKey("dagster_components.dagster", "RawScheduleComponent"): "schedule",
+    ComponentKey("dagster_components.dagster", "RawAssetComponent"): "dagster.asset",
+    ComponentKey("dagster_components.dagster", "RawSensorComponent"): "dagster.sensor",
+    ComponentKey("dagster_components.dagster", "RawScheduleComponent"): "dagster.schedule",
 }
 
 for key, command_name in SHIM_COMPONENTS.items():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -37,9 +37,9 @@ NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "project"), "foo"),
     CommandSpec(("init",), "foo"),
     CommandSpec(("scaffold", "workspace"), "foo"),
-    CommandSpec(("scaffold", "asset"), "foo"),
-    CommandSpec(("scaffold", "schedule"), "foo"),
-    CommandSpec(("scaffold", "sensor"), "foo"),
+    CommandSpec(("scaffold", "dagster.asset"), "foo"),
+    CommandSpec(("scaffold", "dagster.schedule"), "foo"),
+    CommandSpec(("scaffold", "dagster.sensor"), "foo"),
     CommandSpec(("plus", "login")),
 ]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -597,14 +597,14 @@ def test_scaffold_asset() -> None:
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "asset", "assets/foo.py")
+        result = runner.invoke("scaffold", "dagster.asset", "assets/foo.py")
         assert_runner_result(result)
         assert Path("foo_bar/defs/assets/foo.py").exists()
         assert Path("foo_bar/defs/assets/foo.py").read_text().startswith("# import dagster as dg")
         assert not Path("foo_bar/defs/assets/foo.py").is_dir()
         assert not Path("foo_bar/defs/assets/component.yaml").exists()
 
-        result = runner.invoke("scaffold", "asset", "assets/bar.py")
+        result = runner.invoke("scaffold", "dagster.asset", "assets/bar.py")
         assert_runner_result(result)
         assert Path("foo_bar/defs/assets/bar.py").exists()
         assert not Path("foo_bar/defs/assets/component.yaml").exists()
@@ -615,7 +615,7 @@ def test_scaffold_bad_extension() -> None:
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "asset", "assets/foo")
+        result = runner.invoke("scaffold", "dagster.asset", "assets/foo")
         assert_runner_result(result, exit_0=False)
 
 
@@ -624,7 +624,7 @@ def test_scaffold_sensor() -> None:
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "sensor", "my_sensor.py")
+        result = runner.invoke("scaffold", "dagster.sensor", "my_sensor.py")
         assert_runner_result(result)
         assert Path("foo_bar/defs/my_sensor.py").exists()
         assert not Path("foo_bar/defs/component.yaml").exists()


### PR DESCRIPTION
## Summary & Motivation

This updates the traditional dagster def scaffolding logic:

1. `dg scaffold asset` -> `dg scaffold dagster.asset`
2. Scaffolded files now have functions with the name of the definition populated
3. Raise a nicer-looking exception if the user supplies an invalid scaffolding path

## How I Tested These Changes

"integration" test with the docs system handles actually instantiating these in a "real" environment.

workflow is basically

`dg scaffold dagster.asset my_great_asset.py` 

this creates a file called `my_great_asset.py` which has a stub asset-decorated function `def my_great_asset(context: AssetExecutionContext)`

## Changelog

NOCHANGELOG
