### PR TITLE
[dg] Add `dg plus login` CLI flow

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -39,7 +39,6 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │            workspace.                                                                  │
 │ launch     Launch a Dagster run.                                                       │
 │ list       Commands for listing Dagster entities.                                      │
-│ plus       Commands for interacting with Dagster Plus.                                 │
 │ scaffold   Commands for scaffolding Dagster code.                                      │
 │ utils      Assorted utility commands.                                                  │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/1-help.txt
@@ -39,6 +39,7 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │            workspace.                                                                  │
 │ launch     Launch a Dagster run.                                                       │
 │ list       Commands for listing Dagster entities.                                      │
+│ plus       Commands for interacting with Dagster Plus.                                 │
 │ scaffold   Commands for scaffolding Dagster code.                                      │
 │ utils      Assorted utility commands.                                                  │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -9,6 +9,7 @@ from dagster_dg.cli.docs import docs_group
 from dagster_dg.cli.init import init_command
 from dagster_dg.cli.launch import launch_command
 from dagster_dg.cli.list import list_group
+from dagster_dg.cli.plus import plus_group
 from dagster_dg.cli.scaffold import scaffold_group
 from dagster_dg.cli.shared_options import dg_global_options
 from dagster_dg.cli.utils import utils_group
@@ -33,6 +34,7 @@ def create_dg_cli():
             "scaffold": scaffold_group,
             "dev": dev_command,
             "init": init_command,
+            "plus": plus_group,
         },
         context_settings={
             "max_content_width": DG_CLI_MAX_OUTPUT_WIDTH,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -1,0 +1,35 @@
+import webbrowser
+
+import click
+from dagster_shared.plus.config import DagsterPlusCliConfig, get_active_config_path
+from dagster_shared.plus.login_server import start_login_server
+
+from dagster_dg.utils import DgClickCommand, DgClickGroup
+
+
+@click.group(name="plus", cls=DgClickGroup)
+def plus_group():
+    """Commands for interacting with Dagster Plus."""
+
+
+@plus_group.command(name="login", cls=DgClickCommand)
+def login_command() -> None:
+    """Login to Dagster Plus."""
+    server, url = start_login_server()
+
+    try:
+        webbrowser.open(url, new=0, autoraise=True)
+        click.echo(
+            f"Opening browser...\nIf a window does not open automatically, visit {url} to"
+            " finish authorization"
+        )
+    except webbrowser.Error as e:
+        click.echo(f"Error launching web browser: {e}\n\nTo finish authorization, visit {url}\n")
+
+    server.serve_forever()
+    new_org = server.get_organization()
+    new_api_token = server.get_token()
+
+    config = DagsterPlusCliConfig(organization=new_org, user_token=new_api_token)
+    config.write_to_file(get_active_config_path())
+    click.echo(f"Authorized for organization {new_org}\n")

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -7,7 +7,7 @@ from dagster_shared.plus.login_server import start_login_server
 from dagster_dg.utils import DgClickCommand, DgClickGroup
 
 
-@click.group(name="plus", cls=DgClickGroup)
+@click.group(name="plus", cls=DgClickGroup, hidden=True)
 def plus_group():
     """Commands for interacting with Dagster Plus."""
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
@@ -1,0 +1,62 @@
+import json
+import os
+import queue
+import tempfile
+import threading
+import time
+from unittest import mock
+
+import pytest
+import requests
+from click.testing import CliRunner
+from dagster_dg.cli.plus import plus_group
+from dagster_shared.plus.config import DagsterPlusCliConfig, get_active_config_path
+
+
+@pytest.fixture()
+def test_config_file(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config")
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", config_path)
+        yield config_path
+
+
+# Test setup command, using the web auth option
+def test_setup_command_web(test_config_file):
+    runner = CliRunner()
+    with (
+        mock.patch(
+            "dagster_shared.utils.find_free_port",
+            mock.Mock(return_value=4000),
+        ),
+        mock.patch(
+            "dagster_shared.plus.login_server._generate_nonce",
+            mock.Mock(return_value="ABCDEFGH"),
+        ),
+        mock.patch("dagster_dg.cli.plus.webbrowser.open", mock.Mock(return_value=True)),
+    ):
+        # Send configuration response to CLI endpoint, HTTP response passed back in queue
+        q = queue.Queue()
+
+        def respond_with_callback():
+            time.sleep(0.25)
+            response = requests.post(
+                "http://localhost:4000/callback",
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"nonce": "ABCDEFGH", "organization": "hooli", "token": "abc123"}),
+            )
+            q.put(response)
+
+        th = threading.Thread(target=respond_with_callback)
+        th.start()
+
+        result = runner.invoke(plus_group, ["login"])
+        th.join()
+
+        assert result.exit_code == 0, result.output + " : " + str(result.exception)
+
+        assert q.get().json().get("ok") is True, "JSON response from callback not as expected"
+
+        # Verify new configuration success
+        assert DagsterPlusCliConfig.from_file(get_active_config_path()).organization == "hooli"
+        assert DagsterPlusCliConfig.from_file(get_active_config_path()).user_token == "abc123"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -40,6 +40,7 @@ NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "asset"), "foo"),
     CommandSpec(("scaffold", "schedule"), "foo"),
     CommandSpec(("scaffold", "sensor"), "foo"),
+    CommandSpec(("plus", "login")),
 ]
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
@@ -1,0 +1,43 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+DEFAULT_CLOUD_CLI_FOLDER = os.path.join(os.path.expanduser("~"), ".dagster_cloud_cli")
+DEFAULT_CLOUD_CLI_CONFIG = os.path.join(DEFAULT_CLOUD_CLI_FOLDER, "config")
+
+DEFAULT_DG_CLI_FOLDER = os.path.join(os.path.expanduser("~"), ".dg")
+DEFAULT_DG_CLI_CONFIG = os.path.join(DEFAULT_DG_CLI_FOLDER, "config")
+
+
+@dataclass
+class DagsterPlusCliConfig:
+    organization: Optional[str] = None
+    default_deployment: Optional[str] = None
+    user_token: Optional[str] = None
+    agent_timeout: Optional[int] = None
+
+    @classmethod
+    def from_file(cls, config_file: Path) -> "DagsterPlusCliConfig":
+        contents = config_file.read_text()
+        return cls(**yaml.safe_load(contents))
+
+    def write_to_file(self, config_file: Path):
+        config_file.write_text(yaml.dump({k: v for k, v in self.__dict__.items() if v is not None}))
+
+
+def get_active_config_path() -> Path:
+    cloud_config_path = get_dagster_cloud_cli_config_path()
+    if cloud_config_path.exists():
+        return cloud_config_path
+    return get_dg_config_path()
+
+
+def get_dg_config_path() -> Path:
+    return Path(os.getenv("DG_CLI_CONFIG", DEFAULT_DG_CLI_CONFIG))
+
+
+def get_dagster_cloud_cli_config_path() -> Path:
+    return Path(os.getenv("DAGSTER_CLOUD_CLI_CONFIG", DEFAULT_CLOUD_CLI_CONFIG))

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
@@ -25,6 +25,7 @@ class DagsterPlusCliConfig:
         return cls(**yaml.safe_load(contents))
 
     def write_to_file(self, config_file: Path):
+        config_file.parent.mkdir(parents=True, exist_ok=True)
         config_file.write_text(yaml.dump({k: v for k, v in self.__dict__.items() if v is not None}))
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
@@ -31,9 +31,16 @@ class DagsterPlusCliConfig:
 
 def get_active_config_path() -> Path:
     cloud_config_path = get_dagster_cloud_cli_config_path()
-    if cloud_config_path.exists():
+    dg_config_path = get_dg_config_path()
+
+    if cloud_config_path.exists() and dg_config_path.exists():
+        raise Exception(
+            f"Found Dagster Plus config in both {cloud_config_path} and {dg_config_path}. Please consolidate your config files."
+        )
+    elif cloud_config_path.exists():
         return cloud_config_path
-    return get_dg_config_path()
+
+    return dg_config_path
 
 
 def get_dg_config_path() -> Path:

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/login_server.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/login_server.py
@@ -1,0 +1,111 @@
+import json
+import random
+import string
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional
+from urllib import parse
+
+
+def create_token_callback_handler(nonce: str) -> type[BaseHTTPRequestHandler]:
+    class TokenCallbackHandler(BaseHTTPRequestHandler):
+        def _send_shared_headers(self):
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "POST,OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+        def _error(self, code, message=None):
+            self.send_error(code, message)
+            self._send_shared_headers()
+            self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(200)
+            self._send_shared_headers()
+            self.end_headers()
+
+        def do_POST(self):
+            url = parse.urlparse(self.path)
+
+            if url.path != "/callback":
+                self._error(404, "Page not found")
+                return
+
+            content = self.rfile.read(int(self.headers["Content-Length"]))
+            body = json.loads(content)
+
+            if not body.get("nonce") or body.get("nonce") != nonce:
+                self._error(400, "Invalid nonce")
+                return
+            if not body.get("token"):
+                self._error(400, "No user token provided")
+                return
+            if not body.get("organization"):
+                self._error(400, "No organization provided")
+                return
+
+            organization = body.get("organization")
+            token = body.get("token")
+
+            self.send_response(200)
+            self._send_shared_headers()
+            response = b'{ "ok": true }'
+            self.send_header("Content-length", str(len(response)))
+            self.end_headers()
+
+            self.wfile.write(response)
+
+            # Pass back result values
+            assert isinstance(self.server, TokenServer)
+            self.server.set_result(organization=organization, token=token)
+            self.server.shutdown()
+
+        # Overridden so that the webserver doesn't log requests to the console
+
+        def log_request(self, code="-", size="-"):
+            return
+
+    return TokenCallbackHandler
+
+
+class TokenServer(HTTPServer):
+    organization: Optional[str] = None
+    token: Optional[str] = None
+
+    def __init__(self, host: tuple[str, int], nonce: str):
+        super().__init__(host, create_token_callback_handler(nonce))
+
+    def shutdown(self):
+        # Stop serving the token server
+        # https://stackoverflow.com/a/36017741
+        setattr(self, "_BaseServer__shutdown_request", True)
+
+    def set_result(self, organization: str, token: str):
+        self.organization = organization
+        self.token = token
+
+    def get_organization(self) -> Optional[str]:
+        return self.organization
+
+    def get_token(self) -> Optional[str]:
+        return self.token
+
+
+def _generate_nonce():
+    return "".join(
+        random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(8)
+    )
+
+
+def start_login_server() -> tuple[TokenServer, str]:
+    """Starts a login server on a free port and returns
+    the server and the URL to open in the browser.
+    """
+    from dagster_shared.utils import find_free_port
+
+    port = find_free_port()
+    nonce = _generate_nonce()
+    escaped = parse.quote(f"/cli-auth/{nonce}?port={port}")
+    auth_url = f"https://dagster.cloud?next={escaped}"
+
+    server = TokenServer(("localhost", port), nonce)
+    return server, auth_url

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
@@ -1,8 +1,6 @@
 import contextlib
 import socket
 
-from dagster._utils.internal_init import IHasInternalInit as IHasInternalInit
-
 
 def find_free_port() -> int:
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
@@ -1,0 +1,11 @@
+import contextlib
+import socket
+
+from dagster._utils.internal_init import IHasInternalInit as IHasInternalInit
+
+
+def find_free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]


### PR DESCRIPTION
## Summary

Moves the Plus CLI auth flow to dagster-shared, impls in the `dg` CLI as `dg plus login`.

A corresponding internal PR will cut over to using the shared impl for the `dagster-cloud` CLI.

## Test Plan

Unit test.
