### PR TITLE
[ruff] 0.8.4 -> 0.11.5

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -271,9 +271,9 @@ class PackageSpec:
         # If self._should_skip is not None, then the result is cached on self._skip_reason and we can return it.
         if self._should_skip is not None:
             if self._should_skip is True:
-                assert (
-                    self._skip_reason is not None
-                ), "Expected skip reason to be set if self._should_skip is True."
+                assert self._skip_reason is not None, (
+                    "Expected skip reason to be set if self._should_skip is True."
+                )
             return self._skip_reason
 
         # If the result is not cached, check for NO_SKIP signifier first, so that it always

--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -48,9 +48,9 @@ class PythonPackage:
             self.name = distribution.get_name()
         else:
             pyproject_toml = setup_path / "pyproject.toml"
-            assert (
-                pyproject_toml.exists()
-            ), f"expected pyproject.toml to exist in directory {setup_path}"
+            assert pyproject_toml.exists(), (
+                f"expected pyproject.toml to exist in directory {setup_path}"
+            )
 
             try:
                 with open(pyproject_toml, "rb") as f:

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -233,9 +233,9 @@ def library_version_from_core_version(core_version: str) -> str:
 
 def parse_package_version(version_str: str) -> packaging.version.Version:
     parsed_version = packaging.version.parse(version_str)
-    assert isinstance(
-        parsed_version, packaging.version.Version
-    ), f"Found LegacyVersion: {version_str}"
+    assert isinstance(parsed_version, packaging.version.Version), (
+        f"Found LegacyVersion: {version_str}"
+    )
     return parsed_version
 
 

--- a/.buildkite/dagster-buildkite/lints.py
+++ b/.buildkite/dagster-buildkite/lints.py
@@ -48,11 +48,13 @@ def test_no_subdirectory_pytest_ini():
             pytest_ini_file = os.path.join(root, "tox.ini")
             pytest_ini_files.append(pytest_ini_file)
 
-    assert not pytest_ini_files, f"Subdirectory pytest.ini files conflict with our root pyproject.toml settings and conftest.py discovery. Please remove: {pytest_ini_files}"
+    assert not pytest_ini_files, (
+        f"Subdirectory pytest.ini files conflict with our root pyproject.toml settings and conftest.py discovery. Please remove: {pytest_ini_files}"
+    )
 
 
 def test_no_tox_pytest_config_override(tox_config):
     if "commands" in tox_config["testenv"]:
-        assert (
-            "pyproject.toml" not in tox_config["testenv"]["commands"]
-        ), "We use a global PYTEST_CONFIG that uses the root directory's pyproject.toml. Remove any -c overrides in pytest commands in tox.ini"
+        assert "pyproject.toml" not in tox_config["testenv"]["commands"], (
+            "We use a global PYTEST_CONFIG that uses the root directory's pyproject.toml. Remove any -c overrides in pytest commands in tox.ini"
+        )

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -165,9 +165,9 @@ T_Node = TypeVar("T_Node", bound=nodes.Node)
 
 def get_child_as(node: nodes.Node, index: int, node_type: type[T_Node]) -> T_Node:
     child = node.children[index]
-    assert isinstance(
-        child, node_type
-    ), f"Docutils node not of expected type. Expected `{node_type}`, got `{type(child)}`."
+    assert isinstance(child, node_type), (
+        f"Docutils node not of expected type. Expected `{node_type}`, got `{type(child)}`."
+    )
     return child
 
 

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
@@ -40,13 +40,13 @@ def type_repr(config_type: ConfigType) -> str:
     elif config_type.kind == ConfigTypeKind.ANY:
         return "Any"
     elif config_type.kind == ConfigTypeKind.SCALAR:
-        config_type = cast(ConfigScalar, config_type)
+        config_type = cast("ConfigScalar", config_type)
         return config_type.scalar_kind.name.lower()
     elif config_type.kind == ConfigTypeKind.ENUM:
-        config_type = cast(Enum, config_type)
+        config_type = cast("Enum", config_type)
         return "Enum{" + ", ".join(str(val) for val in config_type.config_values) + "}"
     elif config_type.kind == ConfigTypeKind.ARRAY:
-        config_type = cast(Array, config_type)
+        config_type = cast("Array", config_type)
         return f"List[{type_repr(config_type.inner_type)}]"
     elif config_type.kind == ConfigTypeKind.SELECTOR:
         return "selector"
@@ -57,12 +57,12 @@ def type_repr(config_type: ConfigType) -> str:
     elif config_type.kind == ConfigTypeKind.MAP:
         return "dict"
     elif config_type.kind == ConfigTypeKind.SCALAR_UNION:
-        config_type = cast(ScalarUnion, config_type)
+        config_type = cast("ScalarUnion", config_type)
         return (
             f"Union[{type_repr(config_type.scalar_type)}, {type_repr(config_type.non_scalar_type)}]"
         )
     elif config_type.kind == ConfigTypeKind.NONEABLE:
-        config_type = cast(Noneable, config_type)
+        config_type = cast("Noneable", config_type)
         return f"Union[{type_repr(config_type.inner_type)}, None]"
     else:
         raise Exception(f"Unhandled config type {config_type}")
@@ -141,7 +141,7 @@ class ConfigurableDocumenter(DataDocumenter):
             obj = self.object
 
         obj = cast(
-            Union[ConfigurableDefinition, type[ConfigurableClass], ConfigurableResource], obj
+            "Union[ConfigurableDefinition, type[ConfigurableClass], ConfigurableResource]", obj
         )
 
         config_field = None

--- a/docs/sphinx/_ext/sphinx-click/sphinx_click/ext.py
+++ b/docs/sphinx/_ext/sphinx-click/sphinx_click/ext.py
@@ -422,7 +422,7 @@ def nested(argument: ty.Optional[str]) -> NestedT:
             % directives.format_values(values)
         )
 
-    return ty.cast(NestedT, argument)
+    return ty.cast("NestedT", argument)
 
 
 class ClickDirective(rst.Directive):

--- a/examples/airlift-migration-tutorial/tutorial_example_tests/integration_tests/utils.py
+++ b/examples/airlift-migration-tutorial/tutorial_example_tests/integration_tests/utils.py
@@ -62,7 +62,7 @@ def poll_for_materialization(
 
         mat_events = instance.get_latest_materialization_events(asset_keys=target_list)
 
-    return cast(dict[AssetKey, EventLogEntry], mat_events)
+    return cast("dict[AssetKey, EventLogEntry]", mat_events)
 
 
 def poll_for_asset_check(

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/lib.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/lib.py
@@ -77,7 +77,7 @@ def load_prices_csv(path: str) -> pd.DataFrame:
     `DATA_ROOT`.
     """
     path = normalize_path(path)
-    df = cast(pd.DataFrame, pd.read_csv(path, parse_dates=["date"]))
+    df = cast("pd.DataFrame", pd.read_csv(path, parse_dates=["date"]))
     df = df.rename(columns={"Name": "name"})
     df = df.dropna()
     return df

--- a/examples/deploy_ecs/tests/test_deploy.py
+++ b/examples/deploy_ecs/tests/test_deploy.py
@@ -124,4 +124,4 @@ def docker_compose(
 
 @pytest.mark.xfail
 def test_deploy(docker_compose, retrying_requests):
-    assert retrying_requests.get(f'http://{docker_compose["webserver"]}:3000/server_info').ok
+    assert retrying_requests.get(f"http://{docker_compose['webserver']}:3000/server_info").ok

--- a/examples/docs_projects/project_llm_fine_tune/setup.py
+++ b/examples/docs_projects/project_llm_fine_tune/setup.py
@@ -10,5 +10,5 @@ setup(
         "pandas",
         "openai",
     ],
-    extras_require={"dev": ["dagster-webserver", "pytest", "ruff==0.8.4"]},
+    extras_require={"dev": ["dagster-webserver", "pytest", "ruff==0.11.5"]},
 )

--- a/examples/docs_projects/project_prompt_eng/setup.py
+++ b/examples/docs_projects/project_prompt_eng/setup.py
@@ -9,5 +9,5 @@ setup(
         "pydantic",
         "requests",
     ],
-    extras_require={"dev": ["dagster-webserver", "pytest", "ruff==0.8.4"]},
+    extras_require={"dev": ["dagster-webserver", "pytest", "ruff==0.11.5"]},
 )

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configurable_op_asset_resource.py
@@ -9,13 +9,13 @@ class MyDatabaseConnection:
 # start_marker
 @dg.op(config_schema={"person_name": str})
 def op_using_config(context: dg.OpExecutionContext):
-    return f'hello {context.op_config["person_name"]}'
+    return f"hello {context.op_config['person_name']}"
 
 
 @dg.asset(config_schema={"person_name": str})
 def asset_using_config(context: dg.AssetExecutionContext):
     # Note how dg.asset config is accessed with context.op_execution_context.op_config
-    return f'hello {context.op_execution_context.op_config["person_name"]}'
+    return f"hello {context.op_execution_context.op_config['person_name']}"
 
 
 @dg.resource(config_schema={"url": str})

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/loading_multiple_upstream_partitions.py
@@ -27,6 +27,6 @@ result = dg.materialize(
     partition_key=start.strftime(daily_partitions.fmt),
 )
 downstream_asset_data = result.output_for_node("downstream_asset", "result")
-assert (
-    len(downstream_asset_data) == 24
-), "downstream day should map to upstream 24 hours"
+assert len(downstream_asset_data) == 24, (
+    "downstream day should map to upstream 24 hours"
+)

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
@@ -15,7 +15,7 @@ def download_cereals():
 @op
 def find_sugariest(context: OpExecutionContext, cereals):
     sorted_by_sugar = sorted(cereals, key=lambda cereal: cereal["sugars"])
-    context.log.info(f'{sorted_by_sugar[-1]["name"]} is the sugariest cereal')
+    context.log.info(f"{sorted_by_sugar[-1]['name']} is the sugariest cereal")
 
 
 @job

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types.py
@@ -36,7 +36,7 @@ def download_csv():
 @op(ins={"cereals": In(SimpleDataFrame)})
 def sort_by_calories(cereals):
     sorted_cereals = sorted(cereals, key=lambda cereal: cereal["calories"])
-    get_dagster_logger().info(f'Most caloric cereal: {sorted_cereals[-1]["name"]}')
+    get_dagster_logger().info(f"Most caloric cereal: {sorted_cereals[-1]['name']}")
 
 
 # end_custom_types_marker_1

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_2.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/testing/custom_types_2.py
@@ -35,7 +35,7 @@ def bad_download_csv():
 @op(ins={"cereals": In(SimpleDataFrame)})
 def sort_by_calories(cereals):
     sorted_cereals = sorted(cereals, key=lambda cereal: cereal["calories"])
-    get_dagster_logger().info(f'Most caloric cereal: {sorted_cereals[-1]["name"]}')
+    get_dagster_logger().info(f"Most caloric cereal: {sorted_cereals[-1]['name']}")
 
 
 @job

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/utils.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/utils.py
@@ -181,9 +181,9 @@ def _assert_matches_or_update_snippet(
         else:
             print(f"Snippet {snippet_path} passed")  # noqa: T201
 
-        assert comparison_fn(
-            contents, snippet_contents
-        ), "CLI snippets do not match.\nYou may need to run `make regenerate_cli_snippets` in the `dagster/docs` directory.\nYou may also use `make test_cli_snippets_simulate_bk` to simulate the CI environment locally."
+        assert comparison_fn(contents, snippet_contents), (
+            "CLI snippets do not match.\nYou may need to run `make regenerate_cli_snippets` in the `dagster/docs` directory.\nYou may also use `make test_cli_snippets_simulate_bk` to simulate the CI environment locally."
+        )
 
 
 def create_file(

--- a/examples/experimental/dagster-dlift/dagster_dlift/translator.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift/translator.py
@@ -103,7 +103,7 @@ class DagsterDbtCloudTranslator:
                 continue
         # Haven't actually figured out if it's possible for there to be more than one "asset-creatable" entity per test
         parent_specs = cast(
-            Sequence[AssetSpec], [self.get_spec(data) for data in associated_data_per_parent]
+            "Sequence[AssetSpec]", [self.get_spec(data) for data in associated_data_per_parent]
         )
         check.invariant(len(parent_specs) > 0, "Must have at least one parent asset for a check.")
         return AssetCheckSpec(

--- a/examples/experimental/dagster-dlift/dagster_dlift_tests/conftest.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift_tests/conftest.py
@@ -45,9 +45,9 @@ def build_expected_requests(
     }
 
 
-def jaffle_shop_contents() -> (
-    Mapping[DbtCloudContentType, Mapping[str, Optional[AbstractSet[str]]]]
-):
+def jaffle_shop_contents() -> Mapping[
+    DbtCloudContentType, Mapping[str, Optional[AbstractSet[str]]]
+]:
     return {
         DbtCloudContentType.MODEL: {
             "model.jaffle_shop.customers": {

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -575,9 +575,9 @@ def _helm_chart_helper(
                         time.sleep(5)
 
             else:
-                assert (
-                    len(pod_names) == 0
-                ), f"celery-worker pods {pod_names} exists when celery is not enabled."
+                assert len(pod_names) == 0, (
+                    f"celery-worker pods {pod_names} exists when celery is not enabled."
+                )
 
         dagster_user_deployments_values = helm_config.get("dagster-user-deployments", {})
         if (

--- a/integration_tests/test_suites/auto_materialize_perf_tests/partition_mappings_galore_perf_scenario.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/partition_mappings_galore_perf_scenario.py
@@ -77,7 +77,7 @@ defs = Definitions(assets)
 
 
 def build_run_request_for_all_partitions(asset_def: AssetsDefinition) -> RunRequest:
-    partitions_def = cast(PartitionsDefinition, asset_def.partitions_def)
+    partitions_def = cast("PartitionsDefinition", asset_def.partitions_def)
     return RunRequest(
         asset_selection=[asset_def.key],
         tags={

--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -67,7 +67,7 @@ perf_scenarios = [
         partition_keys_to_backfill=["2020-01-01", "2020-01-02"], max_execution_time_seconds=40
     ),
     all_daily_partitioned_500_assets.build_scenario(
-        partition_keys_to_backfill=[f"2020-01-{i+1:02}" for i in range(20)],
+        partition_keys_to_backfill=[f"2020-01-{i + 1:02}" for i in range(20)],
         max_execution_time_seconds=40,
     ),
     all_hourly_partitioned_100_assets.build_scenario(

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -911,7 +911,7 @@ def test_strategy(instance: DagsterInstance):
 
 def test_subset_run(instance: DagsterInstance, workspace_context):
     instance.wipe()
-    run_coordinator = cast(MockedRunCoordinator, instance.run_coordinator)
+    run_coordinator = cast("MockedRunCoordinator", instance.run_coordinator)
     run_coordinator.queue().clear()
 
     # retries failure

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -426,7 +426,8 @@ Container 'goodcontainer2' status: Terminated with exit code 0: Completed"""
                 "pullfail",
                 "missingsecret",
                 "goodpod1",
-                "goodpod2" "waitforever",
+                "goodpod2",
+                "waitforever",
                 "execformaterror",
                 "resourcelimit",
             ]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ extend-exclude = [
 line-length = 100
 
 # Fail if Ruff is not running this version.
-required-version = "0.8.4"
+required-version = "0.11.5"
 
 [tool.ruff.lint]
 

--- a/python_modules/automation/automation/graphql/python_client/utils.py
+++ b/python_modules/automation/automation/graphql/python_client/utils.py
@@ -51,4 +51,4 @@ def deserialize_from_query_filename(query_filename: str) -> tuple[str, str]:
         len(parts) == 2,
         f"Invalid query filename {query_filename}; must have 2 '-' separated parts.",
     )
-    return cast(tuple[str, str], parts)
+    return cast("tuple[str, str]", parts)

--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -194,7 +194,7 @@ class SparkConfigNode:
             assert self.value
             self.value.write(printer)
         else:
-            self.children = cast(dict[str, Union[SparkConfig, SparkConfigNode]], self.children)
+            self.children = cast("dict[str, Union[SparkConfig, SparkConfigNode]]", self.children)
             retdict: dict[str, Union[SparkConfig, SparkConfigNode]]
             if self.value:
                 retdict = {"root": self.value}

--- a/python_modules/automation/automation_tests/test_repo.py
+++ b/python_modules/automation/automation_tests/test_repo.py
@@ -37,10 +37,12 @@ def test_all_packages_have_py_typed():
                             missing_py_typed_in_manifest_in.append(str(package_root))
 
         nl = "\n"
-        assert (
-            not missing_py_typed_file
-        ), f"Missing py.typed files in these packages:\n{nl.join(missing_py_typed_file)}"
-        assert not missing_py_typed_in_manifest_in, f"Missing py.typed in MANIFEST.in for these packages:\n{nl.join(missing_py_typed_in_manifest_in)}"
+        assert not missing_py_typed_file, (
+            f"Missing py.typed files in these packages:\n{nl.join(missing_py_typed_file)}"
+        )
+        assert not missing_py_typed_in_manifest_in, (
+            f"Missing py.typed in MANIFEST.in for these packages:\n{nl.join(missing_py_typed_in_manifest_in)}"
+        )
 
 
 def _find_root_python_package(package_root: Path) -> Path:

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -10,7 +10,7 @@ passenv =
     PYTEST_PLUGINS
 install_command = uv pip install -b ../libraries/dagster-pyspark/build-constraints {opts} {packages}
 deps =
-  -e ../dagster[test]
+  -e ../dagster[test,ruff]
   -e ../dagster-pipes
   -e ../libraries/dagster-shared
   -e ../dagster-graphql

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator, Mapping, Sequence
 from math import isnan
-from typing import Any, cast, no_type_check
+from typing import TYPE_CHECKING, Any, cast, no_type_check
 
 import dagster._check as check
 import dagster_shared.seven as seven
@@ -23,7 +23,6 @@ from dagster import (
     TimestampMetadataValue,
     UrlMetadataValue,
 )
-from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluationPlanned
 from dagster._core.definitions.metadata import (
     CodeReferencesMetadataValue,
     DagsterRunMetadataValue,
@@ -38,8 +37,11 @@ from dagster._core.events import (
     StepExpectationResultData,
 )
 from dagster._core.events.log import EventLogEntry
-from dagster._core.execution.plan.inputs import StepInputData
-from dagster._core.execution.plan.outputs import StepOutputData
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluationPlanned
+    from dagster._core.execution.plan.inputs import StepInputData
+    from dagster._core.execution.plan.outputs import StepOutputData
 
 MAX_INT = 2147483647
 MIN_INT = -2147483648
@@ -286,14 +288,14 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
     elif dagster_event.event_type == DagsterEventType.STEP_SUCCESS:
         return GrapheneExecutionStepSuccessEvent(**basic_params)
     elif dagster_event.event_type == DagsterEventType.STEP_INPUT:
-        data = cast(StepInputData, dagster_event.event_specific_data)
+        data = cast("StepInputData", dagster_event.event_specific_data)
         return GrapheneExecutionStepInputEvent(
             input_name=data.input_name,
             type_check=data.type_check_data,
             **basic_params,
         )
     elif dagster_event.event_type == DagsterEventType.STEP_OUTPUT:
-        data = cast(StepOutputData, dagster_event.event_specific_data)
+        data = cast("StepOutputData", dagster_event.event_specific_data)
         return GrapheneExecutionStepOutputEvent(
             output_name=data.output_name,
             type_check=data.type_check_data,
@@ -310,7 +312,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
     elif dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED:
         return GrapheneAssetMaterializationPlannedEvent(event=event_record)
     elif dagster_event.event_type == DagsterEventType.STEP_EXPECTATION_RESULT:
-        data = cast(StepExpectationResultData, dagster_event.event_specific_data)
+        data = cast("StepExpectationResultData", dagster_event.event_specific_data)
         return GrapheneStepExpectationResultEvent(
             expectation_result=GrapheneExpectationResult(data.expectation_result), **basic_params
         )
@@ -381,7 +383,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
     elif dagster_event.event_type == DagsterEventType.ALERT_FAILURE:
         return GrapheneAlertFailureEvent(pipelineName=pipeline_name, **basic_params)
     elif dagster_event.event_type == DagsterEventType.HANDLED_OUTPUT:
-        data = cast(HandledOutputData, dagster_event.event_specific_data)
+        data = cast("HandledOutputData", dagster_event.event_specific_data)
         return GrapheneHandledOutputEvent(
             output_name=data.output_name,
             manager_key=data.manager_key,
@@ -389,7 +391,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             **basic_params,
         )
     elif dagster_event.event_type == DagsterEventType.LOADED_INPUT:
-        data = cast(LoadedInputData, dagster_event.event_specific_data)
+        data = cast("LoadedInputData", dagster_event.event_specific_data)
         return GrapheneLoadedInputEvent(
             input_name=data.input_name,
             manager_key=data.manager_key,
@@ -487,7 +489,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             **basic_params,
         )
     elif dagster_event.event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED:
-        data = cast(AssetCheckEvaluationPlanned, dagster_event.event_specific_data)
+        data = cast("AssetCheckEvaluationPlanned", dagster_event.event_specific_data)
         return GrapheneAssetCheckEvaluationPlannedEvent(
             assetKey=data.asset_key, checkName=data.check_name, **basic_params
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -59,7 +59,7 @@ def get_asset_backfill_preview(
     check.invariant(backfill_preview_params.get("partitionNames") is not None)
 
     asset_selection = [
-        cast(AssetKey, AssetKey.from_graphql_input(asset_key))
+        cast("AssetKey", AssetKey.from_graphql_input(asset_key))
         for asset_key in backfill_preview_params["assetSelection"]
     ]
     partition_names: list[str] = backfill_preview_params["partitionNames"]
@@ -105,7 +105,7 @@ def create_and_launch_partition_backfill(
 
     asset_selection = (
         [
-            cast(AssetKey, AssetKey.from_graphql_input(asset_key))
+            cast("AssetKey", AssetKey.from_graphql_input(asset_key))
             for asset_key in backfill_params["assetSelection"]
         ]
         if backfill_params.get("assetSelection")

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -111,7 +111,7 @@ def launch_reexecution_from_parent_run(
     external_pipeline = get_remote_job_or_raise(graphene_info, selector)
 
     run = instance.create_reexecuted_run(
-        parent_run=cast(DagsterRun, parent_run),
+        parent_run=cast("DagsterRun", parent_run),
         code_location=repo_location,
         remote_job=external_pipeline,
         strategy=ReexecutionStrategy(strategy),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -24,7 +24,7 @@ def _get_run(instance: DagsterInstance, run_id: str) -> DagsterRun:
     run = instance.get_run_by_id(run_id)
     if not run:
         raise DagsterRunNotFoundError(invalid_run_id=run_id)
-    return cast(DagsterRun, run)
+    return cast("DagsterRun", run)
 
 
 def compute_step_keys_to_execute(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -570,17 +570,17 @@ def build_partition_statuses(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,
                 PartitionRangeStatus.FAILED: cast(
-                    TimeWindowPartitionsSubset, failed_partitions_subset
+                    "TimeWindowPartitionsSubset", failed_partitions_subset
                 ),
                 PartitionRangeStatus.MATERIALIZING: cast(
-                    TimeWindowPartitionsSubset, in_progress_partitions_subset
+                    "TimeWindowPartitionsSubset", in_progress_partitions_subset
                 ),
             },
         )
         graphene_ranges = []
         for r in ranges:
             partition_key_range = cast(
-                TimeWindowPartitionsDefinition,
+                "TimeWindowPartitionsDefinition",
                 materialized_partitions_subset.partitions_def,
             ).get_partition_key_range_for_time_window(r.time_window)
             graphene_ranges.append(
@@ -720,7 +720,7 @@ def get_2d_run_length_encoded_partitions(
                 primary_partitions_def = primary_dim.partitions_def
                 if isinstance(primary_partitions_def, TimeWindowPartitionsDefinition):
                     time_windows = cast(
-                        TimeWindowPartitionsDefinition, primary_partitions_def
+                        "TimeWindowPartitionsDefinition", primary_partitions_def
                     ).time_windows_for_partition_keys(
                         frozenset([start_key, end_key]),
                         current_time=current_time,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -240,7 +240,7 @@ def partition_statuses_from_run_partition_data(
 
     results = []
     for name in partition_names:
-        partition_id = f'{partition_set_name or "__NO_PARTITION_SET__"}:{name}{suffix}'
+        partition_id = f"{partition_set_name or '__NO_PARTITION_SET__'}:{name}{suffix}"
         if not partition_data_by_name.get(name):
             results.append(
                 GraphenePartitionStatus(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -14,12 +14,13 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
 from dagster._core.execution.backfill import PartitionBackfill
-from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from dagster._utils.error import serializable_error_info_from_exc_info
 from typing_extensions import ParamSpec, TypeAlias
 
 if TYPE_CHECKING:
+    from dagster._core.workspace.context import BaseWorkspaceRequestContext
+
     from dagster_graphql.schema.errors import GrapheneError, GraphenePythonError
     from dagster_graphql.schema.util import ResolveInfo
 
@@ -35,7 +36,7 @@ def assert_permission_for_location(
 ) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
-    context = cast(BaseWorkspaceRequestContext, graphene_info.context)
+    context = cast("BaseWorkspaceRequestContext", graphene_info.context)
     if not context.has_permission_for_location(permission, location_name):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
@@ -76,7 +77,7 @@ def check_permission(
 def assert_permission(graphene_info: "ResolveInfo", permission: str) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
-    context = cast(BaseWorkspaceRequestContext, graphene_info.context)
+    context = cast("BaseWorkspaceRequestContext", graphene_info.context)
     if not context.has_permission(permission):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
@@ -88,7 +89,7 @@ def has_permission_for_asset_graph(
     permission: str,
 ) -> bool:
     asset_keys = set(asset_selection or [])
-    context = cast(BaseWorkspaceRequestContext, graphene_info.context)
+    context = cast("BaseWorkspaceRequestContext", graphene_info.context)
 
     if asset_keys:
         location_names = set()
@@ -242,9 +243,9 @@ class UserFacingGraphQLError(Exception):
 
 
 def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> JobSubsetSelector:
-    asset_selection = cast(Optional[Iterable[dict[str, list[str]]]], data.get("assetSelection"))
+    asset_selection = cast("Optional[Iterable[dict[str, list[str]]]]", data.get("assetSelection"))
     asset_check_selection = cast(
-        Optional[Iterable[dict[str, Any]]], data.get("assetCheckSelection")
+        "Optional[Iterable[dict[str, Any]]]", data.get("assetCheckSelection")
     )
     return JobSubsetSelector(
         location_name=data["repositoryLocationName"],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -71,7 +71,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
         self.timestamp = evaluation_event.timestamp
 
         evaluation_data = cast(
-            AssetCheckEvaluation,
+            "AssetCheckEvaluation",
             check.not_none(evaluation_event.dagster_event).event_specific_data,
         )
         target_materialization_data = evaluation_data.target_materialization_data

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -353,7 +353,7 @@ def get_expanded_label(
     if use_label and label is not None:
         return [label]
     node_text = name or description
-    child_labels = [f'({" ".join(get_expanded_label(c, use_label=True))})' for c in children]
+    child_labels = [f"({' '.join(get_expanded_label(c, use_label=True))})" for c in children]
     if len(child_labels) == 0:
         return [node_text]
     elif len(child_labels) == 1:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1486,7 +1486,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                     ),
                 )
                 for dimension in cast(
-                    MultiPartitionsSnap,
+                    "MultiPartitionsSnap",
                     self._asset_node_snap.partitions,
                 ).partition_dimensions
             ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -451,7 +451,7 @@ class GrapheneRepository(graphene.ObjectType):
         repository = self.get_repository(graphene_info)
         plugin_docs_json = (
             cast(
-                list,
+                "list",
                 repository.repository_snap.metadata.get(
                     PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY, [[]]
                 ),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -523,7 +523,7 @@ class GraphenePartitionDefinition(graphene.ObjectType):
                     type=GraphenePartitionDefinitionType.from_partition_def_data(dim.partitions),
                     isPrimaryDimension=dim.name
                     == cast(
-                        MultiPartitionsDefinition, partition_def_data.get_partitions_definition()
+                        "MultiPartitionsDefinition", partition_def_data.get_partitions_definition()
                     ).primary_dimension.name,
                     dynamicPartitionsDefinitionName=(
                         dim.partitions.name

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1105,7 +1105,7 @@ class GrapheneQuery(graphene.ObjectType):
         return sorted(nodes, key=lambda node: node.id)
 
     def resolve_assetNodeOrError(self, graphene_info: ResolveInfo, assetKey: GrapheneAssetKeyInput):
-        asset_key_input = cast(Mapping[str, Sequence[str]], assetKey)
+        asset_key_input = cast("Mapping[str, Sequence[str]]", assetKey)
         return get_asset_node(graphene_info, AssetKey.from_graphql_input(asset_key_input))
 
     @capture_error
@@ -1132,7 +1132,7 @@ class GrapheneQuery(graphene.ObjectType):
         assetKeys: Sequence[GrapheneAssetKeyInput],
     ):
         assert assetKeys is not None
-        raw_asset_keys = cast(Sequence[Mapping[str, Sequence[str]]], assetKeys)
+        raw_asset_keys = cast("Sequence[Mapping[str, Sequence[str]]]", assetKeys)
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)
         return get_additional_required_keys(graphene_info, asset_keys)
 
@@ -1142,7 +1142,7 @@ class GrapheneQuery(graphene.ObjectType):
         assetKeys: Sequence[GrapheneAssetKeyInput],
     ):
         assert assetKeys is not None
-        raw_asset_keys = cast(Sequence[Mapping[str, Sequence[str]]], assetKeys)
+        raw_asset_keys = cast("Sequence[Mapping[str, Sequence[str]]]", assetKeys)
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)
         return get_asset_node_definition_collisions(graphene_info, asset_keys)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/util.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/util.py
@@ -8,7 +8,7 @@ from dagster._core.workspace.context import WorkspaceRequestContext
 class ResolveInfo(graphene.ResolveInfo):
     @property
     def context(self) -> WorkspaceRequestContext:
-        return cast(WorkspaceRequestContext, super().context)
+        return cast("WorkspaceRequestContext", super().context)
 
 
 def non_null_list(of_type):

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -236,9 +236,9 @@ def infer_resource_selector(graphql_context: WorkspaceRequestContext, name: str)
 
 def ensure_dagster_graphql_tests_import() -> None:
     dagster_package_root = (Path(dagster_graphql_init_py) / ".." / "..").resolve()
-    assert (
-        dagster_package_root / "dagster_graphql_tests"
-    ).exists(), "Could not find dagster_graphql_tests where expected"
+    assert (dagster_package_root / "dagster_graphql_tests").exists(), (
+        "Could not find dagster_graphql_tests where expected"
+    )
     sys.path.append(dagster_package_root.as_posix())
 
 
@@ -251,7 +251,7 @@ def materialize_assets(
     from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 
     gql_asset_selection = (
-        cast(Sequence[GqlAssetKey], [key.to_graphql_input() for key in asset_selection])
+        cast("Sequence[GqlAssetKey]", [key.to_graphql_input() for key in asset_selection])
         if asset_selection
         else None
     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1199,9 +1199,9 @@ def _get_backfill_data(
 ) -> tuple[str, AssetBackfillData]:
     assert launch_backfill_result
     assert launch_backfill_result.data
-    assert (
-        "backfillId" in launch_backfill_result.data["launchPartitionBackfill"]
-    ), _get_error_message(launch_backfill_result)
+    assert "backfillId" in launch_backfill_result.data["launchPartitionBackfill"], (
+        _get_error_message(launch_backfill_result)
+    )
 
     backfill_id = launch_backfill_result.data["launchPartitionBackfill"]["backfillId"]
 
@@ -1291,9 +1291,9 @@ def test_get_backfills_with_filters():
                         }
                     },
                 )
-                assert (
-                    "backfillId" in launch_backfill_result.data["launchPartitionBackfill"]
-                ), _get_error_message(launch_backfill_result)
+                assert "backfillId" in launch_backfill_result.data["launchPartitionBackfill"], (
+                    _get_error_message(launch_backfill_result)
+                )
 
                 backfill_id = launch_backfill_result.data["launchPartitionBackfill"]["backfillId"]
                 backfill = instance.get_backfill(backfill_id)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -858,9 +858,9 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        assert (
-            result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-        ), result.data
+        assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess", (
+            result.data
+        )
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
@@ -169,9 +169,9 @@ class TestConfigTypes(NonLaunchableGraphQLContextTestMatrix):
 
         assert not result.errors
         assert result.data
-        assert (
-            result.data["isPipelineConfigValid"]["__typename"] == "RunConfigValidationInvalid"
-        ), result.data
+        assert result.data["isPipelineConfigValid"]["__typename"] == "RunConfigValidationInvalid", (
+            result.data
+        )
         assert result.data["isPipelineConfigValid"]["pipelineName"] == "csv_hello_world"
 
     def test_basic_valid_config_non_dict_config(self, graphql_context: WorkspaceRequestContext):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
@@ -70,9 +70,9 @@ def test_dynamic_resume_reexecution(graphql_context: WorkspaceRequestContext):
     )
     assert not retry_one.errors
     assert retry_one.data
-    assert (
-        retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
-    ), retry_one.data["launchPipelineReexecution"].get("message")
+    assert retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess", (
+        retry_one.data["launchPipelineReexecution"].get("message")
+    )
 
     run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
 
@@ -143,9 +143,9 @@ def test_dynamic_full_reexecution(graphql_context: WorkspaceRequestContext):
     )
     assert not retry_one.errors
     assert retry_one.data
-    assert (
-        retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
-    ), retry_one.data["launchPipelineReexecution"].get("message")
+    assert retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess", (
+        retry_one.data["launchPipelineReexecution"].get("message")
+    )
 
     run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
 
@@ -222,9 +222,9 @@ def test_dynamic_subset(graphql_context: WorkspaceRequestContext):
     )
     assert not retry_one.errors
     assert retry_one.data
-    assert (
-        retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
-    ), retry_one.data["launchPipelineReexecution"].get("message")
+    assert retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess", (
+        retry_one.data["launchPipelineReexecution"].get("message")
+    )
 
     run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -122,9 +122,9 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         )
 
         assert result.data
-        assert (
-            result.data["instigationStateOrError"]["__typename"] == "InstigationState"
-        ), result.data["instigationStateOrError"]
+        assert result.data["instigationStateOrError"]["__typename"] == "InstigationState", (
+            result.data["instigationStateOrError"]
+        )
 
         # need to be running and create a sensor tick in the last 30 seconds in order to generate a
         # future tick
@@ -141,9 +141,9 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         )
 
         assert result.data
-        assert (
-            result.data["instigationStateOrError"]["__typename"] == "InstigationState"
-        ), result.data["instigationStateOrError"]
+        assert result.data["instigationStateOrError"]["__typename"] == "InstigationState", (
+            result.data["instigationStateOrError"]
+        )
         next_tick = result.data["instigationStateOrError"]["nextTick"]
         assert next_tick
 
@@ -154,9 +154,9 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         )
 
         assert result.data
-        assert (
-            result.data["instigationStateOrError"]["__typename"] == "InstigationState"
-        ), result.data["instigationStateOrError"]
+        assert result.data["instigationStateOrError"]["__typename"] == "InstigationState", (
+            result.data["instigationStateOrError"]
+        )
         next_tick = result.data["instigationStateOrError"]["nextTick"]
         assert next_tick
 
@@ -177,9 +177,9 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         )
 
         assert result.data
-        assert (
-            result.data["instigationStatesOrError"]["__typename"] == "InstigationStates"
-        ), result.data["instigationStatesOrError"]
+        assert result.data["instigationStatesOrError"]["__typename"] == "InstigationStates", (
+            result.data["instigationStatesOrError"]
+        )
 
         results = result.data["instigationStatesOrError"]["results"]
         assert results == [{"name": schedule_name, "instigationType": "SCHEDULE"}]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -409,9 +409,9 @@ class TestPartitionBackillReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert (
-            result.data["partitionBackfillOrError"]["__typename"] == "BackfillNotFoundError"
-        ), result.data
+        assert result.data["partitionBackfillOrError"]["__typename"] == "BackfillNotFoundError", (
+            result.data
+        )
         assert "Junk" in result.data["partitionBackfillOrError"]["message"]
 
     def test_resume_backfill_failure(self, graphql_context):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -197,9 +197,9 @@ class TestLoadWorkspace(BaseTestSuite):
             assert failure_node["name"] == "error_location"
             assert failure_node["loadStatus"] == "LOADED"
 
-            assert "No such file or directory" in str(
-                failure_node["locationOrLoadError"]
-            ), failure_node
+            assert "No such file or directory" in str(failure_node["locationOrLoadError"]), (
+                failure_node
+            )
 
             for node in nodes:
                 assert node["loadStatus"] == "LOADED"
@@ -259,9 +259,9 @@ class TestLoadWorkspace(BaseTestSuite):
 
             assert len(nodes) == 3
 
-            assert all(
-                [node["__typename"] == "WorkspaceLocationStatusEntry" for node in nodes]
-            ), str(nodes)
+            assert all([node["__typename"] == "WorkspaceLocationStatusEntry" for node in nodes]), (
+                str(nodes)
+            )
 
             for node in nodes:
                 assert node["loadStatus"] == "LOADED"
@@ -323,9 +323,9 @@ class TestLoadWorkspace(BaseTestSuite):
 
             assert failure_node["name"] == "error_location"
             assert failure_node["loadStatus"] == "LOADED"
-            assert "No such file or directory" not in str(
-                failure_node["locationOrLoadError"]
-            ), failure_node["locationOrLoadError"]["message"]
+            assert "No such file or directory" not in str(failure_node["locationOrLoadError"]), (
+                failure_node["locationOrLoadError"]["message"]
+            )
             assert (
                 "Search in logs for this error ID for more details"
                 in failure_node["locationOrLoadError"]["message"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_schema.py
@@ -35,9 +35,9 @@ def test_schema_type_names_without_graphene(runner):
         for graphql_type in graphql_schema_types
         if "Graphene".casefold() in graphql_type["name"].casefold()
     ]
-    assert (
-        not violations
-    ), f"'Graphene' cannot be included in the GraphQL type name. Violating types: {violations}."
+    assert not violations, (
+        f"'Graphene' cannot be included in the GraphQL type name. Violating types: {violations}."
+    )
 
 
 def test_schema_types_have_descriptions(runner):
@@ -76,9 +76,9 @@ def test_schema_types_have_descriptions(runner):
         for graphql_type in filtered_graphql_schema_types
         if not graphql_type["description"]
     ]
-    assert (
-        not violations
-    ), f"Descriptions must be included in the GraphQL types. Violating types: {violations}."
+    assert not violations, (
+        f"Descriptions must be included in the GraphQL types. Violating types: {violations}."
+    )
 
     enum_violations = [
         f"{graphql_type['name']}.{enum_value['name']}"

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -410,7 +410,7 @@ def _normalize_param_metadata(
                     f" with schema `{{raw_value: ..., type: ...}}`. Got a value `{value}`."
                 )
             _assert_param_value(value["type"], _METADATA_TYPES, method, f"{param}.{key}.type")
-            new_metadata[key] = cast(PipesMetadataValue, value)
+            new_metadata[key] = cast("PipesMetadataValue", value)
         else:
             new_metadata[key] = {"raw_value": value, "type": PIPES_METADATA_TYPE_INFER}
     return new_metadata
@@ -757,7 +757,7 @@ class PipesDefaultContextLoader(PipesContextLoader):
                 yield data
         elif self.DIRECT_KEY in params:
             data = _assert_env_param_type(params, self.DIRECT_KEY, dict, self.__class__)
-            yield cast(PipesContextData, data)
+            yield cast("PipesContextData", data)
         else:
             raise DagsterPipesError(
                 f'Invalid params for {self.__class__.__name__}, expected key "{self.FILE_PATH_KEY}"'
@@ -781,7 +781,7 @@ class ExcThread(threading.Thread):
 
         while not self.exceptions.empty():
             exc_info = self.exceptions.get()
-            sys.stderr.write(traceback.format_exception(*exc_info))  # pyright: ignore[reportCallIssue,reportArgumentType]
+            sys.stderr.write(traceback.format_exception(*exc_info))  # type: ignore
 
 
 # log writers can potentially capture other type sof logs (for example, from Spark workers)
@@ -830,9 +830,9 @@ class PipesStdioLogWriterChannel(PipesLogWriterChannel):
         # replaced by various tools and environments (e.g. Databricks) and no longer point to the original IO stream
         # more info in Python docs: https://docs.python.org/3.8/library/sys.html#sys.__stdout__
         if self.stream == "stdout":
-            return cast(TextIOWrapper, sys.__stdout__)
+            return cast("TextIOWrapper", sys.__stdout__)
         elif self.stream == "stderr":
-            return cast(TextIOWrapper, sys.__stderr__)
+            return cast("TextIOWrapper", sys.__stderr__)
         else:
             raise ValueError(f"stream must be 'stdout' or 'stderr', got {self.stream}")
 
@@ -850,7 +850,7 @@ class PipesStdioLogWriterChannel(PipesLogWriterChannel):
 
             stdio_fileno = self.stdio.fileno()
             prev_fd = os.dup(stdio_fileno)
-            os.dup2(cast(IO[bytes], tee.stdin).fileno(), stdio_fileno)
+            os.dup2(cast("IO[bytes]", tee.stdin).fileno(), stdio_fileno)
 
             thread = ExcThread(
                 target=self.handler,

--- a/python_modules/dagster-test/dagster_test/toys/conditional_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/conditional_assets.py
@@ -8,7 +8,7 @@ def may_not_materialize(context):
     random.seed()
     rand_num = random.randint(1, 10)
     context.log.info(
-        f"Random number is {rand_num}. Asset will {'not' if rand_num >=5 else ''} materialize."
+        f"Random number is {rand_num}. Asset will {'not' if rand_num >= 5 else ''} materialize."
     )
     if rand_num < 5:
         yield Output([1, 2, 3])

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -1,9 +1,7 @@
 import warnings
-from collections.abc import Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dagster import BetaWarning, PreviewWarning
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._time import get_current_timestamp
 
 # squelch preview and beta warnings since we often include preview and beta things in toys for development
@@ -71,6 +69,11 @@ from dagster_test.toys.sensors import get_toys_sensors
 from dagster_test.toys.sleepy import sleepy_job
 from dagster_test.toys.software_defined_assets import software_defined_assets
 from dagster_test.toys.unreliable import unreliable_job
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from dagster._core.definitions.assets import AssetsDefinition
 
 
 @op
@@ -170,20 +173,20 @@ def column_schema_repository():
 def table_metadata_repository():
     from dagster_test.toys import table_metadata
 
-    return cast(Sequence[AssetsDefinition], load_assets_from_modules([table_metadata]))
+    return cast("Sequence[AssetsDefinition]", load_assets_from_modules([table_metadata]))
 
 
 @repository
 def long_asset_keys_repository():
     from dagster_test.toys import long_asset_keys
 
-    return cast(Sequence[AssetsDefinition], load_assets_from_modules([long_asset_keys]))
+    return cast("Sequence[AssetsDefinition]", load_assets_from_modules([long_asset_keys]))
 
 
 @repository
 def big_honkin_assets_repository():
     return cast(
-        Sequence[AssetsDefinition], [load_assets_from_modules([big_honkin_asset_graph_module])]
+        "Sequence[AssetsDefinition]", [load_assets_from_modules([big_honkin_asset_graph_module])]
     )
 
 
@@ -216,14 +219,14 @@ def assets_with_sensors_repository():
 def conditional_assets_repository():
     from dagster_test.toys import conditional_assets
 
-    return cast(Sequence[AssetsDefinition], load_assets_from_modules([conditional_assets]))
+    return cast("Sequence[AssetsDefinition]", load_assets_from_modules([conditional_assets]))
 
 
 @repository
 def data_versions_repository():
     from dagster_test.toys import data_versions
 
-    return cast(Sequence[AssetsDefinition], load_assets_from_modules([data_versions]))
+    return cast("Sequence[AssetsDefinition]", load_assets_from_modules([data_versions]))
 
 
 @repository

--- a/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
@@ -95,7 +95,7 @@ def external_asset(asset_spec: AssetInfo):
     keys_by_output_name = {"result": key}
     op_def = OpDefinition(
         name=key.path[-1],
-        ins={k.to_user_string(): In(cast(type, Nothing)) for k in dependencies},
+        ins={k.to_user_string(): In(cast("type", Nothing)) for k in dependencies},
         outs={"result": Out(Nothing)},
         code_version=code_version,
         compute_fn=fn,

--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -138,7 +138,7 @@ class GraphQLServer(ABC, Generic[TRequestContext]):
 
         if isinstance(variables, str):
             try:
-                variables = cast(dict[str, Any], json.loads(variables))
+                variables = cast("dict[str, Any]", json.loads(variables))
             except json.JSONDecodeError:
                 return PlainTextResponse(
                     "Malformed GraphQL variables. Passed as string but not valid"

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
@@ -170,9 +170,9 @@ def test_report_asset_materialization_apis_consistent(
         elif k == "description":
             assert mat.description == v
         else:
-            assert (
-                False
-            ), "need to add validation that sample payload content was written successfully"
+            assert False, (
+                "need to add validation that sample payload content was written successfully"
+            )
 
     # all ext report_asset_materialization kwargs should be in sample payload
     sig = inspect.signature(PipesContext.report_asset_materialization)
@@ -261,9 +261,9 @@ def test_report_asset_check_evaluation_apis_consistent(
         elif k == "severity":
             assert evaluation.severity.value == v
         else:
-            assert (
-                False
-            ), "need to add validation that sample payload content was written successfully"
+            assert False, (
+                "need to add validation that sample payload content was written successfully"
+            )
 
     # all ext report_asset_materialization kwargs should be in sample payload
     sig = inspect.signature(PipesContext.report_asset_check)
@@ -331,8 +331,8 @@ def test_report_asset_observation_apis_consistent(
         elif k == "description":
             assert obs.description == v
         else:
-            assert (
-                False
-            ), "need to add validation that sample payload content was written successfully"
+            assert False, (
+                "need to add validation that sample payload content was written successfully"
+            )
 
     # expect test to cover PipesContext.report_asset_observation once added

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -152,7 +152,7 @@ def _execute_run_command_body(
     else:
         metrics_thread, metrics_thread_shutdown_event = None, None
 
-    recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
+    recon_job = recon_job_from_origin(cast("JobPythonOrigin", dagster_run.job_code_origin))
 
     pid = os.getpid()
     instance.report_engine_event(
@@ -284,7 +284,7 @@ def _resume_run_command_body(
     else:
         metrics_thread, metrics_thread_shutdown_event = None, None
 
-    recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
+    recon_job = recon_job_from_origin(cast("JobPythonOrigin", dagster_run.job_code_origin))
 
     pid = os.getpid()
     instance.report_engine_event(
@@ -495,7 +495,7 @@ def _execute_step_command_body(
             repository_load_data = None
 
         recon_job = (
-            recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
+            recon_job_from_origin(cast("JobPythonOrigin", dagster_run.job_code_origin))
             .with_repository_load_data(repository_load_data)
             .get_subset(
                 op_selection=dagster_run.resolved_op_selection,

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -810,7 +810,7 @@ def get_remote_job_from_remote_repo(
 
 def get_run_config_from_file_list(file_list: list[str]) -> Mapping[str, object]:
     check.opt_sequence_param(file_list, "file_list", of_type=str)
-    return cast(Mapping[str, object], load_yaml_from_glob_list(file_list) if file_list else {})
+    return cast("Mapping[str, object]", load_yaml_from_glob_list(file_list) if file_list else {})
 
 
 def get_run_config_from_cli_opts(

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -200,7 +200,7 @@ class Noneable(ConfigType):
     def __init__(self, inner_type: object):
         from dagster._config.field import resolve_to_config_type
 
-        self.inner_type = cast(ConfigType, resolve_to_config_type(inner_type))
+        self.inner_type = cast("ConfigType", resolve_to_config_type(inner_type))
         super().__init__(
             key=f"Noneable.{self.inner_type.key}",
             kind=ConfigTypeKind.NONEABLE,
@@ -223,7 +223,7 @@ class Array(ConfigType):
     def __init__(self, inner_type: object):
         from dagster._config.field import resolve_to_config_type
 
-        self.inner_type = cast(ConfigType, resolve_to_config_type(inner_type))
+        self.inner_type = cast("ConfigType", resolve_to_config_type(inner_type))
         super().__init__(
             key=f"Array.{self.inner_type.key}",
             type_params=[self.inner_type],

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -382,4 +382,4 @@ class Field:
 
 
 def check_opt_field_param(obj: object, param_name: str) -> Optional[Field]:
-    return check.opt_inst_param(cast(Optional[Field], obj), param_name, Field)
+    return check.opt_inst_param(cast("Optional[Field]", obj), param_name, Field)

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -65,7 +65,7 @@ def _memoize_inst_in_field_cache(passed_cls, defined_cls, key):
         return FIELD_HASH_CACHE[key]
 
     defined_cls_inst = super(defined_cls, passed_cls).__new__(defined_cls)
-    defined_cls_inst._initialized = False  # noqa: SLF001
+    defined_cls_inst._initialized = False
     FIELD_HASH_CACHE[key] = defined_cls_inst
     return defined_cls_inst
 

--- a/python_modules/dagster/dagster/_config/post_process.py
+++ b/python_modules/dagster/dagster/_config/post_process.py
@@ -232,7 +232,7 @@ def _recurse_in_to_map(context: TraversalContext, config_value: Any) -> Evaluate
     if not config_value:
         return EvaluateValueResult.for_value({})
 
-    config_value = cast(dict[object, object], config_value)
+    config_value = cast("dict[object, object]", config_value)
 
     if any(ck is None for ck in config_value.keys()):
         check.failed("Null map key not caught in validation")

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -320,7 +320,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         This is useful when interacting with legacy code that expects a dictionary of fields but you
         want the source of truth to be a config class.
         """
-        return cast(Shape, cls.to_config_schema().as_field().config_type).fields  # pyright: ignore[reportReturnType]
+        return cast("Shape", cls.to_config_schema().as_field().config_type).fields  # pyright: ignore[reportReturnType]
 
 
 def _discriminated_union_config_dict_to_selector_config_dict(

--- a/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
@@ -43,14 +43,14 @@ class ConfigurableIOManagerFactoryResourceDefinition(  # pyright: ignore[reportI
         dagster_maintained: bool = False,
     ):
         input_config_schema_resolved: CoercableToConfigSchema = (
-            cast(type[Config], input_config_schema).to_config_schema()
+            cast("type[Config]", input_config_schema).to_config_schema()
             if safe_is_subclass(input_config_schema, Config)
-            else cast(CoercableToConfigSchema, input_config_schema)
+            else cast("CoercableToConfigSchema", input_config_schema)
         )
         output_config_schema_resolved: CoercableToConfigSchema = (
-            cast(type[Config], output_config_schema).to_config_schema()
+            cast("type[Config]", output_config_schema).to_config_schema()
             if safe_is_subclass(output_config_schema, Config)
-            else cast(CoercableToConfigSchema, output_config_schema)
+            else cast("CoercableToConfigSchema", output_config_schema)
         )
         super().__init__(
             resource_fn=resource_fn,
@@ -181,7 +181,7 @@ class PartialIOManager(
         output_config_schema = None
         if safe_is_subclass(self.resource_cls, ConfigurableIOManagerFactory):
             factory_cls: type[ConfigurableIOManagerFactory] = cast(
-                type[ConfigurableIOManagerFactory], self.resource_cls
+                "type[ConfigurableIOManagerFactory]", self.resource_cls
             )
             input_config_schema = factory_cls.input_config_schema()
             output_config_schema = factory_cls.output_config_schema()

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -657,7 +657,7 @@ class ConfigurableResource(ConfigurableResourceFactory[TResValue]):
         For ConfigurableResource, this function will return itself, passing
         the actual ConfigurableResource object to user code.
         """
-        return cast(TResValue, self)
+        return cast("TResValue", self)
 
 
 def _is_fully_configured(resource: "CoercibleToResource") -> bool:
@@ -907,7 +907,7 @@ def _call_resource_fn_with_default(
     from dagster._config.validate import process_config
 
     if isinstance(obj.config_schema, ConfiguredDefinitionConfigSchema):
-        value = cast(dict[str, Any], obj.config_schema.resolve_config({}).value)
+        value = cast("dict[str, Any]", obj.config_schema.resolve_config({}).value)
         context = context.replace_config(value["config"])
     elif obj.config_schema.default_provided:
         # To explain why we need to process config here;
@@ -924,12 +924,12 @@ def _call_resource_fn_with_default(
                 evr.errors,
                 unprocessed_config,
             )
-        context = context.replace_config(cast(dict, evr.value)["config"])
+        context = context.replace_config(cast("dict", evr.value)["config"])
 
     if has_at_least_one_parameter(obj.resource_fn):
-        result = cast(ResourceFunctionWithContext, obj.resource_fn)(context)
+        result = cast("ResourceFunctionWithContext", obj.resource_fn)(context)
     else:
-        result = cast(ResourceFunctionWithoutContext, obj.resource_fn)()
+        result = cast("ResourceFunctionWithoutContext", obj.resource_fn)()
 
     is_fn_generator = (
         inspect.isgenerator(obj.resource_fn)
@@ -937,7 +937,7 @@ def _call_resource_fn_with_default(
         or isinstance(result, contextlib.AbstractContextManager)
     )
     if is_fn_generator:
-        return stack.enter_context(cast(contextlib.AbstractContextManager, result))
+        return stack.enter_context(cast("contextlib.AbstractContextManager", result))
     else:
         return result
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -186,7 +186,7 @@ class TypecheckAllowPartialResourceInitParams:
 
     def __get__(self: Self, obj: Any, owner: Any) -> Self:
         # no-op implementation (only used to affect type signature)
-        return cast(Self, getattr(obj, self._assigned_name))
+        return cast("Self", getattr(obj, self._assigned_name))
 
     # The annotation her has been temporarily changed from:
     #     value: Union[Self, "PartialResource[Self]"]

--- a/python_modules/dagster/dagster/_config/snap.py
+++ b/python_modules/dagster/dagster/_config/snap.py
@@ -145,17 +145,18 @@ class ConfigTypeSnap(IHaveNew):
     def get_child_type_keys(self) -> Sequence[str]:
         if ConfigTypeKind.is_closed_generic(self.kind):
             # all closed generics have type params
-            return cast(list[str], self.type_param_keys)
+            return cast("list[str]", self.type_param_keys)
         elif ConfigTypeKind.has_fields(self.kind):
             return [
-                field.type_key for field in cast(list[ConfigFieldSnap], check.not_none(self.fields))
+                field.type_key
+                for field in cast("list[ConfigFieldSnap]", check.not_none(self.fields))
             ]
         else:
             return []
 
     def has_enum_value(self, value: object) -> bool:
         check.invariant(self.kind == ConfigTypeKind.ENUM)
-        for enum_value in cast(list[ConfigEnumValueSnap], self.enum_values):
+        for enum_value in cast("list[ConfigEnumValueSnap]", self.enum_values):
             if enum_value.value == value:
                 return True
         return False

--- a/python_modules/dagster/dagster/_config/validate.py
+++ b/python_modules/dagster/dagster/_config/validate.py
@@ -138,7 +138,7 @@ def _validate_scalar_union_config(
     if isinstance(config_value, (dict, list)):
         return _validate_config(
             context.for_new_config_type_key(context.config_type_snap.non_scalar_type_key),
-            cast(T, config_value),
+            cast("T", config_value),
         )
     else:
         return _validate_config(
@@ -161,7 +161,7 @@ def _validate_empty_selector_config(
     if defined_field_snap.is_required:
         return EvaluateValueResult.for_error(create_selector_unspecified_value_error(context))
 
-    return EvaluateValueResult.for_value(cast(Mapping[str, object], {}))
+    return EvaluateValueResult.for_value(cast("Mapping[str, object]", {}))
 
 
 def validate_selector_config(
@@ -184,7 +184,7 @@ def validate_selector_config(
 
     if not isinstance(config_value, dict):
         return EvaluateValueResult.for_error(create_selector_type_error(context, config_value))
-    config_value = cast(Mapping[str, object], config_value)
+    config_value = cast("Mapping[str, object]", config_value)
 
     if len(config_value) > 1:
         return EvaluateValueResult.for_error(
@@ -233,7 +233,7 @@ def _validate_shape_config(
     check.bool_param(check_for_extra_incoming_fields, "check_for_extra_incoming_fields")
 
     field_aliases = check.opt_dict_param(
-        cast(dict[str, str], context.config_type_snap.field_aliases),
+        cast("dict[str, str]", context.config_type_snap.field_aliases),
         "field_aliases",
         key_type=str,
         value_type=str,
@@ -241,10 +241,10 @@ def _validate_shape_config(
 
     if not isinstance(config_value, dict):
         return EvaluateValueResult.for_error(create_dict_type_mismatch_error(context, config_value))
-    config_value = cast(dict[str, object], config_value)
+    config_value = cast("dict[str, object]", config_value)
 
     field_snaps = check.not_none(context.config_type_snap.fields)
-    defined_field_names = cast(set[str], {fs.name for fs in field_snaps})
+    defined_field_names = cast("set[str]", {fs.name for fs in field_snaps})
     defined_field_names = defined_field_names.union(set(field_aliases.values()))
 
     incoming_field_names = set(config_value.keys())
@@ -320,7 +320,7 @@ def validate_map_config(
 
     if not isinstance(config_value, dict):
         return EvaluateValueResult.for_error(create_map_error(context, config_value))
-    config_value = cast(dict[object, object], config_value)
+    config_value = cast("dict[object, object]", config_value)
 
     evaluation_results = [
         _validate_config(context.for_map_key(key), key) for key in config_value.keys()
@@ -332,7 +332,7 @@ def validate_map_config(
     errors = []
     for result in evaluation_results:
         if not result.success:
-            errors += cast(list, result.errors)
+            errors += cast("list", result.errors)
 
     return EvaluateValueResult(
         success=not bool(errors),
@@ -378,10 +378,10 @@ def _compute_missing_fields_error(
     missing_fields: list[str] = []
 
     for field_snap in field_snaps:
-        field_alias = field_aliases.get(cast(str, field_snap.name))
+        field_alias = field_aliases.get(cast("str", field_snap.name))
         if field_snap.is_required and field_snap.name not in incoming_fields:
             if field_alias is None or field_alias not in incoming_fields:
-                missing_fields.append(cast(str, field_snap.name))
+                missing_fields.append(cast("str", field_snap.name))
 
     if missing_fields:
         if len(missing_fields) == 1:
@@ -403,7 +403,7 @@ def validate_array_config(
 
     evaluation_results = [
         _validate_config(context.for_array(index), config_item)
-        for index, config_item in enumerate(cast(list[object], config_value))
+        for index, config_item in enumerate(cast("list[object]", config_value))
     ]
 
     values: list[object] = []
@@ -441,7 +441,7 @@ def process_config(
     config_type: object, config_dict: Mapping[str, object]
 ) -> EvaluateValueResult[Mapping[str, Any]]:
     config_type = resolve_to_config_type(config_type)
-    config_type = check.inst(cast(ConfigType, config_type), ConfigType)
+    config_type = check.inst(cast("ConfigType", config_type), ConfigType)
     validate_evr = validate_config(config_type, config_dict)
     if not validate_evr.success:
         return validate_evr

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -304,7 +304,7 @@ class CustomPointer(
         )
 
     def load_target(self) -> object:
-        reconstructor = cast(Callable, self.reconstructor_pointer.load_target())
+        reconstructor = cast("Callable", self.reconstructor_pointer.load_target())
 
         return reconstructor(
             *self.reconstructable_args, **{key: value for key, value in self.reconstructable_kwargs}

--- a/python_modules/dagster/dagster/_core/container_context/config.py
+++ b/python_modules/dagster/dagster/_core/container_context/config.py
@@ -34,4 +34,4 @@ def process_shared_container_context_config(
             container_context_config,
         )
 
-    return cast(dict[str, Any], shared_container_context.value)
+    return cast("dict[str, Any]", shared_container_context.value)

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -194,7 +194,7 @@ def _wrap_with_pre_call_fn(
             pre_call_fn()
         return fn(*args, **kwargs)
 
-    return cast(T_Callable, wrapped_with_pre_call_fn)
+    return cast("T_Callable", wrapped_with_pre_call_fn)
 
 
 def apply_context_manager_decorator(
@@ -214,7 +214,7 @@ def _wrap_with_context_manager(
         with cm():
             return fn(*args, **kwargs)
 
-    return cast(T_Callable, wrapped_with_context_manager_fn)
+    return cast("T_Callable", wrapped_with_context_manager_fn)
 
 
 def _update_decoratable(decoratable: T_Decoratable, new_fn: Callable[..., Any]) -> T_Decoratable:
@@ -251,7 +251,7 @@ def _update_decoratable(decoratable: T_Decoratable, new_fn: Callable[..., Any]) 
 
     # Pyright is unable to infer based on our checks that the return type is the same as the input
     # type.
-    return cast(T_Decoratable, val)
+    return cast("T_Decoratable", val)
 
 
 def is_decoratable(obj: Any) -> TypeGuard[Decoratable]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -189,7 +189,7 @@ def _build_freshness_multi_check(
                 datetime.datetime,
             )
 
-            last_update_time_lower_bound = cast(datetime.datetime, deadline - lower_bound_delta)
+            last_update_time_lower_bound = cast("datetime.datetime", deadline - lower_bound_delta)
 
             latest_record = retrieve_last_update_record(
                 instance=context.instance, asset_key=asset_key, partition_key=None

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
@@ -208,7 +208,7 @@ def freshness_checks_get_evaluations_iter(
                 continue
             # Previous run was not kicked off by the sensor, check if it's overdue.
             next_deadline = cast(
-                float, latest_completed_evaluation.metadata[FRESH_UNTIL_METADATA_KEY].value
+                "float", latest_completed_evaluation.metadata[FRESH_UNTIL_METADATA_KEY].value
             )
             if next_deadline < start_time.timestamp():
                 context.log.info(
@@ -252,7 +252,7 @@ def freshness_checks_get_evaluations_iter(
         # Case 5: The previous evaluation passed and there is no in progress evaluation. We should kick off another evaluation only if the check is overdue.
         else:
             next_deadline = cast(
-                float, latest_completed_evaluation.metadata[FRESH_UNTIL_METADATA_KEY].value
+                "float", latest_completed_evaluation.metadata[FRESH_UNTIL_METADATA_KEY].value
             )
             if next_deadline < start_time.timestamp():
                 context.log.info(

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Sequence
-from typing import Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import dagster._check as check
 from dagster._annotations import beta
@@ -16,10 +16,12 @@ from dagster._core.definitions.asset_check_spec import (
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
-from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.utils import INVALID_NAME_CHARS
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.events import AssetMaterialization
 
 
 @beta
@@ -84,7 +86,7 @@ def build_metadata_bounds_checks(
         if not event:
             return False, "Asset has not been materialized"
 
-        metadata = cast(AssetMaterialization, event.asset_materialization).metadata
+        metadata = cast("AssetMaterialization", event.asset_materialization).metadata
         if metadata_key not in metadata:
             return False, f"Metadata key `{metadata_key}` not found"
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/schema_change_checks.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 from pydantic import BaseModel
 
@@ -13,9 +13,11 @@ from dagster._core.definitions.asset_check_spec import (
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
-from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.metadata import TableColumn, TableMetadataSet, TableSchema
 from dagster._core.instance import DagsterInstance
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.events import AssetMaterialization
 
 
 @beta
@@ -100,8 +102,8 @@ def build_column_schema_change_checks(
             return True, "The asset has been materialized fewer than 2 times"
 
         record, prev_record = materialization_records
-        metadata = cast(AssetMaterialization, record.asset_materialization).metadata
-        prev_metadata = cast(AssetMaterialization, prev_record.asset_materialization).metadata
+        metadata = cast("AssetMaterialization", record.asset_materialization).metadata
+        prev_metadata = cast("AssetMaterialization", prev_record.asset_materialization).metadata
 
         column_schema = TableMetadataSet.extract(metadata).column_schema
         prev_column_schema = TableMetadataSet.extract(prev_metadata).column_schema

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
@@ -159,7 +159,7 @@ class AssetGraphComputation(IHaveNew):
         dep_op_handles_by_entity_key = cast(
             # because self.node_def is a graph, these NodeHandles that reference ops inside it will
             # not be None
-            Mapping[EntityKey, AbstractSet[NodeHandle]],
+            "Mapping[EntityKey, AbstractSet[NodeHandle]]",
             self.dep_op_handles_by_entity_key,
         )
         op_selection: list[str] = []

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -270,7 +270,7 @@ class AssetGraphSubset(NamedTuple):
         return AssetGraphSubset(
             partitions_subsets_by_asset_key={
                 asset_key: (
-                    cast(PartitionsDefinition, asset_graph.get(asset_key).partitions_def)
+                    cast("PartitionsDefinition", asset_graph.get(asset_key).partitions_def)
                     .empty_subset()
                     .with_partition_keys(partition_keys)
                 )

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -544,7 +544,7 @@ class AssetSelection(ABC):
         elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, str) for el in selection
         ):
-            return reduce(operator.or_, [cls.from_string(cast(str, s)) for s in selection])
+            return reduce(operator.or_, [cls.from_string(cast("str", s)) for s in selection])
         elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
         ):
@@ -553,14 +553,16 @@ class AssetSelection(ABC):
                     key
                     for el in selection
                     for key in (
-                        el.keys if isinstance(el, AssetsDefinition) else [cast(SourceAsset, el).key]
+                        el.keys
+                        if isinstance(el, AssetsDefinition)
+                        else [cast("SourceAsset", el).key]
                     )
                 )
             )
         elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, AssetKey) for el in selection
         ):
-            return cls.assets(*cast(Sequence[AssetKey], selection))
+            return cls.assets(*cast("Sequence[AssetKey]", selection))
         else:
             check.failed(
                 "selection argument must be one of str, Sequence[str], Sequence[AssetKey],"
@@ -871,7 +873,7 @@ class MaterializableAssetSelection(ChainedAssetSelection):
         return {
             asset_key
             for asset_key in self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
-            if cast(BaseAssetNode, asset_graph.get(asset_key)).is_materializable
+            if cast("BaseAssetNode", asset_graph.get(asset_key)).is_materializable
         }
 
 
@@ -1014,7 +1016,7 @@ class CodeLocationAssetSelection(AssetSelection):
 
         return {
             key
-            for key in cast(RemoteAssetGraph, asset_graph).remote_asset_nodes_by_key
+            for key in cast("RemoteAssetGraph", asset_graph).remote_asset_nodes_by_key
             if (
                 asset_graph.get(key)
                 .resolve_to_singular_repo_scoped_node()

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -819,7 +819,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             isinstance(node_def, OpDefinition),
             "The NodeDefinition for this AssetsDefinition is not of type OpDefinition.",
         )
-        return cast(OpDefinition, node_def)
+        return cast("OpDefinition", node_def)
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -72,11 +72,11 @@ class ParentUpdatedRuleEvaluationData(
     def metadata(self) -> MetadataMapping:
         return {
             **{
-                f"updated_parent_{i+1}": MetadataValue.asset(k)
+                f"updated_parent_{i + 1}": MetadataValue.asset(k)
                 for i, k in enumerate(sorted(self.updated_asset_keys))
             },
             **{
-                f"will_update_parent_{i+1}": MetadataValue.asset(k)
+                f"will_update_parent_{i + 1}": MetadataValue.asset(k)
                 for i, k in enumerate(sorted(self.will_update_asset_keys))
             },
         }
@@ -94,7 +94,7 @@ class WaitingOnAssetsRuleEvaluationData(
     def metadata(self) -> MetadataMapping:
         return {
             **{
-                f"waiting_on_ancestor_{i+1}": MetadataValue.asset(k)
+                f"waiting_on_ancestor_{i + 1}": MetadataValue.asset(k)
                 for i, k in enumerate(sorted(self.waiting_on_asset_keys))
             },
         }

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -195,7 +195,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
 
     @property
     def asset_selection(self) -> AssetSelection:
-        return cast(AssetSelection, super().asset_selection)
+        return cast("AssetSelection", super().asset_selection)
 
     @property
     def emit_backfills(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -142,7 +142,7 @@ class AutomationTickEvaluationContext:
                 asset_key
                 for run_request in observe_run_requests
                 for asset_key in cast(
-                    Sequence[AssetKey],
+                    "Sequence[AssetKey]",
                     run_request.asset_selection,  # auto-observe run requests always have asset_selection
                 )
             ],
@@ -233,7 +233,7 @@ def _build_backfill_request(
             if not node.is_materializable:
                 # if the asset is not materializable, it cannot be included in a backfill
                 return
-            subset = cast(EntitySubset[AssetKey], entity_subsets_by_key.pop(k))
+            subset = cast("EntitySubset[AssetKey]", entity_subsets_by_key.pop(k))
             backfill_subsets.append(subset)
             for sk in [
                 # include all parent and child assets
@@ -385,7 +385,7 @@ def build_run_requests_with_backfill_policies(
             )
         elif backfill_policy is None:
             # just use the normal single-partition behavior
-            entity_keys = cast(set[EntityKey], asset_keys)
+            entity_keys = cast("set[EntityKey]", asset_keys)
             mapping: _PartitionsDefKeyMapping = {
                 (partitions_def, pk): entity_keys for pk in (partition_keys or [None])
             }

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -577,7 +577,9 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         """
         partition_key = check.opt_str_param(partition_key, "partition_key")
 
-        child_partitions_def = cast(PartitionsDefinition, self.get(child_asset_key).partitions_def)
+        child_partitions_def = cast(
+            "PartitionsDefinition", self.get(child_asset_key).partitions_def
+        )
         parent_partitions_def = self.get(parent_asset_key).partitions_def
 
         if parent_partitions_def is None:

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -407,7 +407,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
         # is an OpDefinition, then permit it to be invoked and executed like an OpDefinition.
         if not is_in_composition() and isinstance(self.node_def, OpDefinition):
             return direct_invocation_result(
-                cast(PendingNodeInvocation[OpDefinition], self), *args, **kwargs
+                cast("PendingNodeInvocation[OpDefinition]", self), *args, **kwargs
             )
 
         assert_in_composition(node_name, self.node_def)

--- a/python_modules/dagster/dagster/_core/definitions/config.py
+++ b/python_modules/dagster/dagster/_core/definitions/config.py
@@ -95,7 +95,7 @@ class ConfigMapping(
         outer_config = outer_evr.value
         if not receive_processed_config_values:
             outer_config = resolve_defaults(
-                cast(ConfigType, self.config_schema.config_type),
+                cast("ConfigType", self.config_schema.config_type),
                 outer_config,
             ).value
 

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar, Union, cast
 
 from typing_extensions import Self
 
@@ -14,6 +14,9 @@ from dagster._core.definitions.definition_config_schema import (
     IDefinitionConfigSchema,
     convert_user_facing_definition_config_schema,
 )
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
 class ConfigurableDefinition(ABC):
@@ -230,7 +233,7 @@ def _wrap_user_fn_if_pythonic_config(
     )
 
     config_schema_from_class = infer_schema_from_config_annotation(param.annotation, param.default)
-    config_cls = cast(type[Config], param.annotation)
+    config_cls = cast("type[Config]", param.annotation)
 
     param_name = param.name
 
@@ -314,15 +317,14 @@ def configured(
     _check_configurable_param(configurable)
 
     from dagster._config.pythonic_config import ConfigurableResourceFactory, safe_is_subclass
-    from dagster._core.definitions.resource_definition import ResourceDefinition
 
     # we specially handle ConfigurableResources, treating it as @configured of the
     # underlying resource definition (which is indeed a ConfigurableDefinition)
     if safe_is_subclass(configurable, ConfigurableResourceFactory):
         configurable_inner = cast(
-            ResourceDefinition,
+            "ResourceDefinition",
             (
-                cast(type[ConfigurableResourceFactory], configurable)
+                cast("type[ConfigurableResourceFactory]", configurable)
                 .configure_at_launch()
                 .get_resource_definition()
             ),

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -507,7 +507,7 @@ class CachingDataTimeResolver:
         if None in data_times or not data_times:
             return None
 
-        return min(cast(AbstractSet[datetime.datetime], data_times), default=None)
+        return min(cast("AbstractSet[datetime.datetime]", data_times), default=None)
 
     def _get_source_data_time(
         self, asset_key: AssetKey, current_time: datetime.datetime
@@ -530,7 +530,7 @@ class CachingDataTimeResolver:
             return None
         else:
             return datetime.datetime.fromtimestamp(
-                cast(float, data_time.value), datetime.timezone.utc
+                cast("float", data_time.value), datetime.timezone.utc
             )
 
     def get_minutes_overdue(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -901,7 +901,7 @@ class AutomationResult(Generic[T_EntityKey]):
         ret = f"AutomationResult(label={self.condition.name}, description={self.condition.description}, true={self.true_subset})"
         for child in self.child_results:
             nindent = indent + 4
-            ret += f"\n{' '*nindent}{child.pprint(indent=nindent)}"
+            ret += f"\n{' ' * nindent}{child.pprint(indent=nindent)}"
         return ret
 
     def __repr__(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -115,7 +115,7 @@ class AutomationConditionEvaluator:
 
         async def _evaluate_entity_async(entity_key: EntityKey, offset: int):
             self.logger.debug(
-                f"Evaluating {entity_key.to_user_string()} ({num_evaluated+offset}/{num_conditions})"
+                f"Evaluating {entity_key.to_user_string()} ({num_evaluated + offset}/{num_conditions})"
             )
 
             try:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
@@ -44,7 +44,7 @@ class _ConfigMapping:
             )
 
             config_schema = infer_schema_from_config_annotation(param.annotation, param.default)
-            config_cls = cast(type[Config], param.annotation)
+            config_cls = cast("type[Config]", param.annotation)
 
             param_name = param.name
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -144,7 +144,7 @@ def build_and_validate_named_ins(
         if dep.asset_key not in named_ins_by_asset_key:
             named_ins_by_asset_key[dep.asset_key] = NamedIn(
                 stringify_asset_key_to_input_name(dep.asset_key),
-                In(cast(type, Nothing)),
+                In(cast("type", Nothing)),
             )
 
     return named_ins_by_asset_key

--- a/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
@@ -63,7 +63,7 @@ class _Hook:
             required_resource_keys=self.required_resource_keys,
             decorated_fn=self.decorated_fn or fn,
         )
-        update_wrapper(cast(Callable[..., Any], hook_def), fn)
+        update_wrapper(cast("Callable[..., Any]", hook_def), fn)
         return hook_def
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -415,7 +415,7 @@ def resolve_checked_op_fn_inputs(
     inputs_to_infer = set()
     has_kwargs = False
 
-    for param in cast(list[Parameter], input_args):
+    for param in cast("list[Parameter]", input_args):
         if param.kind == Parameter.VAR_KEYWORD:
             has_kwargs = True
         elif param.kind == Parameter.VAR_POSITIONAL:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -176,10 +176,10 @@ def schedule(
                         tags=evaluated_tags,
                     )
                 elif isinstance(result, list):
-                    yield from cast(list[RunRequest], result)
+                    yield from cast("list[RunRequest]", result)
                 else:
                     # this is a run-request based decorated function
-                    yield from cast(RunRequestIterator, ensure_gen(result))
+                    yield from cast("RunRequestIterator", ensure_gen(result))
 
         has_context_arg = has_at_least_one_parameter(fn)
         evaluation_fn = DecoratedScheduleFunction(

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -185,7 +185,7 @@ class StateBackedDefinitionsLoader(ABC, Generic[TState]):
     def get_or_fetch_state(self) -> TState:
         context = DefinitionsLoadContext.get()
         state = (
-            cast(TState, deserialize_value(context.reconstruction_metadata[self.defs_key]))
+            cast("TState", deserialize_value(context.reconstruction_metadata[self.defs_key]))
             if (
                 context.load_type == DefinitionsLoadType.RECONSTRUCTION
                 and self.defs_key in context.reconstruction_metadata

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -958,7 +958,7 @@ class DependencyStructure:
 
                     node_output_list.append(node_output)
             elif dep_type == DependencyType.DIRECT:
-                node_output = cast(NodeOutput, node_output_or_list)
+                node_output = cast("NodeOutput", node_output_or_list)
 
                 if node_output.is_dynamic:
                     self._validate_and_set_fan_out(node_input, node_output)
@@ -970,7 +970,7 @@ class DependencyStructure:
 
                 node_output_list = [node_output]
             elif dep_type == DependencyType.DYNAMIC_COLLECT:
-                node_output = cast(NodeOutput, node_output_or_list)
+                node_output = cast("NodeOutput", node_output_or_list)
 
                 if node_output.is_dynamic:
                     self._validate_and_set_collect(node_input, node_output)
@@ -1088,7 +1088,7 @@ class DependencyStructure:
             dep_type == DependencyType.DIRECT,
             f"Cannot call get_direct_dep when dep is not singular, got {dep_type}",
         )
-        return cast(NodeOutput, dep)
+        return cast("NodeOutput", dep)
 
     def get_dependency_definition(self, node_input: NodeInput) -> Optional[IDependencyDefinition]:
         return self._deps_by_node_name[node_input.node_name].get(node_input.input_name)
@@ -1109,7 +1109,7 @@ class DependencyStructure:
             dep_type == DependencyType.FAN_IN,
             f"Cannot call get_multi_dep when dep is not fan in, got {dep_type}",
         )
-        return cast(list[Union[NodeOutput, type["MappedInputPlaceholder"]]], deps)
+        return cast("list[Union[NodeOutput, type[MappedInputPlaceholder]]]", deps)
 
     def has_dynamic_fan_in_dep(self, node_input: NodeInput) -> bool:
         check.inst_param(node_input, "node_input", NodeInput)
@@ -1125,7 +1125,7 @@ class DependencyStructure:
             dep_type == DependencyType.DYNAMIC_COLLECT,
             f"Cannot call get_dynamic_fan_in_dep when dep is not, got {dep_type}",
         )
-        return cast(NodeOutput, dep)
+        return cast("NodeOutput", dep)
 
     def has_deps(self, node_input: NodeInput) -> bool:
         check.inst_param(node_input, "node_input", NodeInput)
@@ -1136,9 +1136,9 @@ class DependencyStructure:
         check.invariant(self.has_deps(node_input))
         dep_type, handle_or_list = self._input_to_output_map[node_input]
         if dep_type == DependencyType.DIRECT:
-            return [cast(NodeOutput, handle_or_list)]
+            return [cast("NodeOutput", handle_or_list)]
         elif dep_type == DependencyType.DYNAMIC_COLLECT:
-            return [cast(NodeOutput, handle_or_list)]
+            return [cast("NodeOutput", handle_or_list)]
         elif dep_type == DependencyType.FAN_IN:
             return [handle for handle in handle_or_list if isinstance(handle, NodeOutput)]
         else:

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -564,7 +564,7 @@ class AssetMaterialization(
             asset_key = path
 
         return AssetMaterialization(
-            asset_key=cast(Union[str, AssetKey, list[str]], asset_key),
+            asset_key=cast("Union[str, AssetKey, list[str]]", asset_key),
             description=description,
             metadata={"path": MetadataValue.path(path)},
         )
@@ -850,7 +850,7 @@ class HookExecutionResult(
         return super().__new__(
             cls,
             hook_name=check.str_param(hook_name, "hook_name"),
-            is_skipped=cast(bool, check.opt_bool_param(is_skipped, "is_skipped", default=False)),
+            is_skipped=cast("bool", check.opt_bool_param(is_skipped, "is_skipped", default=False)),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -385,7 +385,7 @@ class GraphDefinition(NodeDefinition):
         while lineage:
             name = lineage.pop()
             # We know that this is a current node is a graph while ascending lineage
-            definition = cast(GraphDefinition, node.definition)
+            definition = cast("GraphDefinition", node.definition)
             node = definition.node_named(name)
 
         return node
@@ -582,7 +582,7 @@ class GraphDefinition(NodeDefinition):
                 f'"{self.name}" does not have a config mapping, and thus has nothing to be '
                 "configured."
             )
-        config_mapping = cast(ConfigMapping, self.config_mapping)
+        config_mapping = cast("ConfigMapping", self.config_mapping)
         return self.copy(
             name=name,
             description=check.opt_str_param(description, "description", default=self.description),
@@ -1087,7 +1087,7 @@ def _validate_in_mappings(
         node_input = NodeInput(target_node, target_input_def)
 
         if mapping.maps_to_fan_in:
-            maps_to = cast(FanInInputPointer, mapping.maps_to)
+            maps_to = cast("FanInInputPointer", mapping.maps_to)
             if not dependency_structure.has_fan_in_deps(node_input):
                 raise DagsterInvalidDefinitionError(
                     f"In {class_name} '{name}' input mapping target"

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -483,9 +483,9 @@ class JobDefinition(IHasInternalInit):
 
     def get_op(self, handle: NodeHandle) -> OpNode:
         node = self.get_node(handle)
-        assert isinstance(
-            node, OpNode
-        ), f"Tried to retrieve node {handle} as op, but it represents a nested graph."
+        assert isinstance(node, OpNode), (
+            f"Tried to retrieve node {handle} as op, but it represents a nested graph."
+        )
         return node
 
     def has_node_named(self, name: str) -> bool:
@@ -587,7 +587,7 @@ class JobDefinition(IHasInternalInit):
         while lineage:
             name = lineage.pop()
             # While lineage is non-empty, definition is guaranteed to be a graph
-            definition = cast(GraphDefinition, node.definition)
+            definition = cast("GraphDefinition", node.definition)
             node = definition.node_named(name)
             hook_defs = hook_defs.union(node.hook_defs)
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -251,7 +251,7 @@ class MetadataEntry(
         value: Optional["RawMetadataValue"] = None,
     ):
         value = cast(
-            RawMetadataValue,
+            "RawMetadataValue",
             normalize_renamed_param(
                 new_val=value,
                 new_arg="value",

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
@@ -99,7 +99,7 @@ def load_assets_from_modules(
         else tuple(t for t in get_args(AssetLoaderTypes) if t != AssetSpec)
     )
     return cast(
-        Sequence[AssetLoaderTypes],
+        "Sequence[AssetLoaderTypes]",
         ModuleScopedDagsterDefs.from_modules(modules, types_to_load=types_to_load)
         .get_object_list()
         .with_attributes(

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
@@ -220,7 +220,7 @@ class DagsterObjectsList:
     @cached_property
     def checks_defs(self) -> Sequence[AssetChecksDefinition]:
         return [
-            cast(AssetChecksDefinition, asset)
+            cast("AssetChecksDefinition", asset)
             for asset in self.loaded_defs
             if isinstance(asset, AssetsDefinition) and has_only_asset_checks(asset)
         ]

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -684,9 +684,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         return all([partition in materialized_partitions for partition in partitions])
 
     def _get_asset(self, asset_key: AssetKey, fn_name: str) -> AssetsDefinition:
-        from dagster._core.definitions.repository_definition import RepositoryDefinition
-
-        repo_def = cast(RepositoryDefinition, self._repository_def)
+        repo_def = cast("RepositoryDefinition", self._repository_def)
         if asset_key in self._assets_by_key:
             asset_def = self._assets_by_key[asset_key]
             if asset_def is None:
@@ -1056,7 +1054,7 @@ def build_multi_asset_sensor_context(
         asset_keys: Sequence[AssetKey]
         if isinstance(monitored_assets, AssetSelection):
             asset_keys = cast(
-                list[AssetKey],
+                "list[AssetKey]",
                 list(monitored_assets.resolve(list(set(repository_def.asset_graph.assets_defs)))),
             )
         else:

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -482,7 +482,7 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         return self._get_primary_and_secondary_dimension()[1]
 
     def get_tags_for_partition_key(self, partition_key: str) -> Mapping[str, str]:
-        partition_key = cast(MultiPartitionKey, self.get_partition_key_from_str(partition_key))
+        partition_key = cast("MultiPartitionKey", self.get_partition_key_from_str(partition_key))
         tags = {**super().get_tags_for_partition_key(partition_key)}
         tags.update(get_tags_from_multi_partition_key(partition_key))
         return tags
@@ -510,7 +510,7 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
     def time_window_partitions_def(self) -> TimeWindowPartitionsDefinition:
         check.invariant(self.has_time_window_dimension, "Must have time window dimension")
         return cast(
-            TimeWindowPartitionsDefinition,
+            "TimeWindowPartitionsDefinition",
             check.inst(self.primary_dimension.partitions_def, TimeWindowPartitionsDefinition),
         )
 
@@ -520,9 +520,9 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
 
         time_window_dimension = self.time_window_dimension
         return cast(
-            TimeWindowPartitionsDefinition, time_window_dimension.partitions_def
+            "TimeWindowPartitionsDefinition", time_window_dimension.partitions_def
         ).time_window_for_partition_key(
-            cast(MultiPartitionKey, partition_key).keys_by_dimension[time_window_dimension.name]
+            cast("MultiPartitionKey", partition_key).keys_by_dimension[time_window_dimension.name]
         )
 
     def get_multipartition_keys_with_dimension_value(

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -136,7 +136,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             resolved_input_defs: Sequence[InputDefinition] = resolve_checked_op_fn_inputs(
                 decorator_name="@op",
                 fn_name=name,
-                compute_fn=cast(DecoratedOpFunction, compute_fn),
+                compute_fn=cast("DecoratedOpFunction", compute_fn),
                 explicit_input_defs=input_defs,
                 exclude_nothing=True,
             )
@@ -339,7 +339,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional[NodeHandle] = None
     ) -> Sequence[InputDefinition]:
-        handle = cast(NodeHandle, check.inst_param(handle, "handle", NodeHandle))
+        handle = cast("NodeHandle", check.inst_param(handle, "handle", NodeHandle))
         unresolveable_input_defs = []
         for input_def in self.input_defs:
             if (

--- a/python_modules/dagster/dagster/_core/definitions/op_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_selection.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, AbstractSet, NamedTuple, Optional, Union, cast  # noqa: UP035
 
 from dagster import _check as check
-from dagster._core.definitions.composition import MappedInputPlaceholder
 from dagster._core.definitions.dependency import (
     DependencyDefinition,
     DynamicCollectDependencyDefinition,
@@ -19,6 +18,7 @@ from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import parse_op_queries
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.composition import MappedInputPlaceholder
     from dagster._core.definitions.node_definition import NodeDefinition
 
 
@@ -183,7 +183,7 @@ def _get_graph_subset(
                 ]
                 node_deps[node_input.input_name] = MultiDependencyDefinition(
                     cast(
-                        list[Union[DependencyDefinition, type[MappedInputPlaceholder]]],
+                        "list[Union[DependencyDefinition, type[MappedInputPlaceholder]]]",
                         multi_dependencies,
                     )
                 )

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -263,7 +263,7 @@ class PartitionsDefinition(ABC, Generic[T_str]):
 
         # in the simple case, simply return the single key in the range
         if partition_key_range.start == partition_key_range.end:
-            return [cast(T_str, partition_key_range.start)]
+            return [cast("T_str", partition_key_range.start)]
 
         # defer this call as it is potentially expensive
         partition_keys = self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
@@ -876,7 +876,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             hardcoded_config = config if config else {}
             return cls(
                 partitions_def,  # type: ignore # ignored for update, fix me!
-                run_config_for_partition_key_fn=lambda _: cast(Mapping, hardcoded_config),
+                run_config_for_partition_key_fn=lambda _: cast("Mapping", hardcoded_config),
             )
 
     def __call__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -558,7 +558,7 @@ class BaseMultiPartitionMapping(ABC):
                     [
                         dep_b_keys_by_a_dim_and_key[dim_name][
                             (
-                                cast(MultiPartitionsDefinition, a_partitions_def)
+                                cast("MultiPartitionsDefinition", a_partitions_def)
                                 .get_partition_key_from_str(key)
                                 .keys_by_dimension[dim_name]
                                 if dim_name
@@ -578,7 +578,7 @@ class BaseMultiPartitionMapping(ABC):
                 b_partition_keys.add(
                     MultiPartitionKey(
                         {
-                            cast(str, (mapped_b_dim_names + unmapped_b_dim_names)[i]): key
+                            cast("str", (mapped_b_dim_names + unmapped_b_dim_names)[i]): key
                             for i, key in enumerate(b_key_values)
                         }
                     )
@@ -611,7 +611,7 @@ class BaseMultiPartitionMapping(ABC):
         result = self._get_dependency_partitions_subset(
             check.not_none(downstream_partitions_def),
             downstream_partitions_subset,
-            cast(MultiPartitionsDefinition, upstream_partitions_def),
+            cast("MultiPartitionsDefinition", upstream_partitions_def),
             a_upstream_of_b=False,
             dynamic_partitions_store=dynamic_partitions_store,
             current_time=current_time,
@@ -636,7 +636,7 @@ class BaseMultiPartitionMapping(ABC):
         result = self._get_dependency_partitions_subset(
             upstream_partitions_def,
             upstream_partitions_subset,
-            cast(MultiPartitionsDefinition, downstream_partitions_def),
+            cast("MultiPartitionsDefinition", downstream_partitions_def),
             a_upstream_of_b=True,
             dynamic_partitions_store=dynamic_partitions_store,
         )
@@ -697,7 +697,7 @@ class MultiToSingleDimensionPartitionMapping(
         )
         if not infer_mapping_result.can_infer:
             check.invariant(isinstance(infer_mapping_result.inference_failure_reason, str))
-            check.failed(cast(str, infer_mapping_result.inference_failure_reason))
+            check.failed(cast("str", infer_mapping_result.inference_failure_reason))
 
     def get_dimension_dependencies(
         self,
@@ -710,9 +710,9 @@ class MultiToSingleDimensionPartitionMapping(
 
         if not infer_mapping_result.can_infer:
             check.invariant(isinstance(infer_mapping_result.inference_failure_reason, str))
-            check.failed(cast(str, infer_mapping_result.inference_failure_reason))
+            check.failed(cast("str", infer_mapping_result.inference_failure_reason))
 
-        return [cast(DimensionDependency, infer_mapping_result.dimension_dependency)]
+        return [cast("DimensionDependency", infer_mapping_result.dimension_dependency)]
 
 
 @whitelist_for_serdes
@@ -904,11 +904,11 @@ class MultiPartitionMapping(
 
         upstream_dimension_names = {
             dim.name
-            for dim in cast(MultiPartitionsDefinition, upstream_partitions_def).partitions_defs
+            for dim in cast("MultiPartitionsDefinition", upstream_partitions_def).partitions_defs
         }
         dimension_names = {
             dim.name
-            for dim in cast(MultiPartitionsDefinition, downstream_partitions_def).partitions_defs
+            for dim in cast("MultiPartitionsDefinition", downstream_partitions_def).partitions_defs
         }
 
         for (
@@ -992,10 +992,10 @@ class StaticPartitionMapping(
             "Downstream partitions definition must be a StaticPartitionsDefinition",
         )
         self._check_upstream(
-            upstream_partitions_def=cast(StaticPartitionsDefinition, upstream_partitions_def)
+            upstream_partitions_def=cast("StaticPartitionsDefinition", upstream_partitions_def)
         )
         self._check_downstream(
-            downstream_partitions_def=cast(StaticPartitionsDefinition, downstream_partitions_def)
+            downstream_partitions_def=cast("StaticPartitionsDefinition", downstream_partitions_def)
         )
 
     @cached_method
@@ -1132,7 +1132,7 @@ def _get_infer_single_to_multi_dimension_deps_result(
             f" Instead received {len(multipartitions_defs)} multi-partitioned assets.",
         )
 
-    multipartitions_def = cast(MultiPartitionsDefinition, next(iter(multipartitions_defs)))
+    multipartitions_def = cast("MultiPartitionsDefinition", next(iter(multipartitions_defs)))
 
     single_dimension_partitions_def = next(
         iter(

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -270,11 +270,7 @@ def _check_valid_schedule_partitions_def(
         )
 
     return cast(
-        Union[
-            TimeWindowPartitionsDefinition,
-            MultiPartitionsDefinition,
-            StaticPartitionsDefinition,
-        ],
+        "Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition, StaticPartitionsDefinition]",
         partitions_def,
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
@@ -121,7 +121,7 @@ class CacheingDefinitionIndex(Generic[T_RepositoryLevelDefinition]):
             self._definition_cache[definition_name] = self._validation_fn(definition_source)
             return definition_source
         else:
-            definition = cast(Callable, definition_source)()
+            definition = cast("Callable", definition_source)()
             self._validate_and_cache_definition(definition, definition_name)
             return definition
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -88,7 +88,7 @@ def _env_vars_from_resource_defaults(resource_def: ResourceDefinition) -> set[st
     from dagster._core.execution.build_resources import wrap_resource_for_execution
 
     config_schema_default = cast(
-        Mapping[str, Any],
+        "Mapping[str, Any]",
         (
             json.loads(resource_def.config_schema.default_value_as_json_str)
             if resource_def.config_schema.default_provided
@@ -351,7 +351,7 @@ def build_caching_repository_data_from_list(
             job_def
             if isfunction(job_def)
             else _process_resolved_job(
-                cast(JobDefinition, job_def), default_executor_def, default_logger_defs
+                cast("JobDefinition", job_def), default_executor_def, default_logger_defs
             )
         )
         for name, job_def in jobs.items()

--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -160,7 +160,7 @@ def resolve_assets_def_deps(
         for input_name, upstream_key in assets_def.keys_by_input_name.items():
             group_and_upstream_name = (group_name, upstream_key.path[-1])
             matching_asset_keys = asset_keys_by_group_and_name.get(
-                cast(tuple[str, str], group_and_upstream_name)
+                cast("tuple[str, str]", group_and_upstream_name)
             )
             if upstream_key in all_asset_keys:
                 pass

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -190,7 +190,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, IHasInternalInit):
         # Make sure telemetry info gets passed in to hardcoded resources
         if hasattr(value, "_is_dagster_maintained"):
             resource_def._dagster_maintained = value._is_dagster_maintained()  # noqa: SLF001
-            resource_def._hardcoded_resource_type = type(value)  # noqa: SLF001
+            resource_def._hardcoded_resource_type = type(value)
 
         return resource_def
 
@@ -268,7 +268,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, IHasInternalInit):
             if args:
                 check.opt_inst_param(args[0], context_param_name, UnboundInitResourceContext)
                 return resource_invocation_result(
-                    self, cast(Optional[UnboundInitResourceContext], args[0])
+                    self, cast("Optional[UnboundInitResourceContext]", args[0])
                 )
             else:
                 if context_param_name not in kwargs:
@@ -280,7 +280,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, IHasInternalInit):
                 )
 
                 return resource_invocation_result(
-                    self, cast(Optional[UnboundInitResourceContext], kwargs[context_param_name])
+                    self, cast("Optional[UnboundInitResourceContext]", kwargs[context_param_name])
                 )
         elif len(args) + len(kwargs) > 0:
             raise DagsterInvalidInvocationError(
@@ -406,7 +406,7 @@ def resource(
 
     def _wrap(resource_fn: ResourceFunction) -> "ResourceDefinition":
         return _ResourceDecoratorCallable(
-            config_schema=cast(Optional[dict[str, Any]], config_schema),
+            config_schema=cast("Optional[dict[str, Any]]", config_schema),
             description=description,
             required_resource_keys=required_resource_keys,
             version=version,

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -122,7 +122,7 @@ def resolve_bound_config(config: Any, configurable_def: ConfigurableDefinition) 
             config_evr.errors,
             config,
         )
-    validated_config = cast(dict[str, Any], config_evr.value).get("config")
+    validated_config = cast("dict[str, Any]", config_evr.value).get("config")
     mapped_config_evr = configurable_def.apply_config_mapping({"config": validated_config})
     if not mapped_config_evr.success:
         raise DagsterInvalidConfigError(
@@ -130,5 +130,5 @@ def resolve_bound_config(config: Any, configurable_def: ConfigurableDefinition) 
             mapped_config_evr.errors,
             validated_config,
         )
-    validated_config = cast(dict[str, Any], mapped_config_evr.value).get("config")
+    validated_config = cast("dict[str, Any]", mapped_config_evr.value).get("config")
     return validated_config

--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -74,7 +74,7 @@ class ResourceKeyRequirement(ResourceRequirement, ABC):
         resource_def = resource_defs[self.key]
         if not isinstance(resource_def, self.expected_type):
             raise DagsterInvalidDefinitionError(
-                f"{self.describe_requirement()}, but received" f" {type(resource_def)}."
+                f"{self.describe_requirement()}, but received {type(resource_def)}."
             )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -171,7 +171,7 @@ def define_run_config_schema_type(creation_data: RunConfigSchemaCreationData) ->
     }
 
     if creation_data.graph_def.has_config_mapping:
-        config_schema = cast(IDefinitionConfigSchema, creation_data.graph_def.config_schema)
+        config_schema = cast("IDefinitionConfigSchema", creation_data.graph_def.config_schema)
         nodes_field = Field(
             {"config": config_schema.as_field()},
             description="Configure runtime parameters for ops or assets.",

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -3,7 +3,6 @@ import logging
 import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import ExitStack
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union, cast, overload
 
 from dagster_shared.serdes import deserialize_value
@@ -51,6 +50,8 @@ from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.warnings import normalize_renamed_param
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from dagster._core.definitions.resource_definition import ResourceDefinition
     from dagster._core.definitions.selector import (
         CodeLocationSelector,
@@ -115,7 +116,7 @@ class RunStatusSensorCursor(
             return False
 
     def to_json(self) -> str:
-        return serialize_value(cast(NamedTuple, self))
+        return serialize_value(cast("NamedTuple", self))
 
     @staticmethod
     def from_json(json_str: str) -> "RunStatusSensorCursor":
@@ -328,7 +329,7 @@ class RunFailureSensorContext(RunStatusSensorContext):
         records = self.instance.get_records_for_run(
             run_id=self.dagster_run.run_id, of_type=DagsterEventType.STEP_FAILURE
         ).records
-        return [cast(DagsterEvent, record.event_log_entry.dagster_event) for record in records]
+        return [cast("DagsterEvent", record.event_log_entry.dagster_event) for record in records]
 
 
 @beta_param(param="repository_def")
@@ -731,7 +732,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             process_limit = _get_run_status_sensor_process_limit()
 
             fetch_limit = _get_run_status_sensor_fetch_limit(
-                monitor_all_code_locations=cast(bool, monitor_all_code_locations)
+                monitor_all_code_locations=cast("bool", monitor_all_code_locations)
             )
 
             # Fetch events after the cursor id
@@ -746,9 +747,9 @@ class RunStatusSensorDefinition(SensorDefinition):
                 # index shard instead of the run shard.
                 event_records = context.instance.fetch_run_status_changes(
                     records_filter=RunStatusChangeRecordsFilter(
-                        event_type=cast(RunStatusChangeEventType, event_type),
+                        event_type=cast("RunStatusChangeEventType", event_type),
                         after_timestamp=cast(
-                            datetime, parse_time_string(sensor_cursor.update_timestamp)
+                            "datetime", parse_time_string(sensor_cursor.update_timestamp)
                         ).timestamp(),
                     ),
                     ascending=True,
@@ -770,20 +771,13 @@ class RunStatusSensorDefinition(SensorDefinition):
                 # avoid fetching events that we will filter out later on.
                 job_names = _job_names_for_monitored(
                     cast(
-                        Sequence[
-                            Union[
-                                JobDefinition,
-                                GraphDefinition,
-                                UnresolvedAssetJobDefinition,
-                                "JobSelector",
-                            ]
-                        ],
+                        "Sequence[Union[JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition, JobSelector]]",
                         monitored_jobs,
                     )
                 )
                 event_records = context.instance.fetch_run_status_changes(
                     records_filter=RunStatusChangeRecordsFilter(
-                        event_type=cast(RunStatusChangeEventType, event_type),
+                        event_type=cast("RunStatusChangeEventType", event_type),
                         after_storage_id=sensor_cursor.record_id,
                         job_names=job_names,
                     ),
@@ -797,7 +791,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                 # API only queries the global index shard instead of the run shard.
                 event_records = context.instance.fetch_run_status_changes(
                     records_filter=RunStatusChangeRecordsFilter(
-                        event_type=cast(RunStatusChangeEventType, event_type),
+                        event_type=cast("RunStatusChangeEventType", event_type),
                         after_storage_id=sensor_cursor.record_id,
                     ),
                     ascending=True,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -304,7 +304,7 @@ class ScheduleEvaluationContext:
             self._instance = self._exit_stack.enter_context(
                 DagsterInstance.from_ref(self._instance_ref)
             )
-        return cast(DagsterInstance, self._instance)
+        return cast("DagsterInstance", self._instance)
 
     @property
     def instance_ref(self) -> Optional[InstanceRef]:
@@ -693,7 +693,7 @@ class ScheduleDefinition(IHasInternalInit):
             self._tags = normalize_tags(tags, allow_private_system_tags=False, warning_stacklevel=4)
             if tags_fn:
                 self._tags_fn = check.opt_callable_param(
-                    tags_fn, "tags_fn", default=lambda _context: cast(Mapping[str, str], {})
+                    tags_fn, "tags_fn", default=lambda _context: cast("Mapping[str, str]", {})
                 )
             else:
                 tags_fn = lambda _context: self._tags or {}
@@ -938,7 +938,7 @@ class ScheduleDefinition(IHasInternalInit):
             execution_fn = self._execution_fn.wrapped_fn
         else:
             execution_fn = cast(
-                Callable[..., "ScheduleEvaluationFunctionReturn"],
+                "Callable[..., ScheduleEvaluationFunctionReturn]",
                 self._execution_fn,
             )
 
@@ -961,7 +961,7 @@ class ScheduleDefinition(IHasInternalInit):
         else:
             # NOTE: mypy is not correctly reading this cast-- not sure why
             # (pyright reads it fine). Hence the type-ignores below.
-            result = cast(list[RunRequest], check.is_list(result, of_type=RunRequest))
+            result = cast("list[RunRequest]", check.is_list(result, of_type=RunRequest))
             check.invariant(
                 not any(not request.run_key for request in result),
                 "Schedules that return multiple RunRequests must specify a run_key in each"

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -328,7 +328,7 @@ class SensorEvaluationContext:
             self._instance = self._exit_stack.enter_context(
                 DagsterInstance.from_ref(self._instance_ref)
             )
-        return cast(DagsterInstance, self._instance)
+        return cast("DagsterInstance", self._instance)
 
     @property
     def instance_ref(self) -> Optional[InstanceRef]:
@@ -426,7 +426,7 @@ class SensorEvaluationContext:
                     instigator_name=self._sensor_name,
                 )
             )
-            return cast(logging.Logger, self._logger)
+            return cast("logging.Logger", self._logger)
 
         self._logger = self._exit_stack.enter_context(
             InstigationLogger(
@@ -436,7 +436,7 @@ class SensorEvaluationContext:
                 instigator_name=self._sensor_name,
             )
         )
-        return cast(logging.Logger, self._logger)
+        return cast("logging.Logger", self._logger)
 
     def has_captured_logs(self):
         return self._logger and self._logger.has_captured_logs()
@@ -918,7 +918,9 @@ class SensorDefinition(IHasInternalInit):
                 skip_message = item.skip_message if isinstance(item, SkipReason) else None
             elif isinstance(item, DagsterRunReaction):
                 dagster_run_reactions = (
-                    [cast(DagsterRunReaction, item)] if isinstance(item, DagsterRunReaction) else []
+                    [cast("DagsterRunReaction", item)]
+                    if isinstance(item, DagsterRunReaction)
+                    else []
                 )
             else:
                 check.failed(f"Unexpected type {type(item)} in sensor result")

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -328,7 +328,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
     def io_manager_def(self) -> Optional[IOManagerDefinition]:
         io_manager_key = self.get_io_manager_key()
         return cast(
-            Optional[IOManagerDefinition],
+            "Optional[IOManagerDefinition]",
             self.resource_defs.get(io_manager_key) if io_manager_key else None,
         )
 
@@ -344,7 +344,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
             isinstance(self.node_def, OpDefinition),
             "The NodeDefinition for this AssetsDefinition is not of type OpDefinition.",
         )
-        return cast(OpDefinition, self.node_def)
+        return cast("OpDefinition", self.node_def)
 
     @property
     def execution_type(self) -> AssetExecutionType:

--- a/python_modules/dagster/dagster/_core/definitions/tags/tag_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/tags/tag_set.py
@@ -50,4 +50,4 @@ class NamespacedTagSet(NamespacedKVSet):
     @classmethod
     def _extract_value(cls, field_name: str, value: Any) -> str:
         """Since all tag values are strings, we don't need to do any type coercion."""
-        return cast(str, value)
+        return cast("str", value)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -133,7 +133,7 @@ class TimeWindowPartitionMapping(
             return TimeWindowPartitionsSubset.from_all_partitions_subset(subset)
         else:
             return check.inst_param(
-                cast(TimeWindowPartitionsSubset, subset),
+                cast("TimeWindowPartitionsSubset", subset),
                 param_name,
                 TimeWindowPartitionsSubset,
             )
@@ -142,7 +142,7 @@ class TimeWindowPartitionMapping(
         self, param_name: str, partitions_def: Optional[PartitionsDefinition]
     ) -> TimeWindowPartitionsDefinition:
         return check.inst_param(
-            cast(TimeWindowPartitionsDefinition, partitions_def),
+            cast("TimeWindowPartitionsDefinition", partitions_def),
             param_name,
             TimeWindowPartitionsDefinition,
         )
@@ -185,8 +185,10 @@ class TimeWindowPartitionMapping(
             "Downstream partitions definition must be a TimeWindowPartitionsDefinition",
         )
 
-        upstream_partitions_def = cast(TimeWindowPartitionsDefinition, upstream_partitions_def)
-        downstream_partitions_def = cast(TimeWindowPartitionsDefinition, downstream_partitions_def)
+        upstream_partitions_def = cast("TimeWindowPartitionsDefinition", upstream_partitions_def)
+        downstream_partitions_def = cast(
+            "TimeWindowPartitionsDefinition", downstream_partitions_def
+        )
 
         if upstream_partitions_def.timezone != downstream_partitions_def.timezone:
             raise DagsterInvalidDefinitionError(
@@ -551,13 +553,13 @@ def _offsetted_datetime(
     for _ in range(abs(offset)):
         if offset < 0:
             prev_window = cast(
-                TimeWindow,
+                "TimeWindow",
                 partitions_def.get_prev_partition_window(result, respect_bounds=False),
             )
             result = prev_window.start
         else:
             next_window = cast(
-                TimeWindow,
+                "TimeWindow",
                 partitions_def.get_next_partition_window(result, respect_bounds=False),
             )
             result = next_window.end

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -65,11 +65,11 @@ def is_second_ambiguous_time(dt: datetime, tz: str):
         return False
 
     offset_before = cast(
-        timedelta,
+        "timedelta",
         (tzinfo.utcoffset(dt.replace(fold=0)) if dt.fold else tzinfo.utcoffset(dt)),
     )
     offset_after = cast(
-        timedelta,
+        "timedelta",
         (tzinfo.utcoffset(dt) if dt.fold else tzinfo.utcoffset(dt.replace(fold=1))),
     )
     return offset_before > offset_after
@@ -1011,7 +1011,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
             )
 
         minute_of_hour = cast(
-            int,
+            "int",
             check.opt_int_param(minute_of_hour, "minute_of_hour", default=self.minute_offset),
         )
 
@@ -1021,7 +1021,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
             )
         else:
             hour_of_day = cast(
-                int, check.opt_int_param(hour_of_day, "hour_of_day", default=self.hour_offset)
+                "int", check.opt_int_param(hour_of_day, "hour_of_day", default=self.hour_offset)
             )
 
         if schedule_type == ScheduleType.DAILY:
@@ -1991,10 +1991,10 @@ class TimeWindowPartitionsSubset(
         Each time window is a single partition.
         """
         first_tw = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            "TimeWindowPartitionsDefinition", self.partitions_def
         ).get_first_partition_window(current_time=current_time)
         last_tw = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            "TimeWindowPartitionsDefinition", self.partitions_def
         ).get_last_partition_window(current_time=current_time)
 
         if not first_tw or not last_tw:
@@ -2065,7 +2065,7 @@ class TimeWindowPartitionsSubset(
         for tw in self._get_partition_time_windows_not_in_subset(current_time):
             partition_keys.extend(
                 cast(
-                    TimeWindowPartitionsDefinition, self.partitions_def
+                    "TimeWindowPartitionsDefinition", self.partitions_def
                 ).get_partition_keys_in_time_window(tw)
             )
         return partition_keys
@@ -2079,7 +2079,7 @@ class TimeWindowPartitionsSubset(
     ) -> Sequence[PartitionKeyRange]:
         return [
             cast(
-                TimeWindowPartitionsDefinition, self.partitions_def
+                "TimeWindowPartitionsDefinition", self.partitions_def
             ).get_partition_key_range_for_time_window(
                 window.to_public_time_window(), respect_bounds=respect_bounds
             )
@@ -2097,7 +2097,7 @@ class TimeWindowPartitionsSubset(
         """
         result_windows = [*initial_windows]
         time_windows = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
+            "TimeWindowPartitionsDefinition", self.partitions_def
         ).time_windows_for_partition_keys(frozenset(partition_keys), validate=validate)
 
         num_added_partitions = 0
@@ -2201,7 +2201,7 @@ class TimeWindowPartitionsSubset(
     ) -> "PartitionsSubset":
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
-        partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
+        partitions_def = cast("TimeWindowPartitionsDefinition", partitions_def)
         return cls(partitions_def, 0, [])
 
     def with_partitions_def(
@@ -2347,7 +2347,7 @@ class TimeWindowPartitionsSubset(
 
         try:
             time_window = cast(
-                TimeWindowPartitionsDefinition, self.partitions_def
+                "TimeWindowPartitionsDefinition", self.partitions_def
             ).time_window_for_partition_key(partition_key)
         except ValueError:
             # invalid partition key
@@ -2407,7 +2407,7 @@ class TimeWindowPartitionsSubset(
     ) -> "PartitionsSubset":
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
-        partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
+        partitions_def = cast("TimeWindowPartitionsDefinition", partitions_def)
 
         loaded = json.loads(serialized)
 
@@ -2641,7 +2641,7 @@ def get_time_partitions_def(
         partitions_def, MultiPartitionsDefinition
     ) and has_one_dimension_time_window_partitioning(partitions_def):
         return cast(
-            TimeWindowPartitionsDefinition, partitions_def.time_window_dimension.partitions_def
+            "TimeWindowPartitionsDefinition", partitions_def.time_window_dimension.partitions_def
         )
     else:
         return None

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -221,7 +221,7 @@ def config_from_files(config_files: Sequence[str]) -> Mapping[str, Any]:
             f"loaded by file/patterns {config_files}."
         ) from err
 
-    return check.is_dict(cast(dict[str, object], run_config), key_type=str)
+    return check.is_dict(cast("dict[str, object]", run_config), key_type=str)
 
 
 def config_from_yaml_strings(yaml_strings: Sequence[str]) -> Mapping[str, Any]:
@@ -246,7 +246,7 @@ def config_from_yaml_strings(yaml_strings: Sequence[str]) -> Mapping[str, Any]:
             f"Encountered error attempting to parse yaml. Parsing YAMLs {yaml_strings} "
         ) from err
 
-    return check.is_dict(cast(dict[str, object], run_config), key_type=str)
+    return check.is_dict(cast("dict[str, object]", run_config), key_type=str)
 
 
 def config_from_pkg_resources(pkg_resource_defs: Sequence[tuple[str, str]]) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -382,7 +382,7 @@ def log_job_event(job_context: IPlanContext, event: "DagsterEvent") -> None:
 
 
 def log_resource_event(log_manager: DagsterLogManager, event: "DagsterEvent") -> None:
-    event_specific_data = cast(EngineEventData, event.event_specific_data)
+    event_specific_data = cast("EngineEventData", event.event_specific_data)
 
     log_level = logging.ERROR if event_specific_data.error else logging.DEBUG
     log_manager.log_dagster_event(level=log_level, msg=event.message or "", dagster_event=event)
@@ -583,7 +583,7 @@ class DagsterEvent(
     @property
     def node_name(self) -> str:
         check.invariant(self.node_handle is not None)
-        node_handle = cast(NodeHandle, self.node_handle)
+        node_handle = cast("NodeHandle", self.node_handle)
         return node_handle.name
 
     @public
@@ -776,44 +776,44 @@ class DagsterEvent(
     @property
     def step_input_data(self) -> "StepInputData":
         _assert_type("step_input_data", DagsterEventType.STEP_INPUT, self.event_type)
-        return cast(StepInputData, self.event_specific_data)
+        return cast("StepInputData", self.event_specific_data)
 
     @property
     def run_enqueued_data(self) -> Optional["RunEnqueuedData"]:
         _assert_type("run_enqueued_data", DagsterEventType.RUN_ENQUEUED, self.event_type)
-        return cast(Optional[RunEnqueuedData], self.event_specific_data)
+        return cast("Optional[RunEnqueuedData]", self.event_specific_data)
 
     @property
     def step_output_data(self) -> StepOutputData:
         _assert_type("step_output_data", DagsterEventType.STEP_OUTPUT, self.event_type)
-        return cast(StepOutputData, self.event_specific_data)
+        return cast("StepOutputData", self.event_specific_data)
 
     @property
     def step_success_data(self) -> "StepSuccessData":
         _assert_type("step_success_data", DagsterEventType.STEP_SUCCESS, self.event_type)
-        return cast(StepSuccessData, self.event_specific_data)
+        return cast("StepSuccessData", self.event_specific_data)
 
     @property
     def step_failure_data(self) -> "StepFailureData":
         _assert_type("step_failure_data", DagsterEventType.STEP_FAILURE, self.event_type)
-        return cast(StepFailureData, self.event_specific_data)
+        return cast("StepFailureData", self.event_specific_data)
 
     @property
     def step_retry_data(self) -> "StepRetryData":
         _assert_type("step_retry_data", DagsterEventType.STEP_UP_FOR_RETRY, self.event_type)
-        return cast(StepRetryData, self.event_specific_data)
+        return cast("StepRetryData", self.event_specific_data)
 
     @property
     def step_materialization_data(self) -> "StepMaterializationData":
         _assert_type(
             "step_materialization_data", DagsterEventType.ASSET_MATERIALIZATION, self.event_type
         )
-        return cast(StepMaterializationData, self.event_specific_data)
+        return cast("StepMaterializationData", self.event_specific_data)
 
     @property
     def asset_observation_data(self) -> "AssetObservationData":
         _assert_type("asset_observation_data", DagsterEventType.ASSET_OBSERVATION, self.event_type)
-        return cast(AssetObservationData, self.event_specific_data)
+        return cast("AssetObservationData", self.event_specific_data)
 
     @property
     def asset_materialization_planned_data(self) -> "AssetMaterializationPlannedData":
@@ -822,7 +822,7 @@ class DagsterEvent(
             DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
             self.event_type,
         )
-        return cast(AssetMaterializationPlannedData, self.event_specific_data)
+        return cast("AssetMaterializationPlannedData", self.event_specific_data)
 
     @property
     def asset_check_planned_data(self) -> "AssetCheckEvaluationPlanned":
@@ -831,7 +831,7 @@ class DagsterEvent(
             DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
             self.event_type,
         )
-        return cast(AssetCheckEvaluationPlanned, self.event_specific_data)
+        return cast("AssetCheckEvaluationPlanned", self.event_specific_data)
 
     @property
     def asset_failed_to_materialize_data(
@@ -842,7 +842,7 @@ class DagsterEvent(
             DagsterEventType.ASSET_FAILED_TO_MATERIALIZE,
             self.event_type,
         )
-        return cast(AssetFailedToMaterializeData, self.event_specific_data)
+        return cast("AssetFailedToMaterializeData", self.event_specific_data)
 
     @property
     def step_expectation_result_data(self) -> "StepExpectationResultData":
@@ -851,31 +851,31 @@ class DagsterEvent(
             DagsterEventType.STEP_EXPECTATION_RESULT,
             self.event_type,
         )
-        return cast(StepExpectationResultData, self.event_specific_data)
+        return cast("StepExpectationResultData", self.event_specific_data)
 
     @property
     def materialization(self) -> AssetMaterialization:
         _assert_type(
             "step_materialization_data", DagsterEventType.ASSET_MATERIALIZATION, self.event_type
         )
-        return cast(StepMaterializationData, self.event_specific_data).materialization
+        return cast("StepMaterializationData", self.event_specific_data).materialization
 
     @property
     def asset_check_evaluation_data(self) -> AssetCheckEvaluation:
         _assert_type(
             "asset_check_evaluation", DagsterEventType.ASSET_CHECK_EVALUATION, self.event_type
         )
-        return cast(AssetCheckEvaluation, self.event_specific_data)
+        return cast("AssetCheckEvaluation", self.event_specific_data)
 
     @property
     def job_failure_data(self) -> "JobFailureData":
         _assert_type("job_failure_data", DagsterEventType.RUN_FAILURE, self.event_type)
-        return cast(JobFailureData, self.event_specific_data)
+        return cast("JobFailureData", self.event_specific_data)
 
     @property
     def job_canceled_data(self) -> "JobCanceledData":
         _assert_type("job_canceled_data", DagsterEventType.RUN_CANCELED, self.event_type)
-        return cast(JobCanceledData, self.event_specific_data)
+        return cast("JobCanceledData", self.event_specific_data)
 
     @property
     def engine_event_data(self) -> "EngineEventData":
@@ -891,7 +891,7 @@ class DagsterEvent(
             ],
             self.event_type,
         )
-        return cast(EngineEventData, self.event_specific_data)
+        return cast("EngineEventData", self.event_specific_data)
 
     @property
     def hook_completed_data(self) -> Optional["EventSpecificData"]:
@@ -901,7 +901,7 @@ class DagsterEvent(
     @property
     def hook_errored_data(self) -> "HookErroredData":
         _assert_type("hook_errored_data", DagsterEventType.HOOK_ERRORED, self.event_type)
-        return cast(HookErroredData, self.event_specific_data)
+        return cast("HookErroredData", self.event_specific_data)
 
     @property
     def hook_skipped_data(self) -> Optional["EventSpecificData"]:
@@ -911,7 +911,7 @@ class DagsterEvent(
     @property
     def logs_captured_data(self) -> "ComputeLogsCaptureData":
         _assert_type("logs_captured_data", DagsterEventType.LOGS_CAPTURED, self.event_type)
-        return cast(ComputeLogsCaptureData, self.event_specific_data)
+        return cast("ComputeLogsCaptureData", self.event_specific_data)
 
     @staticmethod
     def step_output_event(
@@ -1783,7 +1783,7 @@ class ObjectStoreOperationResultData(
     ):
         return super().__new__(
             cls,
-            op=cast(ObjectStoreOperationType, check.str_param(op, "op")),
+            op=cast("ObjectStoreOperationType", check.str_param(op, "op")),
             value_name=check.opt_str_param(value_name, "value_name"),
             metadata=normalize_metadata(
                 check.opt_mapping_param(metadata, "metadata", key_type=str)
@@ -2086,9 +2086,9 @@ def _handle_back_compat(
 
     # changes asset store ops in to get/set asset
     elif event_type_value == "ASSET_STORE_OPERATION":
-        assert (
-            event_specific_data is not None
-        ), "ASSET_STORE_OPERATION event must have specific data"
+        assert event_specific_data is not None, (
+            "ASSET_STORE_OPERATION event must have specific data"
+        )
         if event_specific_data["op"] in (
             "GET_ASSET",
             '{"__enum__": "AssetStoreOperationType.GET_ASSET"}',
@@ -2121,9 +2121,9 @@ def _handle_back_compat(
 
     # transform PIPELINE_INIT_FAILURE to PIPELINE_FAILURE
     if event_type_value == "PIPELINE_INIT_FAILURE":
-        assert (
-            event_specific_data is not None
-        ), "PIPELINE_INIT_FAILURE event must have specific data"
+        assert event_specific_data is not None, (
+            "PIPELINE_INIT_FAILURE event must have specific data"
+        )
         return "PIPELINE_FAILURE", {
             "__class__": "PipelineFailureData",
             "error": event_specific_data.get("error"),

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -544,7 +544,7 @@ def _reexecute_job(
                 execute_instance,
                 job_arg,
                 run_config,
-                cast(DagsterRun, parent_dagster_run),
+                cast("DagsterRun", parent_dagster_run),
                 reexecution_options.step_selection,
             )
         # else all steps will be executed and parent state is not needed

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -667,7 +667,7 @@ def _get_requested_asset_graph_subset_from_run_requests(
         if range_start and range_end:
             # When a run request targets a range of partitions, each asset is expected to
             # have the same partitions def
-            selected_assets = cast(Sequence[AssetKey], run_request.asset_selection)
+            selected_assets = cast("Sequence[AssetKey]", run_request.asset_selection)
             check.invariant(len(selected_assets) > 0)
             partition_range = PartitionKeyRange(range_start, range_end)
             entity_subsets = [
@@ -681,7 +681,7 @@ def _get_requested_asset_graph_subset_from_run_requests(
             requested_subset = requested_subset | AssetGraphSubset.from_asset_partition_set(
                 {
                     AssetKeyPartitionKey(asset_key, run_request.partition_key)
-                    for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
+                    for asset_key in cast("Sequence[AssetKey]", run_request.asset_selection)
                 },
                 asset_graph,
             )
@@ -721,7 +721,7 @@ def _submit_runs_and_update_backfill_in_chunks(
     from dagster._core.execution.backfill import BulkActionStatus
     from dagster._daemon.utils import DaemonErrorCapture
 
-    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
+    asset_graph = cast("RemoteWorkspaceAssetGraph", asset_graph_view.asset_graph)
     instance = asset_graph_view.instance
 
     run_requests = asset_backfill_iteration_result.run_requests
@@ -826,8 +826,7 @@ def _check_target_partitions_subset_is_valid(
     if target_partitions_subset:  # Asset was partitioned at storage time
         if partitions_def is None:
             raise DagsterDefinitionChangedDeserializationError(
-                f"Asset {asset_key} had a PartitionsDefinition at storage-time, but no longer"
-                " does"
+                f"Asset {asset_key} had a PartitionsDefinition at storage-time, but no longer does"
             )
 
         # If the asset was time-partitioned at storage time but the time partitions def
@@ -1087,7 +1086,7 @@ def execute_asset_backfill_iteration(
             )
 
         updated_backfill = cast(
-            PartitionBackfill, instance.get_backfill(updated_backfill.backfill_id)
+            "PartitionBackfill", instance.get_backfill(updated_backfill.backfill_id)
         )
         if updated_backfill.status == BulkActionStatus.REQUESTED:
             check.invariant(
@@ -1181,7 +1180,7 @@ def execute_asset_backfill_iteration(
             )
 
         # Refetch, in case the backfill was forcibly marked as canceled in the meantime
-        backfill = cast(PartitionBackfill, instance.get_backfill(backfill.backfill_id))
+        backfill = cast("PartitionBackfill", instance.get_backfill(backfill.backfill_id))
         updated_backfill: PartitionBackfill = backfill.with_asset_backfill_data(
             updated_asset_backfill_data,
             dynamic_partitions_store=instance,
@@ -1232,7 +1231,7 @@ def get_canceling_asset_backfill_iteration_data(
     """For asset backfills in the "canceling" state, fetch the asset backfill data with the updated
     materialized and failed subsets.
     """
-    asset_graph = cast(RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph)
+    asset_graph = cast("RemoteWorkspaceAssetGraph", asset_graph_view.asset_graph)
     instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
     updated_materialized_subset = None
     for updated_materialized_subset in get_asset_backfill_iteration_materialized_subset(
@@ -1330,9 +1329,9 @@ def _get_subset_in_target_subset(
         asset_graph_view.iterate_asset_subsets(candidate_asset_graph_subset)
     )
 
-    assert (
-        len(candidate_entity_subsets) == 1
-    ), "Since include_execution_set=False, there should be exactly one candidate entity subset"
+    assert len(candidate_entity_subsets) == 1, (
+        "Since include_execution_set=False, there should be exactly one candidate entity subset"
+    )
 
     candidate_entity_subset = next(iter(candidate_entity_subsets))
 
@@ -1451,7 +1450,7 @@ def execute_asset_backfill_iteration_inner(
     """
     instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
     asset_graph: RemoteWorkspaceAssetGraph = cast(
-        RemoteWorkspaceAssetGraph, asset_graph_view.asset_graph
+        "RemoteWorkspaceAssetGraph", asset_graph_view.asset_graph
     )
 
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
@@ -1791,7 +1790,7 @@ def get_can_run_with_parent_subsets(
     parent_asset_key = parent_subset.key
 
     assert isinstance(asset_graph_view.asset_graph, RemoteWorkspaceAssetGraph)
-    asset_graph: RemoteWorkspaceAssetGraph = asset_graph_view.asset_graph
+    asset_graph = asset_graph_view.asset_graph
 
     parent_node = asset_graph.get(parent_asset_key)
     candidate_node = asset_graph.get(candidate_asset_key)
@@ -1827,8 +1826,8 @@ def get_can_run_with_parent_subsets(
             ],
         )
     if (
-        parent_node.resolve_to_singular_repo_scoped_node().repository_handle
-        != candidate_node.resolve_to_singular_repo_scoped_node().repository_handle
+        parent_node.resolve_to_singular_repo_scoped_node().repository_handle  # type: ignore
+        != candidate_node.resolve_to_singular_repo_scoped_node().repository_handle  # type: ignore
     ):
         return (
             asset_graph_view.get_empty_subset(key=candidate_asset_key),

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -35,7 +35,7 @@ def get_mapped_resource_config(
             config_evr.errors,
             resource_config,
         )
-    config_value = cast(dict[str, Any], config_evr.value)
+    config_value = cast("dict[str, Any]", config_evr.value)
     return config_map_resources(resource_defs, config_value)
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -2,12 +2,11 @@ from abc import abstractmethod
 from asyncio import AbstractEventLoop
 from collections.abc import Mapping, Sequence
 from contextlib import ExitStack
-from typing import AbstractSet, Any, NamedTuple, Optional, Union, cast  # noqa: UP035
+from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional, Union, cast  # noqa: UP035
 
 import dagster._check as check
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.composition import PendingNodeInvocation
-from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.definitions.events import (
     AssetMaterialization,
@@ -17,7 +16,6 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.repository_definition import RepositoryDefinition
@@ -48,6 +46,10 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.merger import merge_dicts
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
+    from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 
 
 def _property_msg(prop_name: str, method_name: str) -> str:
@@ -478,7 +480,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         per_invocation_properties = self._check_bound_to_invocation(
             fn_name="op_def", fn_type="property"
         )
-        return cast(OpDefinition, per_invocation_properties.op_def)
+        return cast("OpDefinition", per_invocation_properties.op_def)
 
     @property
     def has_assets_def(self) -> bool:
@@ -555,7 +557,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         per_invocation_properties = self._check_bound_to_invocation(
             fn_name="alias", fn_type="property"
         )
-        return cast(str, per_invocation_properties.alias)
+        return cast("str", per_invocation_properties.alias)
 
     def get_step_execution_context(self) -> StepExecutionContext:
         raise DagsterInvalidPropertyError(_property_msg("get_step_execution_context", "method"))
@@ -607,7 +609,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
 
     def for_type(self, dagster_type: DagsterType) -> TypeCheckContext:
         self._check_bound_to_invocation(fn_name="for_type", fn_type="method")
-        resources = cast(NamedTuple, self.resources)
+        resources = cast("NamedTuple", self.resources)
         return TypeCheckContext(
             self.run_id,
             self.log,
@@ -635,7 +637,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         if mapping_key:
             if output_name not in self._execution_properties.seen_outputs:
                 self._execution_properties.seen_outputs[output_name] = set()
-            cast(set[str], self._execution_properties.seen_outputs[output_name]).add(mapping_key)
+            cast("set[str]", self._execution_properties.seen_outputs[output_name]).add(mapping_key)
         else:
             self._execution_properties.seen_outputs[output_name] = "seen"
 
@@ -662,7 +664,7 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
             )
 
         return cast(
-            Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition], partitions_def
+            "Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition]", partitions_def
         ).time_window_for_partition_key(self.partition_key)
 
     @property
@@ -857,7 +859,7 @@ def _validate_resource_requirements(
     resource_defs: Mapping[str, ResourceDefinition], op_def: OpDefinition
 ) -> None:
     """Validate correctness of resources against required resource keys."""
-    if cast(DecoratedOpFunction, op_def.compute_fn).has_context_arg():
+    if cast("DecoratedOpFunction", op_def.compute_fn).has_context_arg():
         for requirement in op_def.get_resource_requirements(
             asset_layer=None,
             handle=None,

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -239,7 +239,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     @property
     def op_def(self) -> OpDefinition:
         """OpDefinition: The current op definition."""
-        return cast(OpDefinition, self.op.definition)
+        return cast("OpDefinition", self.op.definition)
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -258,15 +258,13 @@ class OutputContext:
     @property
     def op_def(self) -> "OpDefinition":
         """The definition of the op that produced the output."""
-        from dagster._core.definitions import OpDefinition
-
         if self._op_def is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access op_def, "
                 "but it was not provided when constructing the OutputContext"
             )
 
-        return cast(OpDefinition, self._op_def)
+        return cast("OpDefinition", self._op_def)
 
     @public
     @property
@@ -544,9 +542,9 @@ class OutputContext:
             self.name is not None,
             "Unable to find the run scoped output identifier: name is None on OutputContext.",
         )
-        run_id = cast(str, self.run_id)
-        step_key = cast(str, self.step_key)
-        name = cast(str, self.name)
+        run_id = cast("str", self.run_id)
+        step_key = cast("str", self.step_key)
+        name = cast("str", self.name)
 
         if self.mapping_key:
             return [run_id, step_key, name, self.mapping_key]

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -19,7 +19,6 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import RawMetadataValue
-from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -64,6 +63,7 @@ from dagster._core.types.dagster_type import DagsterType
 if TYPE_CHECKING:
     from dagster._core.definitions.data_version import DataVersion
     from dagster._core.definitions.dependency import NodeHandle
+    from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
     from dagster._core.definitions.resource_definition import Resources
     from dagster._core.execution.context.hook import HookContext
     from dagster._core.execution.plan.plan import ExecutionPlan
@@ -353,7 +353,7 @@ class PlanExecutionContext(IPlanContext):
             self._execution_data.repository_def is not None,
             "No repository definition was set on the step context",
         )
-        return cast(RepositoryDefinition, self._execution_data.repository_def)
+        return cast("RepositoryDefinition", self._execution_data.repository_def)
 
     @property
     def resolved_run_config(self) -> ResolvedRunConfig:
@@ -439,7 +439,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._known_state = known_state
         self._input_lineage: list[AssetLineageInfo] = []
 
-        resources_iter = cast(Iterable, self._resources)
+        resources_iter = cast("Iterable", self._resources)
 
         step_launcher_resources = [
             resource for resource in resources_iter if isinstance(resource, StepLauncher)
@@ -522,7 +522,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             self._execution_data.repository_def is not None,
             "No repository definition was set on the step context",
         )
-        return cast(RepositoryDefinition, self._execution_data.repository_def)
+        return cast("RepositoryDefinition", self._execution_data.repository_def)
 
     @property
     def op(self) -> OpNode:
@@ -664,7 +664,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         if mapping_key:
             if output_name not in self._seen_outputs:
                 self._seen_outputs[output_name] = set()
-            cast(set[str], self._seen_outputs[output_name]).add(mapping_key)
+            cast("set[str]", self._seen_outputs[output_name]).add(mapping_key)
         else:
             self._seen_outputs[output_name] = "seen"
 
@@ -992,9 +992,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             else:
                 if isinstance(self.run_partitions_def, MultiPartitionsDefinition):
                     return self.run_partitions_def.get_partition_key_from_str(
-                        cast(str, range_start)
+                        cast("str", range_start)
                     )
-                return cast(str, range_start)
+                return cast("str", range_start)
 
     @property
     def partition_key_range(self) -> PartitionKeyRange:
@@ -1051,7 +1051,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         )
 
         partition_key_ranges = subset.get_partition_key_ranges(
-            partitions_def=cast(PartitionsDefinition, upstream_asset_partitions_def),
+            partitions_def=cast("PartitionsDefinition", upstream_asset_partitions_def),
             dynamic_partitions_store=self.instance,
         )
 
@@ -1180,7 +1180,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             )
 
         partitions_def = cast(
-            Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition], partitions_def
+            "Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition]", partitions_def
         )
         partition_key_range = self.asset_partition_key_range_for_output(output_name)
         return TimeWindow(
@@ -1204,12 +1204,12 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         if self.has_partition_key:
             return cast(
-                Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition], partitions_def
+                "Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition]", partitions_def
             ).time_window_for_partition_key(self.partition_key)
         elif self.has_partition_key_range:
             partition_key_range = self.partition_key_range
             partitions_def = cast(
-                Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition], partitions_def
+                "Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition]", partitions_def
             )
             return TimeWindow(
                 partitions_def.time_window_for_partition_key(partition_key_range.start).start,
@@ -1251,7 +1251,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             )
 
         upstream_asset_partitions_def = cast(
-            Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition],
+            "Union[TimeWindowPartitionsDefinition, MultiPartitionsDefinition]",
             upstream_asset_partitions_def,
         )
         partition_key_range = self.asset_partition_key_range_for_input(input_name)

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -189,7 +189,7 @@ def execution_context_event_generator(
     output_capture: Optional[dict["StepOutputHandle", Any]] = None,
 ) -> Generator[Union[DagsterEvent, PlanExecutionContext], None, None]:
     scoped_resources_builder_cm = cast(
-        Callable[..., EventGenerationManager[ScopedResourcesBuilder]],
+        "Callable[..., EventGenerationManager[ScopedResourcesBuilder]]",
         check.opt_callable_param(
             scoped_resources_builder_cm,
             "scoped_resources_builder_cm",
@@ -332,7 +332,7 @@ def orchestration_context_event_generator(
 
         yield execution_context
     except DagsterError as dagster_error:
-        dagster_error = cast(DagsterUserCodeExecutionError, dagster_error)
+        dagster_error = cast("DagsterUserCodeExecutionError", dagster_error)
         user_facing_exc_info = (
             # pylint does not know original_exc_info exists is is_user_code_error is true
             dagster_error.original_exc_info if dagster_error.is_user_code_error else sys.exc_info()

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -17,11 +17,11 @@ from dagster._core.execution.context_creation_job import (
 )
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.types.dagster_type import DagsterTypeKind
 
 if TYPE_CHECKING:
     from dagster._core.execution.plan.outputs import StepOutputHandle
+    from dagster._core.storage.dagster_run import DagsterRun
 
 
 def core_execute_in_process(
@@ -79,7 +79,7 @@ def core_execute_in_process(
     return ExecuteInProcessResult(
         job_def=ephemeral_job,
         event_list=event_list,
-        dagster_run=cast(DagsterRun, run),
+        dagster_run=cast("DagsterRun", run),
         output_capture=output_capture,
     )
 
@@ -108,7 +108,7 @@ def _check_top_level_inputs_for_node(
     parent_handle: Optional[NodeHandle],
 ) -> None:
     if isinstance(node.definition, GraphDefinition):
-        graph_def = cast(GraphDefinition, node.definition)
+        graph_def = cast("GraphDefinition", node.definition)
         for input_mapping in graph_def.input_mappings:
             next_node = graph_def.node_named(input_mapping.maps_to.node_name)
             input_name = input_mapping.maps_to.input_name
@@ -122,7 +122,7 @@ def _check_top_level_inputs_for_node(
             )
     else:
         cur_node_handle = NodeHandle(node.name, parent_handle)
-        op_def = cast(OpDefinition, node.definition)
+        op_def = cast("OpDefinition", node.definition)
         input_def = op_def.input_def_named(input_name)
         if (
             not input_def.dagster_type.loader

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -63,7 +63,7 @@ class ExecutionResult(ABC):
         def _is_event_from_node(event: DagsterEvent) -> bool:
             if not event.is_step_event:
                 return False
-            node_handle = cast(NodeHandle, event.node_handle)
+            node_handle = cast("NodeHandle", event.node_handle)
             return node_handle.is_or_descends_from(handle)
 
         return self.filter_events(_is_event_from_node)
@@ -159,14 +159,14 @@ class ExecutionResult(ABC):
 
     def asset_materializations_for_node(self, node_name: str) -> Sequence[AssetMaterialization]:
         return [
-            cast(StepMaterializationData, event.event_specific_data).materialization
+            cast("StepMaterializationData", event.event_specific_data).materialization
             for event in self.events_for_node(node_name)
             if event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION.value
         ]
 
     def asset_observations_for_node(self, node_name: str) -> Sequence[AssetObservation]:
         return [
-            cast(AssetObservationData, event.event_specific_data).asset_observation
+            cast("AssetObservationData", event.event_specific_data).asset_observation
             for event in self.events_for_node(node_name)
             if event.event_type_value == DagsterEventType.ASSET_OBSERVATION.value
         ]
@@ -179,7 +179,7 @@ class ExecutionResult(ABC):
 
     def get_asset_check_evaluations(self) -> Sequence[AssetCheckEvaluation]:
         return [
-            cast(AssetCheckEvaluation, event.event_specific_data)
+            cast("AssetCheckEvaluation", event.event_specific_data)
             for event in self.all_events
             if event.event_type_value == DagsterEventType.ASSET_CHECK_EVALUATION.value
         ]
@@ -220,7 +220,7 @@ class ExecutionResult(ABC):
             )
         )
         return [
-            cast(StepExpectationResultData, event.event_specific_data).expectation_result
+            cast("StepExpectationResultData", event.event_specific_data).expectation_result
             for event in expectation_result_events
         ]
 

--- a/python_modules/dagster/dagster/_core/execution/job_execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/job_execution_result.py
@@ -137,7 +137,7 @@ class JobExecutionResult(ExecutionResult):
                     if result is None:
                         result = {mapping_key: value}
                     else:
-                        cast(dict, result)[mapping_key] = value
+                        cast("dict", result)[mapping_key] = value
                 else:
                     result = value
 

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -493,7 +493,7 @@ class ActiveExecution:
     def handle_event(self, dagster_event: DagsterEvent) -> None:
         check.inst_param(dagster_event, "dagster_event", DagsterEvent)
 
-        step_key = cast(str, dagster_event.step_key)
+        step_key = cast("str", dagster_event.step_key)
         if dagster_event.is_step_failure:
             self.mark_failed(step_key)
             if self._instance_concurrency_context:
@@ -530,7 +530,7 @@ class ActiveExecution:
             if self._instance_concurrency_context:
                 self._instance_concurrency_context.free_step(step_key)
         elif dagster_event.is_successful_output:
-            event_specific_data = cast(StepOutputData, dagster_event.event_specific_data)
+            event_specific_data = cast("StepOutputData", dagster_event.event_specific_data)
             self.mark_step_produced_output(event_specific_data.step_output_handle)
             if dagster_event.step_output_data.step_output_handle.mapping_key:
                 check.not_none(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import AsyncIterator, Awaitable, Iterator, Mapping, Sequence
 from functools import wraps
-from typing import Any, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 from typing_extensions import get_args
 
@@ -14,7 +14,6 @@ from dagster._core.definitions import (
     Output,
     OutputDefinition,
 )
-from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.result import AssetResult, ObserveResult
@@ -24,11 +23,14 @@ from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_
 from dagster._utils import is_named_tuple_instance
 from dagster._utils.warnings import disable_dagster_warnings
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
+
 
 def create_op_compute_wrapper(
     op_def: OpDefinition,
 ) -> Callable[[ExecutionContextTypes, Mapping[str, InputDefinition]], Any]:
-    compute_fn = cast(DecoratedOpFunction, op_def.compute_fn)
+    compute_fn = cast("DecoratedOpFunction", op_def.compute_fn)
     fn = compute_fn.decorated_fn
     input_defs = op_def.input_defs
     output_defs = op_def.output_defs
@@ -210,7 +212,7 @@ def _validate_multi_return(
             "documentation on outputs for more: "
             "https://legacy-docs.dagster.io/concepts/ops-jobs-graphs/ops#outputs."
         )
-    output_tuple = cast(tuple, result)
+    output_tuple = cast("tuple", result)
     if not len(output_tuple) == len(output_defs):
         raise DagsterInvariantViolationError(
             "Length mismatch between returned tuple of outputs and number of "
@@ -311,7 +313,7 @@ def validate_and_coerce_op_result_to_iterator(
                             "list of DynamicOutput objects, but received an "
                             f"item with type {type(item)}."
                         )
-                    dynamic_output = cast(DynamicOutput, item)
+                    dynamic_output = cast("DynamicOutput", item)
                     _check_output_object_name(dynamic_output, output_def, position)
 
                     with disable_dagster_warnings():

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -65,7 +65,7 @@ def inner_plan_execution_iterator(
                     continue
 
                 step_context = cast(
-                    StepExecutionContext,
+                    "StepExecutionContext",
                     job_context.for_step(step, active_execution.get_known_state()),
                 )
                 step_event_list = []

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -188,7 +188,7 @@ def _step_output_error_checked_user_event_sequence(
 
         # do additional processing on Outputs
         output = user_event
-        if not step.has_step_output(cast(str, output.output_name)):
+        if not step.has_step_output(cast("str", output.output_name)):
             raise DagsterInvariantViolationError(
                 f'Core compute for {op_label} returned an output "{output.output_name}" that does '
                 f"not exist. The available outputs are {output_names}"
@@ -200,7 +200,7 @@ def _step_output_error_checked_user_event_sequence(
                 f"not selected. The selected outputs are {selected_output_names}"
             )
 
-        step_output = step.step_output_named(cast(str, output.output_name))
+        step_output = step.step_output_named(cast("str", output.output_name))
         output_def = step_context.job_def.get_node(step_output.node_handle).output_def_named(
             step_output.name
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -82,7 +82,7 @@ class LocalExternalStepLauncher(StepLauncher):
         file_manager = LocalFileManager(".")
         events_file_handle = LocalFileHandle(events_file_path)
         events_data = file_manager.read_data(events_file_handle)
-        all_events = cast(Sequence[EventLogEntry], deserialize_value(pickle.loads(events_data)))
+        all_events = cast("Sequence[EventLogEntry]", deserialize_value(pickle.loads(events_data)))
 
         for event in all_events:
             # write each pickled event from the external instance to the local instance
@@ -224,7 +224,7 @@ def step_run_ref_to_step_context(
     # Since for_step is abstract for IPlanContext, its return type is IStepContext.
     # Since we are launching from a PlanExecutionContext, the type will always be
     # StepExecutionContext.
-    step_execution_context = cast(StepExecutionContext, step_execution_context)
+    step_execution_context = cast("StepExecutionContext", step_execution_context)
 
     return step_execution_context
 

--- a/python_modules/dagster/dagster/_core/execution/plan/handle.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/handle.py
@@ -16,7 +16,7 @@ class StepHandle(NamedTuple("_StepHandle", [("node_handle", NodeHandle), ("key",
             cls,
             node_handle=check.inst_param(node_handle, "node_handle", NodeHandle),
             # mypy can't tell that if default is set, this is guaranteed to be a str
-            key=cast(str, check.opt_str_param(key, "key", default=str(node_handle))),
+            key=cast("str", check.opt_str_param(key, "key", default=str(node_handle))),
         )
 
     def to_key(self) -> str:
@@ -77,7 +77,7 @@ class ResolvedFromDynamicStepHandle(
             mapping_key=check.str_param(mapping_key, "mapping_key"),
             # mypy can't tell that if default is set, this is guaranteed to be a str
             key=cast(
-                str,
+                "str",
                 check.opt_str_param(key, "key", default=f"{node_handle}[{mapping_key}]"),
             ),
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -64,7 +64,7 @@ def join_and_hash(*args: Optional[str]) -> Optional[str]:
     if None in lst:
         return None
 
-    str_lst = cast(list[str], lst)
+    str_lst = cast("list[str]", lst)
     unhashed = "".join(sorted(str_lst))
     return hashlib.sha1(unhashed.encode("utf-8")).hexdigest()
 
@@ -608,9 +608,7 @@ class FromMultipleSourcesLoadSingleSource(MultiStepInputSource, IHaveNew):
 def _load_input_with_input_manager(
     input_manager: "InputManager", context: "InputContext"
 ) -> Iterator[object]:
-    from dagster._core.execution.context.system import StepExecutionContext
-
-    step_context = cast(StepExecutionContext, context.step_context)
+    step_context = cast("StepExecutionContext", context.step_context)
     with op_execution_error_boundary(
         DagsterExecutionLoadInputError,
         msg_fn=lambda: f'Error occurred while loading input "{context.name}" of step "{step_context.step.key}":',

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -298,7 +298,7 @@ class _PlanBuilder:
                         handle=UnresolvedStepHandle(node_handle=handle),
                         job_name=self.job_def.name,
                         step_inputs=cast(
-                            list[Union[StepInput, UnresolvedMappedStepInput]], step_inputs
+                            "list[Union[StepInput, UnresolvedMappedStepInput]]", step_inputs
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
@@ -309,7 +309,7 @@ class _PlanBuilder:
                         handle=StepHandle(node_handle=handle),
                         job_name=self.job_def.name,
                         step_inputs=cast(
-                            list[Union[StepInput, UnresolvedCollectStepInput]], step_inputs
+                            "list[Union[StepInput, UnresolvedCollectStepInput]]", step_inputs
                         ),
                         step_outputs=step_outputs,
                         tags=node.tags,
@@ -319,7 +319,7 @@ class _PlanBuilder:
                     new_step = ExecutionStep(
                         handle=StepHandle(node_handle=handle),
                         job_name=self.job_def.name,
-                        step_inputs=cast(list[StepInput], step_inputs),
+                        step_inputs=cast("list[StepInput]", step_inputs),
                         step_outputs=step_outputs,
                         tags=node.tags,
                         pool=node.definition.pool,
@@ -837,7 +837,7 @@ class ExecutionPlan(
 
         if bad_keys:
             raise DagsterExecutionStepNotFoundError(
-                f"Can not build subset plan from unknown step{'s' if len(bad_keys)> 1 else ''}:"
+                f"Can not build subset plan from unknown step{'s' if len(bad_keys) > 1 else ''}:"
                 f" {', '.join(bad_keys)}",
                 step_keys=bad_keys,
             )
@@ -910,7 +910,7 @@ class ExecutionPlan(
             if not isinstance(only_step, ExecutionStep):
                 return None
 
-            return cast(ExecutionStep, only_step).handle
+            return cast("ExecutionStep", only_step).handle
 
         return None
 
@@ -1248,7 +1248,7 @@ def _get_steps_to_execute_by_level(
     executable_map: Mapping[str, Union[StepHandle, ResolvedFromDynamicStepHandle]],
 ) -> Sequence[Sequence[ExecutionStep]]:
     return [
-        [cast(ExecutionStep, step_dict_by_key[step_key]) for step_key in sorted(step_key_level)]
+        [cast("ExecutionStep", step_dict_by_key[step_key]) for step_key in sorted(step_key_level)]
         for step_key_level in toposort(
             _get_executable_step_deps(step_dict, step_handles_to_execute, executable_map)
         )
@@ -1272,7 +1272,7 @@ def _get_executable_step_deps(
     step_keys_to_execute = [handle.to_key() for handle in step_handles_to_execute]
 
     for key, handle in executable_map.items():
-        step = cast(ExecutionStep, step_dict[handle])
+        step = cast("ExecutionStep", step_dict[handle])
         filtered_deps = []
         depends_on_unresolved = False
         for dep in step.get_execution_dependency_keys():

--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -60,7 +60,7 @@ class PastExecutionState(
         )
 
     def get_parent_state(self) -> Optional["PastExecutionState"]:
-        return cast(Optional[PastExecutionState], self.parent_state)
+        return cast("Optional[PastExecutionState]", self.parent_state)
 
 
 # Previously, step_output_versions was stored as a list of StepOutputVersionData objects. It
@@ -91,8 +91,8 @@ class StepOutputVersionSerializer(FieldSerializer):
         mapping: dict[StepOutputHandle, str] = {}
         for unknown_serdes_value in value:
             item = unknown_serdes_value.value
-            step_output_handle = cast(StepOutputHandle, item["step_output_handle"])
-            version = cast(str, item["version"])
+            step_output_handle = cast("StepOutputHandle", item["step_output_handle"])
+            version = cast("str", item["version"])
             mapping[step_output_handle] = version
             context.clear_ignored_unknown_values(unknown_serdes_value)
         return mapping
@@ -307,7 +307,7 @@ def _derive_state_of_past_run(
                 _update_tracking_dict(interrupted_steps_in_parent_run_logs, step_handle)
 
     # expand type to allow filling in None mappings for skips
-    dynamic_outputs = cast(dict[str, dict[str, Optional[list[str]]]], observed_dynamic_outputs)
+    dynamic_outputs = cast("dict[str, dict[str, Optional[list[str]]]]", observed_dynamic_outputs)
     to_retry: TrackingDict = defaultdict(set)
     execution_deps = execution_plan.execution_deps()
     for step_snap in execution_plan.topological_steps():

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -168,7 +168,7 @@ class ExecutionStep(  # pyright: ignore[reportIncompatibleVariableOverride]
                 check.opt_mapping_param(logging_tags, "logging_tags"),
             ),
             # mypy can't tell that if default is set, this is guaranteed to be a str
-            key=cast(str, check.opt_str_param(key, "key", default=handle.to_key())),
+            key=cast("str", check.opt_str_param(key, "key", default=handle.to_key())),
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -134,7 +134,7 @@ def _core_resource_initialization_event_generator(
             "If emit_persistent_events is enabled, then dagster_run and execution_plan must be"
             " provided",
         )
-        job_name = cast(DagsterRun, dagster_run).job_name
+        job_name = cast("DagsterRun", dagster_run).job_name
     resource_keys_to_init = check.opt_set_param(resource_keys_to_init, "resource_keys_to_init")
     resource_instances: dict[str, InitializedResource] = {}
     resource_init_times = {}
@@ -142,7 +142,7 @@ def _core_resource_initialization_event_generator(
         if emit_persistent_events and resource_keys_to_init:
             yield DagsterEvent.resource_init_start(
                 job_name,
-                cast(ExecutionPlan, execution_plan),
+                cast("ExecutionPlan", execution_plan),
                 resource_log_manager,
                 resource_keys_to_init,
             )
@@ -154,7 +154,7 @@ def _core_resource_initialization_event_generator(
                 if resource_name not in resource_keys_to_init:
                     continue
 
-                resource_fn = cast(Callable[[InitResourceContext], Any], resource_def.resource_fn)
+                resource_fn = cast("Callable[[InitResourceContext], Any]", resource_def.resource_fn)
                 resources = ScopedResourcesBuilder(resource_instances).build(
                     resource_def.get_required_resource_keys(resource_defs)
                 )
@@ -187,7 +187,7 @@ def _core_resource_initialization_event_generator(
         if emit_persistent_events and resource_keys_to_init:
             yield DagsterEvent.resource_init_success(
                 job_name,
-                cast(ExecutionPlan, execution_plan),
+                cast("ExecutionPlan", execution_plan),
                 resource_log_manager,
                 resource_instances,
                 resource_init_times,
@@ -205,7 +205,7 @@ def _core_resource_initialization_event_generator(
         if emit_persistent_events:
             yield DagsterEvent.resource_init_failure(
                 job_name,
-                cast(ExecutionPlan, execution_plan),
+                cast("ExecutionPlan", execution_plan),
                 resource_log_manager,
                 resource_keys_to_init,
                 serializable_error_info_from_exc_info(dagster_user_error.original_exc_info),
@@ -235,11 +235,11 @@ def resource_initialization_event_generator(
     if execution_plan and execution_plan.step_handle_for_single_step_plans():
         step = execution_plan.get_step(
             cast(
-                StepHandleUnion,
-                cast(ExecutionPlan, execution_plan).step_handle_for_single_step_plans(),
+                "StepHandleUnion",
+                cast("ExecutionPlan", execution_plan).step_handle_for_single_step_plans(),
             )
         )
-        resource_log_manager = log_manager.with_tags(**cast(ExecutionStep, step).logging_tags)
+        resource_log_manager = log_manager.with_tags(**cast("ExecutionStep", step).logging_tags)
     else:
         resource_log_manager = log_manager
 
@@ -275,8 +275,8 @@ def resource_initialization_event_generator(
                     error = dagster_user_error
             if error and emit_persistent_events:
                 yield DagsterEvent.resource_teardown_failure(
-                    cast(DagsterRun, dagster_run).job_name,
-                    cast(ExecutionPlan, execution_plan),
+                    cast("DagsterRun", dagster_run).job_name,
+                    cast("ExecutionPlan", execution_plan),
                     resource_log_manager,
                     resource_keys_to_init,
                     serializable_error_info_from_exc_info(error.original_exc_info),

--- a/python_modules/dagster/dagster/_core/execution/stats.py
+++ b/python_modules/dagster/dagster/_core/execution/stats.py
@@ -309,7 +309,7 @@ def build_run_step_stats_snapshot_from_events(
             materialization_events.append(event)
             by_step_key[step_key]["materialization_events"] = materialization_events
         if dagster_event.event_type == DagsterEventType.STEP_EXPECTATION_RESULT:
-            expectation_data = cast(StepExpectationResultData, dagster_event.event_specific_data)
+            expectation_data = cast("StepExpectationResultData", dagster_event.event_specific_data)
             expectation_result = expectation_data.expectation_result
             step_expectation_results = by_step_key[step_key].get("expectation_results", [])
             step_expectation_results.append(expectation_result)

--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -105,6 +105,6 @@ def with_resources(
 
     transformed_defs: list[T] = []
     for definition in definitions:
-        transformed_defs.append(cast(T, definition.with_resources(resource_defs)))
+        transformed_defs.append(cast("T", definition.with_resources(resource_defs)))
 
     return transformed_defs

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -293,8 +293,7 @@ class MultiprocessExecutor(Executor):
                     for key in empty_iters:
                         del active_iters[key]
                         del term_events[key]
-                        if key in processes:
-                            del processes[key]
+                        processes.pop(key, None)
                         active_execution.verify_complete(plan_context, key)
 
                     # process skipped and abandoned steps

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -60,11 +60,11 @@ class StepDelegatingExecutor(Executor):
             check.invariant(self._max_concurrent > 0, "max_concurrent must be > 0")
 
         self._sleep_seconds = cast(
-            float,
+            "float",
             check.opt_float_param(sleep_seconds, "sleep_seconds", default=_default_sleep_seconds()),
         )
         self._check_step_health_interval_seconds = cast(
-            int,
+            "int",
             check.opt_int_param(
                 check_step_health_interval_seconds, "check_step_health_interval_seconds", default=20
             ),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -778,7 +778,7 @@ class DagsterInstance(DynamicPartitionsStore):
             check.invariant(
                 self._ref, "Run coordinator not provided, and no instance ref available"
             )
-            run_coordinator = cast(InstanceRef, self._ref).run_coordinator
+            run_coordinator = cast("InstanceRef", self._ref).run_coordinator
             check.invariant(run_coordinator, "Run coordinator not configured in instance ref")
             self._run_coordinator = cast("RunCoordinator", run_coordinator)
             self._run_coordinator.register_instance(self)
@@ -803,7 +803,7 @@ class DagsterInstance(DynamicPartitionsStore):
         # that loads the instance (e.g. The EcsRunLauncher requires boto3)
         if not self._run_launcher:
             check.invariant(self._ref, "Run launcher not provided, and no instance ref available")
-            launcher = cast(InstanceRef, self._ref).run_launcher
+            launcher = cast("InstanceRef", self._ref).run_launcher
             check.invariant(launcher, "Run launcher not configured in instance ref")
             self._run_launcher = cast("RunLauncher", launcher)
             self._run_launcher.register_instance(self)
@@ -817,7 +817,7 @@ class DagsterInstance(DynamicPartitionsStore):
             check.invariant(
                 self._ref, "Compute log manager not provided, and no instance ref available"
             )
-            compute_log_manager = cast(InstanceRef, self._ref).compute_log_manager
+            compute_log_manager = cast("InstanceRef", self._ref).compute_log_manager
             check.invariant(
                 compute_log_manager, "Compute log manager not configured in instance ref"
             )
@@ -1432,9 +1432,9 @@ class DagsterInstance(DynamicPartitionsStore):
         elif check.not_none(output.properties).is_asset_partitioned and partition_tag:
             individual_partitions = [partition_tag]
 
-        assert not (
-            individual_partitions and partitions_subset
-        ), "Should set either individual_partitions or partitions_subset, but not both"
+        assert not (individual_partitions and partitions_subset), (
+            "Should set either individual_partitions or partitions_subset, but not both"
+        )
 
         if not individual_partitions and not partitions_subset:
             materialization_planned = DagsterEvent.build_asset_materialization_planned_event(
@@ -2968,7 +2968,7 @@ class DagsterInstance(DynamicPartitionsStore):
                 )
             )
         else:
-            data = cast(SensorInstigatorData, stored_state.instigator_data)
+            data = cast("SensorInstigatorData", stored_state.instigator_data)
             return self.update_instigator_state(
                 stored_state.with_status(InstigatorStatus.RUNNING).with_data(
                     data.with_sensor_start_timestamp(get_current_timestamp())

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -76,7 +76,7 @@ def dagster_instance_config(
             )
 
         custom_instance_class = cast(
-            type["DagsterInstance"],
+            "type[DagsterInstance]",
             class_from_code_pointer(
                 custom_instance_class_data["module"],
                 custom_instance_class_data["class"],

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -118,7 +118,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
         )
 
         DefaultRunLauncher.launch_run_from_grpc_client(
-            self._instance, run, cast(GrpcServerCodeLocation, code_location).client
+            self._instance, run, cast("GrpcServerCodeLocation", code_location).client
         )
 
         self._run_ids.add(run.run_id)

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -110,7 +110,7 @@ def construct_log_record_message(metadata: DagsterLogRecordMetadata) -> str:
     from dagster._core.events import EVENT_TYPE_TO_DISPLAY_STRING
 
     if metadata["resource_name"] is not None:
-        log_source = f'resource:{metadata["resource_name"]}'
+        log_source = f"resource:{metadata['resource_name']}"
     else:
         log_source = metadata["job_name"] or "system"
 
@@ -204,7 +204,7 @@ class DagsterLogHandler(logging.Handler):
 
     def with_tags(self, **new_tags: str) -> "DagsterLogHandler":
         return DagsterLogHandler(
-            metadata={**self._metadata, **cast(DagsterLogHandlerMetadata, new_tags)},
+            metadata={**self._metadata, **cast("DagsterLogHandlerMetadata", new_tags)},
             loggers=self._loggers,
             handlers=self._handlers,
         )

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -216,7 +216,7 @@ class PipesMessageHandler:
                 f"[pipes] unexpected message received after closed: `{message}`"
             )
 
-        method = cast(Method, message["method"])
+        method = cast("Method", message["method"])
         if method == "opened":
             self._handle_opened(message["params"])  # type: ignore
         elif method == "closed":

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -163,8 +163,7 @@ class CodeLocation(AbstractContextManager):
                 raise DagsterInvalidSubsetError(check.not_none(error.message))
             else:
                 check.failed(
-                    f"Failed to fetch subset data, success: {subset_result.success} error:"
-                    f" {error}"
+                    f"Failed to fetch subset data, success: {subset_result.success} error: {error}"
                 )
 
         return RemoteJob(job_data_snap, repo_handle)
@@ -759,7 +758,7 @@ class GrpcServerCodeLocation(CodeLocation):
 
     @property
     def container_image(self) -> str:
-        return cast(str, self._container_image)
+        return cast("str", self._container_image)
 
     @cached_property
     def container_context(self) -> Optional[Mapping[str, Any]]:
@@ -767,7 +766,7 @@ class GrpcServerCodeLocation(CodeLocation):
 
     @property
     def repository_code_pointer_dict(self) -> Mapping[str, CodePointer]:
-        return cast(Mapping[str, CodePointer], self._repository_code_pointer_dict)
+        return cast("Mapping[str, CodePointer]", self._repository_code_pointer_dict)
 
     @property
     def executable_path(self) -> Optional[str]:

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1234,7 +1234,7 @@ class ResourceSnap(IHaveNew):
         unconfigured_config_type_snap = snap_from_config_type(config_type)
 
         config_schema_default = cast(
-            Mapping[str, Any],
+            "Mapping[str, Any]",
             (
                 json.loads(resource_def.config_schema.default_value_as_json_str)
                 if resource_def.config_schema.default_provided
@@ -1360,7 +1360,7 @@ class BackcompatTeamOwnerFieldDeserializer(FieldSerializer):
         return (
             [
                 owner if (is_valid_email(owner) or owner.startswith("team:")) else f"team:{owner}"
-                for owner in cast(Sequence[str], __unpacked_value)
+                for owner in cast("Sequence[str]", __unpacked_value)
             ]
             if __unpacked_value is not None
             else None
@@ -1673,7 +1673,7 @@ def asset_node_snaps_from_repo(repo: RepositoryDefinition) -> Sequence[AssetNode
                 root_node_handle.name if root_node_handle != output_handle.node_handle else None
             )
             op_defs = [
-                cast(OpDefinition, job_def.graph.get_node(node_handle).definition)
+                cast("OpDefinition", job_def.graph.get_node(node_handle).definition)
                 for node_handle in node_handles
                 if isinstance(job_def.graph.get_node(node_handle).definition, OpDefinition)
             ]

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -245,7 +245,7 @@ class GrpcServerRegistry(AbstractContextManager):
 
     def __exit__(self, exception_type, exception_value, traceback):
         if self._cleanup_thread:
-            cast(threading.Event, self._cleanup_thread_shutdown_event).set()
+            cast("threading.Event", self._cleanup_thread_shutdown_event).set()
             self._cleanup_thread.join()
 
         self.shutdown_all_processes()

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -55,7 +55,7 @@ def _assign_loadable_target_origin_name(loadable_target_origin: LoadableTargetOr
         else (
             loadable_target_origin.module_name
             if loadable_target_origin.module_name
-            else os.path.basename(cast(str, loadable_target_origin.python_file))
+            else os.path.basename(cast("str", loadable_target_origin.python_file))
         )
     )
 
@@ -336,7 +336,7 @@ class GrpcServerCodeLocationOrigin(
             # Handle case when this is called against `dagster api grpc` servers that don't have this API method implemented
             if (
                 isinstance(e.__cause__, grpc.RpcError)
-                and cast(grpc.RpcError, e.__cause__).code() == grpc.StatusCode.UNIMPLEMENTED
+                and cast("grpc.RpcError", e.__cause__).code() == grpc.StatusCode.UNIMPLEMENTED
             ):
                 pass
             else:

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -416,7 +416,7 @@ def parse_step_selection(
     invalid_keys = [key for key in step_keys if key not in step_deps]
     if invalid_keys:
         raise DagsterExecutionStepNotFoundError(
-            f"Step selection refers to unknown step{'s' if len(invalid_keys)> 1 else ''}:"
+            f"Step selection refers to unknown step{'s' if len(invalid_keys) > 1 else ''}:"
             f" {', '.join(invalid_keys)}",
             step_keys=invalid_keys,
         )

--- a/python_modules/dagster/dagster/_core/snap/job_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/job_snapshot.py
@@ -259,12 +259,12 @@ def _construct_fields(
 ) -> Mapping[str, Field]:
     fields = check.not_none(config_type_snap.fields)
     return {
-        cast(str, field.name): Field(
+        cast("str", field.name): Field(
             construct_config_type_from_snap(config_snap_map[field.type_key], config_snap_map),
             description=field.description,
             is_required=field.is_required,
             default_value=(
-                deserialize_value(cast(str, field.default_value_as_json_str))
+                deserialize_value(cast("str", field.default_value_as_json_str))
                 if field.default_provided
                 else FIELD_NO_DEFAULT_PROVIDED
             ),

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -109,7 +109,7 @@ class AssetCheckExecutionRecord(
     def evaluation(self) -> Optional[AssetCheckEvaluation]:
         if self.event and self.event.dagster_event:
             return cast(
-                AssetCheckEvaluation,
+                "AssetCheckEvaluation",
                 self.event.dagster_event.event_specific_data,
             )
         return None

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from contextlib import ExitStack
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import dagster._check as check
 from dagster._annotations import deprecated_param, public
@@ -18,10 +18,12 @@ from dagster._core.execution.context.output import build_output_context
 from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.config import is_dagster_home_set
-from dagster._core.storage.io_manager import IOManager
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import normalize_renamed_param
+
+if TYPE_CHECKING:
+    from dagster._core.storage.io_manager import IOManager
 
 
 class AssetValueLoader:
@@ -132,7 +134,7 @@ class AssetValueLoader:
             {k: v for k, v in resource_defs.items() if k in required_resource_keys},
             resource_config=resource_config,
         )
-        io_manager = cast(IOManager, self._resource_instance_cache[io_manager_key])
+        io_manager = cast("IOManager", self._resource_instance_cache[io_manager_key])
 
         io_config = resource_config.get(io_manager_key)
         io_resource_config = {io_manager_key: io_config} if io_config else {}

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -171,7 +171,7 @@ class DbIOManager(IOManager):
 
         self._check_supported_type(load_type)
 
-        table_slice = self._get_table_slice(context, cast(OutputContext, context.upstream_output))
+        table_slice = self._get_table_slice(context, cast("OutputContext", context.upstream_output))
 
         with self._db_client.connect(context, table_slice) as conn:
             return self._resolve_handler(load_type).load_input(context, table_slice, conn)  # type: ignore  # (pyright bug)
@@ -196,7 +196,7 @@ class DbIOManager(IOManager):
             table = asset_key_path[-1]
             # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
             if output_context_metadata.get("schema"):
-                schema = cast(str, output_context_metadata["schema"])
+                schema = cast("str", output_context_metadata["schema"])
             elif self._schema:
                 schema = self._schema
             elif len(asset_key_path) > 1:
@@ -216,7 +216,7 @@ class DbIOManager(IOManager):
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
                     multi_partition_key_mapping = cast(
-                        MultiPartitionKey, context.asset_partition_key
+                        "MultiPartitionKey", context.asset_partition_key
                     ).keys_by_dimension
                     for part in context.asset_partitions_def.partitions_defs:
                         partition_key = multi_partition_key_mapping[part.name]
@@ -227,7 +227,9 @@ class DbIOManager(IOManager):
                         else:
                             partitions = [partition_key]
 
-                        partition_expr_str = cast(Mapping[str, str], partition_expr).get(part.name)
+                        partition_expr_str = cast("Mapping[str, str]", partition_expr).get(
+                            part.name
+                        )
                         if partition_expr is None:
                             raise ValueError(
                                 f"Asset '{context.asset_key}' has partition {part.name}, but the"
@@ -238,13 +240,14 @@ class DbIOManager(IOManager):
                             )
                         partition_dimensions.append(
                             TablePartitionDimension(
-                                partition_expr=cast(str, partition_expr_str), partitions=partitions
+                                partition_expr=cast("str", partition_expr_str),
+                                partitions=partitions,
                             )
                         )
                 elif isinstance(context.asset_partitions_def, TimeWindowPartitionsDefinition):
                     partition_dimensions.append(
                         TablePartitionDimension(
-                            partition_expr=cast(str, partition_expr),
+                            partition_expr=cast("str", partition_expr),
                             partitions=(
                                 context.asset_partitions_time_window
                                 if context.asset_partition_keys
@@ -255,14 +258,14 @@ class DbIOManager(IOManager):
                 else:
                     partition_dimensions.append(
                         TablePartitionDimension(
-                            partition_expr=cast(str, partition_expr),
+                            partition_expr=cast("str", partition_expr),
                             partitions=context.asset_partition_keys,
                         )
                     )
         else:
             table = output_context.name
             if output_context_metadata.get("schema"):
-                schema = cast(str, output_context_metadata["schema"])
+                schema = cast("str", output_context_metadata["schema"])
             elif self._schema:
                 schema = self._schema
             else:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -27,10 +27,6 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.assets import AssetDetails
-from dagster._core.definitions.asset_check_evaluation import (
-    AssetCheckEvaluation,
-    AssetCheckEvaluationPlanned,
-)
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
@@ -113,6 +109,10 @@ from dagster._utils.concurrency import (
 from dagster._utils.warnings import deprecation_warning
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_check_evaluation import (
+        AssetCheckEvaluation,
+        AssetCheckEvaluationPlanned,
+    )
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 MIN_ASSET_ROWS = 25
@@ -1212,11 +1212,11 @@ class SqlEventLogStorage(EventLogStorage):
             event_rows = db_fetch_mappings(conn, backcompat_query)
 
         for row in event_rows:
-            asset_key = AssetKey.from_db_string(cast(Optional[str], row["asset_key"]))
+            asset_key = AssetKey.from_db_string(cast("Optional[str]", row["asset_key"]))
             if asset_key:
                 results[asset_key] = EventLogRecord(
-                    storage_id=cast(int, row["id"]),
-                    event_log_entry=deserialize_value(cast(str, row["event"]), EventLogEntry),
+                    storage_id=cast("int", row["id"]),
+                    event_log_entry=deserialize_value(cast("str", row["event"]), EventLogEntry),
                 )
         return results
 
@@ -1358,7 +1358,7 @@ class SqlEventLogStorage(EventLogStorage):
                 asset_keys=asset_keys, prefix=prefix, limit=fetch_limit, cursor=current_cursor
             )
             result.extend(rows)
-            should_query = bool(has_more) and bool(limit) and len(result) < cast(int, limit)
+            should_query = bool(has_more) and bool(limit) and len(result) < cast("int", limit)
 
         is_partial_query = asset_keys is not None or bool(prefix) or bool(limit) or bool(cursor)
         if not is_partial_query and self._can_mark_assets_as_migrated(rows):  # pyright: ignore[reportPossiblyUnboundVariable]
@@ -1421,7 +1421,7 @@ class SqlEventLogStorage(EventLogStorage):
         row_by_asset_key: dict[AssetKey, SqlAlchemyRow] = OrderedDict()
 
         for row in rows:
-            asset_key = AssetKey.from_db_string(cast(str, row["asset_key"]))
+            asset_key = AssetKey.from_db_string(cast("str", row["asset_key"]))
             if not asset_key:
                 continue
             asset_details = AssetDetails.from_db_string(row["asset_details"])
@@ -1429,7 +1429,7 @@ class SqlEventLogStorage(EventLogStorage):
                 row_by_asset_key[asset_key] = row
                 continue
             materialization_or_event_or_record = (
-                deserialize_value(cast(str, row["last_materialization"]), NamedTuple)
+                deserialize_value(cast("str", row["last_materialization"]), NamedTuple)
                 if row["last_materialization"]
                 else None
             )
@@ -1562,8 +1562,8 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
             asset_key_to_details = {
-                cast(str, row["asset_key"]): (
-                    deserialize_value(cast(str, row["asset_details"]), AssetDetails)
+                cast("str", row["asset_key"]): (
+                    deserialize_value(cast("str", row["asset_details"]), AssetDetails)
                     if row["asset_details"]
                     else None
                 )
@@ -1784,7 +1784,7 @@ class SqlEventLogStorage(EventLogStorage):
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()
 
-        return set([cast(str, row[0]) for row in results])
+        return set([cast("str", row[0]) for row in results])
 
     def _latest_event_ids_by_partition_subquery(
         self,
@@ -1858,7 +1858,9 @@ class SqlEventLogStorage(EventLogStorage):
 
         latest_materialization_storage_id_by_partition: dict[str, int] = {}
         for row in rows:
-            latest_materialization_storage_id_by_partition[cast(str, row[0])] = cast(int, row[1])
+            latest_materialization_storage_id_by_partition[cast("str", row[0])] = cast(
+                "int", row[1]
+            )
         return latest_materialization_storage_id_by_partition
 
     def get_latest_tags_by_partition(
@@ -1912,7 +1914,7 @@ class SqlEventLogStorage(EventLogStorage):
             rows = conn.execute(latest_tags_by_partition_query).fetchall()
 
         for row in rows:
-            latest_tags_by_partition[cast(str, row[0])][cast(str, row[1])] = cast(str, row[2])
+            latest_tags_by_partition[cast("str", row[0])][cast("str", row[1])] = cast("str", row[2])
 
         # convert defaultdict to dict
         return dict(latest_tags_by_partition)
@@ -2023,7 +2025,7 @@ class SqlEventLogStorage(EventLogStorage):
         with self.index_connection() as conn:
             rows = conn.execute(query).fetchall()
 
-        return [cast(str, row[1]) for row in rows]
+        return [cast("str", row[1]) for row in rows]
 
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         self._check_partitions_table()
@@ -2317,7 +2319,7 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             )
         ).fetchone()
-        existing = cast(int, count_row[0]) if count_row else 0
+        existing = cast("int", count_row[0]) if count_row else 0
 
         if existing > num:
             # need to delete some slots, favoring ones where the slot is unallocated
@@ -2392,8 +2394,8 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
             ).fetchone()
-        pending_count = cast(int, pending_row[0]) if pending_row else 0
-        slots_count = cast(int, slots[0]) if slots else 0
+        pending_count = cast("int", pending_row[0]) if pending_row else 0
+        slots_count = cast("int", slots[0]) if slots else 0
         return slots_count > pending_count
 
     def check_concurrency_claim(
@@ -2426,9 +2428,9 @@ class SqlEventLogStorage(EventLogStorage):
                     enqueued_timestamp=None,
                 )
 
-            priority = cast(int, pending_row[1]) if pending_row[1] else None
-            assigned_timestamp = cast(datetime, pending_row[0]) if pending_row[0] else None
-            create_timestamp = cast(datetime, pending_row[2]) if pending_row[2] else None
+            priority = cast("int", pending_row[1]) if pending_row[1] else None
+            assigned_timestamp = cast("datetime", pending_row[0]) if pending_row[0] else None
+            create_timestamp = cast("datetime", pending_row[2]) if pending_row[2] else None
             if assigned_timestamp is None:
                 return ConcurrencyClaimStatus(
                     concurrency_key=concurrency_key,
@@ -2487,7 +2489,7 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
             ).fetchone()
-            return row and cast(int, row[0]) > 0
+            return row and cast("int", row[0]) > 0
 
     def assign_pending_steps(self, concurrency_keys: Sequence[str]):
         if not concurrency_keys:
@@ -2574,7 +2576,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
         # return the concurrency keys for the freed slots which were assigned
-        to_assign = [cast(str, row[2]) for row in rows if row[1] is not None]
+        to_assign = [cast("str", row[2]) for row in rows if row[1] is not None]
         return to_assign
 
     def claim_concurrency_slot(
@@ -2667,9 +2669,9 @@ class SqlEventLogStorage(EventLogStorage):
                 rows = conn.execute(query).fetchall()
                 return [
                     PoolLimit(
-                        name=cast(str, row[0]),
-                        limit=cast(int, row[1]),
-                        from_default=cast(bool, row[2]),
+                        name=cast("str", row[0]),
+                        limit=cast("int", row[1]),
+                        from_default=cast("bool", row[2]),
                     )
                     for row in rows
                 ]
@@ -2699,8 +2701,8 @@ class SqlEventLogStorage(EventLogStorage):
             rows = conn.execute(query).fetchall()
             return [
                 PoolLimit(
-                    name=cast(str, row[0]),
-                    limit=cast(int, row[1]),
+                    name=cast("str", row[0]),
+                    limit=cast("int", row[1]),
                     from_default=False,
                 )
                 for row in rows
@@ -2723,7 +2725,7 @@ class SqlEventLogStorage(EventLogStorage):
                     .distinct()
                 )
             rows = conn.execute(query).fetchall()
-            return {cast(str, row[0]) for row in rows}
+            return {cast("str", row[0]) for row in rows}
 
     def get_concurrency_info(self, concurrency_key: str) -> ConcurrencyKeyInfo:
         """Get the list of concurrency slots for a given concurrency key.
@@ -2764,8 +2766,8 @@ class SqlEventLogStorage(EventLogStorage):
                 ).fetchone()
 
                 if limit_row:
-                    limit = cast(int, limit_row[0])
-                    using_default = cast(bool, limit_row[1])
+                    limit = cast("int", limit_row[0])
+                    using_default = cast("bool", limit_row[1])
                 elif not slot_count:
                     limit = self._instance.global_op_concurrency_default_limit
                     using_default = True
@@ -2812,7 +2814,7 @@ class SqlEventLogStorage(EventLogStorage):
     def get_concurrency_run_ids(self) -> set[str]:
         with self.index_connection() as conn:
             rows = conn.execute(db_select([PendingStepsTable.c.run_id]).distinct()).fetchall()
-            return set([cast(str, row[0]) for row in rows])
+            return set([cast("str", row[0]) for row in rows])
 
     def free_concurrency_slots_for_run(self, run_id: str) -> None:
         self._free_concurrency_slots(run_id=run_id)
@@ -2878,7 +2880,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
             # return the concurrency keys for the freed slots
-            return [cast(str, row[1]) for row in rows]
+            return [cast("str", row[1]) for row in rows]
 
     def store_asset_check_event(self, event: EventLogEntry, event_id: Optional[int]) -> None:
         check.inst_param(event, "event", EventLogEntry)
@@ -2901,7 +2903,7 @@ class SqlEventLogStorage(EventLogStorage):
         self, event: EventLogEntry, event_id: Optional[int]
     ) -> None:
         planned = cast(
-            AssetCheckEvaluationPlanned, check.not_none(event.dagster_event).event_specific_data
+            "AssetCheckEvaluationPlanned", check.not_none(event.dagster_event).event_specific_data
         )
         with self.index_connection() as conn:
             conn.execute(
@@ -2923,7 +2925,7 @@ class SqlEventLogStorage(EventLogStorage):
         self, event: EventLogEntry, event_id: Optional[int]
     ) -> None:
         evaluation = cast(
-            AssetCheckEvaluation, check.not_none(event.dagster_event).event_specific_data
+            "AssetCheckEvaluation", check.not_none(event.dagster_event).event_specific_data
         )
         with self.index_connection() as conn:
             conn.execute(
@@ -2949,7 +2951,7 @@ class SqlEventLogStorage(EventLogStorage):
 
     def _update_asset_check_evaluation(self, event: EventLogEntry, event_id: Optional[int]) -> None:
         evaluation = cast(
-            AssetCheckEvaluation, check.not_none(event.dagster_event).event_specific_data
+            "AssetCheckEvaluation", check.not_none(event.dagster_event).event_specific_data
         )
         with self.index_connection() as conn:
             rows_updated = conn.execute(
@@ -3105,8 +3107,8 @@ class SqlEventLogStorage(EventLogStorage):
         results = {}
         for row in rows:
             check_key = AssetCheckKey(
-                asset_key=check.not_none(AssetKey.from_db_string(cast(str, row["asset_key"]))),
-                name=cast(str, row["check_name"]),
+                asset_key=check.not_none(AssetKey.from_db_string(cast("str", row["asset_key"]))),
+                name=cast("str", row["check_name"]),
             )
             results[check_key] = AssetCheckExecutionRecord.from_db_row(row, key=check_key)
         return results
@@ -3221,7 +3223,7 @@ class SqlEventLogStorage(EventLogStorage):
         with self.index_connection() as conn:
             rows = conn.execute(latest_data_version_by_partition_query).fetchall()
 
-        return {cast(str, row[0]): cast(str, row[1]) for row in rows}
+        return {cast("str", row[0]): cast("str", row[1]) for row in rows}
 
     def get_updated_data_version_partitions(
         self, asset_key: AssetKey, partitions: Iterable[str], since_storage_id: int

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -179,7 +179,7 @@ def input_manager(
 
     def _wrap(load_fn: InputLoadFn) -> InputManagerDefinition:
         return _InputManagerDecoratorCallable(
-            config_schema=cast(CoercableToConfigSchema, config_schema),
+            config_schema=cast("CoercableToConfigSchema", config_schema),
             description=description,
             version=version,
             input_config_schema=input_config_schema,

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -15,7 +15,6 @@ from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.config import is_callable_valid_config_arg
 from dagster._core.definitions.definition_config_schema import (
@@ -28,6 +27,7 @@ from dagster._core.storage.input_manager import IInputManagerDefinition, InputMa
 from dagster._core.storage.output_manager import IOutputManagerDefinition, OutputManager
 
 if TYPE_CHECKING:
+    from dagster._config import UserConfigSchema
     from dagster._core.execution.context.init import InitResourceContext
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.output import OutputContext
@@ -108,7 +108,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             output_config_schema=self.output_config_schema,
         )
 
-        io_def._dagster_maintained = self._is_dagster_maintained()  # noqa: SLF001
+        io_def._dagster_maintained = self._is_dagster_maintained()
 
         return io_def
 
@@ -236,12 +236,12 @@ def io_manager(
 
     """
     if callable(config_schema) and not is_callable_valid_config_arg(config_schema):
-        config_schema = cast(IOManagerFunction, config_schema)
+        config_schema = cast("IOManagerFunction", config_schema)
         return _IOManagerDecoratorCallable()(config_schema)
 
     def _wrap(resource_fn: IOManagerFunction) -> IOManagerDefinition:
         return _IOManagerDecoratorCallable(
-            config_schema=cast(Optional[UserConfigSchema], config_schema),
+            config_schema=cast("Optional[UserConfigSchema]", config_schema),
             description=description,
             required_resource_keys=required_resource_keys,
             version=version,

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -235,7 +235,7 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn: Optional[PrintFn] =
 
             has_more = len(rows) >= CHUNK_SIZE
             for row in rows:
-                run = deserialize_value(cast(str, row[0]), DagsterRun)
+                run = deserialize_value(cast("str", row[0]), DagsterRun)
                 cursor = row[1]
                 write_repo_tag(conn, run)
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -1023,7 +1023,7 @@ class SqlRunStorage(RunStorage):
             key=partition_backfill.backfill_id,
             status=partition_backfill.status.value,
             timestamp=datetime_from_timestamp(partition_backfill.backfill_timestamp),
-            body=serialize_value(cast(NamedTuple, partition_backfill)),
+            body=serialize_value(cast("NamedTuple", partition_backfill)),
         )
 
         if self.has_bulk_actions_selector_cols():

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -175,7 +175,7 @@ def _composite_descent(
                     asset_layer,
                 )
                 if node.definition.has_config_mapping
-                else cast(Mapping[str, RawNodeConfig], current_op_config.get("ops", {}))
+                else cast("Mapping[str, RawNodeConfig]", current_op_config.get("ops", {}))
             )
 
             yield from _composite_descent(

--- a/python_modules/dagster/dagster/_core/system_config/objects.py
+++ b/python_modules/dagster/dagster/_core/system_config/objects.py
@@ -1,10 +1,9 @@
 """System-provided config objects and constructors."""
 
 from collections.abc import Mapping, Sequence
-from typing import AbstractSet, Any, NamedTuple, Optional, Union, cast  # noqa: UP035
+from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional, Union, cast  # noqa: UP035
 
 import dagster._check as check
-from dagster._core.definitions.configurable import ConfigurableDefinition
 from dagster._core.definitions.executor_definition import (
     ExecutorDefinition,
     execute_in_process_executor,
@@ -17,6 +16,9 @@ from dagster._core.errors import (
     user_code_error_boundary,
 )
 from dagster._utils import ensure_single_item
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.configurable import ConfigurableDefinition
 
 
 class OpConfig(
@@ -161,7 +163,7 @@ class ResolvedRunConfig(
                 run_config,
             )
 
-        config_value = cast(dict[str, Any], config_evr.value)
+        config_value = cast("dict[str, Any]", config_evr.value)
 
         # If using the `execute_in_process` executor, we ignore the execution config value, since it
         # may be pointing to the executor for the job rather than the `execute_in_process` executor.
@@ -335,7 +337,7 @@ def config_map_objects(
         f"Could not find a {def_type} definition on the selected mode that matches the "
         f'{def_type} "{obj_name}" given in run config',
     )
-    obj_def = cast(ConfigurableDefinition, obj_def)
+    obj_def = cast("ConfigurableDefinition", obj_def)
 
     obj_config_evr = obj_def.apply_config_mapping(obj_config)
     if not obj_config_evr.success:

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -702,9 +702,9 @@ def raise_exception_on_warnings():
 
 def ensure_dagster_tests_import() -> None:
     dagster_package_root = (Path(dagster_init_py) / ".." / "..").resolve()
-    assert (
-        dagster_package_root / "dagster_tests"
-    ).exists(), "Could not find dagster_tests where expected"
+    assert (dagster_package_root / "dagster_tests").exists(), (
+        "Could not find dagster_tests where expected"
+    )
     sys.path.append(dagster_package_root.as_posix())
 
 

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -99,9 +99,9 @@ def dagster_type_loader(
     from dagster._config import resolve_to_config_type
 
     config_type = resolve_to_config_type(config_schema)
-    assert isinstance(
-        config_type, ConfigType
-    ), f"{config_schema} could not be resolved to config type"
+    assert isinstance(config_type, ConfigType), (
+        f"{config_schema} could not be resolved to config type"
+    )
     EXPECTED_POSITIONALS = ["context", "*"]
 
     def wrapper(func: DagsterTypeLoaderFn) -> DagsterTypeLoaderFromDecorator:

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -115,7 +115,7 @@ def parse_env_var(env_var_str: str) -> tuple[str, str]:
         env_var_value = os.getenv(env_var_str)
         if env_var_value is None:
             raise Exception(f"Tried to load environment variable {env_var_str}, but it was not set")
-        return (env_var_str, cast(str, env_var_value))
+        return (env_var_str, cast("str", env_var_value))
 
 
 class RequestUtilizationMetrics(TypedDict):

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -38,7 +38,7 @@ def ensure_workspace_config(
             validation_result.errors,
             workspace_config,
         )
-    return cast(dict[str, object], validation_result.value)
+    return cast("dict[str, object]", validation_result.value)
 
 
 def _get_target_config() -> Mapping[str, ScalarUnion]:

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -46,7 +46,7 @@ def location_origins_from_yaml_paths(
         )
 
         origins_by_name.update(
-            location_origins_from_config(cast(dict, workspace_config), yaml_path)
+            location_origins_from_config(cast("dict", workspace_config), yaml_path)
         )
 
     return list(origins_by_name.values())
@@ -326,15 +326,15 @@ def _location_origin_from_target_config(
     check.str_param(yaml_path, "yaml_path")
 
     if "python_file" in target_config:
-        python_file_config = cast(Union[str, dict], target_config["python_file"])
+        python_file_config = cast("Union[str, dict]", target_config["python_file"])
         return _location_origin_from_python_file_config(python_file_config, yaml_path)
 
     elif "python_module" in target_config:
-        python_module_config = cast(Union[str, dict], target_config["python_module"])
+        python_module_config = cast("Union[str, dict]", target_config["python_module"])
         return _location_origin_from_module_config(python_module_config)
 
     elif "python_package" in target_config:
-        python_package_config = cast(Union[str, dict], target_config["python_package"])
+        python_package_config = cast("Union[str, dict]", target_config["python_package"])
         return _location_origin_from_package_config(python_package_config)
 
     else:

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -52,7 +52,7 @@ class InProcessWorkspaceLoadTarget(WorkspaceLoadTarget):
         self, origin: Union[InProcessCodeLocationOrigin, Sequence[InProcessCodeLocationOrigin]]
     ):
         self._origins = cast(
-            Sequence[InProcessCodeLocationOrigin],
+            "Sequence[InProcessCodeLocationOrigin]",
             origin if isinstance(origin, list) else [origin],
         )
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -177,7 +177,7 @@ def get_current_evaluation_id(
             sensor_origin.get_id(), sensor_origin.get_selector().get_id()
         )
         serialized_cursor = (
-            cast(SensorInstigatorData, instigator_state.instigator_data).cursor
+            cast("SensorInstigatorData", instigator_state.instigator_data).cursor
             if instigator_state
             else None
         )
@@ -785,7 +785,7 @@ class AssetDaemon(DagsterDaemon):
             if sensor:
                 stored_cursor = asset_daemon_cursor_from_instigator_serialized_cursor(
                     cast(
-                        SensorInstigatorData,
+                        "SensorInstigatorData",
                         check.not_none(auto_materialize_instigator_state).instigator_data,
                     ).cursor,
                     workspace_asset_graph,

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -229,7 +229,7 @@ def consume_new_runs_for_automatic_reexecution(
     retry the run again.
     """
     for run in filter_runs_to_should_retry(
-        [cast(DagsterRun, run_record.dagster_run) for run_record in run_records],
+        [cast("DagsterRun", run_record.dagster_run) for run_record in run_records],
         workspace_process_context.instance,
     ):
         yield

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -18,8 +18,8 @@ from dagster._daemon.utils import DaemonErrorCapture
 if TYPE_CHECKING:
     from dagster._core.events.log import EventLogEntry
 
-_INTERVAL_SECONDS = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_INTERVAL_SECONDS", 5))
-_EVENT_LOG_FETCH_LIMIT = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_FETCH_LIMIT", 500))
+_INTERVAL_SECONDS = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_INTERVAL_SECONDS", "5"))
+_EVENT_LOG_FETCH_LIMIT = int(os.environ.get("DAGSTER_EVENT_LOG_CONSUMER_DAEMON_FETCH_LIMIT", "500"))
 
 DAGSTER_EVENT_TYPES = [DagsterEventType.RUN_FAILURE, DagsterEventType.RUN_SUCCESS]
 

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -43,7 +43,7 @@ def _get_instigation_logger_if_log_storage_enabled(
             logger_name=default_logger.name,
             console_logger=default_logger,
         ) as _logger:
-            backfill_logger = cast(logging.Logger, _logger)
+            backfill_logger = cast("logging.Logger", _logger)
             yield backfill_logger
 
     else:
@@ -151,7 +151,7 @@ def execute_backfill_iteration_with_instigation_logger(
     with _get_instigation_logger_if_log_storage_enabled(instance, backfill, logger) as _logger:
         # create a logger that will always include the backfill_id as an `extra`
         backfill_logger = cast(
-            logging.Logger,
+            "logging.Logger",
             logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
         )
         try:
@@ -227,7 +227,7 @@ def execute_backfill_jobs(
         backfill_id = backfill_job.backfill_id
 
         # refetch, in case the backfill was updated in the meantime
-        backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
+        backfill = cast("PartitionBackfill", instance.get_backfill(backfill_id))
 
         try:
             if threadpool_executor:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -160,21 +160,17 @@ class SensorLaunchContext(AbstractContextManager):
             kwargs["failure_count"] = 0
             kwargs["consecutive_failure_count"] = 0
 
-        skip_reason = cast(Optional[str], kwargs.get("skip_reason"))
-        cursor = cast(Optional[str], kwargs.get("cursor"))
-        origin_run_id = cast(Optional[str], kwargs.get("origin_run_id"))
-        user_interrupted = cast(Optional[bool], kwargs.get("user_interrupted"))
-        if "skip_reason" in kwargs:
-            del kwargs["skip_reason"]
+        skip_reason = cast("Optional[str]", kwargs.get("skip_reason"))
+        cursor = cast("Optional[str]", kwargs.get("cursor"))
+        origin_run_id = cast("Optional[str]", kwargs.get("origin_run_id"))
+        user_interrupted = cast("Optional[bool]", kwargs.get("user_interrupted"))
+        kwargs.pop("skip_reason", None)
 
-        if "cursor" in kwargs:
-            del kwargs["cursor"]
+        kwargs.pop("cursor", None)
 
-        if "origin_run_id" in kwargs:
-            del kwargs["origin_run_id"]
+        kwargs.pop("origin_run_id", None)
 
-        if "user_interrupted" in kwargs:
-            del kwargs["user_interrupted"]
+        kwargs.pop("user_interrupted", None)
 
         if kwargs:
             check.inst_param(status, "status", TickStatus)

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -488,7 +488,7 @@ class DagsterGrpcClient:
     def _is_unimplemented_error(self, e: Exception) -> bool:
         return (
             isinstance(e.__cause__, grpc.RpcError)
-            and cast(grpc.RpcError, e.__cause__).code() == grpc.StatusCode.UNIMPLEMENTED
+            and cast("grpc.RpcError", e.__cause__).code() == grpc.StatusCode.UNIMPLEMENTED
         )
 
     def external_schedule_execution(

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -886,8 +886,8 @@ class DagsterApiServer(DagsterApiServicer):
     ) -> Iterable[dagster_api_pb2.StreamingExternalRepositoryEvent]:
         serialized_external_repository_data = self._get_serialized_external_repository_data(request)
 
-        num_chunks = int(
-            math.ceil(float(len(serialized_external_repository_data)) / STREAMING_CHUNK_SIZE)
+        num_chunks = math.ceil(
+            float(len(serialized_external_repository_data)) / STREAMING_CHUNK_SIZE
         )
 
         for i in range(num_chunks):
@@ -907,7 +907,7 @@ class DagsterApiServer(DagsterApiServicer):
     def _split_serialized_data_into_chunk_events(
         self, serialized_data: str
     ) -> Iterable[dagster_api_pb2.StreamingChunkEvent]:
-        num_chunks = int(math.ceil(float(len(serialized_data)) / STREAMING_CHUNK_SIZE))
+        num_chunks = math.ceil(float(len(serialized_data)) / STREAMING_CHUNK_SIZE)
         for i in range(num_chunks):
             start_index = i * STREAMING_CHUNK_SIZE
             end_index = min(
@@ -1141,7 +1141,7 @@ class DagsterApiServer(DagsterApiServicer):
             self._executions[run_id] = (
                 # Cast here to convert `SpawnProcess` from event into regular `Process`-- not sure
                 # why not recognized as subclass, multiprocessing typing is a little rough.
-                cast(multiprocessing.Process, execution_process),
+                cast("multiprocessing.Process", execution_process),
                 check.not_none(execute_external_job_args.instance_ref),
             )
             self._termination_events[run_id] = termination_event
@@ -1383,13 +1383,13 @@ def wait_for_grpc_server(
         if timeout > 0 and (time.time() - start_time > timeout):
             raise Exception(
                 f"Timed out waiting for gRPC server to start after {timeout}s. {additional_timeout_msg}Launched with arguments:"
-                f" \"{' '.join(subprocess_args)}\". Most recent connection error: {last_error}"
+                f' "{" ".join(subprocess_args)}". Most recent connection error: {last_error}'
             )
 
         if server_process.poll() is not None:
             raise Exception(
                 f"gRPC server exited with return code {server_process.returncode} while starting up"
-                f" with the command: \"{' '.join(subprocess_args)}\""
+                f' with the command: "{" ".join(subprocess_args)}"'
             )
 
         sleep(0.1)

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -121,8 +121,7 @@ class _ScheduleLaunchContext(AbstractContextManager):
             kwargs["consecutive_failure_count"] = 0
 
         skip_reason = kwargs.get("skip_reason")
-        if "skip_reason" in kwargs:
-            del kwargs["skip_reason"]
+        kwargs.pop("skip_reason", None)
 
         self._tick = self._tick.with_status(status=status, error=error, **kwargs)
 
@@ -321,7 +320,7 @@ def launch_scheduled_runs(
                         _write_and_get_next_checkpoint_timestamp(
                             instance,
                             all_schedule_states[selector_id],
-                            cast(ScheduleInstigatorData, schedule_state.instigator_data),
+                            cast("ScheduleInstigatorData", schedule_state.instigator_data),
                             now_timestamp,
                         )
 
@@ -563,7 +562,7 @@ def launch_scheduled_runs_for_schedule_iterator(
     ticks = instance.get_ticks(instigator_origin_id, remote_schedule.selector_id, limit=1)
     latest_tick: Optional[InstigatorTick] = ticks[0] if ticks else None
 
-    instigator_data = cast(ScheduleInstigatorData, schedule_state.instigator_data)
+    instigator_data = cast("ScheduleInstigatorData", schedule_state.instigator_data)
     start_timestamp_utc: float = instigator_data.start_timestamp or 0
 
     if latest_tick:

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -93,7 +93,7 @@ class ConfigurableClassData(
             # they do not. However, not all rehydrated classes actually have `ConfigurableClass` as
             # an ancestor due to some subtleties around multiple abstract classes that cause an
             # error when `ConfigurableClass` is added as an ancestor to storage classes.
-            klass = cast(type[ConfigurableClass], getattr(module, self.class_name))
+            klass = cast("type[ConfigurableClass]", getattr(module, self.class_name))
         except AttributeError:
             check.failed(
                 f"Couldn't find class {self.class_name} in module when attempting to load the "

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -315,7 +315,7 @@ def ensure_gen(
     thing_or_gen: Union[T, Iterator[T], Generator[T, Any, Any]],
 ) -> Generator[T, Any, Any]:
     if not inspect.isgenerator(thing_or_gen):
-        thing_or_gen = cast(T, thing_or_gen)
+        thing_or_gen = cast("T", thing_or_gen)
 
         def _gen_thing():
             yield thing_or_gen
@@ -446,7 +446,7 @@ class EventGenerationManager(Generic[T_GeneratedContext]):
     def get_object(self) -> T_GeneratedContext:
         if not self.did_setup:
             check.failed("Called `get_object` before `generate_setup_events`")
-        return cast(T_GeneratedContext, self.object)
+        return cast("T_GeneratedContext", self.object)
 
     def generate_teardown_events(self) -> Iterator["DagsterEvent"]:
         self.did_teardown = True
@@ -601,7 +601,7 @@ def traced(func: T_Callable) -> T_Callable:
 
         return func(*args, **kwargs)
 
-    return cast(T_Callable, inner)
+    return cast("T_Callable", inner)
 
 
 def get_terminate_signal() -> signal.Signals:

--- a/python_modules/dagster/dagster/_utils/aiodataloader.py
+++ b/python_modules/dagster/dagster/_utils/aiodataloader.py
@@ -114,9 +114,9 @@ class DataLoader(_BaseDataLoader[KeyT, ReturnT]):
 
         self.batch_load_fn = batch_load_fn
 
-        assert iscoroutinefunctionorpartial(
-            self.batch_load_fn
-        ), f"batch_load_fn must be coroutine. Received: {self.batch_load_fn}"
+        assert iscoroutinefunctionorpartial(self.batch_load_fn), (
+            f"batch_load_fn must be coroutine. Received: {self.batch_load_fn}"
+        )
 
         if not callable(self.batch_load_fn):
             raise TypeError(
@@ -167,7 +167,7 @@ class DataLoader(_BaseDataLoader[KeyT, ReturnT]):
         """Loads a key, returning a `Future` for the value represented by that key."""
         if key is None:
             raise TypeError(
-                "The loader.load() function must be called with a value, " f"but got: {key}."
+                f"The loader.load() function must be called with a value, but got: {key}."
             )
 
         cache_key = self.get_cache_key(key)

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -501,7 +501,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         materializations_planned = self.instance.get_records_for_run(
             run_id=run_id, of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED
         ).records
-        return set(cast(AssetKey, record.asset_key) for record in materializations_planned)
+        return set(cast("AssetKey", record.asset_key) for record in materializations_planned)
 
     def get_planned_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
         """Returns the set of asset keys that are planned to be materialized by the run.
@@ -550,7 +550,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             run_id=run_id,
             of_type=DagsterEventType.ASSET_MATERIALIZATION,
         ).records
-        return set(cast(AssetKey, record.asset_key) for record in materializations)
+        return set(cast("AssetKey", record.asset_key) for record in materializations)
 
     ####################
     # BACKFILLS

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -271,7 +271,7 @@ class FilesystemTestScheduler(Scheduler, ConfigurableClass):
     def from_config_value(
         cls, inst_data: object, config_value: Mapping[str, object]
     ) -> "FilesystemTestScheduler":
-        artifacts_dir = cast(str, config_value["base_dir"])
+        artifacts_dir = cast("str", config_value["base_dir"])
         return FilesystemTestScheduler(artifacts_dir=artifacts_dir, inst_data=inst_data)
 
     def debug_info(self) -> str:

--- a/python_modules/dagster/dagster/_utils/test/data_versions.py
+++ b/python_modules/dagster/dagster/_utils/test/data_versions.py
@@ -50,7 +50,7 @@ def mock_io_manager():
 def get_mat_from_result(result: ExecuteInProcessResult, node_str: str) -> AssetMaterialization:
     mats = result.asset_materializations_for_node(node_str)
     assert all(isinstance(m, AssetMaterialization) for m in mats)
-    return cast(AssetMaterialization, mats[0])
+    return cast("AssetMaterialization", mats[0])
 
 
 def get_mats_from_result(
@@ -60,7 +60,7 @@ def get_mats_from_result(
     for asset_def in assets:
         node_str = asset_def.node_def.name if asset_def.node_def else asset_def.key.path[-1]
         for mat in result.asset_materializations_for_node(node_str):
-            mats[mat.asset_key] = cast(AssetMaterialization, mat)
+            mats[mat.asset_key] = cast("AssetMaterialization", mat)
     return MaterializationTable(mats)
 
 

--- a/python_modules/dagster/dagster/_utils/typed_dict.py
+++ b/python_modules/dagster/dagster/_utils/typed_dict.py
@@ -24,4 +24,4 @@ def init_optional_typeddict(cls: type[_TypedDictClass]) -> _TypedDictClass:
             continue
         else:
             raise Exception("fields must be either optional or typed dicts")
-    return cast(_TypedDictClass, result)
+    return cast("_TypedDictClass", result)

--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -88,7 +88,7 @@ def scaffold_object(
         ScaffoldRequest(
             type_name=typename,
             target_path=path,
-            scaffold_format=cast(ScaffoldFormatOptions, scaffold_format),
+            scaffold_format=cast("ScaffoldFormatOptions", scaffold_format),
         ),
         scaffold_params,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -123,7 +123,7 @@ def test_partitions_definition_valid_subset():
             asset0.key,
         )
 
-        subset = cast(TimeWindowPartitionsSubset, entity_subset.get_internal_subset_value())
+        subset = cast("TimeWindowPartitionsSubset", entity_subset.get_internal_subset_value())
         assert subset.included_time_windows == old_partitions_subset.included_time_windows
         assert subset.partitions_def == current_partitions_def
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -302,7 +302,7 @@ def test_bfs_filter_time_window_partitions():
             for asset_partition in entity_subset.expensively_compute_asset_partitions():
                 partition_date = (
                     cast(
-                        TimeWindowPartitionsDefinition,
+                        "TimeWindowPartitionsDefinition",
                         graph_view.asset_graph.get(entity_subset.key).partitions_def,
                     )
                     .time_window_for_partition_key(asset_partition.partition_key)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -932,9 +932,9 @@ def test_multi_partition_mapping_with_asset_deps():
             assert current_partition_key - asset_1_key == timedelta(days=1)
             assert current_partition_key - asset_2_key == timedelta(days=2)
         else:
-            assert (
-                False
-            ), "partition keys for asset_1, asset_2, and multi_asset_2 should be MultiPartitionKeys"
+            assert False, (
+                "partition keys for asset_1, asset_2, and multi_asset_2 should be MultiPartitionKeys"
+            )
 
         return
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_antlr_asset_selection.py
@@ -242,4 +242,6 @@ def test_full_test_coverage() -> None:
         name_substr = name.strip("'")
         assert any(
             name_substr in selection_str for selection_str in all_selection_strings_we_are_testing
-        ), f"Antlr literal {name_substr} is not under test in test_antlr_asset_selection.py:test_antlr_visit_basic"
+        ), (
+            f"Antlr literal {name_substr} is not under test in test_antlr_asset_selection.py:test_antlr_visit_basic"
+        )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -96,7 +96,7 @@ def test_asset_code_origins() -> None:
                     LocalFileCodeReference,
                 )
                 meta = cast(
-                    LocalFileCodeReference,
+                    "LocalFileCodeReference",
                     asset.specs_by_key[key].metadata["dagster/code_references"].code_references[-1],
                 )
 
@@ -147,7 +147,7 @@ def test_asset_code_origins_source_control() -> None:
                     UrlCodeReference,
                 )
                 meta = cast(
-                    UrlCodeReference,
+                    "UrlCodeReference",
                     asset.specs_by_key[key].metadata["dagster/code_references"].code_references[-1],
                 )
 
@@ -219,7 +219,7 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
                     UrlCodeReference,
                 )
                 meta = cast(
-                    UrlCodeReference,
+                    "UrlCodeReference",
                     asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
                 )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -203,6 +203,6 @@ def test_perf() -> None:
 
     avg_elapsed_time_secs = total_elapsed_time_secs / NUM_PERF_TRIALS
 
-    assert (
-        avg_elapsed_time_secs < PERF_CUTOFF_SECS
-    ), "Performance of resolve_similar_asset_names has regressed"
+    assert avg_elapsed_time_secs < PERF_CUTOFF_SECS, (
+        "Performance of resolve_similar_asset_names has regressed"
+    )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -112,14 +112,14 @@ def test_time_window_partitions_subset_serialization_deserialization(
         end_offset=partitions_def.end_offset,
     )
     subset = cast(
-        TimeWindowPartitionsSubset,
+        "TimeWindowPartitionsSubset",
         TimeWindowPartitionsSubset.create_empty_subset(
             time_window_partitions_def
         ).with_partition_keys(["2023-01-01"]),
     )
 
     deserialized = deserialize_value(
-        serialize_value(cast(TimeWindowPartitionsSubset, subset)), TimeWindowPartitionsSubset
+        serialize_value(cast("TimeWindowPartitionsSubset", subset)), TimeWindowPartitionsSubset
     )
     assert deserialized == subset
     assert deserialized.get_partition_keys() == ["2023-01-01"]

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -288,9 +288,9 @@ def _wait_for_instance_dir_to_be_written(parent_dir: Path) -> Path:
 def _validate_job_available(port: int, job_name: str) -> None:
     client = DagsterGraphQLClient(hostname="localhost", port_number=port)
     locations_and_names = client._get_repo_locations_and_names_with_pipeline(job_name)  # noqa: SLF001
-    assert (
-        len(locations_and_names) > 0
-    ), f"repo failed to load or was missing a job called '{job_name}'"
+    assert len(locations_and_names) > 0, (
+        f"repo failed to load or was missing a job called '{job_name}'"
+    )
 
 
 def _validate_expected_child_processes(dev_process: subprocess.Popen, expected_count: int) -> None:

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -164,9 +164,9 @@ def test_execute_run_with_secrets_loader(capfd):
 
         # Step subprocess is logged to capfd since its in a subprocess of the CLi command
         _, err = capfd.readouterr()
-        assert (
-            "STEP_FAILURE" in err and "Exception: Missing env var" in err
-        ), f"no match, result: {err}"
+        assert "STEP_FAILURE" in err and "Exception: Missing env var" in err, (
+            f"no match, result: {err}"
+        )
 
 
 def test_execute_run_fail_job():
@@ -274,9 +274,9 @@ def test_execute_run_cannot_load():
 
             assert result.exit_code != 0
 
-            assert f"Run with id '{run_id}' not found for run execution" in str(
-                result.exception
-            ), f"no match, result: {result.stdout}"
+            assert f"Run with id '{run_id}' not found for run execution" in str(result.exception), (
+                f"no match, result: {result.stdout}"
+            )
 
 
 def runner_execute_step(runner: CliRunner, cli_args, env=None):

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -1,15 +1,18 @@
-from collections.abc import Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import dagster as dg
 from component_component_deps.defs import my_python_defs  # type:ignore
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster.components.core.context import ComponentLoadContext
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from dagster._core.definitions.assets import AssetsDefinition
 
 ctx = ComponentLoadContext.current()
 
 assets_from_my_python_defs = cast(
-    Sequence[AssetsDefinition],
+    "Sequence[AssetsDefinition]",
     ctx.load_defs(my_python_defs).assets,
 )
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -1,9 +1,11 @@
-from collections.abc import Sequence
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import dagster as dg
 from dagster.components import Component, ComponentLoadContext
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
@@ -13,7 +15,7 @@ class MyCustomComponent(Component):
         from component_component_deps_custom_component.defs import my_python_defs  # type:ignore
 
         assets_from_my_python_defs = cast(
-            Sequence[dg.AssetsDefinition],
+            "Sequence[dg.AssetsDefinition]",
             context.load_defs(my_python_defs).assets,
         )
 

--- a/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
+++ b/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
@@ -129,9 +129,9 @@ def test_all_components_have_defined_summary():
     registry = discover_entry_point_package_objects()
     for component_name, component_type in registry.items():
         if isinstance(component_type, type) and issubclass(component_type, Component):
-            assert get_package_entry_snap(
-                PluginObjectKey("a", "a"), component_type
-            ).summary, f"Component {component_name} has no summary defined"
+            assert get_package_entry_snap(PluginObjectKey("a", "a"), component_type).summary, (
+                f"Component {component_name} has no summary defined"
+            )
 
 
 # Our pyproject.toml installs local dagster components

--- a/python_modules/dagster/dagster_tests/components_tests/test_integrity.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_integrity.py
@@ -14,6 +14,6 @@ def test_all_components_have_component_suffix():
         module = importlib.import_module(module_name)
         for name, obj in get_package_objects_in_module(module):
             if isinstance(obj, type) and issubclass(obj, Component):
-                assert name.endswith(
-                    "Component"
-                ), f"Component {name} in module {module_name} does not have 'Component' suffix"
+                assert name.endswith("Component"), (
+                    f"Component {name} in module {module_name} does not have 'Component' suffix"
+                )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
@@ -39,7 +39,7 @@ def test_validate_dynamic_partitions(
 
     run_request = RunRequest(partition_key="a")
     with instance_for_test() as instance:
-        instance.add_dynamic_partitions(cast(str, partitions_def.name), prior_partitions)
+        instance.add_dynamic_partitions(cast("str", partitions_def.name), prior_partitions)
 
         if expect_success:
             run_request.with_resolved_tags_and_config(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -120,7 +120,7 @@ def scenario(
         assets_by_repo_name = assets
 
     return AssetBackfillScenario(
-        assets_by_repo_name=cast(Mapping[str, Sequence[AssetsDefinition]], assets_by_repo_name),
+        assets_by_repo_name=cast("Mapping[str, Sequence[AssetsDefinition]]", assets_by_repo_name),
         evaluation_time=evaluation_time if evaluation_time else get_current_datetime(),
         target_root_partition_keys=target_root_partition_keys,
         last_storage_id_cursor_offset=last_storage_id_cursor_offset,
@@ -569,7 +569,7 @@ def test_materializations_outside_of_backfill():
         all_assets=one_asset_one_partition,
         asset_keys=[one_asset_one_partition[0].key],
         partition_key=cast(
-            PartitionsDefinition, one_asset_one_partition[0].partitions_def
+            "PartitionsDefinition", one_asset_one_partition[0].partitions_def
         ).get_partition_keys()[0],
         instance=instance,
         tags={},
@@ -1032,9 +1032,9 @@ def _requested_asset_partitions_in_run_request(
         # backfill was a partition by partition backfill
         for asset_key in asset_keys:
             asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
-            assert (
-                asset_partition not in requested_asset_partitions
-            ), f"{asset_partition} requested twice. Requested: {requested_asset_partitions}."
+            assert asset_partition not in requested_asset_partitions, (
+                f"{asset_partition} requested twice. Requested: {requested_asset_partitions}."
+            )
             requested_asset_partitions.add(asset_partition)
     return requested_asset_partitions
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -174,7 +174,7 @@ def test_config_mapping_fn():
         config_schema={"msg": str},
     )
     def do_stuff(context):
-        return f"{context.op_config['msg'] } on {context.resources.date}"
+        return f"{context.op_config['msg']} on {context.resources.date}"
 
     @graph
     def needs_config():
@@ -209,7 +209,7 @@ def test_default_config():
         config_schema={"msg": str},
     )
     def do_stuff(context):
-        return f"{context.op_config['msg'] } on {context.resources.date}"
+        return f"{context.op_config['msg']} on {context.resources.date}"
 
     @graph
     def needs_config():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -271,7 +271,7 @@ def test_bind_resource_to_instigator(include_job_in_definitions) -> None:
     )
 
     assert (
-        cast(JobDefinition, defs.get_sensor_def("hello_world_sensor").job)
+        cast("JobDefinition", defs.get_sensor_def("hello_world_sensor").job)
         .execute_in_process()
         .success
     )
@@ -280,7 +280,7 @@ def test_bind_resource_to_instigator(include_job_in_definitions) -> None:
     out_txt.clear()
 
     assert (
-        cast(JobDefinition, defs.get_schedule_def("hello_world_schedule").job)
+        cast("JobDefinition", defs.get_schedule_def("hello_world_schedule").job)
         .execute_in_process()
         .success
     )
@@ -324,7 +324,7 @@ def test_bind_resource_to_instigator_by_name() -> None:
     )
 
     assert (
-        defs.get_job_def(cast(str, defs.get_sensor_def("hello_world_sensor").job_name))
+        defs.get_job_def(cast("str", defs.get_sensor_def("hello_world_sensor").job_name))
         .execute_in_process()
         .success
     )
@@ -333,7 +333,7 @@ def test_bind_resource_to_instigator_by_name() -> None:
     out_txt.clear()
 
     assert (
-        defs.get_job_def(cast(str, defs.get_schedule_def("hello_world_schedule").job_name))
+        defs.get_job_def(cast("str", defs.get_schedule_def("hello_world_schedule").job_name))
         .execute_in_process()
         .success
     )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -291,8 +291,7 @@ def test_asset_io_manager_transitive_dependencies():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "resource with key 'foo' required by resource with key 'the_resource' was not"
-            " provided."
+            "resource with key 'foo' required by resource with key 'the_resource' was not provided."
         ),
     ):
         with_resources([the_asset], resource_defs={"the_resource": the_resource})

--- a/python_modules/dagster/dagster_tests/core_tests/test_decorator_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_decorator_utils.py
@@ -40,11 +40,11 @@ def test_required_positional_parameters_not_missing():
 
 def test_format_docstring_for_description():
     def multiline_indented_docstring():
-        """abc
+        """Abc
         123.
         """
 
-    multiline_indented_docstring_expected = "abc\n123."
+    multiline_indented_docstring_expected = "Abc\n123."
 
     assert (
         format_docstring_for_description(multiline_indented_docstring)
@@ -52,11 +52,11 @@ def test_format_docstring_for_description():
     )
 
     def no_indentation_at_start():
-        """abc
+        """Abc
         123.
         """
 
-    no_indentation_at_start_expected = "abc\n123."
+    no_indentation_at_start_expected = "Abc\n123."
 
     assert (
         format_docstring_for_description(no_indentation_at_start)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -154,7 +154,7 @@ def test_run_status_sensor(
             started_sensor.get_remote_origin_id(), started_sensor.selector_id
         )
         assert (
-            cast(SensorInstigatorData, check.not_none(state).instigator_data).sensor_type
+            cast("SensorInstigatorData", check.not_none(state).instigator_data).sensor_type
             == SensorType.RUN_STATUS
         )
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1862,9 +1862,9 @@ def test_sensor_spans(workspace_context):
 
     for _i in range(10):
         next_span = next(loop)
-        assert (
-            next_span != SpanMarker.START_SPAN
-        ), "Started another span before finishing the previous one"
+        assert next_span != SpanMarker.START_SPAN, (
+            "Started another span before finishing the previous one"
+        )
 
         if next_span == SpanMarker.END_SPAN:
             break

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -68,7 +68,7 @@ def code_location_fixture(
     workspace_context: WorkspaceProcessContext,
 ) -> CodeLocation:
     return cast(
-        CodeLocation,
+        "CodeLocation",
         next(
             iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -693,7 +693,7 @@ def test_two_backfills_at_the_same_time(
             instance=instance,
         ) as workspace_context:
             remote_repo = cast(
-                CodeLocation,
+                "CodeLocation",
                 next(
                     iter(
                         workspace_context.create_request_context()

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -294,7 +294,7 @@ def test_monitor_started(
     run_record = instance.get_run_record_by_id(run_id)
     assert run_record is not None
     workspace = workspace_context.create_request_context()
-    run_launcher = cast(TestRunLauncher, instance.run_launcher)
+    run_launcher = cast("TestRunLauncher", instance.run_launcher)
     with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
         monitor_started_run(instance, workspace, run_record, logger)
         run = instance.get_run_by_id(run_record.dagster_run.run_id)
@@ -390,7 +390,7 @@ def test_long_running_termination(
         assert no_tag_record.start_time == started_time.timestamp()
 
         workspace = workspace_context.create_request_context()
-        run_launcher = cast(TestRunLauncher, instance.run_launcher)
+        run_launcher = cast("TestRunLauncher", instance.run_launcher)
 
         eval_time = started_time + datetime.timedelta(seconds=501)
         with freeze_time(eval_time):
@@ -492,7 +492,7 @@ def test_long_running_termination_failure(
         assert too_long_record.start_time == started_time.timestamp()
 
         workspace = workspace_context.create_request_context()
-        run_launcher = cast(TestRunLauncher, instance.run_launcher)
+        run_launcher = cast("TestRunLauncher", instance.run_launcher)
 
         eval_time = started_time + datetime.timedelta(seconds=501)
         with freeze_time(eval_time):

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -517,7 +517,7 @@ def test_auto_materialize_sensor_no_transition():
         # new sensor started with an empty cursor, reached evaluation ID 1
         assert (
             asset_daemon_cursor_from_instigator_serialized_cursor(
-                cast(SensorInstigatorData, sensor_states[0].instigator_data).cursor,
+                cast("SensorInstigatorData", sensor_states[0].instigator_data).cursor,
                 None,
             ).evaluation_id
             == 1
@@ -538,7 +538,7 @@ def test_auto_materialize_sensor_no_transition():
         # now on evaluation ID 2
         assert (
             asset_daemon_cursor_from_instigator_serialized_cursor(
-                cast(SensorInstigatorData, sensor_states[0].instigator_data).cursor,
+                cast("SensorInstigatorData", sensor_states[0].instigator_data).cursor,
                 None,
             ).evaluation_id
             == 2
@@ -609,7 +609,7 @@ def test_auto_materialize_sensor_transition():
             # cursor was propagated to each sensor, so all subsequent evaluation IDs are higher
             assert (
                 asset_daemon_cursor_from_instigator_serialized_cursor(
-                    cast(SensorInstigatorData, sensor_state.instigator_data).cursor,
+                    cast("SensorInstigatorData", sensor_state.instigator_data).cursor,
                     None,
                 ).evaluation_id
                 > pre_sensor_evaluation_id
@@ -694,7 +694,7 @@ def test_auto_materialize_sensor_name_transition() -> None:
             # value in the real world (as each evaluation creates a new tick)
             assert (
                 asset_daemon_cursor_from_instigator_serialized_cursor(
-                    cast(SensorInstigatorData, sensor_state.instigator_data).cursor,
+                    cast("SensorInstigatorData", sensor_state.instigator_data).cursor,
                     None,
                 ).evaluation_id
                 > 0  # real world should be larger

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -210,7 +210,7 @@ def _get_current_cursors(context: WorkspaceProcessContext) -> Mapping[str, Asset
 
     return {
         name: asset_daemon_cursor_from_instigator_serialized_cursor(
-            cast(SensorInstigatorData, check.not_none(state).instigator_data).cursor,
+            cast("SensorInstigatorData", check.not_none(state).instigator_data).cursor,
             request_context.asset_graph,
         )
         for name, state in _get_current_state(request_context).items()

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -186,9 +186,9 @@ class AssetDaemonScenarioState(ScenarioState):
     ]:
         with self._create_workspace_context() as workspace_context:
             workspace = workspace_context.create_request_context()
-            assert (
-                workspace.get_code_location_error("test_location") is None
-            ), workspace.get_code_location_error("test_location")
+            assert workspace.get_code_location_error("test_location") is None, (
+                workspace.get_code_location_error("test_location")
+            )
 
             sensor = (
                 next(
@@ -237,7 +237,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 )
                 new_cursor = asset_daemon_cursor_from_instigator_serialized_cursor(
                     cast(
-                        SensorInstigatorData,
+                        "SensorInstigatorData",
                         check.not_none(auto_materialize_instigator_state).instigator_data,
                     ).cursor,
                     self.asset_graph,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -325,9 +325,10 @@ class AssetReconciliationScenario(
                     with_remote_asset_graph=with_remote_asset_graph,
                 )
                 for run_request in run_requests:
+                    asset_selection = check.not_none(run_request.asset_selection)
                     instance.create_run_for_job(
-                        prior_repo.get_implicit_job_def_for_assets(run_request.asset_selection),
-                        asset_selection=set(run_request.asset_selection),
+                        prior_repo.get_implicit_job_def_for_assets(asset_selection),
+                        asset_selection=set(asset_selection),
                         tags=run_request.tags,
                     )
 
@@ -377,9 +378,9 @@ class AssetReconciliationScenario(
                     instance=instance,
                 ) as workspace_context:
                     workspace = workspace_context.create_request_context()
-                    assert (
-                        workspace.get_code_location_error("test_location") is None
-                    ), workspace.get_code_location_error("test_location")
+                    assert workspace.get_code_location_error("test_location") is None, (
+                        workspace.get_code_location_error("test_location")
+                    )
                     asset_graph = workspace.asset_graph
 
             with mock.patch.object(
@@ -416,13 +417,13 @@ class AssetReconciliationScenario(
         scenario_name,
         debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
     ):
-        assert bool(self.assets) != bool(
-            self.code_locations
-        ), "Must specify either assets or code_locations"
+        assert bool(self.assets) != bool(self.code_locations), (
+            "Must specify either assets or code_locations"
+        )
 
-        assert (
-            not self.active_backfill_targets
-        ), "setting active_backfill_targets not supported for daemon tests"
+        assert not self.active_backfill_targets, (
+            "setting active_backfill_targets not supported for daemon tests"
+        )
 
         test_time = self.current_time or get_current_datetime()
 
@@ -488,9 +489,9 @@ class AssetReconciliationScenario(
                 instance=instance,
             ) as workspace_context:
                 workspace = workspace_context.create_request_context()
-                assert (
-                    workspace.get_code_location_error("test_location") is None
-                ), workspace.get_code_location_error("test_location")
+                assert workspace.get_code_location_error("test_location") is None, (
+                    workspace.get_code_location_error("test_location")
+                )
 
                 try:
                     list(

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -85,7 +85,7 @@ def get_code_location_origin(
     )
 
     return _get_code_location_origin_from_repository(
-        cast(RepositoryDefinition, repository), location_name=location_name
+        cast("RepositoryDefinition", repository), location_name=location_name
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
@@ -1,7 +1,6 @@
 # pyright: reportPrivateImportUsage=false
 
 import datetime
-import logging  # noqa: F401; used by mock in string form
 import time
 
 import pytest

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_source_metadata_set.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_source_metadata_set.py
@@ -23,7 +23,9 @@ def test_source_metadata_set() -> None:
 
     dict_source_metadata = dict(source_metadata)
     assert dict_source_metadata == {"dagster/code_references": source_metadata.code_references}
-    source_data = cast(CodeReferencesMetadataValue, dict_source_metadata["dagster/code_references"])
+    source_data = cast(
+        "CodeReferencesMetadataValue", dict_source_metadata["dagster/code_references"]
+    )
     assert len(source_data.code_references) == 1
     assert isinstance(
         source_data.code_references[0],
@@ -34,7 +36,7 @@ def test_source_metadata_set() -> None:
     splat_source_metadata = {**source_metadata}
     assert splat_source_metadata == {"dagster/code_references": source_metadata.code_references}
     source_data = cast(
-        CodeReferencesMetadataValue, splat_source_metadata["dagster/code_references"]
+        "CodeReferencesMetadataValue", splat_source_metadata["dagster/code_references"]
     )
     assert len(source_data.code_references) == 1
     assert isinstance(

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Sequence
-from typing import Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 import pytest
 from dagster import (
@@ -17,7 +17,9 @@ from dagster import (
 )
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 
 get_unique_asset_identifier = lambda asset: (
     asset.node_def.name if isinstance(asset, AssetsDefinition) else asset.key
@@ -360,7 +362,7 @@ def test_load_assets_cacheable(load_fn, prefix):
     assert len(assets_defs) == 3
 
     for assets_def in assets_defs:
-        cacheable_def = cast(CacheableAssetsDefinition, assets_def)
+        cacheable_def = cast("CacheableAssetsDefinition", assets_def)
         resolved_asset_defs = cacheable_def.build_definitions(
             cacheable_def.compute_cacheable_data()
         )
@@ -371,7 +373,7 @@ def test_load_assets_cacheable(load_fn, prefix):
     assert len(assets_defs) == 3
 
     for assets_def in assets_defs:
-        cacheable_def = cast(CacheableAssetsDefinition, assets_def)
+        cacheable_def = cast("CacheableAssetsDefinition", assets_def)
         resolved_asset_defs = cacheable_def.build_definitions(
             cacheable_def.compute_cacheable_data()
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_module_loaders.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_module_loaders.py
@@ -335,7 +335,7 @@ def test_load_with_executor() -> None:
     defs = load_definitions_from_module(module_fake, executor=my_executor)
     assert (
         defs.executor is not None
-        and cast(dg.ExecutorDefinition, defs.executor).name == "my_executor"
+        and cast("dg.ExecutorDefinition", defs.executor).name == "my_executor"
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import dagster as dg
 import pytest
@@ -13,9 +13,11 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from pydantic import BaseModel, TypeAdapter
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
 
 
 def test_validate_asset_owner() -> None:
@@ -206,9 +208,9 @@ def test_map_asset_specs_mixed_specs_defs() -> None:
 
     assert all(
         spec.owners == ["ben@dagsterlabs.com"]
-        for spec in cast(AssetsDefinition, mapped_specs_and_defs[0]).specs
+        for spec in cast("AssetsDefinition", mapped_specs_and_defs[0]).specs
     )
-    assert cast(AssetSpec, mapped_specs_and_defs[1]).owners == ["ben@dagsterlabs.com"]
+    assert cast("AssetSpec", mapped_specs_and_defs[1]).owners == ["ben@dagsterlabs.com"]
 
 
 def test_map_asset_specs_multi_asset() -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dagster import DailyPartitionsDefinition, PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import (
@@ -10,13 +9,16 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._time import parse_time_string
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 DATE_FORMAT = "%Y-%m-%d"
 
 
 def time_window(start: str, end: str) -> TimeWindow:
     return TimeWindow(
-        cast(datetime, parse_time_string(start)),
-        cast(datetime, parse_time_string(end)),
+        cast("datetime", parse_time_string(start)),
+        cast("datetime", parse_time_string(end)),
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
@@ -16,7 +16,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 def my_asset(context: AssetExecutionContext):
     if context.has_tag("my_value"):
         return MaterializeResult(
-            metadata={"my_metadata": int(cast(str, context.get_tag("my_value")))}
+            metadata={"my_metadata": int(cast("str", context.get_tag("my_value")))}
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -713,7 +713,7 @@ def test_basic_pagination():
     ]
     for i, key in enumerate(paginated_results.results):
         assert isinstance(key, MultiPartitionKey)
-        assert cast(MultiPartitionKey, key).keys_by_dimension == expected_keys[i]
+        assert cast("MultiPartitionKey", key).keys_by_dimension == expected_keys[i]
 
     paginated_results2 = multi_partitions.get_paginated_partition_keys(
         context=PartitionLoadingContext(
@@ -735,7 +735,7 @@ def test_basic_pagination():
     ]
     for i, key in enumerate(paginated_results2.results):
         assert isinstance(key, MultiPartitionKey)
-        assert cast(MultiPartitionKey, key).keys_by_dimension == expected_keys2[i]
+        assert cast("MultiPartitionKey", key).keys_by_dimension == expected_keys2[i]
 
 
 def test_reverse_pagination():
@@ -764,7 +764,7 @@ def test_reverse_pagination():
     ]
     for i, key in enumerate(paginated_results.results):
         assert isinstance(key, MultiPartitionKey)
-        assert cast(MultiPartitionKey, key).keys_by_dimension == expected_keys[i]
+        assert cast("MultiPartitionKey", key).keys_by_dimension == expected_keys[i]
 
     paginated_results2 = multi_partitions.get_paginated_partition_keys(
         context=PartitionLoadingContext(
@@ -786,7 +786,7 @@ def test_reverse_pagination():
     ]
     for i, key in enumerate(paginated_results2.results):
         assert isinstance(key, MultiPartitionKey)
-        assert cast(MultiPartitionKey, key).keys_by_dimension == expected_keys2[i]
+        assert cast("MultiPartitionKey", key).keys_by_dimension == expected_keys2[i]
 
 
 def test_pagination_accumulation():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -113,7 +113,7 @@ def test_schedule_invocation_resources() -> None:
 
     # Just need to pass context, which splats out into resource parameters
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(
             build_schedule_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
@@ -140,7 +140,7 @@ def test_schedule_invocation_resources_direct() -> None:
 
     # Can pass resource through context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(
             context=build_schedule_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
@@ -148,7 +148,7 @@ def test_schedule_invocation_resources_direct() -> None:
 
     # Can pass resource directly
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -163,13 +163,13 @@ def test_schedule_invocation_resources_direct() -> None:
         # We don't allow providing resources as args, this adds too much complexity
         # They must be kwargs, and we will error accordingly
         assert cast(
-            RunRequest,
+            "RunRequest",
             basic_schedule_resource_req(MyResource(a_str="foo")),
         ).run_config == {"foo": "foo"}
 
     # Can pass resource directly with context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(build_schedule_context(), my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -179,7 +179,7 @@ def test_schedule_invocation_resources_direct() -> None:
         return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
 
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_with_context_resource_req(
             build_schedule_context(), my_resource=MyResource(a_str="foo")
         ),
@@ -201,7 +201,7 @@ def test_recreating_schedule_with_resource_arg() -> None:
     updated_schedule = basic_schedule_with_context_resource_req.with_updated_job(junk_job)
 
     assert cast(
-        RunRequest,
+        "RunRequest",
         updated_schedule(build_schedule_context(), my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -221,7 +221,7 @@ def test_schedule_invocation_resources_direct_many() -> None:
 
     # Can pass resource directly
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(
             my_other_resource=MyResource(a_str="bar"), my_resource=MyResource(a_str="foo")
         ),
@@ -229,7 +229,7 @@ def test_schedule_invocation_resources_direct_many() -> None:
 
     # Can pass resources both directly and in context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_schedule_resource_req(
             context=build_schedule_context(
                 resources={"my_other_resource": MyResource(a_str="bar")}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -129,7 +129,7 @@ def test_sensor_invocation_resources() -> None:
 
     # Just need to pass context, which splats out into resource parameters
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(
             build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
@@ -151,13 +151,13 @@ def test_sensor_invocation_resources_callable() -> None:
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=("Resource with key 'my_resource' required by sensor 'weird' was not" " provided."),
+        match=("Resource with key 'my_resource' required by sensor 'weird' was not provided."),
     ):
         weird_sensor()
 
     # Just need to pass context, which splats out into resource parameters
     assert cast(
-        RunRequest,
+        "RunRequest",
         weird_sensor(build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})),
     ).run_config == {"foo": "foo"}
 
@@ -182,7 +182,7 @@ def test_sensor_invocation_resources_direct() -> None:
 
     # Can pass resource through context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(
             context=build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
@@ -190,7 +190,7 @@ def test_sensor_invocation_resources_direct() -> None:
 
     # Can pass resource directly
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -205,13 +205,13 @@ def test_sensor_invocation_resources_direct() -> None:
         # We don't allow providing resources as args, this adds too much complexity
         # They must be kwargs, and we will error accordingly
         assert cast(
-            RunRequest,
+            "RunRequest",
             basic_sensor_resource_req(MyResource(a_str="foo")),
         ).run_config == {"foo": "foo"}
 
     # Can pass resource directly with context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(build_sensor_context(), my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -221,7 +221,7 @@ def test_sensor_invocation_resources_direct() -> None:
         return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
 
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_with_context_resource_req(
             build_sensor_context(), my_resource=MyResource(a_str="foo")
         ),
@@ -243,7 +243,7 @@ def test_recreating_sensor_with_resource_arg() -> None:
     updated_sensor = basic_sensor_with_context_resource_req.with_updated_job(junk_job)
 
     assert cast(
-        RunRequest,
+        "RunRequest",
         updated_sensor(build_sensor_context(), my_resource=MyResource(a_str="foo")),
     ).run_config == {"foo": "foo"}
 
@@ -263,7 +263,7 @@ def test_sensor_invocation_resources_direct_many() -> None:
 
     # Can pass resource directly
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(
             my_other_resource=MyResource(a_str="bar"), my_resource=MyResource(a_str="foo")
         ),
@@ -271,7 +271,7 @@ def test_sensor_invocation_resources_direct_many() -> None:
 
     # Pass resources both directly and in context
     assert cast(
-        RunRequest,
+        "RunRequest",
         basic_sensor_resource_req(
             context=build_sensor_context(resources={"my_other_resource": MyResource(a_str="bar")}),
             my_resource=MyResource(a_str="foo"),
@@ -299,7 +299,9 @@ def test_sensor_invocation_resources_context_manager() -> None:
 
     assert "with build_sensor_context" in str(exc_info.value)
     with build_sensor_context(resources={"my_resource": my_cm_resource}) as context:
-        assert cast(RunRequest, basic_sensor_str_resource_req(context)).run_config == {"foo": "foo"}
+        assert cast("RunRequest", basic_sensor_str_resource_req(context)).run_config == {
+            "foo": "foo"
+        }
 
 
 def test_sensor_invocation_resources_deferred() -> None:
@@ -364,7 +366,7 @@ def test_multi_asset_sensor_invocation_resources() -> None:
             repository_def=my_repo,
             resources={"my_resource": MyResource(a_str="bar")},
         )
-        assert cast(RunRequest, a_and_b_sensor(ctx)).run_config == {"foo": "bar"}
+        assert cast("RunRequest", a_and_b_sensor(ctx)).run_config == {"foo": "bar"}
 
 
 def test_multi_asset_sensor_with_source_assets() -> None:
@@ -406,7 +408,7 @@ def test_multi_asset_sensor_with_source_assets() -> None:
             instance=instance,
             repository_def=my_repo,
         )
-        run_requests = cast(list[RunRequest], my_sensor(ctx))
+        run_requests = cast("list[RunRequest]", my_sensor(ctx))
         assert len(run_requests) == 1
         assert run_requests[0].partition_key == "2023-03-01"
 
@@ -1775,7 +1777,7 @@ def test_sensor_invocation_runconfig() -> None:
             tags={},
         )
 
-    assert cast(RunRequest, basic_sensor()).run_config.get("ops", {}) == {
+    assert cast("RunRequest", basic_sensor()).run_config.get("ops", {}) == {
         "foo": {"config": {"a_str": "foo", "an_int": 55}}
     }
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -39,8 +39,8 @@ DATE_FORMAT = "%Y-%m-%d"
 
 def time_window(start: str, end: str) -> TimeWindow:
     return TimeWindow(
-        cast(datetime, parse_time_string(start)),
-        cast(datetime, parse_time_string(end)),
+        cast("datetime", parse_time_string(start)),
+        cast("datetime", parse_time_string(end)),
     )
 
 
@@ -921,7 +921,7 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
             expected_keys_not_in_subset.append(full_set_keys[i])
 
     subset = cast(
-        TimeWindowPartitionsSubset,
+        "TimeWindowPartitionsSubset",
         TimeWindowPartitionsSubset.create_empty_subset(partitions_def).with_partition_keys(
             subset_keys
         ),
@@ -937,7 +937,7 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
     )
     assert (
         cast(
-            TimeWindowPartitionsSubset, partitions_def.deserialize_subset(subset.serialize())
+            "TimeWindowPartitionsSubset", partitions_def.deserialize_subset(subset.serialize())
         ).included_time_windows
         == subset.included_time_windows
     )
@@ -1057,7 +1057,9 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
         initial_subset_keys
     )
     assert all(partition_key in subset for partition_key in initial_subset_keys)
-    updated_subset = cast(TimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys))
+    updated_subset = cast(
+        "TimeWindowPartitionsSubset", subset.with_partition_keys(added_subset_keys)
+    )
     assert all(partition_key in updated_subset for partition_key in added_subset_keys)
     assert (
         updated_subset.get_partition_keys_not_in_subset(
@@ -1299,7 +1301,7 @@ def test_time_window_partition_len():
     def my_partitioned_config(_start, _end):
         return {}
 
-    partitions_def = cast(TimeWindowPartitionsDefinition, my_partitioned_config.partitions_def)
+    partitions_def = cast("TimeWindowPartitionsDefinition", my_partitioned_config.partitions_def)
     assert partitions_def.get_num_partitions() == len(partitions_def.get_partition_keys())
     assert (
         partitions_def.get_partition_keys_between_indexes(50, 53)
@@ -1325,7 +1327,7 @@ def test_time_window_partition_len():
     def my_partitioned_config_2(_start, _end):
         return {}
 
-    partitions_def = cast(TimeWindowPartitionsDefinition, my_partitioned_config_2.partitions_def)
+    partitions_def = cast("TimeWindowPartitionsDefinition", my_partitioned_config_2.partitions_def)
     current_time = datetime.strptime("2021-06-20", "%Y-%m-%d")
     assert (
         partitions_def.get_partition_keys_between_indexes(50, 53, current_time=current_time)
@@ -1349,7 +1351,7 @@ def test_time_window_partition_len():
         return {}
 
     partitions_def = cast(
-        TimeWindowPartitionsDefinition, my_daily_dst_transition_partitioned_config.partitions_def
+        "TimeWindowPartitionsDefinition", my_daily_dst_transition_partitioned_config.partitions_def
     )
 
     current_time_post_transition = datetime.strptime("2024-05-22", "%Y-%m-%d")

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -287,9 +287,9 @@ def test_max_concurrent():
             assert active_step is None, "A second step started before the first finished!"
             active_step = event.step_key
         elif event.event_type_value == DagsterEventType.STEP_SUCCESS.value:
-            assert (
-                active_step == event.step_key
-            ), "A step finished that wasn't supposed to be active!"
+            assert active_step == event.step_key, (
+                "A step finished that wasn't supposed to be active!"
+            )
             active_step = None
 
 
@@ -320,9 +320,9 @@ def test_tag_concurrency_limits():
                     assert active_step is None, "A second step started before the first finished!"
                     active_step = event.step_key
                 elif event.event_type_value == DagsterEventType.STEP_SUCCESS.value:
-                    assert (
-                        active_step == event.step_key
-                    ), "A step finished that wasn't supposed to be active!"
+                    assert active_step == event.step_key, (
+                        "A step finished that wasn't supposed to be active!"
+                    )
                     active_step = None
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor_retries.py
@@ -56,9 +56,9 @@ class TestStepHandler(StepHandler):
             assert TestStepHandler.launched_second_attempt is False
         elif attempt_count == 1:
             assert TestStepHandler.launched_first_attempt is True
-            assert (
-                TestStepHandler.launched_second_attempt
-            ), "Second attempt not launched, shouldn't be checking on it"
+            assert TestStepHandler.launched_second_attempt, (
+                "Second attempt not launched, shouldn't be checking on it"
+            )
 
         return CheckStepHealthResult.healthy()
 

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_threaded_message_reader.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_threaded_message_reader.py
@@ -76,7 +76,7 @@ class PipesFileMessageReader(PipesThreadedMessageReader):
                 return (file.tell(), chunk)
 
     def no_messages_debug_text(self) -> str:
-        return "Attempted to read messages by extracting them from a file." ""
+        return "Attempted to read messages by extracting them from a file."
 
 
 def test_file_log_reader(tmp_path_factory, capsys):

--- a/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
@@ -152,9 +152,9 @@ def test_resolve_wrong_data():
         recon_repo.get_definition()
 
 
-def define_uncacheable_and_resource_dependent_cacheable_assets() -> (
-    Sequence[Union[CacheableAssetsDefinition, AssetsDefinition]]
-):
+def define_uncacheable_and_resource_dependent_cacheable_assets() -> Sequence[
+    Union[CacheableAssetsDefinition, AssetsDefinition]
+]:
     class ResourceDependentCacheableAsset(CacheableAssetsDefinition):
         def __init__(self):
             super().__init__("res_midstream")
@@ -343,7 +343,7 @@ def test_multiple_wrapped_cached_assets() -> None:
 
         my_cool_group_sel = AssetSelection.groups("my_cool_group")
         cacheable_resource_asset = cast(
-            CacheableAssetsDefinition, my_cacheable_assets_with_group_and_asset[0]
+            "CacheableAssetsDefinition", my_cacheable_assets_with_group_and_asset[0]
         )
         resolved_defs = list(
             cacheable_resource_asset.build_definitions(
@@ -354,7 +354,7 @@ def test_multiple_wrapped_cached_assets() -> None:
             len(
                 my_cool_group_sel.resolve(
                     resolved_defs
-                    + cast(list[AssetsDefinition], my_cacheable_assets_with_group_and_asset[1:])
+                    + cast("list[AssetsDefinition]", my_cacheable_assets_with_group_and_asset[1:])
                 )
             )
             == 1

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -15,9 +15,9 @@ def _is_namedtuple(cls: type) -> bool:
 
 @pytest.mark.parametrize("cls", INTERNAL_INIT_SUBCLASSES)
 def test_dagster_internal_init_class_follow_rules(cls: type):
-    assert hasattr(
-        cls, "dagster_internal_init"
-    ), f"{cls.__name__} does not have dagster_internal_init method"
+    assert hasattr(cls, "dagster_internal_init"), (
+        f"{cls.__name__} does not have dagster_internal_init method"
+    )
 
     dagster_internal_init_params = signature(cls.dagster_internal_init).parameters
 
@@ -29,9 +29,9 @@ def test_dagster_internal_init_class_follow_rules(cls: type):
 
     dagster_internal_init_return = signature(cls.dagster_internal_init).return_annotation
 
-    assert (
-        dagster_internal_init_return == cls or dagster_internal_init_return == cls.__name__
-    ), f"{cls.__name__}.dagster_internal_init has a different return type than the class itself"
+    assert dagster_internal_init_return == cls or dagster_internal_init_return == cls.__name__, (
+        f"{cls.__name__}.dagster_internal_init has a different return type than the class itself"
+    )
 
     assert all(p.default == Parameter.empty for p in dagster_internal_init_params.values()), (
         f"{cls.__name__}.dagster_internal_init has one or more default values,"
@@ -50,6 +50,6 @@ def test_dagster_internal_init_class_follow_rules(cls: type):
     dagster_internal_init_expected_param_names = [
         k for k in init_params.keys() if k not in excluded_args and k != "self"
     ]
-    assert (
-        [*dagster_internal_init_params.keys()] == dagster_internal_init_expected_param_names
-    ), f"{cls.__name__}.dagster_internal_init has different arguments than __init__"
+    assert [*dagster_internal_init_params.keys()] == dagster_internal_init_expected_param_names, (
+        f"{cls.__name__}.dagster_internal_init has different arguments than __init__"
+    )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -76,7 +76,7 @@ def workspace_fixture(
 @pytest.fixture(name="remote_repo", scope="session")
 def remote_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
     return cast(
-        CodeLocation,
+        "CodeLocation",
         next(
             iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -486,9 +486,13 @@ def test_dst_transition_advances(execution_timezone, cron_string, times, force_c
         for j in range(i, len(times)):
             next_time = next(fresh_cron_iter)
 
-            assert (
-                next_time.timestamp() == times[j].timestamp()
-            ), f"Expected ({datetime.datetime.from_timestamp(orig_start_timestamp, tz=get_timezone(execution_timezone))}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {next_time.timestamp() - times[j].timestamp()})"  # pyright: ignore[reportAttributeAccessIssue]
+            orig_timestamp_str = datetime.datetime.fromtimestamp(
+                orig_start_timestamp, tz=get_timezone(execution_timezone)
+            )
+            diff_str = next_time.timestamp() - times[j].timestamp()
+            assert next_time.timestamp() == times[j].timestamp(), (
+                f"Expected ({orig_timestamp_str}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {diff_str})"
+            )
             prev_time = next_time
 
         start_timestamp = orig_start_timestamp + 1
@@ -515,9 +519,13 @@ def test_dst_transition_advances(execution_timezone, cron_string, times, force_c
             for j in range(i + 1, len(times)):
                 next_time = next(fresh_cron_iter)
 
-                assert (
-                    next_time.timestamp() == times[j].timestamp()
-                ), f"Expected ({datetime.datetime.from_timestamp(start_timestamp, tz=get_timezone(execution_timezone))}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {next_time.timestamp() - times[j].timestamp()})"  # pyright: ignore[reportAttributeAccessIssue]
+                orig_timestamp_str = datetime.datetime.fromtimestamp(
+                    orig_start_timestamp, tz=get_timezone(execution_timezone)
+                )
+                diff_str = next_time.timestamp() - times[j].timestamp()
+                assert next_time.timestamp() == times[j].timestamp(), (
+                    f"Expected ({orig_timestamp_str}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {diff_str})"
+                )
 
                 prev_time = next_time
 
@@ -576,9 +584,13 @@ def test_reversed_dst_transition_advances(execution_timezone, cron_string, times
             for j in range(i + 1, len(times)):
                 next_time = next(fresh_cron_iter)
 
-                assert (
-                    next_time.timestamp() == times[j].timestamp()
-                ), f"Expected ({datetime.datetime.from_timestamp(start_timestamp, tz=get_timezone(execution_timezone))}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {next_time.timestamp() - times[j].timestamp()})"  # pyright: ignore[reportAttributeAccessIssue]
+                orig_timestamp_str = datetime.datetime.fromtimestamp(
+                    orig_start_timestamp, tz=get_timezone(execution_timezone)
+                )
+                diff_str = next_time.timestamp() - times[j].timestamp()
+                assert next_time.timestamp() == times[j].timestamp(), (
+                    f"Expected ({orig_timestamp_str}) to advance from {prev_time} to {times[j]}, got {next_time} (Difference: {diff_str})"
+                )
 
                 prev_time = next_time
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1192,7 +1192,7 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
     ) as full_workspace_context:
         with freeze_time(freeze_datetime):
             full_location = cast(
-                CodeLocation,
+                "CodeLocation",
                 next(
                     iter(
                         full_workspace_context.create_request_context()

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
@@ -20,7 +20,7 @@ from dagster_tests.storage_tests.branching_io_manager_tests.utils import (
 
 @asset
 def now_time() -> int:
-    return int(math.floor(time.time() * 100))
+    return math.floor(time.time() * 100)
 
 
 def get_now_time_plus_N(N: int) -> AssetsDefinition:
@@ -256,7 +256,7 @@ def test_basic_workflow():
 
 @op
 def now_time_op() -> int:
-    return int(math.floor(time.time() * 100))
+    return math.floor(time.time() * 100)
 
 
 @op(ins={"now_time": In(int)})
@@ -282,7 +282,7 @@ def test_job_op_usecase() -> Any:
         ),
     ) as runner:
         assert (
-            cast(DefinitionsRunner, runner)
+            cast("DefinitionsRunner", runner)
             .defs.get_job_def("now_time_job")
             .execute_in_process(instance=runner.instance)
             .success

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_partitioned_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_partitioned_branching_io_manager.py
@@ -39,7 +39,7 @@ primary_tertiary_partition_mapping = StaticPartitionMapping(
 
 @asset(partitions_def=partitioning_scheme)
 def now_time():
-    return int(math.floor(time.time() * 100))
+    return math.floor(time.time() * 100)
 
 
 @asset(
@@ -450,7 +450,7 @@ def test_job_op_usecase_partitioned() -> Any:
         ),
     ) as runner:
         result = (
-            cast(DefinitionsRunner, runner)
+            cast("DefinitionsRunner", runner)
             .defs.get_job_def("my_math_job")
             .execute_in_process(instance=runner.instance, partition_key="A")
         )
@@ -458,7 +458,7 @@ def test_job_op_usecase_partitioned() -> Any:
         assert result.output_for_node("divide_input_by_two") == 5
 
         result = (
-            cast(DefinitionsRunner, runner)
+            cast("DefinitionsRunner", runner)
             .defs.get_job_def("my_math_job")
             .execute_in_process(instance=runner.instance, partition_key="B")
         )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -72,7 +72,7 @@ def dummy_io_manager(tmp_path: Path) -> IOManagerDefinition:
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
-        return DummyIOManager(base_path=cast(UPath, base_path))
+        return DummyIOManager(base_path=cast("UPath", base_path))
 
     io_manager_def = dummy_io_manager.configured({"base_path": str(tmp_path)})
 
@@ -113,7 +113,7 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
-        return JSONIOManager(base_path=cast(UPath, base_path))
+        return JSONIOManager(base_path=cast("UPath", base_path))
 
     manager = json_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
     context = build_output_context(
@@ -150,7 +150,7 @@ def test_upath_io_manager_with_non_any_type_annotation(tmp_path: Path):
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
-        return MyIOManager(base_path=cast(UPath, base_path))
+        return MyIOManager(base_path=cast("UPath", base_path))
 
     manager = my_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
 
@@ -444,7 +444,7 @@ def test_upath_io_manager_custom_metadata(tmp_path: Path, json_data: Any):
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
-        return MetadataIOManager(base_path=cast(UPath, base_path))
+        return MetadataIOManager(base_path=cast("UPath", base_path))
 
     manager = metadata_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1,5 +1,4 @@
 import datetime
-import logging  # noqa: F401; used by mock in string form
 import random
 import re
 import string
@@ -4765,7 +4764,7 @@ class TestEventLogStorage:
             )
         )
 
-        index = cast(int, storage.get_maximum_record_id())
+        index = cast("int", storage.get_maximum_record_id())
         assert isinstance(index, int)
 
         for i in range(10):

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -162,7 +162,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.8.4",
+            "ruff==0.11.5",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -179,12 +179,12 @@ def _build_airbyte_assets_from_metadata(
     assets_defn_meta: AssetsDefinitionCacheableData,
     resource_defs: Optional[Mapping[str, ResourceDefinition]],
 ) -> AssetsDefinition:
-    metadata = cast(Mapping[str, Any], assets_defn_meta.extra_metadata)
-    connection_id = cast(str, metadata["connection_id"])
-    group_name = cast(Optional[str], metadata["group_name"])
-    destination_tables = cast(list[str], metadata["destination_tables"])
-    normalization_tables = cast(Mapping[str, list[str]], metadata["normalization_tables"])
-    io_manager_key = cast(Optional[str], metadata["io_manager_key"])
+    metadata = cast("Mapping[str, Any]", assets_defn_meta.extra_metadata)
+    connection_id = cast("str", metadata["connection_id"])
+    group_name = cast("Optional[str]", metadata["group_name"])
+    destination_tables = cast("list[str]", metadata["destination_tables"])
+    normalization_tables = cast("Mapping[str, list[str]]", metadata["normalization_tables"])
+    io_manager_key = cast("Optional[str]", metadata["io_manager_key"])
 
     @multi_asset(
         name=f"airbyte_sync_{connection_id.replace('-', '_')}",
@@ -501,7 +501,7 @@ class AirbyteConnectionMetadata(
     def from_config(
         cls, contents: Mapping[str, Any], destination: Mapping[str, Any]
     ) -> "AirbyteConnectionMetadata":
-        config_contents = cast(Mapping[str, Any], contents.get("configuration"))
+        config_contents = cast("Mapping[str, Any]", contents.get("configuration"))
         check.invariant(
             config_contents is not None, "Airbyte connection config is missing 'configuration' key"
         )
@@ -531,7 +531,7 @@ class AirbyteConnectionMetadata(
         ]
 
         for stream in enabled_streams:
-            name = cast(str, stream.get("stream", {}).get("name"))
+            name = cast("str", stream.get("stream", {}).get("name"))
             prefixed_name = f"{self.stream_prefix}{name}"
 
             schema = (
@@ -567,7 +567,7 @@ def _get_schema_by_table_name(
                 [
                     (k, v.schema)
                     for k, v in cast(
-                        dict[str, AirbyteTableMetadata], meta.normalization_tables
+                        "dict[str, AirbyteTableMetadata]", meta.normalization_tables
                     ).items()
                 ]
                 for meta in stream_table_metadata.values()
@@ -740,7 +740,7 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
         workspace_id = self._workspace_id
         if not workspace_id:
             workspaces = cast(
-                list[dict[str, Any]],
+                "list[dict[str, Any]]",
                 check.not_none(
                     self._airbyte_instance.make_request(endpoint="/workspaces/list", data={})
                 ).get("workspaces", []),
@@ -752,7 +752,7 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
             workspace_id = workspaces[0].get("workspaceId")
 
         connections = cast(
-            list[dict[str, Any]],
+            "list[dict[str, Any]]",
             check.not_none(
                 self._airbyte_instance.make_request(
                     endpoint="/connections/list", data={"workspaceId": workspace_id}
@@ -762,10 +762,10 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
 
         output_connections: list[tuple[str, AirbyteConnectionMetadata]] = []
         for connection_json in connections:
-            connection_id = cast(str, connection_json.get("connectionId"))
+            connection_id = cast("str", connection_json.get("connectionId"))
 
             operations_json = cast(
-                dict[str, Any],
+                "dict[str, Any]",
                 check.not_none(
                     self._airbyte_instance.make_request(
                         endpoint="/operations/list",
@@ -774,9 +774,9 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
                 ),
             )
 
-            destination_id = cast(str, connection_json.get("destinationId"))
+            destination_id = cast("str", connection_json.get("destinationId"))
             destination_json = cast(
-                dict[str, Any],
+                "dict[str, Any]",
                 check.not_none(
                     self._airbyte_instance.make_request(
                         endpoint="/destinations/get",
@@ -850,7 +850,7 @@ class AirbyteYAMLCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinition)
                 connection_data = yaml.safe_load(f.read())
 
             destination_configuration_path = cast(
-                str, connection_data.get("destination_configuration_path")
+                "str", connection_data.get("destination_configuration_path")
             )
             with open(
                 os.path.join(self._project_dir, destination_configuration_path), encoding="utf-8"
@@ -886,7 +886,7 @@ class AirbyteYAMLCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinition)
                 )
                 state_file = state_files[0]
 
-            with open(os.path.join(connection_dir, cast(str, state_file)), encoding="utf-8") as f:
+            with open(os.path.join(connection_dir, cast("str", state_file)), encoding="utf-8") as f:
                 state = yaml.safe_load(f.read())
                 connection_id = state.get("resource_id")
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -212,7 +212,7 @@ def reconcile_sources(
             else:
                 if not dry_run:
                     create_result = cast(
-                        dict[str, str],
+                        "dict[str, str]",
                         check.not_none(
                             res.make_request(
                                 endpoint="/sources/create",
@@ -300,7 +300,7 @@ def reconcile_destinations(
             else:
                 if not dry_run:
                     create_result = cast(
-                        dict[str, str],
+                        "dict[str, str]",
                         check.not_none(
                             res.make_request(
                                 endpoint="/destinations/create",
@@ -346,13 +346,13 @@ def reconcile_config(
         workspace_id = res.get_default_workspace()
 
         existing_sources_raw = cast(
-            dict[str, list[dict[str, Any]]],
+            "dict[str, list[dict[str, Any]]]",
             check.not_none(
                 res.make_request(endpoint="/sources/list", data={"workspaceId": workspace_id})
             ),
         )
         existing_dests_raw = cast(
-            dict[str, list[dict[str, Any]]],
+            "dict[str, list[dict[str, Any]]]",
             check.not_none(
                 res.make_request(endpoint="/destinations/list", data={"workspaceId": workspace_id})
             ),
@@ -422,7 +422,7 @@ def reconcile_normalization(
     existing_basic_norm_op_id = None
     if existing_connection_id:
         operations = cast(
-            dict[str, list[dict[str, str]]],
+            "dict[str, list[dict[str, str]]]",
             check.not_none(
                 res.make_request(
                     endpoint="/operations/list",
@@ -450,7 +450,7 @@ def reconcile_normalization(
                 return existing_basic_norm_op_id
             else:
                 return cast(
-                    dict[str, str],
+                    "dict[str, str]",
                     check.not_none(
                         res.make_request(
                             endpoint="/operations/create",
@@ -492,7 +492,7 @@ def reconcile_connections_pre(
     diff = ManagedElementDiff()
 
     existing_connections_raw = cast(
-        dict[str, list[dict[str, Any]]],
+        "dict[str, list[dict[str, Any]]]",
         check.not_none(
             res.make_request(endpoint="/connections/list", data={"workspaceId": workspace_id})
         ),
@@ -537,7 +537,7 @@ def reconcile_connections_post(
 ) -> None:
     """Creates new and modifies existing connections based on the config if dry_run is False."""
     existing_connections_raw = cast(
-        dict[str, list[dict[str, Any]]],
+        "dict[str, list[dict[str, Any]]]",
         check.not_none(
             res.make_request(endpoint="/connections/list", data={"workspaceId": workspace_id})
         ),
@@ -592,7 +592,7 @@ def reconcile_connections_post(
             connection_base_json["namespaceDefinition"] = config_conn.destination_namespace.value
         else:
             connection_base_json["namespaceDefinition"] = "customformat"
-            connection_base_json["namespaceFormat"] = cast(str, config_conn.destination_namespace)
+            connection_base_json["namespaceFormat"] = cast("str", config_conn.destination_namespace)
 
         if config_conn.prefix:
             connection_base_json["prefix"] = config_conn.prefix

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -217,8 +217,8 @@ class BaseAirbyteResource(ConfigurableResource):
         """
         connection_details = self.get_connection_details(connection_id)
         job_details = self.start_sync(connection_id)
-        job_info = cast(dict[str, object], job_details.get("job", {}))
-        job_id = cast(int, job_info.get("id"))
+        job_info = cast("dict[str, object]", job_details.get("job", {}))
+        job_id = cast("int", job_info.get("id"))
 
         self._log.info(f"Job {job_id} initialized for connection_id={connection_id}.")
         start = time.monotonic()
@@ -235,7 +235,7 @@ class BaseAirbyteResource(ConfigurableResource):
                     )
                 time.sleep(poll_interval or self.poll_interval)
                 job_details = self.get_job_status(connection_id, job_id)
-                attempts = cast(list, job_details.get("attempts", []))
+                attempts = cast("list", job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
                 if cur_attempt:
@@ -252,7 +252,7 @@ class BaseAirbyteResource(ConfigurableResource):
                         logged_lines = 0
                         logged_attempts += 1
 
-                job_info = cast(dict[str, object], job_details.get("job", {}))
+                job_info = cast("dict[str, object]", job_details.get("job", {}))
                 state = job_info.get("status")
 
                 if state in (
@@ -577,7 +577,7 @@ class AirbyteResource(BaseAirbyteResource):
 
     def get_default_workspace(self) -> str:
         workspaces = cast(
-            list[dict[str, Any]],
+            "list[dict[str, Any]]",
             check.not_none(self.make_request_cached(endpoint="/workspaces/list", data={})).get(
                 "workspaces", []
             ),
@@ -589,7 +589,7 @@ class AirbyteResource(BaseAirbyteResource):
         definitions = check.not_none(
             self.make_request_cached(endpoint="/source_definitions/list", data={})
         )
-        source_definitions = cast(list[dict[str, Any]], definitions["sourceDefinitions"])
+        source_definitions = cast("list[dict[str, Any]]", definitions["sourceDefinitions"])
 
         return next(
             (
@@ -603,7 +603,7 @@ class AirbyteResource(BaseAirbyteResource):
     def get_destination_definition_by_name(self, name: str):
         name_lower = name.lower()
         definitions = cast(
-            dict[str, list[dict[str, str]]],
+            "dict[str, list[dict[str, str]]]",
             check.not_none(
                 self.make_request_cached(endpoint="/destination_definitions/list", data={})
             ),
@@ -619,7 +619,7 @@ class AirbyteResource(BaseAirbyteResource):
 
     def get_source_catalog_id(self, source_id: str):
         result = cast(
-            dict[str, Any],
+            "dict[str, Any]",
             check.not_none(
                 self.make_request(endpoint="/sources/discover_schema", data={"sourceId": source_id})
             ),
@@ -628,7 +628,7 @@ class AirbyteResource(BaseAirbyteResource):
 
     def get_source_schema(self, source_id: str) -> Mapping[str, Any]:
         return cast(
-            dict[str, Any],
+            "dict[str, Any]",
             check.not_none(
                 self.make_request(endpoint="/sources/discover_schema", data={"sourceId": source_id})
             ),
@@ -640,7 +640,7 @@ class AirbyteResource(BaseAirbyteResource):
         # Airbyte API changed source of truth for normalization in PR
         # https://github.com/airbytehq/airbyte/pull/21005
         norm_dest_def_spec: bool = cast(
-            dict[str, Any],
+            "dict[str, Any]",
             check.not_none(
                 self.make_request_cached(
                     endpoint="/destination_definition_specifications/get",
@@ -654,7 +654,7 @@ class AirbyteResource(BaseAirbyteResource):
 
         norm_dest_def: bool = (
             cast(
-                dict[str, Any],
+                "dict[str, Any]",
                 check.not_none(
                     self.make_request_cached(
                         endpoint="/destination_definitions/get",
@@ -687,7 +687,9 @@ class AirbyteResource(BaseAirbyteResource):
                     },
                 )
             )
-            job = next((job for job in cast(list, out["jobs"]) if job["job"]["id"] == job_id), None)
+            job = next(
+                (job for job in cast("list", out["jobs"]) if job["job"]["id"] == job_id), None
+            )
 
             return check.not_none(job)
 
@@ -722,8 +724,8 @@ class AirbyteResource(BaseAirbyteResource):
         """
         connection_details = self.get_connection_details(connection_id)
         job_details = self.start_sync(connection_id)
-        job_info = cast(dict[str, object], job_details.get("job", {}))
-        job_id = cast(int, job_info.get("id"))
+        job_info = cast("dict[str, object]", job_details.get("job", {}))
+        job_id = cast("int", job_info.get("id"))
 
         self._log.info(f"Job {job_id} initialized for connection_id={connection_id}.")
         start = time.monotonic()
@@ -740,7 +742,7 @@ class AirbyteResource(BaseAirbyteResource):
                     )
                 time.sleep(poll_interval or self.poll_interval)
                 job_details = self.get_job_status(connection_id, job_id)
-                attempts = cast(list, job_details.get("attempts", []))
+                attempts = cast("list", job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
                 if cur_attempt:
@@ -757,7 +759,7 @@ class AirbyteResource(BaseAirbyteResource):
                         logged_lines = 0
                         logged_attempts += 1
 
-                job_info = cast(dict[str, object], job_details.get("job", {}))
+                job_info = cast("dict[str, object]", job_details.get("job", {}))
                 state = job_info.get("status")
 
                 if state in (

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
@@ -4,14 +4,13 @@
 import os
 import time
 from datetime import datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest import mock
 
 import pytest
 import requests
 import requests_mock
 from dagster import AssetKey, materialize
-from dagster._core.events import StepMaterializationData
 from dagster._core.test_utils import environ
 from dagster._utils import file_relative_path
 from dagster_airbyte import airbyte_resource, load_assets_from_connections
@@ -20,6 +19,9 @@ from dagster_managed_elements.cli import apply, check
 from dagster_managed_elements.utils import diff_dicts
 
 from dagster_airbyte_tests.integration.example_stacks import example_airbyte_stack
+
+if TYPE_CHECKING:
+    from dagster._core.events import StepMaterializationData
 
 TEST_ROOT_DIR = str(file_relative_path(__file__, "./example_stacks"))
 
@@ -189,7 +191,7 @@ def test_basic_integration(
     res = materialize(ab_assets)
 
     materializations = [
-        cast(StepMaterializationData, event.event_specific_data).materialization
+        cast("StepMaterializationData", event.event_specific_data).materialization
         for event in res.all_events
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -108,7 +108,7 @@ class DagsterHook(BaseHook):
         self.url = f"{base_url}{self.organization_id}/{self.deployment_name}/graphql"
 
     def set_hook_for_oss(self, conn: Connection):
-        self.url = cast(str, conn.login)
+        self.url = cast("str", conn.login)
 
     def launch_run(
         self,
@@ -236,7 +236,7 @@ fragment PythonErrorFragment on PythonError {
                 status = response_json["data"]["runOrError"]["status"]
             else:
                 raise AirflowException(
-                    f'Error fetching run status: {response_json["data"]["runOrError"]["message"]}'
+                    f"Error fetching run status: {response_json['data']['runOrError']['message']}"
                 )
 
             if status == DagsterRunStatus.SUCCESS.value:

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/multiple_tasks.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/multiple_tasks.py
@@ -83,7 +83,7 @@ def targeted_by_multiple_tasks(
     return replace_assets_in_defs(
         defs,
         assets_with_multiple_task_mappings(
-            cast(Sequence[Union[AssetSpec, AssetsDefinition]], defs.assets),
+            cast("Sequence[Union[AssetSpec, AssetsDefinition]]", defs.assets),
             task_handles=task_handles,
         ),
     )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -47,14 +47,16 @@ def default_event_transformer(
             yield mat
             continue
         airflow_logical_date_timestamp: float = cast(
-            TimestampMetadataValue, mat.metadata[AIRFLOW_TASK_INSTANCE_LOGICAL_DATE_METADATA_KEY]
+            "TimestampMetadataValue", mat.metadata[AIRFLOW_TASK_INSTANCE_LOGICAL_DATE_METADATA_KEY]
         ).value
-        partitions_def = cast(TimeWindowPartitionsDefinition, asset_spec.partitions_def)
+        partitions_def = cast("TimeWindowPartitionsDefinition", asset_spec.partitions_def)
         calcs_for_def = cached_partition_calculations[partitions_def]
         if airflow_logical_date_timestamp not in calcs_for_def:
             cached_partition_calculations[partitions_def][airflow_logical_date_timestamp] = (
                 get_partition_key_from_timestamp(
-                    partitions_def=cast(TimeWindowPartitionsDefinition, asset_spec.partitions_def),
+                    partitions_def=cast(
+                        "TimeWindowPartitionsDefinition", asset_spec.partitions_def
+                    ),
                     timestamp=airflow_logical_date_timestamp,
                 )
             )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -383,7 +383,7 @@ def test_cached_loading() -> None:
             assert {
                 key
                 for assets_def in reloaded_repo_def.assets_defs_by_key.values()
-                for key in cast(AssetsDefinition, assets_def).keys
+                for key in cast("AssetsDefinition", assets_def).keys
             } == {AssetKey("a"), make_test_dag_asset_key("dag")}
 
 
@@ -409,7 +409,7 @@ def test_multiple_tasks_per_asset(init_load_context: None) -> None:
     # 3 Full assets definitions, but 4 keys
     assert len(list(defs.assets)) == 3
     assert {
-        key for assets_def in defs.assets for key in cast(AssetsDefinition, assets_def).keys
+        key for assets_def in defs.assets for key in cast("AssetsDefinition", assets_def).keys
     } == {
         AssetKey("a"),
         AssetKey("b"),

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
@@ -31,9 +31,9 @@ def temp_venv():
             capture_output=True,
             text=True,
         )
-        assert (
-            uv_install_output.returncode == 0
-        ), f"Failed to install uv: {uv_install_output.stderr}"
+        assert uv_install_output.returncode == 0, (
+            f"Failed to install uv: {uv_install_output.stderr}"
+        )
         yield temp_dir_venv
 
 
@@ -55,19 +55,19 @@ def test_in_airflow_package_implicit_requirements(temp_venv: Path):
         text=True,
         cwd=path_to_package,
     )
-    assert (
-        install_result.returncode == 0
-    ), f"Failed to install package in virtual environment: {install_result.stderr}"
+    assert install_result.returncode == 0, (
+        f"Failed to install package in virtual environment: {install_result.stderr}"
+    )
 
     uv_pip_freeze_output = subprocess.run(
         [*uv_entrypoint, "pip", "freeze"], check=True, capture_output=True, text=True
     )
-    assert (
-        install_result.returncode == 0
-    ), f"Failed to get pip freeze output: {uv_pip_freeze_output.stderr}"
-    assert (
-        "dagster-airlift" in uv_pip_freeze_output.stdout
-    ), "dagster-airlift not found in pip freeze output"
+    assert install_result.returncode == 0, (
+        f"Failed to get pip freeze output: {uv_pip_freeze_output.stderr}"
+    )
+    assert "dagster-airlift" in uv_pip_freeze_output.stdout, (
+        "dagster-airlift not found in pip freeze output"
+    )
 
     # Run the import script
     import_script_path = Path(__file__).parent / "import_script.py"
@@ -83,14 +83,14 @@ def test_in_airflow_package_implicit_requirements(temp_venv: Path):
         capture_output=True,
         text=True,
     )
-    assert (
-        airflow_install_result.returncode == 0
-    ), f"Failed to install Airflow: {airflow_install_result.stderr}"
+    assert airflow_install_result.returncode == 0, (
+        f"Failed to install Airflow: {airflow_install_result.stderr}"
+    )
 
     import_airflow_script_path = Path(__file__).parent / "import_script_with_airflow.py"
     airflow_script_result = subprocess.run(
         [python_executable, import_airflow_script_path], check=True, capture_output=True, text=True
     )
-    assert (
-        airflow_script_result.returncode == 0
-    ), f"Script execution failed: {airflow_script_result.stderr}"
+    assert airflow_script_result.returncode == 0, (
+        f"Script execution failed: {airflow_script_result.stderr}"
+    )

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/conftest.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/conftest.py
@@ -127,15 +127,15 @@ def poll_for_expected_mats(
                 dagster_run = dagster_instance.get_run_by_id(dagster_run_id)
                 assert dagster_run
                 run_ids = dagster_instance.get_run_ids()
-                assert (
-                    dagster_run
-                ), f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
-                assert (
-                    DAG_RUN_ID_TAG_KEY in dagster_run.tags
-                ), f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
-                assert (
-                    dagster_run.tags[DAG_RUN_ID_TAG_KEY] == airflow_run_id
-                ), "dagster run tag does not match dag run id"
+                assert dagster_run, (
+                    f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
+                )
+                assert DAG_RUN_ID_TAG_KEY in dagster_run.tags, (
+                    f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
+                )
+                assert dagster_run.tags[DAG_RUN_ID_TAG_KEY] == airflow_run_id, (
+                    "dagster run tag does not match dag run id"
+                )
 
 
 def poll_for_materialization(

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,8 +1,7 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import requests
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.run_request import SensorResult
 from dagster._core.definitions.sensor_definition import build_sensor_context
 from dagster._core.test_utils import instance_for_test
@@ -19,6 +18,9 @@ from kitchen_sink.airflow_instance import (
     local_airflow_instance,
 )
 from pytest_mock import MockFixture
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
 
 
 @pytest.fixture
@@ -72,7 +74,7 @@ def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
     defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
     assert defs.assets
     for assets_def in defs.assets:
-        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        metadata = next(iter(cast("AssetsDefinition", assets_def).specs)).metadata
         assert SOURCE_CODE_METADATA_KEY not in metadata
 
     change_dag_limit_source_code(200)
@@ -81,7 +83,7 @@ def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
     defs = build_defs_from_airflow_instance(airflow_instance=af_instance)
     assert defs.assets
     for assets_def in defs.assets:
-        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        metadata = next(iter(cast("AssetsDefinition", assets_def).specs)).metadata
         assert SOURCE_CODE_METADATA_KEY in metadata
 
     # If source code retrieval is explicitly enabled, we don't use the limit.
@@ -92,7 +94,7 @@ def test_disable_source_code_retrieval_at_scale(airflow_instance: None) -> None:
     )
     assert defs.assets
     for assets_def in defs.assets:
-        metadata = next(iter(cast(AssetsDefinition, assets_def).specs)).metadata
+        metadata = next(iter(cast("AssetsDefinition", assets_def).specs)).metadata
         assert SOURCE_CODE_METADATA_KEY in metadata
 
 

--- a/python_modules/libraries/dagster-airlift/setup.py
+++ b/python_modules/libraries/dagster-airlift/setup.py
@@ -49,8 +49,7 @@ setup(
     license="Apache-2.0",
     description="A toolkit for observing integration and migration between Apache Airflow and Dagster.",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-airlift"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-airlift"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -399,7 +399,7 @@ class EcsContainerContext(
                 run_ecs_container_context,
             )
 
-        processed_context_value = cast(Mapping[str, Any], processed_container_context.value)
+        processed_context_value = cast("Mapping[str, Any]", processed_container_context.value)
 
         return shared_container_context.merge(
             EcsContainerContext(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
@@ -318,7 +318,7 @@ class EcsStepHandler(StepHandler):
 
     def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
         step_keys_to_execute = cast(
-            list[str], step_handler_context.execute_step_args.step_keys_to_execute
+            "list[str]", step_handler_context.execute_step_args.step_keys_to_execute
         )
         assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
         return step_keys_to_execute[0]
@@ -328,7 +328,7 @@ class EcsStepHandler(StepHandler):
     ) -> EcsContainerContext:
         return EcsContainerContext.create_for_run(
             step_handler_context.dagster_run,
-            cast(EcsRunLauncher, step_handler_context.instance.run_launcher),
+            cast("EcsRunLauncher", step_handler_context.instance.run_launcher),
         )
 
     def _run_task(self, **run_task_kwargs):

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
@@ -104,7 +104,7 @@ class PipesECSClient(PipesClient, TreatAsResourceParam):
             task_definition = run_task_params["taskDefinition"]
             cluster = run_task_params.get("cluster")
 
-            overrides = cast(dict, run_task_params.get("overrides") or {})
+            overrides = cast("dict", run_task_params.get("overrides") or {})
             overrides["containerOverrides"] = overrides.get("containerOverrides", [])
 
             # get all containers from task definition
@@ -213,7 +213,7 @@ class PipesECSClient(PipesClient, TreatAsResourceParam):
                     pipes_container_name = containers[0]["name"]  # pyright: ignore (reportTypedDictNotRequiredAccess)
 
                 if isinstance(self._message_reader, PipesCloudWatchMessageReader):
-                    pipes_container_name = cast(str, pipes_container_name)
+                    pipes_container_name = cast("str", pipes_container_name)
 
                     params = get_cloudwatch_params(pipes_container_name)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr.py
@@ -136,7 +136,7 @@ class PipesEMRClient(PipesClient, TreatAsResourceParam):
     ) -> "RunJobFlowInputTypeDef":
         params["Configurations"] = emr_inject_pipes_env_vars(
             session,
-            cast(list["ConfigurationTypeDef"], params.get("Configurations", [])),
+            cast("list[ConfigurationTypeDef]", params.get("Configurations", [])),
             emr_flavor="standard",
         )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/glue.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/glue.py
@@ -81,7 +81,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         params = start_job_run_params
 
         params["Arguments"] = params.get("Arguments") or {}
-        job_name = cast(str, params["JobName"])
+        job_name = cast("str", params["JobName"])
 
         with open_pipes_session(
             context=context,

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/utils.py
@@ -71,9 +71,11 @@ def add_emr_configuration(
             properties = {**existing_configuration.get(properties_key, {})}
             properties.update(properties)
 
-            inner_configurations = cast(list[C], existing_configuration.get(classification_key, []))
+            inner_configurations = cast(
+                "list[C]", existing_configuration.get(classification_key, [])
+            )
 
-            for inner_configuration in cast(list[C], configuration.get(configurations_key, [])):
+            for inner_configuration in cast("list[C]", configuration.get(configurations_key, [])):
                 add_emr_configuration(
                     inner_configurations,  # type: ignore
                     inner_configuration,  # type: ignore

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/message_readers.py
@@ -319,9 +319,9 @@ class PipesCloudWatchLogReader(PipesLogReader):
         self.thread.start()
 
     def _start(self, params: PipesParams, is_session_closed: Event) -> None:
-        log_group = cast(str, params.get("log_group") or self.log_group)
-        log_stream = cast(str, params.get("log_stream") or self.log_stream)
-        start_time = cast(int, self.start_time or params.get("start_time"))
+        log_group = cast("str", params.get("log_group") or self.log_group)
+        log_stream = cast("str", params.get("log_stream") or self.log_stream)
+        start_time = cast("int", self.start_time or params.get("start_time"))
 
         for events in tail_cloudwatch_events(
             self.client, log_group, log_stream, start_time=start_time, max_retries=self.max_retries
@@ -414,9 +414,9 @@ class PipesCloudWatchMessageReader(PipesThreadedMessageReader):
         if not events:
             return None
         else:
-            cursor = cast(str, response["nextForwardToken"])
+            cursor = cast("str", response["nextForwardToken"])
             return cursor, "\n".join(
-                cast(str, event.get("message")) for event in events if event.get("message")
+                cast("str", event.get("message")) for event in events if event.get("message")
             )
 
     def no_messages_debug_text(self) -> str:

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -402,6 +402,6 @@ def redshift_resource(context) -> RedshiftClient:
 )
 def fake_redshift_resource(context) -> FakeRedshiftClient:
     return cast(
-        FakeRedshiftClient,
+        "FakeRedshiftClient",
         FakeRedshiftClientResource.from_resource_context(context).get_client(),
     )

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -49,7 +49,7 @@ def get_objects(
     objects: list[ObjectTypeDef] = []
     for page in page_iterator:
         contents = page.get("Contents", [])
-        objects.extend([cast(ObjectTypeDef, obj) for obj in contents])
+        objects.extend([cast("ObjectTypeDef", obj) for obj in contents])
 
     if since_key and not any(obj.get("Key") == since_key for obj in objects):
         raise Exception("Provided `since_key` is not present in list of objects")

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -7,7 +7,6 @@ from dagster import (
     resource,
 )
 from dagster._annotations import beta
-from dagster._config.field_utils import Shape
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
@@ -22,6 +21,7 @@ from dagster_aws.utils import ResourceWithBoto3Configuration
 
 if TYPE_CHECKING:
     import botocore
+    from dagster._config.field_utils import Shape
 
 
 @beta
@@ -245,7 +245,7 @@ class SecretsManagerSecretsResource(ResourceWithBoto3Configuration):
 
 
 LEGACY_SECRETSMANAGER_SECRETS_SCHEMA = {
-    **cast(Shape, SecretsManagerSecretsResource.to_config_schema().as_field().config_type).fields,
+    **cast("Shape", SecretsManagerSecretsResource.to_config_schema().as_field().config_type).fields,
     "add_to_environment": LegacyDagsterField(
         bool,
         default_value=False,

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -8,7 +8,6 @@ from dagster import (
     resource,
 )
 from dagster._annotations import beta
-from dagster._config.field_utils import Shape
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.test_utils import environ
 from dagster._utils.merger import merge_dicts
@@ -24,6 +23,7 @@ from dagster_aws.utils import ResourceWithBoto3Configuration
 
 if TYPE_CHECKING:
     import botocore
+    from dagster._config.field_utils import Shape
 
 
 @beta
@@ -293,7 +293,7 @@ class ParameterStoreResource(ResourceWithBoto3Configuration):
 
 
 LEGACY_PARAMETERSTORE_SCHEMA = {
-    **cast(Shape, ParameterStoreResource.to_config_schema().as_field().config_type).fields,
+    **cast("Shape", ParameterStoreResource.to_config_schema().as_field().config_type).fields,
     "add_to_environment": LegacyDagsterField(
         bool,
         default_value=False,

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -65,7 +65,7 @@ class ResourceWithBoto3Configuration(ConfigurableResource):
 
 def ensure_dagster_aws_tests_import() -> None:
     dagster_package_root = (Path(dagster_aws_init_py) / ".." / "..").resolve()
-    assert (
-        dagster_package_root / "dagster_aws_tests"
-    ).exists(), "Could not find dagster_aws_tests where expected"
+    assert (dagster_package_root / "dagster_aws_tests").exists(), (
+        "Could not find dagster_aws_tests where expected"
+    )
     sys.path.append(dagster_package_root.as_posix())

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
@@ -54,5 +54,5 @@ def test_long_names():
 
     assert (
         get_task_definition_family("foo", remote_job_origin)
-        == f"foo_{'c'*55}_d9023790_{'b'*55}_3956139d_{'a'*55}_164557fa"
+        == f"foo_{'c' * 55}_d9023790_{'b' * 55}_3956139d_{'a' * 55}_164557fa"
     )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_ecs.py
@@ -47,9 +47,9 @@ class LocalECSMockClient:
 
     def describe_task_definition(self, **kwargs):
         response = self.ecs_client.describe_task_definition(**kwargs)
-        assert (
-            len(response["taskDefinition"]["containerDefinitions"]) == 1
-        ), "Only 1 container is supported in tests"
+        assert len(response["taskDefinition"]["containerDefinitions"]) == 1, (
+            "Only 1 container is supported in tests"
+        )
         # unlike real ECS, moto doesn't use cloudwatch logging by default
         # so let's add it here
         response["taskDefinition"]["containerDefinitions"][0]["logConfiguration"] = (
@@ -84,16 +84,16 @@ class LocalECSMockClient:
             "taskDefinition"
         ]
 
-        assert (
-            len(task_definition["containerDefinitions"]) == 1
-        ), "Only 1 container is supported in tests"
+        assert len(task_definition["containerDefinitions"]) == 1, (
+            "Only 1 container is supported in tests"
+        )
 
         # execute in a separate process
         command = task_definition["containerDefinitions"][0]["command"]
 
-        assert (
-            command[0] == sys.executable
-        ), "Only the current Python interpreter is supported in tests"
+        assert command[0] == sys.executable, (
+            "Only the current Python interpreter is supported in tests"
+        )
 
         created_at = datetime.now()
 
@@ -134,7 +134,7 @@ class LocalECSMockClient:
     def describe_tasks(self, cluster: str, tasks: list[str]):
         assert len(tasks) == 1, "Only 1 task is supported in tests"
 
-        simulated_task = cast(SimulatedTaskRun, self._task_runs[tasks[0]])
+        simulated_task = cast("SimulatedTaskRun", self._task_runs[tasks[0]])
 
         response = self.ecs_client.describe_tasks(cluster=cluster, tasks=tasks)
 
@@ -144,9 +144,9 @@ class LocalECSMockClient:
             taskDefinition=response["tasks"][0]["taskDefinitionArn"]
         )["taskDefinition"]
 
-        assert (
-            len(task_definition["containerDefinitions"]) == 1
-        ), "Only 1 container is supported in tests"
+        assert len(task_definition["containerDefinitions"]) == 1, (
+            "Only 1 container is supported in tests"
+        )
 
         # need to inject container name since moto doesn't return it
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
@@ -145,13 +145,13 @@ class LocalGlueMockClient:
         stdout, stderr = self._job_runs[job_run_id].popen.communicate()
 
         if self.pipes_messages_backend == "cloudwatch":
-            assert (
-                self.cloudwatch_client is not None
-            ), "cloudwatch_client has to be provided with cloudwatch messages backend"
+            assert self.cloudwatch_client is not None, (
+                "cloudwatch_client has to be provided with cloudwatch messages backend"
+            )
 
-            assert (
-                self.cloudwatch_client is not None
-            ), "cloudwatch_client has to be provided with cloudwatch messages backend"
+            assert self.cloudwatch_client is not None, (
+                "cloudwatch_client has to be provided with cloudwatch messages backend"
+            )
 
             try:
                 self.cloudwatch_client.create_log_group(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_components.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_components.py
@@ -116,9 +116,9 @@ def test_cloudwatch_logs_reader(cloudwatch_client: "CloudWatchLogsClient", capsy
     log_group = "/pipes/tests"
     log_stream = "test-cloudwatch-logs-reader"
 
-    assert not reader.target_is_readable(
-        {"log_group": log_group, "log_stream": log_stream}
-    ), "Should not be able to read without the stream existing"
+    assert not reader.target_is_readable({"log_group": log_group, "log_stream": log_stream}), (
+        "Should not be able to read without the stream existing"
+    )
 
     cloudwatch_client.create_log_group(logGroupName=log_group)
     cloudwatch_client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
@@ -131,9 +131,9 @@ def test_cloudwatch_logs_reader(cloudwatch_client: "CloudWatchLogsClient", capsy
 
     time.sleep(0.1)
 
-    assert reader.target_is_readable(
-        {"log_group": log_group, "log_stream": log_stream}
-    ), "Should be able to read after the stream is created"
+    assert reader.target_is_readable({"log_group": log_group, "log_stream": log_stream}), (
+        "Should be able to read after the stream is created"
+    )
 
     reader.start({"log_group": log_group, "log_stream": log_stream}, is_session_closed)
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -123,16 +123,16 @@ compute_logs:
     storage_account: "{storage_account}"
     container: {container}
     secret_credential:
-        client_id: "{credential['client_id']}"
-        client_secret: "{credential['client_secret']}"
-        tenant_id: "{credential['tenant_id']}"
+        client_id: "{credential["client_id"]}"
+        client_secret: "{credential["client_secret"]}"
+        tenant_id: "{credential["tenant_id"]}"
     local_dir: "/tmp/cool"
     prefix: "{prefix}"
 """
 
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, "dagster.yaml"), "wb") as f:
-            f.write(dagster_yaml.encode("utf-8"))
+            f.write(dagster_yaml.encode("utf-8"))  # codeql-suppress [*]: test
 
         instance = DagsterInstance.from_config(tempdir)
     assert instance.compute_log_manager._storage_account == storage_account  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import kubernetes
 from dagster import (
@@ -11,7 +11,6 @@ from dagster._core.events import EngineEventData
 from dagster._core.execution.retries import RetryMode
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.launcher.base import CheckRunHealthResult, WorkerStatus
-from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
@@ -26,6 +25,9 @@ from dagster_k8s.job import (
 )
 
 from dagster_celery_k8s.config import CELERY_K8S_CONFIG_KEY, celery_k8s_executor_config
+
+if TYPE_CHECKING:
+    from dagster._core.origin import JobPythonOrigin
 
 
 class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
@@ -160,7 +162,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
 
         job_image_from_executor_config = exc_config.get("job_image")  # pyright: ignore[reportOptionalMemberAccess]
 
-        job_origin = cast(JobPythonOrigin, context.job_code_origin)
+        job_origin = cast("JobPythonOrigin", context.job_code_origin)
         repository_origin = job_origin.repository_origin
 
         job_image = repository_origin.container_image

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -112,7 +112,7 @@ def create_execute_job_task(celery: Celery, **task_kwargs: dict) -> celery.Task:
                 ),
             )
 
-    return cast(celery.Task, _execute_job)  # type: ignore # ignored for update, fix me!
+    return cast("celery.Task", _execute_job)
 
 
 def create_resume_job_task(celery: Celery, **task_kwargs: dict) -> celery.Task:
@@ -139,4 +139,4 @@ def create_resume_job_task(celery: Celery, **task_kwargs: dict) -> celery.Task:
                 ),
             )
 
-    return cast(celery.Task, _resume_job)  # type: ignore # ignored for update, fix me!
+    return cast("celery.Task", _resume_job)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -405,7 +405,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             if not serialized_records:
                 return []
             return cast(
-                Sequence[EventLogEntry],
+                "Sequence[EventLogEntry]",
                 deserialize_value(pickle.loads(gzip.decompress(serialized_records))),
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -433,11 +433,11 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
     def _build_dbt_cloud_assets_from_cacheable_data(
         self, assets_definition_cacheable_data: AssetsDefinitionCacheableData
     ) -> AssetsDefinition:
-        metadata = cast(Mapping[str, Any], assets_definition_cacheable_data.extra_metadata)
-        job_id = cast(int, metadata["job_id"])
-        job_commands = cast(list[str], list(metadata["job_commands"]))
-        job_materialization_command_step = cast(int, metadata["job_materialization_command_step"])
-        fqns_by_output_name = cast(Mapping[str, list[str]], metadata["fqns_by_output_name"])
+        metadata = cast("Mapping[str, Any]", assets_definition_cacheable_data.extra_metadata)
+        job_id = cast("int", metadata["job_id"])
+        job_commands = cast("list[str]", list(metadata["job_commands"]))
+        job_materialization_command_step = cast("int", metadata["job_materialization_command_step"])
+        fqns_by_output_name = cast("Mapping[str, list[str]]", metadata["fqns_by_output_name"])
 
         @multi_asset(
             name=f"dbt_cloud_job_{job_id}",
@@ -448,7 +448,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             compute_kind="dbt",
         )
         def _assets(context: AssetExecutionContext):
-            dbt_cloud = cast(DbtCloudClient, context.resources.dbt_cloud)
+            dbt_cloud = cast("DbtCloudClient", context.resources.dbt_cloud)
 
             # Add the partition variable as a variable to the dbt Cloud job command.
             dbt_options: list[str] = []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -354,7 +354,7 @@ class DbtCloudClient:
         """
         query_params = f"?step={step}" if step else ""
         return cast(
-            list,
+            "list",
             self.make_request(
                 "GET",
                 f"{self._account_id}/runs/{run_id}/artifacts/{query_params}",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -280,7 +280,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 "order_by": "finished_at",
             },
         )
-        data = cast(Sequence[Mapping[str, Any]], resp["data"])
+        data = cast("Sequence[Mapping[str, Any]]", resp["data"])
         total_count = resp["extra"]["pagination"]["total_count"]
         return data, total_count
 
@@ -353,7 +353,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
             List[str]: a list of artifact names taken from the response to this request.
         """
         return cast(
-            Sequence[str],
+            "Sequence[str]",
             self._make_request(
                 method="get",
                 endpoint=f"runs/{run_id}/artifacts",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -2,11 +2,10 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from types import ModuleType
-from typing import Annotated, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Optional, Union, cast
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components import Resolvable, Resolver
@@ -28,6 +27,9 @@ from dagster_dbt.core.resource import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
 from dagster_dbt.dbt_project import DbtProject
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
 
 
 class ComponentDagsterDbtTranslator(DagsterDbtTranslator):
@@ -189,4 +191,4 @@ def get_asset_key_for_model_from_module(
                 ...
     """
     defs = context.load_defs(dbt_component_module)
-    return get_asset_key_for_model(cast(Sequence[AssetsDefinition], defs.assets), model_name)
+    return get_asset_key_for_model(cast("Sequence[AssetsDefinition]", defs.assets), model_name)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -117,7 +117,7 @@ def _build_column_lineage_metadata(
         dbt_resource_props["original_file_path"].replace("\\", "/"),
     )
     optimized_node_ast = cast(
-        exp.Query,
+        "exp.Query",
         optimize(
             parse_one(sql=node_sql_path.read_text(), dialect=sql_dialect),
             schema=sqlglot_mapping_schema,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -351,7 +351,7 @@ class DbtCliInvocation:
                 with contextlib.suppress(orjson.JSONDecodeError):
                     column_level_metadata = orjson.loads(event.raw_event["info"]["msg"])
 
-                    event_history_metadata_by_unique_id[cast(str, unique_id)] = (
+                    event_history_metadata_by_unique_id[cast("str", unique_id)] = (
                         column_level_metadata
                     )
 
@@ -406,7 +406,7 @@ class DbtCliInvocation:
     @property
     def dbt_command(self) -> str:
         """The dbt CLI command that was invoked."""
-        return " ".join(cast(Sequence[str], self.process.args))
+        return " ".join(cast("Sequence[str]", self.process.args))
 
     def _stream_stdout(self) -> Iterator[Union[str, dict[str, Any]]]:
         """Stream the stdout from the dbt CLI process."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -39,7 +39,7 @@ T = TypeVar("T", bound=DbtDagsterEventType)
 def _get_dbt_resource_props_from_event(
     invocation: "DbtCliInvocation", event: DbtDagsterEventType
 ) -> dict[str, Any]:
-    unique_id = cast(TextMetadataValue, event.metadata["unique_id"]).text
+    unique_id = cast("TextMetadataValue", event.metadata["unique_id"]).text
     return check.not_none(invocation.manifest["nodes"].get(unique_id))
 
 
@@ -283,17 +283,15 @@ class DbtEventIterator(Iterator[T]):
             if isinstance(self._dbt_cli_invocation.adapter, DuckDBAdapter):
                 event_stream = exhaust_iterator_and_yield_results_with_exception(self)
 
-        def _threadpool_wrap_map_fn() -> (
-            Iterator[
-                Union[
-                    Output,
-                    AssetMaterialization,
-                    AssetObservation,
-                    AssetCheckResult,
-                    AssetCheckEvaluation,
-                ]
+        def _threadpool_wrap_map_fn() -> Iterator[
+            Union[
+                Output,
+                AssetMaterialization,
+                AssetObservation,
+                AssetCheckResult,
+                AssetCheckEvaluation,
             ]
-        ):
+        ]:
             with ThreadPoolExecutor(
                 max_workers=self._dbt_cli_invocation.postprocessing_threadpool_num_threads,
                 thread_name_prefix=f"dbt_attach_metadata_{fn.__name__}",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -61,7 +61,7 @@ DAGSTER_GITHUB_REPO_DBT_PACKAGE = "https://github.com/dagster-io/dagster.git"
 def _dbt_packages_has_dagster_dbt(packages_file: Path) -> bool:
     """Checks whether any package in the passed yaml file is the Dagster dbt package."""
     packages = cast(
-        list[dict[str, Any]], yaml.safe_load(packages_file.read_text()).get("packages", [])
+        "list[dict[str, Any]]", yaml.safe_load(packages_file.read_text()).get("packages", [])
     )
     return any(package.get("git") == DAGSTER_GITHUB_REPO_DBT_PACKAGE for package in packages)
 
@@ -404,13 +404,13 @@ class DbtCliResource(ConfigurableResource):
         if IS_DBT_CORE_VERSION_LESS_THAN_1_8_0:
             register_adapter(config)  # type: ignore
         else:
-            from dbt.adapters.protocol import MacroContextGeneratorCallable
+            from dbt.adapters.protocol import MacroContextGeneratorCallable  # noqa: TC002
             from dbt.context.providers import generate_runtime_macro_context
             from dbt.mp_context import get_mp_context
             from dbt.parser.manifest import ManifestLoader
 
             register_adapter(config, get_mp_context())
-            adapter = cast(BaseAdapter, get_adapter(config))
+            adapter = cast("BaseAdapter", get_adapter(config))
             manifest = ManifestLoader.load_macros(
                 config,
                 adapter.connections.set_query_header,  # type: ignore
@@ -418,10 +418,10 @@ class DbtCliResource(ConfigurableResource):
             )
             adapter.set_macro_resolver(manifest)
             adapter.set_macro_context_generator(
-                cast(MacroContextGeneratorCallable, generate_runtime_macro_context)
+                cast("MacroContextGeneratorCallable", generate_runtime_macro_context)
             )
 
-        adapter = cast(BaseAdapter, get_adapter(config))
+        adapter = cast("BaseAdapter", get_adapter(config))
 
         return adapter
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest.py
@@ -24,7 +24,7 @@ def read_manifest_path(manifest_path: Path) -> Mapping[str, Any]:
     if not manifest_path.exists():
         raise DagsterDbtManifestNotFoundError(f"{manifest_path} does not exist.")
 
-    return cast(Mapping[str, Any], orjson.loads(manifest_path.read_bytes()))
+    return cast("Mapping[str, Any]", orjson.loads(manifest_path.read_bytes()))
 
 
 def validate_manifest(manifest: DbtManifestParam) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_and_package.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_and_package.py
@@ -3,15 +3,17 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import yaml
 from dagster import AssetsDefinition, materialize
 from dagster_dbt.cli.app import app
 from dagster_dbt.core.resource import DbtCliResource
-from dagster_dbt.dbt_project import DbtProject
 from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from dagster_dbt.dbt_project import DbtProject
 
 runner = CliRunner()
 
@@ -206,8 +208,10 @@ def test_prepare_and_package_with_state(
     assert result.exit_code == 0
 
     scaffold_defs_module = importlib.import_module(f"{project_name}.{project_name}.definitions")
-    my_dbt_assets = cast(AssetsDefinition, getattr(scaffold_defs_module, "jaffle_shop_dbt_assets"))
-    project = cast(DbtProject, getattr(scaffold_defs_module, "jaffle_shop_project"))
+    my_dbt_assets = cast(
+        "AssetsDefinition", getattr(scaffold_defs_module, "jaffle_shop_dbt_assets")
+    )
+    project = cast("DbtProject", getattr(scaffold_defs_module, "jaffle_shop_project"))
     dbt = DbtCliResource(project_dir=project)
 
     assert project.packaged_project_dir

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -210,10 +210,11 @@ def test_asset_attributes_is_comprehensive():
         all_asset_attribute_keys.extend(test_arg[0].keys())
     from dagster.components.resolved.core_models import AssetAttributesModel
 
-    assert (
-        set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS
-        == set(all_asset_attribute_keys)
-    ), f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
+    assert set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS == set(
+        all_asset_attribute_keys
+    ), (
+        f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
+    )
 
 
 def test_subselection(dbt_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -489,7 +489,7 @@ def test_column_lineage_real_warehouse(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     test_metadata_manifest: dict[str, Any] = cast(
-        dict[str, Any], request.getfixturevalue(manifest_fixture_name)
+        "dict[str, Any]", request.getfixturevalue(manifest_fixture_name)
     )
     sql_dialect = target
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -490,7 +490,7 @@ def test_asset_checks_results(
 
         for event in events:
             if isinstance(event, AssetCheckResult):
-                assert cast(int, event.metadata["Execution Duration"].value) > 0
+                assert cast("int", event.metadata["Execution Duration"].value) > 0
 
         expected_results = [
             AssetCheckResult(
@@ -603,7 +603,7 @@ def test_asset_checks_evaluations(
 
         for event in events:
             if isinstance(event, AssetCheckEvaluation):
-                assert cast(int, event.metadata["Execution Duration"].value) > 0
+                assert cast("int", event.metadata["Execution Duration"].value) > 0
 
         # Sanity check that we don't have AssetCheckResult events when using an op
         assert not any([event for event in events if isinstance(event, AssetCheckResult)])

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -1,17 +1,19 @@
 import copy
 import os
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from unittest import mock
 
 import pytest
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_selection import AndAssetSelection
 from dagster._core.definitions.events import AssetKey
 from dagster._record import replace
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_selection import AndAssetSelection
 
 
 @pytest.mark.parametrize(
@@ -267,7 +269,7 @@ def test_dbt_asset_selection_equality(
             [my_dbt_assets], dbt_select="new_select"
         )
 
-        dbt_manifest_asset_selection = cast(AndAssetSelection, asset_selection).operands[0]
+        dbt_manifest_asset_selection = cast("AndAssetSelection", asset_selection).operands[0]
 
         assert isinstance(dbt_manifest_asset_selection, DbtManifestAssetSelection)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -30,7 +30,7 @@ def standalone_duckdb_dbfile_path_fixture(request) -> None:
     """Generate a unique duckdb dbfile path for certain tests which need
     it, rather than using the default one-file-per-worker approach.
     """
-    node_name = cast(str, request.node.name).replace("[", "_").replace("]", "_")
+    node_name = cast("str", request.node.name).replace("[", "_").replace("]", "_")
     jaffle_shop_duckdb_db_file_name = f"{node_name}_jaffle_shop"
     jaffle_shop_duckdb_dbfile_path = f"target/{jaffle_shop_duckdb_db_file_name}.duckdb"
 
@@ -103,7 +103,7 @@ def test_jaffle_shop_manifest_bigquery_fixture() -> dict[str, Any]:
     ],
 )
 def test_row_count(request: pytest.FixtureRequest, target: str, manifest_fixture_name: str) -> None:
-    manifest = cast(dict[str, Any], request.getfixturevalue(manifest_fixture_name))
+    manifest = cast("dict[str, Any]", request.getfixturevalue(manifest_fixture_name))
 
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
@@ -176,7 +176,7 @@ def test_insights_err_not_snowflake_or_bq(
 def test_row_count_does_not_obscure_errors(
     request: pytest.FixtureRequest, target: str, manifest_fixture_name: str
 ) -> None:
-    manifest = cast(dict[str, Any], request.getfixturevalue(manifest_fixture_name))
+    manifest = cast("dict[str, Any]", request.getfixturevalue(manifest_fixture_name))
 
     # Test that row count fetching does not obscure other errors in the dbt run
     # First, run dbt without any row count fetching, and ensure that it fails
@@ -314,7 +314,7 @@ def test_attach_metadata(
     )
 
     summaries_by_asset_key = {
-        asset_key: cast(TableMetadataValue, metadata["summary"])
+        asset_key: cast("TableMetadataValue", metadata["summary"])
         for asset_key, metadata in metadata_by_asset_key.items()
     }
     assert all(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -55,7 +55,7 @@ def test_dbt_cli(global_config_flags: list[str]) -> None:
 
 
 def test_dbt_cli_executable() -> None:
-    dbt_executable = cast(str, shutil.which("dbt"))
+    dbt_executable = cast("str", shutil.which("dbt"))
     invocation = DbtCliResource(
         project_dir=os.fspath(test_jaffle_shop_path), dbt_executable=dbt_executable
     ).cli(["parse"])
@@ -632,7 +632,7 @@ def test_custom_subclass():
 def test_metadata(test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource) -> None:
     def assert_on_expected_metadata(metadata):
         assert isinstance(metadata["Execution Duration"], FloatMetadataValue)
-        assert cast(float, metadata["Execution Duration"].value) > 0
+        assert cast("float", metadata["Execution Duration"].value) > 0
 
         assert isinstance(metadata["unique_id"], TextMetadataValue)
         assert isinstance(metadata["invocation_id"], TextMetadataValue)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -88,7 +88,7 @@ def test_dbt_build_schedule(
     assert len(job.selection.operands) == 2
 
     [dbt_assets_selection, job_selection] = cast(
-        Sequence[DbtManifestAssetSelection], job.selection.operands
+        "Sequence[DbtManifestAssetSelection]", job.selection.operands
     )
     assert dbt_assets_selection.select == "fqn:*"
     assert dbt_assets_selection.exclude == ""

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -1,12 +1,11 @@
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import Any, Generic, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.dataset as ds
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
-from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import DbTypeHandler, TablePartitionDimension, TableSlice
 from deltalake import DeltaTable, WriterProperties, write_deltalake
 from deltalake.schema import (
@@ -23,6 +22,9 @@ except ImportError:
     from pyarrow.parquet import _filters_to_expression as filters_to_expression
 
 from dagster_deltalake.io_manager import DELTA_DATE_FORMAT, DELTA_DATETIME_FORMAT, TableConnection
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.time_window_partitions import TimeWindow
 
 T = TypeVar("T")
 ArrowTypes: TypeAlias = Union[pa.Table, pa.RecordBatchReader]
@@ -191,7 +193,7 @@ def partition_dimensions_to_dnf(
 
 def _value_dnf(table_partition: TablePartitionDimension, data_type: str, str_values: bool):
     # ", ".join(f"'{partition}'" for partition in table_partition.partitions)
-    partition = cast(Sequence[str], table_partition.partitions)
+    partition = cast("Sequence[str]", table_partition.partitions)
     if len(partition) > 1:
         raise ValueError(f"Array partition values are not yet supported: {data_type} / {partition}")
     if str_values:
@@ -203,7 +205,7 @@ def _value_dnf(table_partition: TablePartitionDimension, data_type: str, str_val
 def _time_window_partition_dnf(
     table_partition: TablePartitionDimension, data_type: str, str_values: bool
 ) -> FilterLiteralType:
-    partition = cast(TimeWindow, table_partition.partitions)
+    partition = cast("TimeWindow", table_partition.partitions)
     start_dt, _ = partition
     start_dt = start_dt.replace(tzinfo=None)
     if str_values:

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -207,7 +207,7 @@ class DeltaLakeDbClient(DbClient):
     @staticmethod
     @contextmanager
     def connect(context, table_slice: TableSlice) -> Iterator[TableConnection]:
-        resource_config = cast(_DeltaTableIOManagerResourceConfig, context.resource_config)
+        resource_config = cast("_DeltaTableIOManagerResourceConfig", context.resource_config)
         root_uri = resource_config["root_uri"].rstrip("/")
         storage_options = resource_config["storage_options"]
 
@@ -255,7 +255,7 @@ def _partition_where_clause(
 
 
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
-    partition = cast(TimeWindow, table_partition.partitions)
+    partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DELTA_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DELTA_DATETIME_FORMAT)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -69,9 +69,7 @@ def error_dict_to_formatted_error(
         value_error=False,
     )
 
-    fmt_filename = (
-        f"{source.file_name}" f":{typer.style(source.start_line_no, fg=typer.colors.GREEN)}"
-    )
+    fmt_filename = f"{source.file_name}:{typer.style(source.start_line_no, fg=typer.colors.GREEN)}"
     fmt_location = typer.style(source.location, fg=typer.colors.BRIGHT_WHITE)
     fmt_name = typer.style(f"{key.to_typename()} " if key else "", fg=typer.colors.RED)
     return f"{fmt_filename} - {fmt_name}{fmt_location} {error_details.message}\n{source.snippet}\n"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -504,7 +504,7 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
             instance_name,
             key_value_params,
             json_params,
-            cast(ScaffoldFormatOptions, format),
+            cast("ScaffoldFormatOptions", format),
         )
 
     # If there are defined scaffold params, add them to the command

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -358,7 +358,7 @@ def _validate_cli_config(cli_opts: Mapping[str, object]) -> DgRawCliConfig:
         _validate_cli_config_no_extraneous_keys(cli_opts)
     except DgValidationError as e:
         _raise_cli_config_validation_error(str(e))
-    return cast(DgRawCliConfig, cli_opts)
+    return cast("DgRawCliConfig", cli_opts)
 
 
 def _validate_cli_config_setting(cli_opts: Mapping[str, object], key: str, type_: type) -> None:
@@ -499,14 +499,14 @@ class _DgConfigValidator:
             self._validate_file_config_no_extraneous_keys(
                 set(DgWorkspaceFileConfig.__annotations__.keys()), raw_dict, None
             )
-            return cast(DgWorkspaceFileConfig, raw_dict)
+            return cast("DgWorkspaceFileConfig", raw_dict)
         elif raw_dict["directory_type"] == "project":
             self._validate_file_config_setting(raw_dict, "project", dict)
             self._validate_file_config_project_section(raw_dict.get("project", {}))
             self._validate_file_config_no_extraneous_keys(
                 set(DgProjectFileConfig.__annotations__.keys()), raw_dict, None
             )
-            return cast(DgProjectFileConfig, raw_dict)
+            return cast("DgProjectFileConfig", raw_dict)
         else:
             raise DgError("Unreachable")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/trace
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs/.next/trace
@@ -1,0 +1,2 @@
+[{"name":"next-dev","duration":1342557936013,"timestamp":1576075277233,"id":1,"tags":{},"startTime":1743110183930,"traceId":"08cca0ea05c9109d"}]
+[{"name":"next-dev","duration":1342550391438,"timestamp":1576082844311,"id":1,"tags":{},"startTime":1743110191497,"traceId":"9bb53951c04cb79a"}]

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -266,9 +266,9 @@ def ensure_dagster_dg_tests_import() -> None:
     from dagster_dg import __file__ as dagster_dg_init_py
 
     dagster_dg_package_root = (Path(dagster_dg_init_py) / ".." / "..").resolve()
-    assert (
-        dagster_dg_package_root / "dagster_dg_tests"
-    ).exists(), "Could not find dagster_dg_tests where expected"
+    assert (dagster_dg_package_root / "dagster_dg_tests").exists(), (
+        "Could not find dagster_dg_tests where expected"
+    )
     sys.path.append(dagster_dg_package_root.as_posix())
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
@@ -11,9 +11,9 @@ from dagster_dg_tests.utils import ProxyRunner, isolated_dg_venv
 # Command/Group subclasses to ensure that the help formatting is consistent.
 def test_all_commands_custom_subclass():
     def crawl(command):
-        assert isinstance(
-            command, (DgClickGroup, DgClickCommand)
-        ), f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        assert isinstance(command, (DgClickGroup, DgClickCommand)), (
+            f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        )
         if isinstance(command, DgClickGroup):
             for command in command.commands.values():
                 crawl(command)
@@ -25,9 +25,9 @@ def test_all_commands_custom_subclass():
 # Command/Group subclasses to ensure that the help formatting is consistent.
 def test_all_commands_have_global_options():
     def crawl(command):
-        assert isinstance(
-            command, (DgClickGroup, DgClickCommand)
-        ), f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        assert isinstance(command, (DgClickGroup, DgClickCommand)), (
+            f"Group is not a DgClickGroup or DgClickCommand: {command}"
+        )
         if isinstance(command, DgClickGroup):
             for command in command.commands.values():
                 crawl(command)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
@@ -73,9 +73,9 @@ def test_basic_logging_success_failure(caplog: pytest.LogCaptureFixture, success
 
         assert first_message["action"] == "check_yaml_command_started"
         assert second_message["action"] == "check_yaml_command_ended"
-        assert (
-            second_message["metadata"]["command_success"] == "True" if success else "False"
-        ), second_message["metadata"]
+        assert second_message["metadata"]["command_success"] == "True" if success else "False", (
+            second_message["metadata"]
+        )
 
 
 def test_telemetry_disabled_dagster_yaml(caplog: pytest.LogCaptureFixture) -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -368,9 +368,9 @@ def convert_dg_toml_to_pyproject_toml(dg_toml_path: Path, pyproject_toml_path: P
     if not pyproject_toml_path.exists():
         pyproject_toml_path.write_text(tomlkit.dumps({}))
     with modify_toml(pyproject_toml_path) as pyproject_toml:
-        assert not has_toml_node(
-            pyproject_toml, ("tool", "dg")
-        ), "pyproject.toml already has a tool.dg section"
+        assert not has_toml_node(pyproject_toml, ("tool", "dg")), (
+            "pyproject.toml already has a tool.dg section"
+        )
         if not has_toml_node(pyproject_toml, ("tool",)):
             set_toml_node(pyproject_toml, ("tool",), tomlkit.table())
         set_toml_node(pyproject_toml, ("tool", "dg"), dg_toml)

--- a/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
@@ -155,7 +155,7 @@ class DockerContainerContext(
                 run_docker_container_context,
             )
 
-        processed_context_value = cast(Mapping[str, Any], processed_container_context.value)
+        processed_context_value = cast("Mapping[str, Any]", processed_container_context.value)
 
         return shared_container_context.merge(
             DockerContainerContext(

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import dagster._check as check
 import docker
@@ -18,13 +18,15 @@ from dagster._core.executor.step_delegating.step_handler.base import (
     StepHandler,
     StepHandlerContext,
 )
-from dagster._core.origin import JobPythonOrigin
 from dagster._core.utils import parse_env_var
 from dagster._utils.merger import merge_dicts
 from dagster_shared.serdes.utils import hash_str
 
 from dagster_docker.container_context import DockerContainerContext
 from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
+
+if TYPE_CHECKING:
+    from dagster._core.origin import JobPythonOrigin
 
 
 @executor(
@@ -119,7 +121,7 @@ class DockerStepHandler(StepHandler):
         from dagster_docker import DockerRunLauncher
 
         image = cast(
-            JobPythonOrigin, step_handler_context.dagster_run.job_code_origin
+            "JobPythonOrigin", step_handler_context.dagster_run.job_code_origin
         ).repository_origin.container_image
         if not image:
             image = self._image
@@ -172,7 +174,7 @@ class DockerStepHandler(StepHandler):
 
     def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
         step_keys_to_execute = cast(
-            list[str], step_handler_context.execute_step_args.step_keys_to_execute
+            "list[str]", step_handler_context.execute_step_args.step_keys_to_execute
         )
         assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
         return step_keys_to_execute[0]
@@ -205,10 +207,7 @@ class DockerStepHandler(StepHandler):
         step_key = step_keys_to_execute[0]
 
         container_kwargs = {**container_context.container_kwargs}
-        if "stop_timeout" in container_kwargs:
-            # This should work, but does not due to https://github.com/docker/docker-py/issues/3168
-            # Pull it out and apply it in the terminate() method instead
-            del container_kwargs["stop_timeout"]
+        container_kwargs.pop("stop_timeout", None)
 
         env_vars = dict([parse_env_var(env_var) for env_var in container_context.env_vars])
         env_vars["DAGSTER_RUN_JOB_NAME"] = step_handler_context.dagster_run.job_name
@@ -301,9 +300,9 @@ class DockerStepHandler(StepHandler):
         step_keys_to_execute = check.not_none(
             step_handler_context.execute_step_args.step_keys_to_execute
         )
-        assert (
-            len(step_keys_to_execute) == 1
-        ), "Terminating multiple steps is not currently supported"
+        assert len(step_keys_to_execute) == 1, (
+            "Terminating multiple steps is not currently supported"
+        )
         step_key = step_keys_to_execute[0]
 
         container_name = self._get_container_name(step_handler_context)

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -107,10 +107,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         container_kwargs = {**container_context.container_kwargs}
         labels = container_kwargs.pop("labels", {})
 
-        if "stop_timeout" in container_kwargs:
-            # This should work, but does not due to https://github.com/docker/docker-py/issues/3168
-            # Pull it out and apply it in the terminate() method instead
-            del container_kwargs["stop_timeout"]
+        container_kwargs.pop("stop_timeout", None)
 
         if isinstance(labels, list):
             labels = {key: "" for key in labels}

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -1,5 +1,5 @@
 import os
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import duckdb
 import pandas as pd
@@ -24,8 +24,10 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 from dagster_duckdb_pandas import DuckDBPandasIOManager, duckdb_pandas_io_manager
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 
 
 @pytest.fixture
@@ -252,7 +254,7 @@ def test_time_window_partitioned_asset(tmp_path, io_managers):
             if event.event_type_value == "ASSET_MATERIALIZATION"
         )
         meta = materialization.materialization.metadata["dagster/partition_row_count"]
-        assert cast(IntMetadataValue, meta).value == 3
+        assert cast("IntMetadataValue", meta).value == 3
 
         duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -330,7 +330,7 @@ def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensi
 
 
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
-    partition = cast(TimeWindow, table_partition.partitions)
+    partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DUCKDB_DATETIME_FORMAT)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -363,12 +363,12 @@ class FivetranConnectionMetadata(
     ) -> AssetsDefinitionCacheableData:
         schema_table_meta: dict[str, RawMetadataMapping] = {}
         if "schemas" in self.schemas:
-            schemas_inner = cast(dict[str, Any], self.schemas["schemas"])
+            schemas_inner = cast("dict[str, Any]", self.schemas["schemas"])
             for schema in schemas_inner.values():
                 if schema["enabled"]:
                     schema_name = schema["name_in_destination"]
                     schema_tables: dict[str, dict[str, Any]] = cast(
-                        dict[str, dict[str, Any]], schema["tables"]
+                        "dict[str, dict[str, Any]]", schema["tables"]
                     )
                     for table in schema_tables.values():
                         if table["enabled"]:
@@ -422,10 +422,10 @@ def _build_fivetran_assets_from_metadata(
     fetch_column_metadata: bool,
     translator: Optional[type[DagsterFivetranTranslator]] = None,
 ) -> AssetsDefinition:
-    metadata = cast(Mapping[str, Any], assets_defn_meta.extra_metadata)
-    connector_id = cast(str, metadata["connector_id"])
-    io_manager_key = cast(Optional[str], metadata["io_manager_key"])
-    storage_kind = cast(Optional[str], metadata.get("storage_kind"))
+    metadata = cast("Mapping[str, Any]", assets_defn_meta.extra_metadata)
+    connector_id = cast("str", metadata["connector_id"])
+    io_manager_key = cast("Optional[str]", metadata["io_manager_key"])
+    storage_kind = cast("Optional[str]", metadata.get("storage_kind"))
 
     connection_metadata = FivetranConnectionMetadata.from_serializable_repr(
         metadata["connection_metadata"]
@@ -440,7 +440,7 @@ def _build_fivetran_assets_from_metadata(
         ),
         asset_key_prefix=list(assets_defn_meta.key_prefix or []),
         metadata_by_table_name=cast(
-            dict[str, RawMetadataMapping], assets_defn_meta.metadata_by_output_name
+            "dict[str, RawMetadataMapping]", assets_defn_meta.metadata_by_output_name
         ),
         io_manager_key=io_manager_key,
         table_to_asset_key_map=assets_defn_meta.keys_by_output_name,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
@@ -163,7 +163,7 @@ def test_list_connectors_for_group_cursor(connector_id: str, group_id: str):
             )
             return client.list_connectors_for_group(group_id=group_id)
 
-    assert len(cast(list, _mock_interaction())) == 2
+    assert len(cast("list", _mock_interaction())) == 2
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -47,7 +47,7 @@ class MockFivetran(AbstractContextManager):
             dest_id: [
                 conn_id
                 for conn_id, conn in connectors.items()
-                if cast(FivetranDestination, conn.destination).name == dest.name
+                if cast("FivetranDestination", conn.destination).name == dest.name
             ]
             for dest_id, dest in destinations.items()
         }
@@ -62,28 +62,28 @@ class MockFivetran(AbstractContextManager):
         )
         self.rsps.add_callback(
             responses.GET,
-            re.compile(r"https://api.fivetran.com/v1/destinations/.*"),
+            re.compile(r"https://api\.fivetran\.com/v1/destinations/.*"),
             callback=format_callback(self.mock_destination),
         )
         self.rsps.add_callback(
             responses.GET,
-            re.compile(r"https://api.fivetran.com/v1/groups/.*/connectors"),
+            re.compile(r"https://api\.fivetran\.com/v1/groups/.*/connectors"),
             callback=format_callback(self.mock_connectors),
         )
         self.rsps.add_callback(
             responses.GET,
-            re.compile(r"https://api.fivetran.com/v1/connectors/.*"),
+            re.compile(r"https://api\.fivetran\.com/v1/connectors/.*"),
             callback=format_callback(self.mock_connector),
         )
 
         self.rsps.add_callback(
             responses.PATCH,
-            re.compile(r"https://api.fivetran.com/v1/destinations/.*"),
+            re.compile(r"https://api\.fivetran\.com/v1/destinations/.*"),
             callback=format_callback(self.mock_patch_destination),
         )
         self.rsps.add_callback(
             responses.PATCH,
-            re.compile(r"https://api.fivetran.com/v1/connectors/.*"),
+            re.compile(r"https://api\.fivetran\.com/v1/connectors/.*"),
             callback=format_callback(self.mock_patch_connector),
         )
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -265,7 +265,7 @@ def get_sample_columns_response():
                 "enabled_patch_settings": {
                     "allowed": False,
                     "reason_code": "SYSTEM_COLUMN",
-                    "reason": ("The column does not support exclusion as it is a" " Primary Key"),
+                    "reason": ("The column does not support exclusion as it is a Primary Key"),
                 },
             },
             "column_2": {

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import pandas as pd
 import pandas_gbq
@@ -28,9 +28,11 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 from dagster_gcp_pandas import BigQueryPandasIOManager, bigquery_pandas_io_manager
 from google.cloud import bigquery
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -211,7 +213,7 @@ def test_time_window_partitioned_asset(io_manager):
             if event.event_type_value == "ASSET_MATERIALIZATION"
         )
         meta = materialization.materialization.metadata["dagster/partition_row_count"]
-        assert cast(IntMetadataValue, meta).value == 3
+        assert cast("IntMetadataValue", meta).value == 3
 
         out_df = pandas_gbq.read_gbq(
             f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -389,7 +389,7 @@ def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensi
 
 
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
-    partition = cast(TimeWindow, table_partition.partitions)
+    partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(BIGQUERY_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(BIGQUERY_DATETIME_FORMAT)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_sensor.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_sensor.py
@@ -81,8 +81,8 @@ def test_get_gcs_keys(
         bucket=bucket_name, prefix=blob_prefix, since_key=since_key, gcs_session=gcs_client
     )
 
-    assert len(keys) == len(
-        expected_keys
-    ), f"{test_name}: {len(expected_keys)} key(s) should be returned"
+    assert len(keys) == len(expected_keys), (
+        f"{test_name}: {len(expected_keys)} key(s) should be returned"
+    )
     assert keys == expected_keys
     assert gcs_client.list_blobs.call_count == 1

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -528,7 +528,7 @@ class K8sContainerContext(
                 run_k8s_container_context,
             )
 
-        processed_context_value = cast(dict, processed_container_context.value)
+        processed_context_value = cast("dict", processed_container_context.value)
 
         return shared_container_context.merge(
             K8sContainerContext(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -154,12 +154,12 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
     )
 
     if "load_incluster_config" in exc_cfg:
-        load_incluster_config = cast(bool, exc_cfg["load_incluster_config"])
+        load_incluster_config = cast("bool", exc_cfg["load_incluster_config"])
     else:
         load_incluster_config = run_launcher.load_incluster_config if run_launcher else True
 
     if "kubeconfig_file" in exc_cfg:
-        kubeconfig_file = cast(Optional[str], exc_cfg["kubeconfig_file"])
+        kubeconfig_file = cast("Optional[str]", exc_cfg["kubeconfig_file"])
     else:
         kubeconfig_file = run_launcher.kubeconfig_file if run_launcher else None
 
@@ -218,7 +218,7 @@ class K8sStepHandler(StepHandler):
 
     def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
         step_keys_to_execute = cast(
-            list[str], step_handler_context.execute_step_args.step_keys_to_execute
+            "list[str]", step_handler_context.execute_step_args.step_keys_to_execute
         )
         assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
         return step_keys_to_execute[0]
@@ -230,7 +230,7 @@ class K8sStepHandler(StepHandler):
 
         context = K8sContainerContext.create_for_run(
             step_handler_context.dagster_run,
-            cast(K8sRunLauncher, step_handler_context.instance.run_launcher),
+            cast("K8sRunLauncher", step_handler_context.instance.run_launcher),
             include_run_tags=False,  # For now don't include job-level dagster-k8s/config tags in step pods
         )
         context = context.merge(self._executor_container_context)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -173,7 +173,7 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
                         raise
                     retries_remaining -= 1
                     context.log.warning(
-                        f"Error consuming pod logs. {retries_remaining} retr{('y' if retries_remaining==1 else 'ies')} remaining",
+                        f"Error consuming pod logs. {retries_remaining} retr{('y' if retries_remaining == 1 else 'ies')} remaining",
                         exc_info=True,
                     )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_version.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_version.py
@@ -13,9 +13,9 @@ from dagster_k8s.kubernetes_version import KUBERNETES_VERSION_UPPER_BOUND
 
 def parse_package_version(version_str: str) -> packaging.version.Version:
     parsed_version = packaging.version.parse(version_str)
-    assert isinstance(
-        parsed_version, packaging.version.Version
-    ), f"Found LegacyVersion: {version_str}"
+    assert isinstance(parsed_version, packaging.version.Version), (
+        f"Found LegacyVersion: {version_str}"
+    )
     return parsed_version
 
 

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 from dagster import AssetExecutionContext, AssetsDefinition, Failure, multi_asset
 from dagster._annotations import beta
@@ -13,7 +13,9 @@ from dagster_looker.api.dagster_looker_api_translator import (
     LookmlView,
     RequestStartPdtBuild,
 )
-from dagster_looker.api.resource import LookerResource
+
+if TYPE_CHECKING:
+    from dagster_looker.api.resource import LookerResource
 
 
 @beta
@@ -71,7 +73,7 @@ def build_looker_pdt_assets_definitions(
             required_resource_keys={resource_key},
         )
         def pdts(context: AssetExecutionContext):
-            looker = cast(LookerResource, getattr(context.resources, resource_key))
+            looker = cast("LookerResource", getattr(context.resources, resource_key))
 
             context.log.info(
                 f"Starting pdt build for Looker view `{request_start_pdt_build.view_name}` "

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/resource.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/resource.py
@@ -347,7 +347,7 @@ class LookerApiDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
             ]
             explores_by_id = dict(
                 cast(
-                    list[tuple[str, "LookmlModelExplore"]],
+                    "list[tuple[str, LookmlModelExplore]]",
                     (
                         entry
                         for entry in executor.map(

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
@@ -146,7 +146,7 @@ def build_deps_for_looker_view(
 
         upstream_sqlglot_tables = [
             source
-            for scope in cast(Iterator[Scope], root_scope.traverse() if root_scope else [])
+            for scope in cast("Iterator[Scope]", root_scope.traverse() if root_scope else [])
             for (_, source) in scope.selected_sources.values()
             if isinstance(source, exp.Table)
         ]

--- a/python_modules/libraries/dagster-looker/setup.py
+++ b/python_modules/libraries/dagster-looker/setup.py
@@ -22,8 +22,7 @@ setup(
     license="Apache-2.0",
     description="",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-looker"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-looker"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/client.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/client.py
@@ -37,7 +37,7 @@ class TeamsClient:
         if parsed_url.hostname is None:
             check.failed(f"No hostname found in webhook URL: {self._hook_url}")
 
-        return cast(str, parsed_url.hostname).endswith(".webhook.office.com")
+        return cast("str", parsed_url.hostname).endswith(".webhook.office.com")
 
     def post_message(self, payload: Mapping) -> bool:  # pragma: no cover
         response = post(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -142,7 +142,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if not row:
             return None
 
-        return cast(str, row[0])
+        return cast("str", row[0])
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         # last_materialization_timestamp is updated upon observation, materialization, materialization_planned

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -117,7 +117,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         if not row:
             return None
 
-        return cast(str, row[0])
+        return cast("str", row[0])
 
     @classmethod
     def from_config_value(  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -150,7 +150,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         if not row:
             return None
 
-        return cast(str, row[0])
+        return cast("str", row[0])
 
     def upgrade(self) -> None:
         with self.connect() as conn:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -36,7 +36,7 @@ class DagsterMySQLException(Exception):
 def get_conn(conn_string: str) -> MySQLConnectionUnion:
     parsed = urlparse(conn_string)
     conn = cast(
-        MySQLConnectionUnion,
+        "MySQLConnectionUnion",
         mysql.connect(
             user=parsed.username,
             passwd=parsed.password,
@@ -154,7 +154,7 @@ def wait_for_connection(conn_string: str, retry_limit: int = 5, retry_wait: floa
     parsed = urlparse(conn_string)
     retry_mysql_connection_fn(
         lambda: cast(
-            Union[mysql.MySQLConnection, PooledMySQLConnection],
+            "Union[mysql.MySQLConnection, PooledMySQLConnection]",
             mysql.connect(
                 user=parsed.username,
                 passwd=parsed.password,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/resources.py
@@ -145,7 +145,7 @@ class PagerDutyService(ConfigurableResource):
         if dedup_key is not None:
             data["dedup_key"] = dedup_key
 
-        payload: dict[str, object] = cast(dict[str, object], data["payload"])
+        payload: dict[str, object] = cast("dict[str, object]", data["payload"])
 
         if timestamp is not None:
             payload["timestamp"] = timestamp

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -286,9 +286,9 @@ def _pandera_check_to_column_constraint(pa_check: pa.Check) -> str:
     if pa_check.description:
         return pa_check.description
     elif pa_check.name in CHECK_OPERATORS:
-        assert isinstance(
-            pa_check.error, str
-        ), "Expected pandera check to have string `error` attr."
+        assert isinstance(pa_check.error, str), (
+            "Expected pandera check to have string `error` attr."
+        )
         return f"{CHECK_OPERATORS[pa_check.name]} {_extract_operand(pa_check.error)}"
     else:
         return _get_pandera_check_identifier(pa_check)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -228,7 +228,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         insert_event_statement = self.prepare_insert_event_batch(events)
         with self._connect() as conn:
             result = conn.execute(insert_event_statement.returning(SqlEventLogStorageTable.c.id))
-            event_ids = [cast(int, row[0]) for row in result.fetchall()]
+            event_ids = [cast("int", row[0]) for row in result.fetchall()]
 
         # We only update the asset table with the last event
         self.store_asset_event(events[-1], event_ids[-1])

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/assets.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/assets.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dagster import (
     _check as check,
@@ -9,8 +9,10 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 
-from dagster_powerbi.resource import PowerBIWorkspace
 from dagster_powerbi.translator import PowerBIMetadataSet, PowerBITagSet
+
+if TYPE_CHECKING:
+    from dagster_powerbi.resource import PowerBIWorkspace
 
 
 @beta
@@ -27,7 +29,7 @@ def build_semantic_model_refresh_asset_definition(
         required_resource_keys={resource_key},
     )
     def asset_fn(context: AssetExecutionContext) -> None:
-        power_bi = cast(PowerBIWorkspace, getattr(context.resources, resource_key))
+        power_bi = cast("PowerBIWorkspace", getattr(context.resources, resource_key))
         power_bi.trigger_and_poll_refresh(dataset_id)
 
     return asset_fn

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -379,7 +379,7 @@ class PowerBIWorkspace(ConfigurableResource):
         """
         from dagster_powerbi.assets import build_semantic_model_refresh_asset_definition
 
-        resource_key = f'power_bi_{self.workspace_id.replace("-", "_")}'
+        resource_key = f"power_bi_{self.workspace_id.replace('-', '_')}"
 
         return Definitions(
             assets=[

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -324,9 +324,9 @@ def test_state_derived_defs(
                 if key.path[0] == "semantic_model":
                     continue
                 assert len(deps) > 0, f"Expected upstreams for {key}"
-                assert all(
-                    dep in repository_def.assets_defs_by_key for dep in deps
-                ), f"Asset {key} depends on {deps} which are not in the repository"
+                assert all(dep in repository_def.assets_defs_by_key for dep in deps), (
+                    f"Asset {key} depends on {deps} which are not in the repository"
+                )
 
         job_def = repository_def.get_job("all_asset_job")
         repository_load_data = repository_def.repository_load_data

--- a/python_modules/libraries/dagster-powerbi/setup.py
+++ b/python_modules/libraries/dagster-powerbi/setup.py
@@ -22,8 +22,7 @@ setup(
     license="Apache-2.0",
     description="Build assets representing Power BI dashboards and reports.",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-powerbi"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-powerbi"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-shared/dagster_shared/merger.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/merger.py
@@ -16,7 +16,7 @@ def _deep_merge_dicts(
     check.mapping_param(from_dict, "from_dict")
     check.dict_param(onto_dict, "onto_dict")
 
-    _onto_dict = cast(dict[Union[K, K2], Union[V, V2, dict[object, object]]], onto_dict)
+    _onto_dict = cast("dict[Union[K, K2], Union[V, V2, dict[object, object]]]", onto_dict)
     for from_key, from_value in from_dict.items():
         if from_key not in onto_dict:
             _onto_dict[from_key] = from_value

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/serdes.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/serdes.py
@@ -441,7 +441,7 @@ def _whitelist_for_serdes(
                 skip_when_none_fields=skip_when_none_fields,
                 field_serializers=field_serializers,
             )
-            return klass
+            return klass  # type: ignore
         else:
             raise SerdesUsageError(f"Can not whitelist class {klass} for serializer {serializer}")
 
@@ -487,7 +487,7 @@ class UnpackContext:
             for v in obj.values():
                 self.assert_no_unknown_values(v)
 
-        return cast(PackableValue, obj)
+        return cast("PackableValue", obj)
 
     def observe_unknown_value(self, val: "UnknownSerdesValue") -> "UnknownSerdesValue":
         self.observed_unknown_serdes_values.add(val)
@@ -513,7 +513,7 @@ class UnpackContext:
                 f"{message}\nThis error can occur due to version skew, verify processes are"
                 " running expected versions."
             )
-        return cast(PackableValue, unpacked)
+        return cast("PackableValue", unpacked)
 
 
 class Serializer(ABC):
@@ -921,7 +921,7 @@ def _transform_for_serialization(
                 object_handler,
                 f"{descent_path}[{idx}]",
             )
-            for idx, item in enumerate(cast(list, val))
+            for idx, item in enumerate(cast("list", val))
         ]
     if tval is dict:
         return {
@@ -931,7 +931,7 @@ def _transform_for_serialization(
                 object_handler,
                 f"{descent_path}.{key}",
             )
-            for key, value in cast(dict, val).items()
+            for key, value in cast("dict", val).items()
         }
     if tval is SerializableNonScalarKeyMapping:
         return {
@@ -950,7 +950,7 @@ def _transform_for_serialization(
                         f"{descent_path}.{k}",
                     ),
                 ]
-                for k, v in cast(dict, val).items()
+                for k, v in cast("dict", val).items()
             ]
         }
 
@@ -975,7 +975,7 @@ def _transform_for_serialization(
                 f" {val}.\nDescent path: {descent_path}",
             )
         return object_handler(
-            cast(SerializableObject, val),
+            cast("SerializableObject", val),
             whitelist_map,
             descent_path,
         )
@@ -1220,7 +1220,7 @@ def _unpack_object(val: dict, whitelist_map: WhitelistMap, context: UnpackContex
         return deserializer.unpack(val, whitelist_map, context)
 
     if "__enum__" in val:
-        enum = cast(str, val["__enum__"])
+        enum = cast("str", val["__enum__"])
         name, member = enum.split(".")
         if name not in whitelist_map.enum_serializers:
             return context.observe_unknown_value(
@@ -1234,16 +1234,16 @@ def _unpack_object(val: dict, whitelist_map: WhitelistMap, context: UnpackContex
         return enum_serializer.unpack(member)
 
     if "__set__" in val:
-        items = cast(list[JsonSerializableValue], val["__set__"])
+        items = cast("list[JsonSerializableValue]", val["__set__"])
         return set(items)
 
     if "__frozenset__" in val:
-        items = cast(list[JsonSerializableValue], val["__frozenset__"])
+        items = cast("list[JsonSerializableValue]", val["__frozenset__"])
         return frozenset(items)
 
     if "__mapping_items__" in val:
         return {
-            cast(Any, _unpack_value(k, whitelist_map, context)): _unpack_value(
+            cast("Any", _unpack_value(k, whitelist_map, context)): _unpack_value(
                 v, whitelist_map, context
             )
             for k, v in val["__mapping_items__"]

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
@@ -114,7 +114,7 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
                 cache[key] = result
             return cache[key]
 
-        return cast(Callable[Concatenate[S, P], T], _async_cached_method_wrapper)
+        return cast("Callable[Concatenate[S, P], T]", _async_cached_method_wrapper)
 
     else:
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/hash.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/hash.py
@@ -25,9 +25,9 @@ def hash_collection(
                     self._hash = hash_named_tuple(self)
                 return self._hash
     """
-    assert isinstance(
-        collection, (list, dict, set, tuple)
-    ), f"Cannot hash collection of type {type(collection)}"
+    assert isinstance(collection, (list, dict, set, tuple)), (
+        f"Cannot hash collection of type {type(collection)}"
+    )
     return hash(make_hashable(collection))
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
@@ -213,7 +213,7 @@ def parse_yaml_with_source_positions(
                 dict_with_raw_values: dict[Any, Any] = {}
                 child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
                 for k, v in cast(
-                    Mapping[ValueAndSourcePositionTree, ValueAndSourcePositionTree], value
+                    "Mapping[ValueAndSourcePositionTree, ValueAndSourcePositionTree]", value
                 ).items():
                     dict_with_raw_values[k.value] = v.value
                     child_trees[k.value] = SourcePositionTree(
@@ -227,7 +227,7 @@ def parse_yaml_with_source_positions(
             if isinstance(value, list):
                 list_with_raw_values: list[Any] = []
                 child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
-                for i, v in enumerate(cast(Sequence[ValueAndSourcePositionTree], value)):
+                for i, v in enumerate(cast("Sequence[ValueAndSourcePositionTree]", value)):
                     list_with_raw_values.append(v.value)
                     child_trees[i] = v.source_position_tree
                 return ValueAndSourcePositionTree(

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/source_position.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/source_position.py
@@ -256,7 +256,7 @@ def populate_source_position_and_key_paths(
 
     for child_key_segment, child_tree in source_position_tree.children.items():
         try:
-            child_obj = cast(Any, obj)[child_key_segment]
+            child_obj = cast("Any", obj)[child_key_segment]
         except TypeError:
             if not isinstance(child_key_segment, str):
                 raise

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_libraries.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_libraries.py
@@ -45,9 +45,9 @@ def test_all_libraries_register() -> None:
         ):
             continue
         result = subprocess.run(["grep", register_call, (library_dir / library), "-r"], check=False)
-        assert (
-            result.returncode == 0
-        ), f"Dagster library {library} is missing call to {register_call}."
+        assert result.returncode == 0, (
+            f"Dagster library {library} is missing call to {register_call}."
+        )
 
 
 @pytest.fixture

--- a/python_modules/libraries/dagster-shared/setup.py
+++ b/python_modules/libraries/dagster-shared/setup.py
@@ -22,8 +22,7 @@ setup(
     license="Apache-2.0",
     description="Shared code between dagster and dagster-dg.",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-shared"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-shared"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/assets.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/assets.py
@@ -1,7 +1,10 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dagster import AssetExecutionContext, AssetsDefinition, AssetSpec, multi_asset
 from dagster._annotations import beta
+
+if TYPE_CHECKING:
+    from dagster_sigma import SigmaOrganization
 
 
 @beta
@@ -24,7 +27,6 @@ def build_materialize_workbook_assets_definition(
     Returns:
         AssetsDefinition: The AssetsDefinition which rebuilds a Sigma workbook.
     """
-    from dagster_sigma import SigmaOrganization
 
     @multi_asset(
         name=f"sigma_materialize_{spec.key.to_python_identifier()}",
@@ -32,7 +34,7 @@ def build_materialize_workbook_assets_definition(
         required_resource_keys={resource_key},
     )
     def asset_fn(context: AssetExecutionContext):
-        sigma = cast(SigmaOrganization, getattr(context.resources, resource_key))
+        sigma = cast("SigmaOrganization", getattr(context.resources, resource_key))
         yield from sigma.run_materializations_for_workbook(spec)
 
     return asset_fn

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -28,7 +28,7 @@ def asset_key_from_table_name(table_name: str) -> AssetKey:
 
 def _inode_from_url(url: str) -> str:
     """Builds a Sigma internal inode value from a Sigma URL."""
-    return f'inode-{url.split("/")[-1]}'
+    return f"inode-{url.split('/')[-1]}"
 
 
 class SigmaWorkbookMetadataSet(NamespacedMetadataSet):

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -22,8 +22,7 @@ setup(
     license="Apache-2.0",
     description="Build assets representing Sigma dashboards.",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-sigma"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-sigma"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -33,7 +33,7 @@ def _build_slack_blocks_and_text(
     else:
         text = (
             f'*Job "{context.dagster_run.job_name}" failed.'
-            f' `{context.dagster_run.run_id.split("-")[0]}`*'
+            f" `{context.dagster_run.run_id.split('-')[0]}`*"
         )
 
         blocks.extend(

--- a/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/sling_event_iterator.py
@@ -83,7 +83,7 @@ def fetch_row_count_metadata(
     if not materialization.metadata:
         raise Exception("Missing required metadata to retrieve stream_name")
 
-    stream_name = cast(str, materialization.metadata["stream_name"])
+    stream_name = cast("str", materialization.metadata["stream_name"])
     target_table_name = _get_target_table_name(stream_name, sling_cli)
 
     if target_table_name:
@@ -111,7 +111,7 @@ def fetch_column_metadata(
     if not materialization.metadata:
         raise Exception("Missing required metadata to retrieve stream_name")
 
-    stream_name = cast(str, materialization.metadata["stream_name"])
+    stream_name = cast("str", materialization.metadata["stream_name"])
 
     upstream_assets = set()
     if isinstance(context, AssetExecutionContext):

--- a/python_modules/libraries/dagster-sling/dagster_sling/sling_replication.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/sling_replication.py
@@ -16,7 +16,7 @@ def read_replication_path(replication_path: Path) -> Mapping[str, Any]:
     This function is cached to ensure that we don't read the same path multiple times, which
     creates multiple copies of the parsed manifest in memory.
     """
-    return cast(Mapping[str, Any], yaml.safe_load(replication_path.read_bytes()))
+    return cast("Mapping[str, Any]", yaml.safe_load(replication_path.read_bytes()))
 
 
 def validate_replication(replication: Optional[SlingReplicationParam]) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -503,7 +503,7 @@ def test_subset_with_run_config(
                 "my_sling_assets": {
                     "config": {
                         "context_streams": {
-                            f'file://{os.path.join(path_to_dataworks_folder, "Orders.csv")}': {
+                            f"file://{os.path.join(path_to_dataworks_folder, 'Orders.csv')}": {
                                 "object": "main.orders"
                             }
                         }

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -262,10 +262,11 @@ def test_asset_attributes_is_comprehensive():
         all_asset_attribute_keys.extend(test_arg[0].keys())
     from dagster.components.resolved.core_models import AssetAttributesModel
 
-    assert (
-        set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS
-        == set(all_asset_attribute_keys)
-    ), f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
+    assert set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS == set(
+        all_asset_attribute_keys
+    ), (
+        f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
+    )
 
 
 def test_scaffold_sling():

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 
 import pandas
@@ -32,7 +32,6 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager
@@ -47,6 +46,9 @@ from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
     _convert_timestamp_to_string,
 )
 from pandas import DataFrame, Timestamp
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.metadata.metadata_value import IntMetadataValue
 
 resource_config = {
     "database": "database_abc",
@@ -366,7 +368,7 @@ def test_time_window_partitioned_asset(io_manager):
             if event.event_type_value == "ASSET_MATERIALIZATION"
         )
         meta = materialization.materialization.metadata["dagster/partition_row_count"]
-        assert cast(IntMetadataValue, meta).value == 3
+        assert cast("IntMetadataValue", meta).value == 3
 
         with snowflake_conn.get_connection() as conn:
             out_df = (

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -421,7 +421,7 @@ def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensi
 
 
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
-    partition = cast(TimeWindow, table_partition.partitions)
+    partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/assets.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/assets.py
@@ -1,10 +1,11 @@
 from collections.abc import Sequence
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from dagster import AssetExecutionContext, AssetsDefinition, AssetSpec, multi_asset
 from dagster._annotations import beta
 
-from dagster_tableau.resources import BaseTableauWorkspace
+if TYPE_CHECKING:
+    from dagster_tableau.resources import BaseTableauWorkspace
 
 
 @beta
@@ -41,7 +42,7 @@ def build_tableau_materializable_assets_definition(
         required_resource_keys={resource_key},
     )
     def asset_fn(context: AssetExecutionContext):
-        tableau = cast(BaseTableauWorkspace, getattr(context.resources, resource_key))
+        tableau = cast("BaseTableauWorkspace", getattr(context.resources, resource_key))
         with tableau.get_client() as client:
             yield from client.refresh_and_materialize_workbooks(
                 specs=specs, refreshable_workbook_ids=refreshable_workbook_ids

--- a/python_modules/libraries/dagster-tableau/setup.py
+++ b/python_modules/libraries/dagster-tableau/setup.py
@@ -22,8 +22,7 @@ setup(
     license="Apache-2.0",
     description="Build assets representing Tableau workbooks and sheets.",
     url=(
-        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/"
-        "dagster-tableau"
+        "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-tableau"
     ),
     classifiers=[
         "Programming Language :: Python :: 3.9",

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -392,7 +392,7 @@ class ArtifactsIOManager(IOManager):
                     artifact_name = context.asset_key.path[0]  # name of asset
 
                 partitions = [
-                    (key, f"{artifact_name}.{ str(key).replace('|', '-')}")
+                    (key, f"{artifact_name}.{str(key).replace('|', '-')}")
                     for key in context.asset_partition_keys
                 ]
 

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -198,7 +198,7 @@ def define_dagstermill_asset(
     }
 
     if safe_is_subclass(config_schema, Config):
-        config_schema = infer_schema_from_config_class(cast(type[Config], config_schema))
+        config_schema = infer_schema_from_config_class(cast("type[Config]", config_schema))
 
     return asset(
         name=name,

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -123,7 +123,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
     @property
     def run(self) -> DagsterRun:
         """:class:`dagster.DagsterRun`: The job run for the context."""
-        return cast(DagsterRun, self._job_context.dagster_run)
+        return cast("DagsterRun", self._job_context.dagster_run)
 
     @property
     def log(self) -> DagsterLogManager:
@@ -141,7 +141,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         In interactive contexts, this may be a dagstermill-specific shim, depending whether an
         op definition was passed to ``dagstermill.get_context``.
         """
-        return cast(OpDefinition, self._job_def.node_def_named(self.op_name))
+        return cast("OpDefinition", self._job_def.node_def_named(self.op_name))
 
     @property
     def node(self) -> Node:

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -408,7 +408,7 @@ def define_dagstermill_op(
         required_resource_keys.add(io_mgr_key)
         outs = {
             **outs,
-            cast(str, output_notebook_name): Out(io_manager_key=io_mgr_key),
+            cast("str", output_notebook_name): Out(io_manager_key=io_mgr_key),
         }
 
     if isinstance(asset_key_prefix, str):
@@ -437,7 +437,7 @@ def define_dagstermill_op(
     }
 
     if safe_is_subclass(config_schema, Config):
-        config_schema = infer_schema_from_config_class(cast(type[Config], config_schema))
+        config_schema = infer_schema_from_config_class(cast("type[Config]", config_schema))
 
     return OpDefinition(
         name=name,

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -30,7 +30,6 @@ from dagster._core.execution.api import create_execution_plan, scoped_job_contex
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.state import KnownExecutionState
-from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.resources_init import (
     get_required_resource_keys_to_init,
     resource_initialization_event_generator,
@@ -51,6 +50,7 @@ from dagstermill.serialize import PICKLE_PROTOCOL
 
 if TYPE_CHECKING:
     from dagster._core.definitions.node_definition import NodeDefinition
+    from dagster._core.execution.plan.step import ExecutionStep
 
 
 class DagstermillResourceEventGenerationManager(EventGenerationManager):
@@ -196,9 +196,9 @@ class Manager:
                 op_name=op.name,
                 node_handle=node_handle,
                 step_context=cast(
-                    StepExecutionContext,
+                    "StepExecutionContext",
                     job_context.for_step(
-                        cast(ExecutionStep, execution_plan.get_step_by_key(step_key)),
+                        cast("ExecutionStep", execution_plan.get_step_by_key(step_key)),
                         known_state=known_state,
                     ),
                 ),

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -1,10 +1,9 @@
 import os
 from contextlib import contextmanager
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from dagster import AssetKey, DagsterEventType
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.metadata import NotebookMetadataValue, PathMetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.execution.api import execute_job
@@ -12,6 +11,9 @@ from dagster._core.execution.execution_result import ExecutionResult
 from dagster._core.test_utils import instance_for_test
 from dagstermill.compat import ExecutionError
 from dagstermill.examples.repository import custom_io_mgr_key_asset
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
 
 
 def get_path(materialization_event):
@@ -113,8 +115,8 @@ def test_hello_world_resource_asset():
 
 @pytest.mark.notebook_test
 def test_asset_tags() -> None:
-    key = cast(AssetsDefinition, custom_io_mgr_key_asset).key
-    assert cast(AssetsDefinition, custom_io_mgr_key_asset).tags_by_key[key] == {"foo": "bar"}
+    key = cast("AssetsDefinition", custom_io_mgr_key_asset).key
+    assert cast("AssetsDefinition", custom_io_mgr_key_asset).tags_by_key[key] == {"foo": "bar"}
 
 
 @pytest.mark.notebook_test

--- a/scripts/gen_airbyte_classes.py
+++ b/scripts/gen_airbyte_classes.py
@@ -386,7 +386,7 @@ def create_connector_class_definition(
             if field_type.const_value is not None
         ]
         + [
-            f"        self.{field_name} = {field_type.get_check(field_name, scope = cls_name)}"
+            f"        self.{field_name} = {field_type.get_check(field_name, scope=cls_name)}"
             for field_name, field_type in cls_def.items()
             if field_type.const_value is None
         ]

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -146,7 +146,7 @@ def main(
     cmd += ["--config-settings", "editable-mode=compat"]
 
     if quiet is not None:
-        cmd.append(f'-{"q" * quiet}')
+        cmd.append(f"-{'q' * quiet}")
 
     print(" ".join(cmd))
     subprocess.run(cmd, check=True)

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -446,7 +446,7 @@ def run_pyright(
             raise Exception(f"Pyright output was not valid JSON. Output was:\n\n{output}")
     return {
         "returncode": result.returncode,
-        "output": cast(PyrightOutput, json_result),
+        "output": cast("PyrightOutput", json_result),
     }
 
 
@@ -483,7 +483,7 @@ def merge_pyright_results(result_1: RunResult, result_2: RunResult) -> RunResult
         "output": {
             "time": output_1["time"],
             "version": output_1["version"],
-            "summary": cast(Summary, summary),
+            "summary": cast("Summary", summary),
             "generalDiagnostics": diagnostics,
         },
     }
@@ -535,7 +535,7 @@ def get_hints(output: PyrightOutput) -> Sequence[str]:
     dagster_pyright_version = get_dagster_pyright_version()
     if dagster_pyright_version != output["version"]:
         hints.append(
-            f'Your local version of pyright is {output["version"]}, which does not match Dagster\'s'
+            f"Your local version of pyright is {output['version']}, which does not match Dagster's"
             f" pinned version of {dagster_pyright_version}. Please run `make install_pyright` to"
             " install the correct version."
         )


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/14414

Update `ruff` from version 0.8.4 to 0.11.0.

This encompasses a few major version changes, so there were changes that hit a lot of files. The vast majority of changes are:

- formatter
    - f-string quoting
    - assert statements
    - certain type annotations
- `cast` now quotes type args by default

## How I Tested These Changes

Existing test suite.