### PR TITLE
[dg] Renaming to reserve DefsModule and DefsModuleDecl

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/components/defs_module/component.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 from dagster_components import AssetPostProcessorModel, Component, ComponentLoadContext
 from dagster_components.core.defs_module import (
-    DefsModule,
+    DefsModuleResolver,
     PythonModuleDecl,
     SubpackageDefsModuleDecl,
 )
@@ -15,12 +15,12 @@ from dagster_components.resolved.core_models import AssetPostProcessor
 from dagster_components.resolved.model import ResolvableModel, ResolvedFrom, Resolver, resolve_model
 
 
-class DefsModuleArgsModel(ResolvableModel):
+class DefsModuleResolverArgsModel(ResolvableModel):
     asset_post_processors: Optional[Sequence[AssetPostProcessorModel]] = None
 
 
 @dataclass
-class ResolvedDefsModuleArgs(ResolvedFrom[DefsModuleArgsModel]):
+class ResolvedDefsModuleArgs(ResolvedFrom[DefsModuleResolverArgsModel]):
     asset_post_processors: Annotated[Sequence[AssetPostProcessor], Resolver.from_annotation()]
 
 
@@ -28,17 +28,19 @@ class DefsModuleComponent(Component):
     """Wraps a DefsModule to allow the addition of arbitrary attributes."""
 
     def __init__(
-        self, post_processors: Sequence[AssetPostProcessor], defs_module: Optional[DefsModule]
+        self,
+        post_processors: Sequence[AssetPostProcessor],
+        defs_module: Optional[DefsModuleResolver],
     ):
         self.post_processors = post_processors
         self.defs_module = defs_module
 
     @classmethod
-    def get_schema(cls) -> type[DefsModuleArgsModel]:
-        return DefsModuleArgsModel
+    def get_schema(cls) -> type[DefsModuleResolverArgsModel]:
+        return DefsModuleResolverArgsModel
 
     @classmethod
-    def load(cls, attributes: DefsModuleArgsModel, context: ComponentLoadContext) -> Self:
+    def load(cls, attributes: DefsModuleResolverArgsModel, context: ComponentLoadContext) -> Self:
         path = context.path
         decl = PythonModuleDecl.from_path(path) or SubpackageDefsModuleDecl.from_path(path)
         defs_module = decl.load(context) if decl else None

--- a/python_modules/libraries/dagster-components/dagster_components/core/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/component.py
@@ -28,7 +28,7 @@ from dagster_components.scaffold import ScaffolderUnavailableReason, get_scaffol
 from dagster_components.utils import format_error_message, get_path_from_module
 
 if TYPE_CHECKING:
-    from dagster_components.core.defs_module import DefsModuleDecl
+    from dagster_components.core.defs_module import DefsModuleDeclNode
 
 
 class ComponentsEntryPointLoadError(DagsterError):
@@ -235,9 +235,9 @@ class DefinitionsModuleCache:
 
     @cached_method
     def _load_defs_inner(self, module: ModuleType) -> Definitions:
-        from dagster_components.core.defs_module import DefsModuleDecl
+        from dagster_components.core.defs_module import DefsModuleDeclNode
 
-        decl_node = DefsModuleDecl.from_module(module)
+        decl_node = DefsModuleDeclNode.from_module(module)
         if not decl_node:
             raise Exception(f"No component found at module {module}")
 
@@ -261,7 +261,7 @@ class ComponentLoadContext:
 
     defs_root: Path
     defs_module_name: str
-    decl_node: Optional["DefsModuleDecl"]
+    decl_node: Optional["DefsModuleDeclNode"]
     resolution_context: ResolutionContext
     module_cache: DefinitionsModuleCache
 
@@ -278,7 +278,7 @@ class ComponentLoadContext:
     def for_test(
         *,
         resources: Optional[Mapping[str, object]] = None,
-        decl_node: Optional["DefsModuleDecl"] = None,
+        decl_node: Optional["DefsModuleDeclNode"] = None,
     ) -> "ComponentLoadContext":
         return ComponentLoadContext(
             defs_root=Path.cwd(),
@@ -298,7 +298,7 @@ class ComponentLoadContext:
             resolution_context=self.resolution_context.with_scope(**rendering_scope),
         )
 
-    def for_decl(self, decl: "DefsModuleDecl") -> "ComponentLoadContext":
+    def for_decl(self, decl: "DefsModuleDeclNode") -> "ComponentLoadContext":
         return dataclasses.replace(self, decl_node=decl)
 
     def defs_relative_module_name(self, path: Path) -> str:

--- a/python_modules/libraries/dagster-components/dagster_components/test/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing_extensions import TypeVar
 
 from dagster_components.core.component import Component, ComponentLoadContext
-from dagster_components.core.defs_module import DirectForTestComponentDecl
+from dagster_components.core.defs_module import DirectForTestComponentDeclNode
 
 TComponent = TypeVar("TComponent", bound=Component)
 
@@ -12,7 +12,7 @@ def load_direct(
     component_type: type[TComponent],
     attribute_yaml: str,
 ) -> TComponent:
-    decl_node = DirectForTestComponentDecl(
+    decl_node = DirectForTestComponentDeclNode(
         path=Path("/"),
         component_type=component_type,
         attributes_yaml=attribute_yaml,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_dbt_project.py
@@ -12,7 +12,7 @@ from dagster import AssetKey, AssetsDefinition, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
 from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
 from dagster_components.core.component_defs_builder import build_component_defs
-from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
+from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDeclNode
 from dagster_components.resolved.core_models import AssetAttributesModel
 from dagster_dbt import DbtProject
 
@@ -60,7 +60,7 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
     elif backfill_policy == "multi_run_with_max_partitions":
         backfill_policy_arg["backfill_policy"] = {"type": "multi_run", "max_partitions_per_run": 3}
 
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
@@ -111,7 +111,7 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
         def get_additional_scope(cls) -> Mapping[str, Any]:
             return {"get_tags_for_node": lambda node: {"model_id": node["name"].replace("_", "-")}}
 
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="debug_dbt_project",
@@ -203,7 +203,7 @@ def test_asset_attributes(
 ) -> None:
     wrapper = pytest.raises(Exception) if should_error else nullcontext()
     with wrapper:
-        decl_node = YamlComponentDecl(
+        decl_node = YamlComponentDeclNode(
             path=dbt_path / COMPONENT_RELPATH,
             component_file_model=ComponentFileModel(
                 type="dbt_project",
@@ -240,7 +240,7 @@ def test_asset_attributes_is_comprehensive():
 
 
 def test_subselection(dbt_path: Path) -> None:
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
@@ -258,7 +258,7 @@ def test_subselection(dbt_path: Path) -> None:
 
 
 def test_exclude(dbt_path: Path) -> None:
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
@@ -298,7 +298,7 @@ def test_dependency_on_dbt_project():
 
 
 def test_spec_is_available_in_scope(dbt_path: Path) -> None:
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="  ",
@@ -340,7 +340,7 @@ def test_udf_map_spec(dbt_path: Path, map_fn: Callable[[AssetSpec], Any]) -> Non
         def get_additional_scope(cls) -> Mapping[str, Any]:
             return {"map_spec": map_fn}
 
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="debug_dbt_project",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -27,8 +27,8 @@ from dagster_components.components.sling_replication_collection.component import
 from dagster_components.core.component_defs_builder import load_defs
 from dagster_components.core.defs_module import (
     ComponentFileModel,
-    DefsModuleDecl,
-    YamlComponentDecl,
+    DefsModuleDeclNode,
+    YamlComponentDeclNode,
 )
 from dagster_components.resolved.context import ResolutionException
 from dagster_components.resolved.core_models import AssetAttributesModel
@@ -60,7 +60,7 @@ def _modify_yaml(path: Path) -> Iterator[dict[str, Any]]:
 @contextmanager
 def temp_sling_component_instance(
     replication_specs: Optional[list[dict[str, Any]]] = None,
-) -> Iterator[YamlComponentDecl]:
+) -> Iterator[YamlComponentDeclNode]:
     """Sets up a temporary directory with a replication.yaml and component.yaml file that reference
     the proper temp path.
     """
@@ -84,8 +84,8 @@ def temp_sling_component_instance(
                 # update the defs yaml to add a duckdb instance
                 data["attributes"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
 
-            decl_node = DefsModuleDecl.from_path(Path(temp_dir) / COMPONENT_RELPATH)
-            assert isinstance(decl_node, YamlComponentDecl)
+            decl_node = DefsModuleDeclNode.from_path(Path(temp_dir) / COMPONENT_RELPATH)
+            assert isinstance(decl_node, YamlComponentDeclNode)
             yield decl_node
 
 
@@ -203,7 +203,7 @@ def test_sling_subclass() -> None:
         ) -> Iterator[Union[AssetMaterialization, MaterializeResult]]:
             return sling.replicate(context=context, debug=True)
 
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="debug_sling_replication",
@@ -369,7 +369,7 @@ def test_udf_map_spec(map_fn: Callable[[AssetSpec], Any]) -> None:
         def get_additional_scope(cls) -> Mapping[str, Any]:
             return {"map_spec": map_fn}
 
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=STUB_LOCATION_PATH / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="debug_sling_replication",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_templated_custom_keys_dbt_project.py
@@ -9,7 +9,7 @@ import pytest
 from dagster import AssetKey
 from dagster._utils.env import environ
 from dagster_components.components.dbt_project.component import DbtProjectComponent, DbtProjectModel
-from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDecl
+from dagster_components.core.defs_module import ComponentFileModel, YamlComponentDeclNode
 from dagster_dbt import DbtProject
 
 from dagster_components_tests.integration_tests.component_loader import load_test_component_defs
@@ -58,7 +58,7 @@ def dbt_path() -> Iterator[Path]:
 
 
 def test_python_attributes_node_rename(dbt_path: Path) -> None:
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
@@ -77,7 +77,7 @@ def test_python_attributes_node_rename(dbt_path: Path) -> None:
 
 
 def test_python_attributes_group(dbt_path: Path) -> None:
-    decl_node = YamlComponentDecl(
+    decl_node = YamlComponentDeclNode(
         path=dbt_path / COMPONENT_RELPATH,
         component_file_model=ComponentFileModel(
             type="dbt_project",
@@ -105,7 +105,7 @@ def test_load_from_path(dbt_path: Path) -> None:
 
 def test_render_vars_root(dbt_path: Path) -> None:
     with environ({"GROUP_AS_ENV": "group_in_env"}):
-        decl_node = YamlComponentDecl(
+        decl_node = YamlComponentDeclNode(
             path=dbt_path / COMPONENT_RELPATH,
             component_file_model=ComponentFileModel(
                 type="dbt_project",
@@ -128,7 +128,7 @@ def test_render_vars_root(dbt_path: Path) -> None:
 
 def test_render_vars_asset_key(dbt_path: Path) -> None:
     with environ({"ASSET_KEY_PREFIX": "some_prefix"}):
-        decl_node = YamlComponentDecl(
+        decl_node = YamlComponentDeclNode(
             path=dbt_path / COMPONENT_RELPATH,
             component_file_model=ComponentFileModel(
                 type="dbt_project",

--- a/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/utils.py
@@ -16,13 +16,13 @@ from click.testing import Result
 from dagster import AssetKey, DagsterInstance
 from dagster._utils import alter_sys_path, pushd
 from dagster_components.core.component import Component, ComponentLoadContext
-from dagster_components.core.defs_module import DefsModuleDecl
+from dagster_components.core.defs_module import DefsModuleDeclNode
 from dagster_components.utils import ensure_loadable_path
 
 T = TypeVar("T")
 
 
-def script_load_context(decl_node: Optional[DefsModuleDecl] = None) -> ComponentLoadContext:
+def script_load_context(decl_node: Optional[DefsModuleDeclNode] = None) -> ComponentLoadContext:
     return ComponentLoadContext.for_test(decl_node=decl_node)
 
 


### PR DESCRIPTION
## Summary & Motivation

In order to preserve DefsModule for a new public-facing API renaming existing DefsModule to DefsModuleResolver. 

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG