### PR TITLE
Make asset selection filtering case-insensitive insensitive

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.oss.ts
@@ -149,8 +149,10 @@ export class AntlrAssetSelectionVisitor
 
   visitKeyExpr(ctx: KeyExprContext) {
     const value: string = getValue(ctx.keyValue());
-    const regex: RegExp = new RegExp(`^${escapeRegExp(value).replaceAll('\\*', '.*')}$`);
-    const selection = [...this.all_assets].filter((i) => regex.test(i.name));
+    const regex: RegExp = new RegExp(
+      `^${escapeRegExp(value.toLowerCase()).replaceAll('\\*', '.*')}$`,
+    );
+    const selection = [...this.all_assets].filter((i) => regex.test(i.name.toLowerCase()));
 
     selection.forEach((i) => this.focus_assets.add(i));
     return new Set(selection);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
@@ -83,6 +83,7 @@ describe('parseAssetSelectionQuery', () => {
 
     it('should parse key query', () => {
       assertQueryResult('key:A', ['A']);
+      assertQueryResult('key:a', ['A']);
     });
 
     it('should parse and query', () => {
@@ -99,6 +100,7 @@ describe('parseAssetSelectionQuery', () => {
     it('should parse not query', () => {
       assertQueryResult('not key:A', ['B', 'B2', 'C']);
       assertQueryResult('NOT key:A', ['B', 'B2', 'C']);
+      assertQueryResult('NOT key:a', ['B', 'B2', 'C']);
     });
 
     it('should parse upstream plus query', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/op-selection/AntlrOpSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/op-selection/AntlrOpSelectionVisitor.ts
@@ -139,8 +139,10 @@ export class AntlrOpSelectionVisitor<T extends GraphQueryItem>
 
   visitNameExpr(ctx: NameExprContext) {
     const value: string = getValue(ctx.keyValue());
-    const regex: RegExp = new RegExp(`^${escapeRegExp(value).replaceAll('\\*', '.*')}$`);
-    const selection = [...this.all_ops].filter((i) => regex.test(i.name));
+    const regex: RegExp = new RegExp(
+      `^${escapeRegExp(value.toLowerCase()).replaceAll('\\*', '.*')}$`,
+    );
+    const selection = [...this.all_ops].filter((i) => regex.test(i.name.toLowerCase()));
     selection.forEach((i) => this.focus_ops.add(i));
     return new Set(selection);
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/op-selection/__tests__/AntlrOpSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/op-selection/__tests__/AntlrOpSelection.test.ts
@@ -61,11 +61,13 @@ describe('parseOpSelectionQuery', () => {
 
     it('should parse name query', () => {
       assertQueryResult('name:A', ['A']);
+      assertQueryResult('name:a', ['A']);
     });
 
     it('should handle name wildcard queries', () => {
       assertQueryResult('name:*A*', ['A']);
       assertQueryResult('name:B*', ['B', 'B2']);
+      assertQueryResult('name:b*', ['B', 'B2']);
     });
 
     it('should parse and query', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/run-selection/AntlrRunSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/run-selection/AntlrRunSelectionVisitor.ts
@@ -141,8 +141,10 @@ export class AntlrRunSelectionVisitor
 
   visitNameExpr(ctx: NameExprContext) {
     const value: string = getValue(ctx.keyValue());
-    const regex: RegExp = new RegExp(`^${escapeRegExp(value).replaceAll('\\*', '.*')}$`);
-    const selection = [...this.all_runs].filter((i) => regex.test(i.name));
+    const regex: RegExp = new RegExp(
+      `^${escapeRegExp(value.toLowerCase()).replaceAll('\\*', '.*')}$`,
+    );
+    const selection = [...this.all_runs].filter((i) => regex.test(i.name.toLowerCase()));
     selection.forEach((i) => this.focus_runs.add(i));
     return new Set(selection);
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/run-selection/__tests__/AntlrRunSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/run-selection/__tests__/AntlrRunSelection.test.ts
@@ -82,6 +82,8 @@ describe('parseRunSelectionQuery', () => {
     it('should handle name wildcard queries', () => {
       assertQueryResult('name:*A*', ['A']);
       assertQueryResult('name:B*', ['B', 'B2']);
+      assertQueryResult('name:a', ['A']);
+      assertQueryResult('name:b', ['B', 'B2']);
     });
 
     it('should parse and query', () => {


### PR DESCRIPTION
## Summary & Motivation

As titled. A previous PR only made the auto-complete suggestion case in-sensitive but not the actual filtering itself.

## How I Tested These Changes
jest + local testing