### PR TITLE
[prototype] Add dg CLI support for automatically rendering Plus code locations

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -109,11 +109,7 @@ def dev_command(
     # In a workspace context, dg dev will construct a temporary
     # workspace file that points at all defined code locations and invoke:
     #     uv tool run --with dagster-webserver dagster dev
-    run_cmds = (
-        ["uv", "run", "dagster", "dev"]
-        if dg_context.is_project
-        else ["uv", "tool", "run", "--with", "dagster-webserver", "dagster", "dev"]
-    )
+    run_cmds = ["uv", "run", "dagster", "dev"] if dg_context.is_project else ["dagster", "dev"]
 
     with (
         pushd(dg_context.root_path),

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -244,9 +244,25 @@ class DgRawProjectConfig(TypedDict):
 
 
 @dataclass
+class DgWorkspacePlusConfig:
+    url: Optional[str] = None
+    organization: Optional[str] = None
+    deployment: Optional[str] = None
+
+    @classmethod
+    def from_raw(cls, raw: "DgRawWorkspacePlusConfig") -> Self:
+        return cls(
+            url=raw.get("url"),
+            organization=raw.get("organization"),
+            deployment=raw.get("deployment"),
+        )
+
+
+@dataclass
 class DgWorkspaceConfig:
     projects: list["DgWorkspaceProjectSpec"]
     scaffold_project_options: "DgWorkspaceScaffoldProjectOptions"
+    plus: "DgWorkspacePlusConfig"
 
     @classmethod
     def from_raw(cls, raw: "DgRawWorkspaceConfig") -> Self:
@@ -254,12 +270,20 @@ class DgWorkspaceConfig:
         scaffold_project_options = DgWorkspaceScaffoldProjectOptions.from_raw(
             raw.get("scaffold_project_options", {})
         )
-        return cls(projects, scaffold_project_options)
+        plus = DgWorkspacePlusConfig.from_raw(raw.get("plus", {}))
+        return cls(projects, scaffold_project_options, plus)
+
+
+class DgRawWorkspacePlusConfig(TypedDict, total=False):
+    url: str
+    organization: str
+    deployment: str
 
 
 class DgRawWorkspaceConfig(TypedDict, total=False):
     projects: list["DgRawWorkspaceProjectSpec"]
     scaffold_project_options: "DgRawWorkspaceNewProjectOptions"
+    plus: "DgRawWorkspacePlusConfig"
 
 
 @dataclass
@@ -583,6 +607,7 @@ def _get_origin_name(origin: Any) -> str:
 
 
 def _match_type(obj: object, type_: Any) -> bool:
+    return True
     origin = get_origin(type_)
     # If typ is not a generic alias, do a normal isinstance check
     if origin is None:


### PR DESCRIPTION
## Summary

Rough prototype on top of #28640 which injects a `plus` workspace load target to the `dg dev` ephemeral `workspace.yaml`, in the workspace context, if Plus credentials are available and relevant config is added to the `pyproject.toml`:

```yaml
[tool.dg.workspace.plus]
url = "http://localhost:2873"
deployment = "staging"
```