### PR TITLE
[dagster-airlift] fix tests on 3.12

### DIFF
--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/conftest.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/conftest.py
@@ -48,10 +48,20 @@ def dagster_home_fixture(local_env: None) -> str:
     return os.environ["DAGSTER_HOME"]
 
 
+@pytest.fixture(name="expected_num_dags")
+def expected_num_dags_fixture() -> int:
+    return 1
+
+
 @pytest.fixture(name="airflow_instance")
-def airflow_instance_fixture(local_env: None) -> Generator[subprocess.Popen, None, None]:
+def airflow_instance_fixture(
+    local_env: None, expected_num_dags: int
+) -> Generator[subprocess.Popen, None, None]:
     with stand_up_airflow(
-        airflow_cmd=["make", "run_airflow"], env=os.environ, cwd=makefile_dir()
+        airflow_cmd=["make", "run_airflow"],
+        env=os.environ,
+        cwd=makefile_dir(),
+        expected_num_dags=expected_num_dags,
     ) as process:
         yield process
 

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+import pytest
 import requests
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.run_request import SensorResult
@@ -17,6 +18,11 @@ from kitchen_sink.airflow_instance import (
     local_airflow_instance,
 )
 from pytest_mock import MockFixture
+
+
+@pytest.fixture
+def expected_num_dags() -> int:
+    return 16
 
 
 def test_configure_dag_list_limit(airflow_instance: None, mocker: MockFixture) -> None:


### PR DESCRIPTION
## Summary & Motivation
New kitchen sink tests were failing on 3.12 because of increased airflow spinup time.

Fix by waiting until all dags exist in scope to move forward with testing.

