### PR TITLE
[dagster-components][wip] Airflow instance component

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/airflow_instance/component.py
@@ -1,0 +1,173 @@
+import itertools
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Annotated, Callable, Literal, Optional, Union, cast
+
+import dagster_airlift.core as dg_airlift_core
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_airlift.core.airflow_instance import AirflowAuthBackend
+from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
+from pydantic import Field
+
+from dagster_components import AssetPostProcessorModel, Component
+from dagster_components.core.component import ComponentLoadContext
+from dagster_components.resolved.context import ResolutionContext
+from dagster_components.resolved.core_models import (
+    AssetAttributesModel,
+    AssetPostProcessor,
+    ResolvedAssetSpec,
+)
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
+
+
+class AirflowBasicAuthBackendModel(ResolvableModel):
+    type: Literal["basic_auth"]
+    webserver_url: str = Field(default=..., description="The URL of the Airflow webserver.")
+    username: str = Field(default=..., description="The username to use for basic authentication.")
+    password: str = Field(default=..., description="The password to use for basic authentication.")
+
+
+class AirflowMwaaAuthBackendModel(ResolvableModel):
+    type: Literal["mwaa"]
+
+
+class AirflowDagSelectionModel(ResolvableModel, ResolvedFrom["AirflowDagSelectionModel"]):
+    dag_ids: Optional[list[str]] = Field(
+        default=None, description="A subselection of DAG ids to load from the Airflow instance."
+    )
+
+
+class AirflowTaskModel(ResolvableModel):
+    task_id: str = Field(default=..., description="The ID of the task.")
+    asset_specs: Optional[Sequence[AssetAttributesModel]] = Field(
+        default=None, description="Asset specs to optionally associate with this task."
+    )
+
+
+@dataclass
+class ResolvedAirflowTask(ResolvedFrom[AirflowTaskModel]):
+    task_id: str
+    asset_specs: Optional[Sequence[ResolvedAssetSpec]]
+
+
+class AirflowDagModel(ResolvableModel):
+    dag_id: str = Field(default=..., description="The ID of the DAG.")
+    asset_specs: Optional[Sequence[AssetAttributesModel]] = Field(
+        default=None, description="Asset specs to optionally associate with this DAG."
+    )
+    task_mappings: Optional[Sequence[AirflowTaskModel]] = Field(
+        default=None,
+        description="Asset specs to optionally associate with each task within the DAG.",
+    )
+
+
+@dataclass
+class ResolvedAirflowDag(ResolvedFrom[AirflowDagModel]):
+    dag_id: str
+    asset_specs: Optional[Sequence[ResolvedAssetSpec]]
+    task_mappings: Annotated[Optional[Sequence[ResolvedAirflowTask]], Resolver.from_annotation()]
+
+
+class AirflowInstanceModel(ResolvableModel):
+    auth: Union[AirflowBasicAuthBackendModel, AirflowMwaaAuthBackendModel] = Field(
+        default=..., description="The authentication backend to use for the Airflow instance."
+    )
+    name: str = Field(default=..., description="A unique name for the Airflow instance.")
+    dags_to_load: Optional[AirflowDagSelectionModel] = Field(
+        default=None,
+        description="A subselection of DAG ids to load from the Airflow instance. Defaults to loading all DAGs.",
+    )
+    asset_post_processors: Optional[Sequence[AssetPostProcessorModel]] = Field(
+        default=None, description="Post-processing attributes to apply to the assets."
+    )
+    dag_mappings: Optional[Sequence[AirflowDagModel]] = Field(
+        default=None,
+        description="Asset specs to optionally associate with each DAG or task within the Airflow instance.",
+    )
+
+
+def resolve_auth(context: ResolutionContext, model: AirflowInstanceModel) -> AirflowAuthBackend:
+    if model.auth.type == "basic_auth":
+        return AirflowBasicAuthBackend(
+            webserver_url=model.auth.webserver_url,
+            username=model.auth.username,
+            password=model.auth.password,
+        )
+    else:
+        raise ValueError(f"Unsupported auth type: {model.auth.type}")
+
+
+@dataclass
+class AirflowInstanceComponent(Component, ResolvedFrom[AirflowInstanceModel]):
+    """Represent an Airflow instance in Dagster as a set of assets. Automatically polls
+    and represents the state of the Airflow DAGs in Dagster.
+
+    Scaffold by running `dagster scaffold component dagster_components.airlift.AirflowInstanceComponent`
+    in the Dagster project directory.
+    """
+
+    auth: Annotated[AirflowAuthBackend, Resolver.from_model(resolve_auth)]
+    name: str
+    dags_to_load: Annotated[Optional[AirflowDagSelectionModel], Resolver.from_annotation()]
+    asset_post_processors: Annotated[
+        Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
+    ]
+    dag_mappings: Annotated[Optional[Sequence[ResolvedAirflowDag]], Resolver.from_annotation()]
+
+    def _get_instance(self) -> dg_airlift_core.AirflowInstance:
+        return dg_airlift_core.AirflowInstance(
+            auth_backend=self.auth,
+            name=self.name,
+        )
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        dag_selector_fn: Optional[Callable[[dg_airlift_core.DagInfo], bool]] = None
+        if self.dags_to_load and self.dags_to_load.dag_ids:
+            dag_list = self.dags_to_load.dag_ids
+
+            def _dag_selector_fn(dag: dg_airlift_core.DagInfo) -> bool:
+                return dag.dag_id in dag_list
+
+            dag_selector_fn = _dag_selector_fn
+
+        airflow_instance = self._get_instance()
+
+        mapped_assets_and_tasks = Definitions.merge(
+            Definitions(
+                assets=dg_airlift_core.assets_with_dag_mappings(
+                    {
+                        dag.dag_id: cast(Sequence[AssetSpec], dag.asset_specs)
+                        for dag in self.dag_mappings or []
+                        if dag.asset_specs
+                    }
+                )
+            ),
+            Definitions(
+                assets=[
+                    *itertools.chain.from_iterable(
+                        dg_airlift_core.assets_with_task_mappings(
+                            dag_id=dag.dag_id,
+                            task_mappings={
+                                task_mapping.task_id: cast(
+                                    Sequence[AssetSpec], task_mapping.asset_specs
+                                )
+                                for task_mapping in dag.task_mappings or []
+                            },
+                        )
+                        for dag in self.dag_mappings or []
+                        if dag.task_mappings
+                    )
+                ]
+            ),
+        )
+
+        defs = dg_airlift_core.build_defs_from_airflow_instance(
+            airflow_instance=airflow_instance,
+            dag_selector_fn=dag_selector_fn,
+            defs=mapped_assets_and_tasks,
+        )
+
+        for post_processor in self.asset_post_processors or []:
+            defs = post_processor.fn(defs)
+        return defs

--- a/python_modules/libraries/dagster-components/dagster_components/dagster_airlift.py
+++ b/python_modules/libraries/dagster-components/dagster_components/dagster_airlift.py
@@ -1,0 +1,8 @@
+import importlib.util
+
+_has_dagster_airlift = importlib.util.find_spec("dagster_airlift") is not None
+
+if _has_dagster_airlift:
+    from dagster_components.components.airflow_instance.component import (
+        AirflowInstanceComponent as AirflowInstanceComponent,
+    )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_airlift_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_airlift_integration_test.py
@@ -1,0 +1,246 @@
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+import dagster_airlift.core as dg_airlift_core
+import pytest
+from dagster import AssetKey
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_airlift.test import make_instance
+from dagster_components.components.airflow_instance.component import (
+    AirflowInstanceComponent,
+    AirflowInstanceModel,
+)
+from dagster_components.core.component_decl_builder import ComponentFileModel
+from dagster_components.core.component_defs_builder import YamlComponentDecl
+from dagster_components.utils import ensure_dagster_components_tests_import
+
+ensure_dagster_components_tests_import()
+
+from dagster_components_tests.utils import script_load_context
+
+
+@pytest.fixture
+def component_dir():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+@pytest.fixture
+def debug_airflow_component_type():
+    airflow_instance = make_instance(
+        {"dag_1": ["dag_1_task_1", "dag_1_task_2"], "dag_2": ["dag_2_task_1", "dag_2_task_2"]}
+    )
+
+    class DebugAirflowInstanceComponent(AirflowInstanceComponent):
+        def _get_instance(self) -> dg_airlift_core.AirflowInstance:
+            return airflow_instance
+
+    return DebugAirflowInstanceComponent
+
+
+@pytest.fixture(name="defs_for_airflow_asset")
+def defs_for_airflow_asset_fixture(
+    debug_airflow_component_type: type[AirflowInstanceComponent], component_dir: Path
+) -> Callable[[dict[str, Any]], Definitions]:
+    def _defs_for_airflow_asset(attrs: dict[str, Any]) -> Definitions:
+        decl_node = YamlComponentDecl(
+            path=component_dir,
+            component_file_model=ComponentFileModel(
+                type="debug_sling_replication",
+                attributes=attrs,
+            ),
+        )
+        context = script_load_context(decl_node)
+        attributes = decl_node.get_attributes(AirflowInstanceModel)
+        component_inst = debug_airflow_component_type.load(attributes=attributes, context=context)
+        return component_inst.build_defs(context)
+
+    return _defs_for_airflow_asset
+
+
+def test_load_dags_basic(defs_for_airflow_asset: Callable[[dict[str, Any]], Definitions]) -> None:
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["test_instance", "dag", "dag_1"]),
+        AssetKey(["test_instance", "dag", "dag_2"]),
+    }
+
+
+def test_load_dags_filter(defs_for_airflow_asset: Callable[[dict[str, Any]], Definitions]) -> None:
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "dags_to_load": {"dag_ids": ["dag_1"]},
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["test_instance", "dag", "dag_1"])
+    }
+
+
+def test_load_dags_dag_mapping(
+    defs_for_airflow_asset: Callable[[dict[str, Any]], Definitions],
+) -> None:
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "dag_mappings": [
+                {
+                    "dag_id": "dag_1",
+                    "asset_specs": [{"key": "dag_1_asset_1"}, {"key": "dag_1_asset_2"}],
+                },
+            ],
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["dag_1_asset_1"]),
+        AssetKey(["dag_1_asset_2"]),
+        AssetKey(["test_instance", "dag", "dag_1"]),
+        AssetKey(["test_instance", "dag", "dag_2"]),
+    }
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "dag_mappings": [
+                {
+                    "dag_id": "dag_1",
+                    "asset_specs": [{"key": "dag_1_asset_1"}, {"key": "dag_1_asset_2"}],
+                },
+                {
+                    "dag_id": "dag_2",
+                    "asset_specs": [{"key": "dag_2_asset_1"}, {"key": "dag_2_asset_2"}],
+                },
+            ],
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["dag_1_asset_1"]),
+        AssetKey(["dag_1_asset_2"]),
+        AssetKey(["dag_2_asset_1"]),
+        AssetKey(["dag_2_asset_2"]),
+        AssetKey(["test_instance", "dag", "dag_1"]),
+        AssetKey(["test_instance", "dag", "dag_2"]),
+    }
+
+
+def test_load_dags_task_mapping(
+    defs_for_airflow_asset: Callable[[dict[str, Any]], Definitions],
+) -> None:
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "dag_mappings": [
+                {
+                    "dag_id": "dag_1",
+                    "task_mappings": [
+                        {
+                            "task_id": "dag_1_task_1",
+                            "asset_specs": [{"key": "dag_1_task_1_asset_1"}],
+                        },
+                        {
+                            "task_id": "dag_1_task_2",
+                            "asset_specs": [{"key": "dag_1_task_2_asset_1"}],
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["dag_1_task_1_asset_1"]),
+        AssetKey(["dag_1_task_2_asset_1"]),
+        AssetKey(["test_instance", "dag", "dag_1"]),
+        AssetKey(["test_instance", "dag", "dag_2"]),
+    }
+
+
+def test_load_dags_dag_and_task_mapping_complex(
+    defs_for_airflow_asset: Callable[[dict[str, Any]], Definitions],
+) -> None:
+    defs = defs_for_airflow_asset(
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "dag_mappings": [
+                {
+                    "dag_id": "dag_1",
+                    "asset_specs": [{"key": "dag_1_asset_1"}, {"key": "dag_1_asset_2"}],
+                    "task_mappings": [
+                        {
+                            "task_id": "dag_1_task_1",
+                            "asset_specs": [
+                                {
+                                    "key": "dag_1_task_1_asset_1",
+                                    "tags": {"foo": "bar"},
+                                    "description": "foo",
+                                }
+                            ],
+                        },
+                        {
+                            "task_id": "dag_1_task_2",
+                            "asset_specs": [{"key": "dag_1_task_2_asset_1"}],
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    assert defs.get_asset_graph().get_all_asset_keys() == {
+        AssetKey(["dag_1_asset_1"]),
+        AssetKey(["dag_1_asset_2"]),
+        AssetKey(["dag_1_task_1_asset_1"]),
+        AssetKey(["dag_1_task_2_asset_1"]),
+        AssetKey(["test_instance", "dag", "dag_1"]),
+        AssetKey(["test_instance", "dag", "dag_2"]),
+    }
+    dag_1_task_1_asset_1_spec = defs.get_assets_def(
+        AssetKey(["dag_1_task_1_asset_1"])
+    ).specs_by_key[AssetKey(["dag_1_task_1_asset_1"])]
+    assert dag_1_task_1_asset_1_spec.tags["foo"] == "bar"
+    assert dag_1_task_1_asset_1_spec.description == "foo"

--- a/python_modules/libraries/dagster-components/setup.py
+++ b/python_modules/libraries/dagster-components/setup.py
@@ -47,6 +47,7 @@ setup(
             "dagster-components-dagster = dagster_components.dagster",
             "dagster-components-dbt = dagster_components.dagster_dbt",
             "dagster-components-sling = dagster_components.dagster_sling",
+            "dagster-components-airlift = dagster_components.dagster_airlift",
         ],
     },
     extras_require={
@@ -61,5 +62,6 @@ setup(
             "pandas",
             "duckdb",
         ],
+        "airlift": ["dagster-airlift"],
     },
 )

--- a/python_modules/libraries/dagster-components/tox.ini
+++ b/python_modules/libraries/dagster-components/tox.ini
@@ -16,6 +16,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-dbt
   -e ../../../python_modules/libraries/dagster-dg
   -e ../../../python_modules/libraries/dagster-shared
+  -e ../../../python_modules/libraries/dagster-airlift
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
## Summary

Basic Airlift component which allows pulling in asset representations of Airflow DAGs, and optionally asset specs onto an Airflow DAG or task.

```yaml
type: dagster_components.dagster_airlift.AirflowInstanceComponent

attributes:
  auth:
    type: basic_auth
    webserver_url: "localhost:8080"
    username: "{{ env('AIRFLOW_USERNAME') }}"
    password: "{{ env('AIRFLOW_PASSWORD') }}"
  name: test_instance
  dag_mappings:
    - dag_id: my_cool_dag
      task_mappings:
        - task_id: task_one
          asset_specs:
            - key: staging_customers
            - key: staging_payments
        - task_id: task_two
          asset_specs:
            - key: final_customers

```

## To do
- [ ] Proxy state
- [x] Kick off execution from Dagster #28543 
- [ ] Handle fully migrated assets somehow

## Test Plan

Basic component functionality tests.
