### PR TITLE
[ui] Display the backfill overview info on all backfill tabs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
@@ -95,15 +95,17 @@ export const RunsFeedBackfillPage = () => {
           <Alert intent="error" title={error.graphQLErrors.map((err) => err.message)} />
         )}
         <Box flex={{direction: 'column'}} style={{flex: 1, position: 'relative', minHeight: 0}}>
+          <Box border={selectedTab === 'overview' ? null : 'bottom'}>
+            <BackfillOverviewDetails backfill={backfill} />
+            {isDaemonHealthy ? null : (
+              <Box padding={{horizontal: 24, bottom: 16}}>
+                <DaemonNotRunningAlert />
+              </Box>
+            )}
+          </Box>
+
           {selectedTab === 'overview' && (
             <Box style={{overflow: 'hidden'}} flex={{direction: 'column'}}>
-              {isDaemonHealthy ? null : (
-                <Box padding={{horizontal: 24, top: 16}}>
-                  <DaemonNotRunningAlert />
-                </Box>
-              )}
-
-              <BackfillOverviewDetails backfill={backfill} />
               {backfill.isAssetBackfill ? (
                 <BackfillAssetPartitionsTable backfill={backfill} />
               ) : (


### PR DESCRIPTION
## Summary & Motivation

<img width="1370" alt="image" src="https://github.com/user-attachments/assets/50354e49-f1a5-4060-84d3-707b6e660657" />

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/4a5f482d-4f4b-4eaf-8ba2-5d5ecb4b22cc" />

<img width="1376" alt="image" src="https://github.com/user-attachments/assets/7c44c670-272c-4b43-9bd7-90aa8477f1d5" />


## How I Tested These Changes

Just visual testing - did verify it looks good with and without the "daemon not running banner"

## Changelog

[ui] The backfill pages now show summary information on all tabs for easier backfill monitoring.