### PR TITLE
[components] Update components schema to allow declaring env var requirements, validate in check yaml

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -23,6 +23,7 @@ from dagster._cli.workspace.cli_target import (
 from dagster._core.definitions.asset_job import is_reserved_asset_job_name
 from dagster._utils.hosted_user_process import recon_repository_from_origin
 from dagster.components.component.component import Component
+from dagster.components.core.defs_module import ComponentRequirementsModel
 from dagster.components.core.package_entry import (
     discover_entry_point_package_objects,
     discover_package_objects,
@@ -71,6 +72,7 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
                     key.name,
                     type=(Literal[key_string], key_string),
                     attributes=(model_cls, None),
+                    requirements=(Optional[ComponentRequirementsModel], None),
                     __config__=ConfigDict(extra="forbid"),
                 )
             )

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -31,11 +31,18 @@ from dagster.components.resolved.core_models import AssetPostProcessor
 T = TypeVar("T", bound=BaseModel)
 
 
+class ComponentRequirementsModel(BaseModel):
+    """Describes dependencies for a component to load."""
+
+    env: Optional[list[str]] = None
+
+
 class ComponentFileModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: str
     attributes: Optional[Mapping[str, Any]] = None
+    requirements: Optional[ComponentRequirementsModel] = None
 
 
 #########

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_missing_declared_env/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_missing_declared_env/component.yaml
@@ -1,0 +1,5 @@
+type: .MyComponent
+
+attributes:
+  a_string: "{{ env('A_STRING') }}"
+  an_int: 5

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_with_env/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_with_env/component.yaml
@@ -1,0 +1,9 @@
+type: .MyComponent
+
+attributes:
+  a_string: "{{ env('UNDEFINED_ENV_STRING') }}"
+  an_int: 5
+
+requirements:
+  env:
+    - UNDEFINED_ENV_STRING

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -32,11 +32,19 @@ def check_group():
 @click.option(
     "--watch", is_flag=True, help="Watch for changes to the component files and re-validate them."
 )
+@click.option(
+    "--validate-requirements",
+    "--no-validate-requirements",
+    is_flag=True,
+    default=True,
+    help="Validate environment variables in requirements for all components in the given module.",
+)
 @dg_global_options
 @cli_telemetry_wrapper
 def check_yaml_command(
     paths: Sequence[str],
     watch: bool,
+    validate_requirements: bool,
     **global_options: object,
 ) -> None:
     """Check component.yaml files against their schemas, showing validation errors."""
@@ -45,7 +53,7 @@ def check_yaml_command(
     resolved_paths = [Path(path).absolute() for path in paths]
 
     def run_check(_: Any = None) -> bool:
-        return check_yaml_fn(dg_context, resolved_paths)
+        return check_yaml_fn(dg_context, resolved_paths, validate_requirements)
 
     if watch:
         watched_paths = (
@@ -146,6 +154,7 @@ def check_definitions_command(
                 check_result = check_yaml_fn(
                     dg_context.for_project_environment(project_dir, cli_config),
                     [],
+                    validate_requirements=False,
                 )
                 overall_check_result = overall_check_result and check_result
             if not overall_check_result:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -150,6 +150,7 @@ def dev_command(
                 check_result = check_yaml_fn(
                     dg_context.for_project_environment(project_dir, cli_config),
                     [],
+                    validate_requirements=False,
                 )
                 overall_check_result = overall_check_result and check_result
             if not overall_check_result:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
@@ -59,7 +59,7 @@ def install_or_update_yaml_schema_extension(
     template_package_json_path = Path(__file__).parent / "vscode_extension_package.json"
     template_package_json = json.loads(template_package_json_path.read_text())
     template_package_json["contributes"]["yamlValidation"] = [
-        {"fileMatch": f"{yaml_dir}/**/*.y*ml", "url": f"{schema_path}"}
+        {"fileMatch": f"{yaml_dir}/**/component.y*ml", "url": f"{schema_path}"}
     ]
 
     extension_working_dir.mkdir(parents=True, exist_ok=True)
@@ -73,7 +73,7 @@ def install_or_update_yaml_schema_extension(
             template_package_json["contributes"]["yamlValidation"].extend(
                 entry
                 for entry in existing_yaml_validation
-                if entry["fileMatch"] != f"{yaml_dir}/**/*.y*ml"
+                if entry["fileMatch"] != f"{yaml_dir}/**/component.y*ml"
             )
 
     extension_package_json_path.write_text(json.dumps(template_package_json, indent=2))


### PR DESCRIPTION
## Summary

Adds a new top-level key to the component file which allows declaring requirements, including `env` vars (and in the future, resources and UDFs for the profiles system).

```yaml
type: ...

attributes: ...

requirements:
  env:
    - MY_ENV_VAR
```

This enables us to validate if dependencies are fully satisfied without fully loading a code location.:
```sh
$ dg check yaml

/Users/ben/repos/components_demo/03-28-env-demo/projects/data_ingest/data_ingest/defs/sling_elt/component.yaml:1 - requirements.env Component uses environment variables that are not specified in the component file: GROUP_NAME
     | 
   1 | type: dagster_sling.SlingReplicationCollectionComponent
     | ^ Component uses environment variables that are not specified in the component file: GROUP_NAME
   2 | attributes:
   3 |   replications:
   4 |   - path: replication.yaml
   5 |     asset_attributes:
   6 |       group_name: "{{ env('GROUP_NAME') }}"
     | 
```

```sh
$ dg check yaml

The following environment variables are used in components but not specified in the .env file or the current shell environment:
GROUP_NAME
```

This behavior can be opted out with the `--no-validate-requirements` flag.

Similar support could be implemented on `@component`/`@defs_module`: 

```python
@defs_module(requires_env={"MY_ENV_VAR"})
def loader(context: ComponentLoadContext): ...
```

These requirements are validated through `dg check yaml`, which will warn the user if an env var is not specified in the requirements field or not provided locally.

#28750 introduces a check yaml flag to automatically fill in these requirements so this will hopefully not be a big lift from the user's perspective.

## Test Plan

New unit tests.
