### PR TITLE
[ui] Allow toast actions to be links

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Toaster.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Toaster.tsx
@@ -16,10 +16,13 @@ export type ToastConfig = {
   message: ReactNode;
   icon?: IconName;
   timeout?: number;
-  action?: {
-    text: string;
-    onClick: (e: MouseEvent<HTMLButtonElement>) => void;
-  };
+  action?:
+    | {
+        type: 'button';
+        text: string;
+        onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+      }
+    | {type: 'custom'; element: ReactNode};
 };
 
 export const showToast = async (config: ToastConfig, sonnerConfig: ExternalToast = {}) => {
@@ -40,6 +43,34 @@ const Toast = (props: ToastProps) => {
   const {id, intent, message, action} = props;
   const {backgroundColor, textColor, icon, iconColor} = intentToStyles(intent);
 
+  const actionElement = () => {
+    if (!action) {
+      return null;
+    }
+
+    if (action.type === 'custom') {
+      return action.element;
+    }
+
+    return (
+      <BaseButton
+        fillColor={Colors.backgroundGray()}
+        fillColorHover={Colors.backgroundGrayHover()}
+        textColor={Colors.textDefault()}
+        strokeColor={Colors.backgroundGray()}
+        strokeColorHover={Colors.backgroundGrayHover()}
+        label={action.text}
+        style={{fontSize: 13, fontFamily: FontFamily.default}}
+        onClick={(e) => {
+          if (action.onClick) {
+            action.onClick(e);
+          }
+          toast.dismiss(id);
+        }}
+      />
+    );
+  };
+
   return (
     <div style={{backgroundColor: Colors.backgroundDefault(), borderRadius: 8}}>
       <Box
@@ -51,23 +82,7 @@ const Toast = (props: ToastProps) => {
       >
         {icon ? <Icon name={icon} color={iconColor} /> : null}
         <div style={{color: textColor}}>{message}</div>
-        {action ? (
-          <BaseButton
-            fillColor={Colors.backgroundGray()}
-            fillColorHover={Colors.backgroundGrayHover()}
-            textColor={Colors.textDefault()}
-            strokeColor={Colors.backgroundGray()}
-            strokeColorHover={Colors.backgroundGrayHover()}
-            label={action.text}
-            style={{fontSize: 13, fontFamily: FontFamily.default}}
-            onClick={(e) => {
-              if (action.onClick) {
-                action.onClick(e);
-              }
-              toast.dismiss(id);
-            }}
-          />
-        ) : null}
+        {actionElement()}
       </Box>
     </div>
   );

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Toaster.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Toaster.stories.tsx
@@ -74,6 +74,7 @@ export const Sizes = () => {
             message: 'Oh no an error! Look at the console!',
             timeout: 300000,
             action: {
+              type: 'button',
               text: 'View error',
               onClick: () => {
                 console.log('HERE IS AN ERROR IN THE CONSOLE');

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -180,11 +180,11 @@ export const AppProvider = (props: AppProviderProps) => {
   return (
     <AppContext.Provider value={appContextValue}>
       <WebSocketProvider websocketClient={websocketClient}>
-        <GlobalStyleProvider />
         <ApolloProvider client={apolloClient}>
           <AssetLiveDataProvider>
             <PermissionsProvider>
               <BrowserRouter basename={basePath || ''}>
+                <GlobalStyleProvider />
                 <CompatRouter>
                   <TimeProvider>
                     <CodeLinkProtocolProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
@@ -185,6 +185,7 @@ const ReportEventDialogBody = ({
         intent: 'danger',
         action: data
           ? {
+              type: 'button',
               text: 'View error',
               onClick: () => showCustomAlert({body: <PythonErrorInfo error={data} />}),
             }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
@@ -51,6 +51,7 @@ export function useReexecuteBackfill(
         icon: 'error',
         intent: 'danger',
         action: {
+          type: 'button',
           text: 'View error',
           onClick: () =>
             showCustomAlert({

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useResumeBackfill.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useResumeBackfill.tsx
@@ -39,6 +39,7 @@ export function useResumeBackfill(backfill: BackfillActionsBackfillFragment, ref
         icon: 'error',
         intent: 'danger',
         action: {
+          type: 'button',
           text: 'View error',
           onClick: () =>
             showCustomAlert({

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
@@ -14,6 +14,7 @@ import {showSharedToaster} from '../app/DomUtils';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {LaunchPartitionBackfillMutation} from '../instance/backfill/types/BackfillUtils.types';
 import {getBackfillPath} from '../runs/RunsFeedUtils';
+import {AnchorButton} from '../ui/AnchorButton';
 
 const DEFAULT_RUN_LAUNCHER_NAME = 'DefaultRunLauncher';
 
@@ -82,10 +83,8 @@ export async function showBackfillSuccessToast(
       </div>
     ),
     action: {
-      text: 'View',
-      onClick: () => {
-        history.push({pathname, search});
-      },
+      type: 'custom',
+      element: <AnchorButton to={history.createHref({pathname, search})}>View</AnchorButton>,
     },
   });
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -22,6 +22,7 @@ import {Timestamp} from '../app/time/Timestamp';
 import {asAssetCheckHandleInput, asAssetKeyInput} from '../assets/asInput';
 import {AssetKey} from '../assets/types';
 import {ExecutionParams, RunStatus} from '../graphql/types';
+import {AnchorButton} from '../ui/AnchorButton';
 
 export function titleForRun(run: {id: string}) {
   return run.id.split('-').shift();
@@ -93,10 +94,8 @@ export async function handleLaunchResult(
           </div>
         ),
         action: {
-          text: 'View',
-          onClick: () => {
-            history.push({pathname, search});
-          },
+          type: 'custom',
+          element: <AnchorButton to={history.createHref({pathname, search})}>View</AnchorButton>,
         },
       });
     }
@@ -195,10 +194,8 @@ export async function handleLaunchMultipleResult(
     intent: 'success',
     message: <div>Launched {successfulRunIds.length} runs</div>,
     action: {
-      text: 'View',
-      onClick: () => {
-        history.push(queryString);
-      },
+      type: 'custom',
+      element: <AnchorButton to={history.createHref({pathname: queryString})}>View</AnchorButton>,
     },
   });
 


### PR DESCRIPTION
## Summary & Motivation

We received user feedback that with the new toasts, kicking off a materialization does not currently allow command-click to view the launched run in a new tab. This is a regression from previous toasts, which just rendered a link when an href was provided.

To resolve this, allow `showSharedToaster` to receive a `custom` action, which allows rendering a custom element in the toast. This lets callsites specify an `AnchorButton` to enable react-router-based navigation on click, or command-click to open the link in a new tab.

This required moving `GlobalStyleProvider` under the `BrowserRouter` provider in the `AppProvider` root, in order to enable react-router links to be rendered within toasts. This seems safe to me, since `GlobalStyleProvider` is mostly responsible for injecting global stylesheets anyway, so no providers higher up the tree should really be affected.

## How I Tested These Changes

Materialize an asset. Verify that I can click the resulting toast to view the run within the current tab, or command-click to open it in a new tab.

## Changelog

[ui] Allow using command-click to view a run from the toast message that appears when starting a materialization of an asset.
