### PR TITLE
output the duration of the slowest 10 dagster-dg tests in buildkite

### DIFF
--- a/python_modules/libraries/dagster-dg/tox.ini
+++ b/python_modules/libraries/dagster-dg/tox.ini
@@ -24,4 +24,4 @@ allowlist_externals =
   jsonschema
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  pytest ./dagster_dg_tests -vv {posargs}
+  pytest ./dagster_dg_tests -vv --durations 10 {posargs}

--- a/scripts/templates_create_dagster_package/tox.ini.tmpl
+++ b/scripts/templates_create_dagster_package/tox.ini.tmpl
@@ -19,4 +19,4 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -c ../../../pyproject.toml -vv ./{{ underscore_name }}_tests {posargs}
+  pytest -c ../../../pyproject.toml -vv ./{{ underscore_name }}_tests --durations 10 {posargs}


### PR DESCRIPTION
## Summary & Motivation
To help understand where speedup opportunities can be found.
