### PR TITLE
fix description of Hex integration

### DIFF
--- a/docs/docs/integrations/libraries/hex.md
+++ b/docs/docs/integrations/libraries/hex.md
@@ -18,6 +18,6 @@ sidebar_custom_props:
   community: true
 ---
 
-The community-supported `dagster-hex` package provides an integration with HashiCorp Nomad.
+The community-supported `dagster-hex` package provides an integration with Hex.
 
 For more information, see the [Dagster Community Integrations GitHub repository](https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-hex).


### PR DESCRIPTION
## Summary & Motivation
Docs for Hex integration incorrectly (copy/paste bug?) referred to Hashicorp Nomad instead of Hex.

## How I Tested These Changes
n/a
