### PR TITLE
Inject env vars in dagster-components list definitions

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/list.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/list.py
@@ -1,8 +1,8 @@
 import json
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import click
-from dagster._cli.utils import assert_no_remaining_opts
+from dagster._cli.utils import assert_no_remaining_opts, get_possibly_temporary_instance_for_cli
 from dagster._cli.workspace.cli_target import (
     PythonPointerOpts,
     get_repository_python_origin_from_cli_opts,
@@ -79,54 +79,66 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
 
 @list_cli.command(name="definitions")
 @python_pointer_options
+@click.option(
+    "--location", "-l", help="Name of the code location, can be used to scope environment variables"
+)
 @click.pass_context
-def list_definitions_command(ctx: click.Context, **other_opts: object) -> None:
+def list_definitions_command(
+    ctx: click.Context, location: Optional[str], **other_opts: object
+) -> None:
     """List Dagster definitions."""
     python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
     assert_no_remaining_opts(other_opts)
 
-    repository_origin = get_repository_python_origin_from_cli_opts(python_pointer_opts)
-    recon_repo = recon_repository_from_origin(repository_origin)
-    repo_def = recon_repo.get_definition()
+    with get_possibly_temporary_instance_for_cli(
+        "``dagster-components definitions list``"
+    ) as instance:
+        instance.inject_env_vars(location)
 
-    all_defs: list[DgDefinitionMetadata] = []
+        repository_origin = get_repository_python_origin_from_cli_opts(python_pointer_opts)
+        recon_repo = recon_repository_from_origin(repository_origin)
+        repo_def = recon_repo.get_definition()
 
-    asset_graph = repo_def.asset_graph
-    for key in sorted(list(asset_graph.get_all_asset_keys()), key=lambda key: key.to_user_string()):
-        node = asset_graph.get(key)
-        all_defs.append(
-            DgAssetMetadata(
-                type="asset",
-                key=key.to_user_string(),
-                deps=sorted([k.to_user_string() for k in node.parent_keys]),
-                group=node.group_name,
-                kinds=sorted(list(node.kinds)),
-                description=node.description,
-                automation_condition=node.automation_condition.__name__
-                if node.automation_condition
-                else None,
+        all_defs: list[DgDefinitionMetadata] = []
+
+        asset_graph = repo_def.asset_graph
+        for key in sorted(
+            list(asset_graph.get_all_asset_keys()), key=lambda key: key.to_user_string()
+        ):
+            node = asset_graph.get(key)
+            all_defs.append(
+                DgAssetMetadata(
+                    type="asset",
+                    key=key.to_user_string(),
+                    deps=sorted([k.to_user_string() for k in node.parent_keys]),
+                    group=node.group_name,
+                    kinds=sorted(list(node.kinds)),
+                    description=node.description,
+                    automation_condition=node.automation_condition.__name__
+                    if node.automation_condition
+                    else None,
+                )
             )
-        )
-    for job in repo_def.get_all_jobs():
-        if not is_reserved_asset_job_name(job.name):
-            all_defs.append(DgJobMetadata(type="job", name=job.name))
-    for schedule in repo_def.schedule_defs:
-        schedule_str = (
-            schedule.cron_schedule
-            if isinstance(schedule.cron_schedule, str)
-            else ", ".join(schedule.cron_schedule)
-        )
-        all_defs.append(
-            DgScheduleMetadata(
-                type="schedule",
-                name=schedule.name,
-                cron_schedule=schedule_str,
+        for job in repo_def.get_all_jobs():
+            if not is_reserved_asset_job_name(job.name):
+                all_defs.append(DgJobMetadata(type="job", name=job.name))
+        for schedule in repo_def.schedule_defs:
+            schedule_str = (
+                schedule.cron_schedule
+                if isinstance(schedule.cron_schedule, str)
+                else ", ".join(schedule.cron_schedule)
             )
-        )
-    for sensor in repo_def.sensor_defs:
-        all_defs.append(DgSensorMetadata(type="sensor", name=sensor.name))
+            all_defs.append(
+                DgScheduleMetadata(
+                    type="schedule",
+                    name=schedule.name,
+                    cron_schedule=schedule_str,
+                )
+            )
+        for sensor in repo_def.sensor_defs:
+            all_defs.append(DgSensorMetadata(type="sensor", name=sensor.name))
 
-    click.echo(json.dumps(all_defs))
+        click.echo(json.dumps(all_defs))
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -126,7 +126,16 @@ def list_defs_command(output_json: bool, **global_options: object) -> None:
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
 
     result = dg_context.external_components_command(
-        ["list", "definitions", "-m", dg_context.code_location_target_module_name]
+        [
+            "list",
+            "definitions",
+            "-m",
+            dg_context.code_location_target_module_name,
+        ],
+        # Sets the "--location" option for "dagster-components definitions list"
+        # using the click auto-envvar prefix for backwards compatibility on older versions
+        # before that option was added
+        additional_env={"DG_CLI_LIST_DEFINITIONS_LOCATION": dg_context.code_location_name},
     )
     definitions = [_resolve_definition(x) for x in json.loads(result)]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -83,8 +83,8 @@ def cross_platfrom_string_path(path: str):
 # uv commands should be executed in an environment with no pre-existing VIRTUAL_ENV set. If this
 # variable is set (common during development) and does not match the venv resolved by uv, it prints
 # undesireable warnings.
-def strip_activated_venv_from_env_vars() -> Mapping[str, str]:
-    return {k: v for k, v in os.environ.items() if not k == "VIRTUAL_ENV"}
+def strip_activated_venv_from_env_vars(env: Mapping[str, str]) -> Mapping[str, str]:
+    return {k: v for k, v in env.items() if not k == "VIRTUAL_ENV"}
 
 
 def discover_git_root(path: Path) -> Path:


### PR DESCRIPTION
Summary:
Make this command create an instance, which causes it to load from a local .env file.

## How I Tested These Changes
New test case

## Changelog
[dagster-dg] `dagster list defs` will now read environment variables from a local .env file if present when constructing the definitions.

