### PR TITLE
[dg] Remove `component` subcommand

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-scaffold-jdbt.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/19-dg-scaffold-jdbt.txt
@@ -1,4 +1,4 @@
-dg scaffold component dagster_components.dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt
+dg scaffold dagster_components.dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/defs/jdbt.
 Using /.../jaffle-platform/.venv/bin/dagster-components

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/index/9-dg-scaffold-sling-replication.txt
@@ -1,4 +1,4 @@
-dg scaffold component 'dagster_components.dagster_sling.SlingReplicationCollectionComponent' ingest_files
+dg scaffold 'dagster_components.dagster_sling.SlingReplicationCollectionComponent' ingest_files
 
 Creating a Dagster component instance folder at /.../jaffle-platform/jaffle_platform/defs/ingest_files.
 Using /.../jaffle-platform/.venv/bin/dagster-components

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
@@ -1,4 +1,4 @@
-dg scaffold component 'my_component_library.lib.ShellCommand' my_shell_command
+dg scaffold 'my_component_library.lib.ShellCommand' my_shell_command
 
 Using /.../my-component-library/.venv/bin/dagster-components
 Creating a Dagster component instance folder at /.../my-component-library/my_component_library/defs/my_shell_command.

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -120,7 +120,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
         # Scaffold new ingestion, validate new files
         run_command_and_snippet_output(
-            cmd="dg scaffold component 'dagster_components.dagster_sling.SlingReplicationCollectionComponent' ingest_files",
+            cmd="dg scaffold 'dagster_components.dagster_sling.SlingReplicationCollectionComponent' ingest_files",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{next_snip_no()}-dg-scaffold-sling-replication.txt",
             update_snippets=update_snippets,
@@ -252,7 +252,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
 
             # Scaffold dbt project components
             run_command_and_snippet_output(
-                cmd="dg scaffold component dagster_components.dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt",
+                cmd="dg scaffold dagster_components.dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-dg-scaffold-jdbt.txt",
                 update_snippets=update_snippets,

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -132,7 +132,7 @@ def test_components_docs_index(
             contents=(COMPONENTS_SNIPPETS_DIR / "with-scaffolder.py").read_text(),
         )
         run_command_and_snippet_output(
-            cmd="dg scaffold component 'my_component_library.lib.ShellCommand' my_shell_command",
+            cmd="dg scaffold 'my_component_library.lib.ShellCommand' my_shell_command",
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffold-instance-of-component.txt",
             update_snippets=update_snippets,

--- a/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/sling_replication_collection/component.py
@@ -140,7 +140,7 @@ class SlingReplicationCollectionComponent(Component, ResolvedFrom[SlingReplicati
     [Sling](https://slingdata.io/) is a Powerful Data Integration tool enabling seamless ELT
     operations as well as quality checks across files, databases, and storage systems.
 
-    dg scaffold component dagster_components.dagster_sling.SlingReplicationCollectionComponent {component_name} to get started.
+    dg scaffold dagster_components.dagster_sling.SlingReplicationCollectionComponent {component_name} to get started.
 
     This will create a component.yaml as well as a `replication.yaml` which is a Sling-specific configuration
     file. See Sling's [documentation](https://docs.slingdata.io/concepts/replication#overview) on `replication.yaml`.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -181,10 +181,7 @@ def test_dynamic_subcommand_help_message():
     ):
         with fixed_panel_width(width=120):
             result = runner.invoke(
-                "scaffold",
-                "component",
-                "dagster_test.components.SimplePipesScriptComponent",
-                "--help",
+                "scaffold", "dagster_test.components.SimplePipesScriptComponent", "--help"
             )
             assert_runner_result(result)
             # Strip interpreter logging line
@@ -192,12 +189,10 @@ def test_dynamic_subcommand_help_message():
         assert match_terminal_box_output(
             output.strip(),
             textwrap.dedent("""
-                 Usage: dg scaffold component [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS]             
-                                                                                                      COMPONENT_INSTANCE_NA 
-                 ME
+                 Usage: dg scaffold [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] INSTANCE_NAME 
 
                 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ *    component_instance_name      TEXT  [required]                                                                   │
+                │ *    instance_name      TEXT  [required]                                                                             │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
                 │ --json-params          TEXT  JSON string of component parameters.                                                    │

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -65,7 +65,7 @@ PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "component")),
     CommandSpec(("list", "defs")),
-    CommandSpec(("scaffold", "component"), DEFAULT_COMPONENT_TYPE, "foot"),
+    CommandSpec(("scaffold", DEFAULT_COMPONENT_TYPE, "foot")),
 ]
 
 WORKSPACE_CONTEXT_COMMANDS = [
@@ -213,11 +213,11 @@ def test_no_workspace_or_project_failure(spec: CommandSpec) -> None:
 # ########################
 
 
-# `dg scaffold component` is special because global options have to be inserted before the
+# `dg scaffold` is special because global options have to be inserted before the
 # subcommand name, instead of just at the end.
 def _add_global_cli_options(cli_args: tuple[str, ...], *global_opts: str) -> list[str]:
-    if cli_args[:2] == ("scaffold", "component"):
-        return [*cli_args[:2], *global_opts, *cli_args[2:]]
+    if cli_args[0] == "scaffold":
+        return [cli_args[0], *global_opts, *cli_args[1:]]
     else:
         return [*cli_args, *global_opts]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
@@ -41,10 +41,7 @@ def test_launch_assets(capfd) -> None:
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_components.dagster.DefinitionsComponent",
-            "mydefs",
+            "scaffold", "dagster_components.dagster.DefinitionsComponent", "mydefs"
         )
         assert_runner_result(result)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -56,10 +56,7 @@ def test_list_components_success():
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         result = runner.invoke("list", "component")
@@ -240,10 +237,7 @@ def test_list_defs_succeeds(use_json: bool):
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_components.dagster.DefinitionsComponent",
-            "mydefs",
+            "scaffold", "dagster_components.dagster.DefinitionsComponent", "mydefs"
         )
         assert_runner_result(result)
 
@@ -302,10 +296,7 @@ def test_list_defs_complex_assets_succeeds():
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_components.dagster.DefinitionsComponent",
-            "mydefs",
+            "scaffold", "dagster_components.dagster.DefinitionsComponent", "mydefs"
         )
         assert_runner_result(result)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -124,6 +124,12 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         #     # No tool.uv.sources added without --use-editable-dagster
         #     assert "uv" not in toml["tool"]
 
+        # Populate cache
+        with pushd("projects/foo-bar"):
+            result = runner.invoke("list", "component-type", "--verbose")
+            assert_runner_result(result)
+            assert "CACHE [miss]" in result.output
+
         # Check cache was populated
         with pushd("projects/foo-bar"):
             result = runner.invoke("list", "component-type", "--verbose")
@@ -374,13 +380,14 @@ def test_scaffold_component_dynamic_subcommand_generation() -> None:
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "component", "--help")
+        result = runner.invoke("scaffold", "--help")
         assert_runner_result(result)
 
         normalized_output = standardize_box_characters(result.output)
         # These are wrapped in a table so it's hard to check exact output.
         for line in [
             "╭─ Commands",
+            "│ project",
             "│ dagster_test.components.AllMetadataEmptyComponent",
             "│ dagster_test.components.ComplexAssetComponent",
             "│ dagster_test.components.SimpleAssetComponent",
@@ -396,10 +403,7 @@ def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         assert Path("foo_bar/defs/qux").exists()
@@ -419,7 +423,6 @@ def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
     ):
         result = runner.invoke(
             "scaffold",
-            "component",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--json-params",
@@ -444,7 +447,6 @@ def test_scaffold_component_key_value_params_success(in_workspace: bool) -> None
     ):
         result = runner.invoke(
             "scaffold",
-            "component",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--asset-key=foo",
@@ -468,7 +470,6 @@ def test_scaffold_component_json_params_and_key_value_params_fails() -> None:
     ):
         result = runner.invoke(
             "scaffold",
-            "component",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--json-params",
@@ -483,7 +484,7 @@ def test_scaffold_component_json_params_and_key_value_params_fails() -> None:
 
 def test_scaffold_component_undefined_component_type_fails() -> None:
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
-        result = runner.invoke("scaffold", "component", "fake.Fake", "qux")
+        result = runner.invoke("scaffold", "fake.Fake", "qux")
         assert_runner_result(result, exit_0=False)
         assert "No component type `fake.Fake` is registered" in result.output
 
@@ -498,10 +499,7 @@ def test_scaffold_component_command_with_non_matching_module_name():
         python_module.rename("module_not_same_as_project")
 
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "Cannot find module `foo_bar.lib`" in str(result.exception)
@@ -514,17 +512,11 @@ def test_scaffold_component_already_exists_fails(in_workspace: bool) -> None:
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "already exists" in result.output
@@ -540,10 +532,7 @@ def test_scaffold_component_succeeds_non_default_defs_module() -> None:
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             create_toml_node(toml_dict, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         assert Path("foo_bar/_defs/qux").exists()
@@ -563,10 +552,7 @@ def test_scaffold_component_fails_defs_module_does_not_exist() -> None:
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             create_toml_node(toml_dict, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_test.components.AllMetadataEmptyComponent",
-            "qux",
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "Cannot find module `foo_bar._defs`" in str(result.exception)
@@ -581,7 +567,7 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
         assert_runner_result(result)
         assert Path("foo_bar/lib/baz.py").exists()
 
-        result = runner.invoke("scaffold", "component", "foo_bar.lib.Baz", "qux")
+        result = runner.invoke("scaffold", "foo_bar.lib.Baz", "qux")
         assert_runner_result(result)
         assert Path("foo_bar/defs/qux").exists()
         component_yaml_path = Path("foo_bar/defs/qux/component.yaml")
@@ -652,11 +638,7 @@ def test_scaffold_dbt_project_instance(params) -> None:
         # direct dependencies will be resolved by uv.tool.sources.
         subprocess.run(["uv", "add", "dagster-components[dbt]", "dagster-dbt"], check=True)
         result = runner.invoke(
-            "scaffold",
-            "component",
-            "dagster_components.dagster_dbt.DbtProjectComponent",
-            "my_project",
-            *params,
+            "scaffold", "dagster_components.dagster_dbt.DbtProjectComponent", "my_project", *params
         )
         assert_runner_result(result)
         assert Path("foo_bar/defs/my_project").exists()
@@ -708,11 +690,7 @@ def test_scaffold_component_type_succeeds_non_default_component_lib_package() ->
         ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner, lib_module_name="foo_bar._lib"),
     ):
-        result = runner.invoke(
-            "scaffold",
-            "component-type",
-            "Baz",
-        )
+        result = runner.invoke("scaffold", "component-type", "Baz")
         assert_runner_result(result)
         assert Path("foo_bar/_lib/baz.py").exists()
         dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
@@ -730,11 +708,7 @@ def test_scaffold_component_type_fails_components_lib_package_does_not_exist(cap
 
         # An entry point load error will occur before we even get to component type scaffolding
         # code, because the entry points are loaded first.
-        result = runner.invoke(
-            "scaffold",
-            "component-type",
-            "Baz",
-        )
+        result = runner.invoke("scaffold", "component-type", "Baz")
         assert_runner_result(result, exit_0=False)
 
         captured = capfd.readouterr()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -37,7 +37,7 @@ STANDARD_TEST_COMPONENT_MODULE = "dagster_test.components"
 
 def crawl_cli_commands() -> dict[tuple[str, ...], click.Command]:
     """Note that this does not pick up:
-    - all `component scaffold` subcommands, because these are dynamically generated and vary across
+    - all `scaffold` subcommands, because these are dynamically generated and vary across
       environment.
     - special --ACTION options with callbacks (e.g. `--rebuild-component-registry`).
     """
@@ -46,7 +46,7 @@ def crawl_cli_commands() -> dict[tuple[str, ...], click.Command]:
     def _crawl(command: click.Command, path: tuple[str, ...]):
         assert command.name
         new_path = (*path, command.name)
-        if isinstance(command, click.Group) and not new_path == ("dg", "scaffold", "component"):
+        if isinstance(command, click.Group) and not new_path == ("dg", "scaffold"):
             for subcommand in command.commands.values():
                 assert subcommand.name
                 _crawl(subcommand, new_path)
@@ -435,11 +435,11 @@ class ProxyRunner:
             yield cls(CliRunner(), append_args=append_opts, console_width=console_width)
 
     def invoke(self, *args: str, **invoke_kwargs: Any) -> Result:
-        # We need to find the right spot to inject global options. For the `dg scaffold component`
+        # We need to find the right spot to inject global options. For the `dg scaffold`
         # command, we need to inject the global options before the final subcommand. For everything
         # else they can be appended at the end of the options.
-        if args[:2] == ("scaffold", "component"):
-            index = 2
+        if args[0] == "scaffold":
+            index = 1
         elif "--help" in args:
             index = args.index("--help")
         elif "--" in args:


### PR DESCRIPTION
## Summary & Motivation

When you scaffold a component, you can now do this via

`dg scaffold foo.bar.Component` instead of `dg scaffold component foo.bar.Component`.

Essentially, this makes scaffolding a uniform action that can be taken against any scaffoldable object, rather than having special-casing for components.

We very likely should rework all the special-purpose commands (e.g. `dg scaffold workspace`) to use the `scaffold_with` framework, but that will require some updates / extension to the ScaffolderSnap to represent the "scope" of the command (i.e. are you scaffolding a completely parallel directory tree (project, workspace), something that lives in an arbitrary spot in a given project (component-type), or something that lives in the `defs` module (dagster.asset, any component)

## How I Tested These Changes

## Changelog

When scaffolding a component, the command is now `dg scaffold my_project.ComponentType` instead of `dg scaffold component my_project.ComponentType`.
