### PR TITLE
[resolved] add flag to point at value in yaml error snippets

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/resolved/context.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/context.py
@@ -62,6 +62,7 @@ class ResolutionContext:
         source = self.source_position_tree.source_error(
             yaml_path=self.path,
             inline_error_message=inline_err,
+            value_error=True,
         )
         return [
             f"{source.file_name}:{source.start_line_no} - {source.location}\n{source.snippet}\n",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -26,6 +26,7 @@ DEFS_TEST_CASES = [
         validate_error_msg=msg_includes_all_of(
             "'fake' not found in scope",
             'a_string: "{{ fake.x }}"',
+            "                ^ 'fake' is undefined",
             "component.yaml:4",
             "available scope is: env, automation_condition",
         ),
@@ -36,7 +37,8 @@ DEFS_TEST_CASES = [
         should_error=True,
         validate_error_msg=msg_includes_all_of(
             "component.yaml:4",
-            "{{ error() }}",
+            'a_string: "{{ error() }}"',
+            "                ^ Exception: boom",
             'raise Exception("boom")',
             "_inner_error()",
         ),
@@ -48,6 +50,7 @@ DEFS_TEST_CASES = [
         validate_error_msg=msg_includes_all_of(
             "component.yaml:6",
             "throw: true",
+            "         ^ Exception: boom",
             'raise Exception("boom")',
             "_inner_error()",
         ),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -63,8 +63,11 @@ def error_dict_to_formatted_error(
     source = source_position_tree.source_error(
         yaml_path=yaml_path,
         inline_error_message=augment_inline_error_message(
-            last_location_part, error_details.message
+            last_location_part,
+            error_details.message,
         ),
+        # May be able to discern certain error types that at the value instead of keys
+        value_error=False,
     )
 
     fmt_filename = (


### PR DESCRIPTION
For most of the check defs errors, we know we want to point at the value in the yaml file and not they key - so add a flag that says to do that to `source_error`


## How I Tested These Changes

updated tests

```
2025-03-14 15:45:24 -0500 - dagster - ERROR - Validation failed for code location jaffle-platform:

dagster_components.resolved.context.ResolutionException: /Users/alangenfeld/playground/dg/jaffle-platform/jaffle_platform/defs/ingest_files/component.yaml:7 - attributes.replications.0.asset_attributes.metadata
     |
   5 |   - path: replication.yaml
   6 |     asset_attributes:
   7 |       metadata: "{{ barf() }}"
     |                       ^ 'barf' is undefined
     |
UndefinedError: 'barf' not found in scope, available scope is: env, automation_condition, stream_definition, spec


Stack Trace:
  [12 dagster system frames hidden, run with --verbose to see the full stack trace]
  File "/Users/alangenfeld/playground/dg/jaffle-platform/jaffle_platform/definitions.py", line 5, in <module>
    defs = build_component_defs(components_root=Path(__file__).parent / "defs")
  [25 dagster system frames hidden]

2025-03-14 15:45:24 -0500 - dagster - ERROR - Validation for 1 code locations failed.
```