### PR TITLE
[dagster-fivetran] Remove replace_attributes import from docstring

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -72,7 +72,6 @@ def fivetran_assets(
             )
 
             import dagster as dg
-            from dagster._core.definitions.asset_spec import replace_attributes
 
             class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -787,7 +787,6 @@ def build_fivetran_assets_definitions(
             )
 
             import dagster as dg
-            from dagster._core.definitions.asset_spec import replace_attributes
 
             class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
                 def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:


### PR DESCRIPTION
## Summary & Motivation

`replace_attributes` is now a method of `AssetSpec`, but it used to be a function of the `asset_spec` module. Fix example to be accurate with the current state.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
