### PR TITLE
[dg] Demonstrate how you could make attributes an annotation

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/core/defs_module.py
+++ b/python_modules/libraries/dagster-components/dagster_components/core/defs_module.py
@@ -92,6 +92,7 @@ class DefsFactoryModuleResolver(DefsModuleResolver):
 
     context: ComponentLoadContext
     defs_factory: DefsLoader
+    defs_module: Optional[DefsModule]  # created for pythonic components
 
     def build_defs(self) -> Definitions:
         return self.defs_factory.build_defs(self.context)
@@ -248,7 +249,9 @@ class YamlComponentDeclNode(DefsModuleDeclNode):
 
         attributes = self.get_attributes(component_schema) if component_schema else None
         component = component_type.load(attributes, context)
-        return DefsFactoryModuleResolver(path=self.path, context=context, defs_factory=component)
+        return DefsFactoryModuleResolver(
+            path=self.path, context=context, defs_factory=component, defs_module=None
+        )
 
 
 @record
@@ -281,6 +284,7 @@ class PythonComponentDeclNode(DefsModuleDeclNode):
                 path=self.path,
                 context=context,
                 defs_factory=defs_module.create_defs_loader(context),
+                defs_module=defs_module,
             )
 
 

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
@@ -10,7 +10,6 @@ from dagster_components.core.component import (
     DefsLoader,
     defs_module,
 )
-from pydantic import TypeAdapter
 
 
 def test_simple_component_defs():
@@ -55,21 +54,7 @@ def test_tags():
     assert loader.tags == {"tag1": "value1"}
 
 
-# T_Resolvable
-
-from dagster_shared import check
-
 T = TypeVar("T")
-
-
-def from_defs_module(context: ComponentLoadContext, as_type: type[T]) -> T:
-    check.param_invariant(context.defs_module, "context", "context must have a defs_module")
-    assert context.defs_module
-    check.param_invariant(
-        context.defs_module.attributes, "context", "Must have defs_module.attributes"
-    )
-    assert context.defs_module.attributes is not None
-    return TypeAdapter(as_type).validate_python(context.defs_module.attributes)
 
 
 def test_attibutes():
@@ -83,8 +68,7 @@ def test_attibutes():
             return Definitions(assets=[my_asset])
 
     @defs_module(attributes={"value": "value1"})
-    def loader(context: ComponentLoadContext) -> SimpleModelComponent:
-        return from_defs_module(context, SimpleModelComponent)
+    def loader(context: ComponentLoadContext) -> SimpleModelComponent: ...
 
     context = ComponentLoadContext.for_test()
     definitions = loader.load_definitions(context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_defs_module.py
@@ -1,4 +1,8 @@
+from typing import TypeVar
+
 from dagster import asset
+from dagster._core.definitions.asset_key import AssetKey
+from dagster_components import ResolvableModel
 from dagster_components.core.component import (
     Component,
     ComponentLoadContext,
@@ -6,6 +10,7 @@ from dagster_components.core.component import (
     DefsLoader,
     defs_module,
 )
+from pydantic import TypeAdapter
 
 
 def test_simple_component_defs():
@@ -48,3 +53,40 @@ def test_tags():
         return DefsLoader.for_eager_definitions(Definitions(assets=[an_asset]))
 
     assert loader.tags == {"tag1": "value1"}
+
+
+# T_Resolvable
+
+from dagster_shared import check
+
+T = TypeVar("T")
+
+
+def from_defs_module(context: ComponentLoadContext, as_type: type[T]) -> T:
+    check.param_invariant(context.defs_module, "context", "context must have a defs_module")
+    assert context.defs_module
+    check.param_invariant(
+        context.defs_module.attributes, "context", "Must have defs_module.attributes"
+    )
+    assert context.defs_module.attributes is not None
+    return TypeAdapter(as_type).validate_python(context.defs_module.attributes)
+
+
+def test_attibutes():
+    class SimpleModelComponent(ResolvableModel, Component):
+        value: str
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            @asset(tags={"tag1": self.value})
+            def my_asset() -> None: ...
+
+            return Definitions(assets=[my_asset])
+
+    @defs_module(attributes={"value": "value1"})
+    def loader(context: ComponentLoadContext) -> SimpleModelComponent:
+        return from_defs_module(context, SimpleModelComponent)
+
+    context = ComponentLoadContext.for_test()
+    definitions = loader.load_definitions(context)
+    specs = {spec.key: spec for spec in definitions.get_all_asset_specs()}
+    assert specs[AssetKey("my_asset")].tags == {"tag1": "value1"}


### PR DESCRIPTION
## Summary & Motivation

This PR is demonstrate of how one could use `DefsModule` to mirror some of the features of the YAML DSL.

It adds an `attributes` property to `defs_module`. If you pass this property you don't have to implement the function. It parses and resolves the python dictionary to an instance on your behalf.

The mental model this is the functional equivalent of using the yaml file, but is more fleixble. E.g. a user has the flexility to programmatically construct the dictionary, if so desired, for example.

Specifically this declaration:

```python
    @defs_module(attributes={"value": "value1"})
    def loader(context: ComponentLoadContext) -> SimpleModelComponent: ...
```

Is precisely the same as declaring this in yaml

```yaml
type: SimpleModelComponent
attributes:
    value: value_1
```

The `defs_module` is design to be fairly cheap to load, which means that we can do a `check` pass without loading all of the definitions. `dg check modules` could do this.


Here is a full test case:

```python
ef test_attibutes():
    class SimpleModelComponent(ResolvableModel, Component):
        value: str
        def build_defs(self, context: ComponentLoadContext) -> Definitions:
            @asset(tags={"tag1": self.value})
            def my_asset() -> None: ...
            return Definitions(assets=[my_asset])
    
    @defs_module(attributes={"value": "value1"})
    def loader(context: ComponentLoadContext) -> SimpleModelComponent: ...
    
    context = ComponentLoadContext.for_test()
    definitions = loader.load_definitions(context)
    specs = {spec.key: spec for spec in definitions.get_all_asset_specs()}
    assert specs[AssetKey("my_asset")].tags == {"tag1": "value1"}
```
## How I Tested These Changes

BK

## Changelog

NOCHANGELOG