### PR TITLE
[dagster-dbt] Exclude kitchen sink from pytest in .tox

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -35,8 +35,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> Iterator[None]:
     for item in items:
         if "cloud" in item.path.parts or "cloud_v2" in item.path.parts:
             item.add_marker(pytest.mark.cloud)
-        elif "kitchen-sink" in item.path.parts:
-            item.add_marker(pytest.mark.kitchen_sink)
         else:
             item.add_marker(pytest.mark.core)
 

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -37,8 +37,8 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --durations 10  --reruns 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core-main: pytest --durations 10  --reruns 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --durations 10 --reruns 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
-  snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
-  bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'
+  cloud: pytest --ignore=./kitchen-sink --durations 10  --reruns 3 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core-main: pytest --ignore=./kitchen-sink --durations 10  --reruns 3 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --ignore=./kitchen-sink --durations 10 --reruns 3 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  snowflake: pytest --ignore=./kitchen-sink -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
+  bigquery: pytest --ignore=./kitchen-sink -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
## Summary & Motivation

Even with their own marker, kitchen sink tests are collected by pytest - they are not executed, but we raise an exception in the kitchen test suite when env vars are not set, which is enough to break dbt tests, see [here](https://buildkite.com/dagster/dagster-dagster/builds/115687#0195b4f1-e08a-4eae-acdc-100d8977bd99).

This PR also removes the kitchen sink marker to avoid confusion - `--ignore=./kitchen-sink` excludes the tests, not the marker.

## How I Tested These Changes

BK
