### PR TITLE
[docs] remove duplicate entry for EMR guide redirect in vercel.json

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -962,6 +962,11 @@
       "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
     },
     {
+      "source": "/guides/build/external-pipelines/aws-emr-pipeline",
+      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
+    },
+
+    {
       "source": "/guides/build/external-pipelines/aws-emr-containers-pipeline",
       "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
     },
@@ -980,14 +985,6 @@
     {
       "source": "/guides/build/external-pipelines/aws-glue-pipeline",
       "destination": "/guides/build/external-pipelines/aws/aws-glue-pipeline"
-    },
-    {
-      "source": "/guides/build/external-pipelines/aws-emr-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-pipeline"
-    },
-    {
-      "source": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline",
-      "destination": "/guides/build/external-pipelines/aws/aws-emr-containers-pipeline"
     },
     {
       "source": "/guides/build/external-pipelines/aws-emr-serverless-pipeline",


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-951.

## How I Tested These Changes

Confirmed redirect worked as expected on preview deployment:

https://dagster-docs-9b7i8pplc-elementl.vercel.app/guides/build/external-pipelines/aws/aws-emr-containers-pipeline

## Changelog

NOCHANGELOG
