### PR TITLE
[ui] Fix overflow of long runs feed table on backfill page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
@@ -94,7 +94,7 @@ export const RunsFeedBackfillPage = () => {
         {error?.graphQLErrors && (
           <Alert intent="error" title={error.graphQLErrors.map((err) => err.message)} />
         )}
-        <Box flex={{direction: 'column'}} style={{flex: 1, position: 'relative', minHeight: 0}}>
+        <Box flex={{direction: 'column'}} style={{flex: 1, minHeight: 0}}>
           <Box border={selectedTab === 'overview' ? null : 'bottom'}>
             <BackfillOverviewDetails backfill={backfill} />
             {isDaemonHealthy ? null : (
@@ -103,19 +103,20 @@ export const RunsFeedBackfillPage = () => {
               </Box>
             )}
           </Box>
-
-          {selectedTab === 'overview' && (
-            <Box style={{overflow: 'hidden'}} flex={{direction: 'column'}}>
-              {backfill.isAssetBackfill ? (
-                <BackfillAssetPartitionsTable backfill={backfill} />
-              ) : (
-                <BackfillOpJobPartitionsTable backfill={backfill} />
-              )}
-            </Box>
-          )}
-          {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} view="list" />}
-          {selectedTab === 'timeline' && <BackfillRunsTab backfill={backfill} view="timeline" />}
-          {selectedTab === 'logs' && <BackfillLogsTab backfill={backfill} />}
+          <Box flex={{direction: 'column'}} style={{flex: 1, minHeight: 0, position: 'relative'}}>
+            {selectedTab === 'overview' && (
+              <Box style={{overflow: 'hidden'}} flex={{direction: 'column'}}>
+                {backfill.isAssetBackfill ? (
+                  <BackfillAssetPartitionsTable backfill={backfill} />
+                ) : (
+                  <BackfillOpJobPartitionsTable backfill={backfill} />
+                )}
+              </Box>
+            )}
+            {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} view="list" />}
+            {selectedTab === 'timeline' && <BackfillRunsTab backfill={backfill} view="timeline" />}
+            {selectedTab === 'logs' && <BackfillLogsTab backfill={backfill} />}
+          </Box>
         </Box>
       </Box>
     );


### PR DESCRIPTION
## Summary & Motivation

If you have enough backfill runs to trigger scrolling and the "daemon not running" alert is visible, the runs feed table was overflowing off the page by ~2 rows following the change I made in #28503.

## How I Tested These Changes

Tested the scroll behavior of all three tabs with and without the "daemon not running" alert

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/6323fa6e-dded-4466-aa5a-5420c1b6eece" />
