### PR TITLE
AssetMaterializationFailure class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -357,6 +357,7 @@ class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
             metadata=metadata,
             partition=self.partition,
             tags=self.tags,
+            reason=self.reason,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -40,6 +40,7 @@ from dagster._core.definitions.metadata import (
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.utils import DEFAULT_OUTPUT, check_valid_name
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, REPORTING_USER_TAG
+from dagster._record import IHaveNew, record_custom
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
 
@@ -246,6 +247,116 @@ class DynamicOutput(Generic[T]):
             and self.output_name == other.output_name
             and self.mapping_key == other.mapping_key
             and self.metadata == other.metadata
+        )
+
+
+@whitelist_for_serdes
+class AssetFailedToMaterializeReason(Enum):
+    COMPUTE_FAILED = "COMPUTE_FAILED"  # The step to compute the asset failed
+    UPSTREAM_COMPUTE_FAILED = (
+        "UPSTREAM_COMPUTE_FAILED"  # An upstream step failed, so the step for the asset was not run
+    )
+    SKIPPED_OPTIONAL = "SKIPPED_OPTIONAL"  # The asset is optional and was not materialized
+    UPSTREAM_SKIPPED = "UPSTREAM_SKIPPED"  # An upstream asset is optional and was not materialized, so the step for the asset was not run
+    USER_TERMINATION = "USER_TERMINATION"  # A user took an action to terminate the run
+    UNEXPECTED_TERMINATION = (
+        "UNEXPECTED_TERMINATION"  # An external event resulted in the run being terminated
+    )
+    UNKNOWN = "UNKNOWN"
+
+
+# The asset can fail to materialize in two ways, an unexpected/unintentional failure that should update
+# the global state of the asset to failed, and one that indicates that the asset not materializing
+# is expected (like an optional asset, user canceled the run)
+MATERIALIZATION_ATTEMPT_FAILED_TYPES = [
+    AssetFailedToMaterializeReason.COMPUTE_FAILED,
+    AssetFailedToMaterializeReason.UPSTREAM_COMPUTE_FAILED,
+    AssetFailedToMaterializeReason.UNEXPECTED_TERMINATION,
+    AssetFailedToMaterializeReason.UNKNOWN,
+]
+
+MATERIALIZATION_ATTEMPT_SKIPPED_TYPES = [
+    AssetFailedToMaterializeReason.SKIPPED_OPTIONAL,
+    AssetFailedToMaterializeReason.UPSTREAM_SKIPPED,
+    AssetFailedToMaterializeReason.USER_TERMINATION,
+]
+
+
+@whitelist_for_serdes(
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
+)
+@record_custom
+class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
+    asset_key: AssetKey
+    description: Optional[str]
+    metadata: Mapping[str, MetadataValue]
+    partition: Optional[str]
+    tags: Mapping[str, str]
+    reason: AssetFailedToMaterializeReason
+
+    """Event that indicates that an asset failed to materialize.
+
+    Args:
+        asset_key (Union[str, List[str], AssetKey]): A key to identify the asset.
+        partition (Optional[str]): The name of a partition of the asset.
+        tags (Optional[Mapping[str, str]]): A mapping containing tags for the failure event.
+        metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
+            Arbitrary metadata about the asset.  Keys are displayed string labels, and values are
+            one of the following: string, float, int, JSON-serializable dict, JSON-serializable
+            list, and one of the data classes returned by a MetadataValue static method.
+    """
+
+    def __new__(
+        cls,
+        asset_key: CoercibleToAssetKey,
+        reason: AssetFailedToMaterializeReason,
+        description: Optional[str] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        partition: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
+    ):
+        if isinstance(asset_key, AssetKey):
+            check.inst_param(asset_key, "asset_key", AssetKey)
+        elif isinstance(asset_key, str):
+            asset_key = AssetKey(parse_asset_key_string(asset_key))
+        else:
+            check.sequence_param(asset_key, "asset_key", of_type=str)
+            asset_key = AssetKey(asset_key)
+
+        validate_asset_event_tags(tags)
+
+        normed_metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
+
+        return super().__new__(
+            cls,
+            asset_key=asset_key,
+            description=description,
+            metadata=normed_metadata,
+            tags=tags or {},
+            partition=partition,
+            reason=reason,
+        )
+
+    @property
+    def label(self) -> str:
+        return " ".join(self.asset_key.path)
+
+    @property
+    def data_version(self) -> Optional[str]:
+        return self.tags.get(DATA_VERSION_TAG)
+
+    def with_metadata(
+        self, metadata: Optional[Mapping[str, RawMetadataValue]]
+    ) -> "AssetFailedToMaterialize":
+        return AssetFailedToMaterialize(
+            asset_key=self.asset_key,
+            description=self.description,
+            metadata=metadata,
+            partition=self.partition,
+            tags=self.tags,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -251,7 +251,7 @@ class DynamicOutput(Generic[T]):
 
 
 @whitelist_for_serdes
-class AssetFailedToMaterializeReason(Enum):
+class AssetMaterializationFailureReason(Enum):
     COMPUTE_FAILED = "COMPUTE_FAILED"  # The step to compute the asset failed
     UPSTREAM_COMPUTE_FAILED = (
         "UPSTREAM_COMPUTE_FAILED"  # An upstream step failed, so the step for the asset was not run
@@ -269,16 +269,16 @@ class AssetFailedToMaterializeReason(Enum):
 # the global state of the asset to failed, and one that indicates that the asset not materializing
 # is expected (like an optional asset, user canceled the run)
 MATERIALIZATION_ATTEMPT_FAILED_TYPES = [
-    AssetFailedToMaterializeReason.COMPUTE_FAILED,
-    AssetFailedToMaterializeReason.UPSTREAM_COMPUTE_FAILED,
-    AssetFailedToMaterializeReason.UNEXPECTED_TERMINATION,
-    AssetFailedToMaterializeReason.UNKNOWN,
+    AssetMaterializationFailureReason.COMPUTE_FAILED,
+    AssetMaterializationFailureReason.UPSTREAM_COMPUTE_FAILED,
+    AssetMaterializationFailureReason.UNEXPECTED_TERMINATION,
+    AssetMaterializationFailureReason.UNKNOWN,
 ]
 
 MATERIALIZATION_ATTEMPT_SKIPPED_TYPES = [
-    AssetFailedToMaterializeReason.SKIPPED_OPTIONAL,
-    AssetFailedToMaterializeReason.UPSTREAM_SKIPPED,
-    AssetFailedToMaterializeReason.USER_TERMINATION,
+    AssetMaterializationFailureReason.SKIPPED_OPTIONAL,
+    AssetMaterializationFailureReason.UPSTREAM_SKIPPED,
+    AssetMaterializationFailureReason.USER_TERMINATION,
 ]
 
 
@@ -287,13 +287,13 @@ MATERIALIZATION_ATTEMPT_SKIPPED_TYPES = [
     field_serializers={"metadata": MetadataFieldSerializer},
 )
 @record_custom
-class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
+class AssetMaterializationFailure(EventWithMetadata, IHaveNew):
     asset_key: AssetKey
     description: Optional[str]
     metadata: Mapping[str, MetadataValue]
     partition: Optional[str]
     tags: Mapping[str, str]
-    reason: AssetFailedToMaterializeReason
+    reason: AssetMaterializationFailureReason
 
     """Event that indicates that an asset failed to materialize.
 
@@ -305,14 +305,14 @@ class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
             Arbitrary metadata about the asset.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
             list, and one of the data classes returned by a MetadataValue static method.
-        reason: (AssetFailedToMaterializeReason): An enum indicating why the asset failed to
-            materialize. 
+        reason: (AssetMaterializationFailureReason): An enum indicating why the asset failed to
+            materialize.
     """
 
     def __new__(
         cls,
         asset_key: CoercibleToAssetKey,
-        reason: AssetFailedToMaterializeReason,
+        reason: AssetMaterializationFailureReason,
         description: Optional[str] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         partition: Optional[str] = None,
@@ -352,8 +352,8 @@ class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
 
     def with_metadata(
         self, metadata: Optional[Mapping[str, RawMetadataValue]]
-    ) -> "AssetFailedToMaterialize":
-        return AssetFailedToMaterialize(
+    ) -> "AssetMaterializationFailure":
+        return AssetMaterializationFailure(
             asset_key=self.asset_key,
             description=self.description,
             metadata=metadata,

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -305,6 +305,8 @@ class AssetFailedToMaterialize(EventWithMetadata, IHaveNew):
             Arbitrary metadata about the asset.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
             list, and one of the data classes returned by a MetadataValue static method.
+        reason: (AssetFailedToMaterializeReason): An enum indicating why the asset failed to
+            materialize. 
     """
 
     def __new__(

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1553,12 +1553,15 @@ class DagsterEvent(
         job_name: str,
         step_key: Optional[str],
         asset_failed_to_materialize: "AssetFailedToMaterialize",
+        error: Optional[SerializableErrorInfo] = None,
     ) -> "DagsterEvent":
         return DagsterEvent(
             event_type_value=DagsterEventType.ASSET_FAILED_TO_MATERIALIZE.value,
             job_name=job_name,
             message=f"Asset {asset_failed_to_materialize.asset_key.to_string()} failed to materialize",
-            event_specific_data=AssetFailedToMaterializeData(asset_failed_to_materialize),
+            event_specific_data=AssetFailedToMaterializeData(
+                asset_failed_to_materialize, error=error
+            ),
             step_key=step_key,
         )
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2120,6 +2120,31 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.fetch_materializations(records_filter, limit, cursor, ascending)
 
     @traced
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> "EventRecordsResult":
+        """Return a list of AssetFailedToMaterialization records stored in the event log storage.
+
+        Args:
+            records_filter (Union[AssetKey, AssetRecordsFilter]): the filter by which to
+                filter event records.
+            limit (int): Number of results to get.
+            cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            ascending (Optional[bool]): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
+
+        Returns:
+            EventRecordsResult: Object containing a list of event log records and a cursor string
+        """
+        return self._event_storage.fetch_failed_materializations(
+            records_filter, limit, cursor, ascending
+        )
+
+    @traced
     @deprecated(breaking_version="2.0")
     def fetch_planned_materializations(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -61,11 +61,12 @@ class AssetEntry(
             ("last_run_id", Optional[str]),
             ("asset_details", Optional[AssetDetails]),
             ("cached_status", Optional["AssetStatusCacheValue"]),
-            # This is an optional field which can be used for more performant last observation
+            # Below are optional fields which can be used for more performant
             # queries if the underlying storage supports it
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),
             ("last_planned_materialization_run_id", Optional[str]),
+            ("last_failed_to_materialize_record", Optional[EventLogRecord]),
         ],
     )
 ):
@@ -79,6 +80,7 @@ class AssetEntry(
         last_observation_record: Optional[EventLogRecord] = None,
         last_planned_materialization_storage_id: Optional[int] = None,
         last_planned_materialization_run_id: Optional[str] = None,
+        last_failed_to_materialize_record: Optional[EventLogRecord] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -106,6 +108,11 @@ class AssetEntry(
                 last_planned_materialization_run_id,
                 "last_planned_materialization_run_id",
             ),
+            last_failed_to_materialize_record=check.opt_inst_param(
+                last_failed_to_materialize_record,
+                "last_failed_to_materialize_record",
+                EventLogRecord,
+            ),
         )
 
     @property
@@ -125,6 +132,18 @@ class AssetEntry(
         if self.last_materialization_record is None:
             return None
         return self.last_materialization_record.storage_id
+
+    @property
+    def last_failed_to_materialize_entry(self) -> Optional["EventLogEntry"]:
+        if self.last_failed_to_materialize_record is None:
+            return None
+        return self.last_failed_to_materialize_record.event_log_entry
+
+    @property
+    def last_failed_to_materialize_storage_id(self) -> Optional[int]:
+        if self.last_failed_to_materialize_record is None:
+            return None
+        return self.last_failed_to_materialize_record.storage_id
 
 
 class AssetRecord(
@@ -625,6 +644,16 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def fetch_materializations(
+        self,
+        records_filter: Union[AssetKey, AssetRecordsFilter],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def fetch_failed_materializations(
         self,
         records_filter: Union[AssetKey, AssetRecordsFilter],
         limit: int,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -991,6 +991,15 @@ class SqlEventLogStorage(EventLogStorage):
 
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, AssetRecordsFilter],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return EventRecordsResult(records=[], cursor=cursor or "", has_more=False)
+
     def fetch_observations(
         self,
         records_filter: Union[AssetKey, AssetRecordsFilter],

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -493,6 +493,17 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             filters, limit, cursor, ascending
         )
 
+    def fetch_failed_materializations(
+        self,
+        records_filter: Union[AssetKey, "AssetRecordsFilter"],
+        limit: int,
+        cursor: Optional[str] = None,
+        ascending: bool = False,
+    ) -> EventRecordsResult:
+        return self._storage.event_log_storage.fetch_failed_materializations(
+            records_filter, limit, cursor, ascending
+        )
+
     def fetch_observations(
         self,
         filters: Union[AssetKey, "AssetRecordsFilter"],

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6603,3 +6603,80 @@ class TestEventLogStorage:
         assert limit.name == "bar"
         assert limit.limit == 1
         assert limit.from_default
+
+    def test_fetch_failed_materializations(self, test_run_id, storage: EventLogStorage):
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
+        asset_key_1 = AssetKey("asset_1")
+        asset_key_2 = AssetKey("asset_2")
+        asset_keys = [asset_key_1, asset_key_2]
+        for i in range(5):
+            for asset_key in asset_keys:
+                event_to_store = EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=test_run_id,
+                    timestamp=time.time(),
+                    dagster_event=DagsterEvent.build_asset_failed_to_materialize_event(
+                        job_name="the_job",
+                        step_key="the_step",
+                        asset_materialization_failure=AssetMaterializationFailure(
+                            asset_key=asset_key,
+                            partition=str(i),
+                            reason=AssetMaterializationFailureReason.COMPUTE_FAILED,
+                        ),
+                    ),
+                )
+                storage.store_event(event_to_store)
+
+        all_failed_records_result = storage.fetch_failed_materializations(
+            records_filter=asset_key_1, limit=10
+        )
+        if not storage.asset_records_have_last_planned_and_failed_materializations:
+            assert len(all_failed_records_result.records) == 0
+        else:
+            assert len(all_failed_records_result.records) == 5
+            assert all(
+                failed_record.asset_key == asset_key_1
+                for failed_record in all_failed_records_result.records
+            )
+            assert not all_failed_records_result.has_more
+
+            first_two_failed_records_result = storage.fetch_failed_materializations(
+                records_filter=asset_key_1, limit=2
+            )
+            assert len(first_two_failed_records_result.records) == 2
+            assert all(
+                failed_record.asset_key == asset_key_1
+                for failed_record in first_two_failed_records_result.records
+            )
+            assert first_two_failed_records_result.has_more
+            assert first_two_failed_records_result.cursor
+
+            remaining_failed_records_result = storage.fetch_failed_materializations(
+                records_filter=asset_key_1, limit=5, cursor=first_two_failed_records_result.cursor
+            )
+            assert len(remaining_failed_records_result.records) == 3
+            assert all(
+                failed_record.asset_key == asset_key_1
+                for failed_record in remaining_failed_records_result.records
+            )
+            assert not remaining_failed_records_result.has_more
+
+            assert set(
+                record.storage_id for record in first_two_failed_records_result.records
+            ) | set(record.storage_id for record in remaining_failed_records_result.records) == set(
+                record.storage_id for record in all_failed_records_result.records
+            )
+
+            failed_records_for_partitions = storage.fetch_failed_materializations(
+                records_filter=AssetRecordsFilter(
+                    asset_key=asset_key_1, asset_partitions=["1", "2"]
+                ),
+                limit=5,
+            )
+            assert len(failed_records_for_partitions.records) == 2
+            assert all(
+                failed_record.asset_key == asset_key_1
+                for failed_record in failed_records_for_partitions.records
+            )

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -62,8 +62,8 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import (
-    AssetFailedToMaterialize,
-    AssetFailedToMaterializeReason,
+    AssetMaterializationFailure,
+    AssetMaterializationFailureReason,
 )
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
@@ -3027,10 +3027,10 @@ class TestEventLogStorage:
                 DagsterEvent.build_asset_failed_to_materialize_event(
                     job_name="my_fake_job",
                     step_key=step_key,
-                    asset_failed_to_materialize=AssetFailedToMaterialize(
+                    asset_failed_to_materialize=AssetMaterializationFailure(
                         asset_key=a,
                         partition=partition,
-                        reason=AssetFailedToMaterializeReason.COMPUTE_FAILED,
+                        reason=AssetMaterializationFailureReason.COMPUTE_FAILED,
                     ),
                     error=None,
                 )

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -61,6 +61,10 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.dependency import NodeHandle
+from dagster._core.definitions.events import (
+    AssetFailedToMaterialize,
+    AssetFailedToMaterializeReason,
+)
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 from dagster._core.definitions.partition import (
@@ -77,8 +81,6 @@ from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariant
 from dagster._core.event_api import EventLogCursor, EventRecordsResult, RunStatusChangeRecordsFilter
 from dagster._core.events import (
     EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
-    AssetFailedToMaterializeData,
-    AssetFailedToMaterializeReason,
     AssetMaterializationPlannedData,
     AssetObservationData,
     DagsterEvent,
@@ -3025,12 +3027,12 @@ class TestEventLogStorage:
                 DagsterEvent.build_asset_failed_to_materialize_event(
                     job_name="my_fake_job",
                     step_key=step_key,
-                    asset_failed_to_materialize_data=AssetFailedToMaterializeData(
+                    asset_failed_to_materialize=AssetFailedToMaterialize(
                         asset_key=a,
                         partition=partition,
-                        error=None,
                         reason=AssetFailedToMaterializeReason.COMPUTE_FAILED,
                     ),
+                    error=None,
                 )
                 for partition in partitions
             ]

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3027,7 +3027,7 @@ class TestEventLogStorage:
                 DagsterEvent.build_asset_failed_to_materialize_event(
                     job_name="my_fake_job",
                     step_key=step_key,
-                    asset_failed_to_materialize=AssetMaterializationFailure(
+                    asset_materialization_failure=AssetMaterializationFailure(
                         asset_key=a,
                         partition=partition,
                         reason=AssetMaterializationFailureReason.COMPUTE_FAILED,


### PR DESCRIPTION
## Summary & Motivation
Small refactor of the `AssetFailedToMaterializeData` class to accept an `AssetMaterializationFailure` class. This class is like the `AssetMaterialization` and `AssetObservation` classes. We'll need the `AssetMaterializationFailure` class in order to report runless failed materializations (ie for airlift) and it makes some of the GQL changes in the stacked PR follow existing convention a bit better

internal pr https://github.com/dagster-io/internal/pull/14413

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
