### PR TITLE
Explicitly pass through BUILDKITE_ANALYTICS_TOKEN

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -84,6 +84,7 @@ class CommandStepBuilder:
             for env in list(os.environ.keys())
             if env.startswith("BUILDKITE") or env.startswith("CI_")
         ]
+        buildkite_envvars.append("BUILDKITE_ANALYTICS_TOKEN")
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary


### PR DESCRIPTION
I think what's happening here is that the pre-command hook is running,
but the docker command was already pre-generated in the initial generate
pipeline step.

I don't love this pattern of passing everything through - as we converge
our OSS and internal build tooling, presumably that'll end up on the
chopping block.

But for now, I'm just appending the env I expect to exist so it gets set
on the docker container.