### PR TITLE
[buildkite] Add dbt Cloud kitchen sink to library packages

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -404,20 +404,6 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "examples/experimental/dagster-dlift",
         name="dlift",
     ),
-    # Runs against live dbt cloud instance, we only want to run on commits and on the
-    # nightly build
-    PackageSpec(
-        "python_modules/libraries/dagster-dbt/kitchen-sink",
-        skip_if=skip_if_not_dagster_dbt_cloud_commit,
-        name="dagster-dbt-cloud-live",
-        env_vars=[
-            "KS_DBT_CLOUD_ACCOUNT_ID",
-            "KS_DBT_CLOUD_ACCESS_URL",
-            "KS_DBT_CLOUD_TOKEN",
-            "KS_DBT_CLOUD_PROJECT_ID",
-            "KS_DBT_CLOUD_ENVIRONMENT_ID",
-        ],
-    ),
 ]
 
 
@@ -753,6 +739,20 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-airlift/kitchen-sink",
         always_run_if=has_dagster_airlift_changes,
+    ),
+    # Runs against live dbt cloud instance, we only want to run on commits and on the
+    # nightly build
+    PackageSpec(
+        "python_modules/libraries/dagster-dbt/kitchen-sink",
+        skip_if=skip_if_not_dagster_dbt_cloud_commit,
+        name="dagster-dbt-cloud-live",
+        env_vars=[
+            "KS_DBT_CLOUD_ACCOUNT_ID",
+            "KS_DBT_CLOUD_ACCESS_URL",
+            "KS_DBT_CLOUD_TOKEN",
+            "KS_DBT_CLOUD_PROJECT_ID",
+            "KS_DBT_CLOUD_ENVIRONMENT_ID",
+        ],
     ),
     PackageSpec(
         ".buildkite/dagster-buildkite",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -359,7 +359,7 @@ def skip_if_not_dagster_dbt_cloud_commit() -> Optional[str]:
             any("dagster_dbt/cloud_v2" in str(path) for path in ChangedFiles.all)
             # The kitchen sink in dagster-dbt in only testing the dbt Cloud integration v2.
             # Do not skip tests if changes are made to this test suite.
-            or any("dagster_dbt/kitchen-sink" in str(path) for path in ChangedFiles.all)
+            or any("dagster-dbt/kitchen-sink" in str(path) for path in ChangedFiles.all)
         )
         else "Not a dagster-dbt Cloud commit"
     )


### PR DESCRIPTION
## Summary & Motivation

The kitchen sink for dbt cloud was under examples and not libraries in buildkite, hence why it was only running on no skip.

## How I Tested These Changes

BK

