### PR TITLE
[dagster-dbt] Enable user-defined job name in DbtCloudWorkspace

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -51,6 +51,14 @@ class DbtCloudWorkspace(ConfigurableResource):
     environment_id: int = Field(
         description="The ID of environment to use for the dbt Cloud project used in this resource."
     )
+    adhoc_job_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The name of the ad hoc job that will be created by Dagster in your dbt Cloud workspace. "
+            "This ad hoc job is used to parse your project and materialize your dbt Cloud assets. "
+            "If not provided, this job name will be generated using your project ID and environment ID."
+        ),
+    )
     request_max_retries: int = Field(
         default=3,
         description=(
@@ -99,7 +107,7 @@ class DbtCloudWorkspace(ConfigurableResource):
             DbtCloudJob: Internal representation of the dbt Cloud job.
         """
         client = self.get_client()
-        expected_job_name = get_dagster_adhoc_job_name(
+        expected_job_name = self.adhoc_job_name or get_dagster_adhoc_job_name(
             project_id=self.project_id, environment_id=self.environment_id
         )
         jobs = [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -26,9 +26,10 @@ TEST_ENVIRONMENT_ID = 3333
 
 TEST_JOB_ID = 4444
 TEST_RUN_ID = 5555
-TEST_ADHOC_JOB_NAME = get_dagster_adhoc_job_name(
+TEST_DEFAULT_ADHOC_JOB_NAME = get_dagster_adhoc_job_name(
     project_id=TEST_PROJECT_ID, environment_id=TEST_ENVIRONMENT_ID
 )
+TEST_CUSTOM_ADHOC_JOB_NAME = "test_custom_adhoc_job_name"
 TEST_ANOTHER_JOB_NAME = "test_another_job_name"
 
 TEST_REST_API_BASE_URL = f"{TEST_ACCESS_URL}/api/v2/accounts/{TEST_ACCOUNT_ID}"
@@ -126,8 +127,18 @@ def get_sample_job_data(job_name: str) -> Mapping[str, Any]:
     }
 
 
-SAMPLE_CREATE_JOB_RESPONSE = {
-    "data": get_sample_job_data(job_name=TEST_ADHOC_JOB_NAME),
+SAMPLE_DEFAULT_CREATE_JOB_RESPONSE = {
+    "data": get_sample_job_data(job_name=TEST_DEFAULT_ADHOC_JOB_NAME),
+    "status": {
+        "code": 201,
+        "is_success": True,
+        "user_message": "string",
+        "developer_message": "string",
+    },
+}
+
+SAMPLE_CUSTOM_CREATE_JOB_RESPONSE = {
+    "data": get_sample_job_data(job_name=TEST_CUSTOM_ADHOC_JOB_NAME),
     "status": {
         "code": 201,
         "is_success": True,
@@ -335,7 +346,7 @@ def job_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
         response.add(
             method=responses.POST,
             url=f"{TEST_REST_API_BASE_URL}/jobs",
-            json=SAMPLE_CREATE_JOB_RESPONSE,
+            json=SAMPLE_DEFAULT_CREATE_JOB_RESPONSE,
             status=201,
         )
         yield response


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-947.

Users can pass a custom ad hoc job name to their DbtCloudWorkspace object instead of using the default name created by Dagster.

## How I Tested These Changes

Additional test with bk

