### PR TITLE
[da] Add .allow() and .ignore() to CheckOperator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
         AutomationContext,
     )
     from dagster._core.definitions.declarative_automation.operators import AndAutomationCondition
+    from dagster._core.definitions.declarative_automation.operators.check_operators import (
+        ChecksAutomationCondition,
+    )
     from dagster._core.definitions.declarative_automation.operators.dep_operators import (
         DepsAutomationCondition,
     )
@@ -313,7 +316,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     @staticmethod
     def any_checks_match(
         condition: "AutomationCondition[AssetCheckKey]", blocking_only: bool = False
-    ) -> "BuiltinAutomationCondition":
+    ) -> "ChecksAutomationCondition":
         """Returns an AutomationCondition that is true for if at least one of the target's
         checks evaluate to True for the given condition.
 
@@ -331,7 +334,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     @staticmethod
     def all_checks_match(
         condition: "AutomationCondition[AssetCheckKey]", blocking_only: bool = False
-    ) -> "BuiltinAutomationCondition[AssetKey]":
+    ) -> "ChecksAutomationCondition":
         """Returns an AutomationCondition that is true for an asset partition if all of its checks
         evaluate to True for the given condition.
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -9,10 +9,12 @@ from dagster._core.definitions.declarative_automation.operators.boolean_operator
 from dagster._core.definitions.declarative_automation.operators.check_operators import (
     AllChecksCondition as AllChecksCondition,
     AnyChecksCondition as AnyChecksCondition,
+    ChecksAutomationCondition as ChecksAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
+    DepsAutomationCondition as DepsAutomationCondition,
     EntityMatchesCondition as EntityMatchesCondition,
 )
 from dagster._core.definitions.declarative_automation.operators.newly_true_operator import (

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -2,8 +2,6 @@ import asyncio
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Union
 
-from typing_extensions import TypeIs
-
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_key import T_EntityKey
@@ -13,41 +11,12 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._core.definitions.declarative_automation.operators.dep_operators import (
-    DepsAutomationCondition,
-)
+from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
 from dagster._record import copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AssetSelection
-
-
-def _has_allow_ignore(
-    condition: AutomationCondition,
-) -> TypeIs[
-    Union[
-        DepsAutomationCondition,
-        "AndAutomationCondition",
-        "OrAutomationCondition",
-        "NotAutomationCondition",
-    ]
-]:
-    from dagster._core.definitions.declarative_automation.operators.boolean_operators import (
-        AndAutomationCondition,
-        NotAutomationCondition,
-        OrAutomationCondition,
-    )
-
-    return isinstance(
-        condition,
-        (
-            DepsAutomationCondition,
-            AndAutomationCondition,
-            OrAutomationCondition,
-            NotAutomationCondition,
-        ),
-    )
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")
@@ -130,7 +99,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.allow(selection) if _has_allow_ignore(child) else child
+                child.allow(selection) if has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -150,7 +119,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.ignore(selection) if _has_allow_ignore(child) else child
+                child.ignore(selection) if has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -231,7 +200,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.allow(selection) if _has_allow_ignore(child) else child
+                child.allow(selection) if has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -251,7 +220,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operands=[
-                child.ignore(selection) if _has_allow_ignore(child) else child
+                child.ignore(selection) if has_allow_ignore(child) else child
                 for child in self.operands
             ],
         )
@@ -320,7 +289,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operand=self.operand.allow(selection)
-            if _has_allow_ignore(self.operand)
+            if has_allow_ignore(self.operand)
             else self.operand,
         )
 
@@ -339,6 +308,6 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(
             self,
             operand=self.operand.ignore(selection)
-            if _has_allow_ignore(self.operand)
+            if has_allow_ignore(self.operand)
             else self.operand,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, Union
+
+from typing_extensions import TypeIs
+
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.declarative_automation.operators import (
+        AndAutomationCondition,
+        ChecksAutomationCondition,
+        DepsAutomationCondition,
+        NotAutomationCondition,
+        OrAutomationCondition,
+    )
+
+
+def has_allow_ignore(
+    condition: AutomationCondition,
+) -> TypeIs[
+    Union[
+        "AndAutomationCondition",
+        "ChecksAutomationCondition",
+        "DepsAutomationCondition",
+        "NotAutomationCondition",
+        "OrAutomationCondition",
+    ]
+]:
+    from dagster._core.definitions.declarative_automation.operators import (
+        AndAutomationCondition,
+        ChecksAutomationCondition,
+        DepsAutomationCondition,
+        NotAutomationCondition,
+        OrAutomationCondition,
+    )
+
+    return isinstance(
+        condition,
+        (
+            AndAutomationCondition,
+            ChecksAutomationCondition,
+            DepsAutomationCondition,
+            NotAutomationCondition,
+            OrAutomationCondition,
+        ),
+    )


### PR DESCRIPTION
## Summary & Motivation

This is a powerful utility for `any_deps_match` / `all_deps_match`, and is valuable for similar reasons for `any_checks_match` / `all_checks_match`.

Also refactored the `has_allow_ignore` method out into a separate utils file for cleanliness

## How I Tested These Changes

## Changelog

NOCHANGELOG
