### PR TITLE
Add tips for debugging performance issues with dagster jobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,40 @@
 - [bigquery-insights][bugfix] Support querying for insights from the configured `execution_project` if defined.
 - [bigquery-insights][bugfix] When `execution_project` is defined in the dbt profile, fall back to fetching the dataset from the dbt profile's `project` if the dataset cannot be found in the `execution_project`.
 
+
+
+### Performance
+
+- Added tips for debugging performance issues with Dagster jobs:
+  - **Check Executor Configuration**:
+    - The default `multiprocess_executor` spins up a process for each op, which can become a bottleneck if you have many small ops.
+    - Try using the `in_process_executor` to see if it improves performance.
+    - Example:
+      ```python
+      from dagster import job, in_process_executor
+
+      @job(executor_def=in_process_executor)
+      def my_job():
+          # your ops here
+      ```
+
+  - **Use Py-Spy**:
+    - Py-Spy is a sampling profiler for Python programs. It can help you identify slow parts of your Dagster processes.
+    - Install Py-Spy: `pip install py-spy`
+    - Run Py-Spy: `py-spy top --pid <dagster_process_pid>`
+
+  - **Database Performance**:
+    - Writing to SQLite can be a bottleneck. Consider using PostgreSQL for better performance.
+    - Update your Dagster configuration to use PostgreSQL and compare the performance.
+
+  - **Profiling and Logging**:
+    - Enable detailed logging to identify slow operations.
+    - Use Python's built-in profiling tools to gather more insights.
+
+  For more detailed information, refer to the [Dagster documentation](https://docs.dagster.io/).
+
+
+
 ## 1.10.1 (core) / 0.26.1 (libraries)
 
 ### Bugfixes


### PR DESCRIPTION
## Summary & Motivation

Add tips for debugging performance issues with dagster jobs - issue #5433

Conversation excerpt:

U01DKNMKVJQ: *Improve performance of jobs*
Hello,
I wonder how we can improve jobs performance ? I experience big delay between each ops (10s in local dev mode with SQLite and with UI).

I also see difference of 5s duration for 30s jobs between UI and CLI.

How do I know where dagster spend most of the time ? I will share further information when I am permitted to do so.
U016C4E5CP8: Hi Thomas - the first thing I would check here is whether there's a notable difference if the run is using the multiprocess_executor (which I believe is the default) and the in_process_executor  - the former spins up a process for each op, so if you have a lot of small ops the process spinup time can become a bottleneck (10 seconds seems like a long time though)

You can swap out the executors by changing the executor_def property on your job: <https://docs.dagster.io/_apidocs/jobs#jobs>

I've also had some luck using pyspy to see what dagster processes are up to and what the slowest parts are: <https://github.com/benfred/py-spy>
U016C4E5CP8: It's also possible that writing to sqlite is the bottleneck here - you could try running against a postgres DB to see if that speeds things up (in the past when people have reported long delays between ops we were able to trace it back to writing to the event log being the issue)
U016C4E5CP8: <@U018K0G2Y85> docs Add tips for debugging performance issues with dagster jobs

 

## How I Tested These Changes

To run the Dagster documentation website locally, run the following commands:
cd docs
yarn install && yarn start

## Changelog

Author: Johnny Santamaria <johnnysantamaria603@gmail.com>
Date:   Fri Mar 14 21:59:44 2025 +0000

    Add tips for debugging performance issues with dagster jobs
