### PR TITLE
[Runs][Re-execute from selected] pass legacy step selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -189,18 +189,18 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
         return Promise.resolve();
       }
 
-      const legacySelection = selection.keys.map((k) => `${k}*`).join(',');
-      const selectionAndDownstreamQuery = featureEnabled(FeatureFlag.flagSelectionSyntax)
+      const selectionForPythonFiltering = selection.keys.map((k) => `${k}*`).join(',');
+      const selectionForUIFiltering = featureEnabled(FeatureFlag.flagSelectionSyntax)
         ? selection.keys.map((k) => `name:"${k}"*`).join(' or ')
-        : legacySelection;
+        : selectionForPythonFiltering;
 
-      const selectionKeys = filterRunSelectionByQuery(graph, selectionAndDownstreamQuery).all.map(
+      const selectionKeys = filterRunSelectionByQuery(graph, selectionForUIFiltering).all.map(
         (node) => node.name,
       );
 
       await reexecuteWithSelection({
         keys: selectionKeys,
-        query: legacySelection,
+        query: selectionForPythonFiltering,
       });
     },
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -188,9 +188,11 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
         console.warn('Run execution plan must be present to launch from-selected execution');
         return Promise.resolve();
       }
+
+      const legacySelection = selection.keys.map((k) => `${k}*`).join(',');
       const selectionAndDownstreamQuery = featureEnabled(FeatureFlag.flagSelectionSyntax)
         ? selection.keys.map((k) => `name:"${k}"*`).join(' or ')
-        : selection.keys.map((k) => `${k}*`).join(',');
+        : legacySelection;
 
       const selectionKeys = filterRunSelectionByQuery(graph, selectionAndDownstreamQuery).all.map(
         (node) => node.name,
@@ -198,7 +200,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
 
       await reexecuteWithSelection({
         keys: selectionKeys,
-        query: selectionAndDownstreamQuery,
+        query: legacySelection,
       });
     },
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -191,7 +191,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
 
       const selectionForPythonFiltering = selection.keys.map((k) => `${k}*`).join(',');
       const selectionForUIFiltering = featureEnabled(FeatureFlag.flagSelectionSyntax)
-        ? selection.keys.map((k) => `name:"${k}"*`).join(' or ')
+        ? selection.keys.map((k) => `name:"${k}"+`).join(' or ')
         : selectionForPythonFiltering;
 
       const selectionKeys = filterRunSelectionByQuery(graph, selectionForUIFiltering).all.map(


### PR DESCRIPTION
## Summary & Motivation

The backend is expecting [the old step selection syntax](https://github.com/dagster-io/dagster/blob/d301505e189a1636c8675da65c0674af227c2b9e/python_modules/dagster/dagster/_core/execution/api.py#L287-L292) format [here](https://github.com/dagster-io/dagster/blob/d301505e189a1636c8675da65c0674af227c2b9e/python_modules/dagster/dagster/_core/selector/subset_selector.py#L385): 

## How I Tested These Changes

tested locally that re-execution from steps works



## Changelog

[ui] Fixed a bug where Re-execute from selected would fail to launch asset-checks.