### PR TITLE
[docs] document that sso_default_role can be set to NO_ACCESS

### DIFF
--- a/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
+++ b/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
@@ -102,8 +102,9 @@ run_retries:
 
 ### SSO default role
 
-{/* dagster-plus/account/managing-users/managing-user-roles-permissions#user-permissions-reference */}
-The `sso_default_role` setting lets you configure the default role on the deployment which is granted to new users that log in via SSO. For more information on available roles, see the [Dagster+ permissions reference](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions).
+The `sso_default_role` setting lets you configure the default role in the deployment which is granted to new users that log in using [Single sign-on (SSO)](/dagster-plus/features/authentication-and-access-control/sso/). For more information on available roles, see the [Dagster+ permissions reference](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions).
+
+The setting can also be configured to `NO_ACCESS` to prevent new user accounts being created automatically upon log in.
 
 ```yaml
 sso_default_role: EDITOR

--- a/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
+++ b/docs/docs/dagster-plus/deployment/management/deployments/deployment-settings-reference.md
@@ -95,7 +95,7 @@ run_retries:
   max_retries: 0
 ```
 
-| Property | Descripton |
+| Property | Description |
 | --- | --- |
 | run_retries.max_retries | The maximum number of times Dagster+ should attempt to retry a failed run. Dagster+ will use the default if this setting is undefined. <ul><li>**Default** - `0`</li></ul> |
 | run_retries.retry_on_asset_or_op_failure | Whether to retry runs that failed due to assets or ops in the run failing. Set this to false if you only want to retry failures that occur due to the run worker crashing or unexpectedly terminating, and instead rely on op or asset-level retry policies to retry assert or op failures. Setting this field to false will only change retry behavior for runs on dagster version 1.6.7 or greater. <ul><li>**Default** - `0`</li></ul> |
@@ -110,7 +110,7 @@ The setting can also be configured to `NO_ACCESS` to prevent new user accounts b
 sso_default_role: EDITOR
 ```
 
-| Property | Descripton |
+| Property | Description |
 | --- | --- |
 | sso_default_role | If SAML SSO is enabled, this is the default role that will be assigned to Dagster+ users for this deployment. If SAML SSO is not enabled, this setting is ignored. <ul><li>**Default** - `Viewer`</li></ul> |
 
@@ -124,7 +124,7 @@ non_isolated_runs:
   max_concurrent_non_isolated_runs: 1
 ```
 
-| Property | Descripton |
+| Property | Description |
 | --- | --- |
 | enabled | If enabled, the `Isolate run environment` checkbox will appear in the Launchpad. <ul><li>**Default** - `true`</li></ul> |
 | max_concurrent_non_isolated_runs | A limit for how many non-isolated runs to launch at once. Once this limit is reached, the checkbox will be greyed out and all runs will be isolated. This helps to avoid running out of RAM on the code location server. <ul><li>**Default** - `1`</li></ul> |


### PR DESCRIPTION
## Summary & Motivation

Addresses [AD-722](https://linear.app/dagster-labs/issue/AD-772/[ib]-document-that-sso-default-role-can-be-set-to-no-access)

`NO_ACCESS` setting for `sso_default_role` was not documented. Also fixed some typos on the same page. 

## How I Tested These Changes
👀