### PR TITLE
[dagster-airlift] wait for process termination in test fixture

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -106,6 +106,7 @@ def stand_up_airflow(
         if process_is_alive(process.pid):
             # Kill process group, since process.kill and process.terminate do not work.
             os.killpg(process.pid, signal.SIGKILL)
+            process.wait(5)
 
 
 @pytest.fixture(name="airflow_instance")


### PR DESCRIPTION
`make wipe` is failing
https://buildkite.com/dagster/dagster-dagster/builds/116060/steps?sid=0195cda7-07e8-4b3f-a6cd-825a136fd624
because something is writing to the directory while the `rm -rf` is processing which i assume is this airflow process
so wait for the process to exit before moving on 

## How I Tested These Changes

bk
