### PR TITLE
[resolved] tweaks for accurate yaml pathing

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -86,8 +86,10 @@ class TranslatorResolvingInfo:
         if isinstance(self.asset_attributes, AssetAttributesModel):
             return self.asset_attributes
 
-        resolved_asset_attributes = self.resolution_context.with_scope(**context).resolve_value(
-            self.asset_attributes
+        resolved_asset_attributes = (
+            self.resolution_context.at_path("asset_attributes")
+            .with_scope(**context)
+            .resolve_value(self.asset_attributes)
         )
 
         if isinstance(resolved_asset_attributes, AssetSpec):
@@ -125,7 +127,7 @@ class TranslatorResolvingInfo:
 
         resolved_attributes = resolve_asset_attributes_to_mapping(
             model=resolved_asset_attributes,
-            context=self.resolution_context.with_scope(**context),
+            context=self.resolution_context.at_path("asset_attributes").with_scope(**context),
         )
         if "code_version" in resolved_attributes:
             resolved_attributes = {


### PR DESCRIPTION
* `at_path` in to `asset_attributes` in `resolve_translator`
* avoid using the `from_model` resolver in the default recurse case 
* `from_seq` adds index (got lost in rebases) 

## How I Tested These Changes

before
```
     |
   2 |
   3 | attributes:
   4 |   replications:
     |               ^ 'barf' is undefined
   5 |   - path: replication.yaml
   6 |     asset_attributes:
   7 |       metadata: "{{ barf() }}"
     |
```

after

```
     |
   5 |   - path: replication.yaml
   6 |     asset_attributes:
   7 |       metadata: "{{ barf() }}"
     |                       ^ 'barf' is undefined
     |
```
