### PR TITLE
Support with_metadata for AssetCheckEvaluation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -127,12 +127,7 @@ class AssetCheckEvaluation(
         return AssetCheckKey(self.asset_key, self.check_name)
 
     def with_metadata(self, metadata: Mapping[str, RawMetadataValue]) -> "AssetCheckEvaluation":
-        return AssetCheckEvaluation(
-            asset_key=self.asset_key,
-            check_name=self.check_name,
-            passed=self.passed,
-            metadata=metadata,
-            target_materialization_data=self.target_materialization_data,
-            severity=self.severity,
-            description=self.description,
+        normed_metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
         )
+        return self._replace(metadata=normed_metadata)

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Optional
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
-from dagster._core.definitions.events import AssetKey, MetadataValue
+from dagster._core.definitions.events import AssetKey, MetadataValue, RawMetadataValue
 from dagster._core.definitions.metadata import normalize_metadata
 from dagster._serdes import whitelist_for_serdes
 
@@ -98,7 +98,7 @@ class AssetCheckEvaluation(
         asset_key: AssetKey,
         check_name: str,
         passed: bool,
-        metadata: Optional[Mapping[str, MetadataValue]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         target_materialization_data: Optional[AssetCheckEvaluationTargetMaterializationData] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
         description: Optional[str] = None,
@@ -125,3 +125,14 @@ class AssetCheckEvaluation(
     @property
     def asset_check_key(self) -> AssetCheckKey:
         return AssetCheckKey(self.asset_key, self.check_name)
+
+    def with_metadata(self, metadata: Mapping[str, RawMetadataValue]) -> "AssetCheckEvaluation":
+        return AssetCheckEvaluation(
+            asset_key=self.asset_key,
+            check_name=self.check_name,
+            passed=self.passed,
+            metadata=metadata,
+            target_materialization_data=self.target_materialization_data,
+            severity=self.severity,
+            description=self.description,
+        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_replace_event_metadata.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_replace_event_metadata.py
@@ -6,6 +6,7 @@ from dagster import (
     AssetObservation,
     Output,
 )
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 
 
 def test_output_object_with_metadata() -> None:
@@ -110,6 +111,39 @@ def test_asset_check_result_object_with_metadata() -> None:
 
     check = _get_check_result()
     assert check.with_metadata({**check.metadata, "new": "metadata"}) == AssetCheckResult(
+        asset_key=AssetKey("my_key"),
+        metadata={"foo": "bar", "new": "metadata"},
+        passed=True,
+        severity=AssetCheckSeverity.WARN,
+        description="foo",
+        check_name="my_check",
+    )
+
+
+def test_asset_check_evaluation_object_with_metadata() -> None:
+    def _get_check_evaluation() -> AssetCheckEvaluation:
+        return AssetCheckEvaluation(
+            asset_key=AssetKey("my_key"),
+            metadata={"foo": "bar"},
+            passed=True,
+            severity=AssetCheckSeverity.WARN,
+            description="foo",
+            check_name="my_check",
+        )
+
+    assert _get_check_evaluation() == _get_check_evaluation()
+
+    assert _get_check_evaluation().with_metadata({"new": "metadata"}) == AssetCheckEvaluation(
+        asset_key=AssetKey("my_key"),
+        metadata={"new": "metadata"},
+        passed=True,
+        severity=AssetCheckSeverity.WARN,
+        description="foo",
+        check_name="my_check",
+    )
+
+    check = _get_check_evaluation()
+    assert check.with_metadata({**check.metadata, "new": "metadata"}) == AssetCheckEvaluation(
         asset_key=AssetKey("my_key"),
         metadata={"foo": "bar", "new": "metadata"},
         passed=True,


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-943. Supports with_metadata in AssetCheckEvalution, which is required for AssetCheckEvaluation to be used in DbtEventIterator in subsequent PR

## How I Tested These Changes

Additional tests with BK
