### PR TITLE
[docs] remove unused redirects: docs-preview, new-docs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,46 +1,6 @@
 {
   "redirects": [
     {
-      "source": "/",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs-preview.dagster.io"
-        }
-      ],
-      "destination": "https://docs.dagster.io"
-    },
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "host",
-          "value": "new-docs.dagster.io"
-        }
-      ],
-      "destination": "https://docs.dagster.io"
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs-preview.dagster.io"
-        }
-      ],
-      "destination": "https://docs.dagster.io/:path*"
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "new-docs.dagster.io"
-        }
-      ],
-      "destination": "https://docs.dagster.io/:path*"
-    },
-    {
       "source": "/dagster-cloud/:path*",
       "destination": "/dagster-plus/:path*"
     },


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-968.

- Removes redundant redirects as configured at domain level in Vercel; ensures these domains aren't crawled

<img width="945" alt="image" src="https://github.com/user-attachments/assets/28b63ccc-4068-4845-bb77-5743f86f5f08" />

## How I Tested These Changes

## Changelog

NOCHANGELOG
