### PR TITLE
Refactor `useIndexedDBCachedQuery`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -74,7 +74,7 @@ describe('useIndexedDBCachedQuery', () => {
     jest.clearAllMocks();
   });
 
-  [true, false].forEach((shouldThrowError) => {
+  [false].forEach((shouldThrowError) => {
     const throwingError = shouldThrowError;
     describe(
       // eslint-disable-next-line jest/valid-title

--- a/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -74,7 +74,7 @@ describe('useIndexedDBCachedQuery', () => {
     jest.clearAllMocks();
   });
 
-  [false].forEach((shouldThrowError) => {
+  [true, false].forEach((shouldThrowError) => {
     const throwingError = shouldThrowError;
     describe(
       // eslint-disable-next-line jest/valid-title

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -82,6 +82,128 @@ export class CacheManager<TQuery> {
   }
 }
 
+const globalFetchStates: Record<string, {onFetched: ((value: any) => void)[]}> = {};
+
+export class IndexedDBQueryCache<TQuery, TVariables extends OperationVariables> {
+  private cacheManager: CacheManager<TQuery>;
+  private key: string;
+  private version: number | string;
+  private queryFn: (variables?: TVariables) => Promise<{data: TQuery | undefined; error: any}>;
+  private variables?: TVariables;
+
+  constructor({
+    key,
+    version,
+    variables,
+    queryFn,
+  }: {
+    key: string;
+    version: number | string;
+    variables?: TVariables;
+    queryFn: (variables?: TVariables) => Promise<{data: TQuery | undefined; error: any}>;
+  }) {
+    this.key = key;
+    this.version = version;
+    this.variables = variables;
+    this.queryFn = queryFn;
+    this.cacheManager = new CacheManager<TQuery>(key);
+
+    // Try to get cached data immediately (but don't await it in constructor)
+    this.getCachedData();
+  }
+
+  async getCachedData(): Promise<TQuery | undefined> {
+    return await this.cacheManager.get(this.version);
+  }
+
+  async fetchData(bypassCache = false): Promise<{data: TQuery | undefined; error: any}> {
+    if (!bypassCache) {
+      const cachedData = await this.getCachedData();
+      if (cachedData !== undefined) {
+        return {data: cachedData, error: undefined};
+      }
+    }
+
+    const currentState = globalFetchStates[this.key];
+    if (currentState) {
+      return new Promise((resolve) => {
+        currentState.onFetched.push(resolve as any);
+      });
+    }
+
+    const state = {onFetched: [] as ((value: {data: TQuery | undefined; error: any}) => void)[]};
+    globalFetchStates[this.key] = state;
+
+    try {
+      const result = await this.queryFn(this.variables);
+
+      if (result.data && !result.error) {
+        await this.cacheManager.set(result.data, this.version);
+      }
+
+      const onFetchedHandlers = state.onFetched;
+      if (globalFetchStates[this.key] === state) {
+        delete globalFetchStates[this.key]; // Clean up fetch state after handling
+      }
+
+      onFetchedHandlers.forEach((handler) => handler(result)); // Notify all waiting fetches
+
+      return result;
+    } catch (error) {
+      if (globalFetchStates[this.key] === state) {
+        delete globalFetchStates[this.key];
+      }
+      return {data: undefined, error};
+    }
+  }
+
+  async clearCache(): Promise<void> {
+    await this.cacheManager.clear();
+  }
+
+  updateVariables(variables: TVariables): void {
+    this.variables = variables;
+  }
+
+  updateVersion(version: number | string): void {
+    this.version = version;
+  }
+}
+
+export class ApolloIndexedDBQueryCache<
+  TQuery,
+  TVariables extends OperationVariables,
+> extends IndexedDBQueryCache<TQuery, TVariables> {
+  constructor({
+    client,
+    key,
+    query,
+    version,
+    variables,
+  }: {
+    client: ApolloClient<any>;
+    key: string;
+    query: DocumentNode;
+    version: number | string;
+    variables?: TVariables;
+  }) {
+    const queryFn = async (vars?: TVariables) => {
+      try {
+        const queryResult = await client.query<TQuery, TVariables>({
+          query,
+          variables: vars,
+          fetchPolicy: 'no-cache',
+        });
+        return {data: queryResult.data, error: queryResult.error};
+      } catch (error) {
+        return {data: undefined, error};
+      }
+    };
+
+    super({key, version, variables, queryFn});
+  }
+}
+
 interface QueryHookParams<TVariables extends OperationVariables, TQuery> {
   key: string;
   query: DocumentNode;
@@ -101,23 +223,43 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   const [data, setData] = React.useState<TQuery | undefined>(undefined);
   const [error, setError] = React.useState<ApolloError | undefined>(undefined);
   const [loading, setLoading] = React.useState(true);
-
   const dataRef = useUpdatingRef(data);
 
-  const getData = useGetData();
-  const getCachedData = useGetCachedData();
+  const cacheRef = React.useRef<ApolloIndexedDBQueryCache<TQuery, TVariables>>();
+
+  // Initialize cache if not initialized
+  if (!cacheRef.current) {
+    cacheRef.current = new ApolloIndexedDBQueryCache<TQuery, TVariables>({
+      client,
+      key,
+      query,
+      version,
+      variables,
+    });
+  }
+
+  // Update variables or version if they change
+  React.useEffect(() => {
+    if (cacheRef.current && variables) {
+      cacheRef.current.updateVariables(variables);
+    }
+  }, [variables]);
+
+  React.useEffect(() => {
+    if (cacheRef.current) {
+      cacheRef.current.updateVersion(version);
+    }
+  }, [version]);
 
   const fetch = useCallback(
     async (bypassCache = false) => {
+      if (!cacheRef.current) {
+        return;
+      }
+
       setLoading(true);
-      const {data, error} = await getData<TQuery, TVariables>({
-        client,
-        key,
-        query,
-        variables,
-        version,
-        bypassCache,
-      });
+      const {data, error} = await cacheRef.current.fetchData(bypassCache);
+
       if (
         data &&
         // Work around a weird jest issue where it returns an empty object if no mocks are found...
@@ -129,22 +271,21 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
       setError(error);
       setLoading(false);
     },
-    // exclude variables, instead JSON stringify it to avoid changing this reference if the caller hasn't memoized it
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getData, client, key, query, JSON.stringify(variables), version, dataRef],
+    [dataRef],
   );
 
   React.useEffect(() => {
-    if (skip) {
+    if (skip || !cacheRef.current) {
       return;
     }
-    getCachedData<TQuery>({key, version}).then((data) => {
+
+    cacheRef.current.getCachedData().then((data) => {
       if (data && !dataRef.current) {
         setData(data);
         setLoading(false);
       }
     });
-  }, [key, version, getCachedData, dataRef, skip]);
+  }, [dataRef, skip]);
 
   React.useEffect(() => {
     if (skip) {
@@ -174,86 +315,52 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   };
 }
 
-interface FetchParams<TVariables extends OperationVariables> {
-  client: ApolloClient<any>;
-  key: string;
-  query: DocumentNode;
-  variables?: TVariables;
-  version: number | string;
-  bypassCache?: boolean;
-}
-
 export function useGetData() {
-  const {getCacheManager, fetchState} = useContext(IndexedDBCacheContext);
+  const apolloClient = useApolloClient();
 
   return useCallback(
-    async <TQuery, TVariables extends OperationVariables>({
+    async <TData, TVariables extends OperationVariables>({
       client,
-      key,
       query,
-      variables,
+      key,
       version,
+      variables,
       bypassCache = false,
-    }: FetchParams<TVariables>): Promise<{data: TQuery; error: ApolloError | undefined}> => {
-      const cacheManager = getCacheManager<TQuery>(key);
+    }: {
+      client?: ApolloClient<any>;
+      query: DocumentNode;
+      key: string;
+      version: number | string;
+      variables?: TVariables;
+      bypassCache?: boolean;
+    }) => {
+      const clientToUse = client || apolloClient;
 
-      if (!bypassCache) {
-        const cachedData = await cacheManager.get(version);
-        if (cachedData !== undefined) {
-          return {data: cachedData, error: undefined};
-        }
-      }
-
-      const currentState = fetchState[key];
-      // Handle concurrent fetch requests
-      if (currentState) {
-        return new Promise((resolve) => {
-          currentState!.onFetched.push(resolve as any);
-        });
-      }
-
-      const state = {
-        onFetched: [] as ((value: Pick<typeof queryResult, 'data' | 'error'>) => void)[],
-      };
-      fetchState[key] = state;
-
-      const queryResult = await client.query<TQuery, TVariables>({
+      // Create a cache instance or reuse an existing one
+      const queryCache = new ApolloIndexedDBQueryCache<TData, TVariables>({
+        client: clientToUse,
+        key,
         query,
+        version,
         variables,
-        fetchPolicy: 'no-cache',
       });
 
-      const {data, error} = queryResult;
+      const result = await queryCache.fetchData(bypassCache);
 
-      if (data && !error) {
-        await cacheManager.set(data, version);
-      }
-
-      const onFetchedHandlers = state.onFetched;
-      if (fetchState[key] === state) {
-        delete fetchState[key]; // Clean up fetch state after handling
-      }
-
-      onFetchedHandlers.forEach((handler) => handler({data, error})); // Notify all waiting fetches
-
-      return {data, error};
+      return {
+        data: result.data,
+        error: result.error,
+      };
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [apolloClient],
   );
 }
 
 export function useGetCachedData() {
-  const {getCacheManager} = useContext(IndexedDBCacheContext);
-
-  return useCallback(
-    async <TQuery,>({key, version}: {key: string; version: number | string}) => {
-      const cacheManager = getCacheManager<TQuery>(key);
-      return await cacheManager.get(version);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  return useCallback(async <TQuery,>({key, version}: {key: string; version: number | string}) => {
+    const cacheManager = new CacheManager<TQuery>(key);
+    return await cacheManager.get(version);
+  }, []);
 }
 export function useClearCachedData() {
   const {getCacheManager} = useContext(IndexedDBCacheContext);
@@ -266,23 +373,18 @@ export function useClearCachedData() {
   );
 }
 
-const contextValue = createIndexedDBCacheContextValue();
-export const IndexedDBCacheContext = createContext(contextValue);
-
 export function createIndexedDBCacheContextValue() {
   return {
     getCacheManager: memoize(<TQuery,>(key: string) => {
       return new CacheManager<TQuery>(key);
     }),
-    fetchState: {} as Record<
-      string,
-      {
-        onFetched: ((value: any) => void)[];
-      }
-    >,
   };
 }
 
+const contextValue = createIndexedDBCacheContextValue();
+export const IndexedDBCacheContext = createContext(contextValue);
+
 export const __resetForJest = () => {
   Object.assign(contextValue, createIndexedDBCacheContextValue());
+  Object.keys(globalFetchStates).forEach((key) => delete globalFetchStates[key]);
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -15,6 +15,7 @@ import {
 import {
   IndexedDBCacheContext,
   KEY_PREFIX,
+  __resetForJest,
   createIndexedDBCacheContextValue,
 } from '../../../search/useIndexedDBCachedQuery';
 import {getMockResultFn} from '../../../testing/mocking';
@@ -55,6 +56,7 @@ afterEach(async () => {
   jest.resetModules();
   jest.clearAllMocks();
   jest.clearAllTimers();
+  __resetForJest();
 });
 const LOCAL_CACHE_ID_PREFIX = 'test';
 function renderWithMocks(mocks: MockedResponse[]) {


### PR DESCRIPTION
## Summary & Motivation

Goal here is to extract the core logic outside of the hooks so that I can use this logic outside of the context of React in my upcoming workspace refactor.

## How I Tested These Changes

existing jest tests for `useIndexedDBCachedQuery` + `WorkspaceContext` tests which make extensive use of it.

Also local testing.
