### PR TITLE
Remove repeated section in example-customizations.md

### DIFF
--- a/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/example-customizations.md
+++ b/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/example-customizations.md
@@ -39,12 +39,6 @@ Alternatively, you can pass in an <PyObject section="assets" module="dagster" ob
 
 <CodeExample path="docs_snippets/docs_snippets/concepts/declarative_automation/allow_dependencies_cron.py" />
 
-### Wait for all blocking asset checks to complete before executing
-
-The `AutomationCondition.all_deps_blocking_checks_passed()` condition becomes true after all upstream blocking checks have passed. This can be combined with built-in conditions such as `AutomationCondition.on_cron()` and `AutomationCondition.eager()` to ensure that your asset does not execute if upstream data is in a bad state:
-
-<CodeExample path="docs_snippets/docs_snippets/concepts/declarative_automation/blocking_checks_condition.py" />
-
 ## Waiting for all blocking asset checks to complete before executing
 
 The `AutomationCondition.all_deps_blocking_checks_passed()` condition becomes true after all upstream blocking checks have passed.


### PR DESCRIPTION
This section is shown twice on the site, 
https://docs.dagster.io/guides/automate/declarative-automation/customizing-automation-conditions/example-customizations#wait-for-all-blocking-asset-checks-to-complete-before-executing

## Summary & Motivation

## How I Tested These Changes

## Changelog
Simply removed a few repeated lines

> Insert changelog entry or delete this section.
