### PR TITLE
[dagster-dbt] Improve default ad hoc job name for DbtCloudWorkspace

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -276,3 +276,35 @@ class DbtCloudWorkspaceClient(DagsterModel):
 
     def get_run_manifest_json(self, run_id: int) -> Mapping[str, Any]:
         return self.get_run_artifact(run_id=run_id, path="manifest.json")
+
+    def get_project_details(self, project_id: int) -> Mapping[str, Any]:
+        """Retrieves the details of a given dbt Cloud Project.
+
+        Args:
+            project_id (str): The dbt Cloud Project ID. You can retrieve this value from the
+                URL of the "Explore" tab in the dbt Cloud UI.
+
+        Returns:
+            Dict[str, Any]: Parsed json data representing the API response.
+        """
+        return self._make_request(
+            method="get",
+            endpoint=f"projects/{project_id}",
+            base_url=self.api_v2_url,
+        )
+
+    def get_environment_details(self, environment_id: int) -> Mapping[str, Any]:
+        """Retrieves the details of a given dbt Cloud Environment.
+
+        Args:
+            environment_id (str): The dbt Cloud Environment ID. You can retrieve this value from the
+                URL of the given environment page the dbt Cloud UI.
+
+        Returns:
+            Dict[str, Any]: Parsed json data representing the API response.
+        """
+        return self._make_request(
+            method="get",
+            endpoint=f"environments/{environment_id}",
+            base_url=self.api_v2_url,
+        )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -118,7 +118,12 @@ class DbtCloudWorkspaceClient(DagsterModel):
         raise Failure(f"Max retries ({self.request_max_retries}) exceeded with url: {url}.")
 
     def create_job(
-        self, *, project_id: int, environment_id: int, job_name: str
+        self,
+        *,
+        project_id: int,
+        environment_id: int,
+        job_name: str,
+        description: Optional[str] = None,
     ) -> Mapping[str, Any]:
         """Creates a dbt cloud job in a dbt Cloud workspace for a given project and environment.
 
@@ -128,10 +133,14 @@ class DbtCloudWorkspaceClient(DagsterModel):
             environment_id (str): The dbt Cloud Environment ID. You can retrieve this value from the
                 URL of the given environment page the dbt Cloud UI.
             job_name (str): The name of the job to create.
+            description (Optional[str]): The description of the job to create.
+                Defaults to `A job that runs dbt models, sources, and tests.`
 
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request
         """
+        if not description:
+            description = "A job that runs dbt models, sources, and tests."
         return self._make_request(
             method="post",
             endpoint="jobs",
@@ -141,7 +150,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 "environment_id": environment_id,
                 "project_id": project_id,
                 "name": job_name,
-                "description": "A job that runs dbt models, sources, and tests.",
+                "description": description,
                 "job_type": "other",
             },
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -33,19 +33,17 @@ DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
 DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
 
 
-def clean_adhoc_job_name(name: str) -> str:
-    return re.sub(r"[^A-Z0-9]+", "_", name.upper())
-
-
 def get_dagster_adhoc_job_name(
     project_id: int,
     project_name: Optional[str],
     environment_id: int,
     environment_name: Optional[str],
 ) -> str:
-    return clean_adhoc_job_name(
+    name = (
         f"{DAGSTER_ADHOC_PREFIX}{project_name or project_id}__{environment_name or environment_id}"
     )
+    # Clean the name and convert it to uppercase
+    return re.sub(r"[^A-Z0-9]+", "_", name.upper())
 
 
 @preview

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import NamedTuple, Optional, Union
@@ -20,15 +21,31 @@ from pydantic import Field
 from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunHandler
-from dagster_dbt.cloud_v2.types import DbtCloudJob, DbtCloudWorkspaceData
+from dagster_dbt.cloud_v2.types import (
+    DbtCloudEnvironment,
+    DbtCloudJob,
+    DbtCloudProject,
+    DbtCloudWorkspaceData,
+)
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
 DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
 
 
-def get_dagster_adhoc_job_name(project_id: int, environment_id: int) -> str:
-    return f"{DAGSTER_ADHOC_PREFIX}{project_id}__{environment_id}"
+def clean_adhoc_job_name(name: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", name.upper())
+
+
+def get_dagster_adhoc_job_name(
+    project_id: int,
+    project_name: Optional[str],
+    environment_id: int,
+    environment_name: Optional[str],
+) -> str:
+    return clean_adhoc_job_name(
+        f"{DAGSTER_ADHOC_PREFIX}{project_name or project_id}__{environment_name or environment_id}"
+    )
 
 
 @preview
@@ -107,8 +124,17 @@ class DbtCloudWorkspace(ConfigurableResource):
             DbtCloudJob: Internal representation of the dbt Cloud job.
         """
         client = self.get_client()
+        project = DbtCloudProject.from_project_details(
+            project_details=client.get_project_details(project_id=self.project_id)
+        )
+        environment = DbtCloudEnvironment.from_environment_details(
+            environment_details=client.get_environment_details(environment_id=self.environment_id)
+        )
         expected_job_name = self.adhoc_job_name or get_dagster_adhoc_job_name(
-            project_id=self.project_id, environment_id=self.environment_id
+            project_id=project.id,
+            project_name=project.name,
+            environment_id=environment.id,
+            environment_name=environment.name,
         )
         jobs = [
             DbtCloudJob.from_job_details(job_details)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -149,6 +149,10 @@ class DbtCloudWorkspace(ConfigurableResource):
                 project_id=self.project_id,
                 environment_id=self.environment_id,
                 job_name=expected_job_name,
+                description=(
+                    "This job is used by Dagster to parse your dbt Cloud workspace "
+                    "and to kick off runs of dbt Cloud models."
+                ),
             )
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/types.py
@@ -9,6 +9,40 @@ from dagster._serdes import whitelist_for_serdes
 
 @preview
 @record
+class DbtCloudProject:
+    """Represents a dbt Cloud Project, based on data as returned from the API."""
+
+    id: int
+    name: Optional[str]
+
+    @classmethod
+    def from_project_details(cls, project_details: Mapping[str, Any]) -> "DbtCloudProject":
+        return cls(
+            id=project_details["id"],
+            name=project_details.get("name"),
+        )
+
+
+@preview
+@record
+class DbtCloudEnvironment:
+    """Represents a dbt Cloud Environment, based on data as returned from the API."""
+
+    id: int
+    name: Optional[str]
+
+    @classmethod
+    def from_environment_details(
+        cls, environment_details: Mapping[str, Any]
+    ) -> "DbtCloudEnvironment":
+        return cls(
+            id=environment_details["id"],
+            name=environment_details.get("name"),
+        )
+
+
+@preview
+@record
 class DbtCloudJob:
     """Represents a dbt Cloud job, based on data as returned from the API."""
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -23,11 +23,16 @@ TEST_TOKEN = "test_token"
 
 TEST_PROJECT_ID = 2222
 TEST_ENVIRONMENT_ID = 3333
+TEST_PROJECT_NAME = "test_project_name"
+TEST_ENVIRONMENT_NAME = "test_environment_name"
 
 TEST_JOB_ID = 4444
 TEST_RUN_ID = 5555
 TEST_DEFAULT_ADHOC_JOB_NAME = get_dagster_adhoc_job_name(
-    project_id=TEST_PROJECT_ID, environment_id=TEST_ENVIRONMENT_ID
+    project_id=TEST_PROJECT_ID,
+    project_name=TEST_PROJECT_NAME,
+    environment_id=TEST_ENVIRONMENT_ID,
+    environment_name=TEST_ENVIRONMENT_NAME,
 )
 TEST_CUSTOM_ADHOC_JOB_NAME = "test_custom_adhoc_job_name"
 TEST_ANOTHER_JOB_NAME = "test_another_job_name"
@@ -89,7 +94,7 @@ def get_sample_job_data(job_name: str) -> Mapping[str, Any]:
         "updated_at": "2019-08-24T14:15:22Z",
         "account": {"name": "string", "state": 1, "docs_job_id": 0, "freshness_job_id": 0},
         "project": {
-            "name": "string",
+            "name": TEST_PROJECT_NAME,
             "account_id": TEST_ACCOUNT_ID,
             "description": "string",
             "connection_id": 0,
@@ -103,7 +108,7 @@ def get_sample_job_data(job_name: str) -> Mapping[str, Any]:
         "environment": {
             "account_id": TEST_ACCOUNT_ID,
             "project_id": TEST_PROJECT_ID,
-            "name": "string",
+            "name": TEST_ENVIRONMENT_NAME,
             "connection_id": 0,
             "credentials_id": 0,
             "repository_id": 0,
@@ -141,6 +146,261 @@ SAMPLE_CUSTOM_CREATE_JOB_RESPONSE = {
     "data": get_sample_job_data(job_name=TEST_CUSTOM_ADHOC_JOB_NAME),
     "status": {
         "code": 201,
+        "is_success": True,
+        "user_message": "string",
+        "developer_message": "string",
+    },
+}
+
+
+# Taken from dbt Cloud REST API documentation
+# https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retrieve%20Project
+SAMPLE_PROJECT_RESPONSE = {
+    "data": {
+        "id": TEST_PROJECT_ID,
+        "name": TEST_PROJECT_NAME,
+        "account_id": TEST_ACCOUNT_ID,
+        "description": "string",
+        "connection_id": 0,
+        "repository_id": 0,
+        "semantic_layer_config_id": 0,
+        "state": 1,
+        "dbt_project_subdirectory": "string",
+        "docs_job_id": 0,
+        "freshness_job_id": 0,
+        "created_at": "2019-08-24T14:15:22Z",
+        "updated_at": "2019-08-24T14:15:22Z",
+        "connection": {
+            "account_id": 0,
+            "project_id": 0,
+            "name": "string",
+            "type": "postgres",
+            "adapter_version": "apache_spark_v0",
+            "created_by_id": 0,
+            "created_by_service_token_id": 0,
+            "state": 1,
+            "private_link_endpoint_id": "string",
+            "oauth_configuration_id": 0,
+        },
+        "environments": [
+            {
+                "account_id": 0,
+                "project_id": 0,
+                "credentials_id": 0,
+                "connection_id": 0,
+                "extended_attributes_id": 0,
+                "name": "string",
+                "dbt_version": "string",
+                "type": "development",
+                "use_custom_branch": True,
+                "custom_branch": "string",
+                "supports_docs": True,
+                "deployment_type": "production",
+                "enable_model_query_history": False,
+                "state": 1,
+            }
+        ],
+        "repository": {
+            "account_id": 0,
+            "project_id": 0,
+            "full_name": "string",
+            "remote_backend": "azure_active_directory",
+            "git_clone_strategy": "azure_active_directory_app",
+            "deploy_key_id": 0,
+            "repository_credentials_id": 0,
+            "github_installation_id": 0,
+            "github_webhook_id": 0,
+            "state": 1,
+            "private_link_endpoint_id": "string",
+            "git_provider_id": 0,
+        },
+        "group_permissions": [
+            {
+                "account_id": 0,
+                "group_id": 0,
+                "project_id": 0,
+                "all_projects": True,
+                "permission_set": "owner",
+                "permission_level": 0,
+                "state": 1,
+                "writable_environment_categories": ["string"],
+            }
+        ],
+        "docs_job": {
+            "environment_id": 0,
+            "account_id": 0,
+            "project_id": 0,
+            "name": "string",
+            "description": "string",
+            "generate_docs": True,
+            "run_generate_sources": True,
+            "state": 1,
+            "dbt_version": "string",
+            "triggers": {
+                "github_webhook": True,
+                "schedule": True,
+                "git_provider_webhook": True,
+                "on_merge": True,
+                "custom_branch_only": True,
+            },
+            "settings": {"threads": 0, "target_name": "string"},
+            "execution": {"timeout_seconds": 0},
+            "schedule": {"cron": "string", "date": "every_day", "time": "every_hour"},
+            "execute_steps": ["string"],
+            "job_type": "ci",
+            "triggers_on_draft_pr": False,
+            "run_compare_changes": False,
+            "compare_changes_flags": "--select state:modified",
+            "run_lint": False,
+            "errors_on_lint_failure": True,
+            "deferring_environment_id": 0,
+            "deferring_job_definition_id": 0,
+        },
+        "freshness_job": {
+            "environment_id": 0,
+            "account_id": 0,
+            "project_id": 0,
+            "name": "string",
+            "description": "string",
+            "generate_docs": True,
+            "run_generate_sources": True,
+            "state": 1,
+            "dbt_version": "string",
+            "triggers": {
+                "github_webhook": True,
+                "schedule": True,
+                "git_provider_webhook": True,
+                "on_merge": True,
+                "custom_branch_only": True,
+            },
+            "settings": {"threads": 0, "target_name": "string"},
+            "execution": {"timeout_seconds": 0},
+            "schedule": {"cron": "string", "date": "every_day", "time": "every_hour"},
+            "execute_steps": ["string"],
+            "job_type": "ci",
+            "triggers_on_draft_pr": False,
+            "run_compare_changes": False,
+            "compare_changes_flags": "--select state:modified",
+            "run_lint": False,
+            "errors_on_lint_failure": True,
+            "deferring_environment_id": 0,
+            "deferring_job_definition_id": 0,
+        },
+    },
+    "status": {
+        "code": 200,
+        "is_success": True,
+        "user_message": "string",
+        "developer_message": "string",
+    },
+}
+
+# Taken from dbt Cloud REST API documentation
+# https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retrieve%20Environment
+SAMPLE_ENVIRONMENT_RESPONSE = {
+    "data": {
+        "id": TEST_ENVIRONMENT_ID,
+        "account_id": TEST_ACCOUNT_ID,
+        "project_id": TEST_PROJECT_ID,
+        "name": TEST_ENVIRONMENT_NAME,
+        "connection_id": 0,
+        "credentials_id": 0,
+        "repository_id": 0,
+        "extended_attributes_id": 0,
+        "custom_branch": "string",
+        "use_custom_branch": False,
+        "dbt_project_subdirectory": "string",
+        "dbt_version": "string",
+        "raw_dbt_version": "string",
+        "supports_docs": False,
+        "deployment_type": "production",
+        "type": "development",
+        "created_by_id": 0,
+        "state": 1,
+        "created_at": "2019-08-24T14:15:22Z",
+        "updated_at": "2019-08-24T14:15:22Z",
+        "repository": {
+            "account_id": 0,
+            "project_id": 0,
+            "full_name": "string",
+            "remote_backend": "azure_active_directory",
+            "git_clone_strategy": "azure_active_directory_app",
+            "deploy_key_id": 0,
+            "repository_credentials_id": 0,
+            "github_installation_id": 0,
+            "github_webhook_id": 0,
+            "state": 1,
+            "git_provider_id": 0,
+            "private_link_endpoint_id": "string",
+        },
+        "connection": {
+            "id": 0,
+            "account_id": 0,
+            "dbt_project_id": 0,
+            "name": "string",
+            "type": "postgres",
+            "state": 1,
+            "created_by_id": 0,
+            "created_by_service_token_id": 0,
+            "hostname": "string",
+            "dbname": "string",
+            "port": 0,
+            "tunnel_enabled": True,
+        },
+        "jobs": [
+            {
+                "account_id": 0,
+                "project_id": 0,
+                "environment_id": 0,
+                "name": "string",
+                "dbt_version": "string",
+                "deferring_environment_id": 0,
+                "deferring_job_definition_id": 0,
+                "description": "",
+                "execute_steps": ["string"],
+                "execution": {"timeout_seconds": 0},
+                "generate_docs": True,
+                "job_type": "ci",
+                "lifecycle_webhooks": True,
+                "run_compare_changes": True,
+                "compare_changes_flags": "--select state:modified",
+                "run_generate_sources": True,
+                "run_lint": True,
+                "errors_on_lint_failure": True,
+                "settings": {"threads": 0, "target_name": "string"},
+                "state": 1,
+                "triggers_on_draft_pr": False,
+                "triggers": {
+                    "github_webhook": True,
+                    "schedule": True,
+                    "git_provider_webhook": True,
+                    "on_merge": True,
+                    "custom_branch_only": True,
+                },
+                "schedule": {
+                    "date": {"type": "every_day", "days": [0], "cron": "string"},
+                    "time": {"type": "every_hour", "hours": [0], "interval": 1},
+                    "cron": "string",
+                },
+                "generate_sources": False,
+            }
+        ],
+        "custom_environment_variables": [
+            {
+                "account_id": 0,
+                "project_id": 0,
+                "name": "string",
+                "type": "project",
+                "user_id": 0,
+                "environment_id": 0,
+                "job_definition_id": 0,
+                "display_value": "string",
+                "state": 1,
+            }
+        ],
+    },
+    "status": {
+        "code": 200,
         "is_success": True,
         "user_message": "string",
         "developer_message": "string",
@@ -348,6 +608,18 @@ def job_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
             url=f"{TEST_REST_API_BASE_URL}/jobs",
             json=SAMPLE_DEFAULT_CREATE_JOB_RESPONSE,
             status=201,
+        )
+        response.add(
+            method=responses.GET,
+            url=f"{TEST_REST_API_BASE_URL}/projects/{TEST_PROJECT_ID}",
+            json=SAMPLE_PROJECT_RESPONSE,
+            status=200,
+        )
+        response.add(
+            method=responses.GET,
+            url=f"{TEST_REST_API_BASE_URL}/environments/{TEST_ENVIRONMENT_ID}",
+            json=SAMPLE_ENVIRONMENT_RESPONSE,
+            status=200,
         )
         yield response
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -50,8 +50,10 @@ def test_basic_resource_request(
     client.get_run_details(run_id=TEST_RUN_ID)
     client.get_run_manifest_json(run_id=TEST_RUN_ID)
     client.get_run_results_json(run_id=TEST_RUN_ID)
+    client.get_project_details(project_id=TEST_PROJECT_ID)
+    client.get_environment_details(environment_id=TEST_ENVIRONMENT_ID)
 
-    assert len(all_api_mocks.calls) == 6
+    assert len(all_api_mocks.calls) == 8
     assert_rest_api_call(call=all_api_mocks.calls[0], endpoint="jobs", method="GET")
     assert_rest_api_call(call=all_api_mocks.calls[1], endpoint="jobs", method="POST")
     assert_rest_api_call(
@@ -68,6 +70,12 @@ def test_basic_resource_request(
         endpoint=f"runs/{TEST_RUN_ID}/artifacts/run_results.json",
         method="GET",
     )
+    assert_rest_api_call(
+        call=all_api_mocks.calls[6], endpoint=f"projects/{TEST_PROJECT_ID}", method="GET"
+    )
+    assert_rest_api_call(
+        call=all_api_mocks.calls[7], endpoint=f"environments/{TEST_ENVIRONMENT_ID}", method="GET"
+    )
 
 
 def test_get_or_create_dagster_adhoc_job(
@@ -77,9 +85,15 @@ def test_get_or_create_dagster_adhoc_job(
     # The expected job name is not in the initial list of jobs so a job is created
     job = workspace._get_or_create_dagster_adhoc_job()  # noqa
 
-    assert len(job_api_mocks.calls) == 2
-    assert_rest_api_call(call=job_api_mocks.calls[0], endpoint="jobs", method="GET")
-    assert_rest_api_call(call=job_api_mocks.calls[1], endpoint="jobs", method="POST")
+    assert len(job_api_mocks.calls) == 4
+    assert_rest_api_call(
+        call=job_api_mocks.calls[0], endpoint=f"projects/{TEST_PROJECT_ID}", method="GET"
+    )
+    assert_rest_api_call(
+        call=job_api_mocks.calls[1], endpoint=f"environments/{TEST_ENVIRONMENT_ID}", method="GET"
+    )
+    assert_rest_api_call(call=job_api_mocks.calls[2], endpoint="jobs", method="GET")
+    assert_rest_api_call(call=job_api_mocks.calls[3], endpoint="jobs", method="POST")
 
     assert job.id == TEST_JOB_ID
     assert job.name == TEST_DEFAULT_ADHOC_JOB_NAME
@@ -110,9 +124,15 @@ def test_custom_adhoc_job_name(
     # The expected job name is not in the initial list of jobs so a job is created
     job = workspace._get_or_create_dagster_adhoc_job()  # noqa
 
-    assert len(job_api_mocks.calls) == 2
-    assert_rest_api_call(call=job_api_mocks.calls[0], endpoint="jobs", method="GET")
-    assert_rest_api_call(call=job_api_mocks.calls[1], endpoint="jobs", method="POST")
+    assert len(job_api_mocks.calls) == 4
+    assert_rest_api_call(
+        call=job_api_mocks.calls[0], endpoint=f"projects/{TEST_PROJECT_ID}", method="GET"
+    )
+    assert_rest_api_call(
+        call=job_api_mocks.calls[1], endpoint=f"environments/{TEST_ENVIRONMENT_ID}", method="GET"
+    )
+    assert_rest_api_call(call=job_api_mocks.calls[2], endpoint="jobs", method="GET")
+    assert_rest_api_call(call=job_api_mocks.calls[3], endpoint="jobs", method="POST")
 
     assert job.id == TEST_JOB_ID
     assert job.name == TEST_CUSTOM_ADHOC_JOB_NAME


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-949.

This PR uses the project name and environment name, if available, to create the ad hoc job. We fallback to project ID and environment ID if the names are not returned in the API responses - the name field is not required in both responses.

## How I Tested These Changes

Updated tests with BK. 

Tested locally with a live instance:
<img width="504" alt="Screenshot 2025-03-17 at 6 15 18 PM" src="https://github.com/user-attachments/assets/d148f6cf-1a39-4d13-9ea7-727916130fb5" /> 

