### PR TITLE
[buildkite] Adds step to build docs in buildkite

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -8,6 +8,7 @@ from dagster_buildkite.steps.dagster_ui import (
     build_dagster_ui_core_steps,
     skip_if_no_dagster_ui_changes,
 )
+from dagster_buildkite.steps.docs import build_docs_steps
 from dagster_buildkite.steps.trigger import build_trigger_step
 from dagster_buildkite.utils import (
     BuildkiteStep,
@@ -64,6 +65,7 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
 
     # Full pipeline.
     steps += build_repo_wide_steps()
+    steps += build_docs_steps()
     steps += build_dagster_ui_components_steps()
     steps += build_dagster_ui_core_steps()
     steps += build_dagster_steps()

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -14,19 +14,12 @@ def build_docs_steps() -> List[BuildkiteStep]:
     steps: List[BuildkiteStep] = []
 
     docs_steps: List[BuildkiteLeafStep] = [
-        CommandStepBuilder("build api docs")
-        .run(
-            "cd docs",
-            "yarn install",
-            "yarn build-api-docs",
-        )
-        .on_test_image(AvailablePythonVersion.get_default())
-        .build(),
         CommandStepBuilder("build docs")
         .run(
             "cd docs",
             "yarn install",
             "yarn test",
+            "yarn build-api-docs",
             "yarn build",
         )
         .with_skip(skip_if_no_docs_changes())

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -17,12 +17,14 @@ def build_docs_steps() -> List[BuildkiteStep]:
         CommandStepBuilder("build api docs")
         .run(
             "cd docs",
+            "yarn install",
             "yarn build-api-docs",
         )
         .on_test_image(AvailablePythonVersion.get_default())
         .build(),
         CommandStepBuilder("build docs")
         .run(
+            "cd docs",
             "yarn install",
             "yarn test",
             "yarn build",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from dagster_buildkite.python_version import AvailablePythonVersion
+from dagster_buildkite.step_builder import CommandStepBuilder
+from dagster_buildkite.utils import (
+    BuildkiteLeafStep,
+    BuildkiteStep,
+    GroupStep,
+    skip_if_no_docs_changes,
+)
+
+
+def build_docs_steps() -> List[BuildkiteStep]:
+    steps: List[BuildkiteStep] = []
+
+    docs_steps: List[BuildkiteLeafStep] = [
+        CommandStepBuilder("build api docs")
+        .run(
+            "cd docs",
+            "yarn build-api-docs",
+        )
+        .on_test_image(AvailablePythonVersion.get_default())
+        .build(),
+        CommandStepBuilder("build docs")
+        .run(
+            "yarn install",
+            "yarn test",
+            "yarn build",
+        )
+        .with_skip(skip_if_no_docs_changes())
+        .on_test_image(AvailablePythonVersion.get_default())
+        .build(),
+    ]
+
+    steps += [
+        GroupStep(
+            group=":book: docs",
+            key="docs",
+            steps=docs_steps,
+        )
+    ]
+
+    return steps

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -385,7 +385,7 @@ def skip_if_no_docs_changes():
     if message_contains("NO_SKIP"):
         return None
 
-    if message_contains("NO_SKIP_DOCS"):
+    if message_contains("BUILDKITE_DOCS"):
         return None
 
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):  # pyright: ignore[reportArgumentType]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -385,6 +385,9 @@ def skip_if_no_docs_changes():
     if message_contains("NO_SKIP"):
         return None
 
+    if message_contains("NO_SKIP_DOCS"):
+        return None
+
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):  # pyright: ignore[reportArgumentType]
         return None
 


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-859.

- Adds buildkite workflow for building docs: `yarn build-api-docs`, `yarn build`, `yarn test`
- Adds check for `BUILDKITE_DOCS` string in buildkite message to force check when `docs/` or `examples/` are unmodified

## How I Tested These Changes

bk

## Changelog

NOCHANGELOG
