### PR TITLE
[SelectionAutoComplete] Use primaryAttributeKey for substring match suggestion

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
@@ -314,7 +314,7 @@ export const createProvider = <
     textCallback?: (text: string) => string;
   }) {
     const attribute = primaryAttributeKey as string;
-    const text = `key:"*${query}*"`;
+    const text = `${primaryAttributeKey as string}:"*${query}*"`;
     let displayAttribute = attribute.replace(/_/g, ' ');
     displayAttribute = displayAttribute[0]!.toUpperCase() + displayAttribute.slice(1);
     const displayText = (

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
@@ -314,7 +314,7 @@ export const createProvider = <
     textCallback?: (text: string) => string;
   }) {
     const attribute = primaryAttributeKey as string;
-    const text = `${primaryAttributeKey as string}:"*${query}*"`;
+    const text = `${attribute}:"*${query}*"`;
     let displayAttribute = attribute.replace(/_/g, ' ');
     displayAttribute = displayAttribute[0]!.toUpperCase() + displayAttribute.slice(1);
     const displayText = (

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/__tests__/SelectionAutoComplete.test.ts
@@ -24,11 +24,11 @@ describe('createAssetSelectionHint', () => {
   });
   const selectionHint = createSelectionAutoComplete(provider);
 
-  function testAutocomplete(testString: string) {
+  function testAutocomplete(testString: string, hintFn = selectionHint) {
     const cursorIndex = testString.indexOf('|');
     const string = testString.replace('|', '');
 
-    const hints = selectionHint(string, cursorIndex);
+    const hints = hintFn(string, cursorIndex);
 
     return {
       list: hints?.list,
@@ -1181,6 +1181,36 @@ describe('createAssetSelectionHint', () => {
         expect.objectContaining({text: 'code_location:"repo1@location1"'}),
       ],
       to: 1,
+    });
+  });
+
+  it('uses primary attribute key for substring suggestions', () => {
+    const attributesMap = {
+      key: [],
+      tag: [],
+      owner: [],
+      group: [],
+      kind: [],
+      code_location: [],
+    };
+    const provider = createProvider({
+      attributesMap,
+      primaryAttributeKey: 'tag',
+      attributeToIcon: {
+        key: 'magnify_glass',
+        tag: 'magnify_glass',
+        owner: 'magnify_glass',
+        group: 'magnify_glass',
+        kind: 'magnify_glass',
+        code_location: 'magnify_glass',
+      },
+    });
+    const selectionHint = createSelectionAutoComplete(provider);
+
+    expect(testAutocomplete('test|', selectionHint)).toEqual({
+      from: 0,
+      list: [expect.objectContaining({text: 'tag:"*test*"'})],
+      to: 4,
     });
   });
 });


### PR DESCRIPTION
## Summary & Motivation
as titled

## How I Tested These Changes
jest + manual testing

## Changelog

[ui] Fixes an issue with the Run step selection input autocomplete where it would suggest `key:"*substring*"` instead  of `name:"*substring*"`.
