### PR TITLE
[dg] `dg plus env pull`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/env.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/env.py
@@ -1,6 +1,8 @@
+from collections.abc import Mapping
 from pathlib import Path
 
 import click
+from dagster_shared.plus.config import DagsterPlusCliConfig
 from rich.console import Console
 from rich.table import Table
 
@@ -9,6 +11,8 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.env import ProjectEnvVars
 from dagster_dg.utils import DgClickCommand, DgClickGroup
+from dagster_dg.utils.plus.gql import LOCAL_SECRETS_FILE_QUERY
+from dagster_dg.utils.plus.gql_client import DagsterCloudGraphQLClient
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 
@@ -42,3 +46,59 @@ def list_env_command(**global_options: object) -> None:
         table.add_row(key, value)
     console = Console()
     console.print(table)
+
+
+# ########################
+# ##### PULL
+# ########################
+
+
+def _get_local_secrets_for_locations(
+    client: DagsterCloudGraphQLClient, location_names: set[str]
+) -> Mapping[str, Mapping[str, str]]:
+    secrets_by_location = {location_name: {} for location_name in location_names}
+
+    result = client.execute(LOCAL_SECRETS_FILE_QUERY)
+    for secret in result["secretsOrError"]["secrets"]:
+        if not secret["localDeploymentScope"]:
+            continue
+        for location_name in location_names:
+            if len(secret["locationNames"]) == 0 or location_name in secret["locationNames"]:
+                secrets_by_location[location_name][secret["secretName"]] = secret["secretValue"]
+
+    return secrets_by_location
+
+
+@env_group.command(name="pull", cls=DgClickCommand)
+@dg_global_options
+def pull_env_command(**global_options: object) -> None:
+    """Pull environment variables from the current project."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    config = DagsterPlusCliConfig.get()
+
+    project_ctxs = []
+    if dg_context.is_workspace:
+        project_ctxs = [
+            dg_context.for_project_environment(project_spec.path, cli_config)
+            for project_spec in dg_context.project_specs
+        ]
+    else:
+        project_ctxs = [dg_context]
+
+    gql_client = DagsterCloudGraphQLClient.from_config(config)
+    secrets_by_location = _get_local_secrets_for_locations(
+        gql_client, {project_ctx.project_name for project_ctx in project_ctxs}
+    )
+
+    for project_ctx in project_ctxs:
+        env = ProjectEnvVars.empty(project_ctx).with_values(
+            secrets_by_location[project_ctx.project_name]
+        )
+        env.write()
+
+    if dg_context.is_project:
+        click.echo("Environment variables saved to .env")
+    else:
+        click.echo("Environment variables saved to .env for all projects in the workspace")

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/env.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/env.py
@@ -1,8 +1,6 @@
-from collections.abc import Mapping
 from pathlib import Path
 
 import click
-from dagster_shared.plus.config import DagsterPlusCliConfig
 from rich.console import Console
 from rich.table import Table
 
@@ -11,8 +9,6 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.env import ProjectEnvVars
 from dagster_dg.utils import DgClickCommand, DgClickGroup
-from dagster_dg.utils.plus.gql import LOCAL_SECRETS_FILE_QUERY
-from dagster_dg.utils.plus.gql_client import DagsterCloudGraphQLClient
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 
@@ -46,70 +42,3 @@ def list_env_command(**global_options: object) -> None:
         table.add_row(key, value)
     console = Console()
     console.print(table)
-
-
-# ########################
-# ##### PULL
-# ########################
-
-
-def _get_local_secrets_for_locations(
-    client: DagsterCloudGraphQLClient, location_names: set[str]
-) -> Mapping[str, Mapping[str, str]]:
-    secrets_by_location = {location_name: {} for location_name in location_names}
-
-    result = client.execute(LOCAL_SECRETS_FILE_QUERY)
-    for secret in result["secretsOrError"]["secrets"]:
-        if not secret["localDeploymentScope"]:
-            continue
-        for location_name in location_names:
-            if len(secret["locationNames"]) == 0 or location_name in secret["locationNames"]:
-                secrets_by_location[location_name][secret["secretName"]] = secret["secretValue"]
-
-    return secrets_by_location
-
-
-@env_group.command(name="pull", cls=DgClickCommand)
-@dg_global_options
-def pull_env_command(**global_options: object) -> None:
-    """Pull environment variables from the current project."""
-    cli_config = normalize_cli_config(global_options, click.get_current_context())
-
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
-    if not DagsterPlusCliConfig.exists():
-        raise click.UsageError(
-            "`dg env pull` requires authentication with Dagster Plus. Run `dg plus login` to authenticate."
-        )
-    config = DagsterPlusCliConfig.get()
-
-    project_ctxs = []
-    if dg_context.is_workspace:
-        project_ctxs = [
-            dg_context.for_project_environment(project_spec.path, cli_config)
-            for project_spec in dg_context.project_specs
-        ]
-    else:
-        project_ctxs = [dg_context]
-
-    gql_client = DagsterCloudGraphQLClient.from_config(config)
-    secrets_by_location = _get_local_secrets_for_locations(
-        gql_client, {project_ctx.project_name for project_ctx in project_ctxs}
-    )
-
-    projects_without_secrets = {project_ctx.project_name for project_ctx in project_ctxs}
-    for project_ctx in project_ctxs:
-        if secrets_by_location[project_ctx.project_name]:
-            env = ProjectEnvVars.empty(project_ctx).with_values(
-                secrets_by_location[project_ctx.project_name]
-            )
-            env.write()
-            projects_without_secrets.remove(project_ctx.project_name)
-
-    if dg_context.is_project:
-        click.echo("Environment variables saved to .env")
-    else:
-        click.echo("Environment variables saved to .env for projects in workspace")
-        if projects_without_secrets:
-            click.echo(
-                f"Environment variables not found for projects: {', '.join(projects_without_secrets)}"
-            )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -11,7 +11,7 @@ from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.env import ProjectEnvVars
 from dagster_dg.utils import DgClickCommand, DgClickGroup
-from dagster_dg.utils.plus.gql import FULL_DEPLOYMENTS_QUERY, LOCAL_SECRETS_FILE_QUERY
+from dagster_dg.utils.plus.gql import FULL_DEPLOYMENTS_QUERY, SECRETS_QUERY
 from dagster_dg.utils.plus.gql_client import DagsterCloudGraphQLClient
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
@@ -86,8 +86,10 @@ def _get_local_secrets_for_locations(
 ) -> Mapping[str, Mapping[str, str]]:
     secrets_by_location = {location_name: {} for location_name in location_names}
 
-    result = client.execute(LOCAL_SECRETS_FILE_QUERY)
-    for secret in result["viewableLocalSecretsOrError"]["secrets"]:
+    result = client.execute(
+        SECRETS_QUERY, variables={"onlyViewable": True, "scopes": {"localDeploymentScope": True}}
+    )
+    for secret in result["secretsOrError"]["secrets"]:
         if not secret["localDeploymentScope"]:
             continue
         for location_name in location_names:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -1,11 +1,17 @@
 import webbrowser
+from collections.abc import Mapping
+from pathlib import Path
 
 import click
 from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.plus.login_server import start_login_server
 
+from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.config import normalize_cli_config
+from dagster_dg.context import DgContext
+from dagster_dg.env import ProjectEnvVars
 from dagster_dg.utils import DgClickCommand, DgClickGroup
-from dagster_dg.utils.plus.gql import FULL_DEPLOYMENTS_QUERY
+from dagster_dg.utils.plus.gql import FULL_DEPLOYMENTS_QUERY, LOCAL_SECRETS_FILE_QUERY
 from dagster_dg.utils.plus.gql_client import DagsterCloudGraphQLClient
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
@@ -63,3 +69,75 @@ def login_command() -> None:
         url=config.url,
     )
     config.write()
+
+
+# ########################
+# ##### PLUS ENV MANAGEMENT
+# ########################
+
+
+@plus_group.group(name="env", cls=DgClickGroup)
+def plus_env_group():
+    """Commands for managing environment variables in Dagster Plus."""
+
+
+def _get_local_secrets_for_locations(
+    client: DagsterCloudGraphQLClient, location_names: set[str]
+) -> Mapping[str, Mapping[str, str]]:
+    secrets_by_location = {location_name: {} for location_name in location_names}
+
+    result = client.execute(LOCAL_SECRETS_FILE_QUERY)
+    for secret in result["viewableLocalSecretsOrError"]["secrets"]:
+        if not secret["localDeploymentScope"]:
+            continue
+        for location_name in location_names:
+            if len(secret["locationNames"]) == 0 or location_name in secret["locationNames"]:
+                secrets_by_location[location_name][secret["secretName"]] = secret["secretValue"]
+
+    return secrets_by_location
+
+
+@plus_env_group.command(name="pull", cls=DgClickCommand)
+@dg_global_options
+def pull_env_command(**global_options: object) -> None:
+    """Pull environment variables from Dagster Plus and save to a .env file for local use."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    if not DagsterPlusCliConfig.exists():
+        raise click.UsageError(
+            "`dg plus env pull` requires authentication with Dagster Plus. Run `dg plus login` to authenticate."
+        )
+    config = DagsterPlusCliConfig.get()
+
+    project_ctxs = []
+    if dg_context.is_workspace:
+        project_ctxs = [
+            dg_context.for_project_environment(project_spec.path, cli_config)
+            for project_spec in dg_context.project_specs
+        ]
+    else:
+        project_ctxs = [dg_context]
+
+    gql_client = DagsterCloudGraphQLClient.from_config(config)
+    secrets_by_location = _get_local_secrets_for_locations(
+        gql_client, {project_ctx.project_name for project_ctx in project_ctxs}
+    )
+
+    projects_without_secrets = {project_ctx.project_name for project_ctx in project_ctxs}
+    for project_ctx in project_ctxs:
+        if secrets_by_location[project_ctx.project_name]:
+            env = ProjectEnvVars.empty(project_ctx).with_values(
+                secrets_by_location[project_ctx.project_name]
+            )
+            env.write()
+            projects_without_secrets.remove(project_ctx.project_name)
+
+    if dg_context.is_project:
+        click.echo("Environment variables saved to .env")
+    else:
+        click.echo("Environment variables saved to .env for projects in workspace")
+        if projects_without_secrets:
+            click.echo(
+                f"Environment variables not found for projects: {', '.join(projects_without_secrets)}"
+            )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus.py
@@ -99,6 +99,7 @@ def _get_local_secrets_for_locations(
 
 @plus_env_group.command(name="pull", cls=DgClickCommand)
 @dg_global_options
+@cli_telemetry_wrapper
 def pull_env_command(**global_options: object) -> None:
     """Pull environment variables from Dagster Plus and save to a .env file for local use."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())

--- a/python_modules/libraries/dagster-dg/dagster_dg/env.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/env.py
@@ -18,6 +18,10 @@ class ProjectEnvVars:
         self._values = values
 
     @classmethod
+    def empty(cls, ctx: DgContext) -> "Self":
+        return cls(ctx, values={})
+
+    @classmethod
     def from_ctx(cls, ctx: DgContext) -> "Self":
         check.invariant(ctx.is_project, "ProjectEnvVars can only be created from a project context")
         env_path = ctx.root_path / ".env"

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -7,3 +7,19 @@ query CliDeploymentsQuery {
     }
 }
 """
+
+LOCAL_SECRETS_FILE_QUERY = """
+{
+	secretsOrError {
+      __typename
+    ... on Secrets {
+      secrets {
+        localDeploymentScope
+        secretName
+        secretValue
+        locationNames
+      }
+    }
+  }
+}
+"""

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -11,7 +11,7 @@ query CliDeploymentsQuery {
 LOCAL_SECRETS_FILE_QUERY = """
 {
 	secretsOrError {
-      __typename
+    __typename
     ... on Secrets {
       secrets {
         localDeploymentScope

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -8,9 +8,9 @@ query CliDeploymentsQuery {
 }
 """
 
-LOCAL_SECRETS_FILE_QUERY = """
-{
-	viewableLocalSecretsOrError {
+SECRETS_QUERY = """
+query AllSecretsQuery($onlyViewable: Boolean, $scopes: SecretScopesInput) {
+  secretsOrError(onlyViewable: $onlyViewable, scopes: $scopes) {
     __typename
     ... on Secrets {
       secrets {

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -10,7 +10,7 @@ query CliDeploymentsQuery {
 
 LOCAL_SECRETS_FILE_QUERY = """
 {
-	secretsOrError {
+	viewableLocalSecretsOrError {
     __typename
     ... on Secrets {
       secrets {
@@ -19,6 +19,13 @@ LOCAL_SECRETS_FILE_QUERY = """
         secretValue
         locationNames
       }
+    }
+    ... on UnauthorizedError {
+        message
+    }
+    ... on PythonError {
+        message
+        stack
     }
   }
 }

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any, Optional
 
+import click
 from dagster_shared.plus.config import DagsterPlusCliConfig
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
@@ -28,4 +29,10 @@ class DagsterCloudGraphQLClient:
         )
 
     def execute(self, query: str, variables: Optional[Mapping[str, Any]] = None):
-        return self.client.execute(gql(query), variable_values=dict(variables or {}))
+        result = self.client.execute(gql(query), variable_values=dict(variables or {}))
+        value = next(iter(result.values()))
+        if value.get("__typename") == "UnauthorizedError":
+            raise click.ClickException("Unauthorized: " + value["message"])
+        elif value.get("__typename") == "PythonError":
+            raise click.ClickException("Error: " + value["message"])
+        return result

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
@@ -31,8 +31,9 @@ class DagsterCloudGraphQLClient:
     def execute(self, query: str, variables: Optional[Mapping[str, Any]] = None):
         result = self.client.execute(gql(query), variable_values=dict(variables or {}))
         value = next(iter(result.values()))
-        if value.get("__typename") == "UnauthorizedError":
-            raise click.ClickException("Unauthorized: " + value["message"])
-        elif value.get("__typename") == "PythonError":
-            raise click.ClickException("Error: " + value["message"])
+        if isinstance(value, Mapping):
+            if value.get("__typename") == "UnauthorizedError":
+                raise click.ClickException("Unauthorized: " + value["message"])
+            elif value.get("__typename", "").endswith("Error"):
+                raise click.ClickException("Error: " + value["message"])
         return result

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/conftest.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/conftest.py
@@ -1,0 +1,24 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def dg_plus_cli_config(monkeypatch):
+    with (
+        tempfile.TemporaryDirectory() as tmp_dg_dir,
+        tempfile.TemporaryDirectory() as tmp_cloud_dir,
+    ):
+        config_path = Path(tmp_dg_dir) / "dg.toml"
+        config_path.write_text(
+            """
+            [cli.plus]
+            organization = "hooli"
+            user_token = "abc123"
+            default_deployment = "hooli-dev"
+            """
+        )
+        monkeypatch.setenv("DG_CLI_CONFIG", config_path)
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(tmp_cloud_dir) / "config"))
+        yield config_path

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
@@ -13,7 +13,10 @@ import tomlkit
 import yaml
 from click.testing import CliRunner
 from dagster_dg.cli.plus import plus_group
+from dagster_dg.utils import ensure_dagster_dg_tests_import
 from dagster_dg.utils.plus import gql
+
+ensure_dagster_dg_tests_import()
 from dagster_dg_tests.cli_tests.plus_tests.utils import mock_gql_response
 from dagster_shared.plus.config import DagsterPlusCliConfig
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_login_command.py
@@ -13,6 +13,8 @@ import tomlkit
 import yaml
 from click.testing import CliRunner
 from dagster_dg.cli.plus import plus_group
+from dagster_dg.utils.plus import gql
+from dagster_dg_tests.cli_tests.plus_tests.utils import mock_gql_response
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
 
@@ -106,6 +108,13 @@ def test_setup_command_web(fixture_name, request: pytest.FixtureRequest):
                 ]
             }
         },
+    )
+    mock_gql_response(
+        query=gql.FULL_DEPLOYMENTS_QUERY,
+        json_data={"data": {"fullDeployments": [{"deploymentName": "hooli-dev"}]}},
+        url="https://custom_subdomain.dagster.cloud/hooli/graphql"
+        if fixture_name == "setup_dg_cli_config_custom_url"
+        else "https://dagster.cloud/hooli/graphql",
     )
     responses.add_passthru("http://localhost:4000/callback")
     runner = CliRunner()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
@@ -1,13 +1,39 @@
+import tempfile
 from pathlib import Path
 
 import responses
+from dagster_dg.utils import ensure_dagster_dg_tests_import
 from dagster_dg.utils.plus import gql
+
+ensure_dagster_dg_tests_import()
+
 from dagster_dg_tests.cli_tests.plus_tests.utils import mock_gql_response
-from dagster_dg_tests.utils import ProxyRunner, isolated_example_project_foo_bar
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    isolated_example_project_foo_bar,
+    isolated_example_workspace,
+)
 
 
 @responses.activate
-def test_pull_env_command(dg_plus_cli_config):
+def test_pull_env_command_no_auth(monkeypatch):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+        tempfile.TemporaryDirectory() as cloud_config_dir,
+    ):
+        monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
+        result = runner.invoke("env", "pull")
+        assert result.exit_code != 0, result.output + " " + str(result.exception)
+        assert (
+            "`dg env pull` requires authentication with Dagster Plus. Run `dg plus login` to authenticate."
+            in str(result.output)
+        )
+
+
+@responses.activate
+def test_pull_env_command_project(dg_plus_cli_config):
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace=False),
@@ -52,3 +78,59 @@ def test_pull_env_command(dg_plus_cli_config):
         assert result.output.strip() == "Environment variables saved to .env"
 
         assert Path(".env").read_text().strip() == "FOO=bar\nBAZ=qux"
+
+
+@responses.activate
+def test_pull_env_command_workspace(dg_plus_cli_config):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_workspace(runner),
+    ):
+        runner.invoke("scaffold", "project", "foo")
+        runner.invoke("scaffold", "project", "bar")
+        runner.invoke("scaffold", "project", "baz")
+
+        mock_gql_response(
+            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            json_data={
+                "data": {
+                    "secretsOrError": {
+                        "secrets": [
+                            {
+                                "secretName": "FOO",
+                                "secretValue": "bar",
+                                "locationNames": ["foo"],
+                                "localDeploymentScope": True,
+                            },
+                            {
+                                "secretName": "BAZ",
+                                "secretValue": "qux",
+                                "locationNames": ["foo", "bar"],
+                                "localDeploymentScope": True,
+                            },
+                            {
+                                "secretName": "ABC",
+                                "secretValue": "def",
+                                "locationNames": [],
+                                "localDeploymentScope": False,
+                            },
+                            {
+                                "secretName": "QWER",
+                                "secretValue": "asdf",
+                                "locationNames": ["other"],
+                                "localDeploymentScope": True,
+                            },
+                        ]
+                    }
+                }
+            },
+        )
+        result = runner.invoke("env", "pull")
+        assert result.exit_code == 0, result.output + " " + str(result.exception)
+        assert (
+            result.output.strip()
+            == "Environment variables saved to .env for projects in workspace\nEnvironment variables not found for projects: baz"
+        )
+
+        assert (Path("foo") / ".env").read_text().strip() == "FOO=bar\nBAZ=qux"
+        assert (Path("bar") / ".env").read_text().strip() == "BAZ=qux"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import responses
+from dagster_dg.utils.plus import gql
+from dagster_dg_tests.cli_tests.plus_tests.utils import mock_gql_response
+from dagster_dg_tests.utils import ProxyRunner, isolated_example_project_foo_bar
+
+
+@responses.activate
+def test_pull_env_command(dg_plus_cli_config):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        mock_gql_response(
+            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            json_data={
+                "data": {
+                    "secretsOrError": {
+                        "secrets": [
+                            {
+                                "secretName": "FOO",
+                                "secretValue": "bar",
+                                "locationNames": ["foo-bar"],
+                                "localDeploymentScope": True,
+                            },
+                            {
+                                "secretName": "BAZ",
+                                "secretValue": "qux",
+                                "locationNames": [],
+                                "localDeploymentScope": True,
+                            },
+                            {
+                                "secretName": "ABC",
+                                "secretValue": "def",
+                                "locationNames": [],
+                                "localDeploymentScope": False,
+                            },
+                            {
+                                "secretName": "QWER",
+                                "secretValue": "asdf",
+                                "locationNames": ["other"],
+                                "localDeploymentScope": True,
+                            },
+                        ]
+                    }
+                }
+            },
+        )
+        result = runner.invoke("env", "pull")
+        assert result.exit_code == 0, result.output + " " + str(result.exception)
+        assert result.output.strip() == "Environment variables saved to .env"
+
+        assert Path(".env").read_text().strip() == "FOO=bar\nBAZ=qux"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_pull_env_command.py
@@ -39,15 +39,16 @@ def test_pull_env_command_auth_err(dg_plus_cli_config):
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         mock_gql_response(
-            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            query=gql.SECRETS_QUERY,
             json_data={
                 "data": {
-                    "viewableLocalSecretsOrError": {
+                    "secretsOrError": {
                         "__typename": "UnauthorizedError",
                         "message": "Not authorized",
                     }
                 }
             },
+            expected_variables={"onlyViewable": True, "scopes": {"localDeploymentScope": True}},
         )
         result = runner.invoke("plus", "env", "pull")
         assert result.exit_code != 0, result.output + " " + str(result.exception)
@@ -61,16 +62,17 @@ def test_pull_env_command_python_err(dg_plus_cli_config):
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         mock_gql_response(
-            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            query=gql.SECRETS_QUERY,
             json_data={
                 "data": {
-                    "viewableLocalSecretsOrError": {
+                    "secretsOrError": {
                         "__typename": "PythonError",
                         "message": "An error has occurred",
                         "stack": "Stack trace",
                     }
                 }
             },
+            expected_variables={"onlyViewable": True, "scopes": {"localDeploymentScope": True}},
         )
         result = runner.invoke("plus", "env", "pull")
         assert result.exit_code != 0, result.output + " " + str(result.exception)
@@ -84,10 +86,10 @@ def test_pull_env_command_project(dg_plus_cli_config):
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         mock_gql_response(
-            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            query=gql.SECRETS_QUERY,
             json_data={
                 "data": {
-                    "viewableLocalSecretsOrError": {
+                    "secretsOrError": {
                         "secrets": [
                             {
                                 "secretName": "FOO",
@@ -117,6 +119,7 @@ def test_pull_env_command_project(dg_plus_cli_config):
                     }
                 }
             },
+            expected_variables={"onlyViewable": True, "scopes": {"localDeploymentScope": True}},
         )
         result = runner.invoke("plus", "env", "pull")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
@@ -136,10 +139,10 @@ def test_pull_env_command_workspace(dg_plus_cli_config):
         runner.invoke("scaffold", "project", "baz")
 
         mock_gql_response(
-            query=gql.LOCAL_SECRETS_FILE_QUERY,
+            query=gql.SECRETS_QUERY,
             json_data={
                 "data": {
-                    "viewableLocalSecretsOrError": {
+                    "secretsOrError": {
                         "secrets": [
                             {
                                 "secretName": "FOO",
@@ -169,6 +172,7 @@ def test_pull_env_command_workspace(dg_plus_cli_config):
                     }
                 }
             },
+            expected_variables={"onlyViewable": True, "scopes": {"localDeploymentScope": True}},
         )
         result = runner.invoke("plus", "env", "pull")
         assert result.exit_code == 0, result.output + " " + str(result.exception)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/utils.py
@@ -1,0 +1,27 @@
+import json
+from typing import Any
+
+import responses
+
+
+def mock_gql_response(
+    query: str,
+    json_data: dict[str, Any],
+    url: str = "https://dagster.cloud/hooli/graphql",
+) -> None:
+    def match(request) -> tuple[bool, str]:
+        request_body = request.body
+        json_body = json.loads(request_body) if request_body else {}
+        body_query_normalized = [line.strip() for line in json_body["query"].strip().split("\n")]
+        query_normalized = [line.strip() for line in query.strip().split("\n")]
+        return (
+            body_query_normalized == query_normalized,
+            f"'{body_query_normalized}'\n!=\n'{query_normalized}'",
+        )
+
+    responses.add(
+        responses.POST,
+        url,
+        json=json_data,
+        match=[match],
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/utils.py
@@ -14,9 +14,15 @@ def mock_gql_response(
         json_body = json.loads(request_body) if request_body else {}
         body_query_normalized = [line.strip() for line in json_body["query"].strip().split("\n")]
         query_normalized = [line.strip() for line in query.strip().split("\n")]
+        neq_index = next(
+            (i for i, (a, b) in enumerate(zip(body_query_normalized, query_normalized)) if a != b),
+            None,
+        )
         return (
             body_query_normalized == query_normalized,
-            f"'{body_query_normalized}'\n!=\n'{query_normalized}'",
+            f"\n'{body_query_normalized[neq_index]}'\n!=\n'{query_normalized[neq_index]}'\n"
+            if neq_index is not None
+            else "",
         )
 
     responses.add(


### PR DESCRIPTION
## Summary

Implements a `dg plus env pull` command, which fetches a list of env vars available for the local scope for a project (or all projects, in a workspace).

## Test Plan

Unit tests for project, workspace, non-authed cases.