### PR TITLE
cursor for observations on graphene asset

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -47,11 +47,7 @@
   "AssetOverviewMetadataEventsQuery": "dd693e04c3afdca2ec362a298c39efa343ff4371e802496c04e74271fb7f679d",
   "PartitionHealthQuery": "4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af",
   "AssetJobPartitionSetsQuery": "43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7",
-<<<<<<< HEAD
-  "AssetEventsQuery": "e7c886a06e0337a95eb966cef1c1bcc12fb11929ad63c761f1b119102ffe1e09",
-=======
-  "AssetEventsQuery": "669da62d26b1bb6e0989decf1dead0cb7277569177e5f24d86b4a179d672fd2a",
->>>>>>> 91acd66000 (cursor for observations on graphene asset)
+  "AssetEventsQuery": "fcb5311e32b51552a68e40aca83eb48e217acb06b6f27c64d709b7a1ba64e2d4",
   "ReportEventPartitionDefinitionQuery": "e306421344493a9986106de14bca90ec554505d6f1965991ba502725edc41c95",
   "ReportEventMutation": "80b4987cdf27ec8fac25eb6b98b996bd4fdeb4cbfff605d647da5d4bb8244cb0",
   "AssetWipeMutation": "accefb0c47b3d4a980d16965e8af565afed787a8a987a03570df876bd734dc8f",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -44,10 +44,14 @@
   "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
-  "AssetOverviewMetadataEventsQuery": "114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca",
+  "AssetOverviewMetadataEventsQuery": "dd693e04c3afdca2ec362a298c39efa343ff4371e802496c04e74271fb7f679d",
   "PartitionHealthQuery": "4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af",
   "AssetJobPartitionSetsQuery": "43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7",
+<<<<<<< HEAD
   "AssetEventsQuery": "e7c886a06e0337a95eb966cef1c1bcc12fb11929ad63c761f1b119102ffe1e09",
+=======
+  "AssetEventsQuery": "669da62d26b1bb6e0989decf1dead0cb7277569177e5f24d86b4a179d672fd2a",
+>>>>>>> 91acd66000 (cursor for observations on graphene asset)
   "ReportEventPartitionDefinitionQuery": "e306421344493a9986106de14bca90ec554505d6f1965991ba502725edc41c95",
   "ReportEventMutation": "80b4987cdf27ec8fac25eb6b98b996bd4fdeb4cbfff605d647da5d4bb8244cb0",
   "AssetWipeMutation": "accefb0c47b3d4a980d16965e8af565afed787a8a987a03570df876bd734dc8f",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -14,6 +14,7 @@ import {
   buildFreshnessPolicy,
   buildMaterializationEvent,
   buildMaterializationHistoryConnection,
+  buildObservationEvent,
   buildObservationEventConnection,
   buildRegularDagsterType,
   buildRepository,
@@ -22,7 +23,6 @@ import {
   buildRun,
   buildRunNotFoundError,
   buildSolidDefinition,
-  buildObservationEvent
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -14,6 +14,7 @@ import {
   buildFreshnessPolicy,
   buildMaterializationEvent,
   buildMaterializationHistoryConnection,
+  buildObservationEventConnection,
   buildRegularDagsterType,
   buildRepository,
   buildRepositoryLocation,
@@ -21,6 +22,7 @@ import {
   buildRun,
   buildRunNotFoundError,
   buildSolidDefinition,
+  buildObservationEvent
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';
@@ -194,33 +196,32 @@ const buildEventsMock = ({reported}: {reported: boolean}): MockedResponse<AssetE
             }),
           ],
         }),
-        assetObservations: [
-          {
-            __typename: 'ObservationEvent',
-            description: '1234',
-            runId: '12345',
-            metadataEntries: [],
-            partition: null,
-            timestamp: '1234567865400',
-            label: null,
-            stepKey: 'op',
-            tags: [],
-            runOrError: {
-              __typename: 'Run',
-              pipelineName: '__ASSET_JOB_1',
-              mode: 'default',
-              pipelineSnapshotId: null,
-              id: '12345',
-              status: RunStatus.SUCCESS,
-              repositoryOrigin: {
-                __typename: 'RepositoryOrigin',
-                id: 'test.py',
-                repositoryLocationName: 'repo',
-                repositoryName: 'test.py',
-              },
-            },
-          },
-        ],
+        assetObservations: buildObservationEventConnection({
+          results: [
+            buildObservationEvent({
+              description: '1234',
+              runId: '12345',
+              metadataEntries: [],
+              partition: null,
+              timestamp: '1234567865400',
+              label: null,
+              stepKey: 'op',
+              tags: [],
+              runOrError: buildRun({
+                pipelineName: '__ASSET_JOB_1',
+                mode: 'default',
+                pipelineSnapshotId: null,
+                id: '12345',
+                status: RunStatus.SUCCESS,
+                repositoryOrigin: buildRepositoryOrigin({
+                  id: 'test.py',
+                  repositoryLocationName: 'repo',
+                  repositoryName: 'test.py',
+                }),
+              }),
+            }),
+          ],
+        }),
       },
     },
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
@@ -192,123 +192,148 @@ export type AssetOverviewMetadataEventsQuery = {
           >;
         }>;
         assetObservations: Array<{
-          __typename: 'ObservationEvent';
-          timestamp: string;
-          runId: string;
-          partition: string | null;
-          metadataEntries: Array<
-            | {
-                __typename: 'AssetMetadataEntry';
-                label: string;
-                description: string | null;
-                assetKey: {__typename: 'AssetKey'; path: Array<string>};
-              }
-            | {
-                __typename: 'BoolMetadataEntry';
-                boolValue: boolean | null;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'CodeReferencesMetadataEntry';
-                label: string;
-                description: string | null;
-                codeReferences: Array<
-                  | {
-                      __typename: 'LocalFileCodeReference';
-                      filePath: string;
-                      lineNumber: number | null;
-                      label: string | null;
-                    }
-                  | {__typename: 'UrlCodeReference'; url: string; label: string | null}
-                >;
-              }
-            | {
-                __typename: 'FloatMetadataEntry';
-                floatValue: number | null;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'IntMetadataEntry';
-                intValue: number | null;
-                intRepr: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'JobMetadataEntry';
-                jobName: string;
-                repositoryName: string | null;
-                locationName: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'JsonMetadataEntry';
-                jsonString: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'MarkdownMetadataEntry';
-                mdStr: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'NotebookMetadataEntry';
-                path: string;
-                label: string;
-                description: string | null;
-              }
-            | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
-            | {
-                __typename: 'PathMetadataEntry';
-                path: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PipelineRunMetadataEntry';
-                runId: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PoolMetadataEntry';
-                pool: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PythonArtifactMetadataEntry';
-                module: string;
-                name: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'TableColumnLineageMetadataEntry';
-                label: string;
-                description: string | null;
-                lineage: Array<{
-                  __typename: 'TableColumnLineageEntry';
-                  columnName: string;
-                  columnDeps: Array<{
-                    __typename: 'TableColumnDep';
+          __typename: 'ObservationEventConnection';
+          results: Array<{
+            __typename: 'ObservationEvent';
+            timestamp: string;
+            runId: string;
+            partition: string | null;
+            metadataEntries: Array<
+              | {
+                  __typename: 'AssetMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                }
+              | {
+                  __typename: 'BoolMetadataEntry';
+                  boolValue: boolean | null;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'CodeReferencesMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  codeReferences: Array<
+                    | {
+                        __typename: 'LocalFileCodeReference';
+                        filePath: string;
+                        lineNumber: number | null;
+                        label: string | null;
+                      }
+                    | {__typename: 'UrlCodeReference'; url: string; label: string | null}
+                  >;
+                }
+              | {
+                  __typename: 'FloatMetadataEntry';
+                  floatValue: number | null;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'IntMetadataEntry';
+                  intValue: number | null;
+                  intRepr: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'JobMetadataEntry';
+                  jobName: string;
+                  repositoryName: string | null;
+                  locationName: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'JsonMetadataEntry';
+                  jsonString: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'MarkdownMetadataEntry';
+                  mdStr: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'NotebookMetadataEntry';
+                  path: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+              | {
+                  __typename: 'PathMetadataEntry';
+                  path: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PipelineRunMetadataEntry';
+                  runId: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PoolMetadataEntry';
+                  pool: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PythonArtifactMetadataEntry';
+                  module: string;
+                  name: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'TableColumnLineageMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  lineage: Array<{
+                    __typename: 'TableColumnLineageEntry';
                     columnName: string;
-                    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    columnDeps: Array<{
+                      __typename: 'TableColumnDep';
+                      columnName: string;
+                      assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    }>;
                   }>;
-                }>;
-              }
-            | {
-                __typename: 'TableMetadataEntry';
-                label: string;
-                description: string | null;
-                table: {
-                  __typename: 'Table';
-                  records: Array<string>;
+                }
+              | {
+                  __typename: 'TableMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  table: {
+                    __typename: 'Table';
+                    records: Array<string>;
+                    schema: {
+                      __typename: 'TableSchema';
+                      columns: Array<{
+                        __typename: 'TableColumn';
+                        name: string;
+                        description: string | null;
+                        type: string;
+                        tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
+                        constraints: {
+                          __typename: 'TableColumnConstraints';
+                          nullable: boolean;
+                          unique: boolean;
+                          other: Array<string>;
+                        };
+                      }>;
+                      constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                    };
+                  };
+                }
+              | {
+                  __typename: 'TableSchemaMetadataEntry';
+                  label: string;
+                  description: string | null;
                   schema: {
                     __typename: 'TableSchema';
                     columns: Array<{
@@ -326,52 +351,30 @@ export type AssetOverviewMetadataEventsQuery = {
                     }>;
                     constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
                   };
-                };
-              }
-            | {
-                __typename: 'TableSchemaMetadataEntry';
-                label: string;
-                description: string | null;
-                schema: {
-                  __typename: 'TableSchema';
-                  columns: Array<{
-                    __typename: 'TableColumn';
-                    name: string;
-                    description: string | null;
-                    type: string;
-                    tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
-                    constraints: {
-                      __typename: 'TableColumnConstraints';
-                      nullable: boolean;
-                      unique: boolean;
-                      other: Array<string>;
-                    };
-                  }>;
-                  constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
-                };
-              }
-            | {
-                __typename: 'TextMetadataEntry';
-                text: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'TimestampMetadataEntry';
-                timestamp: number;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'UrlMetadataEntry';
-                url: string;
-                label: string;
-                description: string | null;
-              }
-          >;
+                }
+              | {
+                  __typename: 'TextMetadataEntry';
+                  text: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'TimestampMetadataEntry';
+                  timestamp: number;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'UrlMetadataEntry';
+                  url: string;
+                  label: string;
+                  description: string | null;
+                }
+            >;
+          }>;
         }>;
       }
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const AssetOverviewMetadataEventsQueryVersion = '114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca';
+export const AssetOverviewMetadataEventsQueryVersion = 'dd693e04c3afdca2ec362a298c39efa343ff4371e802496c04e74271fb7f679d';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestEvents.types.ts
@@ -191,7 +191,7 @@ export type AssetOverviewMetadataEventsQuery = {
               }
           >;
         }>;
-        assetObservations: Array<{
+        assetObservations: {
           __typename: 'ObservationEventConnection';
           results: Array<{
             __typename: 'ObservationEvent';
@@ -372,7 +372,7 @@ export type AssetOverviewMetadataEventsQuery = {
                 }
             >;
           }>;
-        }>;
+        };
       }
     | {__typename: 'AssetNotFoundError'};
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -557,144 +557,169 @@ export type AssetEventsQuery = {
         id: string;
         key: {__typename: 'AssetKey'; path: Array<string>};
         assetObservations: Array<{
-          __typename: 'ObservationEvent';
-          partition: string | null;
-          runId: string;
-          timestamp: string;
-          stepKey: string | null;
-          label: string | null;
-          description: string | null;
-          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
-          runOrError:
-            | {__typename: 'PythonError'}
-            | {
-                __typename: 'Run';
-                id: string;
-                mode: string;
-                status: Types.RunStatus;
-                pipelineName: string;
-                pipelineSnapshotId: string | null;
-                repositoryOrigin: {
-                  __typename: 'RepositoryOrigin';
+          __typename: 'ObservationEventConnection';
+          results: Array<{
+            __typename: 'ObservationEvent';
+            partition: string | null;
+            runId: string;
+            timestamp: string;
+            stepKey: string | null;
+            label: string | null;
+            description: string | null;
+            tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
+            runOrError:
+              | {__typename: 'PythonError'}
+              | {
+                  __typename: 'Run';
                   id: string;
-                  repositoryName: string;
-                  repositoryLocationName: string;
-                } | null;
-              }
-            | {__typename: 'RunNotFoundError'};
-          metadataEntries: Array<
-            | {
-                __typename: 'AssetMetadataEntry';
-                label: string;
-                description: string | null;
-                assetKey: {__typename: 'AssetKey'; path: Array<string>};
-              }
-            | {
-                __typename: 'BoolMetadataEntry';
-                boolValue: boolean | null;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'CodeReferencesMetadataEntry';
-                label: string;
-                description: string | null;
-                codeReferences: Array<
-                  | {
-                      __typename: 'LocalFileCodeReference';
-                      filePath: string;
-                      lineNumber: number | null;
-                      label: string | null;
-                    }
-                  | {__typename: 'UrlCodeReference'; url: string; label: string | null}
-                >;
-              }
-            | {
-                __typename: 'FloatMetadataEntry';
-                floatValue: number | null;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'IntMetadataEntry';
-                intValue: number | null;
-                intRepr: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'JobMetadataEntry';
-                jobName: string;
-                repositoryName: string | null;
-                locationName: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'JsonMetadataEntry';
-                jsonString: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'MarkdownMetadataEntry';
-                mdStr: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'NotebookMetadataEntry';
-                path: string;
-                label: string;
-                description: string | null;
-              }
-            | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
-            | {
-                __typename: 'PathMetadataEntry';
-                path: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PipelineRunMetadataEntry';
-                runId: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PoolMetadataEntry';
-                pool: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'PythonArtifactMetadataEntry';
-                module: string;
-                name: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'TableColumnLineageMetadataEntry';
-                label: string;
-                description: string | null;
-                lineage: Array<{
-                  __typename: 'TableColumnLineageEntry';
-                  columnName: string;
-                  columnDeps: Array<{
-                    __typename: 'TableColumnDep';
+                  mode: string;
+                  status: Types.RunStatus;
+                  pipelineName: string;
+                  pipelineSnapshotId: string | null;
+                  repositoryOrigin: {
+                    __typename: 'RepositoryOrigin';
+                    id: string;
+                    repositoryName: string;
+                    repositoryLocationName: string;
+                  } | null;
+                }
+              | {__typename: 'RunNotFoundError'};
+            metadataEntries: Array<
+              | {
+                  __typename: 'AssetMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                }
+              | {
+                  __typename: 'BoolMetadataEntry';
+                  boolValue: boolean | null;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'CodeReferencesMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  codeReferences: Array<
+                    | {
+                        __typename: 'LocalFileCodeReference';
+                        filePath: string;
+                        lineNumber: number | null;
+                        label: string | null;
+                      }
+                    | {__typename: 'UrlCodeReference'; url: string; label: string | null}
+                  >;
+                }
+              | {
+                  __typename: 'FloatMetadataEntry';
+                  floatValue: number | null;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'IntMetadataEntry';
+                  intValue: number | null;
+                  intRepr: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'JobMetadataEntry';
+                  jobName: string;
+                  repositoryName: string | null;
+                  locationName: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'JsonMetadataEntry';
+                  jsonString: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'MarkdownMetadataEntry';
+                  mdStr: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'NotebookMetadataEntry';
+                  path: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {__typename: 'NullMetadataEntry'; label: string; description: string | null}
+              | {
+                  __typename: 'PathMetadataEntry';
+                  path: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PipelineRunMetadataEntry';
+                  runId: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PoolMetadataEntry';
+                  pool: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'PythonArtifactMetadataEntry';
+                  module: string;
+                  name: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'TableColumnLineageMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  lineage: Array<{
+                    __typename: 'TableColumnLineageEntry';
                     columnName: string;
-                    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    columnDeps: Array<{
+                      __typename: 'TableColumnDep';
+                      columnName: string;
+                      assetKey: {__typename: 'AssetKey'; path: Array<string>};
+                    }>;
                   }>;
-                }>;
-              }
-            | {
-                __typename: 'TableMetadataEntry';
-                label: string;
-                description: string | null;
-                table: {
-                  __typename: 'Table';
-                  records: Array<string>;
+                }
+              | {
+                  __typename: 'TableMetadataEntry';
+                  label: string;
+                  description: string | null;
+                  table: {
+                    __typename: 'Table';
+                    records: Array<string>;
+                    schema: {
+                      __typename: 'TableSchema';
+                      columns: Array<{
+                        __typename: 'TableColumn';
+                        name: string;
+                        description: string | null;
+                        type: string;
+                        tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
+                        constraints: {
+                          __typename: 'TableColumnConstraints';
+                          nullable: boolean;
+                          unique: boolean;
+                          other: Array<string>;
+                        };
+                      }>;
+                      constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
+                    };
+                  };
+                }
+              | {
+                  __typename: 'TableSchemaMetadataEntry';
+                  label: string;
+                  description: string | null;
                   schema: {
                     __typename: 'TableSchema';
                     columns: Array<{
@@ -712,49 +737,27 @@ export type AssetEventsQuery = {
                     }>;
                     constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
                   };
-                };
-              }
-            | {
-                __typename: 'TableSchemaMetadataEntry';
-                label: string;
-                description: string | null;
-                schema: {
-                  __typename: 'TableSchema';
-                  columns: Array<{
-                    __typename: 'TableColumn';
-                    name: string;
-                    description: string | null;
-                    type: string;
-                    tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
-                    constraints: {
-                      __typename: 'TableColumnConstraints';
-                      nullable: boolean;
-                      unique: boolean;
-                      other: Array<string>;
-                    };
-                  }>;
-                  constraints: {__typename: 'TableConstraints'; other: Array<string>} | null;
-                };
-              }
-            | {
-                __typename: 'TextMetadataEntry';
-                text: string;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'TimestampMetadataEntry';
-                timestamp: number;
-                label: string;
-                description: string | null;
-              }
-            | {
-                __typename: 'UrlMetadataEntry';
-                url: string;
-                label: string;
-                description: string | null;
-              }
-          >;
+                }
+              | {
+                  __typename: 'TextMetadataEntry';
+                  text: string;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'TimestampMetadataEntry';
+                  timestamp: number;
+                  label: string;
+                  description: string | null;
+                }
+              | {
+                  __typename: 'UrlMetadataEntry';
+                  url: string;
+                  label: string;
+                  description: string | null;
+                }
+            >;
+          }>;
         }>;
         assetMaterializationHistory: {
           __typename: 'MaterializationHistoryConnection';
@@ -1179,4 +1182,8 @@ export type AssetEventsQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
+<<<<<<< HEAD
 export const AssetEventsQueryVersion = 'e7c886a06e0337a95eb966cef1c1bcc12fb11929ad63c761f1b119102ffe1e09';
+=======
+export const AssetEventsQueryVersion = '669da62d26b1bb6e0989decf1dead0cb7277569177e5f24d86b4a179d672fd2a';
+>>>>>>> 91acd66000 (cursor for observations on graphene asset)

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -758,26 +758,11 @@ export type AssetEventsQuery = {
                 }
             >;
           }>;
-<<<<<<< HEAD
-        }>;
+        };
         assetMaterializationHistory: {
           __typename: 'MaterializationHistoryConnection';
           cursor: string;
           results: Array<
-=======
-        };
-        assetMaterializations: Array<{
-          __typename: 'MaterializationEvent';
-          partition: string | null;
-          runId: string;
-          timestamp: string;
-          stepKey: string | null;
-          label: string | null;
-          description: string | null;
-          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
-          runOrError:
-            | {__typename: 'PythonError'}
->>>>>>> e2bf5cb58a (fix)
             | {
                 __typename: 'FailedToMaterializeEvent';
                 runId: string;
@@ -1197,8 +1182,4 @@ export type AssetEventsQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-<<<<<<< HEAD
-export const AssetEventsQueryVersion = 'e7c886a06e0337a95eb966cef1c1bcc12fb11929ad63c761f1b119102ffe1e09';
-=======
-export const AssetEventsQueryVersion = '669da62d26b1bb6e0989decf1dead0cb7277569177e5f24d86b4a179d672fd2a';
->>>>>>> 91acd66000 (cursor for observations on graphene asset)
+export const AssetEventsQueryVersion = 'fcb5311e32b51552a68e40aca83eb48e217acb06b6f27c64d709b7a1ba64e2d4';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -556,7 +556,7 @@ export type AssetEventsQuery = {
         __typename: 'Asset';
         id: string;
         key: {__typename: 'AssetKey'; path: Array<string>};
-        assetObservations: Array<{
+        assetObservations: {
           __typename: 'ObservationEventConnection';
           results: Array<{
             __typename: 'ObservationEvent';
@@ -758,11 +758,26 @@ export type AssetEventsQuery = {
                 }
             >;
           }>;
+<<<<<<< HEAD
         }>;
         assetMaterializationHistory: {
           __typename: 'MaterializationHistoryConnection';
           cursor: string;
           results: Array<
+=======
+        };
+        assetMaterializations: Array<{
+          __typename: 'MaterializationEvent';
+          partition: string | null;
+          runId: string;
+          timestamp: string;
+          stepKey: string | null;
+          label: string | null;
+          description: string | null;
+          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
+          runOrError:
+            | {__typename: 'PythonError'}
+>>>>>>> e2bf5cb58a (fix)
             | {
                 __typename: 'FailedToMaterializeEvent';
                 runId: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
@@ -56,7 +56,9 @@ export function useLatestEvents(
       ? data.assetOrError.assetMaterializations[0]
       : undefined;
   const observation =
-    data?.assetOrError.__typename === 'Asset' ? data.assetOrError.assetObservations[0] : undefined;
+    data?.assetOrError.__typename === 'Asset'
+      ? data.assetOrError.assetObservations.results[0]
+      : undefined;
 
   return {materialization, observation, loading: !data};
 }
@@ -75,11 +77,13 @@ export const ASSET_OVERVIEW_METADATA_EVENTS_QUERY = gql`
           }
         }
         assetObservations(limit: 1) {
-          timestamp
-          runId
-          partition
-          metadataEntries {
-            ...MetadataEntryFragment
+          results {
+            timestamp
+            runId
+            partition
+            metadataEntries {
+              ...MetadataEntryFragment
+            }
           }
         }
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
@@ -79,7 +79,7 @@ export function usePaginatedAssetEvents(
 
       const {materializations, observations} = clipEventsToSharedMinimumTime(
         asset?.assetMaterializationHistory?.results || [],
-        asset?.assetObservations || [],
+        asset?.assetObservations.results || [],
         100,
       );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -85,7 +85,7 @@ export function useRecentAssetEvents(
 
     const loaded = {
       materializations: asset?.assetMaterializationHistory?.results || [],
-      observations: asset?.assetObservations || [],
+      observations: asset?.assetObservations.results || [],
     };
 
     const {materializations, observations} = !loadUsingPartitionKeys
@@ -249,7 +249,9 @@ export const ASSET_EVENTS_QUERY = gql`
           partitionInLast: $partitionInLast
           partitions: $partitions
         ) {
-          ...AssetObservationFragment
+          results {
+            ...AssetObservationFragment
+          }
         }
         assetMaterializationHistory(
           limit: $limit

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -615,7 +615,8 @@ type Asset {
     beforeTimestampMillis: String
     afterTimestampMillis: String
     limit: Int
-  ): [ObservationEvent!]!
+    cursor: String
+  ): [ObservationEventConnection!]!
   assetMaterializationHistory(
     partitions: [String!]
     partitionInLast: Int
@@ -626,6 +627,11 @@ type Asset {
     cursor: String
   ): MaterializationHistoryConnection!
   definition: AssetNode
+}
+
+type ObservationEventConnection {
+  results: [ObservationEvent!]!
+  cursor: String!
 }
 
 type MaterializationHistoryConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -616,7 +616,7 @@ type Asset {
     afterTimestampMillis: String
     limit: Int
     cursor: String
-  ): [ObservationEventConnection!]!
+  ): ObservationEventConnection!
   assetMaterializationHistory(
     partitions: [String!]
     partitionInLast: Int

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -101,7 +101,7 @@ export type Asset = {
   __typename: 'Asset';
   assetMaterializationHistory: MaterializationHistoryConnection;
   assetMaterializations: Array<MaterializationEvent>;
-  assetObservations: Array<ObservationEventConnection>;
+  assetObservations: ObservationEventConnection;
   definition: Maybe<AssetNode>;
   id: Scalars['String']['output'];
   key: AssetKey;
@@ -6088,7 +6088,9 @@ export const buildAsset = (
     assetObservations:
       overrides && overrides.hasOwnProperty('assetObservations')
         ? overrides.assetObservations!
-        : [],
+        : relationshipsToOmit.has('ObservationEventConnection')
+          ? ({} as ObservationEventConnection)
+          : buildObservationEventConnection({}, relationshipsToOmit),
     definition:
       overrides && overrides.hasOwnProperty('definition')
         ? overrides.definition!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -101,7 +101,7 @@ export type Asset = {
   __typename: 'Asset';
   assetMaterializationHistory: MaterializationHistoryConnection;
   assetMaterializations: Array<MaterializationEvent>;
-  assetObservations: Array<ObservationEvent>;
+  assetObservations: Array<ObservationEventConnection>;
   definition: Maybe<AssetNode>;
   id: Scalars['String']['output'];
   key: AssetKey;
@@ -128,6 +128,7 @@ export type AssetAssetMaterializationsArgs = {
 export type AssetAssetObservationsArgs = {
   afterTimestampMillis?: InputMaybe<Scalars['String']['input']>;
   beforeTimestampMillis?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   partitionInLast?: InputMaybe<Scalars['Int']['input']>;
   partitions?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -3141,6 +3142,12 @@ export type ObservationEvent = DisplayableEvent &
     tags: Array<EventTag>;
     timestamp: Scalars['String']['output'];
   };
+
+export type ObservationEventConnection = {
+  __typename: 'ObservationEventConnection';
+  cursor: Scalars['String']['output'];
+  results: Array<ObservationEvent>;
+};
 
 export type Output = {
   __typename: 'Output';
@@ -11039,6 +11046,19 @@ export const buildObservationEvent = (
           : buildRunStepStats({}, relationshipsToOmit),
     tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
     timestamp: overrides && overrides.hasOwnProperty('timestamp') ? overrides.timestamp! : 'ut',
+  };
+};
+
+export const buildObservationEventConnection = (
+  overrides?: Partial<ObservationEventConnection>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'ObservationEventConnection'} & ObservationEventConnection => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('ObservationEventConnection');
+  return {
+    __typename: 'ObservationEventConnection',
+    cursor: overrides && overrides.hasOwnProperty('cursor') ? overrides.cursor! : 'veniam',
+    results: overrides && overrides.hasOwnProperty('results') ? overrides.results! : [],
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/__fixtures__/Search.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__fixtures__/Search.fixtures.tsx
@@ -7,6 +7,7 @@ import {
   buildAssetGroup,
   buildAssetKey,
   buildMaterializationHistoryConnection,
+  buildObservationEventConnection,
   buildPipeline,
   buildRepository,
   buildRepositoryLocation,
@@ -170,7 +171,7 @@ export const buildSecondarySearch = (
               id,
               definition: null,
               assetMaterializations: [],
-              assetObservations: [],
+              assetObservations: buildObservationEventConnection({}),
               assetMaterializationHistory: buildMaterializationHistoryConnection({}),
               key: buildAssetKey({
                 path: path.split(' '),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -653,7 +653,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 partitions,
                 before_timestamp=before_timestamp,
                 limit=limit,
-            )
+            )[0]
         ]
 
     def resolve_configField(self, graphene_info: ResolveInfo) -> Optional[GrapheneConfigTypeField]:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -237,7 +237,7 @@ class GrapheneAsset(graphene.ObjectType):
         limit=graphene.Int(),
     )
     assetObservations = graphene.Field(
-        non_null_list(GrapheneObservationEventConnection),
+        graphene.NonNull(GrapheneObservationEventConnection),
         partitions=graphene.List(graphene.NonNull(graphene.String)),
         partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -217,6 +217,14 @@ class GrapheneMaterializationHistoryConnection(graphene.ObjectType):
     cursor = graphene.NonNull(graphene.String)
 
 
+class GrapheneObservationEventConnection(graphene.ObjectType):
+    results = non_null_list(GrapheneObservationEvent)
+    cursor = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "ObservationEventConnection"
+
+
 class GrapheneAsset(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
     key = graphene.NonNull(GrapheneAssetKey)
@@ -229,12 +237,13 @@ class GrapheneAsset(graphene.ObjectType):
         limit=graphene.Int(),
     )
     assetObservations = graphene.Field(
-        non_null_list(GrapheneObservationEvent),
+        non_null_list(GrapheneObservationEventConnection),
         partitions=graphene.List(graphene.NonNull(graphene.String)),
         partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
         limit=graphene.Int(),
+        cursor=graphene.String(),
     )
     assetMaterializationHistory = graphene.Field(
         graphene.NonNull(GrapheneMaterializationHistoryConnection),
@@ -369,7 +378,7 @@ class GrapheneAsset(graphene.ObjectType):
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,
         limit: Optional[int] = None,
-    ) -> Sequence[GrapheneObservationEvent]:
+    ) -> Sequence[GrapheneObservationEventConnection]:
         from dagster_graphql.implementation.fetch_assets import get_asset_observations
 
         before_timestamp = parse_timestamp(beforeTimestampMillis)
@@ -377,17 +386,19 @@ class GrapheneAsset(graphene.ObjectType):
         if partitionInLast and self._definition:
             partitions = self._definition.get_partition_keys()[-int(partitionInLast) :]
 
-        return [
-            GrapheneObservationEvent(event=event)
-            for event in get_asset_observations(
-                graphene_info,
-                self.key,
-                partitions=partitions,
-                before_timestamp=before_timestamp,
-                after_timestamp=after_timestamp,
-                limit=limit,
-            )
-        ]
+        events, new_cursor = get_asset_observations(
+            graphene_info,
+            self.key,
+            partitions=partitions,
+            before_timestamp=before_timestamp,
+            after_timestamp=after_timestamp,
+            limit=limit,
+        )
+
+        return GrapheneObservationEventConnection(
+            results=[GrapheneObservationEvent(event=event) for event in events],
+            cursor=new_cursor,
+        )
 
 
 class GrapheneEventConnection(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -445,23 +445,26 @@ GET_ASSET_OBSERVATIONS = """
         assetOrError(assetKey: $assetKey) {
             ... on Asset {
                 assetObservations {
-                    label
-                    description
-                    runOrError {
-                        ... on Run {
-                            jobName
-                        }
-                    }
-                    assetKey {
-                        path
-                    }
-                    metadataEntries {
+                    results {
                         label
                         description
-                        ... on TextMetadataEntry {
-                            text
+                        runOrError {
+                            ... on Run {
+                                jobName
+                            }
+                        }
+                        assetKey {
+                            path
+                        }
+                        metadataEntries {
+                            label
+                            description
+                            ... on TextMetadataEntry {
+                                text
+                            }
                         }
                     }
+
                 }
             }
         }
@@ -474,21 +477,23 @@ GET_LAST_ASSET_OBSERVATIONS = """
         assetOrError(assetKey: $assetKey) {
             ... on Asset {
                 assetObservations(limit: 1) {
-                    label
-                    description
-                    runOrError {
-                        ... on Run {
-                            jobName
-                        }
-                    }
-                    assetKey {
-                        path
-                    }
-                    metadataEntries {
+                    results {
                         label
                         description
-                        ... on TextMetadataEntry {
-                            text
+                        runOrError {
+                            ... on Run {
+                                jobName
+                            }
+                        }
+                        assetKey {
+                            path
+                        }
+                        metadataEntries {
+                            label
+                            description
+                            ... on TextMetadataEntry {
+                                text
+                            }
                         }
                     }
                 }
@@ -1932,7 +1937,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result.data
         assert result.data["assetOrError"]
-        observations = result.data["assetOrError"]["assetObservations"]
+        observations = result.data["assetOrError"]["assetObservations"]["results"]
 
         assert observations
         assert len(observations) == 2
@@ -1958,7 +1963,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result.data
         assert result.data["assetOrError"]
-        observations = result.data["assetOrError"]["assetObservations"]
+        observations = result.data["assetOrError"]["assetObservations"]["results"]
 
         assert observations
         assert len(observations) == 1


### PR DESCRIPTION
## Summary & Motivation
adds a storage id cursor option for fetching observations from `GrapheneAsset` so that it can be queried like the `AssetMaterializatonHistory` endpoint. Doesn't update the FE to actually use this cursoring strategy though 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
