### PR TITLE
[asset-backfill] Fix bug when target subset contains empty PartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -236,9 +236,13 @@ class AssetGraphSubset(NamedTuple):
     def __eq__(self, other) -> bool:
         return (
             isinstance(other, AssetGraphSubset)
-            and self.partitions_subsets_by_asset_key == other.partitions_subsets_by_asset_key
             and self.non_partitioned_asset_keys == other.non_partitioned_asset_keys
+            and _non_empty(self.partitions_subsets_by_asset_key)
+            == _non_empty(other.partitions_subsets_by_asset_key)
         )
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
 
     def __repr__(self) -> str:
         return (
@@ -435,3 +439,8 @@ class AssetGraphSubset(NamedTuple):
             partitions_subsets_by_asset_key=partitions_subsets_by_asset_key,
             non_partitioned_asset_keys=non_partitioned_asset_keys,
         )
+
+
+def _non_empty(d: Mapping[AssetKey, PartitionsSubset]) -> Mapping[AssetKey, PartitionsSubset]:
+    """Returns a new dictionary with only the non-empty PartitionsSubsets in d."""
+    return {k: v for k, v in d.items() if not v.is_empty}


### PR DESCRIPTION
## Summary & Motivation

When you create an AssetBackfill from the point of failure, and the original root asset had all of its partitions succeed, this creates a target AssetGraphSubset that looks like:


```python
AssetGraphSubset(
    non_partitioned_keys=[...],
    partitions_subsets_by_key={
        AssetKey("root"): DefaultPartitionsSubset([]),
        ...
    }
)
```

That's totally fine and expected! And the asset backfill code mostly graciously handles finding the new roots and all that. The issue is this line: https://sourcegraph.com/github.com/dagster-io/dagster/-/blob/python_modules/dagster/dagster/_core/execution/asset_backfill.py?L239

Where we check if we have successfully found all of the partitions in the target set by mapping from the root partitions. The thing is... we have! It's just that the target set has that `AssetKey("root"): DefaultPartitionsSubset([])` in it, whereas the root_and_downstream_partitions set does not even have a key for that dictionary, so technically those dictionaries are different.

So the solution is to just filter out the empty subsets from the dictionaries before comparing them. The foolproof thing would be to calculate all the asset partition keys explicitly, but that's way too expensive to do in practice, and this should cover the edge case well.

Note that you also have to override `__ne__` to handle the != operator, that doesn't just default to "not __eq__"

## How I Tested These Changes

## Changelog

Fixed an issue that could cause an asset backfill created by re-executing another backfill from the point of failure to error on the first tick in rare cases.
