### PR TITLE
[dg] RFC: Scaffold Pythonic Components

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
@@ -11,7 +11,7 @@ from dagster_components import (
     ComponentLoadContext,
     Scaffolder,
     ScaffoldRequest,
-    scaffold_component_yaml,
+    scaffold_component_decl,
 )
 from dagster_components.resolved.core_models import ResolvedAssetSpec
 from dagster_components.resolved.model import ResolvableModel, ResolvedFrom
@@ -25,7 +25,7 @@ class ShellCommandScaffolder(Scaffolder):
     """Scaffolds a template shell script alongside a filled-out component YAML file."""
 
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None:
-        scaffold_component_yaml(
+        scaffold_component_decl(
             request,
             {
                 "script_path": "script.sh",

--- a/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.component_scaffolding import scaffold_component_yaml
+from dagster_components.component_scaffolding import scaffold_component_decl
 from dagster_components.scaffold import Scaffolder, ScaffoldRequest, scaffold_with
 from pydantic import BaseModel
 
@@ -24,7 +24,7 @@ class SimplePipesScriptScaffolder(Scaffolder):
         return SimplePipesScriptScaffoldParams
 
     def scaffold(self, request: ScaffoldRequest, params: SimplePipesScriptScaffoldParams) -> None:
-        scaffold_component_yaml(request, params.model_dump())
+        scaffold_component_decl(request, params.model_dump())
         Path(request.target_path, params.filename).write_text(
             _SCRIPT_TEMPLATE.format(asset_key=params.asset_key)
         )

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -1,5 +1,5 @@
 from dagster_components.component_scaffolding import (
-    scaffold_component_yaml as scaffold_component_yaml,
+    scaffold_component_decl as scaffold_component_decl,
 )
 from dagster_components.core.component import (
     Component as Component,

--- a/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
+++ b/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
@@ -1,12 +1,18 @@
 from collections.abc import Mapping
 from pathlib import Path
+from pprint import pformat
 from typing import Any, Optional
 
 import click
 import yaml
 
 from dagster_components.core.component import Component
-from dagster_components.scaffold import ScaffolderUnavailableReason, ScaffoldRequest, get_scaffolder
+from dagster_components.scaffold import (
+    DeclFormatOptions,
+    ScaffolderUnavailableReason,
+    ScaffoldRequest,
+    get_scaffolder,
+)
 
 
 class ComponentDumper(yaml.Dumper):
@@ -17,15 +23,33 @@ class ComponentDumper(yaml.Dumper):
         super().write_line_break()
 
 
-def scaffold_component_yaml(
+def scaffold_component_decl(
     request: ScaffoldRequest, attributes: Optional[Mapping[str, Any]]
 ) -> None:
-    with open(request.target_path / "component.yaml", "w") as f:
-        component_data = {"type": request.type_name, "attributes": attributes or {}}
-        yaml.dump(
-            component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
+    if request.decl_format == "yaml":
+        with open(request.target_path / "component.yaml", "w") as f:
+            component_data = {"type": request.type_name, "attributes": attributes or {}}
+            yaml.dump(
+                component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
+            )
+            f.writelines([""])
+
+    elif request.decl_format == "python":
+        class_name = request.type_name.split(".")[-1]  # get the class name only
+        package_name = ".".join(request.type_name.split(".")[:-1])  # package name
+        with open(request.target_path / "component.py", "w") as f:
+            f.write(f"""from dagster_components import component, ComponentLoadContext
+from {package_name} import {class_name}
+
+
+@component
+def load(context: ComponentLoadContext) -> {class_name}:
+    return {class_name}.from_dict(context=context, attributes={pformat(attributes or {}, indent=4)})
+""")
+    else:
+        raise Exception(
+            f"Decl format {request.decl_format} is not supported for component scaffolding."
         )
-        f.writelines([""])
 
 
 def scaffold_component_instance(
@@ -33,6 +57,7 @@ def scaffold_component_instance(
     component_type: type[Component],
     component_type_name: str,
     scaffold_params: Mapping[str, Any],
+    decl_format: DeclFormatOptions,
 ) -> None:
     from dagster_components.components.shim_components.base import ShimComponent
 
@@ -50,13 +75,15 @@ def scaffold_component_instance(
         ScaffoldRequest(
             type_name=component_type_name,
             target_path=path,
+            decl_format=decl_format,
         ),
         scaffold_params,
     )
 
     if not issubclass(component_type, ShimComponent):
         component_yaml_path = path / "component.yaml"
-        if not component_yaml_path.exists():
+        component_py_path = path / "component.py"
+        if not (component_yaml_path.exists() or component_py_path.exists()):
             raise Exception(
-                f"Currently all components require a component.yaml file. Please ensure your implementation of scaffold writes this file at {component_yaml_path}."
+                f"Currently all components require a component.yaml or a component.py file. Please ensure your implementation of scaffold writes this file at {component_yaml_path}."
             )

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/scaffolder.py
@@ -6,7 +6,7 @@ import dagster._check as check
 from dbt.cli.main import dbtRunner
 from pydantic import BaseModel, Field
 
-from dagster_components.component_scaffolding import scaffold_component_yaml
+from dagster_components.component_scaffolding import scaffold_component_decl
 from dagster_components.core.component_scaffolder import Scaffolder, ScaffoldRequest
 
 
@@ -39,4 +39,4 @@ class DbtProjectComponentScaffolder(Scaffolder):
         else:
             relative_path = None
 
-        scaffold_component_yaml(request, {"dbt": {"project_dir": relative_path}})
+        scaffold_component_decl(request, {"dbt": {"project_dir": relative_path}})

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/scaffolder.py
@@ -4,7 +4,7 @@ from typing import Optional
 from dagster._utils import pushd
 from pydantic import BaseModel
 
-from dagster_components.component_scaffolding import scaffold_component_yaml
+from dagster_components.component_scaffolding import scaffold_component_decl
 from dagster_components.core.component_scaffolder import ScaffoldRequest
 from dagster_components.scaffold import Scaffolder
 
@@ -30,7 +30,7 @@ class DefinitionsComponentScaffolder(Scaffolder):
                 else "definitions.py"
             ).touch(exist_ok=True)
 
-        scaffold_component_yaml(
+        scaffold_component_decl(
             request,
             {"definitions_path": scaffold_params.definitions_path}
             if scaffold_params.definitions_path

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/scaffolder.py
@@ -2,13 +2,13 @@ from typing import Any
 
 import yaml
 
-from dagster_components.component_scaffolding import scaffold_component_yaml
+from dagster_components.component_scaffolding import scaffold_component_decl
 from dagster_components.core.component_scaffolder import Scaffolder, ScaffoldRequest
 
 
 class SlingReplicationComponentScaffolder(Scaffolder):
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None:
-        scaffold_component_yaml(request, {"replications": [{"path": "replication.yaml"}]})
+        scaffold_component_decl(request, {"replications": [{"path": "replication.yaml"}]})
         replication_path = request.target_path / "replication.yaml"
         with open(replication_path, "w") as f:
             yaml.dump({"source": {}, "target": {}, "streams": {}}, f)

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_scaffolder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_scaffolder.py
@@ -6,6 +6,6 @@ from dagster_components.scaffold import Scaffolder, ScaffoldRequest
 class DefaultComponentScaffolder(Scaffolder):
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None:
         # This will be deleted once all components are converted to the new ComponentScaffolder API
-        from dagster_components.component_scaffolding import scaffold_component_yaml
+        from dagster_components.component_scaffolding import scaffold_component_decl
 
-        scaffold_component_yaml(request, params.model_dump() if params else {})
+        scaffold_component_decl(request, params.model_dump() if params else {})

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 from dagster import _check as check
 from dagster._record import record
 from pydantic import BaseModel
+from typing_extensions import TypeAlias
 
 # Type variable for generic class handling
 T = TypeVar("T")
@@ -67,12 +68,16 @@ class ScaffolderUnavailableReason:
     message: str
 
 
+DeclFormatOptions: TypeAlias = Literal["yaml", "python"]
+
+
 @record
 class ScaffoldRequest:
     # fully qualified class name of the decorated class
     type_name: str
     # target path for the scaffold request. Typically used to construct absolute paths
     target_path: Path
+    decl_format: DeclFormatOptions
 
 
 class Scaffolder:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
@@ -14,7 +14,7 @@ from dagster_components import (
     ResolvedFrom,
     Scaffolder,
     ScaffoldRequest,
-    scaffold_component_yaml,
+    scaffold_component_decl,
 )
 from dagster_components.resolved.core_models import ResolvedAssetSpec
 from dagster_components.scaffold import scaffold_with
@@ -34,7 +34,7 @@ class DuckDbComponentScaffolder(Scaffolder):
 
         Path(sql_file).touch()
 
-        scaffold_component_yaml(
+        scaffold_component_decl(
             request=request,
             attributes={"sql_file": sql_file, "assets": [{"key": asset_key}]},
         )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_from_dict.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_from_dict.py
@@ -1,0 +1,16 @@
+from dagster_components import Component, ResolvableModel
+from dagster_components.resolved.context import ResolutionContext
+
+
+def test_basic_from_dict() -> None:
+    class AComponent(Component, ResolvableModel):
+        a: int
+        b: str
+
+        def build_defs(self, context): ...
+
+    context = ResolutionContext.default()
+    inst = AComponent.from_dict(context=context, attributes={"a": 1, "b": "test"})
+    assert isinstance(inst, AComponent)
+    assert inst.a == 1
+    assert inst.b == "test"

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -254,6 +254,7 @@ def scaffold_component_instance(
     component_type: str,
     scaffold_params: Optional[Mapping[str, Any]],
     dg_context: "DgContext",
+    decl_format: str,
 ) -> None:
     click.echo(f"Creating a Dagster component instance folder at {path}.")
     os.makedirs(path, exist_ok=True)
@@ -263,5 +264,6 @@ def scaffold_component_instance(
         component_type,
         str(path),
         *(["--json-params", json.dumps(scaffold_params)] if scaffold_params else []),
+        *(["--format", decl_format] if decl_format else []),
     ]
     dg_context.external_components_command(scaffold_command)


### PR DESCRIPTION
## Summary & Motivation

I think we should more strongly support Pythonic component use and scaffolding can help a lot. This RFC adds a `--format` flag to `dg scaffold component` which autogenerates a `component.py` that invokes a new `from_dict` class method on the component to instantiate it.



## How I Tested These Changes

`dg scaffold component dagster_components.dagster.DefinitionsComponent component_two --format python`

Produces

![Screenshot 2025-03-15 at 6.45.00 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/8c12db1c-19d2-402f-8692-7eaf7f391080.png)

and file contents:

```python
from dagster_components import component, ComponentLoadContext
from dagster_components.dagster import DefinitionsComponent


@component
def load(context: ComponentLoadContext) -> DefinitionsComponent:
    return DefinitionsComponent.from_dict(context=context, attributes={})
```
## Changelog

> Insert changelog entry or delete this section.
