### PR TITLE
[dg][BUILD-818] ComponentLoadContext -> DefsLoadContext

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/python-components/component.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/python-components/component.py
@@ -1,4 +1,4 @@
-from dagster_components import ComponentLoadContext, component
+from dagster_components import DefsLoadContext, component
 from dagster_components.dagster_dbt import DbtProjectComponent
 from dagster_dbt import DagsterDbtTranslator, DbtCliResource
 
@@ -7,7 +7,7 @@ class MyTranslator(DagsterDbtTranslator): ...
 
 
 @component
-def my_dbt_component(context: ComponentLoadContext) -> DbtProjectComponent:
+def my_dbt_component(context: DefsLoadContext) -> DbtProjectComponent:
     return DbtProjectComponent(
         dbt=DbtCliResource(project_dir="."),
         translator=MyTranslator(),

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -1,7 +1,7 @@
 from dagster import Definitions
 from dagster_components import (
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
 )
 
@@ -11,6 +11,6 @@ class ShellCommand(Component, ResolvableModel):
     COMPONENT DESCRIPTION HERE.
     """
 
-    def build_defs(self, load_context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> Definitions:
         # Add definition construction logic here.
         return Definitions()

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/custom-schema-resolution.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from dagster_components import (
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolutionContext,
     ResolvableModel,
     ResolvedFrom,
@@ -33,4 +33,4 @@ class MyComponent(Component, ResolvedFrom[MyComponentModel]):
     # to a value for this field
     api_client: Annotated[MyApiClient, Resolver(resolve_api_key)]
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/empty.py
@@ -1,8 +1,8 @@
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, DefsLoadContext, ResolvableModel
 from pydantic import BaseModel
 
 import dagster as dg
 
 
 class ShellCommand(Component, ResolvableModel):
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
     ResolvedFrom,
 )
@@ -27,7 +27,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
     asset_specs: Sequence[ResolvedAssetSpec]
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         resolved_script_path = Path(load_context.path, self.script_path).absolute()
 
         @dg.multi_asset(name=Path(self.script_path).stem, specs=self.asset_specs)

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-class-defined.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
     ResolvedFrom,
 )
@@ -23,4 +23,4 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
     asset_specs: Sequence[ResolvedAssetSpec]
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-config-schema.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
 )
 
@@ -16,4 +16,4 @@ class ShellCommand(Component, ResolvableModel):
     script_path: str
     asset_specs: Sequence[AssetSpecModel]
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions: ...
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions: ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-custom-scope.py
@@ -7,7 +7,7 @@ from typing import Any
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
     ResolvedFrom,
 )
@@ -32,7 +32,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
             "daily_partitions": dg.DailyPartitionsDefinition(start_date="2024-01-01")
         }
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         @dg.multi_asset(name=Path(self.script_path).stem, specs=self.asset_specs)
         def _asset(context: dg.AssetExecutionContext):
             self.execute(context)

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/with-scaffolder.py
@@ -8,7 +8,7 @@ from typing import Any
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     Scaffolder,
     ScaffoldRequest,
     scaffold_component_yaml,
@@ -57,7 +57,7 @@ class ShellCommand(Component, ResolvedFrom[ShellCommandModel]):
     script_path: str
     asset_specs: Sequence[ResolvedAssetSpec]
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         resolved_script_path = Path(load_context.path, self.script_path).absolute()
 
         @dg.multi_asset(name=Path(self.script_path).stem, specs=self.asset_specs)

--- a/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
@@ -1,11 +1,11 @@
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 
 
 class AllMetadataEmptyComponent(Component):
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         @asset
         def hardcoded_asset(context: AssetExecutionContext):
             return 1

--- a/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/complex_schema_asset.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.resolved.core_models import (
     AssetAttributesModel,
     AssetPostProcessor,
@@ -43,7 +43,7 @@ class ComplexAssetComponent(Component, ResolvedFrom[ComplexAssetModel]):
         Optional[Sequence[AssetPostProcessor]], Resolver.from_annotation()
     ] = None
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         @asset(spec=self.asset_attributes)
         def dummy(context: AssetExecutionContext):
             return self.value

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -2,7 +2,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster_components import Component, ComponentLoadContext, ResolvableModel, ResolvedFrom
+from dagster_components import Component, DefsLoadContext, ResolvableModel, ResolvedFrom
 
 
 class SimpleAssetComponentModel(ResolvableModel):
@@ -20,7 +20,7 @@ class SimpleAssetComponent(Component, ResolvedFrom[SimpleAssetComponentModel]):
         self._asset_key = asset_key
         self._value = value
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         @asset(key=self._asset_key)
         def dummy(context: AssetExecutionContext):
             return self._value

--- a/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_pipes_script_asset.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.component_scaffolding import scaffold_component_yaml
 from dagster_components.scaffold import Scaffolder, ScaffoldRequest, scaffold_with
 from pydantic import BaseModel
@@ -55,7 +55,7 @@ class SimplePipesScriptComponent(Component):
         self._asset_key = asset_key
         self._script_path = script_path
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         @asset(key=self._asset_key)
         def _asset(context: AssetExecutionContext, pipes_client: PipesSubprocessClient):
             cmd = [shutil.which("python"), self._script_path]

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -3,7 +3,7 @@ from dagster_components.component_scaffolding import (
 )
 from dagster_components.core.component import (
     Component as Component,
-    ComponentLoadContext as ComponentLoadContext,
+    DefsModuleLoadContext as DefsLoadContext,
     component as component,
 )
 from dagster_components.core.component_defs_builder import (

--- a/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/dbt_project/component.py
@@ -27,7 +27,7 @@ from dagster_dbt.dbt_manifest import validate_manifest
 from dagster_dbt.utils import get_dbt_resource_props_by_dbt_unique_id_from_manifest
 from typing_extensions import override
 
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
 from dagster_components.resolved.core_models import (
     AssetAttributesModel,
@@ -194,7 +194,7 @@ class DbtProjectComponent(Component, ResolvedFrom[DbtProjectModel]):
             exclude=exclude,
         )
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         self.project.prepare_if_dev()
 
         @dbt_assets(
@@ -220,7 +220,7 @@ class DbtProjectComponent(Component, ResolvedFrom[DbtProjectModel]):
 
 
 def get_asset_key_for_model_from_module(
-    context: ComponentLoadContext, dbt_component_module: ModuleType, model_name: str
+    context: DefsLoadContext, dbt_component_module: ModuleType, model_name: str
 ) -> AssetKey:
     """Component-based version of dagster_dbt.get_asset_key_for_model. Returns the corresponding Dagster
     asset key for a dbt model, seed, or snapshot, loaded from the passed component path.
@@ -237,10 +237,10 @@ def get_asset_key_for_model_from_module(
 
             from dagster import asset
             from dagster_components.components.dbt_project import get_asset_key_for_model_from_module
-            from dagster_components.core.component import ComponentLoadContext
+            from dagster_components.core.component import DefsModuleLoadContext
             from my_project.defs import dbt_component
 
-            ctx = ComponentLoadContext.get()
+            ctx = DefsModuleLoadContext.get()
 
             @asset(deps={get_asset_key_for_model_from_module(ctx, dbt_component, "customers")})
             def cleaned_customers():

--- a/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/definitions_component/component.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.module_loaders.load_defs_from_module import (
 from dagster._core.definitions.module_loaders.utils import find_objects_in_module_of_types
 from pydantic import Field
 
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.components.definitions_component.scaffolder import (
     DefinitionsComponentScaffolder,
 )
@@ -24,7 +24,7 @@ class DefinitionsComponent(Component, ResolvableModel):
         None, description="Relative path to a file containing Dagster definitions."
     )
 
-    def _build_defs_for_path(self, context: ComponentLoadContext, defs_path: Path) -> Definitions:
+    def _build_defs_for_path(self, context: DefsLoadContext, defs_path: Path) -> Definitions:
         defs_module = context.load_defs_relative_python_module(defs_path)
         defs_attrs = list(find_objects_in_module_of_types(defs_module, Definitions))
 
@@ -43,7 +43,7 @@ class DefinitionsComponent(Component, ResolvableModel):
         else:
             return load_definitions_from_module(defs_module)
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         defs_paths = (
             [Path(self.definitions_path)]
             if self.definitions_path

--- a/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional
 from dagster._core.definitions.definitions_class import Definitions
 from typing_extensions import Self
 
-from dagster_components import AssetPostProcessorModel, Component, ComponentLoadContext
+from dagster_components import AssetPostProcessorModel, Component, DefsLoadContext
 from dagster_components.core.defs_module import (
     DefsModule,
     PythonModuleDecl,
@@ -38,7 +38,7 @@ class DefsModuleComponent(Component):
         return DefsModuleArgsModel
 
     @classmethod
-    def load(cls, attributes: DefsModuleArgsModel, context: ComponentLoadContext) -> Self:
+    def load(cls, attributes: DefsModuleArgsModel, context: DefsLoadContext) -> Self:
         path = context.path
         decl = PythonModuleDecl.from_path(path) or SubpackageDefsModuleDecl.from_path(path)
         defs_module = decl.load(context) if decl else None
@@ -47,7 +47,7 @@ class DefsModuleComponent(Component):
         )
         return cls(post_processors=resolved_args.asset_post_processors, defs_module=defs_module)
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         defs = self.defs_module.build_defs() if self.defs_module else Definitions()
         for post_processor in self.post_processors:
             defs = post_processor.fn(defs)

--- a/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/pipes_subprocess_script_collection.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
-from dagster_components.core.component import Component, ComponentLoadContext
+from dagster_components.core.component import Component, DefsModuleLoadContext
 from dagster_components.resolved.core_models import AssetSpecModel, ResolvedAssetSpec
 from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver
 
@@ -55,7 +55,7 @@ class PipesSubprocessScriptCollectionComponent(
             ]
         )
 
-    def build_defs(self, context: "ComponentLoadContext") -> "Definitions":
+    def build_defs(self, context: "DefsModuleLoadContext") -> "Definitions":
         from dagster._core.definitions.definitions_class import Definitions
 
         return Definitions(

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -16,7 +16,7 @@ from dagster_sling.resources import AssetExecutionContext
 from pydantic import Field
 from typing_extensions import TypeAlias
 
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.components.sling_replication_collection.scaffolder import (
     SlingReplicationComponentScaffolder,
 )
@@ -153,7 +153,7 @@ class SlingReplicationCollectionComponent(Component, ResolvedFrom[SlingReplicati
     ] = None
 
     def build_asset(
-        self, context: ComponentLoadContext, replication_spec_model: SlingReplicationSpecModel
+        self, context: DefsLoadContext, replication_spec_model: SlingReplicationSpecModel
     ) -> AssetsDefinition:
         op_spec = replication_spec_model.op or OpSpec()
 
@@ -184,7 +184,7 @@ class SlingReplicationCollectionComponent(Component, ResolvedFrom[SlingReplicati
             iterator = iterator.fetch_row_count()
         yield from iterator
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsLoadContext) -> Definitions:
         defs = Definitions(
             assets=[self.build_asset(context, replication) for replication in self.replications],
         )

--- a/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component_defs_builder.py
@@ -10,8 +10,8 @@ from dagster._utils.warnings import suppress_dagster_warnings
 
 from dagster_components.core.component import (
     Component,
-    ComponentLoadContext,
     DefinitionsModuleCache,
+    DefsModuleLoadContext,
 )
 
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 @suppress_dagster_warnings
 def defs_from_components(
     *,
-    context: ComponentLoadContext,
+    context: DefsModuleLoadContext,
     components: Sequence[Component],
     resources: Mapping[str, object],
 ) -> "Definitions":

--- a/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/basic_components.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from pydantic import BaseModel, ConfigDict
 
 from dagster_components import Component, ResolvableModel, ResolvedFrom, Resolver
-from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component import DefsModuleLoadContext
 
 
 def _inner_error():
@@ -39,7 +39,7 @@ class MyComponent(Component, ResolvedFrom[MyComponentModel]):
     an_int: int
     throw: Annotated[bool, Resolver(_maybe_throw)]
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsModuleLoadContext) -> Definitions:
         return Definitions()
 
     @classmethod
@@ -67,5 +67,5 @@ class MyNestedComponent(Component):
     def get_schema(cls) -> type[MyNestedComponentSchema]:
         return MyNestedComponentSchema
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsModuleLoadContext) -> Definitions:
         return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components/test/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/utils.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from typing_extensions import TypeVar
 
-from dagster_components.core.component import Component, ComponentLoadContext
+from dagster_components.core.component import Component, DefsModuleLoadContext
 from dagster_components.core.defs_module import DirectForTestComponentDecl
 
 TComponent = TypeVar("TComponent", bound=Component)
@@ -17,7 +17,7 @@ def load_direct(
         component_type=component_type,
         attributes_yaml=attribute_yaml,
     )
-    context = ComponentLoadContext.for_test(
+    context = DefsModuleLoadContext.for_test(
         decl_node=decl_node,
     )
     components = decl_node.load(context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -4,9 +4,9 @@ from typing import cast
 import dagster as dg
 from component_component_deps.defs import my_python_defs  # type:ignore
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component import DefsModuleLoadContext
 
-ctx = ComponentLoadContext.current()
+ctx = DefsModuleLoadContext.current()
 
 assets_from_my_python_defs = cast(
     Sequence[AssetsDefinition],

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -3,13 +3,13 @@ from pathlib import Path
 from typing import cast
 
 import dagster as dg
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, DefsLoadContext, ResolvableModel
 
 MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 
 class MyCustomComponent(Component, ResolvableModel):
-    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, context: DefsLoadContext) -> dg.Definitions:
         from component_component_deps_custom_component.defs import my_python_defs  # type:ignore
 
         assets_from_my_python_defs = cast(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/my_python_defs/custom_component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/component_component_deps_custom_component/defs/my_python_defs/custom_component.py
@@ -1,9 +1,9 @@
 import dagster as dg
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, DefsLoadContext, ResolvableModel
 
 
 class MyBaseAssetsComponent(Component, ResolvableModel):
-    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, context: DefsLoadContext) -> dg.Definitions:
         @dg.asset
         def my_cool_asset():
             pass

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
@@ -1,9 +1,9 @@
 import dagster as dg
 from dagster_components.components.dbt_project.component import get_asset_key_for_model_from_module
-from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component import DefsModuleLoadContext
 from dependency_on_dbt_project_location.defs import jaffle_shop_dbt  # type: ignore
 
-ctx = ComponentLoadContext.current()
+ctx = DefsModuleLoadContext.current()
 
 
 @dg.asset(deps={get_asset_key_for_model_from_module(ctx, jaffle_shop_dbt, "customers")})

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
@@ -1,4 +1,4 @@
-from dagster_components import ComponentLoadContext
+from dagster_components import DefsLoadContext
 from dagster_components.components.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionComponent,
     PipesSubprocessScriptCollectionModel,
@@ -9,7 +9,7 @@ from dagster_components.resolved.core_models import AssetSpecModel
 
 
 @component
-def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
+def load(context: DefsLoadContext) -> PipesSubprocessScriptCollectionComponent:
     attributes = PipesSubprocessScriptCollectionModel(
         scripts=[
             PipesSubprocessScriptModel(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/local_component_sample/__init__.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component, ResolvableModel
-from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component import DefsModuleLoadContext
 
 
 class MyComponentModel(ResolvableModel):
@@ -12,5 +12,5 @@ class MyComponent(Component):
     a_string: str
     an_int: int
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsModuleLoadContext) -> Definitions:
         return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/other_local_component_sample/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions/other_local_component_sample/__init__.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_components import Component
-from dagster_components.core.component import ComponentLoadContext
+from dagster_components.core.component import DefsModuleLoadContext
 from pydantic import BaseModel
 
 
@@ -16,5 +16,5 @@ class MyNewComponent(Component):
     def get_schema(cls):
         return MyNewComponentSchema
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: DefsModuleLoadContext) -> Definitions:
         return Definitions()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_four.py
@@ -9,7 +9,7 @@ import duckdb
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
     ResolvedFrom,
     Scaffolder,
@@ -53,7 +53,7 @@ class DuckDbComponent(Component, ResolvedFrom[DuckDbComponentModel]):
     assets: Sequence[ResolvedAssetSpec]
     sql_file: str
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         assert len(self.assets) >= 1, "Must have asset"
         name = f"run_{self.assets[0].key.to_user_string()}"
         sql_file_path = (load_context.path / Path(self.sql_file)).absolute()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_one.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_one.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 import dagster as dg
 import duckdb
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 
 
 @dataclass
 class DuckDbComponent(Component):
     """A component that allows you to write SQL without learning dbt or Dagster's concepts."""
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         name = "op_name"
         asset_specs = [dg.AssetSpec(key="the_key")]
         path = (load_context.path / Path("raw_customers.csv")).absolute()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_three.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_three.py
@@ -8,7 +8,7 @@ import duckdb
 from dagster_components import (
     AssetSpecModel,
     Component,
-    ComponentLoadContext,
+    DefsLoadContext,
     ResolvableModel,
     ResolvedFrom,
 )
@@ -27,7 +27,7 @@ class DuckDbComponent(Component, ResolvedFrom[DuckDbComponentModel]):
     assets: Sequence[ResolvedAssetSpec]
     sql_file: str
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         assert len(self.assets) >= 1, "Must have asset"
         name = f"run_{self.assets[0].key.to_user_string()}"
         path = (load_context.path / Path(self.sql_file)).absolute()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_two.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/lib/duckdb_component/step_two.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import dagster as dg
 import duckdb
-from dagster_components import Component, ComponentLoadContext, ResolvableModel
+from dagster_components import Component, DefsLoadContext, ResolvableModel
 
 
 @dataclass
@@ -13,7 +13,7 @@ class DuckDbComponent(Component, ResolvableModel):
     csv_path: str
     asset_key: str
 
-    def build_defs(self, load_context: ComponentLoadContext) -> dg.Definitions:
+    def build_defs(self, load_context: DefsLoadContext) -> dg.Definitions:
         name = f"run_{self.asset_key}"
         asset_specs = [dg.AssetSpec(key=self.asset_key)]
         path = (load_context.path / Path(self.csv_path)).absolute()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/custom_scope_component/component.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from dagster import AssetSpec, AutomationCondition, Definitions
-from dagster_components import AssetAttributesModel, Component, ComponentLoadContext
+from dagster_components import AssetAttributesModel, Component, DefsLoadContext
 from dagster_components.resolved.core_models import ResolvedAssetAttributes
 from dagster_components.resolved.model import ResolvableModel, ResolvedFrom
 
@@ -33,5 +33,5 @@ class HasCustomScope(Component, ResolvedFrom[CustomScopeModel]):
             "custom_automation_condition": my_custom_automation_condition,
         }
 
-    def build_defs(self, context: ComponentLoadContext):
+    def build_defs(self, context: DefsLoadContext):
         return Definitions(assets=[AssetSpec(key="key", **self.asset_attributes)])

--- a/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/resolution_tests/test_resolvable_transformer.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 from dagster_components.resolved.context import ResolutionContext
 from dagster_components.resolved.core_models import (
     AssetSpecKwargs,
@@ -76,13 +76,13 @@ def test_with_resolution_spec_on_component():
             Resolver.from_resolved_kwargs(ExistingBusinessObjectKwargs),
         ]
 
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+        def build_defs(self, load_context: DefsLoadContext) -> Definitions: ...
 
     comp_instance = ComponentWithExistingBusinessObject.load(
         attributes=ComponentWithExistingBusinessObjectModel(
             business_object=ExistingBusinessObjectModel(value="1")
         ),
-        context=ComponentLoadContext.for_test(),
+        context=DefsLoadContext.for_test(),
     )
 
     assert isinstance(comp_instance, ComponentWithExistingBusinessObject)
@@ -105,7 +105,7 @@ def test_reuse_across_components():
     ):
         business_object: ExistingBusinessObjectField
 
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+        def build_defs(self, load_context: DefsLoadContext) -> Definitions: ...
 
     class ComponentWithExistingBusinessObjectSchemaTwo(ResolvableModel):
         business_object: ExistingBusinessObjectModel
@@ -116,13 +116,13 @@ def test_reuse_across_components():
     ):
         business_object: ExistingBusinessObjectField
 
-        def build_defs(self, load_context: ComponentLoadContext) -> Definitions: ...
+        def build_defs(self, load_context: DefsLoadContext) -> Definitions: ...
 
     comp_instance_one = ComponentWithExistingBusinessObjectOne.load(
         attributes=ComponentWithExistingBusinessObjectSchemaTwo(
             business_object=ExistingBusinessObjectModel(value="1")
         ),
-        context=ComponentLoadContext.for_test(),
+        context=DefsLoadContext.for_test(),
     )
 
     assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectOne)
@@ -132,7 +132,7 @@ def test_reuse_across_components():
         attributes=ComponentWithExistingBusinessObjectSchemaTwo(
             business_object=ExistingBusinessObjectModel(value="2")
         ),
-        context=ComponentLoadContext.for_test(),
+        context=DefsLoadContext.for_test(),
     )
 
     assert isinstance(comp_instance_one, ComponentWithExistingBusinessObjectTwo)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_invariant_errors.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_component_invariant_errors.py
@@ -1,8 +1,8 @@
-from dagster_components import Component, ComponentLoadContext
+from dagster_components import Component, DefsLoadContext
 
 
 def test_component_does_not_implement_resolved_anything():
     class AComponent(Component):
         def build_defs(self, context): ...
 
-    assert AComponent.load(attributes=None, context=ComponentLoadContext.for_test())
+    assert AComponent.load(attributes=None, context=DefsLoadContext.for_test())

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -15,28 +15,28 @@ import tomlkit
 from click.testing import Result
 from dagster import AssetKey, DagsterInstance
 from dagster._utils import alter_sys_path, pushd
-from dagster_components.core.component import Component, ComponentLoadContext
+from dagster_components.core.component import Component, DefsModuleLoadContext
 from dagster_components.core.defs_module import DefsModuleDecl
 from dagster_components.utils import ensure_loadable_path
 
 T = TypeVar("T")
 
 
-def script_load_context(decl_node: Optional[DefsModuleDecl] = None) -> ComponentLoadContext:
-    return ComponentLoadContext.for_test(decl_node=decl_node)
+def script_load_context(decl_node: Optional[DefsModuleDecl] = None) -> DefsModuleLoadContext:
+    return DefsModuleLoadContext.for_test(decl_node=decl_node)
 
 
 def get_asset_keys(component: Component) -> AbstractSet[AssetKey]:
     return {
         key
-        for key in component.build_defs(ComponentLoadContext.for_test())
+        for key in component.build_defs(DefsModuleLoadContext.for_test())
         .get_asset_graph()
         .get_all_asset_keys()
     }
 
 
 def assert_assets(component: Component, expected_assets: int) -> None:
-    defs = component.build_defs(ComponentLoadContext.for_test())
+    defs = component.build_defs(DefsModuleLoadContext.for_test())
     assert len(defs.get_asset_graph().get_all_asset_keys()) == expected_assets
     result = defs.get_implicit_global_asset_job_def().execute_in_process(
         instance=DagsterInstance.ephemeral()


### PR DESCRIPTION
## Summary & Motivation

This is used for all types of DefsModule loading, so it should be renamed.

`DefsModuleLoadContext` also considered, opted for brevity, particularly in this sort of snippet:

```python
@component
def the_component(context: DefsLoadContext) -> ...:

```

The term "DefsModule" there feels a bit weird because as a user, I'm thinking "this isn't a module, it's just a single function"

## How I Tested These Changes

## Changelog

`ComponentLoadContext` has been renamed to `DefsLoadContext`
