### PR TITLE
[dg] Change `@component` to `@defs_module`

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/components/python-components/component.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/components/python-components/component.py
@@ -1,4 +1,4 @@
-from dagster_components import ComponentLoadContext, component
+from dagster_components import ComponentLoadContext, defs_module
 from dagster_components.dagster_dbt import DbtProjectComponent
 from dagster_dbt import DagsterDbtTranslator, DbtCliResource
 
@@ -6,7 +6,7 @@ from dagster_dbt import DagsterDbtTranslator, DbtCliResource
 class MyTranslator(DagsterDbtTranslator): ...
 
 
-@component
+@defs_module
 def my_dbt_component(context: ComponentLoadContext) -> DbtProjectComponent:
     return DbtProjectComponent(
         dbt=DbtCliResource(project_dir="."),

--- a/python_modules/libraries/dagster-components/dagster_components/__init__.py
+++ b/python_modules/libraries/dagster-components/dagster_components/__init__.py
@@ -4,7 +4,7 @@ from dagster_components.component_scaffolding import (
 from dagster_components.core.component import (
     Component as Component,
     ComponentLoadContext as ComponentLoadContext,
-    component as component,
+    defs_module as defs_module,
 )
 from dagster_components.core.component_defs_builder import (
     build_component_defs as build_component_defs,

--- a/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
@@ -4,11 +4,11 @@ from dagster_components.components.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionModel,
     PipesSubprocessScriptModel,
 )
-from dagster_components.core.component import component
+from dagster_components.core.component import defs_module
 from dagster_components.resolved.core_models import AssetSpecModel
 
 
-@component
+@defs_module()
 def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
     attributes = PipesSubprocessScriptCollectionModel(
         scripts=[

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
@@ -1,0 +1,50 @@
+from dagster import asset
+from dagster_components.core.component import (
+    Component,
+    ComponentLoadContext,
+    Definitions,
+    DefsLoader,
+    defs_module,
+)
+
+
+def test_simple_component_defs():
+    class SimpleComponent(Component):
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            @asset
+            def an_asset() -> None: ...
+
+            return Definitions(assets=[an_asset])
+
+    @defs_module()
+    def loader(context: ComponentLoadContext) -> SimpleComponent:
+        return SimpleComponent()
+
+    context = ComponentLoadContext.for_test()
+    definitions = loader.load_definitions(context)
+    assert definitions.get_assets_def("an_asset")
+    assert len(definitions.get_all_asset_specs()) == 1
+
+
+def test_eager_definitions():
+    @asset
+    def an_asset() -> None: ...
+
+    @defs_module()
+    def loader(context: ComponentLoadContext) -> DefsLoader:
+        return DefsLoader.for_eager_definitions(Definitions(assets=[an_asset]))
+
+    context = ComponentLoadContext.for_test()
+    definitions = loader.load_definitions(context)
+    assert definitions.get_assets_def("an_asset")
+
+
+def test_tags():
+    @asset
+    def an_asset() -> None: ...
+
+    @defs_module(tags={"tag1": "value1"})
+    def loader(context: ComponentLoadContext) -> DefsLoader:
+        return DefsLoader.for_eager_definitions(Definitions(assets=[an_asset]))
+
+    assert loader.tags == {"tag1": "value1"}


### PR DESCRIPTION
## Summary & Motivation

* Changes `@component` to `@def_module`.
* Adds a lightweight class `DefsModule` which is returned from the `@def_module` decorator. This is what the autoloading code searches for.
* Adds the ability to return arbitrary definitions from this layer.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
