### PR TITLE
[dagster-dbt] Add list_run_artifacts to DbtCloudWorkspaceClient

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -342,6 +342,22 @@ class DbtCloudWorkspaceClient(DagsterModel):
             time.sleep(poll_interval)
         raise Exception(f"Run {run.id} did not complete within {poll_timeout} seconds.")  # pyright: ignore[reportPossiblyUnboundVariable]
 
+    def list_run_artifacts(
+        self,
+        run_id: int,
+    ) -> Mapping[str, Any]:
+        """Retrieves a list of artifact names for a given dbt Cloud Run.
+
+        Returns:
+            Dict[str, Any]: Parsed json data representing the API response.
+        """
+        return self._make_request(
+            method="get",
+            endpoint=f"runs/{run_id}/artifacts",
+            base_url=self.api_v2_url,
+            session_attr="_get_artifact_session",
+        )
+
     def get_run_artifact(self, run_id: int, path: str) -> Mapping[str, Any]:
         """Retrieves an artifact at the given path for a given dbt Cloud Run.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -726,6 +726,21 @@ SAMPLE_LIST_RUNS_RESPONSE = {
     },
 }
 
+# Taken from dbt Cloud REST API documentation
+# https://docs.getdbt.com/dbt-cloud/api-v2#/operations/List%20Run%20Artifacts
+SAMPLE_LIST_RUN_ARTIFACTS = {
+    "data": [
+        "manifest.json",
+        "run_results.json",
+    ],
+    "status": {
+        "code": 200,
+        "is_success": True,
+        "user_message": "string",
+        "developer_message": "string",
+    },
+}
+
 
 @pytest.fixture(name="credentials")
 def credentials_fixture() -> DbtCloudCredentials:
@@ -820,6 +835,12 @@ def all_api_mocks_fixture(
         method=responses.GET,
         url=f"{TEST_REST_API_BASE_URL}/runs",
         json=SAMPLE_LIST_RUNS_RESPONSE,
+        status=200,
+    )
+    fetch_workspace_data_api_mocks.add(
+        method=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}/runs/{TEST_RUN_ID}/artifacts",
+        json=SAMPLE_LIST_RUN_ARTIFACTS,
         status=200,
     )
     yield fetch_workspace_data_api_mocks

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -60,8 +60,9 @@ def test_basic_resource_request(
         finished_at_start=TEST_FINISHED_AT_START,
         finished_at_end=TEST_FINISHED_AT_END,
     )
+    client.list_run_artifacts(run_id=TEST_RUN_ID)
 
-    assert len(all_api_mocks.calls) == 9
+    assert len(all_api_mocks.calls) == 10
     assert_rest_api_call(call=all_api_mocks.calls[0], endpoint="jobs", method="GET")
     assert_rest_api_call(call=all_api_mocks.calls[1], endpoint="jobs", method="POST")
     assert_rest_api_call(
@@ -85,6 +86,9 @@ def test_basic_resource_request(
         call=all_api_mocks.calls[7], endpoint=f"environments/{TEST_ENVIRONMENT_ID}", method="GET"
     )
     assert_rest_api_call(call=all_api_mocks.calls[8], endpoint="runs", method="GET")
+    assert_rest_api_call(
+        call=all_api_mocks.calls[9], endpoint=f"runs/{TEST_RUN_ID}/artifacts", method="GET"
+    )
 
 
 def test_get_or_create_dagster_adhoc_job(

--- a/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
@@ -72,6 +72,9 @@ def test_cloud_job_apis(
     batched_run = DbtCloudRun.from_run_details(run_details=next(iter(batched_runs)))
     assert batched_run.id == run.id
 
+    run_artifacts = client.list_run_artifacts(run_id=run.id)
+    assert "run_results.json" in run_artifacts
+
     run_results = client.get_run_results_json(run_id=polled_run.id)
     assert {result["unique_id"] for result in run_results["results"]} == {
         "model.test_environment.customers",


### PR DESCRIPTION
## Summary & Motivation

This PR adds the list_run_artifacts method that will be needed in the polling sensor. We need this because not all runs will have a `run_results.json` artifact, so we'll want to request and verify that it is in the list of artifacts for a given run before fetching it.

## How I Tested These Changes

New tests with BK

