### PR TITLE
docs(metadata): update TableRecord documentation - issue #16743

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -420,7 +420,7 @@ class MetadataValue(ABC, Generic[T_Packable]):
                         metadata={
                             "errors": MetadataValue.table(
                                 records=[
-                                    TableRecord(code="invalid-data-type", row=2, col="name"),
+                                    TableRecord(data={"code": "invalid-data-type", "row": 2, "col": "name"})
                                 ],
                                 schema=TableSchema(
                                     columns=[


### PR DESCRIPTION
## Summary & Motivation
Fixes #16743

This PR updates the TableRecord documentation to reflect the current API. The existing documentation showed an outdated parameter-based constructor format which no longer works. I've updated the examples to demonstrate the correct method of creating TableRecord objects using the new data dictionary format.
The motivation for this change is to prevent user confusion and errors that arise from following outdated documentation. Issue #16743 reported that users attempting to follow the current documentation examples were encountering errors because the API has changed to require a data dictionary parameter rather than individual parameters.

## How I Tested These Changes
Environment Setup
1. Create a fork
2. Create a branch for an issue
3. Followed environment setup

To run the Dagster documentation website locally, run the following commands: (area: docs)
1. cd docs
5. yarn install && yarn start

## Changelog
Author: Johnny Santamaria <johnnysantamaria603@gmail.com>
Date:   Sat Mar 15 22:30:40 2025 +0000

    docs(metadata): update TableRecord documentation with correct input format
    
    Fix example in TableRecord documentation to use the new input format
    Replace outdated parameter-based constructor with the new data dictionary format
    
    Fixes #16743
