### PR TITLE
[dagster-dbt][rfc] include compiled sql behind a flag for dbt models within the asset materialization metadata.

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -269,9 +269,7 @@ class DbtCliInvocation:
             ),
         )
 
-    def _stream_asset_events(
-        self,
-    ) -> Iterator[DbtDagsterEventType]:
+    def _stream_asset_events(self, include_compiled_sql: bool) -> Iterator[DbtDagsterEventType]:
         """Stream the dbt CLI events and convert them to Dagster events."""
         for event in self.stream_raw_events():
             yield from event.to_default_asset_events(
@@ -279,11 +277,13 @@ class DbtCliInvocation:
                 dagster_dbt_translator=self.dagster_dbt_translator,
                 context=self.context,
                 target_path=self.target_path,
+                include_compiled_sql=include_compiled_sql,
             )
 
     @public
     def stream(
         self,
+        include_compiled_sql: bool = False,
     ) -> "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult, AssetCheckEvaluation]]":
         """Stream the events from the dbt CLI process and convert them to Dagster events.
 
@@ -311,7 +311,7 @@ class DbtCliInvocation:
                     yield from dbt.cli(["run"], context=context).stream()
         """
         return DbtEventIterator(
-            self._stream_asset_events(),
+            self._stream_asset_events(include_compiled_sql),
             self,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/expected_compiled_stg_orders.txt
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/expected_compiled_stg_orders.txt
@@ -1,0 +1,23 @@
+ 
+```sql
+
+
+with source as (
+    select * from "master_jaffle_shop"."main"."raw_orders"
+
+),
+
+renamed as (
+
+    select
+        id as order_id,
+        user_id as customer_id,
+        order_date,
+        status
+
+    from source
+
+)
+
+select * from renamed
+```


### PR DESCRIPTION
## Summary & Motivation
Includes the compiled sql behind an optional (default false) flag to asset materializations of dbt models.
I think there's some level of debate as to whether this should actually exist on the asset def itself as opposed to the materialization. I settled on the materialization to avoid adding additional bulk to snapshots. But open to being convinced otherwise.

## How I Tested These Changes
A new tests that exercises the "flag on" path.
## Changelog
- [dagster-dbt] A new argument to `DbtCliInvocation.stream() called `include_compiled_sql`, which will attach the full compiled sql to the materialization event.
