### PR TITLE
[dg] Eliminate load_module_from_path

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/defs_module.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/defs_module.py
@@ -30,7 +30,6 @@ from dagster_components.core.component import (
     load_component_type,
 )
 from dagster_components.core.component_key import ComponentKey
-from dagster_components.utils import load_module_from_path
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -261,7 +260,7 @@ class PythonComponentDecl(DefsModuleDecl):
             return
 
     def load(self, context: ComponentLoadContext) -> ComponentDefsModule:
-        module = load_module_from_path(self.path.stem, self.path / "component.py")
+        module = context.load_defs_relative_python_module(self.path / "component.py")
         component_loaders = list(inspect.getmembers(module, is_component_loader))
         if len(component_loaders) < 1:
             raise DagsterInvalidDefinitionError("No component loaders found in module")

--- a/python_modules/libraries/dagster-components/dagster_components/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/utils.py
@@ -141,19 +141,6 @@ class TranslatorResolvingInfo:
         )
 
 
-def load_module_from_path(module_name: str, path: Path) -> ModuleType:
-    # Create a spec from the file path
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None:
-        raise ImportError(f"Cannot create a module spec from path: {path}")
-
-    # Create and load the module
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader, "Must have a loader"
-    spec.loader.exec_module(module)
-    return module
-
-
 # ########################
 # ##### PLATFORM
 # ########################

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/component.py
@@ -1,0 +1,24 @@
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component, ComponentLoadContext, component
+
+# This import is used to test relative imports in the same module.
+from .other_file import return_value  # noqa
+
+
+class AComponent(Component):
+    """A simple component class for demonstration purposes."""
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        assert return_value() == "value", "Expected return_value to be 'value'"
+
+        @asset(key=return_value())
+        def an_asset() -> None: ...
+
+        return Definitions(assets=[an_asset])
+
+
+@component
+def load(context: ComponentLoadContext) -> Component:
+    """A component that loads a component from the same module."""
+    return AComponent()

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/other_file.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/other_file.py
@@ -1,0 +1,2 @@
+def return_value() -> str:
+    return "value"

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_pythonic_components.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_pythonic_components.py
@@ -1,0 +1,9 @@
+import pytest
+from dagster import AssetKey, Definitions
+
+from dagster_components_tests.integration_tests.component_loader import chdir as chdir
+
+
+@pytest.mark.parametrize("defs", ["pythonic_components/relative_import"], indirect=True)
+def test_pythonic_components_relative_import(defs: Definitions) -> None:
+    assert {spec.key for spec in defs.get_all_asset_specs()} == {AssetKey("value")}


### PR DESCRIPTION
## Summary & Motivation

`load_module_from_path` can be replaced by the superior `load_defs_relative_python_module` on `ComponentLoadContext` which handles relative imports

## How I Tested These Changes

BK

## Changelog

* Bug fix: Python files with Pythonic Components (i.e. defined with `@component`) can now contain relative imports.