### PR TITLE
[docs] adhere to weekly release procedure for docs.dagster.io

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - docs-prod
       - 'release-*'
     paths:
       - docs/**
@@ -53,8 +52,11 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
         if: |
-          github.event_name == 'pull_request' ||
-          (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
+          github.event_name == 'pull_request' || (
+            github.event_name == 'push' && (
+              github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')
+            )
+          )
         run: |
           BRANCH_PREVIEW_SUBDOMAIN=$(echo "${HEAD_REF:-$REF_NAME}" | sed -e 's/[^a-zA-Z0-9-]/-/g; s/^-*//; s/-*$//' | cut -c1-63)
           BRANCH_PREVIEW_SUBDOMAIN=$(echo $BRANCH_PREVIEW_SUBDOMAIN | sed 's/--/-/g; s/-$//')
@@ -104,11 +106,11 @@ jobs:
         env:
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
+      # Commits to pull requests result in preview deployments
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25
         if: |
-          github.event_name == 'pull_request' ||
-          (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
+          github.event_name == 'pull_request'
         with:
           github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -118,10 +120,30 @@ jobs:
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: ${{ env.BRANCH_PREVIEW_SUBDOMAIN }}.archive.dagster-docs.io
 
+      # Pushes to `master` result in a preview deployment with the `main.` domain alias
+      #
+      # NOTE: alias must match preview version defined in `docs/dagsterVersions.json`
+      #
+      # TODO(colton) - add alias on the `dagster.io` domain
+      # TODO(colton) - use `-e ENVIRONMENT=...` flag for preview-specific site configuration
+      - name: Publish Main Preview to Vercel
+        uses: amondnet/vercel-action@v25
+        if: |
+            github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_DOCS_NEXT_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          scope: ${{ secrets.VERCEL_ORG_ID }}
+          alias-domains: main.archive.dagster-docs.io
+
+      # Pushes to `release-` prefixed branches result in production deployments on the `docs.dagster.io` domain
       - name: Publish to Vercel Production
         uses: amondnet/vercel-action@v25
-        # only deploy to production on master (TODO: switch to docs-prod when beta goes live)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: |
+          github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/docs/dagsterVersions.json
+++ b/docs/dagsterVersions.json
@@ -1,5 +1,4 @@
 {
-  "1.10.4": "https://release-1-10-4.archive.dagster-docs.io/",
   "1.10.3": "https://release-1-10-3.archive.dagster-docs.io/",
   "1.10.2": "https://release-1-10-2.archive.dagster-docs.io/",
   "1.10.1": "https://release-1-10-1.archive.dagster-docs.io/",

--- a/docs/dagsterVersions.json
+++ b/docs/dagsterVersions.json
@@ -1,4 +1,5 @@
 {
+  "1.10.5": "https://release-1-10-5.archive.dagster-docs.io/",
   "1.10.4": "https://release-1-10-4.archive.dagster-docs.io/",
   "1.10.3": "https://release-1-10-3.archive.dagster-docs.io/",
   "1.10.2": "https://release-1-10-2.archive.dagster-docs.io/",

--- a/docs/dagsterVersions.json
+++ b/docs/dagsterVersions.json
@@ -1,4 +1,5 @@
 {
+  "1.10.4": "https://release-1-10-4.archive.dagster-docs.io/",
   "1.10.3": "https://release-1-10-3.archive.dagster-docs.io/",
   "1.10.2": "https://release-1-10-2.archive.dagster-docs.io/",
   "1.10.1": "https://release-1-10-1.archive.dagster-docs.io/",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -184,7 +184,7 @@ const config: Config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.10.5',
+              label: '1.10.6',
               path: '/',
             },
           },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -121,6 +121,10 @@ const config: Config = {
                   href: 'https://legacy-docs.dagster.io',
                   label: '1.9.9 and earlier',
                 },
+                {
+                  href: 'https://main.archive.dagster-docs.io/',
+                  label: 'Upcoming Release (Preview)',
+                },
               ],
             }
           : {
@@ -173,11 +177,14 @@ const config: Config = {
     [
       '@docusaurus/preset-classic',
       {
+
+        // We perform deployments... <todo add notes>
+
         docs: {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.10.5 (master)',
+              label: '1.10.4',
               path: '/',
             },
           },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -177,7 +177,7 @@ const config: Config = {
     [
       '@docusaurus/preset-classic',
       {
-        // Release to `docs.dagster.io` are triggered on pushes to branches prefixed with
+        // Releases to `docs.dagster.io` are triggered on pushes to branches prefixed with
         // `release-*`, therefore the most recent release should be labeled as the version in that
         // branch (eg. `release-1.10.4`). Ultimately we will automate this process.
         docs: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -123,7 +123,7 @@ const config: Config = {
                 },
                 {
                   href: 'https://main.archive.dagster-docs.io/',
-                  label: 'Upcoming Release (Preview)',
+                  label: 'Upcoming release (Preview)',
                 },
               ],
             }

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -177,9 +177,9 @@ const config: Config = {
     [
       '@docusaurus/preset-classic',
       {
-
-        // We perform deployments... <todo add notes>
-
+        // Release to `docs.dagster.io` are triggered on pushes to branches prefixed with
+        // `release-*`, therefore the most recent release should be labeled as the version in that
+        // branch (eg. `release-1.10.4`). Ultimately we will automate this process.
         docs: {
           lastVersion: 'current',
           versions: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -179,12 +179,12 @@ const config: Config = {
       {
         // Releases to `docs.dagster.io` are triggered on pushes to branches prefixed with
         // `release-*`, therefore the most recent release should be labeled as the version in that
-        // branch (eg. `release-1.10.4`). Ultimately we will automate this process.
+        // branch (eg. `release-1.10.5`). Ultimately we will automate this process.
         docs: {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.10.4',
+              label: '1.10.5',
               path: '/',
             },
           },


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-757.

- Makes current link in release dropdown the most recent version (eg. 1.10.4)
- Updates GH action to deploy to `main.archive.dagster.io` on push to _master_
- Updates GH action Production deployment on push to `release-*` prefixed branches
- Updates GH action to only deploy previews on `event_name == 'pull_request'`
- Removes `docs-prod` target for deployments as we will deploy new previews on merget to `master`

---

<img width="462" alt="image" src="https://github.com/user-attachments/assets/b30852a0-a711-4b24-b276-ea2a412e895f" />

## How I Tested These Changes

## Changelog

NOCHANGELOG
