### PR TITLE
[dg] ComponentFileModel -> ComponentConfig

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -12,7 +12,7 @@ from dagster import AssetKey, AssetsDefinition, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
 from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
 from dagster_components.core.component_defs_builder import build_component_defs
-from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
+from dagster_components.core.defs_module import ComponentConfig, YamlComponentDecl
 from dagster_components.resolved.core_models import AssetAttributesModel
 from dagster_dbt import DbtProject
 
@@ -62,7 +62,7 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
 
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -113,7 +113,7 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
 
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="debug_dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -205,7 +205,7 @@ def test_asset_attributes(
     with wrapper:
         decl_node = YamlComponentDecl(
             path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
+            component_config=ComponentConfig(
                 type="dbt_project",
                 attributes={
                     "dbt": {"project_dir": "jaffle_shop"},
@@ -242,7 +242,7 @@ def test_asset_attributes_is_comprehensive():
 def test_subselection(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -260,7 +260,7 @@ def test_subselection(dbt_path: Path) -> None:
 def test_exclude(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -300,7 +300,7 @@ def test_dependency_on_dbt_project():
 def test_spec_is_available_in_scope(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="  ",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -342,7 +342,7 @@ def test_udf_map_spec(dbt_path: Path, map_fn: Callable[[AssetSpec], Any]) -> Non
 
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="debug_dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -25,11 +25,7 @@ from dagster_components.components.sling_replication_collection.component import
     SlingReplicationCollectionModel,
 )
 from dagster_components.core.component_defs_builder import load_defs
-from dagster_components.core.defs_module import (
-    ComponentFileModel,
-    DefsModuleDecl,
-    YamlComponentDecl,
-)
+from dagster_components.core.defs_module import ComponentConfig, DefsModuleDecl, YamlComponentDecl
 from dagster_components.resolved.context import ResolutionException
 from dagster_components.resolved.core_models import AssetAttributesModel
 from dagster_components.utils import ensure_dagster_components_tests_import
@@ -205,7 +201,7 @@ def test_sling_subclass() -> None:
 
     decl_node = YamlComponentDecl(
         path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="debug_sling_replication",
             attributes={"sling": {}, "replications": [{"path": "./replication.yaml"}]},
         ),
@@ -371,7 +367,7 @@ def test_udf_map_spec(map_fn: Callable[[AssetSpec], Any]) -> None:
 
     decl_node = YamlComponentDecl(
         path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="debug_sling_replication",
             attributes={
                 "sling": {},

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -9,7 +9,7 @@ import pytest
 from dagster import AssetKey
 from dagster._utils.env import environ
 from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
-from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
+from dagster_components.core.defs_module import ComponentConfig, YamlComponentDecl
 from dagster_dbt import DbtProject
 
 from dagster_components_tests.integration_tests.component_loader import load_test_component_defs
@@ -60,7 +60,7 @@ def dbt_path() -> Iterator[Path]:
 def test_python_attributes_node_rename(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -79,7 +79,7 @@ def test_python_attributes_node_rename(dbt_path: Path) -> None:
 def test_python_attributes_group(dbt_path: Path) -> None:
     decl_node = YamlComponentDecl(
         path=dbt_path / COMPONENT_RELPATH,
-        component_file_model=ComponentFileModel(
+        component_config=ComponentConfig(
             type="dbt_project",
             attributes={
                 "dbt": {"project_dir": "jaffle_shop"},
@@ -107,7 +107,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
     with environ({"GROUP_AS_ENV": "group_in_env"}):
         decl_node = YamlComponentDecl(
             path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
+            component_config=ComponentConfig(
                 type="dbt_project",
                 attributes={
                     "dbt": {"project_dir": "jaffle_shop"},
@@ -130,7 +130,7 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
     with environ({"ASSET_KEY_PREFIX": "some_prefix"}):
         decl_node = YamlComponentDecl(
             path=dbt_path / COMPONENT_RELPATH,
-            component_file_model=ComponentFileModel(
+            component_config=ComponentConfig(
                 type="dbt_project",
                 attributes={
                     "dbt": {"project_dir": "jaffle_shop"},

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/source_position.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/source_position.py
@@ -77,10 +77,20 @@ class SourcePositionAndKeyPath(NamedTuple):
 
     key_path: KeyPath
     source_position: Optional[SourcePosition]
+    source_position_tree: SourcePositionTree
 
 
 class HasSourcePositionAndKeyPath:
     _source_position_and_key_path: Optional[SourcePositionAndKeyPath] = None
+
+    @property
+    def source_position_tree(self) -> Optional[SourcePositionTree]:
+        """Returns the underlying source position tree for the object."""
+        return (
+            self._source_position_and_key_path.source_position_tree
+            if self._source_position_and_key_path
+            else None
+        )
 
     @property
     def source_position(self) -> SourcePosition:
@@ -132,7 +142,9 @@ def populate_source_position_and_key_paths(
             object.__setattr__(
                 obj,
                 "_source_position_and_key_path",
-                SourcePositionAndKeyPath(key_path, source_position_tree.position),
+                SourcePositionAndKeyPath(
+                    key_path, source_position_tree.position, source_position_tree
+                ),
             )
 
     if source_position_tree is None:


### PR DESCRIPTION
## Summary & Motivation

This is just a minor refactor laying the groundwork for the pr stacked on top. The naming change isn't really that important in this context, but it ends up pairing nicely with the name chosen for the DefsConfig up top.

Not high-conviction on the "Config" naming bit (obvious issues with overlap with the config system), but I do think it's an improvement over calling the loaded thing "component_file_model" in all of our variables.

Other names to be considered:

- ComponentConfigFile
- ComponentInfo
- ComponentData
- ComponentLoadData

## How I Tested These Changes

## Changelog

NOCHANGELOG
