### PR TITLE
[prototype] Add "plus" workspace.yaml config to produce ReadOnlyPlusRemoteCodeLocationOrigin

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -34,6 +34,12 @@ from dagster_graphql.client.utils import (
 )
 
 
+def _create_underlying_client(transport: Transport) -> Client:
+    return Client(
+        transport=transport,
+    )
+
+
 class DagsterGraphQLClient:
     """Official Dagster Python Client for GraphQL.
 
@@ -95,7 +101,7 @@ class DagsterGraphQLClient:
             ),
         )
         try:
-            self._client = Client(transport=self._transport, fetch_schema_from_transport=True)
+            self._client = _create_underlying_client(self._transport)
         except requests.exceptions.ConnectionError as exc:
             raise DagsterGraphQLClientError(
                 f"Error when connecting to url {self._url}. "

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -275,7 +275,7 @@ def _optionally_create_temp_workspace(
     """If not in legacy mode, spin up grpc servers and write a workspace file pointing at them.
     If in legacy mode, do nothing and return the target args.
     """
-    if not use_legacy_code_server_behavior:
+    if not use_legacy_code_server_behavior and False:
         with WorkspaceProcessContext(
             instance=instance,
             workspace_load_target=workspace_opts.to_load_target(),

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -23,7 +23,7 @@ from dagster._core.remote_representation.origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
-    ReadOnlyCloudMirrorCodeLocationOrigin,
+    ReadOnlyPlusRemoteCodeLocationOrigin,
 )
 from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
 from dagster._core.workspace.load_target import (
@@ -389,7 +389,7 @@ class WorkspaceOpts:
 def _origin_executable_matches_current_process(origin: CodeLocationOrigin) -> bool:
     # loadable_target_origin is unknown for GrpcServerCodeLocationOrigin
     return not isinstance(
-        origin, (GrpcServerCodeLocationOrigin, ReadOnlyCloudMirrorCodeLocationOrigin)
+        origin, (GrpcServerCodeLocationOrigin, ReadOnlyPlusRemoteCodeLocationOrigin)
     ) and (
         origin.loadable_target_origin.executable_path is None
         or origin.loadable_target_origin.executable_path == sys.executable

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -23,6 +23,7 @@ from dagster._core.remote_representation.origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
+    ReadOnlyCloudMirrorCodeLocationOrigin,
 )
 from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
 from dagster._core.workspace.load_target import (
@@ -387,7 +388,9 @@ class WorkspaceOpts:
 
 def _origin_executable_matches_current_process(origin: CodeLocationOrigin) -> bool:
     # loadable_target_origin is unknown for GrpcServerCodeLocationOrigin
-    return not isinstance(origin, GrpcServerCodeLocationOrigin) and (
+    return not isinstance(
+        origin, (GrpcServerCodeLocationOrigin, ReadOnlyCloudMirrorCodeLocationOrigin)
+    ) and (
         origin.loadable_target_origin.executable_path is None
         or origin.loadable_target_origin.executable_path == sys.executable
     )

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 import tempfile
@@ -77,7 +78,6 @@ from dagster._grpc.impl import (
     get_partition_tags,
 )
 from dagster._grpc.types import GetCurrentImageResult, GetCurrentRunsResult
-from dagster._record import copy
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import PackableValue
 from dagster._utils.merger import merge_dicts
@@ -748,7 +748,7 @@ def sync_get_external_repositories_from_cloud(
         repository_name = repository["repository_name"]
         presigned_url = repository["presigned_url"]
 
-        presigned_job_urls = copy(repository["presigned_job_urls"])
+        presigned_job_urls = copy.copy(repository["presigned_job_urls"])
 
         def job_ref_to_data_fn(job_ref: JobRefSnap) -> JobDataSnap:
             job_snap_url = presigned_job_urls.get(job_ref.name)

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
         CodeLocation,
         GrpcServerCodeLocation,
         InProcessCodeLocation,
-        ReadOnlyCloudMirrorCodeLocation,
+        ReadOnlyPlusRemoteCodeLocation,
     )
     from dagster._grpc.client import DagsterGrpcClient
 
@@ -208,9 +208,9 @@ class InProcessCodeLocationOrigin(
 
 
 @whitelist_for_serdes
-class ReadOnlyCloudMirrorCodeLocationOrigin(
+class ReadOnlyPlusRemoteCodeLocationOrigin(
     NamedTuple(
-        "_ReadOnlyCloudMirrorCodeLocationOrigin",
+        "_ReadOnlyPlusRemoteCodeLocationOrigin",
         [
             ("location_name", str),
             ("url", str),
@@ -220,23 +220,21 @@ class ReadOnlyCloudMirrorCodeLocationOrigin(
     ),
     CodeLocationOrigin,
 ):
-    """Identifies a repository location constructed in the same process. Primarily
-    used in tests, since Dagster system processes like the webserver and daemon do not
-    load user code in the same process.
+    """Identifies a non-interactable code location which is sourced from a Dagster Plus
+    deployment. Used for a local development context in order to be able to view assets
+    and other definitions from a Plus Deployment while working on local code locations.
     """
 
     def __new__(
         cls,
-        location_name: Optional[str],
         url: str,
         deployment: str,
         token: str,
+        location_name: str,
     ):
         return super().__new__(
             cls,
-            location_name=check.opt_str_param(
-                location_name, "location_name", default="Dagster Plus"
-            ),
+            location_name=check.str_param(location_name, "location_name"),
             url=check.str_param(url, "url"),
             deployment=check.str_param(deployment, "deployment"),
             token=check.str_param(token, "token"),
@@ -249,12 +247,10 @@ class ReadOnlyCloudMirrorCodeLocationOrigin(
     def get_display_metadata(self) -> Mapping[str, Any]:
         return {}
 
-    def create_location(self, instance: "DagsterInstance") -> "ReadOnlyCloudMirrorCodeLocation":
-        from dagster._core.remote_representation.code_location import (
-            ReadOnlyCloudMirrorCodeLocation,
-        )
+    def create_location(self, instance: "DagsterInstance") -> "ReadOnlyPlusRemoteCodeLocation":
+        from dagster._core.remote_representation.code_location import ReadOnlyPlusRemoteCodeLocation
 
-        return ReadOnlyCloudMirrorCodeLocation(
+        return ReadOnlyPlusRemoteCodeLocation(
             code_location_origin=self,
             instance=instance,
             url=self.url,
@@ -262,12 +258,10 @@ class ReadOnlyCloudMirrorCodeLocationOrigin(
             token=self.token,
         )
 
-    def reload_location(self, instance: "DagsterInstance") -> "ReadOnlyCloudMirrorCodeLocation":
-        from dagster._core.remote_representation.code_location import (
-            ReadOnlyCloudMirrorCodeLocation,
-        )
+    def reload_location(self, instance: "DagsterInstance") -> "ReadOnlyPlusRemoteCodeLocation":
+        from dagster._core.remote_representation.code_location import ReadOnlyPlusRemoteCodeLocation
 
-        return ReadOnlyCloudMirrorCodeLocation(
+        return ReadOnlyPlusRemoteCodeLocation(
             code_location_origin=self,
             instance=instance,
             url=self.url,

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -227,10 +227,10 @@ class ReadOnlyPlusRemoteCodeLocationOrigin(
 
     def __new__(
         cls,
+        location_name: str,
         url: str,
         deployment: str,
         token: str,
-        location_name: str,
     ):
         return super().__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -91,6 +91,11 @@ WORKSPACE_CONFIG_SCHEMA = {
                             "ssl": Field(bool, is_required=False),
                             "additional_metadata": Field(Permissive(), is_required=False),
                         },
+                        "cloud_mirror": {
+                            "url": Field(StringSource, is_required=False),
+                            "deployment": Field(StringSource, is_required=False),
+                            "token": Field(StringSource, is_required=False),
+                        },
                     },
                 )
             )

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -91,7 +91,7 @@ WORKSPACE_CONFIG_SCHEMA = {
                             "ssl": Field(bool, is_required=False),
                             "additional_metadata": Field(Permissive(), is_required=False),
                         },
-                        "cloud_mirror": {
+                        "plus": {
                             "url": Field(StringSource, is_required=False),
                             "deployment": Field(StringSource, is_required=False),
                             "token": Field(StringSource, is_required=False),

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Optional, Union, cast
 
+from dagster_graphql.client.client import DagsterGraphQLClient
 from dagster_shared.yaml_utils import load_yaml_from_path
 
 import dagster._check as check
@@ -12,6 +13,7 @@ from dagster._core.remote_representation.origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
+    ReadOnlyCloudMirrorCodeLocationOrigin,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.config_schema import ensure_workspace_config
@@ -59,13 +61,13 @@ def location_origins_from_config(
     location_configs = check.list_elem(workspace_config, "load_from", of_type=dict)
     location_origins: dict[str, CodeLocationOrigin] = OrderedDict()
     for location_config in location_configs:
-        origin = _location_origin_from_location_config(location_config, yaml_path)
-        check.invariant(
-            location_origins.get(origin.location_name) is None,
-            f'Cannot have multiple locations with the same name, got multiple "{origin.location_name}"',
-        )
+        for origin in _location_origins_from_location_config(location_config, yaml_path):
+            check.invariant(
+                location_origins.get(origin.location_name) is None,
+                f'Cannot have multiple locations with the same name, got multiple "{origin.location_name}"',
+            )
 
-        location_origins[origin.location_name] = origin
+            location_origins[origin.location_name] = origin
 
     return location_origins
 
@@ -257,6 +259,64 @@ def location_origin_from_python_file(
     )
 
 
+WORKSPACE_ENTRIES_QUERY = """
+query CliWorkspaceEntries {
+    workspace {
+        workspaceEntries {
+            locationName
+            serializedDeploymentMetadata
+        }
+    }
+}
+"""
+
+
+def _location_origins_from_cloud_mirror_config(
+    cloud_mirror_config: Mapping, yaml_path: str
+) -> Sequence[ReadOnlyCloudMirrorCodeLocationOrigin]:
+    check.mapping_param(cloud_mirror_config, "cloud_mirror_config")
+    check.str_param(yaml_path, "yaml_path")
+
+    url, organization, deployment, token = (
+        cloud_mirror_config.get("url"),
+        cloud_mirror_config.get("organization"),
+        cloud_mirror_config.get("deployment"),
+        cloud_mirror_config.get("token"),
+    )
+
+    check.invariant(
+        (url or organization) and not (url and organization),
+        "Must supply either a url or an organization",
+    )
+    if organization:
+        url = f"https://agent.{organization}.dagster.cloud"
+
+    client = DagsterGraphQLClient(
+        use_https=False,
+        hostname="localhost",
+        port_number=2873,
+        headers={
+            "Dagster-Cloud-Version": "1.0",
+            "Authorization": f"Bearer {check.str_param(token, 'token')}",
+            "Dagster-Cloud-Deployment": check.str_param(deployment, "deployment"),
+        },
+    )
+    code_location_names = [
+        entry["locationName"]
+        for entry in client._execute(WORKSPACE_ENTRIES_QUERY)["workspace"]["workspaceEntries"]
+    ]
+
+    return [
+        ReadOnlyCloudMirrorCodeLocationOrigin(
+            location_name=location_name,
+            url=check.str_param(url, "url"),
+            deployment=check.str_param(deployment, "deployment"),
+            token=check.str_param(token, "token"),
+        )
+        for location_name in code_location_names
+    ]
+
+
 def _location_origin_from_grpc_server_config(
     grpc_server_config: Mapping, yaml_path: str
 ) -> GrpcServerCodeLocationOrigin:
@@ -294,17 +354,22 @@ def _get_executable_path(executable_path: Optional[str]) -> Optional[str]:
     return os.path.expanduser(executable_path) if executable_path else None
 
 
-def _location_origin_from_location_config(
+def _location_origins_from_location_config(
     location_config: Mapping, yaml_path: str
-) -> CodeLocationOrigin:
+) -> Sequence[CodeLocationOrigin]:
     check.mapping_param(location_config, "location_config")
     check.str_param(yaml_path, "yaml_path")
 
     if is_target_config(location_config):
-        return _location_origin_from_target_config(location_config, yaml_path)
+        return [_location_origin_from_target_config(location_config, yaml_path)]
 
     elif "grpc_server" in location_config:
-        return _location_origin_from_grpc_server_config(location_config["grpc_server"], yaml_path)
+        return [_location_origin_from_grpc_server_config(location_config["grpc_server"], yaml_path)]
+
+    elif "cloud_mirror" in location_config:
+        return _location_origins_from_cloud_mirror_config(
+            location_config["cloud_mirror"], yaml_path
+        )
 
     else:
         check.not_implemented(f"Unsupported location config: {location_config}")

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -264,7 +264,6 @@ query CliWorkspaceEntries {
     workspace {
         workspaceEntries {
             locationName
-            serializedDeploymentMetadata
         }
     }
 }
@@ -273,10 +272,22 @@ query CliWorkspaceEntries {
 
 def _fetch_from_plus_gql(url: str, deployment: str, token: str, query: str) -> dict[str, Any]:
     """Fetches data from the Plus API using a GraphQL client."""
+    protocol = "https"
+    port = None
+
+    if "://" in url:
+        protocol, url = url.split("://")
+
+    if ":" in url:
+        host, port = url.split(":")
+        port = int(port)
+    else:
+        host = url
+
     client = DagsterGraphQLClient(
-        use_https=False,
-        hostname="localhost",
-        port_number=2873,
+        use_https=protocol == "https",
+        hostname=host,
+        port_number=port,
         headers={
             "Dagster-Cloud-Version": "1.0",
             "Authorization": f"Bearer {check.str_param(token, 'token')}",

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -10,6 +10,7 @@ from dagster._core.remote_representation.origin import (
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
+    ReadOnlyCloudMirrorCodeLocationOrigin,
 )
 from dagster._core.workspace.load import (
     location_origin_from_module_name,
@@ -55,6 +56,24 @@ class InProcessWorkspaceLoadTarget(WorkspaceLoadTarget):
         )
 
     def create_origins(self) -> Sequence[InProcessCodeLocationOrigin]:
+        return self._origins
+
+
+class ReadOnlyCloudMirrorWorkspaceLoadTarget(WorkspaceLoadTarget):
+    """A workspace load target that is in-process and does not spin up a gRPC server."""
+
+    def __init__(
+        self,
+        origin: Union[
+            ReadOnlyCloudMirrorCodeLocationOrigin, Sequence[ReadOnlyCloudMirrorCodeLocationOrigin]
+        ],
+    ):
+        self._origins = cast(
+            Sequence[ReadOnlyCloudMirrorCodeLocationOrigin],
+            origin if isinstance(origin, list) else [origin],
+        )
+
+    def create_origins(self) -> Sequence[ReadOnlyCloudMirrorCodeLocationOrigin]:
         return self._origins
 
 

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -10,7 +10,7 @@ from dagster._core.remote_representation.origin import (
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
-    ReadOnlyCloudMirrorCodeLocationOrigin,
+    ReadOnlyPlusRemoteCodeLocationOrigin,
 )
 from dagster._core.workspace.load import (
     location_origin_from_module_name,
@@ -65,15 +65,15 @@ class ReadOnlyCloudMirrorWorkspaceLoadTarget(WorkspaceLoadTarget):
     def __init__(
         self,
         origin: Union[
-            ReadOnlyCloudMirrorCodeLocationOrigin, Sequence[ReadOnlyCloudMirrorCodeLocationOrigin]
+            ReadOnlyPlusRemoteCodeLocationOrigin, Sequence[ReadOnlyPlusRemoteCodeLocationOrigin]
         ],
     ):
         self._origins = cast(
-            Sequence[ReadOnlyCloudMirrorCodeLocationOrigin],
+            Sequence[ReadOnlyPlusRemoteCodeLocationOrigin],
             origin if isinstance(origin, list) else [origin],
         )
 
-    def create_origins(self) -> Sequence[ReadOnlyCloudMirrorCodeLocationOrigin]:
+    def create_origins(self) -> Sequence[ReadOnlyPlusRemoteCodeLocationOrigin]:
         return self._origins
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_plus_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_plus_workspace.py
@@ -1,7 +1,6 @@
 import zlib
 from contextlib import ExitStack
 from typing import cast
-from unittest import mock
 from uuid import uuid4
 
 import dagster as dg
@@ -14,7 +13,6 @@ from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.load import location_origins_from_config
 from dagster._serdes import serialize_value
 from dagster._utils import file_relative_path
-from gql import Client
 
 
 @pytest.fixture
@@ -49,65 +47,58 @@ def add_fake_hosted_location(snap: RepositorySnap) -> str:
 
 @responses.activate
 def test_plus_workspace(instance):
-    def _mock_create_underlying_client(transport):
-        return Client(transport=transport, fetch_schema_from_transport=False)
+    MOCK_URL = "https://dagster.cloud"
+    MOCK_TOKEN = "abc123"
 
-    with mock.patch(
-        "dagster_graphql.client.client._create_underlying_client",
-        side_effect=_mock_create_underlying_client,
-    ):
-        MOCK_URL = "https://dagster.cloud"
-        MOCK_TOKEN = "abc123"
-
-        responses.add(
-            method=responses.POST,
-            url=f"{MOCK_URL}/graphql",
-            json={
-                "data": {
-                    "workspace": {
-                        "workspaceEntries": [
-                            {"locationName": "location_one"},
-                            {"locationName": "location_two"},
-                        ]
-                    },
+    responses.add(
+        method=responses.POST,
+        url=f"{MOCK_URL}/graphql",
+        json={
+            "data": {
+                "workspace": {
+                    "workspaceEntries": [
+                        {"locationName": "location_one"},
+                        {"locationName": "location_two"},
+                    ]
                 },
             },
-            status=200,
-        )
+        },
+        status=200,
+    )
 
-        location_one_fake_url = add_fake_hosted_location(location_one_snapshot())
-        location_two_fake_url = add_fake_hosted_location(location_two_snapshot())
+    location_one_fake_url = add_fake_hosted_location(location_one_snapshot())
+    location_two_fake_url = add_fake_hosted_location(location_two_snapshot())
 
-        responses.add(
-            method=responses.GET,
-            url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_one",
-            json={
-                "repositories": [
-                    {
-                        "repository_name": "repository_one",
-                        "presigned_url": location_one_fake_url,
-                        "presigned_job_urls": {},
-                    }
-                ]
-            },
-            status=200,
-        )
-        responses.add(
-            method=responses.GET,
-            url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_two",
-            json={
-                "repositories": [
-                    {
-                        "repository_name": "repository_two",
-                        "presigned_url": location_two_fake_url,
-                        "presigned_job_urls": {},
-                    }
-                ]
-            },
-            status=200,
-        )
+    responses.add(
+        method=responses.GET,
+        url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_one",
+        json={
+            "repositories": [
+                {
+                    "repository_name": "repository_one",
+                    "presigned_url": location_one_fake_url,
+                    "presigned_job_urls": {},
+                }
+            ]
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_two",
+        json={
+            "repositories": [
+                {
+                    "repository_name": "repository_two",
+                    "presigned_url": location_two_fake_url,
+                    "presigned_job_urls": {},
+                }
+            ]
+        },
+        status=200,
+    )
 
-        workspace_yaml = f"""
+    workspace_yaml = f"""
 load_from:
     - plus:
         url: {MOCK_URL}
@@ -115,29 +106,29 @@ load_from:
         token: {MOCK_TOKEN}
             """
 
-        origins = location_origins_from_config(
-            yaml.safe_load(workspace_yaml),
-            # fake out as if it were loaded by a yaml file in this directory
-            file_relative_path(__file__, "not_a_real.yaml"),
-        )
+    origins = location_origins_from_config(
+        yaml.safe_load(workspace_yaml),
+        # fake out as if it were loaded by a yaml file in this directory
+        file_relative_path(__file__, "not_a_real.yaml"),
+    )
 
-        with ExitStack() as stack:
-            code_locations = {
-                name: stack.enter_context(origin.create_location(instance))
-                for name, origin in origins.items()
-            }
-            assert len(code_locations) == 2
+    with ExitStack() as stack:
+        code_locations = {
+            name: stack.enter_context(origin.create_location(instance))
+            for name, origin in origins.items()
+        }
+        assert len(code_locations) == 2
 
-            code_location_one = cast(CodeLocation, code_locations["location_one"])
-            repo_one = code_location_one.get_repository("repository_one")
-            assert repo_one.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_one_asset")}
-            asset_one_snap = repo_one.get_asset_node_snap(dg.AssetKey("location_one_asset"))
-            assert asset_one_snap
-            assert not asset_one_snap.is_executable
+        code_location_one = cast(CodeLocation, code_locations["location_one"])
+        repo_one = code_location_one.get_repository("repository_one")
+        assert repo_one.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_one_asset")}
+        asset_one_snap = repo_one.get_asset_node_snap(dg.AssetKey("location_one_asset"))
+        assert asset_one_snap
+        assert not asset_one_snap.is_executable
 
-            code_location_two = cast(CodeLocation, code_locations["location_two"])
-            repo_two = code_location_two.get_repository("repository_two")
-            assert repo_two.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_two_asset")}
-            asset_two_snap = repo_two.get_asset_node_snap(dg.AssetKey("location_two_asset"))
-            assert asset_two_snap
-            assert not asset_two_snap.is_executable
+        code_location_two = cast(CodeLocation, code_locations["location_two"])
+        repo_two = code_location_two.get_repository("repository_two")
+        assert repo_two.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_two_asset")}
+        asset_two_snap = repo_two.get_asset_node_snap(dg.AssetKey("location_two_asset"))
+        assert asset_two_snap
+        assert not asset_two_snap.is_executable

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_plus_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_plus_workspace.py
@@ -1,0 +1,143 @@
+import zlib
+from contextlib import ExitStack
+from typing import cast
+from unittest import mock
+from uuid import uuid4
+
+import dagster as dg
+import pytest
+import responses
+import yaml
+from dagster._core.remote_representation.code_location import CodeLocation
+from dagster._core.remote_representation.external_data import RepositorySnap
+from dagster._core.test_utils import instance_for_test
+from dagster._core.workspace.load import location_origins_from_config
+from dagster._serdes import serialize_value
+from dagster._utils import file_relative_path
+from gql import Client
+
+
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+def location_one_snapshot() -> RepositorySnap:
+    @dg.asset
+    def location_one_asset():
+        return "location_one_asset"
+
+    return RepositorySnap.from_def(dg.Definitions(assets=[location_one_asset]).get_repository_def())
+
+
+def location_two_snapshot() -> RepositorySnap:
+    @dg.asset
+    def location_two_asset():
+        return "location_two_asset"
+
+    return RepositorySnap.from_def(dg.Definitions(assets=[location_two_asset]).get_repository_def())
+
+
+def add_fake_hosted_location(snap: RepositorySnap) -> str:
+    uuid = str(uuid4())
+    fake_url = f"https://aws.com/location_{uuid}.json.gz"
+    file = zlib.compress(serialize_value(snap).encode("utf-8"))
+    responses.add(method=responses.GET, url=fake_url, body=file, status=200)
+    return fake_url
+
+
+@responses.activate
+def test_plus_workspace(instance):
+    def _mock_create_underlying_client(transport):
+        return Client(transport=transport, fetch_schema_from_transport=False)
+
+    with mock.patch(
+        "dagster_graphql.client.client._create_underlying_client",
+        side_effect=_mock_create_underlying_client,
+    ):
+        MOCK_URL = "https://dagster.cloud"
+        MOCK_TOKEN = "abc123"
+
+        responses.add(
+            method=responses.POST,
+            url=f"{MOCK_URL}/graphql",
+            json={
+                "data": {
+                    "workspace": {
+                        "workspaceEntries": [
+                            {"locationName": "location_one"},
+                            {"locationName": "location_two"},
+                        ]
+                    },
+                },
+            },
+            status=200,
+        )
+
+        location_one_fake_url = add_fake_hosted_location(location_one_snapshot())
+        location_two_fake_url = add_fake_hosted_location(location_two_snapshot())
+
+        responses.add(
+            method=responses.GET,
+            url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_one",
+            json={
+                "repositories": [
+                    {
+                        "repository_name": "repository_one",
+                        "presigned_url": location_one_fake_url,
+                        "presigned_job_urls": {},
+                    }
+                ]
+            },
+            status=200,
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{MOCK_URL}/gen_code_location_snapshot_url?location_name=location_two",
+            json={
+                "repositories": [
+                    {
+                        "repository_name": "repository_two",
+                        "presigned_url": location_two_fake_url,
+                        "presigned_job_urls": {},
+                    }
+                ]
+            },
+            status=200,
+        )
+
+        workspace_yaml = f"""
+load_from:
+    - plus:
+        url: {MOCK_URL}
+        deployment: test
+        token: {MOCK_TOKEN}
+            """
+
+        origins = location_origins_from_config(
+            yaml.safe_load(workspace_yaml),
+            # fake out as if it were loaded by a yaml file in this directory
+            file_relative_path(__file__, "not_a_real.yaml"),
+        )
+
+        with ExitStack() as stack:
+            code_locations = {
+                name: stack.enter_context(origin.create_location(instance))
+                for name, origin in origins.items()
+            }
+            assert len(code_locations) == 2
+
+            code_location_one = cast(CodeLocation, code_locations["location_one"])
+            repo_one = code_location_one.get_repository("repository_one")
+            assert repo_one.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_one_asset")}
+            asset_one_snap = repo_one.get_asset_node_snap(dg.AssetKey("location_one_asset"))
+            assert asset_one_snap
+            assert not asset_one_snap.is_executable
+
+            code_location_two = cast(CodeLocation, code_locations["location_two"])
+            repo_two = code_location_two.get_repository("repository_two")
+            assert repo_two.asset_graph.get_all_asset_keys() == {dg.AssetKey("location_two_asset")}
+            asset_two_snap = repo_two.get_asset_node_snap(dg.AssetKey("location_two_asset"))
+            assert asset_two_snap
+            assert not asset_two_snap.is_executable

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -82,6 +82,7 @@ setup(
         # core (not explicitly expressed atm)
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0",
+        "gql",
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -11,9 +11,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.execution.context.asset_execution_context import (
-    AssetExecutionContext,
-)
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_dbt import (
     DagsterDbtTranslator,
     DbtCliResource,
@@ -23,8 +21,6 @@ from dagster_dbt import (
 )
 from dagster_dbt.asset_utils import (
     get_asset_key_for_model as get_asset_key_for_model,
-)
-from dagster_dbt.asset_utils import (
     get_asset_spec,
 )
 from dagster_dbt.dbt_manifest import validate_manifest
@@ -32,9 +28,7 @@ from dagster_dbt.utils import get_dbt_resource_props_by_dbt_unique_id_from_manif
 from typing_extensions import override
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.components.dbt_project.scaffolder import (
-    DbtProjectComponentScaffolder,
-)
+from dagster_components.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
 from dagster_components.resolved.core_models import (
     AssetAttributesModel,
     AssetPostProcessor,
@@ -61,9 +55,7 @@ class DbtProjectModel(ResolvableModel):
     exclude: Optional[str] = None
 
 
-def resolve_translator(
-    context: ResolutionContext, model: DbtProjectModel
-) -> DagsterDbtTranslator:
+def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> DagsterDbtTranslator:
     class DagsterDbtTranslatorWithSpecs(DagsterDbtTranslator):
         def __init__(self, *, resolving_info: TranslatorResolvingInfo):
             super().__init__()
@@ -85,10 +77,7 @@ def resolve_translator(
 
         @cached_property
         def group_props(self) -> Mapping[str, Any]:
-            return {
-                group["name"]: group
-                for group in self.manifest.get("groups", {}).values()
-            }
+            return {group["name"]: group for group in self.manifest.get("groups", {}).values()}
 
         def get_asset_spec(self, stream_definition: Mapping[str, Any]) -> AssetSpec:
             if id(stream_definition) not in self._specs_map:
@@ -100,14 +89,12 @@ def resolve_translator(
                     project=self.project,
                     resource_props=stream_definition,
                 )
-                self._specs_map[id(stream_definition)] = (
-                    self.resolving_info.get_asset_spec(
-                        base_spec,
-                        {
-                            self.resolving_info.obj_name: stream_definition,
-                            "spec": base_spec,
-                        },
-                    )
+                self._specs_map[id(stream_definition)] = self.resolving_info.get_asset_spec(
+                    base_spec,
+                    {
+                        self.resolving_info.obj_name: stream_definition,
+                        "spec": base_spec,
+                    },
                 )
             return self._specs_map[id(stream_definition)]
 
@@ -116,15 +103,11 @@ def resolve_translator(
             return self.get_asset_spec(dbt_resource_props).key
 
         @override
-        def get_description(
-            self, dbt_resource_props: Mapping[str, Any]
-        ) -> Optional[str]:
+        def get_description(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).description
 
         @override
-        def get_metadata(
-            self, dbt_resource_props: Mapping[str, Any]
-        ) -> Mapping[str, Any]:
+        def get_metadata(self, dbt_resource_props: Mapping[str, Any]) -> Mapping[str, Any]:
             return self.get_asset_spec(dbt_resource_props).metadata
 
         @override
@@ -132,15 +115,11 @@ def resolve_translator(
             return self.get_asset_spec(dbt_resource_props).tags
 
         @override
-        def get_group_name(
-            self, dbt_resource_props: Mapping[str, Any]
-        ) -> Optional[str]:
+        def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).group_name
 
         @override
-        def get_code_version(
-            self, dbt_resource_props: Mapping[str, Any]
-        ) -> Optional[str]:
+        def get_code_version(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).code_version
 
         @override
@@ -195,9 +174,9 @@ class DbtProjectComponent(Component, ResolvedFrom[DbtProjectModel]):
     dbt: Annotated[DbtCliResource, Resolver(resolve_dbt)]
     op: Annotated[Optional[OpSpec], Resolver.from_annotation()] = None
     # This requires from_parent because it access asset_attributes in the model
-    translator: Annotated[
-        DagsterDbtTranslator, Resolver.from_model(resolve_translator)
-    ] = field(default_factory=DagsterDbtTranslator)
+    translator: Annotated[DagsterDbtTranslator, Resolver.from_model(resolve_translator)] = field(
+        default_factory=DagsterDbtTranslator
+    )
     asset_post_processors: Annotated[
         Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
@@ -271,6 +250,4 @@ def get_asset_key_for_model_from_module(
                 ...
     """
     defs = context.load_defs(dbt_component_module)
-    return get_asset_key_for_model(
-        cast(Sequence[AssetsDefinition], defs.assets), model_name
-    )
+    return get_asset_key_for_model(cast(Sequence[AssetsDefinition], defs.assets), model_name)

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -11,7 +11,9 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.asset_execution_context import (
+    AssetExecutionContext,
+)
 from dagster_dbt import (
     DagsterDbtTranslator,
     DbtCliResource,
@@ -21,6 +23,8 @@ from dagster_dbt import (
 )
 from dagster_dbt.asset_utils import (
     get_asset_key_for_model as get_asset_key_for_model,
+)
+from dagster_dbt.asset_utils import (
     get_asset_spec,
 )
 from dagster_dbt.dbt_manifest import validate_manifest
@@ -28,7 +32,9 @@ from dagster_dbt.utils import get_dbt_resource_props_by_dbt_unique_id_from_manif
 from typing_extensions import override
 
 from dagster_components import Component, ComponentLoadContext
-from dagster_components.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
+from dagster_components.components.dbt_project.scaffolder import (
+    DbtProjectComponentScaffolder,
+)
 from dagster_components.resolved.core_models import (
     AssetAttributesModel,
     AssetPostProcessor,
@@ -55,7 +61,9 @@ class DbtProjectModel(ResolvableModel):
     exclude: Optional[str] = None
 
 
-def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> DagsterDbtTranslator:
+def resolve_translator(
+    context: ResolutionContext, model: DbtProjectModel
+) -> DagsterDbtTranslator:
     class DagsterDbtTranslatorWithSpecs(DagsterDbtTranslator):
         def __init__(self, *, resolving_info: TranslatorResolvingInfo):
             super().__init__()
@@ -77,7 +85,10 @@ def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> Da
 
         @cached_property
         def group_props(self) -> Mapping[str, Any]:
-            return {group["name"]: group for group in self.manifest.get("groups", {}).values()}
+            return {
+                group["name"]: group
+                for group in self.manifest.get("groups", {}).values()
+            }
 
         def get_asset_spec(self, stream_definition: Mapping[str, Any]) -> AssetSpec:
             if id(stream_definition) not in self._specs_map:
@@ -89,9 +100,14 @@ def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> Da
                     project=self.project,
                     resource_props=stream_definition,
                 )
-                self._specs_map[id(stream_definition)] = self.resolving_info.get_asset_spec(
-                    base_spec,
-                    {self.resolving_info.obj_name: stream_definition, "spec": base_spec},
+                self._specs_map[id(stream_definition)] = (
+                    self.resolving_info.get_asset_spec(
+                        base_spec,
+                        {
+                            self.resolving_info.obj_name: stream_definition,
+                            "spec": base_spec,
+                        },
+                    )
                 )
             return self._specs_map[id(stream_definition)]
 
@@ -100,11 +116,15 @@ def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> Da
             return self.get_asset_spec(dbt_resource_props).key
 
         @override
-        def get_description(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        def get_description(
+            self, dbt_resource_props: Mapping[str, Any]
+        ) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).description
 
         @override
-        def get_metadata(self, dbt_resource_props: Mapping[str, Any]) -> Mapping[str, Any]:
+        def get_metadata(
+            self, dbt_resource_props: Mapping[str, Any]
+        ) -> Mapping[str, Any]:
             return self.get_asset_spec(dbt_resource_props).metadata
 
         @override
@@ -112,11 +132,15 @@ def resolve_translator(context: ResolutionContext, model: DbtProjectModel) -> Da
             return self.get_asset_spec(dbt_resource_props).tags
 
         @override
-        def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        def get_group_name(
+            self, dbt_resource_props: Mapping[str, Any]
+        ) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).group_name
 
         @override
-        def get_code_version(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        def get_code_version(
+            self, dbt_resource_props: Mapping[str, Any]
+        ) -> Optional[str]:
             return self.get_asset_spec(dbt_resource_props).code_version
 
         @override
@@ -171,9 +195,9 @@ class DbtProjectComponent(Component, ResolvedFrom[DbtProjectModel]):
     dbt: Annotated[DbtCliResource, Resolver(resolve_dbt)]
     op: Annotated[Optional[OpSpec], Resolver.from_annotation()] = None
     # This requires from_parent because it access asset_attributes in the model
-    translator: Annotated[DagsterDbtTranslator, Resolver.from_model(resolve_translator)] = field(
-        default_factory=DagsterDbtTranslator
-    )
+    translator: Annotated[
+        DagsterDbtTranslator, Resolver.from_model(resolve_translator)
+    ] = field(default_factory=DagsterDbtTranslator)
     asset_post_processors: Annotated[
         Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
@@ -247,4 +271,6 @@ def get_asset_key_for_model_from_module(
                 ...
     """
     defs = context.load_defs(dbt_component_module)
-    return get_asset_key_for_model(cast(Sequence[AssetsDefinition], defs.assets), model_name)
+    return get_asset_key_for_model(
+        cast(Sequence[AssetsDefinition], defs.assets), model_name
+    )


### PR DESCRIPTION
## Summary

Prototype of a new code location type which can be specified in `workspace.yaml` - it requires Dagster Plus credentials, and pulls down a read-only/non-executable representation of all code locations defined in that Plus deployment.

This can be useful to allow local dev in the context of a broader organization.


`workspace.yaml`
```yaml
load_from:
  - python_module: my_local_module
  - plus:
      url: localhost:2873
      deployment: staging
      token: user:1234
```