### PR TITLE
[dg] DefsModuleComponent

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/18-dg-list-component-types.txt
@@ -8,6 +8,12 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                                                                      │ arbitrary set   │
 │                                                                      │ of Dagster      │
 │                                                                      │ definitions.    │
+│ dagster_components.dagster.DefsModuleComponent                       │ Wraps a         │
+│                                                                      │ DefsModule to   │
+│                                                                      │ allow the       │
+│                                                                      │ addition of     │
+│                                                                      │ arbitrary       │
+│                                                                      │ attributes.     │
 │ dagster_components.dagster.PipesSubprocessScriptCollectionComponent  │ Assets that     │
 │                                                                      │ wrap Python     │
 │                                                                      │ scripts         │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/7-dg-list-component-types.txt
@@ -7,6 +7,12 @@ dg list component-type
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
+│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│                                                                     │ DefsModule to    │
+│                                                                     │ allow the        │
+│                                                                     │ addition of      │
+│                                                                     │ arbitrary        │
+│                                                                     │ attributes.      │
 │ dagster_components.dagster.PipesSubprocessScriptCollectionComponent │ Assets that wrap │
 │                                                                     │ Python scripts   │
 │                                                                     │ executed with    │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/8-dg-list-component-types.txt
@@ -8,6 +8,12 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                                                                      │ arbitrary set   │
 │                                                                      │ of Dagster      │
 │                                                                      │ definitions.    │
+│ dagster_components.dagster.DefsModuleComponent                       │ Wraps a         │
+│                                                                      │ DefsModule to   │
+│                                                                      │ allow the       │
+│                                                                      │ addition of     │
+│                                                                      │ arbitrary       │
+│                                                                      │ attributes.     │
 │ dagster_components.dagster.PipesSubprocessScriptCollectionComponent  │ Assets that     │
 │                                                                      │ wrap Python     │
 │                                                                      │ scripts         │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
@@ -8,6 +8,12 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
+│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│                                                                     │ DefsModule to    │
+│                                                                     │ allow the        │
+│                                                                     │ addition of      │
+│                                                                     │ arbitrary        │
+│                                                                     │ attributes.      │
 │ dagster_components.dagster.PipesSubprocessScriptCollectionComponent │ Assets that wrap │
 │                                                                     │ Python scripts   │
 │                                                                     │ executed with    │

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/migrating-project/8-dg-list-component-types.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/dg/migrating-project/8-dg-list-component-types.txt
@@ -8,6 +8,12 @@ Using /.../my-existing-project/.venv/bin/dagster-components
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
+│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│                                                                     │ DefsModule to    │
+│                                                                     │ allow the        │
+│                                                                     │ addition of      │
+│                                                                     │ arbitrary        │
+│                                                                     │ attributes.      │
 │ dagster_components.dagster.PipesSubprocessScriptCollectionComponent │ Assets that wrap │
 │                                                                     │ Python scripts   │
 │                                                                     │ executed with    │

--- a/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
@@ -1,0 +1,54 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Annotated, Optional
+
+from dagster._core.definitions.definitions_class import Definitions
+from typing_extensions import Self
+
+from dagster_components import AssetPostProcessorModel, Component, ComponentLoadContext
+from dagster_components.core.defs_module import (
+    DefsModule,
+    PythonModuleDecl,
+    SubpackageDefsModuleDecl,
+)
+from dagster_components.resolved.core_models import AssetPostProcessor
+from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
+
+
+class DefsModuleArgsModel(ResolvableModel):
+    asset_post_processors: Optional[Sequence[AssetPostProcessorModel]] = None
+
+
+@dataclass
+class ResolvedDefsModuleArgs(ResolvedFrom[DefsModuleArgsModel]):
+    asset_post_processors: Annotated[Sequence[AssetPostProcessor], Resolver.from_annotation()]
+
+
+class DefsModuleComponent(Component):
+    """Wraps a DefsModule to allow the addition of arbitrary attributes."""
+
+    def __init__(
+        self, post_processors: Sequence[AssetPostProcessor], defs_module: Optional[DefsModule]
+    ):
+        self.post_processors = post_processors
+        self.defs_module = defs_module
+
+    @classmethod
+    def get_schema(cls) -> type[DefsModuleArgsModel]:
+        return DefsModuleArgsModel
+
+    @classmethod
+    def load(cls, attributes: DefsModuleArgsModel, context: ComponentLoadContext) -> Self:
+        path = context.path
+        decl = PythonModuleDecl.from_path(path) or SubpackageDefsModuleDecl.from_path(path)
+        defs_module = decl.load(context) if decl else None
+        resolved_args = resolve_model(
+            attributes, ResolvedDefsModuleArgs, context.resolution_context.at_path("attributes")
+        )
+        return cls(post_processors=resolved_args.asset_post_processors, defs_module=defs_module)
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        defs = self.defs_module.build_defs() if self.defs_module else Definitions()
+        for post_processor in self.post_processors:
+            defs = post_processor.fn(defs)
+        return defs

--- a/python_modules/libraries/dagster-components/dagster_components/dagster.py
+++ b/python_modules/libraries/dagster-components/dagster_components/dagster.py
@@ -1,6 +1,9 @@
 from dagster_components.components.definitions_component.component import (
     DefinitionsComponent as DefinitionsComponent,
 )
+from dagster_components.components.defs_module.component import (
+    DefsModuleComponent as DefsModuleComponent,
+)
 from dagster_components.components.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionComponent as PipesSubprocessScriptCollectionComponent,
 )

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/component.yaml
@@ -1,0 +1,12 @@
+type: dagster_components.dagster.DefsModuleComponent
+
+attributes:
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        tags:
+          top_level_tag: "true"
+    - target: "tag:defs_tag=true"
+      attributes:
+        tags:
+          added_to_defs_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/asset.py
@@ -1,0 +1,9 @@
+import dagster as dg
+
+
+@dg.asset
+def defs_obj_outer() -> None: ...
+
+
+@dg.asset
+def not_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/component.yaml
@@ -1,0 +1,8 @@
+type: dagster_components.dagster.DefsModuleComponent
+
+attributes:
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        tags:
+          defs_object_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/definitions.py
@@ -1,0 +1,6 @@
+import dagster as dg
+
+from .asset import defs_obj_outer  # noqa
+from .inner.asset import defs_obj_inner  # noqa
+
+defs = dg.Definitions(assets=[defs_obj_inner, defs_obj_outer])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/inner/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/inner/asset.py
@@ -1,0 +1,9 @@
+import dagster as dg
+
+
+@dg.asset
+def defs_obj_inner() -> None: ...
+
+
+@dg.asset
+def not_included() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def in_loose_defs() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/component.yaml
@@ -1,0 +1,8 @@
+type: dagster_components.dagster.DefsModuleComponent
+
+attributes:
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        tags: 
+          loose_defs_tag: "true"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def inner() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/component.yaml
@@ -1,0 +1,9 @@
+type: dagster_components.dagster.DefsModuleComponent
+
+attributes:
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        tags:
+          another_level_tag: "true"
+          env_tag: "{{ env('MY_ENV_VAR') }}"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/in_init/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/in_init/__init__.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def in_init() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/innerest/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/innerest/definitions.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+
+@dg.asset
+def innerest_defs() -> None: ...
+
+
+defs = dg.Definitions(assets=[innerest_defs])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/asset.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def innerer() -> None: ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/top_level.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/top_level.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def top_level() -> None: ...


### PR DESCRIPTION
## Summary & Motivation

This is an alternative version of https://github.com/dagster-io/dagster/pull/28624, in which we create a wrapper component type instead of a new config file format.

The functionality is generally the same -- I copied over the exact test from the other PR, and just updated the files:

Before:

```yaml
asset_post_processors:
  - target: "*"
    attributes:
      tags:
        foo: "bar"
```

After:

```yaml
type: dagster_components.dagster.DefsModuleComponent

attributes:
  asset_post_processors:
    - target: "*"
      attributes:
        tags:
	  foo: "bar"
```

(and renaming from defs.yaml to component.yaml)

The main differences that I think make this a bit less appealing long-term:

1. It can't be used inside a single component's directory (because it itself is a component)
2. Right now, a component conceptually "takes over" the loading of an entire directory. This has implications for things like defs module caching, and future worlds in which we want to render the tree structure of the decl nodes without having to load all of the nodes completely. In my code, I try to make the loading behavior as similar as possible to what it would be without this component existing there (that's why I hijack the `load()` method on the component class -- I want to make sure that the load method for submodules gets called at the same time as it would otherwise, as opposed to (e.g.) calling it inside the `build_defs` function.

That being said, the new `defs.yaml` file is a bit more disruptive than this in the short term, so we can go with this for now

## How I Tested These Changes

## Changelog

Added a new `dagster_components.dagster.DefsModuleComponent` that can be used at any level of your `defs/` folder to apply asset attributes to the definitions at or below that level.
