### PR TITLE
add dynamic partitions from sensor test result

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -205,7 +205,6 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
       (executionParamsList != null && executionParamsList.length > 0) ||
       (dynamicPartitionRequests?.length || 0) > 0
     );
-  });
   }, [executionParamsList, dynamicPartitionRequests]);
 
   const onApply = useCallback(async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -203,9 +203,9 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
   const canApply = useMemo(() => {
     return (
       (executionParamsList != null && executionParamsList.length > 0) ||
-      dynamicPartitionRequests?.length ||
-      0 > 0
+      (dynamicPartitionRequests?.length || 0) > 0
     );
+  });
   }, [executionParamsList, dynamicPartitionRequests]);
 
   const onApply = useCallback(async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -214,9 +214,9 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
 
     try {
       if (dynamicPartitionRequests?.length) {
-        dynamicPartitionRequests.forEach(async (request) => {
+        await Promise.all(dynamicPartitionRequests.map(async (request) => {
           if (request.type === DynamicPartitionsRequestType.ADD_PARTITIONS) {
-            (request.partitionKeys || []).forEach(async (partitionKey) => {
+            await Promise.all((request.partitionKeys || []).map(async (partitionKey) => {
               await createPartition({
                 variables: {
                   repositorySelector: {
@@ -227,7 +227,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
                   partitionKey,
                 },
               });
-            });
+            }));
           } else if (request.partitionKeys && request.partitionKeys.length) {
             await deletePartition({
               variables: {
@@ -240,7 +240,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
               },
             });
           }
-        });
+        }));
       }
       if (executionParamsList) {
         await launchMultipleRunsWithTelemetry({executionParamsList}, 'toast');


### PR DESCRIPTION
## Summary & Motivation
When testing sensors, we can visualize requests to add dynamic partitions, but the `Launch all` action does not apply dynamic partition requests.

This change applies the dynamic partition mutation requests associated with a test sensor result.

## How I Tested These Changes

https://github.com/user-attachments/assets/94d6eed3-4e95-4ec7-a79c-0a6c847554c8


## Changelog

- Applying changes from sensor test results now also apply changes from dynamic partition requests