### PR TITLE
Add python-liquid pin

### DIFF
--- a/python_modules/libraries/dagster-looker/setup.py
+++ b/python_modules/libraries/dagster-looker/setup.py
@@ -42,7 +42,7 @@ setup(
         # Dialect.SET_OP_DISTINCT_BY_DEFAULT was introduced in version 25.19.0:
         # https://github.com/tobymao/sqlglot/blob/v25.19.0/sqlglot/dialects/dialect.py
         "sqlglot>=25.19.0",
-        "python-liquid",
+        "python-liquid<2",
         "cattrs<23.2",  # https://github.com/looker-open-source/sdk-codegen/issues/1410
     ],
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

2.0 release appears to have broken this import;

```
from liquid.builtin.literal import LiteralNode, Token
```

## How I Tested These Changes
BK

## Changelog
[dagster-looker] Added a `python-liquid<2.0` pin.
