### PR TITLE
[dg] Introduce telemetry wrapper

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -14,6 +14,7 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.utils import DgClickCommand, DgClickGroup, pushd
 from dagster_dg.utils.filesystem import watch_paths
+from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 
 @click.group(name="check", cls=DgClickGroup)
@@ -32,6 +33,7 @@ def check_group():
     "--watch", is_flag=True, help="Watch for changes to the component files and re-validate them."
 )
 @dg_global_options
+@cli_telemetry_wrapper
 def check_yaml_command(
     paths: Sequence[str],
     watch: bool,
@@ -88,6 +90,7 @@ def check_yaml_command(
 )
 @dg_global_options
 @click.pass_context
+@cli_telemetry_wrapper
 def check_definitions_command(
     context: click.Context,
     log_level: str,

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -180,6 +180,7 @@ class DgCliConfig:
     use_component_modules: list[str] = field(default_factory=list)
     use_dg_managed_environment: bool = True
     require_local_venv: bool = True
+    telemetry_enabled: bool = True
 
     @classmethod
     def default(cls) -> Self:
@@ -200,7 +201,14 @@ class DgCliConfig:
                 "use_dg_managed_environment", DgCliConfig.use_dg_managed_environment
             ),
             require_local_venv=merged.get("require_local_venv", DgCliConfig.require_local_venv),
+            telemetry_enabled=merged.get("telemetry", {}).get(
+                "enabled", DgCliConfig.telemetry_enabled
+            ),
         )
+
+
+class RawDgTelemetryConfig(TypedDict, total=False):
+    enabled: bool
 
 
 # All fields are optional
@@ -211,6 +219,7 @@ class DgRawCliConfig(TypedDict, total=False):
     use_component_modules: Sequence[str]
     use_dg_managed_environment: bool
     require_local_venv: bool
+    telemetry: RawDgTelemetryConfig
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -9,6 +9,7 @@ from typing import Final, Optional, Union
 
 import tomlkit
 import tomlkit.items
+from dagster_shared.utils.config import does_dg_config_file_exist
 from typing_extensions import Self
 
 from dagster_dg.cache import CachableDataType, DgCache
@@ -19,6 +20,7 @@ from dagster_dg.config import (
     DgWorkspaceProjectSpec,
     discover_config_file,
     load_dg_root_file_config,
+    load_dg_user_file_config,
     load_dg_workspace_file_config,
 )
 from dagster_dg.error import DgError
@@ -173,10 +175,12 @@ class DgContext:
             root_file_config = None
             container_workspace_file_config = None
 
+        user_config = load_dg_user_file_config() if does_dg_config_file_exist() else None
         config = DgConfig.from_partial_configs(
             root_file_config=root_file_config,
             container_workspace_file_config=container_workspace_file_config,
             command_line_config=command_line_config,
+            user_config=user_config,
         )
 
         return cls(

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/telemetry.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/telemetry.py
@@ -1,0 +1,129 @@
+import datetime
+import sys
+from collections.abc import Mapping
+from functools import wraps
+from typing import Any, Callable, Optional, TypeVar, Union, overload
+
+import click
+from dagster_shared.telemetry import (
+    TelemetrySettings,
+    get_or_set_instance_id,
+    get_telemetry_enabled_from_dagster_yaml,
+    log_telemetry_action as shared_log_telemetry_action,
+)
+from dagster_shared.utils.config import does_dg_config_file_exist
+from typing_extensions import ParamSpec
+
+from dagster_dg.config import DgCliConfig, load_dg_user_file_config
+from dagster_dg.version import __version__
+
+
+def get_telemetry_enabled_for_cli() -> bool:
+    """Returns whether telemetry is enabled in the CLI, e.g.
+    if it is disabled through the telemetry.enabled setting in
+    the config file.
+    """
+    user_config = load_dg_user_file_config() if does_dg_config_file_exist() else None
+    if not user_config:
+        return True
+    config = DgCliConfig.from_raw(user_config)
+    if not config.telemetry_enabled:
+        return False
+    return True
+
+
+def get_telemetry_settings_for_cli() -> TelemetrySettings:
+    return TelemetrySettings(
+        dagster_telemetry_enabled=get_telemetry_enabled_for_cli()
+        and get_telemetry_enabled_from_dagster_yaml(),
+        instance_id=get_or_set_instance_id(),
+        run_storage_id=None,
+    )
+
+
+def log_telemetry_action(
+    action: str,
+    client_time: Optional[datetime.datetime] = None,
+    elapsed_time: Optional[datetime.timedelta] = None,
+    metadata: Optional[Mapping[str, str]] = None,
+) -> None:
+    return shared_log_telemetry_action(
+        lambda: get_telemetry_settings_for_cli(),
+        action,
+        client_time,
+        elapsed_time,
+        {"dagster_dg_version": __version__, **(metadata or {})},
+    )
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
+
+
+@overload
+def cli_telemetry_wrapper(target_fn: T_Callable) -> T_Callable: ...
+
+
+@overload
+def cli_telemetry_wrapper(
+    *,
+    metadata: Optional[Mapping[str, str]],
+) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
+
+
+def cli_telemetry_wrapper(
+    target_fn: Optional[T_Callable] = None, *, metadata: Optional[Mapping[str, str]] = None
+) -> Union[T_Callable, Callable[[Callable[P, T]], Callable[P, T]]]:
+    """Wrapper around functions that are logged. Will log the function_name, client_time, and
+    elapsed_time, and success.
+    """
+    if target_fn is not None:
+        return _cli_telemetry_wrapper(target_fn)
+
+    def _wraps(f: Callable[P, T]) -> Callable[P, T]:
+        return _cli_telemetry_wrapper(f, metadata)
+
+    return _wraps
+
+
+def _cli_telemetry_wrapper(
+    f: Callable[P, T], metadata: Optional[Mapping[str, str]] = None
+) -> Callable[P, T]:
+    if isinstance(f, click.Command):
+        raise Exception(
+            "@dg_telemetry_wrapper should be placed on the command function, below the @click.command decorator"
+        )
+
+    @wraps(f)
+    def wrap(*args: P.args, **kwargs: P.kwargs) -> T:
+        start_time = datetime.datetime.now()
+        log_telemetry_action(
+            action=f.__name__ + "_started",
+            client_time=start_time,
+            metadata=metadata,
+        )
+        exception_name = None
+        try:
+            result = f(*args, **kwargs)
+        except Exception as e:
+            if not isinstance(e, click.exceptions.Exit) or e.exit_code != 0:
+                exception_name, _, _ = sys.exc_info()
+            raise
+        finally:
+            end_time = datetime.datetime.now()
+
+            log_telemetry_action(
+                action=f.__name__ + "_ended",
+                client_time=end_time,
+                elapsed_time=end_time - start_time,
+                metadata={
+                    "command_success": str(exception_name is None),
+                    "exception": str(exception_name),
+                    **(metadata or {}),
+                },
+            )
+        return result
+
+    setattr(wrap, "__has_cli_telemetry_wrapper", True)
+    return wrap

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from dagster_components.test.test_cases import BASIC_INVALID_VALUE, BASIC_VALID_VALUE
+from dagster_dg.utils import ensure_dagster_dg_tests_import, pushd
+
+ensure_dagster_dg_tests_import()
+
+import json
+import os
+
+from dagster_shared.telemetry import get_or_create_dir_from_dagster_home
+
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    crawl_cli_commands,
+    create_project_from_components,
+    modify_environment_variable,
+)
+
+TELEMETRY_TEST_COMMANDS = {
+    ("check", "yaml"),
+    ("check", "defs"),
+}
+
+# Temporary, eventually we will have explicit list of all commands that should and should not be logged
+NO_TELEMETRY_COMMANDS = {
+    tuple(key[1:]) for key in crawl_cli_commands().keys()
+} - TELEMETRY_TEST_COMMANDS
+
+
+def test_all_commands_represented_in_telemetry_test() -> None:
+    commands = crawl_cli_commands()
+
+    all_listed_commands = [*TELEMETRY_TEST_COMMANDS, *NO_TELEMETRY_COMMANDS]
+    crawled_commands = [tuple(key[1:]) for key in commands.keys() if len(key) > 1]
+    unlisted_commands = set(crawled_commands) - set(all_listed_commands)
+    commands_which_do_not_exist = set(all_listed_commands) - set(crawled_commands)
+    assert not unlisted_commands, f"Unlisted commands have no telemetry tests: {unlisted_commands}"
+    assert (
+        not commands_which_do_not_exist
+    ), f"Commands which do not exist have telemetry tests: {commands_which_do_not_exist}"
+
+
+def test_telemetry_commands_properly_wrapped():
+    commands = crawl_cli_commands()
+    for command in TELEMETRY_TEST_COMMANDS:
+        command_defn = commands[("dg", *command)]
+
+        fn = command_defn.callback
+        while hasattr(fn, "__wrapped__"):
+            if getattr(fn, "__has_cli_telemetry_wrapper", None) is True:
+                break
+            fn = getattr(fn, "__wrapped__")
+
+        assert (
+            hasattr(fn, "__has_cli_telemetry_wrapper") is True
+        ), f"Command {command} is not properly wrapped"
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_basic_logging_success_failure(caplog: pytest.LogCaptureFixture, success: bool) -> None:
+    test_case = BASIC_VALID_VALUE if success else BASIC_INVALID_VALUE
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            test_case.component_path,
+            local_component_defn_to_inject=test_case.component_type_filepath,
+        ) as tmpdir,
+        TemporaryDirectory() as dagster_home,
+        modify_environment_variable("DAGSTER_HOME", dagster_home),
+    ):
+        with pushd(tmpdir):
+            result = runner.invoke("check", "yaml")
+            assert result.exit_code == 0 if success else 1
+
+        assert os.path.exists(
+            os.path.join(get_or_create_dir_from_dagster_home("logs"), "event.log")
+        )
+        assert len(caplog.records) == 2
+
+        first_message = json.loads(caplog.records[0].getMessage())
+        second_message = json.loads(caplog.records[1].getMessage())
+
+        assert first_message["action"] == "check_yaml_command_started"
+        assert second_message["action"] == "check_yaml_command_ended"
+        assert (
+            second_message["metadata"]["command_success"] == "True" if success else "False"
+        ), second_message["metadata"]
+
+
+def test_telemetry_disabled_dagster_yaml(caplog: pytest.LogCaptureFixture) -> None:
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            BASIC_VALID_VALUE.component_path,
+            local_component_defn_to_inject=BASIC_VALID_VALUE.component_type_filepath,
+        ) as tmpdir,
+        TemporaryDirectory() as dagster_home,
+        modify_environment_variable("DAGSTER_HOME", dagster_home),
+    ):
+        dagster_yaml = Path(dagster_home) / "dagster.yaml"
+        dagster_yaml.write_text(
+            """
+            telemetry:
+                enabled: false
+            """
+        )
+        with pushd(tmpdir):
+            result = runner.invoke("check", "yaml")
+            assert result.exit_code == 0
+
+        assert not os.path.exists(
+            os.path.join(get_or_create_dir_from_dagster_home("logs"), "event.log")
+        )
+        assert len(caplog.records) == 0
+
+
+def test_telemetry_disabled_dg_config(caplog: pytest.LogCaptureFixture) -> None:
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            BASIC_VALID_VALUE.component_path,
+            local_component_defn_to_inject=BASIC_VALID_VALUE.component_type_filepath,
+        ) as tmpdir,
+        TemporaryDirectory() as dg_cli_config_folder,
+        TemporaryDirectory() as dagster_cloud_config_folder,
+        modify_environment_variable("DG_CLI_CONFIG", str(Path(dg_cli_config_folder) / "dg.toml")),
+        modify_environment_variable(
+            "DAGSTER_CLOUD_CLI_CONFIG", str(Path(dagster_cloud_config_folder) / "config.yaml")
+        ),
+    ):
+        dg_config_path = Path(dg_cli_config_folder) / "dg.toml"
+        dg_config_path.write_text(
+            """
+            [cli.telemetry]
+            enabled = false
+            """
+        )
+
+        with pushd(tmpdir):
+            result = runner.invoke("check", "yaml")
+            assert result.exit_code == 0, str(result.exception)
+
+        assert len(caplog.records) == 0

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
@@ -41,8 +41,10 @@ def _get_dagster_plus_config_path_and_raw_config() -> Optional[DagsterPlusConfig
     return None
 
 
-@dataclass
+@dataclass()
 class DagsterPlusCliConfig:
+    """Partial config of ~/.dg/config.yaml or ~/.dagster_cloud_cli/config, including only Plus-specific config."""
+
     organization: Optional[str] = None
     default_deployment: Optional[str] = None
     user_token: Optional[str] = None


### PR DESCRIPTION
## Summary

Adds a `@cli_telemetry_wrapper` annotation which logs calls to the dg CLI. For this PR, just adds to the check CLI commands:

```python
@check_group.command(name="defs", cls=DgClickCommand)
@dg_global_options
@click.pass_context
@cli_telemetry_wrapper
def check_definitions_command(
   ...
) -> None: ...
```

This can be disabled through the config file at `~/.dg/config.yaml` or in `$DAGSTER_HOME/dagster.yaml`

## Test Plan

New tests that ensure all commands have coverage and that check the shape of output telemetry.