### PR TITLE
DOC-956 Add @multi_asset_sensor to API docs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
+++ b/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
@@ -54,7 +54,15 @@ Sensors
 
 .. autodecorator:: asset_sensor
 
+.. autodecorator:: multi_asset_sensor
+
+.. autodecorator:: run_status_sensor
+
+.. autodecorator:: run_failure_sensor
+
 .. autoclass:: AssetSensorDefinition
+
+.. autoclass:: MultiAssetSensorDefinition
 
 .. autoclass:: RunStatusSensorDefinition
 
@@ -67,10 +75,6 @@ Sensors
 .. autoclass:: RepositorySelector
 
 .. autofunction:: build_run_status_sensor_context
-
-.. autodecorator:: run_status_sensor
-
-.. autodecorator:: run_failure_sensor
 
 .. autoclass:: SensorResult
 


### PR DESCRIPTION
## Summary & Motivation

Also added `MultiAssetSensorDefinition`. While it's marked superseded, that's helpful info for people still using it.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
