### PR TITLE
[dagster-dbt] Include cloud v2 tests in dbt cloud test suite

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -33,7 +33,7 @@ from dagster_dbt_tests.dbt_projects import (
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> Iterator[None]:
     """Mark tests in the `cloud` directories. Mark other tests as `core`."""
     for item in items:
-        if "cloud" in item.path.parts:
+        if "cloud" in item.path.parts or "cloud_v2" in item.path.parts:
             item.add_marker(pytest.mark.cloud)
         else:
             item.add_marker(pytest.mark.core)


### PR DESCRIPTION
## Summary & Motivation

Cloud v2 tests are included in dbt core test suite because of how dbt tests are selected (pytest.mark), include them in dbt cloud test suite instead.

Before:

<img width="1993" alt="Screenshot 2025-03-19 at 6 16 54 PM" src="https://github.com/user-attachments/assets/36327ccc-f4c8-45ac-8ab4-f352ca4a145b" />

After:
<img width="1888" alt="Screenshot 2025-03-19 at 6 23 48 PM" src="https://github.com/user-attachments/assets/80bd3929-0dd8-44a8-840f-2b8fa660f97a" />


## How I Tested These Changes

BK
