### PR TITLE
Allow yielding AssetCheckEvaluation objects from ops

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
@@ -223,7 +223,7 @@ def test_report_asset_check_endpoint(instance: DagsterInstance, test_client: Tes
     )
     assert response.status_code == 400
     assert (
-        'Error constructing AssetCheckEvaluation: Param "metadata" is not a dict'
+        'Error constructing AssetCheckEvaluation: Param "metadata" is not'
         in response.json()["error"]
     )
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -112,6 +112,9 @@ from dagster._config.source import (
     StringSource as StringSource,
 )
 from dagster._core.definitions import AssetCheckResult as AssetCheckResult
+from dagster._core.definitions.asset_check_evaluation import (
+    AssetCheckEvaluation as AssetCheckEvaluation,
+)
 from dagster._core.definitions.asset_check_factories.freshness_checks.last_update import (
     build_last_update_freshness_checks as build_last_update_freshness_checks,
 )

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -81,7 +81,7 @@ class AssetCheckEvaluation(
             The name of the check.
         passed (bool):
             The pass/fail result of the check.
-        metadata (Dict[str, MetadataValue]):
+        metadata (Optional[Mapping[str, MetadataValue]]):
             Arbitrary user-provided metadata about the asset.  Keys are displayed string labels, and
             values are one of the following: string, float, int, JSON-serializable dict, JSON-serializable
             list, and one of the data classes returned by a MetadataValue static method.
@@ -98,13 +98,13 @@ class AssetCheckEvaluation(
         asset_key: AssetKey,
         check_name: str,
         passed: bool,
-        metadata: Mapping[str, MetadataValue],
+        metadata: Optional[Mapping[str, MetadataValue]] = None,
         target_materialization_data: Optional[AssetCheckEvaluationTargetMaterializationData] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
         description: Optional[str] = None,
     ):
         normed_metadata = normalize_metadata(
-            check.dict_param(metadata, "metadata", key_type=str),
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
         )
 
         return super().__new__(

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -4,6 +4,7 @@ from typing import AbstractSet, Any, Optional, cast  # noqa: UP035
 
 import dagster._check as check
 from dagster._annotations import deprecated, public
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -432,6 +433,10 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         if isinstance(event, AssetMaterialization):
             self._events.append(
                 DagsterEvent.asset_materialization(self._step_execution_context, event)
+            )
+        elif isinstance(event, AssetCheckEvaluation):
+            self._events.append(
+                DagsterEvent.asset_check_evaluation(self._step_execution_context, event)
             )
         elif isinstance(event, AssetObservation):
             self._events.append(DagsterEvent.asset_observation(self._step_execution_context, event))

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -204,11 +204,6 @@ def execute_core_compute(
                     handle
                 )
                 emitted_result_names.add(output_name)
-        elif isinstance(step_output, AssetCheckEvaluation):
-            output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
-                step_output.asset_check_key
-            )
-            emitted_result_names.add(output_name)
         elif isinstance(step_output, AssetCheckResult):
             if step_output.asset_key and step_output.check_name:
                 handle = AssetCheckKey(step_output.asset_key, step_output.check_name)

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -3039,6 +3039,30 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             ).rowcount
 
+            # TODO fix the idx_asset_check_executions_unique index so that this can be a single
+            # upsert
+            if rows_updated == 0:
+                rows_updated = conn.execute(
+                    AssetCheckExecutionsTable.insert().values(
+                        asset_key=evaluation.asset_key.to_string(),
+                        check_name=evaluation.check_name,
+                        run_id=event.run_id,
+                        execution_status=(
+                            AssetCheckExecutionRecordStatus.SUCCEEDED.value
+                            if evaluation.passed
+                            else AssetCheckExecutionRecordStatus.FAILED.value
+                        ),
+                        evaluation_event=serialize_value(event),
+                        evaluation_event_timestamp=datetime.utcfromtimestamp(event.timestamp),
+                        evaluation_event_storage_id=event_id,
+                        materialization_event_storage_id=(
+                            evaluation.target_materialization_data.storage_id
+                            if evaluation.target_materialization_data
+                            else None
+                        ),
+                    )
+                ).rowcount
+
         # 0 isn't normally expected, but occurs with the external instance of step launchers where
         # they don't have planned events.
         if rows_updated > 1:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5889,8 +5889,15 @@ class TestEventLogStorage:
                 )
             )
 
-    def test_asset_check_evaluation_without_planned_event(self, storage: EventLogStorage):
-        run_id = make_new_run_id()
+    def test_asset_check_evaluation_without_planned_event(
+        self, storage: EventLogStorage, test_run_id: str
+    ):
+        check_key = AssetCheckKey(asset_key=AssetKey(["my_asset"]), name="my_check")
+
+        check_summary_record = storage.get_asset_check_summary_records([check_key])[check_key]
+        assert not check_summary_record.last_check_execution_record
+
+        run_id = test_run_id
         storage.store_event(
             EventLogEntry(
                 error_info=None,
@@ -5915,9 +5922,50 @@ class TestEventLogStorage:
             )
         )
 
-        # since no planned event is logged, we don't create a row in the sumary table
-        assert not storage.get_asset_check_execution_history(
-            AssetCheckKey(asset_key=AssetKey(["my_asset"]), name="my_check"), limit=10
+        check_summary_record = storage.get_asset_check_summary_records([check_key])[check_key]
+        check_execution_record = check_summary_record.last_check_execution_record
+
+        assert check_execution_record
+        assert check_execution_record.status == AssetCheckExecutionRecordStatus.SUCCEEDED
+        assert check_execution_record.run_id == run_id
+        assert check_execution_record.event
+        assert (
+            check_execution_record.event.dagster_event_type
+            == DagsterEventType.ASSET_CHECK_EVALUATION
+        )
+
+    def test_yield_asset_check_evaluation_from_op(
+        self, storage: EventLogStorage, instance: DagsterInstance
+    ):
+        @op
+        def yield_asset_check_evaluation():
+            yield AssetCheckEvaluation(
+                asset_key=AssetKey(["my_asset"]),
+                check_name="my_check",
+                passed=True,
+                metadata={},
+            )
+            yield Output(1)
+
+        @job
+        def yield_asset_check_evaluation_job():
+            yield_asset_check_evaluation()
+
+        result = yield_asset_check_evaluation_job.execute_in_process(instance=instance)
+        run_id = result.run_id
+
+        check_key = AssetCheckKey(asset_key=AssetKey(["my_asset"]), name="my_check")
+
+        check_summary_record = storage.get_asset_check_summary_records([check_key])[check_key]
+        check_execution_record = check_summary_record.last_check_execution_record
+
+        assert check_execution_record
+        assert check_execution_record.status == AssetCheckExecutionRecordStatus.SUCCEEDED
+        assert check_execution_record.run_id == run_id
+        assert check_execution_record.event
+        assert (
+            check_execution_record.event.dagster_event_type
+            == DagsterEventType.ASSET_CHECK_EVALUATION
         )
 
     def test_external_asset_event(


### PR DESCRIPTION
## Summary & Motivation
Lets you yield an AssetCheckEvaluation from an op, just like you can yield an AssetMaterialization. Requires some light storage changes to relax the restriction that a PLANNED event already exists for every asset materialization.

## How I Tested These Changes
New test cases

## Changelog
`AssetCheckEvaluation` can now be yielded from Dagster ops to log an evaluation of an asset check outside of an asset context.
