### PR TITLE
Introduce new default PerProjectEnvFileLoader SecretsLoader

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -563,6 +563,7 @@ class InstanceRef(
 
     @property
     def secrets_loader(self) -> Optional["SecretsLoader"]:
+        from dagster._core.secrets.env_file import PerProjectEnvFileLoader
         from dagster._core.secrets.loader import SecretsLoader
 
         # Defining a default here rather than in stored config to avoid
@@ -571,7 +572,7 @@ class InstanceRef(
         return (
             self.secrets_loader_data.rehydrate(as_type=SecretsLoader)
             if self.secrets_loader_data
-            else None
+            else PerProjectEnvFileLoader()
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -566,9 +566,10 @@ class InstanceRef(
         from dagster._core.secrets.env_file import PerProjectEnvFileLoader
         from dagster._core.secrets.loader import SecretsLoader
 
-        # Defining a default here rather than in stored config to avoid
-        # back-compat issues when loading the config on older versions where
-        # EnvFileLoader was not defined
+        # Default PerProjectEnvFileLoader is injected here, rather than
+        # in config_defaults, to avoid back-compat issues when loading the
+        # config on older versions where PerProjectEnvFileLoader was not
+        # defined.
         return (
             self.secrets_loader_data.rehydrate(as_type=SecretsLoader)
             if self.secrets_loader_data

--- a/python_modules/dagster/dagster/_core/secrets/env_file.py
+++ b/python_modules/dagster/dagster/_core/secrets/env_file.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from collections.abc import Mapping
@@ -6,7 +7,8 @@ from typing import Any, Optional
 from dotenv import dotenv_values
 from typing_extensions import Self
 
-from dagster._config import Field, StringSource
+from dagster._config import Field, Map, StringSource
+from dagster._config.field_utils import Shape
 from dagster._core.secrets.loader import SecretsLoader
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
@@ -18,6 +20,57 @@ def get_env_var_dict(base_dir: str) -> dict[str, str]:
         return {}
 
     return {key: val for key, val in dotenv_values(env_file_path).items() if val is not None}
+
+
+class PerProjectEnvFileLoader(SecretsLoader, ConfigurableClass):
+    """Default secrets loader which loads additional env vars from a per-project .env file.
+
+    Can be manually configured in the dagster.yaml file or implcitly set via the
+    DAGSTER_PROJECT_ENV_FILE_PATHS environment variable.
+    """
+
+    def __init__(
+        self,
+        inst_data: Optional[ConfigurableClassData] = None,
+        location_paths: Optional[Mapping[str, str]] = None,
+    ):
+        self._inst_data = inst_data
+        self._location_paths = location_paths
+
+    @classmethod
+    def config_type(cls) -> Shape:
+        return Shape(
+            fields={
+                "location_paths": Map(key_type=str, inner_type=str),
+            },
+        )
+
+    def get_secrets_for_environment(self, location_name: Optional[str]) -> dict[str, str]:
+        inst_data = self._inst_data
+
+        location_paths = self._location_paths or {}
+        if not inst_data:
+            inst_data_env = os.getenv("DAGSTER_PROJECT_ENV_FILE_PATHS")
+            if inst_data_env:
+                location_paths = json.loads(inst_data_env)
+        else:
+            location_paths = inst_data.config_dict.get("location_paths", {})
+
+        if location_name and location_name in location_paths:
+            env_file_path = os.path.join(os.getcwd(), location_paths[location_name])
+            return get_env_var_dict(env_file_path)
+        else:
+            return {}
+
+    @property
+    def inst_data(self):
+        return self._inst_data
+
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
+        return cls(inst_data=inst_data, **config_value)
 
 
 class EnvFileLoader(SecretsLoader, ConfigurableClass):

--- a/python_modules/dagster/dagster/_core/secrets/env_file.py
+++ b/python_modules/dagster/dagster/_core/secrets/env_file.py
@@ -25,7 +25,7 @@ def get_env_var_dict(base_dir: str) -> dict[str, str]:
 class PerProjectEnvFileLoader(SecretsLoader, ConfigurableClass):
     """Default secrets loader which loads additional env vars from a per-project .env file.
 
-    Can be manually configured in the dagster.yaml file or implcitly set via the
+    Can be manually configured in the dagster.yaml file or implicitly set via the
     DAGSTER_PROJECT_ENV_FILE_PATHS environment variable.
     """
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -106,6 +106,20 @@ def dev_command(
         *(["--verbose"] if dg_context.config.cli.verbose else []),
     ]
 
+    import json
+
+    if dg_context.is_workspace:
+        os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
+            {
+                dg_context.with_root_path(project.path).code_location_name: str(project.path)
+                for project in dg_context.project_specs
+            }
+        )
+    else:
+        os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
+            {dg_context.code_location_name: str(dg_context.root_path)}
+        )
+
     # In a project context, we can just run `dagster dev` directly, using `dagster` from the
     # code location's environment.
     # In a workspace context, dg dev will construct a temporary

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -1,3 +1,4 @@
+import json
 import os
 import signal
 import subprocess
@@ -15,7 +16,7 @@ from dagster_dg.cli.utils import create_dagster_cli_cmd
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.error import DgError
-from dagster_dg.utils import DgClickCommand, pushd
+from dagster_dg.utils import DgClickCommand, pushd, strip_activated_venv_from_env_vars
 from dagster_dg.utils.cli import format_forwarded_option
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
@@ -105,8 +106,6 @@ def dev_command(
         *format_forwarded_option("--live-data-poll-rate", live_data_poll_rate),
         *(["--verbose"] if dg_context.config.cli.verbose else []),
     ]
-
-    import json
 
     if dg_context.is_workspace:
         os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
@@ -200,4 +199,5 @@ def _open_subprocess(command: Sequence[str]) -> "subprocess.Popen":
     return subprocess.Popen(
         command,
         creationflags=creationflags,
+        env=strip_activated_venv_from_env_vars(os.environ),
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -225,3 +225,19 @@ def _resolve_definition(item: dict[str, Any]) -> DgDefinitionMetadata:
         return DgSensorMetadata(**item)
     else:
         raise DgError(f"Unexpected item type: {item['type']}")
+
+
+# ########################
+# ##### ENVIRONMENT
+# ########################
+
+
+@list_group.command(name="env", cls=DgClickCommand)
+@dg_global_options
+def list_environment_command(**global_options: object) -> None:
+    """List environment variables in the current project or workspace."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    for project in dg_context.project_specs:
+        click.echo(project.path)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -225,19 +225,3 @@ def _resolve_definition(item: dict[str, Any]) -> DgDefinitionMetadata:
         return DgSensorMetadata(**item)
     else:
         raise DgError(f"Unexpected item type: {item['type']}")
-
-
-# ########################
-# ##### ENVIRONMENT
-# ########################
-
-
-@list_group.command(name="env", cls=DgClickCommand)
-@dg_global_options
-def list_environment_command(**global_options: object) -> None:
-    """List environment variables in the current project or workspace."""
-    cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
-
-    for project in dg_context.project_specs:
-        click.echo(project.path)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -4,9 +4,10 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, NamedTuple, Optional, cast
+from typing import Any, NamedTuple, Optional
 
 import click
+import packaging.version
 import yaml
 from dagster_shared.serdes.objects import LibraryObjectKey
 
@@ -137,19 +138,13 @@ def _workspace_entry_for_project(dg_context: DgContext) -> dict[str, dict[str, s
     return {"python_module": entry}
 
 
-def _semver(version: str) -> Optional[tuple[int, int, int]]:
-    try:
-        return cast(tuple[int, int, int], tuple(map(int, version.split("."))))
-    except ValueError:
-        return None
-
-
 def _semver_less_than(version: str, other: str) -> bool:
-    version_semver = _semver(version)
-    other_semver = _semver(other)
-    if version_semver is None or other_semver is None:
+    try:
+        parsed_version = packaging.version.parse(version)
+        parsed_other = packaging.version.parse(other)
+        return parsed_version < parsed_other
+    except packaging.version.InvalidVersion:
         return False
-    return version_semver < other_semver
 
 
 MIN_ENV_VAR_INJECTION_VERSION = "1.10.8"

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -152,7 +152,7 @@ def _semver_less_than(version: str, other: str) -> bool:
     return version_semver < other_semver
 
 
-MIN_ENV_VAR_INJECTION_VERSION = "1.10.7"
+MIN_ENV_VAR_INJECTION_VERSION = "1.10.8"
 
 
 @contextmanager

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -302,6 +302,12 @@ class DgContext:
             raise DgError("`project_name` is only available in a Dagster project context")
         return self.root_path.name
 
+    def resolve_package_manager_executable(self) -> list[str]:
+        if self.use_dg_managed_environment:
+            return ["uv", "pip"]
+        else:
+            return [str(self.get_executable("python")), "-m", "pip"]
+
     def get_module_version(self, module_name: str) -> str:
         if not self.use_dg_managed_environment:
             raise DgError("`get_module_version` is only available in a Dagster project context")
@@ -309,8 +315,7 @@ class DgContext:
         with pushd(self.root_path):
             result = subprocess.check_output(
                 [
-                    "uv",
-                    "pip",
+                    *self.resolve_package_manager_executable(),
                     "list",
                     "--format",
                     "json",

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shlex
 import shutil
@@ -300,6 +301,29 @@ class DgContext:
         if not self.is_project:
             raise DgError("`project_name` is only available in a Dagster project context")
         return self.root_path.name
+
+    def get_module_version(self, module_name: str) -> str:
+        if not self.use_dg_managed_environment:
+            raise DgError("`get_module_version` is only available in a Dagster project context")
+
+        with pushd(self.root_path):
+            result = subprocess.check_output(
+                [
+                    "uv",
+                    "pip",
+                    "list",
+                    "--format",
+                    "json",
+                    "--python",
+                    get_venv_executable(Path(".venv")),
+                ],
+                env=strip_activated_venv_from_env_vars(os.environ),
+            )
+        modules = json.loads(result)
+        for module in modules:
+            if module["name"] == module_name:
+                return module["version"]
+        raise DgError(f"Module `{module_name}` not found")
 
     @property
     def project_python_executable(self) -> Path:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -105,7 +105,7 @@ assert os.environ["OVERWRITTEN_ENV_VAR"] == "4"
             projects = {"project-1", "project-2"}
             _assert_projects_loaded_and_exit(projects, port, dev_process)
 
-            assert ("nvironment variables will not be injected") not in Path(
+            assert ("Environment variables will not be injected") not in Path(
                 stdout_file.name
             ).read_text()
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -1,12 +1,19 @@
 import signal
 import subprocess
+import tempfile
 import time
 from pathlib import Path
+from typing import Optional, TextIO
 
 import psutil
 import pytest
 import requests
-from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import, is_windows
+from dagster_dg.utils import (
+    discover_git_root,
+    ensure_dagster_dg_tests_import,
+    install_to_venv,
+    is_windows,
+)
 from dagster_graphql.client import DagsterGraphQLClient
 
 ensure_dagster_dg_tests_import()
@@ -96,6 +103,73 @@ assert os.environ["OVERWRITTEN_ENV_VAR"] == "4"
         dev_process = _launch_dev_command(["--port", str(port)])
         projects = {"project-1", "project-2"}
         _assert_projects_loaded_and_exit(projects, port, dev_process)
+
+
+@pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
+def test_dev_workspace_load_env_files_backcompat(monkeypatch):
+    """Test that when .env files are not loaded, for backcompat reasons (e.g. the PerProjectEnvFileLoader
+    is not yet available), we issue a warning.
+    """
+    dagster_git_repo_dir = str(discover_git_root(Path(__file__)))
+    with ProxyRunner.test() as runner, isolated_example_workspace(runner, create_venv=True):
+        Path(".env").write_text("WORKSPACE_ENV_VAR=1\nOVERWRITTEN_ENV_VAR=3")
+        result = runner.invoke(
+            "scaffold",
+            "project",
+            "--use-editable-dagster",
+            dagster_git_repo_dir,
+            "project-1",
+        )
+        assert_runner_result(result)
+        result = runner.invoke(
+            "scaffold",
+            "project",
+            "project-2",
+        )
+        assert_runner_result(result)
+        with pushd(Path("project-2")):
+            install_to_venv(
+                Path(".venv"),
+                [
+                    "dagster==1.10.6",
+                    "dagster-webserver==1.10.6",
+                    "dagster-shared==0.26.6",
+                    "dagster-components==0.26.6",
+                ],
+            )
+
+        (Path("project-2") / ".env").write_text("PROJECT_ENV_VAR=2\nOVERWRITTEN_ENV_VAR=4")
+
+        # Expect that the project env vars are not loaded, since the Dagster version is old
+        # enough
+        (Path("project-2") / "project_2" / "definitions.py").write_text(
+            """import os
+
+from dagster import __version__
+
+assert __version__ == "1.10.6"
+assert os.getenv("PROJECT_ENV_VAR") is None
+assert os.environ["WORKSPACE_ENV_VAR"] == "1"
+assert os.environ["OVERWRITTEN_ENV_VAR"] == "3"
+
+import dagster as dg
+defs = dg.Definitions()
+"""
+        )
+        port = find_free_port()
+
+        with tempfile.NamedTemporaryFile() as stdout_file, open(stdout_file.name, "w") as stdout:
+            dev_process = _launch_dev_command(
+                ["--port", str(port), "--no-check-yaml"], stdout=stdout
+            )
+            projects = {"project-1", "project-2"}
+
+            _assert_projects_loaded_and_exit(projects, port, dev_process)
+
+            assert (
+                "Warning: Dagster version 1.10.6 is less than the minimum required version for .env file environment variable injection "
+                "(1.10.7). Environment variables will not be injected for location project-2."
+            ) in Path(stdout_file.name).read_text()
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
@@ -209,16 +283,19 @@ def test_implicit_yaml_check_from_dg_dev_workspace() -> None:
 # ########################
 
 
-def _launch_dev_command(options: list[str], capture_output: bool = False) -> subprocess.Popen:
+def _launch_dev_command(
+    options: list[str], capture_output: bool = False, stdout: Optional[TextIO] = None
+) -> subprocess.Popen:
     # We start a new process instead of using the runner to avoid blocking the test. We need to
     # poll the webserver to know when it is ready.
+    assert stdout is None or capture_output is False, "Cannot set both stdout and capture_output"
     return subprocess.Popen(
         [
             "dg",
             "dev",
             *options,
         ],
-        stdout=subprocess.PIPE if capture_output else None,
+        stdout=stdout if stdout else (subprocess.PIPE if capture_output else None),
     )
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -100,9 +100,14 @@ assert os.environ["OVERWRITTEN_ENV_VAR"] == "4"
 """
         )
         port = find_free_port()
-        dev_process = _launch_dev_command(["--port", str(port)])
-        projects = {"project-1", "project-2"}
-        _assert_projects_loaded_and_exit(projects, port, dev_process)
+        with tempfile.NamedTemporaryFile() as stdout_file, open(stdout_file.name, "w") as stdout:
+            dev_process = _launch_dev_command(["--port", str(port)], stdout=stdout)
+            projects = {"project-1", "project-2"}
+            _assert_projects_loaded_and_exit(projects, port, dev_process)
+
+            assert ("nvironment variables will not be injected") not in Path(
+                stdout_file.name
+            ).read_text()
 
 
 @pytest.mark.skipif(is_windows(), reason="Temporarily skipping (signal issues in CLI)..")
@@ -131,10 +136,10 @@ def test_dev_workspace_load_env_files_backcompat(monkeypatch):
             install_to_venv(
                 Path(".venv"),
                 [
-                    "dagster==1.10.6",
-                    "dagster-webserver==1.10.6",
-                    "dagster-shared==0.26.6",
-                    "dagster-components==0.26.6",
+                    "dagster==1.10.7",
+                    "dagster-webserver==1.10.7",
+                    "dagster-shared==0.26.7",
+                    "dagster-components==0.26.7",
                 ],
             )
 
@@ -147,7 +152,7 @@ def test_dev_workspace_load_env_files_backcompat(monkeypatch):
 
 from dagster import __version__
 
-assert __version__ == "1.10.6"
+assert __version__ == "1.10.7"
 assert os.getenv("PROJECT_ENV_VAR") is None
 assert os.environ["WORKSPACE_ENV_VAR"] == "1"
 assert os.environ["OVERWRITTEN_ENV_VAR"] == "3"
@@ -167,7 +172,7 @@ defs = dg.Definitions()
             _assert_projects_loaded_and_exit(projects, port, dev_process)
 
             assert (
-                "Warning: Dagster version 1.10.6 is less than the minimum required version for .env file environment variable injection "
+                "Warning: Dagster version 1.10.7 is less than the minimum required version for .env file environment variable injection "
                 "(1.10.8). Environment variables will not be injected for location project-2."
             ) in Path(stdout_file.name).read_text()
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_dev_command.py
@@ -168,7 +168,7 @@ defs = dg.Definitions()
 
             assert (
                 "Warning: Dagster version 1.10.6 is less than the minimum required version for .env file environment variable injection "
-                "(1.10.7). Environment variables will not be injected for location project-2."
+                "(1.10.8). Environment variables will not be injected for location project-2."
             ) in Path(stdout_file.name).read_text()
 
 


### PR DESCRIPTION
## Summary

Defaults dagster to loading the `PerProjectEnvFileLoader` SecretsLoader, which can be manually configured to provide a mapping from code location to directory with an `.env` file, or can be supplied through the `DAGSTER_PROJECT_ENV_FILE_PATHS` env var.

Allows `dg dev` to pass a mapping for each project in a workspace, so we can load project-level .env contents.

## How I Tested These Changes

New unit tests.
