### PR TITLE
[dg] Update newly_requested to allow invocation in deps context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -137,7 +137,7 @@ class NewlyRequestedCondition(SubsetAutomationCondition):
         return "newly_requested"
 
     def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.previous_requested_subset or context.get_empty_subset()
+        return context.get_previous_requested_subset(context.key) or context.get_empty_subset()
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
@@ -1,7 +1,18 @@
+import datetime
+
 import pytest
+from dagster import (
+    AssetKey,
+    AutomationCondition,
+    DagsterInstance,
+    DailyPartitionsDefinition,
+    Definitions,
+    asset,
+    evaluate_automation_conditions,
+)
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.operands import NewlyRequestedCondition
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from dagster_tests.declarative_automation_tests.automation_condition_tests.builtins.test_dep_condition import (
     get_hardcoded_condition,
@@ -50,3 +61,60 @@ async def test_requested_previous_tick() -> None:
     # requested two ticks ago
     state, result = await state.evaluate("A")
     assert get_result(result).true_subset.size == 0
+
+
+def test_newly_requested_any_deps_match() -> None:
+    @asset(automation_condition=AutomationCondition.cron_tick_passed("@hourly"))
+    def hourly() -> None: ...
+
+    @asset(
+        deps=[hourly],
+        partitions_def=DailyPartitionsDefinition("2024-01-01"),
+        automation_condition=AutomationCondition.in_latest_time_window()
+        & AutomationCondition.any_deps_match(
+            AutomationCondition.newly_requested() | AutomationCondition.execution_failed()
+        ),
+    )
+    def downstream() -> None: ...
+
+    current_time = datetime.datetime(2024, 8, 16, 4, 35)
+    defs = Definitions(assets=[hourly, downstream])
+    instance = DagsterInstance.ephemeral()
+
+    # hasn't passed a cron tick
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=current_time
+    )
+    assert result.total_requested == 0
+
+    # now passed a cron tick, kick off hourly
+    current_time += datetime.timedelta(minutes=30)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=current_time
+    )
+    assert result.get_num_requested(hourly.key) == 1
+    assert result.get_num_requested(downstream.key) == 0
+
+    # now hourly is newly requested, kick off downstream
+    current_time += datetime.timedelta(minutes=1)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=current_time
+    )
+    assert result.get_num_requested(hourly.key) == 0
+    assert result.get_num_requested(downstream.key) == 1
+
+    # now stop
+    current_time += datetime.timedelta(minutes=1)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=current_time
+    )
+    assert result.get_num_requested(hourly.key) == 0
+    assert result.get_num_requested(downstream.key) == 0
+
+    # next hour, kick off again
+    current_time += datetime.timedelta(hours=1)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=current_time
+    )
+    assert result.get_num_requested(hourly.key) == 1
+    assert result.get_num_requested(downstream.key) == 0


### PR DESCRIPTION
## Summary & Motivation

Previously, we used the cursor of the root context to determine if a given entity was newly requested, which doesn't work in cases where the asset key is not the same as they of the root target.

This stashes the full daemon cursor on the context and changes the previous_requested_subset from a property to a function that takes the asset key.

We still want to keep the `_cursor` around as a reference to the root target's cursor as other properties/methods use this in ways that do actually want that cursor (e.g. getting the previous max storage id for an asset).

## How I Tested These Changes

Added test failed before, succeeds now.

## Changelog

Fixed issue with `AutomationCondition.newly_requested()` which could cause it to fail when nested within `AutomationCondition.any_deps_match()` or `AutomationCondition.all_deps_match()`.
