### PR TITLE
[dagster-dbt] Leverage state-backed defs in DbtCloudWorkspace.fetch_workspace_data()

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -745,22 +745,27 @@ SAMPLE_LIST_RUN_ARTIFACTS = {
 }
 
 
+TEST_CREDENTIALS = DbtCloudCredentials(
+    account_id=TEST_ACCOUNT_ID,
+    access_url=TEST_ACCESS_URL,
+    token=TEST_TOKEN,
+)
+
+TEST_WORKSPACE = DbtCloudWorkspace(
+    credentials=TEST_CREDENTIALS,
+    project_id=TEST_PROJECT_ID,
+    environment_id=TEST_ENVIRONMENT_ID,
+)
+
+
 @pytest.fixture(name="credentials")
 def credentials_fixture() -> DbtCloudCredentials:
-    return DbtCloudCredentials(
-        account_id=TEST_ACCOUNT_ID,
-        access_url=TEST_ACCESS_URL,
-        token=TEST_TOKEN,
-    )
+    return TEST_CREDENTIALS
 
 
 @pytest.fixture(name="workspace")
-def workspace_fixture(credentials: DbtCloudCredentials) -> DbtCloudWorkspace:
-    return DbtCloudWorkspace(
-        credentials=credentials,
-        project_id=TEST_PROJECT_ID,
-        environment_id=TEST_ENVIRONMENT_ID,
-    )
+def workspace_fixture() -> DbtCloudWorkspace:
+    return TEST_WORKSPACE
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.definitions_class import Definitions
@@ -19,6 +20,7 @@ def cacheable_dbt_cloud_workspace_data():
     )
 
 
+@pytest.mark.order("last")
 def test_cacheable_dbt_cloud_workspace_data(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
@@ -1,0 +1,49 @@
+import responses
+from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.reconstruct import (
+    initialize_repository_def_from_pointer,
+    reconstruct_repository_def_from_pointer,
+)
+from dagster._utils.test.definitions import lazy_definitions
+
+from dagster_dbt_tests.cloud_v2.conftest import TEST_WORKSPACE
+
+
+@lazy_definitions
+def cacheable_dbt_cloud_workspace_data():
+    TEST_WORKSPACE.fetch_workspace_data()
+
+    return Definitions(
+        resources={"dbt_cloud": TEST_WORKSPACE},
+    )
+
+
+def test_cacheable_dbt_cloud_workspace_data(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    assert len(fetch_workspace_data_api_mocks.calls) == 0
+
+    # first, we resolve the repository to generate our cached metadata
+    pointer = CodePointer.from_python_file(
+        __file__,
+        "cacheable_dbt_cloud_workspace_data",
+        None,
+    )
+    init_repository_def = initialize_repository_def_from_pointer(
+        pointer,
+    )
+
+    # 7 call to creates the defs
+    assert len(fetch_workspace_data_api_mocks.calls) == 7
+
+    repository_load_data = init_repository_def.repository_load_data
+
+    # We use a separate file here just to ensure we get a fresh load
+    _ = reconstruct_repository_def_from_pointer(
+        pointer,
+        repository_load_data,
+    )
+
+    # no additional calls after a fresh load
+    assert len(fetch_workspace_data_api_mocks.calls) == 7

--- a/python_modules/libraries/dagster-dbt/pytest.ini
+++ b/python_modules/libraries/dagster-dbt/pytest.ini
@@ -11,5 +11,4 @@ markers =
     core-derived-metadata: subset of core tests which deal with asset metadata
     snowflake: marks tests that access a Snowflake warehouse, run nightly
     bigquery: marks tests that access a BigQuery warehouse, run nightly
-; order tests first inside modules, order whole modules afterwards
 adopts = --order-group-scope=module

--- a/python_modules/libraries/dagster-dbt/pytest.ini
+++ b/python_modules/libraries/dagster-dbt/pytest.ini
@@ -11,3 +11,5 @@ markers =
     core-derived-metadata: subset of core tests which deal with asset metadata
     snowflake: marks tests that access a Snowflake warehouse, run nightly
     bigquery: marks tests that access a BigQuery warehouse, run nightly
+; order tests first inside modules, order whole modules afterwards
+adopts = --order-group-scope=module

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -54,6 +54,7 @@ setup(
     extras_require={
         "test": [
             "pytest-rerunfailures",
+            "pytest-order",
             "dbt-duckdb<1.9.2",  # concurrency issues
             "dagster-duckdb",
             "dagster-duckdb-pandas",


### PR DESCRIPTION
## Summary & Motivation

Updates `fetch_workspace_data` to use the state loader. The goal is to avoid reloading the workspace data more than once when using the method in the polling sensor (subsequent PR)

## How I Tested These Changes

New tests with bk
