### PR TITLE
Allow passing in the workspace name and/or project name to 'dg init'

### DIFF
--- a/docs/docs/guides/labs/dg/multiple-projects.md
+++ b/docs/docs/guides/labs/dg/multiple-projects.md
@@ -26,11 +26,11 @@ A workspace does not define a Python environment by default. Instead, Python env
 
 ## Scaffold a new workspace and first project
 
-To scaffold a new workspace with an initial project called `project-1`, run `dg init`:
+To scaffold a new workspace with an initial project called `project-1`, run `dg init` with the `--workspace-name` option:
 
 <CliInvocationExample path="docs_beta_snippets/docs_beta_snippets/guides/dg/workspace/1-dg-init.txt" />
 
-This will create a new directory called `workspace` with a `projects` subdirectory that contains `project-1`. It will also set up a new `uv`-managed Python environment for this project. 
+This will create a new directory called `dagster-workspace` with a `projects` subdirectory that contains `project-1`. It will also set up a new `uv`-managed Python environment for this project.
 
 ### Review workspace structure
 

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/workspace/1-dg-init.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/workspace/1-dg-init.txt
@@ -1,8 +1,7 @@
-dg init
+dg init --workspace-name dagster-workspace
 
-Enter the name of your Dagster workspace [dagster-workspace]: 
 Scaffolded files for Dagster workspace at /.../dagster-workspace.
-Enter the name of your first Dagster project (or press Enter to continue without creating a project): project-1
+Enter the name of your Dagster project: project-1
 Creating a Dagster project at /.../dagster-workspace/projects/project-1.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-1.
 ...

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
@@ -32,7 +32,7 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         # Scaffold workspace
         run_command_and_snippet_output(
-            cmd='echo "\nproject-1\n" | dg init --use-editable-dagster',
+            cmd='echo "project-1\n" | dg init --use-editable-dagster --workspace-name dagster-workspace',
             snippet_path=DG_SNIPPETS_DIR / f"{get_next_snip_number()}-dg-init.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[
@@ -41,15 +41,11 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
                 (r"\nUsing[\s\S]*", "\n..."),
                 (r"\nUsing[\s\S]*", "\n..."),
                 (
-                    r"\(or press Enter to continue without creating a project\): ",
-                    "(or press Enter to continue without creating a project): project-1\n",
-                ),
-                (
-                    r"\[dagster-workspace\]: ",
-                    "[dagster-workspace]: \n",  # add newline
+                    r"of your Dagster project: ",
+                    "of your Dagster project: project-1\n",
                 ),
             ],
-            print_cmd="dg init",
+            print_cmd="dg init --workspace-name dagster-workspace",
         )
 
         # Remove files we don't want to show up in the tree

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -3,7 +3,6 @@ from typing import Final, Optional
 
 import click
 
-from dagster_dg.cli.scaffold import DEFAULT_WORKSPACE_NAME
 from dagster_dg.cli.shared_options import dg_editable_dagster_options, dg_global_options
 from dagster_dg.config import (
     DgRawWorkspaceConfig,
@@ -21,8 +20,20 @@ _DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
 @click.command(name="init", cls=DgClickCommand)
 @dg_editable_dagster_options
 @dg_global_options
+@click.option(
+    "--workspace-name",
+    type=str,
+    help="Name of the workspace folder to create.",
+)
+@click.option(
+    "--project-name",
+    type=str,
+    help="Name of an initial project folder to create. Setting to an empty string will skip project scaffolding.",
+)
 def init_command(
     use_editable_dagster: Optional[str],
+    workspace_name: Optional[str],
+    project_name: Optional[str],
     **global_options: object,
 ):
     """Initialize a new Dagster workspace and a first project within that workspace.
@@ -40,48 +51,47 @@ def init_command(
     """  # noqa: D301
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    workspace_name = click.prompt(
-        "Enter the name of your Dagster workspace",
-        type=str,
-        default=DEFAULT_WORKSPACE_NAME,
-    ).strip()
+    workspace_path = None
 
-    workspace_config = DgRawWorkspaceConfig(
-        scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
-            use_editable_dagster,
+    if workspace_name:
+        workspace_config = DgRawWorkspaceConfig(
+            scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
+                use_editable_dagster,
+            )
         )
-    )
 
-    workspace_path = scaffold_workspace(workspace_name, workspace_config)
-    workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
-        workspace_path, cli_config
-    )
+        workspace_path = scaffold_workspace(workspace_name, workspace_config)
 
-    project_name = click.prompt(
-        "Enter the name of your first Dagster project (or press Enter to continue without creating a project)",
-        type=str,
-        default="",
-        show_default=False,
-    ).strip()
-
-    if not project_name:
-        click.echo(
-            "Continuing without adding a project. You can create one later by running `dg scaffold project`."
-        )
+    if project_name is None:
+        project_name = click.prompt(
+            "Enter the name of your Dagster project",
+            type=str,
+            show_default=False,
+        ).strip()
+        assert project_name is not None, "click.prompt returned None"
     else:
-        project_path = Path(workspace_path, _DEFAULT_INIT_PROJECTS_DIR, project_name)
-        if project_path.exists():
-            exit_with_error(f"A file or directory already exists at {project_path}.")
-        workspace_dg_context = DgContext.from_file_discovery_and_command_line_config(
+        project_name = project_name.strip()
+
+    if workspace_path:
+        dg_context = DgContext.from_file_discovery_and_command_line_config(
             workspace_path, cli_config
         )
+        project_path = Path(workspace_path, _DEFAULT_INIT_PROJECTS_DIR, project_name)
 
-        scaffold_project(
-            project_path,
-            workspace_dg_context,
-            use_editable_dagster=use_editable_dagster,
-            skip_venv=False,
-            populate_cache=True,
-        )
+    else:
+        dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
 
-        click.echo("You can create additional projects later by running `dg scaffold project`.")
+        project_path = Path(Path.cwd(), project_name)
+
+    if project_path.exists():
+        exit_with_error(f"A file or directory already exists at {project_path}.")
+
+    scaffold_project(
+        project_path,
+        dg_context,
+        use_editable_dagster=use_editable_dagster,
+        skip_venv=False,
+        populate_cache=True,
+    )
+
+    click.echo("You can create additional projects later by running `dg scaffold project`.")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -81,12 +81,26 @@ def isolated_example_workspace(
         clear_module_from_cache(project_name) if project_name else nullcontext(),
     ):
         result = runner.invoke(
-            "init",
+            "scaffold",
+            "workspace",
+            "dagster-workspace",
             *(["--use-editable-dagster", dagster_git_repo_dir] if use_editable_dagster else []),
-            input=f"\n{project_name or ''}\n",
         )
         assert_runner_result(result)
         with pushd("dagster-workspace"):
+            if project_name:
+                result = runner.invoke(
+                    "scaffold",
+                    "project",
+                    "projects/" + project_name,
+                    *(
+                        ["--use-editable-dagster", dagster_git_repo_dir]
+                        if use_editable_dagster
+                        else []
+                    ),
+                )
+                assert_runner_result(result)
+
             # Create a venv capable of running dagster dev
             if create_venv:
                 subprocess.run(["uv", "venv", ".venv"], check=True)


### PR DESCRIPTION
## Summary & Motivation
Let you go through scaffolding fully via CLI. You can pass in an empty string to skip the project scaffold.

## How I Tested These Changes
BK, run same commands locally

## Changelog
[dagster-dg] The `dg init` command now accepts optional `--workspace-name` and `--project-name` options to allow scaffolding an initial workspace and project via CLI options instead of prompts.
