### PR TITLE
RFC Resolved V2: Autogeneration of Models

### DIFF
--- a/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
@@ -1,47 +1,29 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Optional
+from typing import Optional
 
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster_components import Component, ComponentLoadContext
 from dagster_components.resolved.core_models import (
-    AssetAttributesModel,
     AssetPostProcessor,
-    AssetPostProcessorModel,
-    OpSpecModel,
+    OpSpec,
+    ResolvedAssetAttributes,
 )
-from dagster_components.resolved.metadata import ResolvableFieldInfo
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
-from pydantic import Field
-
-
-class ComplexAssetModel(ResolvableModel):
-    value: str = Field(..., examples=["example_for_value"])
-    list_value: list[str] = Field(
-        ..., examples=[["example_for_list_value_1", "example_for_list_value_2"]]
-    )
-    obj_value: dict[str, str] = Field(..., examples=[{"key_1": "value_1", "key_2": "value_2"}])
-    op: Optional[OpSpecModel] = None
-    asset_attributes: Annotated[
-        Optional[AssetAttributesModel], ResolvableFieldInfo(required_scope={"node"})
-    ] = None
-    asset_post_processors: Optional[Sequence[AssetPostProcessorModel]] = None
+from dagster_components.resolved.model import Resolved
 
 
 @dataclass
-class ComplexAssetComponent(Component, ResolvedFrom[ComplexAssetModel]):
+class ComplexAssetComponent(Component, Resolved):
     """An asset that has a complex schema."""
 
     value: str
     list_value: list[str]
     obj_value: dict[str, str]
-    op: Optional[OpSpecModel] = None
-    asset_attributes: Optional[AssetAttributesModel] = None
-    asset_post_processors: Annotated[
-        Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
-    ] = None
+    op: Optional[OpSpec] = None
+    asset_attributes: Optional[ResolvedAssetAttributes] = None
+    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         @asset(spec=self.asset_attributes)
@@ -50,5 +32,5 @@ class ComplexAssetComponent(Component, ResolvedFrom[ComplexAssetModel]):
 
         defs = Definitions(assets=[dummy])
         for post_processor in self.asset_post_processors or []:
-            defs = post_processor.fn(defs)
+            defs = post_processor(defs)
         return defs

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -1,22 +1,19 @@
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster_components import Component, ComponentLoadContext, ResolvableModel, ResolvedFrom
+from dagster_components import Component, ComponentLoadContext
+from dagster_components.resolved.core_models import ResolvedAssetKey
+from dagster_components.resolved.model import Resolved
 
 
-class SimpleAssetComponentModel(ResolvableModel):
-    asset_key: str
-    value: str
-
-
-class SimpleAssetComponent(Component, ResolvedFrom[SimpleAssetComponentModel]):
+class SimpleAssetComponent(Component, Resolved):
     """A simple asset that returns a constant string value."""
 
-    asset_key: str
-    value: str
-
-    def __init__(self, asset_key: AssetKey, value: str):
+    def __init__(
+        self,
+        asset_key: ResolvedAssetKey,
+        value: str,
+    ):
         self._asset_key = asset_key
         self._value = value
 

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -19,14 +19,11 @@ from dagster_components.resolved.context import ResolutionContext as ResolutionC
 from dagster_components.resolved.core_models import (
     AssetAttributesModel as AssetAttributesModel,
     AssetPostProcessorModel as AssetPostProcessorModel,
-    AssetSpecModel as AssetSpecModel,
-    OpSpecModel as OpSpecModel,
 )
 from dagster_components.resolved.metadata import ResolvableFieldInfo as ResolvableFieldInfo
 from dagster_components.resolved.model import (
-    ResolvableModel as ResolvableModel,
-    ResolvedFrom as ResolvedFrom,
-    ResolvedKwargs as ResolvedKwargs,
+    Model as Model,
+    Resolved as Resolved,
     Resolver as Resolver,
 )
 from dagster_components.scaffold import (

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -12,12 +12,12 @@ from dagster_components import Component, ComponentLoadContext
 from dagster_components.components.definitions_component.scaffolder import (
     DefinitionsComponentScaffolder,
 )
-from dagster_components.resolved.model import ResolvableModel
+from dagster_components.resolved.model import Model, Resolved
 from dagster_components.scaffold import scaffold_with
 
 
 @scaffold_with(DefinitionsComponentScaffolder)
-class DefinitionsComponent(Component, ResolvableModel):
+class DefinitionsComponent(Component, Resolved, Model):
     """Wraps an arbitrary set of Dagster definitions."""
 
     definitions_path: Optional[str] = Field(

--- a/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING
 
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -12,35 +12,24 @@ from dagster._core.execution.context.asset_execution_context import AssetExecuti
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 from dagster_components.core.component import Component, ComponentLoadContext
-from dagster_components.resolved.core_models import AssetSpecModel, ResolvedAssetSpec
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
+from dagster_components.resolved.core_models import ResolvedAssetSpec
+from dagster_components.resolved.model import Resolved
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
 
 
-class PipesSubprocessScriptModel(ResolvableModel):
-    path: str
-    assets: Sequence[AssetSpecModel]
-
-
 @dataclass
-class PipesSubprocessScript(ResolvedFrom[PipesSubprocessScriptModel]):
+class PipesSubprocessScript(Resolved):
     path: str
     assets: Sequence[ResolvedAssetSpec]
 
 
-class PipesSubprocessScriptCollectionModel(ResolvableModel):
-    scripts: Sequence[PipesSubprocessScriptModel]
-
-
 @dataclass
-class PipesSubprocessScriptCollectionComponent(
-    Component, ResolvedFrom[PipesSubprocessScriptCollectionModel]
-):
+class PipesSubprocessScriptCollectionComponent(Component, Resolved):
     """Assets that wrap Python scripts executed with Dagster's PipesSubprocessClient."""
 
-    scripts: Annotated[Sequence[PipesSubprocessScript], Resolver.from_annotation()]
+    scripts: Sequence[PipesSubprocessScript]
 
     @cached_property
     def specs_by_path(self) -> Mapping[str, Sequence[AssetSpec]]:

--- a/python_modules/libraries/dagster-components/dagster_components/resolved/context.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/context.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, overload
+from typing import Any, Optional, TypeVar, Union, overload
 
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -12,11 +12,9 @@ from dagster_shared.yaml_utils.source_position import SourcePositionTree
 from jinja2 import Undefined
 from jinja2.exceptions import UndefinedError
 from jinja2.nativetypes import NativeTemplate
+from pydantic import BaseModel
 
 from dagster_components.resolved.errors import ResolutionException
-
-if TYPE_CHECKING:
-    from dagster_components.resolved.model import ResolvableModel
 
 T = TypeVar("T")
 
@@ -98,7 +96,7 @@ class ResolutionContext:
         self,
         fmt_exc: list[str],
         field_name: str,
-        model: "ResolvableModel",
+        model: BaseModel,
     ) -> ResolutionException:
         msg_parts = self._location_parts(fmt_exc[-1] if fmt_exc else "ResolutionException")
         msg_parts.append(

--- a/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
+++ b/python_modules/libraries/dagster-components/dagster_components/resolved/core_models.py
@@ -13,20 +13,22 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._record import replace
-from pydantic import BaseModel, Field
+from dagster_shared.record import record
+from pydantic import Field
 from typing_extensions import TypeAlias
 
 from dagster_components.resolved.context import ResolutionContext
 from dagster_components.resolved.model import (
-    ResolvableModel,
-    ResolvedFrom,
-    ResolvedKwargs,
+    Injectable,
+    Injected,
+    Model,
+    Resolved,
     Resolver,
     resolve_fields,
 )
 
 
-def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
+def _resolve_asset_key(context: ResolutionContext, key: str) -> AssetKey:
     resolved_val = context.resolve_value(key, as_type=AssetKey)
     return (
         AssetKey.from_user_string(resolved_val) if isinstance(resolved_val, str) else resolved_val
@@ -36,155 +38,99 @@ def _resolve_asset_key(key: str, context: ResolutionContext) -> AssetKey:
 PostProcessorFn: TypeAlias = Callable[[Definitions], Definitions]
 
 
-class SingleRunBackfillPolicyModel(ResolvableModel):
+class SingleRunBackfillPolicyModel(Resolved, Model):
     type: Literal["single_run"] = "single_run"
 
 
-class MultiRunBackfillPolicyModel(ResolvableModel):
+class MultiRunBackfillPolicyModel(Resolved, Model):
     type: Literal["multi_run"] = "multi_run"
     max_partitions_per_run: int = 1
 
 
 def resolve_backfill_policy(
-    context: ResolutionContext, model: "OpSpecModel"
+    context: ResolutionContext,
+    backfill_policy,
 ) -> Optional[BackfillPolicy]:
-    if model.backfill_policy is None:
+    if backfill_policy is None:
         return None
 
-    if model.backfill_policy.type == "single_run":
+    if backfill_policy.type == "single_run":
         return BackfillPolicy.single_run()
-    elif model.backfill_policy.type == "multi_run":
+    elif backfill_policy.type == "multi_run":
         return BackfillPolicy.multi_run(
-            max_partitions_per_run=model.backfill_policy.max_partitions_per_run
+            max_partitions_per_run=backfill_policy.max_partitions_per_run
         )
 
-    raise ValueError(f"Invalid backfill policy: {model.backfill_policy}")
+    raise ValueError(f"Invalid backfill policy: {backfill_policy}")
 
 
 @dataclass
-class OpSpec(ResolvedFrom["OpSpecModel"]):
+class OpSpec(Resolved):
     name: Optional[str] = None
     tags: Optional[dict[str, str]] = None
     backfill_policy: Annotated[
-        Optional[BackfillPolicy], Resolver.from_model(resolve_backfill_policy)
+        Optional[BackfillPolicy],
+        Resolver(
+            resolve_backfill_policy,
+            model_field_type=Union[SingleRunBackfillPolicyModel, MultiRunBackfillPolicyModel],
+            model_field_info=Field(discriminator="type"),
+        ),
     ] = None
 
 
-class OpSpecModel(ResolvableModel):
-    name: Optional[str] = Field(default=None, description="The name of the op.")
-    tags: Optional[dict[str, str]] = Field(
-        default=None, description="Arbitrary metadata for the op."
-    )
-    backfill_policy: Optional[Union[SingleRunBackfillPolicyModel, MultiRunBackfillPolicyModel]] = (
-        Field(default=None, description="The backfill policy to use for the assets.")
-    )
+def _expect_injected(context, val):
+    return check.opt_inst_param(val, "val", AutomationCondition)
 
 
-class _ResolvableAssetAttributesMixin(BaseModel):
-    deps: Sequence[str] = Field(
-        default_factory=list,
-        description="The asset keys for the upstream assets that this asset depends on.",
-        examples=[["my_database/my_schema/upstream_table"]],
-    )
-    description: Optional[str] = Field(
-        default=None,
-        description="Human-readable description of the asset.",
-        examples=["Refined sales data"],
-    )
-    metadata: Union[str, Mapping[str, Any]] = Field(
-        default_factory=dict, description="Additional metadata for the asset."
-    )
-    group_name: Optional[str] = Field(
-        default=None,
-        description="Used to organize assets into groups, defaults to 'default'.",
-        examples=["staging"],
-    )
-    skippable: bool = Field(
-        default=False,
-        description="Whether this asset can be omitted during materialization, causing downstream dependencies to skip.",
-    )
-    code_version: Optional[str] = Field(
-        default=None,
-        description="A version representing the code that produced the asset. Increment this value when the code changes.",
-        examples=["3"],
-    )
-    owners: Sequence[str] = Field(
-        default_factory=list,
-        description="A list of strings representing owners of the asset. Each string can be a user's email address, or a team name prefixed with `team:`, e.g. `team:finops`.",
-        examples=[["team:analytics", "nelson@hooli.com"]],
-    )
-    tags: Union[str, Mapping[str, str]] = Field(
-        default_factory=dict,
-        description="Tags for filtering and organizing.",
-        examples=[{"tier": "prod", "team": "analytics"}],
-    )
-    kinds: Optional[Sequence[str]] = Field(
-        default=None,
-        description="A list of strings representing the kinds of the asset. These will be made visible in the Dagster UI.",
-        examples=[["snowflake"]],
-    )
-    automation_condition: Optional[str] = Field(
-        default=None,
-        description="The condition under which the asset will be automatically materialized.",
-    )
+ResolvedAssetKey = Annotated[
+    AssetKey,
+    Resolver(
+        _resolve_asset_key,
+        model_field_type=str,
+    ),
+]
 
 
-class AssetSpecModel(_ResolvableAssetAttributesMixin, ResolvableModel):
-    key: str = Field(..., description="A unique identifier for the asset.")
+@record
+class SharedAssetKwargs(Resolved):
+    deps: Optional[Sequence[ResolvedAssetKey]] = None
+    description: Optional[str] = None
+    metadata: Injectable[Mapping[str, Any]] = {}
+    group_name: Optional[str] = None
+    skippable: Optional[bool] = None
+    code_version: Optional[str] = None
+    owners: Optional[Sequence[str]] = None
+    tags: Injectable[Mapping[str, str]] = {}
+    kinds: Sequence[str] = []
+    automation_condition: Optional[Injected[AutomationCondition]] = None
 
 
-class SharedAssetKwargs(ResolvedKwargs["AssetAttributesModel", AssetSpec]):
-    deps: Sequence[str]
-    description: Optional[str]
-    metadata: Mapping[str, Any]
-    group_name: Optional[str]
-    skippable: bool
-    code_version: Optional[str]
-    owners: Sequence[str]
-    tags: Mapping[str, str]
-    kinds: Optional[Sequence[str]]
-    automation_condition: Annotated[
-        Optional[AutomationCondition], Resolver.from_template_injection()
-    ]
-
-
+@record
 class AssetSpecKwargs(SharedAssetKwargs):
-    key: Annotated[
-        AssetKey,
-        Resolver.from_model(lambda context, schema: _resolve_asset_key(schema.key, context)),
-    ]
-    deps: Annotated[  # pyright: ignore[reportIncompatibleVariableOverride]
-        Sequence[AssetKey],
-        Resolver.from_model(
-            lambda context, schema: [_resolve_asset_key(dep, context) for dep in schema.deps]
-        ),
-    ]
+    key: ResolvedAssetKey
 
 
+@record
 class AssetAttributesKwargs(SharedAssetKwargs):
-    key: Annotated[
-        Optional[AssetKey],
-        Resolver.from_model(
-            lambda context, schema: _resolve_asset_key(schema.key, context) if schema.key else None
-        ),
-    ] = None
+    key: Optional[ResolvedAssetKey] = None
 
 
-ResolvedAssetSpec: TypeAlias = Annotated[AssetSpec, Resolver.from_resolved_kwargs(AssetSpecKwargs)]
+def resolve_asset_spec(context: ResolutionContext, model):
+    return AssetSpec(**resolve_fields(model, AssetSpecKwargs, context))
 
 
-class AssetAttributesModel(_ResolvableAssetAttributesMixin, ResolvableModel):
-    """Resolves into a dictionary of asset attributes. This is similar to AssetSpecSchema, but
-    does not require a key. This is useful in contexts where you want to modify attributes of
-    an existing AssetSpec.
-    """
-
-    key: Optional[str] = Field(default=None, description="A unique identifier for the asset.")
+ResolvedAssetSpec: TypeAlias = Annotated[
+    AssetSpec,
+    Resolver(
+        resolve_asset_spec,
+        model_field_type=AssetSpecKwargs.model(),
+    ),
+]
 
 
 def resolve_asset_attributes_to_mapping(
     context: ResolutionContext,
-    model: AssetAttributesModel,
+    model,
 ) -> Mapping[str, Any]:
     # only include fields that are explcitly set
     set_fields = model.model_dump(exclude_unset=True).keys()
@@ -192,25 +138,29 @@ def resolve_asset_attributes_to_mapping(
     return {k: v for k, v in resolved_fields.items() if k in set_fields}
 
 
+AssetAttributesModel = AssetAttributesKwargs.model()
+
 ResolvedAssetAttributes: TypeAlias = Annotated[
-    Mapping[str, Any], Resolver(resolve_asset_attributes_to_mapping)
+    Mapping[str, Any],
+    Resolver(
+        resolve_asset_attributes_to_mapping,
+        model_field_type=AssetAttributesKwargs.model(),
+    ),
 ]
 
 
-class AssetPostProcessorModel(ResolvableModel):
+class AssetPostProcessorModel(Resolved, Model):
     target: str = "*"
     operation: Literal["merge", "replace"] = "merge"
-    attributes: AssetAttributesModel
+    attributes: ResolvedAssetAttributes
 
 
 def apply_post_processor_to_spec(
     model: AssetPostProcessorModel, spec: AssetSpec, context: ResolutionContext
 ) -> AssetSpec:
-    # add the original spec to the context and resolve values
-    attributes = resolve_asset_attributes_to_mapping(
-        context=context.with_scope(asset=spec), model=model.attributes
+    attributes = (
+        context.with_scope(asset=spec).at_path("attributes").resolve_value(model.attributes)
     )
-
     if model.operation == "merge":
         mergeable_attributes = {"metadata", "tags"}
         merge_attributes = {k: v for k, v in attributes.items() if k in mergeable_attributes}
@@ -249,6 +199,10 @@ def resolve_schema_to_post_processor(
     return lambda defs: apply_post_processor_to_defs(model, defs, context)
 
 
-@dataclass
-class AssetPostProcessor(ResolvedFrom[AssetPostProcessorModel]):
-    fn: Annotated[PostProcessorFn, Resolver.from_model(resolve_schema_to_post_processor)]
+AssetPostProcessor: TypeAlias = Annotated[
+    PostProcessorFn,
+    Resolver(
+        resolve_schema_to_post_processor,
+        model_field_type=AssetPostProcessorModel,
+    ),
+]

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -9,8 +9,9 @@ from typing import Annotated, Any
 from dagster._core.definitions.definitions_class import Definitions
 from pydantic import BaseModel, ConfigDict
 
-from dagster_components import Component, ResolvableModel, ResolvedFrom, Resolver
+from dagster_components import Component, Resolver
 from dagster_components.core.component import ComponentLoadContext
+from dagster_components.resolved.model import Resolved
 
 
 def _inner_error():
@@ -21,12 +22,6 @@ def _error():
     _inner_error()
 
 
-class MyComponentModel(ResolvableModel):
-    a_string: str
-    an_int: int
-    throw: bool = False
-
-
 def _maybe_throw(ctx, throw):
     if throw:
         _error()
@@ -34,10 +29,10 @@ def _maybe_throw(ctx, throw):
 
 
 @dataclass
-class MyComponent(Component, ResolvedFrom[MyComponentModel]):
+class MyComponent(Component, Resolved):
     a_string: str
     an_int: int
-    throw: Annotated[bool, Resolver(_maybe_throw)]
+    throw: Annotated[bool, Resolver(_maybe_throw)] = False
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         return Definitions()
@@ -64,7 +59,7 @@ class MyNestedComponentSchema(BaseModel):
 
 class MyNestedComponent(Component):
     @classmethod
-    def get_schema(cls) -> type[MyNestedComponentSchema]:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_schema(cls) -> type[MyNestedComponentSchema]:
         return MyNestedComponentSchema
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import cast
 
 import dagster as dg
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, ComponentLoadContext
 
 MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 
-class MyCustomComponent(Component, ResolvableModel):
+class MyCustomComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         from component_component_deps_custom_component.defs import my_python_defs  # type:ignore
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/my_python_defs/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/my_python_defs/custom_component.py
@@ -1,8 +1,8 @@
 import dagster as dg
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, ComponentLoadContext
 
 
-class MyBaseAssetsComponent(Component, ResolvableModel):
+class MyBaseAssetsComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         @dg.asset
         def my_cool_asset():

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
@@ -1,26 +1,24 @@
+from dagster import AssetSpec, AutomationCondition
 from dagster_components import ComponentLoadContext
 from dagster_components.components.pipes_subprocess_script_collection import (
+    PipesSubprocessScript,
     PipesSubprocessScriptCollectionComponent,
-    PipesSubprocessScriptCollectionModel,
-    PipesSubprocessScriptModel,
 )
 from dagster_components.core.component import component
-from dagster_components.resolved.core_models import AssetSpecModel
 
 
 @component
 def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
-    attributes = PipesSubprocessScriptCollectionModel(
+    return PipesSubprocessScriptCollectionComponent(
         scripts=[
-            PipesSubprocessScriptModel(
+            PipesSubprocessScript(
                 path="cool_script.py",
                 assets=[
-                    AssetSpecModel(
+                    AssetSpec(
                         key="cool_script",
-                        automation_condition="{{ automation_condition.eager() }}",
-                    ),
+                        automation_condition=AutomationCondition.eager(),
+                    )
                 ],
-            ),
+            )
         ]
     )
-    return PipesSubprocessScriptCollectionComponent.load(attributes=attributes, context=context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/local_component_sample/__init__.py
@@ -1,11 +1,6 @@
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, ResolvableModel
+from dagster_components import Component
 from dagster_components.core.component import ComponentLoadContext
-
-
-class MyComponentModel(ResolvableModel):
-    a_string: str
-    an_int: int
 
 
 class MyComponent(Component):

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
@@ -1,17 +1,15 @@
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import dagster as dg
 import duckdb
 from dagster_components import (
-    AssetSpecModel,
     Component,
     ComponentLoadContext,
-    ResolvableModel,
-    ResolvedFrom,
+    Model,
+    Resolved,
     Scaffolder,
     ScaffoldRequest,
     scaffold_component_yaml,
@@ -40,23 +38,17 @@ class DuckDbComponentScaffolder(Scaffolder):
         )
 
 
-class DuckDbComponentModel(ResolvableModel):
-    sql_file: str
-    assets: Sequence[AssetSpecModel]
-
-
 @scaffold_with(DuckDbComponentScaffolder)
-@dataclass
-class DuckDbComponent(Component, ResolvedFrom[DuckDbComponentModel]):
+class DuckDbComponent(Component, Model, Resolved):
     """A component that allows you to write SQL without learning dbt or Dagster's concepts."""
 
     assets: Sequence[ResolvedAssetSpec]
     sql_file: str
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         assert len(self.assets) >= 1, "Must have asset"
         name = f"run_{self.assets[0].key.to_user_string()}"
-        sql_file_path = (load_context.path / Path(self.sql_file)).absolute()
+        sql_file_path = (context.path / Path(self.sql_file)).absolute()
         assert sql_file_path.exists(), f"Path {sql_file_path} does not exist."
 
         @dg.multi_asset(name=name, specs=self.assets)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_one.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_one.py
@@ -12,10 +12,10 @@ from dagster_components import Component, ComponentLoadContext
 class DuckDbComponent(Component):
     """A component that allows you to write SQL without learning dbt or Dagster's concepts."""
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         name = "op_name"
         asset_specs = [dg.AssetSpec(key="the_key")]
-        path = (load_context.path / Path("raw_customers.csv")).absolute()
+        path = (context.path / Path("raw_customers.csv")).absolute()
         assert path.exists(), f"Path {path} does not exist."
 
         @dg.multi_asset(name=name, specs=asset_specs)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_two.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_two.py
@@ -1,22 +1,21 @@
-from dataclasses import dataclass
 from pathlib import Path
 
 import dagster as dg
 import duckdb
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, ComponentLoadContext
+from pydantic import BaseModel
 
 
-@dataclass
-class DuckDbComponent(Component, ResolvableModel):
+class DuckDbComponent(Component, BaseModel):
     """A component that allows you to write SQL without learning dbt or Dagster's concepts."""
 
     csv_path: str
     asset_key: str
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         name = f"run_{self.asset_key}"
         asset_specs = [dg.AssetSpec(key=self.asset_key)]
-        path = (load_context.path / Path(self.csv_path)).absolute()
+        path = (context.path / Path(self.csv_path)).absolute()
         assert path.exists(), f"Path {path} does not exist."
 
         @dg.multi_asset(name=name, specs=asset_specs)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 import pytest
 from dagster import AssetKey, AssetsDefinition, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
-from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
+from dagster_components.components.dbt_project.component import DbtProjectComponent
 from dagster_components.core.component_defs_builder import build_component_defs
 from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
 from dagster_components.resolved.core_models import AssetAttributesModel
@@ -70,7 +70,7 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
             },
         ),
     )
-    attributes = decl_node.get_attributes(DbtProjectModel)
+    attributes = decl_node.get_attributes(DbtProjectComponent.model())
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
@@ -215,7 +215,7 @@ def test_asset_attributes(
         )
         context = script_load_context(decl_node)
         component = DbtProjectComponent.load(
-            attributes=decl_node.get_attributes(DbtProjectModel), context=context
+            attributes=decl_node.get_attributes(DbtProjectComponent.model()), context=context
         )
         assert get_asset_keys(component) == JAFFLE_SHOP_KEYS
         defs = component.build_defs(script_load_context())
@@ -252,7 +252,7 @@ def test_subselection(dbt_path: Path) -> None:
     )
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DbtProjectModel), context=context
+        attributes=decl_node.get_attributes(DbtProjectComponent.model()), context=context
     )
     assert get_asset_keys(component) == {AssetKey("raw_customers")}
 
@@ -270,7 +270,7 @@ def test_exclude(dbt_path: Path) -> None:
     )
     context = script_load_context(decl_node)
     component = DbtProjectComponent.load(
-        attributes=decl_node.get_attributes(DbtProjectModel), context=context
+        attributes=decl_node.get_attributes(DbtProjectComponent.model()), context=context
     )
     assert get_asset_keys(component) == set(JAFFLE_SHOP_KEYS) - {AssetKey("customers")}
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -22,7 +22,6 @@ from dagster._utils.env import environ
 from dagster_components.cli import cli
 from dagster_components.components.sling_replication_collection.component import (
     SlingReplicationCollectionComponent,
-    SlingReplicationCollectionModel,
 )
 from dagster_components.core.component_defs_builder import load_defs
 from dagster_components.core.defs_module import (
@@ -92,7 +91,7 @@ def temp_sling_component_instance(
 def test_python_attributes() -> None:
     with temp_sling_component_instance([{"path": "./replication.yaml"}]) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes, context)
 
         replications = component.replications
@@ -116,7 +115,7 @@ def test_python_attributes_op_name() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -138,7 +137,7 @@ def test_python_attributes_op_tags() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -156,7 +155,7 @@ def test_python_params_include_metadata() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes=attributes, context=context)
         replications = component.replications
         assert len(replications) == 1
@@ -211,7 +210,7 @@ def test_sling_subclass() -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+    attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
     component_inst = DebugSlingReplicationComponent.load(attributes=attributes, context=context)
     assert component_inst.build_defs(context).get_asset_graph().get_all_asset_keys() == {
         AssetKey("input_csv"),
@@ -287,7 +286,7 @@ def test_asset_attributes(
         ) as decl_node,
     ):
         context = script_load_context(decl_node)
-        attrs = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attrs = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
         defs = component.build_defs(context)
 
@@ -340,7 +339,7 @@ def test_spec_is_available_in_scope() -> None:
         ]
     ) as decl_node:
         context = script_load_context(decl_node)
-        attrs = decl_node.get_attributes(SlingReplicationCollectionModel)
+        attrs = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
         component = SlingReplicationCollectionComponent.load(attributes=attrs, context=context)
         defs = component.build_defs(context)
 
@@ -384,7 +383,7 @@ def test_udf_map_spec(map_fn: Callable[[AssetSpec], Any]) -> None:
     context = script_load_context(decl_node).with_rendering_scope(
         DebugSlingReplicationComponent.get_additional_scope()
     )
-    attributes = decl_node.get_attributes(SlingReplicationCollectionModel)
+    attributes = decl_node.get_attributes(SlingReplicationCollectionComponent.model())
     component_inst = DebugSlingReplicationComponent.load(attributes=attributes, context=context)
 
     defs = component_inst.build_defs(context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 from dagster import AssetKey
 from dagster._utils.env import environ
-from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
+from dagster_components.components.dbt_project.component import DbtProjectComponent
 from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
 from dagster_dbt import DbtProject
 
@@ -71,7 +71,7 @@ def test_python_attributes_node_rename(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(DbtProjectModel)
+    attributes = decl_node.get_attributes(DbtProjectComponent.model())
     component = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(component) == JAFFLE_SHOP_KEYS_WITH_PREFIX
 
@@ -90,7 +90,7 @@ def test_python_attributes_group(dbt_path: Path) -> None:
         ),
     )
     context = script_load_context(decl_node)
-    attributes = decl_node.get_attributes(DbtProjectModel)
+    attributes = decl_node.get_attributes(DbtProjectComponent.model())
     comp = DbtProjectComponent.load(attributes=attributes, context=context)
     assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
     defs: Definitions = comp.build_defs(script_load_context(None))
@@ -118,7 +118,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(DbtProjectModel)
+        attributes = decl_node.get_attributes(DbtProjectComponent.model())
         comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS
         defs: Definitions = comp.build_defs(script_load_context())
@@ -141,6 +141,6 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
             ),
         )
         context = script_load_context(decl_node)
-        attributes = decl_node.get_attributes(DbtProjectModel)
+        attributes = decl_node.get_attributes(DbtProjectComponent.model())
         comp = DbtProjectComponent.load(attributes=attributes, context=context)
         assert get_asset_keys(comp) == JAFFLE_SHOP_KEYS_WITH_PREFIX

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from dagster import AssetSpec, AutomationCondition, Definitions
-from dagster_components import AssetAttributesModel, Component, ComponentLoadContext
+from dagster_components import Component, ComponentLoadContext
 from dagster_components.resolved.core_models import ResolvedAssetAttributes
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom
+from dagster_components.resolved.model import Resolved
 
 
 def my_custom_fn(a: str, b: str) -> str:
@@ -16,12 +16,8 @@ def my_custom_automation_condition(cron_schedule: str) -> AutomationCondition:
     return AutomationCondition.cron_tick_passed(cron_schedule) & ~AutomationCondition.in_progress()
 
 
-class CustomScopeModel(ResolvableModel):
-    asset_attributes: AssetAttributesModel
-
-
 @dataclass
-class HasCustomScope(Component, ResolvedFrom[CustomScopeModel]):
+class HasCustomScope(Component, Resolved):
     asset_attributes: ResolvedAssetAttributes
 
     @classmethod

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_field_utilites.py
@@ -1,29 +1,13 @@
 from dataclasses import dataclass
 from typing import Annotated
 
-from dagster_components.resolved.model import (
-    ResolvedKwargs,
-    Resolver,
-    get_annotation_field_resolvers,
-)
+from dagster_components.resolved.model import Resolved, Resolver, get_annotation_field_resolvers
 from pydantic import BaseModel
-
-
-def test_inheritance_vanilla() -> None:
-    class Base(ResolvedKwargs):
-        base_field: int
-
-    class Derived(Base):
-        derived_field: str
-
-    resolvers = get_annotation_field_resolvers(Derived)
-    assert "base_field" in resolvers
-    assert "derived_field" in resolvers
 
 
 def test_inheritance_dataclass() -> None:
     @dataclass
-    class Base(ResolvedKwargs):
+    class Base(Resolved):
         base_field: int
 
     @dataclass
@@ -36,7 +20,7 @@ def test_inheritance_dataclass() -> None:
 
 
 def test_inheritance_pydantic() -> None:
-    class Base(BaseModel, ResolvedKwargs):
+    class Base(BaseModel, Resolved):
         base_field: int
 
     class Derived(Base):
@@ -47,23 +31,9 @@ def test_inheritance_pydantic() -> None:
     assert "derived_field" in resolvers
 
 
-def test_override_vanilla() -> None:
-    class Base(ResolvedKwargs):
-        value: int
-
-    class CustomResolver(Resolver): ...
-
-    class Derived(Base):
-        value: Annotated[str, CustomResolver(lambda context, val: str(val))]  # pyright: ignore[reportIncompatibleVariableOverride]
-
-    resolvers = get_annotation_field_resolvers(Derived)
-    assert "value" in resolvers
-    assert isinstance(resolvers["value"], CustomResolver)
-
-
 def test_override_dataclass() -> None:
     @dataclass
-    class Base(ResolvedKwargs):
+    class Base(Resolved):
         value: int
 
     class CustomResolver(Resolver): ...
@@ -79,7 +49,7 @@ def test_override_dataclass() -> None:
 
 
 def test_override_pydantic() -> None:
-    class Base(BaseModel, ResolvedKwargs):
+    class Base(BaseModel, Resolved):
         value: int
 
     class CustomResolver(Resolver): ...

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_from_schema.py
@@ -1,51 +1,69 @@
 from typing import Annotated
 
 from dagster_components.resolved.context import ResolutionContext
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
+from dagster_components.resolved.model import Resolved, Resolver
 
 
-def test_simple_dataclass_resolveable_from_schema():
-    class HelloModel(ResolvableModel):
-        hello: str
-
+def test_simple_dataclass_resolveable_from_model():
     from dataclasses import dataclass
 
     @dataclass
-    class Hello(ResolvedFrom[HelloModel]):
-        hello: Annotated[int, Resolver.from_model(lambda context, schema: int(schema.hello))]
+    class Hello(Resolved):
+        hello: Annotated[
+            int,
+            Resolver.from_model(
+                lambda context, m: int(m.hello),
+                model_field_type=str,
+            ),
+        ]
 
-    hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
+    hello = Hello.resolve(
+        ResolutionContext.default(),
+        Hello.model()(hello="1"),
+    )
 
     assert isinstance(hello, Hello)
     assert hello.hello == 1
 
 
 def test_simple_pydantic_resolveable_from_schema():
-    class HelloModel(ResolvableModel):
-        hello: str
-
     from pydantic import BaseModel
 
-    class Hello(BaseModel, ResolvedFrom[HelloModel]):
-        hello: Annotated[int, Resolver.from_model(lambda context, schema: int(schema.hello))]
+    class Hello(BaseModel, Resolved):
+        hello: Annotated[
+            int,
+            Resolver(
+                lambda context, v: int(v),
+                model_field_type=str,
+            ),
+        ]
 
-    hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
+    hello = Hello.resolve(
+        ResolutionContext.default(),
+        Hello.model()(hello="1"),
+    )
 
     assert isinstance(hello, Hello)
     assert hello.hello == 1
 
 
-def test_simple_dataclass_resolveable_from_schema_with_condense_syntax():
-    class HelloModel(ResolvableModel):
-        hello: str
-
+def test_simple_dataclass_resolveable_field():
     from dataclasses import dataclass
 
     @dataclass
-    class Hello(ResolvedFrom[HelloModel]):
-        hello: Annotated[int, Resolver(lambda context, val: int(val))]
+    class Hello(Resolved):
+        hello: Annotated[
+            int,
+            Resolver(
+                lambda context, val: int(val),
+                model_field_type=str,
+            ),
+        ]
 
-    hello = resolve_model(HelloModel(hello="1"), Hello, ResolutionContext.default())
+    hello = Hello.resolve(
+        ResolutionContext.default(),
+        Hello.model()(hello="1"),
+    )
 
     assert isinstance(hello, Hello)
     assert hello.hello == 1

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_model.py
@@ -2,53 +2,56 @@ from collections.abc import Sequence
 from typing import Annotated, Optional
 
 from dagster_components import ResolutionContext
-from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
+from dagster_components.resolved.model import Injectable, Resolved, Resolver
 from pydantic import BaseModel
 
 
-def resolve_val1(context: ResolutionContext, schema: "InnerModel") -> int:
-    return context.resolve_value(schema.val1, as_type=int) + 20
+def resolve_val1(context: ResolutionContext, val1) -> int:
+    return context.resolve_value(val1, as_type=int) + 20
 
 
-class InnerObject(BaseModel, ResolvedFrom["InnerModel"]):
-    val1_renamed: Annotated[int, Resolver.from_model(resolve_val1)]
+class InnerObject(BaseModel, Resolved):
+    val1_renamed: Annotated[
+        int,
+        Resolver(
+            resolve_val1,
+            model_field_type=str,
+            model_field_name="val1",
+        ),
+    ]
     val2: Optional[str]
 
 
-class TargetObject(BaseModel, ResolvedFrom["TargetModel"]):
-    int_val: int
+class TargetObject(BaseModel, Resolved):
+    int_val: Injectable[int]
     str_val: str
-    inners: Annotated[Optional[Sequence[InnerObject]], Resolver.from_annotation()]
-
-
-class InnerModel(ResolvableModel):
-    val1: str
-    val2: Optional[str]
-    val3: str = "val3"
-
-
-class TargetModel(ResolvableModel):
-    int_val: str
-    str_val: str
-    inners: Optional[Sequence[InnerModel]]
+    inners: Optional[Sequence[InnerObject]]
 
 
 def test_valid_resolution_simple() -> None:
     context = ResolutionContext(scope={"some_int": 1, "some_str": "a"})
-    inner_schema = InnerModel(val1="{{ some_int }}", val2="{{ some_str }}_b")
-    inner = resolve_model(inner_schema, InnerObject, context)
+    inner_schema = InnerObject.model()(
+        val1="{{ some_int }}",
+        val2="{{ some_str }}_b",
+    )
+    inner = InnerObject.resolve(context, inner_schema)
     assert inner == InnerObject(val1_renamed=21, val2="a_b")
 
 
 def test_valid_resolution_nested() -> None:
     context = ResolutionContext(scope={"some_int": 1, "some_str": "a"})
-    params = TargetModel(
+    params = TargetObject.model()(
         int_val="{{ some_int }}",
         str_val="{{ some_str }}_x",
-        inners=[InnerModel(val1="{{ some_int }}", val2="{{ some_str }}_y")],
+        inners=[
+            InnerObject.model()(
+                val1="{{ some_int }}",
+                val2="{{ some_str }}_y",
+            )
+        ],
     )
 
-    target = resolve_model(params, TargetObject, context)
+    target = TargetObject.resolve(context, params)
 
     assert target == TargetObject(
         int_val=1,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -1,159 +1,35 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Optional
+from typing import Optional
 
-from dagster import AssetKey
 from dagster._core.definitions.asset_dep import AssetDep
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, ComponentLoadContext
 from dagster_components.resolved.context import ResolutionContext
 from dagster_components.resolved.core_models import (
     AssetSpecKwargs,
-    AssetSpecModel,
     ResolvedAssetSpec,
+    resolve_asset_spec,
 )
-from dagster_components.resolved.model import (
-    ResolvableModel,
-    ResolvedFrom,
-    ResolvedKwargs,
-    Resolver,
-    resolve_fields,
-    resolve_model_using_kwargs_cls,
-)
-from typing_extensions import TypeAlias
-
-
-# Not allow to modified this. Example is AssetSpec
-@dataclass
-class ExistingBusinessObject:
-    value: int
-
-
-class ExistingBusinessObjectModel(ResolvableModel):
-    value: str
-
-
-class ExistingBusinessObjectKwargs(
-    ResolvedKwargs[ExistingBusinessObjectModel, ExistingBusinessObject]
-):
-    value: Annotated[int, Resolver(lambda context, val: int(val))]
-
-
-def test_resolve_fields_on_transform() -> None:
-    fields = resolve_fields(
-        model=ExistingBusinessObjectModel(value="1"),
-        kwargs_cls=ExistingBusinessObjectKwargs,
-        context=ResolutionContext.default(),
-    )
-    assert fields == {"value": 1}
-
-
-def test_use_transform_to_build_business_object():
-    model = ExistingBusinessObjectModel(value="1")
-    business_object = resolve_model_using_kwargs_cls(
-        model=model,
-        kwargs_cls=ExistingBusinessObjectKwargs,
-        context=ResolutionContext.default(),
-        target_type=ExistingBusinessObject,
-    )
-    assert business_object.value == 1
-
-
-def test_with_resolution_spec_on_component():
-    class ComponentWithExistingBusinessObjectModel(ResolvableModel):
-        business_object: ExistingBusinessObjectModel
-
-    @dataclass
-    class ComponentWithExistingBusinessObject(
-        Component, ResolvedFrom[ComponentWithExistingBusinessObjectModel]
-    ):
-        business_object: Annotated[
-            ExistingBusinessObject,
-            Resolver.from_resolved_kwargs(ExistingBusinessObjectKwargs),
-        ]
-
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...  # pyright: ignore[reportIncompatibleMethodOverride]
-
-    comp_instance = ComponentWithExistingBusinessObject.load(
-        attributes=ComponentWithExistingBusinessObjectModel(
-            business_object=ExistingBusinessObjectModel(value="1")
-        ),
-        context=ComponentLoadContext.for_test(),
-    )
-
-    assert isinstance(comp_instance, ComponentWithExistingBusinessObject)
-    assert comp_instance.business_object.value == 1
-
-
-ExistingBusinessObjectField: TypeAlias = Annotated[
-    ExistingBusinessObject,
-    Resolver.from_resolved_kwargs(ExistingBusinessObjectKwargs),
-]
-
-
-def test_reuse_across_components():
-    class ComponentWithExistingBusinessObjectSchemaOne(ResolvableModel):
-        business_object: ExistingBusinessObjectModel
-
-    @dataclass
-    class ComponentWithExistingBusinessObjectOne(
-        Component, ResolvedFrom[ComponentWithExistingBusinessObjectSchemaOne]
-    ):
-        business_object: ExistingBusinessObjectField
-
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...  # pyright: ignore[reportIncompatibleMethodOverride]
-
-    class ComponentWithExistingBusinessObjectSchemaTwo(ResolvableModel):
-        business_object: ExistingBusinessObjectModel
-
-    @dataclass
-    class ComponentWithExistingBusinessObjectTwo(
-        Component, ResolvedFrom[ComponentWithExistingBusinessObjectSchemaTwo]
-    ):
-        business_object: ExistingBusinessObjectField
-
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...  # pyright: ignore[reportIncompatibleMethodOverride]
-
-    comp_instance_one = ComponentWithExistingBusinessObjectOne.load(
-        attributes=ComponentWithExistingBusinessObjectSchemaTwo(
-            business_object=ExistingBusinessObjectModel(value="1")
-        ),
-        context=ComponentLoadContext.for_test(),
-    )
-
-    assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectOne)
-    assert comp_instance_one.business_object.value == 1
-
-    comp_instance_one = ComponentWithExistingBusinessObjectTwo.load(
-        attributes=ComponentWithExistingBusinessObjectSchemaTwo(
-            business_object=ExistingBusinessObjectModel(value="2")
-        ),
-        context=ComponentLoadContext.for_test(),
-    )
-
-    assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectTwo)
-    assert comp_instance_one.business_object.value == 2
+from dagster_components.resolved.model import Resolved
 
 
 def test_asset_spec():
-    model = AssetSpecModel(
+    model = AssetSpecKwargs.model()(
         key="asset_key",
     )
 
-    asset_spec = resolve_model_using_kwargs_cls(
+    asset_spec = resolve_asset_spec(
         model=model,
-        kwargs_cls=AssetSpecKwargs,
         context=ResolutionContext.default(),
-        target_type=AssetSpec,
     )
 
     assert asset_spec.key == AssetKey("asset_key")
 
-    kitchen_sink_model = AssetSpecModel(
+    kitchen_sink_model = AssetSpecKwargs.model()(
         key="kitchen_sink",
         deps=["upstream", "prefixed/upstream"],
         description="A kitchen sink",
@@ -167,11 +43,9 @@ def test_asset_spec():
         automation_condition="{{automation_condition.eager()}}",
     )
 
-    kitchen_sink_spec = resolve_model_using_kwargs_cls(
+    kitchen_sink_spec = resolve_asset_spec(
         model=kitchen_sink_model,
-        kwargs_cls=AssetSpecKwargs,
         context=ResolutionContext.default(),
-        target_type=AssetSpec,
     )
 
     assert kitchen_sink_spec.key == AssetKey("kitchen_sink")
@@ -192,32 +66,24 @@ def test_asset_spec():
 
 
 def test_resolved_asset_spec() -> None:
-    class SomeObjectModel(ResolvableModel):
-        spec: AssetSpecModel
-        maybe_spec: Optional[AssetSpecModel]
-        specs: Sequence[AssetSpecModel]
-        maybe_specs: Optional[Sequence[AssetSpecModel]]
-
     @dataclass
-    class SomeObject(ResolvedFrom[SomeObjectModel]):
+    class SomeObject(Resolved):
         spec: ResolvedAssetSpec
         maybe_spec: Optional[ResolvedAssetSpec]
         specs: Sequence[ResolvedAssetSpec]
         maybe_specs: Optional[Sequence[ResolvedAssetSpec]]
 
-    some_object = resolve_model_using_kwargs_cls(
-        model=SomeObjectModel(
-            spec=AssetSpecModel(key="asset0"),
+    some_object = SomeObject.resolve(
+        context=ResolutionContext.default(),
+        model=SomeObject.model()(
+            spec=AssetSpecKwargs.model()(key="asset0"),
             maybe_spec=None,
             specs=[
-                AssetSpecModel(key="asset1"),
-                AssetSpecModel(key="asset2"),
+                AssetSpecKwargs.model()(key="asset1"),
+                AssetSpecKwargs.model()(key="asset2"),
             ],
             maybe_specs=None,
         ),
-        kwargs_cls=SomeObject,
-        context=ResolutionContext.default(),
-        target_type=SomeObject,
     )
 
     assert some_object.specs == [AssetSpec(key="asset1"), AssetSpec(key="asset2")]

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolved.py
@@ -1,15 +1,15 @@
 from dataclasses import dataclass
-from typing import Annotated, Optional
+from typing import Optional
 
 import pytest
 from dagster_components.core.component import Component
 from dagster_components.resolved.errors import ResolutionException
-from dagster_components.resolved.model import Resolved, Resolver
+from dagster_components.resolved.model import Resolved
 from dagster_components.test.utils import load_direct
 
 
 class BlankComponent(Component):
-    def build_defs(self): ...
+    def build_defs(self): ...  # type: ignore
 
 
 def test_basic():
@@ -35,7 +35,7 @@ def test_error():
 
         def build_defs(self): ...
 
-    with pytest.raises(ResolutionException, match="Unable to derive ResolvableModel"):
+    with pytest.raises(ResolutionException, match="Could not derive resolver for annotation foo:"):
         load_direct(MyNewThing, "")
 
 
@@ -47,8 +47,8 @@ def test_nested():
     @dataclass
     class MyThing(BlankComponent, Resolved):
         name: str
-        other_thing: Annotated[OtherThing, Resolver.from_annotation()]
-        other_things: Annotated[Optional[list[OtherThing]], Resolver.from_annotation()]
+        other_thing: OtherThing
+        other_things: Optional[list[OtherThing]]
 
         def build_defs(self): ...
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_spec_processing.py
@@ -4,7 +4,6 @@ import pytest
 from dagster import AssetKey, AssetSpec, AutomationCondition, Definitions
 from dagster_components.resolved.context import ResolutionContext
 from dagster_components.resolved.core_models import (
-    AssetAttributesModel,
     AssetPostProcessorModel,
     apply_post_processor_to_defs,
 )
@@ -28,7 +27,7 @@ def test_replace_attributes() -> None:
     op = AssetPostProcessorModel(
         operation="replace",
         target="group:g2",
-        attributes=AssetAttributesModel(tags={"newtag": "newval"}),
+        attributes={"tags": {"newtag": "newval"}},
     )
 
     newdefs = apply_post_processor_to_defs(model=op, defs=defs, context=ResolutionContext.default())
@@ -42,7 +41,7 @@ def test_merge_attributes() -> None:
     op = AssetPostProcessorModel(
         operation="merge",
         target="group:g2",
-        attributes=AssetAttributesModel(tags={"newtag": "newval"}),
+        attributes={"tags": {"newtag": "newval"}},
     )
 
     newdefs = apply_post_processor_to_defs(model=op, defs=defs, context=ResolutionContext.default())
@@ -54,7 +53,7 @@ def test_merge_attributes() -> None:
 
 def test_render_attributes_asset_context() -> None:
     op = AssetPostProcessorModel(
-        attributes=AssetAttributesModel(tags={"group_name_tag": "group__{{ asset.group_name }}"})
+        attributes={"tags": {"group_name_tag": "group__{{ asset.group_name }}"}}
     )
 
     newdefs = apply_post_processor_to_defs(model=op, defs=defs, context=ResolutionContext.default())
@@ -68,11 +67,11 @@ def test_render_attributes_custom_context() -> None:
     op = AssetPostProcessorModel(
         operation="replace",
         target="group:g2",
-        attributes=AssetAttributesModel(
-            tags={"a": "{{ foo }}", "b": "prefix_{{ foo }}"},
-            metadata="{{ metadata }}",
-            automation_condition="{{ custom_cron('@daily') }}",
-        ),
+        attributes={
+            "tags": {"a": "{{ foo }}", "b": "prefix_{{ foo }}"},
+            "metadata": "{{ metadata }}",
+            "automation_condition": "{{ custom_cron('@daily') }}",
+        },
     )
 
     def _custom_cron(s):
@@ -104,14 +103,14 @@ def test_render_attributes_custom_context() -> None:
         # default to merge and a * target
         (
             {"attributes": {"tags": {"a": "b"}}},
-            AssetPostProcessorModel(target="*", attributes=AssetAttributesModel(tags={"a": "b"})),
+            AssetPostProcessorModel(target="*", attributes={"tags": {"a": "b"}}),
         ),
         (
             {"operation": "replace", "attributes": {"tags": {"a": "b"}}},
             AssetPostProcessorModel(
                 operation="replace",
                 target="*",
-                attributes=AssetAttributesModel(tags={"a": "b"}),
+                attributes={"tags": {"a": "b"}},
             ),
         ),
         # explicit target
@@ -119,7 +118,7 @@ def test_render_attributes_custom_context() -> None:
             {"attributes": {"tags": {"a": "b"}}, "target": "group:g2"},
             AssetPostProcessorModel(
                 target="group:g2",
-                attributes=AssetAttributesModel(tags={"a": "b"}),
+                attributes={"tags": {"a": "b"}},
             ),
         ),
         (
@@ -127,7 +126,7 @@ def test_render_attributes_custom_context() -> None:
             AssetPostProcessorModel(
                 operation="replace",
                 target="group:g2",
-                attributes=AssetAttributesModel(tags={"a": "b"}),
+                attributes={"tags": {"a": "b"}},
             ),
         ),
     ],

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -2,10 +2,11 @@ from dagster import Definitions
 from dagster_components import (
     Component,
     ComponentLoadContext,
-    ResolvableModel,
+    Resolved,
+    Model,
 )
 
-class {{ name }}(Component, ResolvableModel):
+class {{ name }}(Component, Resolved, Model):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_sample_yaml.py
@@ -1,16 +1,16 @@
 from collections.abc import Sequence
 from typing import Annotated
 
-from dagster_components import ResolvableFieldInfo, ResolvableModel
+from dagster_components import Model, ResolvableFieldInfo, Resolved
 from dagster_dg.docs import generate_sample_yaml
 
 
-class SampleSubModel(ResolvableModel):
+class SampleSubModel(Model):
     str_field: str
     int_field: int
 
 
-class SampleModel(ResolvableModel):
+class SampleModel(Model, Resolved):
     sub_scoped: Annotated[SampleSubModel, ResolvableFieldInfo(required_scope={"outer_scope"})]
     sub_optional: SampleSubModel
     sub_list: Sequence[SampleSubModel]

--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -34,6 +34,7 @@ TVal = TypeVar("TVal")
 
 
 _RECORD_ANNOTATIONS_FIELD = "__record_annotations__"
+_RECORD_DEFAULTS_FIELD = "__record_defaults__"
 _CHECKED_NEW = "__checked_new__"
 _DEFAULTS_NEW = "__defaults_new__"
 _NAMED_TUPLE_BASE_NEW_FIELD = "__nt_new__"
@@ -163,6 +164,7 @@ def _namedtuple_record_transform(
         "__hidden_replace__": base._replace,
         RECORD_MARKER_FIELD: RECORD_MARKER_VALUE,
         _RECORD_ANNOTATIONS_FIELD: field_set,
+        _RECORD_DEFAULTS_FIELD: defaults,
         _NAMED_TUPLE_BASE_NEW_FIELD: nt_new,
         _REMAPPING_FIELD: field_to_new_mapping or {},
         _ORIGINAL_CLASS_FIELD: cls,
@@ -364,6 +366,11 @@ def has_generated_new(obj) -> bool:
 def get_record_annotations(obj) -> Mapping[str, type]:
     check.invariant(is_record(obj), "Only works for @record decorated classes")
     return getattr(obj, _RECORD_ANNOTATIONS_FIELD)
+
+
+def get_record_defaults(obj) -> Mapping[str, Any]:
+    check.invariant(is_record(obj), "Only works for @record decorated classes")
+    return getattr(obj, _RECORD_DEFAULTS_FIELD)
 
 
 def get_original_class(obj):


### PR DESCRIPTION
This PR decomposes the existing Resolved system, eliminating `ResolvableModel`, `ResolvedFrom`, leaving just a plain `Model` and `Resolved` class in their place.

For cases where you want a Pythonic interface to a component, you no longer have a design a parallel schema. It is generated for you, via instructions on the Resolved objects in annotations.

Explained with three part user story below:

### `step_one.py` Pythonic Component

You just created `DuckDbComponent`  https://github.com/dagster-io/dagster/pull/28671#discussion_r2015042694. You are trying to use `Components` as a way to provide a simple API to the people you support. Your first step was just to get the `Component` working with some hard coded values.

```python
@dataclass
class DuckDbComponent(Component):
    """A component that allows you to write SQL without learning dbt or Dagster's concepts."""

    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
        name = "op_name"
        asset_specs = [dg.AssetSpec(key="the_key")]
        path = (context.path / Path("raw_customers.csv")).absolute()
        assert path.exists(), f"Path {path} does not exist."

        @dg.multi_asset(name=name, specs=asset_specs)
        def _asset(context: dg.AssetExecutionContext):
            return self.execute(context, str(path))

        return dg.Definitions(assets=[_asset])

    def execute(self, context: dg.AssetExecutionContext, csv_path: str): ...
```

### `step_two.py` Simple YAML frontend

Next you want to provide a yaml front end for configuring things. You are familiar with pydantic and know it can be used for this so you subclass `BaseModel` and define a couple string fields https://github.com/dagster-io/dagster/pull/28671#discussion_r2015042242. Now that `DuckDbComponent` is a `BaseModel`, the Component framework knows it can load from yaml so helps facilitate this.

```python
class DuckDbComponent(Component, BaseModel):
    """A component that allows you to write SQL without learning dbt or Dagster's concepts."""

    csv_path: str
    asset_key: str

    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
        name = f"run_{self.asset_key}"
        asset_specs = [dg.AssetSpec(key=self.asset_key)]
        path = (context.path / Path(self.csv_path)).absolute()
        assert path.exists(), f"Path {path} does not exist."

        @dg.multi_asset(name=name, specs=asset_specs)
        def _asset(context: dg.AssetExecutionContext):
            return self.execute(context, str(path))

        return dg.Definitions(assets=[_asset])
```

### `step_three.py` Advanced YAML Frontend

Next you realize there are other properties for defining an `AssetSpec` your users want to set besides just the key and start to consider making your own Model class to handle this. Having to create a create your own model that just exists to get turned in to an `AssetSpec` bums you out so you reference some of the stock components to see how they handle it and come across `Resolved` & `ResolvedAssetSpec`. The docs for `Resolved` articulate that it automates away the process of creating a yaml compliant schema for a python object and resolving to that for you. You also come across `Model` which is a `BaseModel` configured to not accept random keys which you adopt to help catch typos. https://github.com/dagster-io/dagster/pull/28671#discussion_r2015043321

```python
class DuckDbComponent(Component, Model, Resolved):
    """A component that allows you to write SQL without learning dbt or Dagster's concepts."""

    assets: Sequence[ResolvedAssetSpec]
    sql_file: str

    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
        assert len(self.assets) >= 1, "Must have asset"
        name = f"run_{self.assets[0].key.to_user_string()}"
        path = (context.path / Path(self.sql_file)).absolute()
        # assert path.exists(), f"Path {path} does not exist."

        @dg.multi_asset(name=name, specs=self.assets)
        def _asset(context: dg.AssetExecutionContext):
            return self.execute(context, str(path))

        return dg.Definitions(assets=[_asset])
```

Beyond getting a schema over business objects like `AssetSpec`, `Resolved` is a full templating engine, making it flexible and powerful.

* Out-of-the-box templating: You can embed templates into fields. e.g. `group: "{{ env('GROUP_NAME_FROM_ENV') }}" works.
* Customized scope UDFs: Component authors can place variables and udfs into context for invocation within a template string.
* Better metadata: TODO

## How I Tested These Changes

updated tests
