### PR TITLE
docs: Update Sensor Documentation to Include Tag Retrieval Examples

### DIFF
--- a/docs/docs/guides/automate/sensors/index.md
+++ b/docs/docs/guides/automate/sensors/index.md
@@ -85,6 +85,30 @@ The preceding example uses both a `run_key` and a cursor, which means that if th
 If you want to be able to reset a sensor's cursor, don't set `run_key`s on `RunRequest`s.
 :::
 
+## Grabbing Tags Inside Sensors
+
+When working with sensors in Dagster, you might need to access tags from upstream job runs. For example, you can retrieve the partition key from an upstream job's tags. This can be useful for triggering downstream jobs with specific partition keys.
+
+### Example
+
+Here is an example of how to grab the partition key from an upstream job's tags inside an asset sensor:
+
+```python
+from dagster import sensor, AssetKey, RunRequest
+
+@sensor(asset_key=AssetKey("my_asset"))
+def my_asset_sensor(context, asset_event):
+    # Retrieve the partition key from the upstream job's tags
+    partition_key = asset_event.dagster_event.logging_tags.get("dagster/partition")
+    
+    if partition_key:
+        # Trigger the downstream job with the partition key
+        return RunRequest(
+            run_key=partition_key,
+            tags={"dagster/partition": partition_key},
+        )
+    return None
+
 ## Next steps
 
 By understanding and effectively using these automation methods, you can build more efficient data pipelines that respond to your specific needs and constraints.


### PR DESCRIPTION
## Summary & Motivation
This update enhances the Dagster documentation by providing clear guidance on how to retrieve tags within sensors. Previously, there was a gap in the documentation regarding this functionality, which may have led to confusion among users trying to access tags inside sensors. By adding examples and explanations, this update improves clarity and usability, ensuring that developers can effectively leverage tags for dynamic behavior in their sensor logic.

This change is particularly useful for users who need to customize sensor behavior based on metadata stored in tags, such as filtering events, triggering specific pipelines, or logging contextual information.

## How I Tested These Changes
Environment Setup

1. Create a fork
2. Create a branch for an issue
3. Followed environment setup

To run the Dagster documentation website locally, run the following commands: (area: docs)

1. cd docs
2. yarn install && yarn start

## Changelog
Author: Johnny Santamaria <johnnysantamaria603@gmail.com>
Date:   Sun Mar 16 17:45:20 2025 +0000

    docs: Update Sensor Documentation to Include Tag Retrieval Examples
    
    Added documentation and examples demonstrating how to retrieve tags inside sensors
    Addressed a gap in Dagster's documentation by clarifying tag access within sensors
    
    Fixes #7522

