### PR TITLE
[Asset selection filtering] Move workerSpawner into hook 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/jest/mocks/ComputeGraphData.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/jest/mocks/ComputeGraphData.worker.ts
@@ -28,6 +28,8 @@ export default class MockWorker {
       );
     }
   }
+
+  terminate() {}
 }
 
 const originalWorker = global.Worker;


### PR DESCRIPTION
## Summary & Motivation

Currently when you have the catalog view dialog open there are two instances of `useAssetGraphData`. one that belongs to the dialog and the other belongs to the catalog table in the background. Currently what is happening is that the dialog one is killing the worker for the one that belongs to the page causing an infinite loading state when you save your catalog view.

## How I Tested These Changes

Tested locally.  Hard to write jests tests since it involves workers but in my queue is to look into improving how we test workers.


## Changelog

[ui] Fixed an issue where updating a catalog view caused an infinite loading state.
