### PR TITLE
[ez] When merging external assets from multiple code locations, prefer non-stub asset specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -328,7 +328,8 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
     @cached_method
     def resolve_to_singular_repo_scoped_node(self) -> "RemoteRepositoryAssetNode":
         # Return a materialization node if it exists, otherwise return an observable node if it
-        # exists, otherwise return any node. This exists to preserve implicit behavior, where the
+        # exists, otherwise return any non-stub node, otherwise return any node.
+        # This exists to preserve implicit behavior, where the
         # materialization node was previously preferred over the observable node. This is a
         # temporary measure until we can appropriately scope the accessors that could apply to
         # either a materialization or observation node.

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -18,7 +18,10 @@ import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.asset_key import EntityKey
-from dagster._core.definitions.asset_spec import AssetExecutionType
+from dagster._core.definitions.asset_spec import (
+    SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
+    AssetExecutionType,
+)
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.base_asset_graph import (
@@ -342,6 +345,11 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
                     info.asset_node
                     for info in self.repo_scoped_asset_infos
                     if info.asset_node.is_observable
+                ),
+                (
+                    info.asset_node
+                    for info in self.repo_scoped_asset_infos
+                    if not info.asset_node.metadata.get(SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET)
                 ),
                 (info.asset_node for info in self.repo_scoped_asset_infos),
             )


### PR DESCRIPTION
## Summary

Right now, when building the global asset graph, we merge multiple copies of the same asset into a canonical definition.

This generally prefers executable assets to specs, but provides no disambiguation if the only representations for an asset are non-executable specs.

This can lead to a poor UX if, for example, a user adds a kind-and-description-augmented spec to one code location and in another location has a spec autogenerated for an upstream dependency. It's very possible for the bare, auto-generated spec to take precedence.

This PR  de-prioritizes autogenerated specs in this disambiguation logic.

## Changelog

> When merging assets from multiple code locations, autogenerated specs are now prioritized lower than customized external asset specs.
