### PR TITLE
[dg] `defs.yaml` at any level

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs.yaml
@@ -1,0 +1,9 @@
+post_processors:
+  - target: "*"
+    attributes:
+      tags:
+        top_level_tag: "true"
+  - target: "tag:defs_tag=true"
+    attributes:
+      tags:
+        added_to_defs_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/asset.py
@@ -1,0 +1,9 @@
+import dagster as dg
+
+
+@dg.asset
+def defs_obj_outer() -> None: ...
+
+
+@dg.asset
+def not_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/definitions.py
@@ -1,0 +1,6 @@
+import dagster as dg
+
+from .asset import defs_obj_outer  # noqa
+from .inner.asset import defs_obj_inner  # noqa
+
+defs = dg.Definitions(assets=[defs_obj_inner, defs_obj_outer])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/defs.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/defs.yaml
@@ -1,0 +1,5 @@
+post_processors:
+  - target: "*"
+    attributes:
+      tags:
+        defs_object_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/inner/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/inner/asset.py
@@ -1,0 +1,9 @@
+import dagster as dg
+
+
+@dg.asset
+def defs_obj_inner() -> None: ...
+
+
+@dg.asset
+def not_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def in_loose_defs() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/defs.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/defs.yaml
@@ -1,0 +1,5 @@
+post_processors:
+  - target: "*"
+    attributes:
+      tags: 
+        loose_defs_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def inner() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/defs.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/defs.yaml
@@ -1,0 +1,6 @@
+post_processors:
+  - target: "*"
+    attributes:
+      tags:
+        another_level_tag: "true"
+        env_tag: "{{ env('MY_ENV_VAR') }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/in_init/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/in_init/__init__.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def in_init() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/innerest/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/innerest/definitions.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+
+@dg.asset
+def innerest_defs() -> None: ...
+
+
+defs = dg.Definitions(assets=[innerest_defs])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def innerer() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/top_level.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/top_level.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def top_level() -> None: ...


### PR DESCRIPTION
## Summary & Motivation

We can now put a `defs.yaml` file at any level of the defs/ hierarchy and have it configure definition-level information for any asset therein.

For now, this just uses the existing AssetPostProcessor configuration scheme, but we could easily expand this file to do any sort of module-scoped transformation and configuration.

This is demonstrated in the new test which applies tags to assets within different subfolders of a directory.

Note: by using the `resolved` framework, we get stuff like env var injection for free! 

## How I Tested These Changes

## Changelog

NOCHANGELOG
