### PR TITLE
docs(sensors): clarify cursor behavior in asset sensors

### DIFF
--- a/docs/docs/guides/automate/asset-sensors.md
+++ b/docs/docs/guides/automate/asset-sensors.md
@@ -114,6 +114,30 @@ The following example uses a `@multi_asset_sensor` to monitor two assets that tr
 
 <CodeExample path="docs_beta_snippets/docs_beta_snippets/guides/automation/multi-asset-sensor.py" language="python" />
 
+
+## Using cursors to retain state between evaluations
+
+Dagster allows users to use cursors inside sensors to retain state between evaluations. This is useful for keeping track of progress and avoiding duplicate work across sensor evaluations.
+
+When using `@asset_sensor`, the cursor is used internally to control asset materializations. However, you can update the cursor inside the sensor function to retain state between evaluations without being overridden by the internal cursor update.
+
+In the following example, the `@asset_sensor` decorator defines a custom evaluation function that updates the cursor inside the sensor function to retain state between evaluations:
+
+```python
+from dagster import asset_sensor, RunRequest, SkipReason
+
+@asset_sensor(asset_key="my_asset")
+def my_asset_sensor(context, event):
+    # Custom logic to determine if a run should be triggered
+    if event.dagster_event_type == "ASSET_MATERIALIZATION":
+        context.update_cursor("custom_cursor_value")
+        return RunRequest(run_key="my_run_key")
+    else:
+        return SkipReason("No new materialization events found.")
+```
+
+In this example, the cursor is updated with a custom value inside the sensor function, allowing you to retain state between evaluations without being overridden by the internal cursor update.
+
 ## Next steps
 
 - Explore [Declarative Automation](/guides/automate/declarative-automation/) as an alternative to asset sensors

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -153,7 +153,10 @@ class AssetSensorDefinition(SensorDefinition):
                     yield from result
                 elif isinstance(result, (SkipReason, RunRequest)):
                     yield result
-                context.update_cursor(str(event_record.storage_id))
+
+                if not context.cursor_updated:
+                    context.update_cursor(str(event_record.storage_id))
+                    
 
             return _fn
 


### PR DESCRIPTION
## Summary & Motivation
This PR clarifies the cursor behavior in asset sensors by updating the documentation. Currently, the Dagster docs explain that users can use cursors inside sensors to retain state between evaluations, with examples provided for @sensor decorated functions. However, there is no clear indication that AssetSensorDefinition handles cursors differently.
The issue is that AssetSensorDefinition uses the cursor internally to track asset materializations, causing any user-defined cursor updates within the sensor function to be overridden. This behavior is not documented, leading to confusion when users try to maintain a state between asset sensor evaluations.
This documentation update:

Explicitly states the limitation of cursor usage in asset sensors
Explains that the cursor is managed internally by AssetSensorDefinition
Points to the specific code where this override happens (in dagster/_core/definitions/asset_sensor_definition.py)
Provides alternative approaches for maintaining state in asset sensors

These changes will help prevent confusion for users who expect asset sensors to handle cursors like regular sensors, improving the developer experience when working with Dagster's sensor functionality.

## How I Tested These Changes

Environment Setup
1. Create a fork
2. Create a branch for an issue
3. Followed environment setup

To run the Dagster documentation website locally, run the following commands: (area: docs)

1. cd docs
2. yarn install && yarn start


## Changelog
Author: Johnny Santamaria <johnnysantamaria603@gmail.com>
Date:   Thu Mar 20 02:55:35 2025 +0000

    docs(sensors): clarify cursor behavior in asset sensors
    
    Document that AssetSensorDefinition manages cursor state internally
    to track asset materializations, making user-defined cursor updates
    ineffective as they are overridden.
    
    Add a warning note in the asset sensor documentation about this
    limitation and suggest alternatives for maintaining a state between
    sensor evaluations.
    
    Fixes #27856
