### PR TITLE
Emit AssetCheckEvaluation instead of AssetObservation when an op runs dbt tests that map to asset checks

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -17,6 +17,7 @@ from dagster import (
     get_dagster_logger,
 )
 from dagster._annotations import public
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._utils.warnings import disable_dagster_warnings
 from dbt.contracts.results import NodeStatus, TestStatus
@@ -268,7 +269,11 @@ class DbtCliEventMessage:
         dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
         context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
         target_path: Optional[Path] = None,
-    ) -> Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
+    ) -> Iterator[
+        Union[
+            Output, AssetMaterialization, AssetObservation, AssetCheckResult, AssetCheckEvaluation
+        ]
+    ]:
         """Convert a dbt CLI event to a set of corresponding Dagster events.
 
         Args:
@@ -416,10 +421,39 @@ class DbtCliEventMessage:
                 manifest, dagster_dbt_translator, test_unique_id=unique_id
             )
 
-            # If the test was not selected as an asset check, yield an `AssetObservation`.
-            if not (
-                context and asset_check_key and asset_check_key in context.selected_asset_check_keys
+            if (
+                context
+                and has_asset_def
+                and asset_check_key is not None
+                and asset_check_key in context.selected_asset_check_keys
             ):
+                # The test is an asset check in an asset, so yield an `AssetCheckResult`.
+                yield AssetCheckResult(
+                    passed=node_status == TestStatus.Pass,
+                    asset_key=asset_check_key.asset_key,
+                    check_name=asset_check_key.name,
+                    metadata=metadata,
+                    severity=(
+                        AssetCheckSeverity.WARN
+                        if node_status == TestStatus.Warn
+                        else AssetCheckSeverity.ERROR
+                    ),
+                )
+            elif not has_asset_def and asset_check_key is not None:
+                # The test is an asset check in an op, so yield an `AssetCheckEvaluation`.
+                yield AssetCheckEvaluation(
+                    passed=node_status == TestStatus.Pass,
+                    asset_key=asset_check_key.asset_key,
+                    check_name=asset_check_key.name,
+                    metadata=metadata,
+                    severity=(
+                        AssetCheckSeverity.WARN
+                        if node_status == TestStatus.Warn
+                        else AssetCheckSeverity.ERROR
+                    ),
+                )
+            else:
+                # since there is no asset check key, we log observations instead
                 message = None
 
                 # dbt's default indirect selection (eager) will select relationship tests
@@ -458,17 +492,3 @@ class DbtCliEventMessage:
                     metadata=metadata,
                     description=message,
                 )
-                return
-
-            # The test is an asset check, so yield an `AssetCheckResult`.
-            yield AssetCheckResult(
-                passed=node_status == TestStatus.Pass,
-                asset_key=asset_check_key.asset_key,
-                check_name=asset_check_key.name,
-                metadata=metadata,
-                severity=(
-                    AssetCheckSeverity.WARN
-                    if node_status == TestStatus.Warn
-                    else AssetCheckSeverity.ERROR
-                ),
-            )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -12,6 +12,7 @@ from typing import Any, Final, NamedTuple, Optional, Union, cast
 
 import orjson
 from dagster import (
+    AssetCheckEvaluation,
     AssetCheckResult,
     AssetExecutionContext,
     AssetMaterialization,
@@ -283,9 +284,7 @@ class DbtCliInvocation:
     @public
     def stream(
         self,
-    ) -> (
-        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
-    ):
+    ) -> "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult, AssetCheckEvaluation]]":
         """Stream the events from the dbt CLI process and convert them to Dagster events.
 
         Returns:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -11,6 +11,7 @@ from dagster import (
     get_dagster_logger,
 )
 from dagster._annotations import public
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.metadata import TableMetadataSet, TextMetadataValue
 from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.utils import exhaust_iterator_and_yield_results_with_exception, imap
@@ -25,7 +26,9 @@ if TYPE_CHECKING:
 
 logger = get_dagster_logger()
 
-DbtDagsterEventType = Union[Output, AssetMaterialization, AssetCheckResult, AssetObservation]
+DbtDagsterEventType = Union[
+    Output, AssetMaterialization, AssetCheckResult, AssetObservation, AssetCheckEvaluation
+]
 
 # We define DbtEventIterator as a generic type for the sake of type hinting.
 # This is so that users who inspect the type of the return value of `DbtCliInvocation.stream()`

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -284,7 +284,15 @@ class DbtEventIterator(Iterator[T]):
                 event_stream = exhaust_iterator_and_yield_results_with_exception(self)
 
         def _threadpool_wrap_map_fn() -> (
-            Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]
+            Iterator[
+                Union[
+                    Output,
+                    AssetMaterialization,
+                    AssetObservation,
+                    AssetCheckResult,
+                    AssetCheckEvaluation,
+                ]
+            ]
         ):
             with ThreadPoolExecutor(
                 max_workers=self._dbt_cli_invocation.postprocessing_threadpool_num_threads,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -211,9 +211,7 @@ class DbtEventIterator(Iterator[T]):
     @public
     def fetch_row_counts(
         self,
-    ) -> (
-        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
-    ):
+    ) -> "DbtEventIterator[Union[Output, AssetMaterialization, AssetCheckResult, AssetObservation, AssetCheckEvaluation]]":
         """Functionality which will fetch row counts for materialized dbt
         models in a dbt run once they are built. Note that row counts will not be fetched
         for views, since this requires running the view's SQL query which may be costly.
@@ -229,9 +227,7 @@ class DbtEventIterator(Iterator[T]):
     def fetch_column_metadata(
         self,
         with_column_lineage: bool = True,
-    ) -> (
-        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
-    ):
+    ) -> "DbtEventIterator[Union[Output, AssetMaterialization, AssetCheckResult, AssetObservation, AssetCheckEvaluation]]":
         """Functionality which will fetch column schema metadata for dbt models in a run
         once they're built. It will also fetch schema information for upstream models and generate
         column lineage metadata using sqlglot, if enabled.
@@ -310,9 +306,7 @@ class DbtEventIterator(Iterator[T]):
         self,
         skip_config_check: bool = False,
         record_observation_usage: bool = True,
-    ) -> (
-        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
-    ):
+    ) -> "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult, AssetCheckEvaluation]]":
         """Associate each warehouse query with the produced asset materializations for use in Dagster
         Plus Insights. Currently supports Snowflake and BigQuery.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -603,8 +603,11 @@ def test_asset_checks_evaluations(
             if isinstance(event, AssetCheckEvaluation):
                 assert cast(int, event.metadata["Execution Duration"].value) > 0
 
+        # Sanity check that we don't have AssetCheckResult events whe using an op
+        assert not any([event for event in events if isinstance(event, AssetCheckResult)])
+
         expected_results = [
-            AssetCheckResult(
+            AssetCheckEvaluation(
                 passed=True,
                 asset_key=AssetKey(["customers"]),
                 check_name="unique_customers_customer_id",
@@ -617,7 +620,7 @@ def test_asset_checks_evaluations(
                     "dagster_dbt/failed_row_count": 0,
                 },
             ),
-            AssetCheckResult(
+            AssetCheckEvaluation(
                 passed=True,
                 asset_key=AssetKey(["customers"]),
                 check_name="not_null_customers_customer_id",
@@ -630,7 +633,7 @@ def test_asset_checks_evaluations(
                     "dagster_dbt/failed_row_count": 0,
                 },
             ),
-            AssetCheckResult(
+            AssetCheckEvaluation(
                 passed=False,
                 asset_key=AssetKey(["fail_tests_model"]),
                 check_name="unique_fail_tests_model_id",
@@ -644,7 +647,7 @@ def test_asset_checks_evaluations(
                     "dagster_dbt/failed_row_count": 1,
                 },
             ),
-            AssetCheckResult(
+            AssetCheckEvaluation(
                 passed=False,
                 asset_key=AssetKey(["fail_tests_model"]),
                 check_name="accepted_values_fail_tests_model_first_name__foo__bar__baz",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, cast
 
 import pytest
 from dagster import (
+    AssetCheckEvaluation,
     AssetCheckKey,
     AssetCheckResult,
     AssetCheckSeverity,
@@ -12,8 +13,11 @@ from dagster import (
     AssetsDefinition,
     AssetSelection,
     ExecuteInProcessResult,
+    OpExecutionContext,
     asset_check,
+    job,
     materialize,
+    op,
 )
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resource import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY, DbtCliResource
@@ -573,6 +577,123 @@ def test_asset_checks_results(
         resources={"dbt": DbtCliResource(project_dir=os.fspath(test_asset_checks_path))},
     )
     assert result.success
+
+
+def test_asset_checks_evaluations(
+    test_asset_checks_manifest: dict[str, Any], dbt_commands: list[list[str]]
+):
+    @op
+    def my_dbt_op(context: OpExecutionContext, dbt: DbtCliResource):
+        events = []
+        invocation_id = ""
+        for dbt_command in dbt_commands:
+            dbt_invocation = dbt.cli(
+                dbt_command,
+                context=context,
+                raise_on_error=False,
+                manifest=test_asset_checks_manifest,
+                dagster_dbt_translator=dagster_dbt_translator_with_checks,
+            )
+            events += list(dbt_invocation.stream())
+            invocation_id = dbt_invocation.get_artifact("run_results.json")["metadata"][
+                "invocation_id"
+            ]
+
+        for event in events:
+            if isinstance(event, AssetCheckEvaluation):
+                assert cast(int, event.metadata["Execution Duration"].value) > 0
+
+        expected_results = [
+            AssetCheckResult(
+                passed=True,
+                asset_key=AssetKey(["customers"]),
+                check_name="unique_customers_customer_id",
+                metadata={
+                    "unique_id": (
+                        "test.test_dagster_asset_checks.unique_customers_customer_id.c5af1ff4b1"
+                    ),
+                    "invocation_id": invocation_id,
+                    "status": "pass",
+                    "dagster_dbt/failed_row_count": 0,
+                },
+            ),
+            AssetCheckResult(
+                passed=True,
+                asset_key=AssetKey(["customers"]),
+                check_name="not_null_customers_customer_id",
+                metadata={
+                    "unique_id": (
+                        "test.test_dagster_asset_checks.not_null_customers_customer_id.5c9bf9911d"
+                    ),
+                    "invocation_id": invocation_id,
+                    "status": "pass",
+                    "dagster_dbt/failed_row_count": 0,
+                },
+            ),
+            AssetCheckResult(
+                passed=False,
+                asset_key=AssetKey(["fail_tests_model"]),
+                check_name="unique_fail_tests_model_id",
+                severity=AssetCheckSeverity.WARN,
+                metadata={
+                    "unique_id": (
+                        "test.test_dagster_asset_checks.unique_fail_tests_model_id.1619308eb1"
+                    ),
+                    "invocation_id": invocation_id,
+                    "status": "warn",
+                    "dagster_dbt/failed_row_count": 1,
+                },
+            ),
+            AssetCheckResult(
+                passed=False,
+                asset_key=AssetKey(["fail_tests_model"]),
+                check_name="accepted_values_fail_tests_model_first_name__foo__bar__baz",
+                severity=AssetCheckSeverity.ERROR,
+                metadata={
+                    "unique_id": (
+                        "test.test_dagster_asset_checks.accepted_values_fail_tests_model_first_name__foo__bar__baz.5f958cf018"
+                    ),
+                    "invocation_id": invocation_id,
+                    "status": "fail",
+                    "dagster_dbt/failed_row_count": 4,
+                },
+            ),
+        ]
+
+        # filter these out for comparison
+        non_deterministic_metadata_keys = ["Execution Duration"]
+        check_events_without_non_deterministic_metadata = {}
+        for event in events:
+            if isinstance(event, AssetCheckEvaluation):
+                check_events_without_non_deterministic_metadata[
+                    event.asset_key, event.check_name
+                ] = event._replace(
+                    metadata={
+                        k: v
+                        for k, v in event.metadata.items()
+                        if k not in non_deterministic_metadata_keys
+                    }
+                )
+
+        for expected_asset_check_evaluation in expected_results:
+            assert (
+                check_events_without_non_deterministic_metadata[
+                    expected_asset_check_evaluation.asset_key,
+                    expected_asset_check_evaluation.check_name,
+                ]
+                == expected_asset_check_evaluation
+            )
+
+        yield from events
+
+        @job
+        def my_dbt_job():
+            return my_dbt_op()
+
+        result = my_dbt_job.execute_in_process(
+            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_asset_checks_path))}
+        )
+        assert result.success
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -603,7 +603,7 @@ def test_asset_checks_evaluations(
             if isinstance(event, AssetCheckEvaluation):
                 assert cast(int, event.metadata["Execution Duration"].value) > 0
 
-        # Sanity check that we don't have AssetCheckResult events whe using an op
+        # Sanity check that we don't have AssetCheckResult events when using an op
         assert not any([event for event in events if isinstance(event, AssetCheckResult)])
 
         expected_results = [


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

Additional tests with bk

## Changelog

[dagster-dbt] `AssetCheckEvaluations` are now yielded from `ops` leveraging `DbtCliResource.cli(...)` when asset checks are included in the dbt asset lineage.
