### PR TITLE
Env var to skip certain AMP keys

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -2,6 +2,7 @@ import base64
 import dataclasses
 import datetime
 import logging
+import os
 import sys
 import threading
 import zlib
@@ -81,6 +82,7 @@ _PRE_SENSOR_ASSET_DAEMON_PAUSED_KEY = "ASSET_DAEMON_PAUSED"
 _MIGRATED_CURSOR_TO_SENSORS_KEY = "MIGRATED_CURSOR_TO_SENSORS"
 _MIGRATED_SENSOR_NAMES_KEY = "MIGRATED_SENSOR_NAMES_KEY"
 
+SKIP_DECLARATIVE_AUTOMATION_KEYS_ENV_VAR = "DAGSTER_SKIP_DECLARATIVE_AUTOMATION_KEYS"
 
 EVALUATIONS_TTL_DAYS = 30
 
@@ -964,6 +966,15 @@ class AssetDaemon(DagsterDaemon):
                 evaluations_by_key = {}
         else:
             sensor_tags = {SENSOR_NAME_TAG: sensor.name, **sensor.run_tags} if sensor else {}
+
+            skip_key_env_var = os.getenv(SKIP_DECLARATIVE_AUTOMATION_KEYS_ENV_VAR)
+            if skip_key_env_var:
+                skip_keys = skip_key_env_var.split(",")
+
+                skip_keys = {AssetKey.from_user_string(key) for key in skip_keys}
+                auto_materialize_entity_keys = {
+                    key for key in auto_materialize_entity_keys if key not in skip_keys
+                }
 
             # mold this into a shape AutomationTickEvaluationContext expects
             asset_selection = AssetSelection.keys(

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 from dagster import (
+    AssetKey,
     AssetSpec,
     AutoMaterializeRule,
     AutomationCondition,
@@ -35,12 +36,14 @@ from dagster._core.storage.tags import (
     SENSOR_NAME_TAG,
     TICK_ID_TAG,
 )
+from dagster._core.test_utils import environ
 from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._daemon.asset_daemon import (
     _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY,
     _PRE_SENSOR_AUTO_MATERIALIZE_INSTIGATOR_NAME,
     _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
     _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,
+    SKIP_DECLARATIVE_AUTOMATION_KEYS_ENV_VAR,
     asset_daemon_cursor_from_instigator_serialized_cursor,
     get_has_migrated_sensor_names,
     get_has_migrated_to_sensors,
@@ -382,6 +385,58 @@ def test_daemon_paused() -> None:
         assert ticks[-1].timestamp == state.current_time.timestamp()
         assert ticks[-1].tick_data.end_timestamp == state.current_time.timestamp()
         assert ticks[-1].automation_condition_evaluation_id == 2
+
+
+def test_daemon_skip_env_var() -> None:
+    with get_daemon_instance(
+        paused=True, extra_overrides={"auto_materialize": {"use_sensors": False}}
+    ) as instance:
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 0
+
+        set_auto_materialize_paused(instance, False)
+
+        with environ(
+            {
+                SKIP_DECLARATIVE_AUTOMATION_KEYS_ENV_VAR: f"{AssetKey(['A']).to_user_string()},{AssetKey(['B']).to_user_string()}"
+            }
+        ):
+            state = daemon_scenario.evaluate_daemon(instance)
+
+        ticks = _get_asset_daemon_ticks(instance)
+
+        assert len(ticks) == 1
+        assert ticks[0]
+        assert ticks[0].status == TickStatus.SKIPPED
+        assert ticks[0].timestamp == state.current_time.timestamp()
+        assert ticks[0].tick_data.end_timestamp == state.current_time.timestamp()
+
+        runs = instance.get_runs()
+
+        # No materializations for either asset due to the env var
+
+        assert len(runs) == 0
+
+        with environ(
+            {SKIP_DECLARATIVE_AUTOMATION_KEYS_ENV_VAR: f"{AssetKey(['B']).to_user_string()}"}
+        ):
+            state = daemon_scenario.evaluate_daemon(instance)
+
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 2
+
+        assert ticks[-1].status == TickStatus.SUCCESS
+        assert ticks[-1].timestamp == state.current_time.timestamp()
+        assert ticks[-1].tick_data.end_timestamp == state.current_time.timestamp()
+
+        runs = instance.get_runs()
+
+        assert len(runs) == 2
+
+        assert len(instance.fetch_materializations(AssetKey(["A"]), limit=1000).records) == 2
+
+        # No materializations for B due to the env var
+        assert len(instance.fetch_materializations(AssetKey(["B"]), limit=1000).records) == 0
 
 
 three_assets = ScenarioSpec(asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")])


### PR DESCRIPTION
## Summary & Motivation
Can be used by operators to temporarily disable AMP evaluation for a particular asset key without code changes being required.

## How I Tested These Changes
New test case
