### PR TITLE
[ui] Combine groups on the asset graph across code locations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -6,6 +6,7 @@ export enum FeatureFlag {
   flagLegacyRunsPage = 'flagLegacyRunsPage',
   flagSelectionSyntax = 'flagSelectionSyntax',
   flagAssetSelectionWorker = 'flagAssetSelectionWorker',
+  flagAssetGraphGroupsPerCodeLocation = 'flagAssetGraphGroupsPerCodeLocation',
 
   // Flags for tests
   __TestFlagDefaultNone = '__TestFlagDefaultNone',

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -34,6 +34,10 @@ export const useVisibleFeatureFlagRows = () => [
     ),
   },
   {
+    key: 'Revert to separate asset graph groups per code location',
+    flagType: FeatureFlag.flagAssetGraphGroupsPerCodeLocation,
+  },
+  {
     key: 'Enable new selection syntax for Asset/Op/Run graphs',
     flagType: FeatureFlag.flagSelectionSyntax,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -1,6 +1,8 @@
 import {pathHorizontalDiagonal, pathVerticalDiagonal} from '@vx/shape';
 import memoize from 'lodash/memoize';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
+import {featureEnabled} from '../app/Flags';
 import {AssetNodeKeyFragment} from './types/AssetNode.types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {COMMON_COLLATOR} from '../app/Util';
@@ -276,13 +278,15 @@ export const itemWithAssetKey = (key: {path: string[]}) => {
 export const isGroupId = (str: string) => /^[^@:]+@[^@:]+:.+$/.test(str);
 
 export const groupIdForNode = (node: GraphNode) =>
-  [
-    node.definition.repository.name,
-    '@',
-    node.definition.repository.location.name,
-    ':',
-    node.definition.groupName,
-  ].join('');
+  featureEnabled(FeatureFlag.flagAssetGraphGroupsPerCodeLocation)
+    ? [
+        node.definition.repository.name,
+        '@',
+        node.definition.repository.location.name,
+        ':',
+        node.definition.groupName,
+      ].join('')
+    : `global@global:${node.definition.groupName}`;
 
 // Inclusive
 export const getUpstreamNodes = memoize(


### PR DESCRIPTION
This is the new default and a FF allows you to revert to the old behavior

## Summary & Motivation

## How I Tested These Changes

Tested via feature flag toggling on a test setup that has the same group name in multiple code locations

## Changelog

[ui] The asset graph now renders a single box for groups with the same name in separate code locations