### PR TITLE
[SelectionInput] Move `instance.setValue` into raf. 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/SyntaxUpgraderVisitor.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/SyntaxUpgraderVisitor.test.ts
@@ -9,5 +9,11 @@ describe('upgradeSyntax', () => {
     expect(upgradeSyntax('value1 value2', 'key')).toBe('key:"*value1*"  or key:"*value2*"');
     expect(upgradeSyntax('value1 or value2', 'key')).toBe('key:"*value1*" or key:"*value2*"');
     expect(upgradeSyntax('value1, value2', 'key')).toBe('key:"*value1*" or key:"*value2*"');
+    expect(upgradeSyntax('key:value1 or key:value2  value2', 'key')).toBe(
+      'key:value1 or key:value2   or key:"*value2*"',
+    );
+    expect(upgradeSyntax('value1 value2 key:value3', 'key')).toBe(
+      'key:"*value1*"  or key:"*value2*"  or key:value3',
+    );
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInput.tsx
@@ -238,10 +238,10 @@ export const SelectionAutoCompleteInput = ({
     if (cmInstance.current && currentValue !== noNewLineValue) {
       const instance = cmInstance.current;
       const cursor = instance.getCursor();
-      instance.setValue(noNewLineValue);
-      instance.setCursor(cursor);
       setCursorPosition(cursor.ch);
       requestAnimationFrame(() => {
+        instance.setValue(noNewLineValue);
+        instance.setCursor(cursor);
         // Reset selected index on value change
         setSelectedIndex({current: -1});
       });


### PR DESCRIPTION
## Summary & Motivation
Theres a Heisenberg visual glitch if you try to set the value of the codemirror instance in a layout effect. Since it's inconsistent I suspect it's be a timing issue with their own internal layout effects so moving the `setValue` call to a rAF which seems to consistently upgrade the syntax visually.
