### PR TITLE
[dagster-components] fix how `AssetSpecModel` resolves dep asset keys

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
@@ -153,6 +153,10 @@ class AssetSpecKwargs(SharedAssetKwargs):
         AssetKey,
         Resolver.from_model(lambda context, schema: _resolve_asset_key(schema.key, context)),
     ]
+    deps: Annotated[
+        Sequence[AssetKey],
+        Resolver.from_model(lambda context, schema: [_resolve_asset_key(dep, context) for dep in schema.deps])
+    ]
 
 
 class AssetAttributesKwargs(SharedAssetKwargs):

--- a/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
@@ -155,7 +155,9 @@ class AssetSpecKwargs(SharedAssetKwargs):
     ]
     deps: Annotated[
         Sequence[AssetKey],
-        Resolver.from_model(lambda context, schema: [_resolve_asset_key(dep, context) for dep in schema.deps])
+        Resolver.from_model(
+            lambda context, schema: [_resolve_asset_key(dep, context) for dep in schema.deps]
+        ),
     ]
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -155,7 +155,7 @@ def test_asset_spec():
 
     kitchen_sink_model = AssetSpecModel(
         key="kitchen_sink",
-        deps=["upstream"],
+        deps=["upstream","prefixed/upstream"],
         description="A kitchen sink",
         metadata={"key": "value"},
         group_name="group_name",
@@ -175,7 +175,7 @@ def test_asset_spec():
     )
 
     assert kitchen_sink_spec.key == AssetKey("kitchen_sink")
-    assert kitchen_sink_spec.deps == [AssetDep(asset="upstream")]
+    assert kitchen_sink_spec.deps == [AssetDep(asset=AssetKey(["upstream"])), AssetDep(asset=AssetKey(["prefixed", "upstream"]))]
     assert kitchen_sink_spec.description == "A kitchen sink"
     assert kitchen_sink_spec.metadata == {"key": "value"}
     assert kitchen_sink_spec.group_name == "group_name"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -155,7 +155,7 @@ def test_asset_spec():
 
     kitchen_sink_model = AssetSpecModel(
         key="kitchen_sink",
-        deps=["upstream","prefixed/upstream"],
+        deps=["upstream", "prefixed/upstream"],
         description="A kitchen sink",
         metadata={"key": "value"},
         group_name="group_name",
@@ -175,7 +175,10 @@ def test_asset_spec():
     )
 
     assert kitchen_sink_spec.key == AssetKey("kitchen_sink")
-    assert kitchen_sink_spec.deps == [AssetDep(asset=AssetKey(["upstream"])), AssetDep(asset=AssetKey(["prefixed", "upstream"]))]
+    assert kitchen_sink_spec.deps == [
+        AssetDep(asset=AssetKey(["upstream"])),
+        AssetDep(asset=AssetKey(["prefixed", "upstream"])),
+    ]
     assert kitchen_sink_spec.description == "A kitchen sink"
     assert kitchen_sink_spec.metadata == {"key": "value"}
     assert kitchen_sink_spec.group_name == "group_name"


### PR DESCRIPTION
## Summary & Motivation

Resolves #28530

## How I Tested These Changes

Unit test has been updated

## Changelog

- [dagster-components] fix how `AssetSpecModel` resolves dep asset keys
