### PR TITLE
[components] Fix code_location_target_module reading for dagster dev

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -136,7 +136,7 @@ def get_origins_from_toml(
         dg_block = data.get("tool", {}).get("dg", {}).get("project", {})
         if dg_block:
             default_module_name = f"{dg_block['root_module']}.definitions"
-            module_name = dg_block.get("code_location_load_target_module", default_module_name)
+            module_name = dg_block.get("code_location_target_module", default_module_name)
             return ModuleTarget(
                 module_name=module_name,
                 attribute=None,

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -27,7 +27,6 @@ def test_load_python_module_from_dg_toml():
                 [tool.dg.project]
                 root_module = "baaz"
                 code_location_name = "foo"
-                module_name = "baaz.definitions"
             """).strip()
         )
         f.flush()
@@ -36,12 +35,18 @@ def test_load_python_module_from_dg_toml():
         assert origins[0].loadable_target_origin.module_name == "baaz.definitions"
         assert origins[0].location_name == "foo"
 
-    origins = get_origins_from_toml(
-        file_relative_path(__file__, "single_module_with_code_location_name.toml")
-    )
-    assert len(origins) == 1
-    assert origins[0].loadable_target_origin.module_name == "baaz"
-    assert origins[0].location_name == "bar"
+    with NamedTemporaryFile("w") as f:
+        f.write(
+            textwrap.dedent("""
+                [tool.dg.project]
+                root_module = "baaz"
+                code_location_target_module = "baaz.other_definitions"
+            """).strip()
+        )
+        f.flush()
+        origins = get_origins_from_toml(f.name)
+        assert len(origins) == 1
+        assert origins[0].loadable_target_origin.module_name == "baaz.other_definitions"
 
 
 def test_load_empty_toml():


### PR DESCRIPTION
## Summary & Motivation

Fix reading and test of accessing `tool.dg.code_location_target_module` from `dagster dev`. This was looking for the wrong variable and inadequately tested.

## How I Tested These Changes

New unit test.