### PR TITLE
[dagster-shared][dg] Use toml for dg cli config, plus config

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -1,7 +1,7 @@
 import webbrowser
 
 import click
-from dagster_shared.plus.config import DagsterPlusCliConfig, get_active_config_path
+from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.plus.login_server import start_login_server
 
 from dagster_dg.utils import DgClickCommand, DgClickGroup
@@ -31,5 +31,5 @@ def login_command() -> None:
     new_api_token = server.get_token()
 
     config = DagsterPlusCliConfig(organization=new_org, user_token=new_api_token)
-    config.write_to_file(get_active_config_path())
+    config.write()
     click.echo(f"Authorized for organization {new_org}\n")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
@@ -16,7 +16,7 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 
 
 @pytest.fixture()
-def test_cloud_cli_config_file(monkeypatch):
+def setup_cloud_cli_config(monkeypatch):
     with (
         tempfile.TemporaryDirectory() as tmp_cloud_dir,
         tempfile.TemporaryDirectory() as tmp_dg_dir,
@@ -24,17 +24,17 @@ def test_cloud_cli_config_file(monkeypatch):
         config_path = Path(tmp_cloud_dir) / "config"
         config_path.touch()
         monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", config_path)
-        monkeypatch.setenv("DG_CLI_CONFIG", str(Path(tmp_dg_dir) / "config.toml"))
+        monkeypatch.setenv("DG_CLI_CONFIG", str(Path(tmp_dg_dir) / "dg.toml"))
         yield config_path
 
 
 @pytest.fixture()
-def test_dg_cli_config_file(monkeypatch):
+def setup_dg_cli_config(monkeypatch):
     with (
         tempfile.TemporaryDirectory() as tmp_dg_dir,
         tempfile.TemporaryDirectory() as tmp_cloud_dir,
     ):
-        config_path = Path(tmp_dg_dir) / "config.toml"
+        config_path = Path(tmp_dg_dir) / "dg.toml"
         config_path.touch()
         monkeypatch.setenv("DG_CLI_CONFIG", config_path)
         monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(tmp_cloud_dir) / "config"))
@@ -42,12 +42,12 @@ def test_dg_cli_config_file(monkeypatch):
 
 
 @pytest.fixture()
-def test_dg_cli_config_file_additional_config(monkeypatch):
+def setup_dg_cli_config_additional_config(monkeypatch):
     with (
         tempfile.TemporaryDirectory() as tmp_dg_dir,
         tempfile.TemporaryDirectory() as tmp_cloud_dir,
     ):
-        config_path = Path(tmp_dg_dir) / "config.toml"
+        config_path = Path(tmp_dg_dir) / "dg.toml"
         config_path.write_text(
             """
             [cli]
@@ -63,9 +63,9 @@ def test_dg_cli_config_file_additional_config(monkeypatch):
 @pytest.mark.parametrize(
     "fixture_name",
     [
-        "test_cloud_cli_config_file",
-        "test_dg_cli_config_file",
-        "test_dg_cli_config_file_additional_config",
+        "setup_cloud_cli_config",
+        "setup_dg_cli_config",
+        "setup_dg_cli_config_additional_config",
     ],
 )
 def test_setup_command_web(fixture_name, request: pytest.FixtureRequest):
@@ -108,12 +108,12 @@ def test_setup_command_web(fixture_name, request: pytest.FixtureRequest):
         assert DagsterPlusCliConfig.get().organization == "hooli"
         assert DagsterPlusCliConfig.get().user_token == "abc123"
 
-        if fixture_name == "test_cloud_cli_config_file":
+        if fixture_name == "setup_cloud_cli_config":
             assert yaml.safe_load(filepath.read_text()) == {
                 "organization": "hooli",
                 "user_token": "abc123",
             }
-        elif fixture_name == "test_dg_cli_config_file_additional_config":
+        elif fixture_name == "setup_dg_cli_config_additional_config":
             assert tomlkit.parse(filepath.read_text()) == {
                 "cli": {
                     "existing_key": "existing_value",

--- a/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/plus/config.py
@@ -60,9 +60,7 @@ class DagsterPlusCliConfig:
         return cls(**raw_config)
 
     def write(self):
-        print("test")
         existing_config = _get_dagster_plus_config_path_and_raw_config()
-        print(existing_config)
         if existing_config is None:
             config_path = get_dg_config_path()
             raw_config = {}

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
@@ -11,15 +11,14 @@ def is_windows() -> bool:
     return sys.platform == "win32"
 
 
-def _get_default_dg_cli_folder() -> Path:
+def _get_default_dg_cli_file() -> Path:
     if is_windows():
-        return Path.home() / "AppData" / "dg"
+        return Path.home() / "AppData" / "dg" / "dg.toml"
     else:
-        return Path.home() / ".dg"
+        return Path.home() / "dg.toml"
 
 
-DEFAULT_DG_CLI_FOLDER = _get_default_dg_cli_folder()
-DEFAULT_DG_CLI_CONFIG = os.path.join(DEFAULT_DG_CLI_FOLDER, "config.toml")
+DEFAULT_DG_CLI_FILE = _get_default_dg_cli_file()
 
 
 def load_config(config_path: Path) -> dict[str, Any]:
@@ -39,7 +38,7 @@ def write_config(config_path: Path, config: dict[str, Any]):
 
 
 def get_dg_config_path() -> Path:
-    return Path(os.getenv("DG_CLI_CONFIG", DEFAULT_DG_CLI_CONFIG))
+    return Path(os.getenv("DG_CLI_CONFIG", DEFAULT_DG_CLI_FILE))
 
 
 def does_dg_config_file_exist() -> bool:

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+import yaml
+
+DEFAULT_DG_CLI_FOLDER = os.path.join(os.path.expanduser("~"), ".dg")
+DEFAULT_DG_CLI_CONFIG = os.path.join(DEFAULT_DG_CLI_FOLDER, "config.toml")
+
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    if config_path.suffix == ".toml":
+        return tomlkit.parse(config_path.read_text()).unwrap()
+    else:
+        return yaml.safe_load(config_path.read_text()) or {}
+
+
+def write_config(config_path: Path, config: dict[str, Any]):
+    if config_path.suffix == ".toml":
+        with open(config_path, "w") as f:
+            tomlkit.dump(config, f)
+    else:
+        with open(config_path, "w") as f:
+            yaml.safe_dump(config, f)
+
+
+def get_dg_config_path() -> Path:
+    return Path(os.getenv("DG_CLI_CONFIG", DEFAULT_DG_CLI_CONFIG))
+
+
+def does_dg_config_file_exist() -> bool:
+    return get_dg_config_path().exists()

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
@@ -1,11 +1,24 @@
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import tomlkit
 import yaml
 
-DEFAULT_DG_CLI_FOLDER = os.path.join(os.path.expanduser("~"), ".dg")
+
+def is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def _get_default_dg_cli_folder() -> Path:
+    if is_windows():
+        return Path.home() / "AppData" / "dg"
+    else:
+        return Path.home() / ".dg"
+
+
+DEFAULT_DG_CLI_FOLDER = _get_default_dg_cli_folder()
 DEFAULT_DG_CLI_CONFIG = os.path.join(DEFAULT_DG_CLI_FOLDER, "config.toml")
 
 


### PR DESCRIPTION
## Summary

Based on feedback in https://github.com/dagster-io/dagster/pull/28586#issuecomment-2743680003, remaps `~/.dg/config` to live in platform-dependent `config.toml` file.

Updates the Plus config shared code to automatically read from `~/.dagster_cloud_cli/config` (YAML) or dg `config.toml`, nested under the `cli.plus` field.


## Test Plan

Update tests.
