### PR TITLE
Update `parse_spark_configs.py` to use latest docs

### DIFF
--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -14,7 +14,7 @@ import requests
 
 from automation.printer import IndentingBufferPrinter
 
-SPARK_VERSION = "v2.4.0"
+SPARK_VERSION = "v3.5.5"
 TABLE_REGEX = r"### (.{,30}?)\n\n(<table.*?>.*?<\/table>)"
 WHITESPACE_REGEX = r"\s+"
 


### PR DESCRIPTION
## Summary & Motivation

Updated to latest Spark version without changing the set of fields pulled.

## How I Tested These Changes

BK

### EMR `spark_config()` Diff

```diff
(dagster) deepyaman@Deepyamans-MacBook-Pro dagster % diff <(python emr_config_before.py) <(python emr_config_after.py)         
2,11c2,4
< ('spark_blacklist_application_fetchFailure_enabled', 'StringSourceType')
< ('spark_blacklist_application_maxFailedExecutorsPerNode', 'StringSourceType')
< ('spark_blacklist_application_maxFailedTasksPerExecutor', 'StringSourceType')
< ('spark_blacklist_enabled', 'StringSourceType')
< ('spark_blacklist_killBlacklistedExecutors', 'StringSourceType')
< ('spark_blacklist_stage_maxFailedExecutorsPerNode', 'StringSourceType')
< ('spark_blacklist_stage_maxFailedTasksPerExecutor', 'StringSourceType')
< ('spark_blacklist_task_maxTaskAttemptsPerExecutor', 'StringSourceType')
< ('spark_blacklist_task_maxTaskAttemptsPerNode', 'StringSourceType')
< ('spark_blacklist_timeout', 'StringSourceType')
---
> ('spark_appStatusStore_diskStoreDir', 'StringSourceType')
> ('spark_archives', 'StringSourceType')
> ('spark_barrier_sync_timeout', 'StringSourceType')
12a6
> ('spark_broadcast_UDFCompressionThreshold', 'StringSourceType')
15a10
> ('spark_checkpoint_compress', 'StringSourceType')
21d15
< ('spark_core_connection_ack_wait_timeout', 'StringSourceType')
22a17
> ('spark_decommission_enabled', 'StringSourceType')
29a25
> ('spark_driver_defaultJavaOptions', 'StringSourceType')
33a30,33
> ('spark_driver_log_allowErasureCoding', 'StringSourceType')
> ('spark_driver_log_dfsDir', 'StringSourceType')
> ('spark_driver_log_layout', 'StringSourceType')
> ('spark_driver_log_persistToDfs_enabled', 'StringSourceType')
36a37
> ('spark_driver_memoryOverheadFactor', 'StringSourceType')
37a39,41
> ('spark_driver_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_driver_resource_{resourceName}_discoveryScript', 'StringSourceType')
> ('spark_driver_resource_{resourceName}_vendor', 'StringSourceType')
47a52,53
> ('spark_dynamicAllocation_shuffleTracking_enabled', 'StringSourceType')
> ('spark_dynamicAllocation_shuffleTracking_timeout', 'StringSourceType')
50a57
> ('spark_eventLog_compression_codec', 'StringSourceType')
52a60,62
> ('spark_eventLog_erasureCoding_enabled', 'StringSourceType')
> ('spark_eventLog_gcMetrics_oldGenerationGarbageCollectors', 'StringSourceType')
> ('spark_eventLog_gcMetrics_youngGenerationGarbageCollectors', 'StringSourceType')
53a64
> ('spark_eventLog_logStageExecutorMetrics', 'StringSourceType')
55a67,78
> ('spark_eventLog_rolling_enabled', 'StringSourceType')
> ('spark_eventLog_rolling_maxFileSize', 'StringSourceType')
> ('spark_excludeOnFailure_application_fetchFailure_enabled', 'StringSourceType')
> ('spark_excludeOnFailure_application_maxFailedExecutorsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_application_maxFailedTasksPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_enabled', 'StringSourceType')
> ('spark_excludeOnFailure_killExcludedExecutors', 'StringSourceType')
> ('spark_excludeOnFailure_stage_maxFailedExecutorsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_stage_maxFailedTasksPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_task_maxTaskAttemptsPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_task_maxTaskAttemptsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_timeout', 'StringSourceType')
56a80,83
> ('spark_executor_decommission_forceKillTimeout', 'StringSourceType')
> ('spark_executor_decommission_killInterval', 'StringSourceType')
> ('spark_executor_decommission_signal', 'StringSourceType')
> ('spark_executor_defaultJavaOptions', 'StringSourceType')
59a87
> ('spark_executor_failuresValidityInterval', 'StringSourceType')
65a94
> ('spark_executor_maxNumFailures', 'StringSourceType')
67a97,100
> ('spark_executor_memoryOverheadFactor', 'StringSourceType')
> ('spark_executor_metrics_fileSystemSchemes', 'StringSourceType')
> ('spark_executor_metrics_pollingInterval', 'StringSourceType')
> ('spark_executor_processTreeMetrics_enabled', 'StringSourceType')
68a102,104
> ('spark_executor_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_executor_resource_{resourceName}_discoveryScript', 'StringSourceType')
> ('spark_executor_resource_{resourceName}_vendor', 'StringSourceType')
71a108,111
> ('spark_files_ignoreCorruptFiles', 'StringSourceType')
> ('spark_files_ignoreMissingFiles', 'StringSourceType')
> ('spark_files_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_files_io_connectionTimeout', 'StringSourceType')
83a124
> ('spark_io_compression_zstd_bufferPool_enabled', 'StringSourceType')
104a146
> ('spark_log_level', 'StringSourceType')
107d148
< ('spark_maxRemoteBlockSizeFetchToMem', 'IntSourceType')
112c153,154
< ('spark_memory_useLegacyMode', 'Bool')
---
> ('spark_network_io_preferDirectBufs', 'StringSourceType')
> ('spark_network_maxRemoteBlockSizeFetchToMem', 'StringSourceType')
113a156
> ('spark_network_timeoutInterval', 'StringSourceType')
128a172
> ('spark_redaction_string_regex', 'StringSourceType')
131a176
> ('spark_resources_discoveryPlugin', 'StringSourceType')
132a178,180
> ('spark_rpc_io_backLog', 'StringSourceType')
> ('spark_rpc_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_rpc_io_connectionTimeout', 'StringSourceType')
135,136c183,186
< ('spark_rpc_numRetries', 'StringSourceType')
< ('spark_rpc_retry_wait', 'StringSourceType')
---
> ('spark_scheduler_barrier_maxConcurrentTasksCheck_interval', 'StringSourceType')
> ('spark_scheduler_barrier_maxConcurrentTasksCheck_maxFailures', 'StringSourceType')
> ('spark_scheduler_excludeOnFailure_unschedulableTaskSetTimeout', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_appStatus_capacity', 'StringSourceType')
137a188,191
> ('spark_scheduler_listenerbus_eventqueue_eventLog_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_executorManagement_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_shared_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_streams_capacity', 'StringSourceType')
140a195
> ('spark_scheduler_resource_profileMergeConflicts', 'StringSourceType')
144a200,201
> ('spark_shuffle_checksum_algorithm', 'StringSourceType')
> ('spark_shuffle_checksum_enabled', 'StringSourceType')
145a203,204
> ('spark_shuffle_detectCorrupt_root', 'StringSourceType')
> ('spark_shuffle_detectCorrupt_useExtraMemory', 'StringSourceType')
146a206,208
> ('spark_shuffle_io_backLog', 'StringSourceType')
> ('spark_shuffle_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_shuffle_io_connectionTimeout', 'StringSourceType')
150a213
> ('spark_shuffle_mapOutput_minSizeForBroadcast', 'StringSourceType')
152c215,216
< ('spark_shuffle_memoryFraction', 'Float')
---
> ('spark_shuffle_readHostLocalDisk', 'StringSourceType')
> ('spark_shuffle_reduceLocality_enabled', 'StringSourceType')
154a219,220
> ('spark_shuffle_service_db_backend', 'StringSourceType')
> ('spark_shuffle_service_db_enabled', 'StringSourceType')
155a222
> ('spark_shuffle_service_fetch_rdd_enabled', 'StringSourceType')
156a224
> ('spark_shuffle_service_name', 'StringSourceType')
157a226
> ('spark_shuffle_service_removeShuffle', 'StringSourceType')
158a228
> ('spark_shuffle_sort_io_plugin_class', 'StringSourceType')
159a230,235
> ('spark_shuffle_spill_diskWriteBufferSize', 'StringSourceType')
> ('spark_shuffle_unsafe_file_output_buffer', 'StringSourceType')
> ('spark_shuffle_useOldFetchProtocol', 'StringSourceType')
> ('spark_speculation_efficiency_enabled', 'StringSourceType')
> ('spark_speculation_efficiency_longRunTaskFactor', 'StringSourceType')
> ('spark_speculation_efficiency_processRateMultiplier', 'StringSourceType')
160a237
> ('spark_speculation_minTaskRuntime', 'StringSourceType')
163a241
> ('spark_speculation_task_duration_threshold', 'StringSourceType')
164a243
> ('spark_stage_ignoreDecommissionFetchFailure', 'StringSourceType')
166c245,253
< ('spark_storage_memoryFraction', 'Float')
---
> ('spark_standalone_submit_waitAppCompletion', 'StringSourceType')
> ('spark_storage_decommission_enabled', 'StringSourceType')
> ('spark_storage_decommission_fallbackStorage_cleanUp', 'StringSourceType')
> ('spark_storage_decommission_fallbackStorage_path', 'StringSourceType')
> ('spark_storage_decommission_rddBlocks_enabled', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_enabled', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_maxDiskSize', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_maxThreads', 'StringSourceType')
> ('spark_storage_localDiskByExecutors_cacheSize', 'StringSourceType')
169c256
< ('spark_storage_unrollFraction', 'Float')
---
> ('spark_storage_unrollMemoryThreshold', 'StringSourceType')
175d261
< ('spark_streaming_kafka_maxRetries', 'StringSourceType')
190a277,278
> ('spark_task_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_ui_custom_executor_log_url', 'StringSourceType')
194a283
> ('spark_ui_liveUpdate_minFlushPeriod', 'StringSourceType')
196a286,287
> ('spark_ui_proxyRedirectUri', 'StringSourceType')
> ('spark_ui_requestHeaderSize', 'StringSourceType')
203a295,300
> ('spark_ui_store_path', 'StringSourceType')
> ('spark_ui_timeline_executors_maximum', 'StringSourceType')
> ('spark_ui_timeline_jobs_maximum', 'StringSourceType')
> ('spark_ui_timeline_stages_maximum', 'StringSourceType')
> ('spark_ui_timeline_tasks_maximum', 'StringSourceType')
> ('spark_ui_timelineEnabled', 'StringSourceType')
```

### General `spark_config() Diff

```diff
(dagster) deepyaman@Deepyamans-MacBook-Pro dagster % diff <(python spark_config_before.py) <(python spark_config_after.py)
2,11c2,4
< ('spark_blacklist_application_fetchFailure_enabled', 'StringSourceType')
< ('spark_blacklist_application_maxFailedExecutorsPerNode', 'StringSourceType')
< ('spark_blacklist_application_maxFailedTasksPerExecutor', 'StringSourceType')
< ('spark_blacklist_enabled', 'StringSourceType')
< ('spark_blacklist_killBlacklistedExecutors', 'StringSourceType')
< ('spark_blacklist_stage_maxFailedExecutorsPerNode', 'StringSourceType')
< ('spark_blacklist_stage_maxFailedTasksPerExecutor', 'StringSourceType')
< ('spark_blacklist_task_maxTaskAttemptsPerExecutor', 'StringSourceType')
< ('spark_blacklist_task_maxTaskAttemptsPerNode', 'StringSourceType')
< ('spark_blacklist_timeout', 'StringSourceType')
---
> ('spark_appStatusStore_diskStoreDir', 'StringSourceType')
> ('spark_archives', 'StringSourceType')
> ('spark_barrier_sync_timeout', 'StringSourceType')
12a6
> ('spark_broadcast_UDFCompressionThreshold', 'StringSourceType')
15a10
> ('spark_checkpoint_compress', 'StringSourceType')
21d15
< ('spark_core_connection_ack_wait_timeout', 'StringSourceType')
22a17
> ('spark_decommission_enabled', 'StringSourceType')
29a25
> ('spark_driver_defaultJavaOptions', 'StringSourceType')
33a30,33
> ('spark_driver_log_allowErasureCoding', 'StringSourceType')
> ('spark_driver_log_dfsDir', 'StringSourceType')
> ('spark_driver_log_layout', 'StringSourceType')
> ('spark_driver_log_persistToDfs_enabled', 'StringSourceType')
36a37
> ('spark_driver_memoryOverheadFactor', 'StringSourceType')
37a39,41
> ('spark_driver_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_driver_resource_{resourceName}_discoveryScript', 'StringSourceType')
> ('spark_driver_resource_{resourceName}_vendor', 'StringSourceType')
47a52,53
> ('spark_dynamicAllocation_shuffleTracking_enabled', 'StringSourceType')
> ('spark_dynamicAllocation_shuffleTracking_timeout', 'StringSourceType')
50a57
> ('spark_eventLog_compression_codec', 'StringSourceType')
52a60,62
> ('spark_eventLog_erasureCoding_enabled', 'StringSourceType')
> ('spark_eventLog_gcMetrics_oldGenerationGarbageCollectors', 'StringSourceType')
> ('spark_eventLog_gcMetrics_youngGenerationGarbageCollectors', 'StringSourceType')
53a64
> ('spark_eventLog_logStageExecutorMetrics', 'StringSourceType')
55a67,78
> ('spark_eventLog_rolling_enabled', 'StringSourceType')
> ('spark_eventLog_rolling_maxFileSize', 'StringSourceType')
> ('spark_excludeOnFailure_application_fetchFailure_enabled', 'StringSourceType')
> ('spark_excludeOnFailure_application_maxFailedExecutorsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_application_maxFailedTasksPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_enabled', 'StringSourceType')
> ('spark_excludeOnFailure_killExcludedExecutors', 'StringSourceType')
> ('spark_excludeOnFailure_stage_maxFailedExecutorsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_stage_maxFailedTasksPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_task_maxTaskAttemptsPerExecutor', 'StringSourceType')
> ('spark_excludeOnFailure_task_maxTaskAttemptsPerNode', 'StringSourceType')
> ('spark_excludeOnFailure_timeout', 'StringSourceType')
56a80,83
> ('spark_executor_decommission_forceKillTimeout', 'StringSourceType')
> ('spark_executor_decommission_killInterval', 'StringSourceType')
> ('spark_executor_decommission_signal', 'StringSourceType')
> ('spark_executor_defaultJavaOptions', 'StringSourceType')
59a87
> ('spark_executor_failuresValidityInterval', 'StringSourceType')
65a94
> ('spark_executor_maxNumFailures', 'StringSourceType')
67a97,100
> ('spark_executor_memoryOverheadFactor', 'StringSourceType')
> ('spark_executor_metrics_fileSystemSchemes', 'StringSourceType')
> ('spark_executor_metrics_pollingInterval', 'StringSourceType')
> ('spark_executor_processTreeMetrics_enabled', 'StringSourceType')
68a102,104
> ('spark_executor_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_executor_resource_{resourceName}_discoveryScript', 'StringSourceType')
> ('spark_executor_resource_{resourceName}_vendor', 'StringSourceType')
71a108,111
> ('spark_files_ignoreCorruptFiles', 'StringSourceType')
> ('spark_files_ignoreMissingFiles', 'StringSourceType')
> ('spark_files_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_files_io_connectionTimeout', 'StringSourceType')
83a124
> ('spark_io_compression_zstd_bufferPool_enabled', 'StringSourceType')
104a146
> ('spark_log_level', 'StringSourceType')
107d148
< ('spark_maxRemoteBlockSizeFetchToMem', 'IntSourceType')
112c153,154
< ('spark_memory_useLegacyMode', 'Bool')
---
> ('spark_network_io_preferDirectBufs', 'StringSourceType')
> ('spark_network_maxRemoteBlockSizeFetchToMem', 'StringSourceType')
113a156
> ('spark_network_timeoutInterval', 'StringSourceType')
128a172
> ('spark_redaction_string_regex', 'StringSourceType')
131a176
> ('spark_resources_discoveryPlugin', 'StringSourceType')
132a178,180
> ('spark_rpc_io_backLog', 'StringSourceType')
> ('spark_rpc_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_rpc_io_connectionTimeout', 'StringSourceType')
135,136c183,186
< ('spark_rpc_numRetries', 'StringSourceType')
< ('spark_rpc_retry_wait', 'StringSourceType')
---
> ('spark_scheduler_barrier_maxConcurrentTasksCheck_interval', 'StringSourceType')
> ('spark_scheduler_barrier_maxConcurrentTasksCheck_maxFailures', 'StringSourceType')
> ('spark_scheduler_excludeOnFailure_unschedulableTaskSetTimeout', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_appStatus_capacity', 'StringSourceType')
137a188,191
> ('spark_scheduler_listenerbus_eventqueue_eventLog_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_executorManagement_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_shared_capacity', 'StringSourceType')
> ('spark_scheduler_listenerbus_eventqueue_streams_capacity', 'StringSourceType')
140a195
> ('spark_scheduler_resource_profileMergeConflicts', 'StringSourceType')
144a200,201
> ('spark_shuffle_checksum_algorithm', 'StringSourceType')
> ('spark_shuffle_checksum_enabled', 'StringSourceType')
145a203,204
> ('spark_shuffle_detectCorrupt_root', 'StringSourceType')
> ('spark_shuffle_detectCorrupt_useExtraMemory', 'StringSourceType')
146a206,208
> ('spark_shuffle_io_backLog', 'StringSourceType')
> ('spark_shuffle_io_connectionCreationTimeout', 'StringSourceType')
> ('spark_shuffle_io_connectionTimeout', 'StringSourceType')
150a213
> ('spark_shuffle_mapOutput_minSizeForBroadcast', 'StringSourceType')
152c215,216
< ('spark_shuffle_memoryFraction', 'Float')
---
> ('spark_shuffle_readHostLocalDisk', 'StringSourceType')
> ('spark_shuffle_reduceLocality_enabled', 'StringSourceType')
154a219,220
> ('spark_shuffle_service_db_backend', 'StringSourceType')
> ('spark_shuffle_service_db_enabled', 'StringSourceType')
155a222
> ('spark_shuffle_service_fetch_rdd_enabled', 'StringSourceType')
156a224
> ('spark_shuffle_service_name', 'StringSourceType')
157a226
> ('spark_shuffle_service_removeShuffle', 'StringSourceType')
158a228
> ('spark_shuffle_sort_io_plugin_class', 'StringSourceType')
159a230,235
> ('spark_shuffle_spill_diskWriteBufferSize', 'StringSourceType')
> ('spark_shuffle_unsafe_file_output_buffer', 'StringSourceType')
> ('spark_shuffle_useOldFetchProtocol', 'StringSourceType')
> ('spark_speculation_efficiency_enabled', 'StringSourceType')
> ('spark_speculation_efficiency_longRunTaskFactor', 'StringSourceType')
> ('spark_speculation_efficiency_processRateMultiplier', 'StringSourceType')
160a237
> ('spark_speculation_minTaskRuntime', 'StringSourceType')
163a241
> ('spark_speculation_task_duration_threshold', 'StringSourceType')
164a243
> ('spark_stage_ignoreDecommissionFetchFailure', 'StringSourceType')
166c245,253
< ('spark_storage_memoryFraction', 'Float')
---
> ('spark_standalone_submit_waitAppCompletion', 'StringSourceType')
> ('spark_storage_decommission_enabled', 'StringSourceType')
> ('spark_storage_decommission_fallbackStorage_cleanUp', 'StringSourceType')
> ('spark_storage_decommission_fallbackStorage_path', 'StringSourceType')
> ('spark_storage_decommission_rddBlocks_enabled', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_enabled', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_maxDiskSize', 'StringSourceType')
> ('spark_storage_decommission_shuffleBlocks_maxThreads', 'StringSourceType')
> ('spark_storage_localDiskByExecutors_cacheSize', 'StringSourceType')
169c256
< ('spark_storage_unrollFraction', 'Float')
---
> ('spark_storage_unrollMemoryThreshold', 'StringSourceType')
175d261
< ('spark_streaming_kafka_maxRetries', 'StringSourceType')
190a277,278
> ('spark_task_resource_{resourceName}_amount', 'StringSourceType')
> ('spark_ui_custom_executor_log_url', 'StringSourceType')
194a283
> ('spark_ui_liveUpdate_minFlushPeriod', 'StringSourceType')
196a286,287
> ('spark_ui_proxyRedirectUri', 'StringSourceType')
> ('spark_ui_requestHeaderSize', 'StringSourceType')
203a295,300
> ('spark_ui_store_path', 'StringSourceType')
> ('spark_ui_timeline_executors_maximum', 'StringSourceType')
> ('spark_ui_timeline_jobs_maximum', 'StringSourceType')
> ('spark_ui_timeline_stages_maximum', 'StringSourceType')
> ('spark_ui_timeline_tasks_maximum', 'StringSourceType')
> ('spark_ui_timelineEnabled', 'StringSourceType')
```

## Changelog

[dagster-aws][dagster-spark] Updated Spark configuration to the latest version (3.5.5). If necessary, consider pinning your `dagster-aws` and/or `dagster-spark` version while you migrate config. Please see the full list of changed fields below.

```diff
2,11c2,4
< spark.blacklist.application.fetchFailure.enabled
< spark.blacklist.application.maxFailedExecutorsPerNode
< spark.blacklist.application.maxFailedTasksPerExecutor
< spark.blacklist.enabled
< spark.blacklist.killBlacklistedExecutors
< spark.blacklist.stage.maxFailedExecutorsPerNode
< spark.blacklist.stage.maxFailedTasksPerExecutor
< spark.blacklist.task.maxTaskAttemptsPerExecutor
< spark.blacklist.task.maxTaskAttemptsPerNode
< spark.blacklist.timeout
---
> spark.appStatusStore.diskStoreDir
> spark.archives
> spark.barrier.sync.timeout
12a6
> spark.broadcast.UDFCompressionThreshold
15a10
> spark.checkpoint.compress
21d15
< spark.core.connection.ack.wait.timeout
22a17
> spark.decommission.enabled
29a25
> spark.driver.defaultJavaOptions
33a30,33
> spark.driver.log.allowErasureCoding
> spark.driver.log.dfsDir
> spark.driver.log.layout
> spark.driver.log.persistToDfs.enabled
36a37
> spark.driver.memoryOverheadFactor
37a39,41
> spark.driver.resource.{resourceName}.amount
> spark.driver.resource.{resourceName}.discoveryScript
> spark.driver.resource.{resourceName}.vendor
47a52,53
> spark.dynamicAllocation.shuffleTracking.enabled
> spark.dynamicAllocation.shuffleTracking.timeout
50a57
> spark.eventLog.compression.codec
52a60,62
> spark.eventLog.erasureCoding.enabled
> spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
> spark.eventLog.gcMetrics.youngGenerationGarbageCollectors
53a64
> spark.eventLog.logStageExecutorMetrics
55a67,78
> spark.eventLog.rolling.enabled
> spark.eventLog.rolling.maxFileSize
> spark.excludeOnFailure.application.fetchFailure.enabled
> spark.excludeOnFailure.application.maxFailedExecutorsPerNode
> spark.excludeOnFailure.application.maxFailedTasksPerExecutor
> spark.excludeOnFailure.enabled
> spark.excludeOnFailure.killExcludedExecutors
> spark.excludeOnFailure.stage.maxFailedExecutorsPerNode
> spark.excludeOnFailure.stage.maxFailedTasksPerExecutor
> spark.excludeOnFailure.task.maxTaskAttemptsPerExecutor
> spark.excludeOnFailure.task.maxTaskAttemptsPerNode
> spark.excludeOnFailure.timeout
56a80,83
> spark.executor.decommission.forceKillTimeout
> spark.executor.decommission.killInterval
> spark.executor.decommission.signal
> spark.executor.defaultJavaOptions
59a87
> spark.executor.failuresValidityInterval
65a94
> spark.executor.maxNumFailures
67a97,100
> spark.executor.memoryOverheadFactor
> spark.executor.metrics.fileSystemSchemes
> spark.executor.metrics.pollingInterval
> spark.executor.processTreeMetrics.enabled
68a102,104
> spark.executor.resource.{resourceName}.amount
> spark.executor.resource.{resourceName}.discoveryScript
> spark.executor.resource.{resourceName}.vendor
71a108,111
> spark.files.ignoreCorruptFiles
> spark.files.ignoreMissingFiles
> spark.files.io.connectionCreationTimeout
> spark.files.io.connectionTimeout
83a124
> spark.io.compression.zstd.bufferPool.enabled
104a146
> spark.log.level
107d148
< spark.maxRemoteBlockSizeFetchToMem
112c153,154
< spark.memory.useLegacyMode
---
> spark.network.io.preferDirectBufs
> spark.network.maxRemoteBlockSizeFetchToMem
113a156
> spark.network.timeoutInterval
128a172
> spark.redaction.string.regex
131a176
> spark.resources.discoveryPlugin
132a178,180
> spark.rpc.io.backLog
> spark.rpc.io.connectionCreationTimeout
> spark.rpc.io.connectionTimeout
135,136c183,186
< spark.rpc.numRetries
< spark.rpc.retry.wait
---
> spark.scheduler.barrier.maxConcurrentTasksCheck.interval
> spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures
> spark.scheduler.excludeOnFailure.unschedulableTaskSetTimeout
> spark.scheduler.listenerbus.eventqueue.appStatus.capacity
137a188,191
> spark.scheduler.listenerbus.eventqueue.eventLog.capacity
> spark.scheduler.listenerbus.eventqueue.executorManagement.capacity
> spark.scheduler.listenerbus.eventqueue.shared.capacity
> spark.scheduler.listenerbus.eventqueue.streams.capacity
140a195
> spark.scheduler.resource.profileMergeConflicts
144a200,201
> spark.shuffle.checksum.algorithm
> spark.shuffle.checksum.enabled
145a203,204
> spark.shuffle.detectCorrupt.root
> spark.shuffle.detectCorrupt.useExtraMemory
146a206,208
> spark.shuffle.io.backLog
> spark.shuffle.io.connectionCreationTimeout
> spark.shuffle.io.connectionTimeout
150a213
> spark.shuffle.mapOutput.minSizeForBroadcast
152c215,216
< spark.shuffle.memoryFraction
---
> spark.shuffle.readHostLocalDisk
> spark.shuffle.reduceLocality.enabled
154a219,220
> spark.shuffle.service.db.backend
> spark.shuffle.service.db.enabled
155a222
> spark.shuffle.service.fetch.rdd.enabled
156a224
> spark.shuffle.service.name
157a226
> spark.shuffle.service.removeShuffle
158a228
> spark.shuffle.sort.io.plugin.class
159a230,235
> spark.shuffle.spill.diskWriteBufferSize
> spark.shuffle.unsafe.file.output.buffer
> spark.shuffle.useOldFetchProtocol
> spark.speculation.efficiency.enabled
> spark.speculation.efficiency.longRunTaskFactor
> spark.speculation.efficiency.processRateMultiplier
160a237
> spark.speculation.minTaskRuntime
163a241
> spark.speculation.task.duration.threshold
164a243
> spark.stage.ignoreDecommissionFetchFailure
166c245,253
< spark.storage.memoryFraction
---
> spark.standalone.submit.waitAppCompletion
> spark.storage.decommission.enabled
> spark.storage.decommission.fallbackStorage.cleanUp
> spark.storage.decommission.fallbackStorage.path
> spark.storage.decommission.rddBlocks.enabled
> spark.storage.decommission.shuffleBlocks.enabled
> spark.storage.decommission.shuffleBlocks.maxDiskSize
> spark.storage.decommission.shuffleBlocks.maxThreads
> spark.storage.localDiskByExecutors.cacheSize
169c256
< spark.storage.unrollFraction
---
> spark.storage.unrollMemoryThreshold
175d261
< spark.streaming.kafka.maxRetries
190a277,278
> spark.task.resource.{resourceName}.amount
> spark.ui.custom.executor.log.url
194a283
> spark.ui.liveUpdate.minFlushPeriod
196a286,287
> spark.ui.proxyRedirectUri
> spark.ui.requestHeaderSize
203a295,300
> spark.ui.store.path
> spark.ui.timeline.executors.maximum
> spark.ui.timeline.jobs.maximum
> spark.ui.timeline.stages.maximum
> spark.ui.timeline.tasks.maximum
> spark.ui.timelineEnabled
```