### PR TITLE
Allow freshness checks to be blocking

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -49,6 +49,7 @@ def build_last_update_freshness_checks(
     deadline_cron: Optional[str] = None,
     timezone: str = DEFAULT_FRESHNESS_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
+    blocking: bool = False,
 ) -> Sequence[AssetChecksDefinition]:
     r"""Constructs an `AssetChecksDefinition` that checks the freshness of the provided assets.
 
@@ -122,6 +123,7 @@ def build_last_update_freshness_checks(
             that the asset arrived. If not provided, the deadline is the execution time of the check.
         timezone (Optional[str]): The timezone to use when calculating freshness and deadline. If
             not provided, defaults to "UTC".
+        blocking (bool): Whether the check should block execution if it fails. Defaults to False.
 
     Returns:
         Sequence[AssetChecksDefinition]: `AssetChecksDefinition` objects which execute freshness checks
@@ -143,6 +145,7 @@ def build_last_update_freshness_checks(
             timezone=timezone,
             severity=severity,
             lower_bound_delta=lower_bound_delta,
+            blocking=blocking,
         )
     ]
 
@@ -153,6 +156,7 @@ def _build_freshness_multi_check(
     timezone: str,
     severity: AssetCheckSeverity,
     lower_bound_delta: datetime.timedelta,
+    blocking: bool,
 ) -> AssetChecksDefinition:
     params_metadata: dict[str, Any] = {
         TIMEZONE_PARAM_KEY: timezone,
@@ -162,7 +166,7 @@ def _build_freshness_multi_check(
         params_metadata[DEADLINE_CRON_PARAM_KEY] = deadline_cron
 
     @freshness_multi_asset_check(
-        params_metadata=JsonMetadataValue(params_metadata), asset_keys=asset_keys
+        params_metadata=JsonMetadataValue(params_metadata), asset_keys=asset_keys, blocking=blocking
     )
     def the_check(context: AssetCheckExecutionContext) -> Iterable[AssetCheckResult]:
         for check_key in context.selected_asset_check_keys:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -45,6 +45,7 @@ def build_time_partition_freshness_checks(
     deadline_cron: str,
     timezone: str = DEFAULT_FRESHNESS_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
+    blocking: bool = False,
 ) -> Sequence[AssetChecksDefinition]:
     r"""Construct an `AssetChecksDefinition` that checks the freshness of the provided assets.
 
@@ -102,6 +103,8 @@ def build_time_partition_freshness_checks(
             completed by the time of the last cron tick has been observed/materialized.
         timezone (Optional[str]): The timezone to use when calculating freshness and deadline. If
             not provided, defaults to "UTC".
+        severity (AssetCheckSeverity): The severity of the check. Defaults to "ERROR".
+        blocking (bool): Whether the check should block execution if it fails. Defaults to False.
 
     Returns:
         Sequence[AssetChecksDefinition]: `AssetChecksDefinition` objects which execute freshness
@@ -121,6 +124,7 @@ def build_time_partition_freshness_checks(
             deadline_cron=deadline_cron,
             timezone=timezone,
             severity=severity,
+            blocking=blocking,
         )
     ]
 
@@ -130,6 +134,7 @@ def _build_freshness_multi_check(
     deadline_cron: str,
     timezone: str,
     severity: AssetCheckSeverity,
+    blocking: bool,
 ) -> AssetChecksDefinition:
     params_metadata: dict[str, Any] = {
         TIMEZONE_PARAM_KEY: timezone,
@@ -137,7 +142,7 @@ def _build_freshness_multi_check(
     }
 
     @freshness_multi_asset_check(
-        params_metadata=JsonMetadataValue(params_metadata), asset_keys=asset_keys
+        params_metadata=JsonMetadataValue(params_metadata), asset_keys=asset_keys, blocking=blocking
     )
     def the_check(context: AssetCheckExecutionContext) -> Iterable[AssetCheckResult]:
         for check_key in context.selected_asset_check_keys:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
@@ -246,7 +246,9 @@ def seconds_in_words(delta: float) -> str:
     )
 
 
-def freshness_multi_asset_check(params_metadata: JsonMetadataValue, asset_keys: Sequence[AssetKey]):
+def freshness_multi_asset_check(
+    params_metadata: JsonMetadataValue, asset_keys: Sequence[AssetKey], blocking: bool
+):
     def inner(fn: MultiAssetCheckFunction) -> AssetChecksDefinition:
         return multi_asset_check(
             specs=[
@@ -255,6 +257,7 @@ def freshness_multi_asset_check(params_metadata: JsonMetadataValue, asset_keys: 
                     asset=asset_key,
                     metadata={FRESHNESS_PARAMS_METADATA_KEY: params_metadata},
                     description="Evaluates freshness for targeted asset.",
+                    blocking=blocking,
                 )
                 for asset_key in asset_keys
             ],

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
@@ -56,6 +56,13 @@ def test_params() -> None:
             }
         )
     }
+    assert not next(iter(check_specs)).blocking
+
+    blocking_check = build_last_update_freshness_checks(
+        assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10), blocking=True
+    )[0]
+
+    assert next(iter(blocking_check.check_specs)).blocking
 
     @asset
     def other_asset():

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
@@ -64,6 +64,12 @@ def test_params() -> None:
             }
         )
     }
+    assert not next(iter(check.check_specs)).blocking
+
+    blocking_check = build_time_partition_freshness_checks(
+        assets=[my_partitioned_asset], deadline_cron="0 0 * * *", blocking=True
+    )[0]
+    assert next(iter(blocking_check.check_specs)).blocking
     assert (
         check.node_def.name
         == f"freshness_check_{non_secure_md5_hash_str(json.dumps([str(my_partitioned_asset.key)]).encode())[:8]}"


### PR DESCRIPTION
## Summary & Motivation
No reason _not_ to do this. Allows freshness checks to be blocking.

## How I Tested These Changes
Added tests that the flag is set as expected. No reason to reinvent the wheel on how blocking itself is tested I think.

## Changelog
- a new `blocking` parameter has been added to `build_last_update_freshness_checks` and `build_time_partition_freshness_checks`.
