### PR TITLE
[dagster-dbt] Add polling sensor for dbt Cloud v2

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -250,8 +250,8 @@ class DbtCloudWorkspaceClient(DagsterModel):
         self,
         project_id: int,
         environment_id: int,
-        finished_at_start: datetime.datetime,
-        finished_at_end: datetime.datetime,
+        finished_at_lower_bound: datetime.datetime,
+        finished_at_upper_bound: datetime.datetime,
         offset: int = 0,
     ) -> tuple[Sequence[Mapping[str, Any]], int]:
         """Retrieves a batch of dbt Cloud runs from a dbt Cloud workspace for a given project and environment.
@@ -261,9 +261,9 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 URL of the "Explore" tab in the dbt Cloud UI.
             environment_id (str): The dbt Cloud Environment ID. You can retrieve this value from the
                 URL of the given environment page the dbt Cloud UI.
-            finished_at_start (datetime.datetime): The first run in this batch will have finished
+            finished_at_lower_bound (datetime.datetime): The first run in this batch will have finished
                 at a time that is equal to or after this value.
-            finished_at_end (datetime.datetime): The last run in this batch will have finished
+            finished_at_upper_bound (datetime.datetime): The last run in this batch will have finished
                 at a time that is equal to or before this value.
             offset (str): The pagination offset for this request.
 
@@ -282,7 +282,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 "project_id": project_id,
                 "limit": DAGSTER_DBT_CLOUD_BATCH_RUNS_REQUEST_LIMIT,
                 "offset": offset,
-                "finished_at__range": f"""["{finished_at_start.isoformat()}", "{finished_at_end.isoformat()}"]""",
+                "finished_at__range": f"""["{finished_at_lower_bound.isoformat()}", "{finished_at_upper_bound.isoformat()}"]""",
                 "order_by": "finished_at",
             },
             include_full_response=True,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -169,8 +169,6 @@ def build_dbt_cloud_polling_sensor(
         name=f"{workspace.account_name}_{workspace.project_name}_{workspace.environment_name}__run_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,
         default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
-        # This sensor will only ever execute asset checks and not asset materializations.
-        asset_selection=AssetSelection.all_asset_checks(),
     )
     def dbt_cloud_run_sensor(context: SensorEvaluationContext) -> SensorResult:
         """Sensor to report materialization events for each asset as new runs come in."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -1,0 +1,246 @@
+from collections.abc import Iterator, Sequence
+from datetime import timedelta
+from typing import Optional, Union
+
+from dagster import (
+    AssetCheckEvaluation,
+    AssetKey,
+    AssetMaterialization,
+    AssetObservation,
+    DefaultSensorStatus,
+    SensorDefinition,
+    SensorEvaluationContext,
+    SensorResult,
+    _check as check,
+    sensor,
+)
+from dagster._annotations import preview
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.repository_definition.repository_definition import (
+    RepositoryDefinition,
+)
+from dagster._grpc.client import DEFAULT_SENSOR_GRPC_TIMEOUT
+from dagster._record import record
+from dagster._serdes import deserialize_value, serialize_value
+from dagster._time import datetime_from_timestamp, get_current_datetime
+from dagster_shared.serdes import whitelist_for_serdes
+
+from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
+from dagster_dbt.cloud_v2.run_handler import (
+    COMPLETED_AT_TIMESTAMP_METADATA_KEY,
+    DbtCloudJobRunResults,
+)
+from dagster_dbt.cloud_v2.types import DbtCloudRun
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
+DEFAULT_DBT_CLOUD_SENSOR_INTERVAL_SECONDS = 30
+START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
+
+
+@record
+class BatchResult:
+    idx: int
+    asset_events: Sequence[AssetMaterialization]
+    all_asset_keys_materialized: set[AssetKey]
+
+
+@whitelist_for_serdes
+@record
+class DbtCloudPollingSensorCursor:
+    """A cursor that stores the last effective timestamp and offset."""
+
+    finished_at_lower_bound: Optional[float] = None
+    finished_at_upper_bound: Optional[float] = None
+    offset: Optional[int] = None
+
+
+def materializations_from_batch_iter(
+    context: SensorEvaluationContext,
+    finished_at_lower_bound: float,
+    finished_at_upper_bound: float,
+    offset: int,
+    workspace: DbtCloudWorkspace,
+    dagster_dbt_translator: DagsterDbtTranslator,
+) -> Iterator[Optional[BatchResult]]:
+    client = workspace.get_client()
+
+    total_processed_runs = 0
+    while True:
+        latest_offset = total_processed_runs + offset
+        runs, total_runs = client.get_runs_batch(
+            project_id=workspace.project_id,
+            environment_id=workspace.environment_id,
+            finished_at_lower_bound=datetime_from_timestamp(finished_at_lower_bound),
+            finished_at_upper_bound=datetime_from_timestamp(finished_at_upper_bound),
+            offset=latest_offset,
+        )
+        if len(runs) == 0:
+            yield None
+            context.log.info("Received no runs. Breaking.")
+            break
+        context.log.info(
+            f"Processing {len(runs)}/{total_runs} runs for dbt Cloud workspace "
+            f"for project {workspace.project_name} and environment {workspace.environment_name}..."
+        )
+        for i, run_details in enumerate(runs):
+            run = DbtCloudRun.from_run_details(run_details=run_details)
+
+            run_artifacts = client.list_run_artifacts(run_id=run.id)
+            if "run_results.json" not in run_artifacts:
+                context.log.info(
+                    f"Run {run.id} does not have a run_results.json artifact. Continuing."
+                )
+                continue
+
+            run_results = DbtCloudJobRunResults.from_run_results_json(
+                run_results_json=client.get_run_results_json(run_id=run.id)
+            )
+            events = run_results.to_default_asset_events(
+                workspace=workspace,
+                dagster_dbt_translator=dagster_dbt_translator,
+            )
+            # Currently, only materializations are tracked
+            mats = [event for event in events if isinstance(event, AssetMaterialization)]
+            context.log.info(f"Found {len(mats)} materializations for {run.id}")
+
+            all_asset_keys_materialized = {mat.asset_key for mat in mats}
+            yield (
+                BatchResult(
+                    idx=i + latest_offset,
+                    asset_events=mats,
+                    all_asset_keys_materialized=all_asset_keys_materialized,
+                )
+                if mats
+                else None
+            )
+        total_processed_runs += len(runs)
+        context.log.info(
+            f"Processed {total_processed_runs}/{total_runs} runs for dbt Cloud workspace "
+            f"for project {workspace.project_name} and environment {workspace.environment_name}..."
+        )
+        if total_processed_runs == total_runs:
+            yield None
+            context.log.info("Processed all runs. Breaking.")
+            break
+
+
+def sorted_asset_events(
+    asset_events: Sequence[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]],
+    repository_def: RepositoryDefinition,
+) -> list[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]]:
+    """Sort asset events by end date and toposort order."""
+    topo_aks = repository_def.asset_graph.toposorted_asset_keys
+    materializations_and_timestamps = [
+        (mat.metadata[COMPLETED_AT_TIMESTAMP_METADATA_KEY].value, mat) for mat in asset_events
+    ]
+    return [
+        sorted_event[1]
+        for sorted_event in sorted(
+            materializations_and_timestamps, key=lambda x: (x[0], topo_aks.index(x[1].asset_key))
+        )
+    ]
+
+
+@preview
+def build_dbt_cloud_polling_sensor(
+    *,
+    workspace: DbtCloudWorkspace,
+    dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+    minimum_interval_seconds: int = DEFAULT_DBT_CLOUD_SENSOR_INTERVAL_SECONDS,
+    default_sensor_status: Optional[DefaultSensorStatus] = None,
+) -> SensorDefinition:
+    """The constructed sensor polls the dbt Cloud Workspace for activity, and inserts asset events into Dagster's event log.
+
+    Args:
+        workspace (DbtCloudWorkspace): The dbt Cloud workspace to poll for runs.
+        dagster_dbt_translator (Optional[DagsterDbtTranslator], optional): The translator to use
+            to convert dbt Cloud content into :py:class:`dagster.AssetSpec`.
+            Defaults to :py:class:`DagsterDbtTranslator`.
+        minimum_interval_seconds (int, optional): The minimum interval in seconds between sensor runs. Defaults to 30.
+        default_sensor_status (Optional[DefaultSensorStatus], optional): The default status of the sensor.
+
+    Returns:
+        Definitions: A `Definitions` object containing the constructed sensor.
+    """
+    dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
+
+    @sensor(
+        name=f"{workspace.account_name}_{workspace.project_name}_{workspace.environment_name}__run_status_sensor",
+        minimum_interval_seconds=minimum_interval_seconds,
+        default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
+        # This sensor will only ever execute asset checks and not asset materializations.
+        asset_selection=AssetSelection.all_asset_checks(),
+    )
+    def dbt_cloud_run_sensor(context: SensorEvaluationContext) -> SensorResult:
+        """Sensor to report materialization events for each asset as new runs come in."""
+        context.log.info(
+            f"************"
+            f"Running sensor for dbt Cloud workspace for account {workspace.account_name}, "
+            f"project {workspace.project_name} and environment {workspace.environment_name}"
+            f"***********"
+        )
+        try:
+            cursor = (
+                deserialize_value(context.cursor, DbtCloudPollingSensorCursor)
+                if context.cursor
+                else DbtCloudPollingSensorCursor()
+            )
+        except Exception as e:
+            context.log.info(f"Failed to interpret cursor. Starting from scratch. Error: {e}")
+            cursor = DbtCloudPollingSensorCursor()
+        current_date = get_current_datetime()
+        current_offset = cursor.offset or 0
+        finished_at_lower_bound = (
+            cursor.finished_at_lower_bound
+            or (current_date - timedelta(seconds=START_LOOKBACK_SECONDS)).timestamp()
+        )
+        finished_at_upper_bound = cursor.finished_at_upper_bound or current_date.timestamp()
+        sensor_iter = materializations_from_batch_iter(
+            context=context,
+            finished_at_lower_bound=finished_at_lower_bound,
+            finished_at_upper_bound=finished_at_upper_bound,
+            offset=current_offset,
+            workspace=workspace,
+            dagster_dbt_translator=dagster_dbt_translator,
+        )
+
+        all_asset_events: list[AssetMaterialization] = []
+        latest_offset = current_offset
+        repository_def = check.not_none(context.repository_def)
+        batch_result = None
+        while get_current_datetime() - current_date < timedelta(seconds=MAIN_LOOP_TIMEOUT_SECONDS):
+            batch_result = next(sensor_iter, None)
+            if batch_result is None:
+                context.log.info("Received no batch result. Breaking.")
+                break
+            all_asset_events.extend(batch_result.asset_events)
+            latest_offset = batch_result.idx
+
+        if batch_result is not None:
+            new_cursor = DbtCloudPollingSensorCursor(
+                finished_at_lower_bound=finished_at_lower_bound,
+                finished_at_upper_bound=finished_at_upper_bound,
+                offset=latest_offset + 1,
+            )
+        else:
+            # We have completed iteration for this range
+            new_cursor = DbtCloudPollingSensorCursor(
+                finished_at_lower_bound=finished_at_upper_bound,
+                finished_at_upper_bound=None,
+                offset=0,
+            )
+
+        context.update_cursor(serialize_value(new_cursor))
+
+        context.log.info(
+            f"************"
+            f"Exiting sensor for dbt Cloud workspace for account {workspace.account_name}, "
+            f"project {workspace.project_name} and environment {workspace.environment_name}"
+            f"***********"
+        )
+        return SensorResult(
+            asset_events=sorted_asset_events(all_asset_events, repository_def),
+        )
+
+    return dbt_cloud_run_sensor

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -15,7 +15,6 @@ from dagster import (
     sensor,
 )
 from dagster._annotations import preview
-from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -991,7 +991,7 @@ def load_dbt_cloud_definitions() -> Definitions:
         )
     finally:
         # Clearing cache for other tests
-        workspace.load_specs.cache_clear()
+        workspace.load_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 def fully_loaded_repo_from_dbt_cloud_workspace() -> RepositoryDefinition:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -12,8 +12,8 @@ from dagster_dbt_tests.cloud_v2.conftest import (
     TEST_CUSTOM_ADHOC_JOB_NAME,
     TEST_DEFAULT_ADHOC_JOB_NAME,
     TEST_ENVIRONMENT_ID,
-    TEST_FINISHED_AT_END,
-    TEST_FINISHED_AT_START,
+    TEST_FINISHED_AT_LOWER_BOUND,
+    TEST_FINISHED_AT_UPPER_BOUND,
     TEST_JOB_ID,
     TEST_PROJECT_ID,
     TEST_REST_API_BASE_URL,
@@ -58,8 +58,8 @@ def test_basic_resource_request(
     client.get_runs_batch(
         project_id=TEST_PROJECT_ID,
         environment_id=TEST_ENVIRONMENT_ID,
-        finished_at_start=TEST_FINISHED_AT_START,
-        finished_at_end=TEST_FINISHED_AT_END,
+        finished_at_lower_bound=TEST_FINISHED_AT_LOWER_BOUND,
+        finished_at_upper_bound=TEST_FINISHED_AT_UPPER_BOUND,
     )
     client.list_run_artifacts(run_id=TEST_RUN_ID)
     client.get_account_details()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import responses
+from dagster import DagsterInstance, SensorResult, build_sensor_context
+from dagster._core.test_utils import freeze_time
+from dagster._serdes import deserialize_value
+from dagster_dbt.cloud_v2.sensor_builder import DbtCloudPollingSensorCursor
+
+from dagster_dbt_tests.cloud_v2.conftest import (
+    SAMPLE_EMPTY_BATCH_LIST_RUNS_RESPONSE,
+    TEST_REST_API_BASE_URL,
+    TEST_RUN_URL,
+    build_and_invoke_sensor,
+    fully_loaded_repo_from_dbt_cloud_workspace,
+)
+
+
+def test_asset_materializations(
+    init_load_context: None, instance: DagsterInstance, all_api_mocks: responses.RequestsMock
+) -> None:
+    """Test the asset materializations produced by a sensor."""
+    result, _ = build_and_invoke_sensor(
+        instance=instance,
+    )
+    assert len(result.asset_events) == 8
+    first_asset_mat = next(mat for mat in sorted(result.asset_events))
+
+    expected_metadata_keys = {
+        "dagster_dbt/completed_at_timestamp",
+        "unique_id",
+        "invocation_id",
+        "run_url",
+        "execution_duration",
+    }
+    assert set(first_asset_mat.metadata.keys()) == expected_metadata_keys
+
+    # Sanity check
+    assert first_asset_mat.metadata["unique_id"].value == "model.jaffle_shop.customers"
+    assert first_asset_mat.metadata["run_url"].value == TEST_RUN_URL
+
+
+def test_no_runs(
+    init_load_context: None,
+    instance: DagsterInstance,
+    sensor_no_runs_api_mocks: responses.RequestsMock,
+) -> None:
+    """Test the case with no runs."""
+    result, _ = build_and_invoke_sensor(
+        instance=instance,
+    )
+    assert len(result.asset_events) == 0
+
+
+_CALLCOUNT = [0]
+
+
+def _create_datetime_mocker(iter_times: list[datetime]):
+    def _mock_get_current_datetime() -> datetime:
+        the_time = iter_times[_CALLCOUNT[0]]
+        _CALLCOUNT[0] += 1
+        return the_time
+
+    return _mock_get_current_datetime
+
+
+def test_cursor(
+    init_load_context: None, instance: DagsterInstance, all_api_mocks: responses.RequestsMock
+) -> None:
+    """Test the case with no runs."""
+    with freeze_time(datetime(2021, 1, 1, tzinfo=timezone.utc)):
+        # First, run through a full successful iteration of the sensor.
+        # Expect time to move forward, and offset to be 0, since we completed iteration of all runs.
+        # Then, run through a partial iteration of the sensor. We mock get_current_datetime to return a time
+        # after timeout passes iteration start after the first call, meaning we should pause iteration.
+        repo_def = fully_loaded_repo_from_dbt_cloud_workspace()
+        sensor = next(iter(repo_def.sensor_defs))
+        context = build_sensor_context(repository_def=repo_def, instance=instance)
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+        assert context.cursor
+        new_cursor = deserialize_value(context.cursor, DbtCloudPollingSensorCursor)
+        assert (
+            new_cursor.finished_at_lower_bound
+            == datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
+        )
+        assert new_cursor.finished_at_upper_bound is None
+        assert new_cursor.offset == 0
+
+    # Now, we expect that we will not have completed iteration before we need to pause evaluation.
+    datetimes = [
+        datetime(2021, 2, 1, tzinfo=timezone.utc),  # set initial time
+        datetime(2021, 2, 1, 0, 0, 30, tzinfo=timezone.utc),  # initial iteration time
+        datetime(
+            2022, 2, 2, tzinfo=timezone.utc
+        ),  # second iteration time, at which iteration should be paused
+    ]
+    with patch(
+        "dagster._time._mockable_get_current_datetime", wraps=_create_datetime_mocker(datetimes)
+    ):
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+        new_cursor = deserialize_value(context.cursor, DbtCloudPollingSensorCursor)
+        # We didn't advance to the next effective timestamp, since we didn't complete iteration
+        assert (
+            new_cursor.finished_at_lower_bound
+            == datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
+        )
+        # We have not yet moved forward
+        assert (
+            new_cursor.finished_at_upper_bound
+            == datetime(2021, 2, 1, tzinfo=timezone.utc).timestamp()
+        )
+        assert new_cursor.offset == 1
+
+        _CALLCOUNT[0] = 0
+        # We weren't able to complete iteration, so we should pause iteration again
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+        new_cursor = deserialize_value(context.cursor, DbtCloudPollingSensorCursor)
+        assert (
+            new_cursor.finished_at_lower_bound
+            == datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
+        )
+        assert (
+            new_cursor.finished_at_upper_bound
+            == datetime(2021, 2, 1, tzinfo=timezone.utc).timestamp()
+        )
+        assert new_cursor.offset == 2
+
+        _CALLCOUNT[0] = 0
+        # For the last iteration, the batch result must be None
+        all_api_mocks.replace(
+            method_or_response=responses.GET,
+            url=f"{TEST_REST_API_BASE_URL}/runs",
+            json=SAMPLE_EMPTY_BATCH_LIST_RUNS_RESPONSE,
+        )
+
+        # Now it should finish iteration.
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+        new_cursor = deserialize_value(context.cursor, DbtCloudPollingSensorCursor)
+        assert (
+            new_cursor.finished_at_lower_bound
+            == datetime(2021, 2, 1, tzinfo=timezone.utc).timestamp()
+        )
+        assert new_cursor.finished_at_upper_bound is None
+        assert new_cursor.offset == 0

--- a/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
@@ -64,8 +64,8 @@ def test_cloud_job_apis(
     batched_runs, total_count = client.get_runs_batch(
         project_id=project_id,
         environment_id=environment_id,
-        finished_at_start=start_run_process,
-        finished_at_end=end_run_process,
+        finished_at_lower_bound=start_run_process,
+        finished_at_upper_bound=end_run_process,
     )
     assert total_count == 1
     assert len(batched_runs) == 1


### PR DESCRIPTION
## Summary & Motivation

This PR adds the polling sensor for the new dbt Cloud integration.  For now, only asset materializations are added to the sensor results.

This sensor is based on the polling sensor in `dagster-airlift`.

## How I Tested These Changes

New tests with BK.
