### PR TITLE
[ui] Handle intermediate states after creating dynamic partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -168,7 +168,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       return mergedAssetHealth([]);
     }
     if (target.type === 'job' || assetHealthLoading) {
-      return mergedAssetHealth(assetHealth, true);
+      return mergedAssetHealth(assetHealth);
     }
     return assetHealth.find(itemWithAssetKey(target.anchorAssetKey)) || mergedAssetHealth([]);
   }, [assetHealth, assetHealthLoading, target]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/MultipartitioningSupport.test.tsx
@@ -37,6 +37,58 @@ describe('multipartitioning support', () => {
       expect(mergedRanges(KEYS, [])).toEqual([]);
     });
 
+    it('does not throw errors if ranges refer to indexes beyond the length of KEYS (dynamic partitions, partially refreshed data)', () => {
+      expect(
+        mergedRanges(KEYS, [
+          [
+            {
+              start: {idx: 0, key: 'A'},
+              end: {idx: 4, key: 'E'},
+              value: [AssetPartitionStatus.MATERIALIZED],
+            },
+            {
+              start: {idx: 6, key: 'G'},
+              end: {idx: 7, key: 'H'},
+              value: [AssetPartitionStatus.MATERIALIZED],
+            },
+          ],
+          [
+            {
+              start: {idx: 3, key: 'A'},
+              end: {idx: 10, key: 'K'}, // K does not exist in KEYS
+              value: [AssetPartitionStatus.MATERIALIZED],
+            },
+          ],
+        ]),
+      ).toEqual([
+        {
+          start: {idx: 0, key: 'A'},
+          end: {idx: 2, key: 'C'},
+          value: ['MATERIALIZED', 'MISSING'],
+        },
+        {
+          start: {idx: 3, key: 'D'},
+          end: {idx: 4, key: 'E'},
+          value: ['MATERIALIZED'],
+        },
+        {
+          start: {idx: 5, key: 'F'},
+          end: {idx: 5, key: 'F'},
+          value: ['MATERIALIZED', 'MISSING'],
+        },
+        {
+          start: {idx: 6, key: 'G'},
+          end: {idx: 7, key: 'H'},
+          value: ['MATERIALIZED'],
+        },
+        {
+          start: {idx: 8, key: 'I'},
+          end: {idx: 8, key: 'I'},
+          value: ['MATERIALIZED', 'MISSING'],
+        },
+      ]);
+    });
+
     it('makes no modifications to a single range set', () => {
       expect(mergedRanges(KEYS, [[A_I_Partial]])).toEqual([A_I_Partial]);
       expect(mergedRanges(KEYS, [[A_I]])).toEqual([A_I]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -396,6 +396,29 @@ describe('usePartitionHealthData', () => {
       // These should safely no-op
       expect(assetHealth.stateForKey(['2022-01-01'])).toEqual(MISSING);
     });
+
+    it('should return MISSING in all cases where the partition key is invalid / not present', () => {
+      const twoStatic = buildPartitionHealthData(TWO_DIMENSIONAL_ASSET_BOTH_STATIC, {
+        path: ['asset'],
+      });
+      expect(twoStatic.stateForKey(['NOPE', 'TN'])).toEqual(MISSING);
+      expect(twoStatic.stateForKeyIdx([10000, 1])).toEqual(MISSING);
+      expect(twoStatic.stateForKey(['CA', 'NOPE'])).toEqual(MISSING);
+      expect(twoStatic.stateForKeyIdx([1, 10000])).toEqual(MISSING);
+      expect(twoStatic.stateForKey(['NOPE', 'NOPE'])).toEqual(MISSING);
+      expect(twoStatic.stateForKeyIdx([10000, 10000])).toEqual(MISSING);
+
+      const twoD = buildPartitionHealthData(TWO_DIMENSIONAL_ASSET_EMPTY, {path: ['asset']});
+      expect(twoD.assetKey).toEqual({path: ['asset']});
+      expect(twoD.stateForKey(['2050-01-01', 'TN'])).toEqual(MISSING);
+      expect(twoD.stateForKeyIdx([10000, 1])).toEqual(MISSING);
+      expect(twoD.stateForKey(['2022-01-01', 'NOPE'])).toEqual(MISSING);
+      expect(twoD.stateForKeyIdx([1, 10000])).toEqual(MISSING);
+
+      const oneD = buildPartitionHealthData(ONE_DIMENSIONAL_ASSET, {path: ['asset']});
+      expect(oneD.stateForKey(['2050-01-01'])).toEqual(MISSING);
+      expect(oneD.stateForKeyIdx([10000])).toEqual(MISSING);
+    });
   });
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
@@ -49,7 +49,9 @@ export interface PartitionHealthData {
 export interface PartitionHealthDataMerged {
   dimensions: PartitionHealthDimension[];
 
+  // Slower - looks up indexes and then calls `stateForKeyIdx`
   stateForKey: (dimensionKeys: string[]) => AssetPartitionStatus[];
+
   stateForKeyIdx: (dimenstionIdxs: number[]) => AssetPartitionStatus[];
 
   rangesForSingleDimension: (
@@ -132,7 +134,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       return AssetPartitionStatus.MISSING;
     }
     if (!d0Range.subranges || dIndexes.length === 1) {
-      return d0Range.value[0]!; // 1D case
+      return d0Range.value[0] ?? AssetPartitionStatus.MISSING; // 1D case
     }
     const d1Range = d0Range.subranges.find(
       (r) => r.start.idx <= dIndexes[1]! && r.end.idx >= dIndexes[1]!,


### PR DESCRIPTION
## Summary & Motivation

After you create a dynamic partition, asset health data refreshes but some assets data may be pulled from cache while other data is fresh. This creates a scenario where your selection of assets have inconsistent number of partitions. 

We've been supporting this by sidestepping an assertion in the code. This PR goes a step further and adds code + tests to clarify the desired behavior in this case and removes the assertion. 

To test this I simulated the asset health data loading very slowly and noticed a separate bug where smashing Launch Run after creating a new dynamic partition would send `null` as the partitionName if none of the assets' health info had refreshed.  I made the code detect that this is happening and briefly disable the Launch button.  We could alternatively display a "please wait a moment" modal if the user clicks during this period, but it'd be unclear how long to wait before clicking it again.

## How I Tested These Changes

Tested with a dynamic job containing multiple assets + simulated slow asset health responses.

## Changelog

[ui] The Asset > Partitions page no longer displays an error in some cases when creating dynamic partitions.
[ui] The Launch and Report Events buttons no longer error if you click it immediately after creating a new dynamic partition.