### PR TITLE
[dagster-fivetran] Fix fetch_fivetran_workspace_data for incomplete and broken connectors

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -914,6 +914,12 @@ class FivetranWorkspace(ConfigurableResource):
                 connector = FivetranConnector.from_connector_details(
                     connector_details=connector_details,
                 )
+                if not connector.is_connected:
+                    self._log.warning(
+                        f"Ignoring incomplete or broken connector `{connector.name}`. "
+                        f"Dagster requires a connector to be connected before fetching its data."
+                    )
+                    continue
 
                 schema_config_details = client.get_schema_config_for_connector(
                     connector_id=connector.id
@@ -924,7 +930,6 @@ class FivetranWorkspace(ConfigurableResource):
 
                 if (
                     (connector_selector_fn and not connector_selector_fn(connector))
-                    or not connector.is_connected
                     # A connector that has not been synced yet has no `schemas` field in its schema config.
                     # Schemas are required for creating the asset definitions,
                     # so connectors for which the schemas are missing are discarded.

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
@@ -9,6 +9,7 @@ from dagster_fivetran.resources import (
     FIVETRAN_API_VERSION,
     FIVETRAN_CONNECTOR_ENDPOINT,
 )
+from dagster_fivetran.translator import FivetranConnectorSetupStateType
 from dagster_fivetran.types import FivetranOutput
 
 TEST_MAX_TIME_STR = "2024-12-01T15:45:29.013729Z"
@@ -49,80 +50,87 @@ SAMPLE_GROUPS = {
     },
 }
 
+
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/groups/list-all-connectors-in-group
-SAMPLE_CONNECTORS_FOR_GROUP = {
-    "code": "Success",
-    "message": "Operation performed.",
-    "data": {
-        "items": [
-            {
-                "id": TEST_CONNECTOR_ID,
-                "service": TEST_DESTINATION_SERVICE,
-                "schema": TEST_CONNECTOR_NAME,
-                "paused": False,
-                "status": {
-                    "tasks": [
+def get_connectors_for_group(setup_state: str) -> Mapping[str, Any]:
+    return {
+        "code": "Success",
+        "message": "Operation performed.",
+        "data": {
+            "items": [
+                {
+                    "id": TEST_CONNECTOR_ID,
+                    "service": TEST_DESTINATION_SERVICE,
+                    "schema": TEST_CONNECTOR_NAME,
+                    "paused": False,
+                    "status": {
+                        "tasks": [
+                            {
+                                "code": "resync_table_warning",
+                                "message": "Resync Table Warning",
+                                "details": "string",
+                            }
+                        ],
+                        "warnings": [
+                            {
+                                "code": "resync_table_warning",
+                                "message": "Resync Table Warning",
+                                "details": "string",
+                            }
+                        ],
+                        "schema_status": "ready",
+                        "update_state": "delayed",
+                        "setup_state": setup_state,
+                        "sync_state": "scheduled",
+                        "is_historical_sync": False,
+                        "rescheduled_for": "2024-12-01T15:43:29.013729Z",
+                    },
+                    "config": {"property1": {}, "property2": {}},
+                    "daily_sync_time": "14:00",
+                    "succeeded_at": "2024-12-01T15:45:29.013729Z",
+                    "sync_frequency": 360,
+                    "group_id": TEST_GROUP_ID,
+                    "connected_by": "user_id",
+                    "setup_tests": [
                         {
-                            "code": "resync_table_warning",
-                            "message": "Resync Table Warning",
-                            "details": "string",
+                            "title": "Test Title",
+                            "status": "PASSED",
+                            "message": "Test Passed",
+                            "details": "Test Details",
                         }
                     ],
-                    "warnings": [
-                        {
-                            "code": "resync_table_warning",
-                            "message": "Resync Table Warning",
-                            "details": "string",
-                        }
-                    ],
-                    "schema_status": "ready",
-                    "update_state": "delayed",
-                    "setup_state": "connected",
-                    "sync_state": "scheduled",
-                    "is_historical_sync": False,
-                    "rescheduled_for": "2024-12-01T15:43:29.013729Z",
-                },
-                "config": {"property1": {}, "property2": {}},
-                "daily_sync_time": "14:00",
-                "succeeded_at": "2024-12-01T15:45:29.013729Z",
-                "sync_frequency": 360,
-                "group_id": TEST_GROUP_ID,
-                "connected_by": "user_id",
-                "setup_tests": [
-                    {
-                        "title": "Test Title",
-                        "status": "PASSED",
-                        "message": "Test Passed",
-                        "details": "Test Details",
-                    }
-                ],
-                "source_sync_details": {},
-                "service_version": 0,
-                "created_at": "2024-12-01T15:41:29.013729Z",
-                "failed_at": "2024-12-01T15:43:29.013729Z",
-                "private_link_id": "string",
-                "proxy_agent_id": "string",
-                "networking_method": "Directly",
-                "connect_card": {
-                    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkIjp7ImxvZ2luIjp0cnVlLCJ1c2VyIjoiX2FjY291bnR3b3J0aHkiLCJhY2NvdW50IjoiX21vb25iZWFtX2FjYyIsImdyb3VwIjoiX21vb25iZWFtIiwiY29ubmVjdG9yIjoiY29iYWx0X2VsZXZhdGlvbiIsIm1ldGhvZCI6IlBiZkNhcmQiLCJpZGVudGl0eSI6ZmFsc2V9LCJpYXQiOjE2Njc4MzA2MzZ9.YUMGUbzxW96xsKJLo4bTorqzx8Q19GTrUi3WFRFM8BU",
-                    "uri": "https://fivetran.com/connect-card/setup?auth=eyJ0eXAiOiJKV1QiLCJh...",
-                },
-                "pause_after_trial": False,
-                "data_delay_threshold": 0,
-                "data_delay_sensitivity": "LOW",
-                "schedule_type": "auto",
-                "local_processing_agent_id": "string",
-                "connect_card_config": {
-                    "redirect_uri": "https://your.site/path",
-                    "hide_setup_guide": True,
-                },
-                "hybrid_deployment_agent_id": "string",
-            }
-        ],
-        "nextCursor": "cursor_value",
-    },
-}
+                    "source_sync_details": {},
+                    "service_version": 0,
+                    "created_at": "2024-12-01T15:41:29.013729Z",
+                    "failed_at": "2024-12-01T15:43:29.013729Z",
+                    "private_link_id": "string",
+                    "proxy_agent_id": "string",
+                    "networking_method": "Directly",
+                    "connect_card": {
+                        "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkIjp7ImxvZ2luIjp0cnVlLCJ1c2VyIjoiX2FjY291bnR3b3J0aHkiLCJhY2NvdW50IjoiX21vb25iZWFtX2FjYyIsImdyb3VwIjoiX21vb25iZWFtIiwiY29ubmVjdG9yIjoiY29iYWx0X2VsZXZhdGlvbiIsIm1ldGhvZCI6IlBiZkNhcmQiLCJpZGVudGl0eSI6ZmFsc2V9LCJpYXQiOjE2Njc4MzA2MzZ9.YUMGUbzxW96xsKJLo4bTorqzx8Q19GTrUi3WFRFM8BU",
+                        "uri": "https://fivetran.com/connect-card/setup?auth=eyJ0eXAiOiJKV1QiLCJh...",
+                    },
+                    "pause_after_trial": False,
+                    "data_delay_threshold": 0,
+                    "data_delay_sensitivity": "LOW",
+                    "schedule_type": "auto",
+                    "local_processing_agent_id": "string",
+                    "connect_card_config": {
+                        "redirect_uri": "https://your.site/path",
+                        "hide_setup_guide": True,
+                    },
+                    "hybrid_deployment_agent_id": "string",
+                }
+            ],
+            "nextCursor": "cursor_value",
+        },
+    }
+
+
+SAMPLE_CONNECTORS_FOR_GROUP = get_connectors_for_group(
+    setup_state=FivetranConnectorSetupStateType.CONNECTED.value
+)
 
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/destinations/destination-details
@@ -539,6 +547,50 @@ def missing_schemas_fetch_workspace_data_api_mocks_fixture(
         url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
         json=MISSING_SCHEMAS_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR,
         status=200,
+    )
+    yield fetch_workspace_data_api_mocks
+
+
+@pytest.fixture(
+    name="incomplete_connector_fetch_workspace_data_api_mocks",
+)
+def incomplete_connector_fetch_workspace_data_api_mocks_fixture(
+    connector_id: str,
+    destination_id: str,
+    group_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.replace(
+        method_or_response=responses.GET,
+        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
+        json=get_connectors_for_group(setup_state=FivetranConnectorSetupStateType.INCOMPLETE.value),
+        status=200,
+    )
+    fetch_workspace_data_api_mocks.remove(
+        method_or_response=responses.GET,
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
+    )
+    yield fetch_workspace_data_api_mocks
+
+
+@pytest.fixture(
+    name="broken_connector_fetch_workspace_data_api_mocks",
+)
+def broken_connector_fetch_workspace_data_api_mocks_fixture(
+    connector_id: str,
+    destination_id: str,
+    group_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.replace(
+        method_or_response=responses.GET,
+        url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
+        json=get_connectors_for_group(setup_state=FivetranConnectorSetupStateType.BROKEN.value),
+        status=200,
+    )
+    fetch_workspace_data_api_mocks.remove(
+        method_or_response=responses.GET,
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
     )
     yield fetch_workspace_data_api_mocks
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -88,6 +88,32 @@ def test_missing_schemas_fivetran_workspace_data(
     assert len(actual_workspace_data.destinations_by_id) == 1
 
 
+def test_incomplete_connector_fivetran_workspace_data(
+    incomplete_connector_fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    actual_workspace_data = resource.fetch_fivetran_workspace_data()
+    # The connector is discarded because it's incomplete
+    assert len(actual_workspace_data.connectors_by_id) == 0
+    assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+def test_broken_connector_fivetran_workspace_data(
+    broken_connector_fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    actual_workspace_data = resource.fetch_fivetran_workspace_data()
+    # The connector is discarded because it's broken
+    assert len(actual_workspace_data.connectors_by_id) == 0
+    assert len(actual_workspace_data.destinations_by_id) == 1
+
+
 def test_translator_spec(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-936.

This PR handles incomplete and broken connectors fetched from a Fivetran workspace.

Context:

Incomplete connectors in a Fivetran workspace are causing an exception in `fetch_fivetran_workspace_data`.

```
Stack Trace:
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/examples/test/definitions.py", line 14, in <module>
    @fivetran_assets(
     ^^^^^^^^^^^^^^^^
  [1 dagster system frames hidden]
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py", line 118, in fivetran_assets
    for spec in workspace.load_asset_specs(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [1 dagster system frames hidden]
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 985, in load_asset_specs
    return load_fivetran_asset_specs(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  [1 dagster system frames hidden]
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 1154, in load_fivetran_asset_specs
    .build_defs()
     ^^^^^^^^^^^^
  [2 dagster system frames hidden]
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 1172, in fetch_state
    return self.workspace.fetch_fivetran_workspace_data(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 918, in fetch_fivetran_workspace_data
    schema_config_details = client.get_schema_config_for_connector(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 594, in get_schema_config_for_connector
    return self._make_request("GET", f"connectors/{connector_id}/schemas")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 560, in _make_request
    raise Failure(f"Max retries ({self.request_max_retries}) exceeded with url: {url}.")
```

## How I Tested These Changes

Tested locally with a Fivetran workspace + additional tests with BK.

## Changelog

[dagster-fivetran] Loading assets for a Fivetran workspace containing incomplete and broken connectors raised an exception. This bug is now fixed.
