### PR TITLE
[RFC] Definitions.map_asset_specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,14 +1,16 @@
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union
 
 from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import deprecated, preview, public
+from dagster._core.definitions import AssetSelection
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
+from dagster._core.definitions.asset_spec import AssetSpec, map_asset_specs
 from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.decorators import repository
@@ -37,7 +39,7 @@ from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
-from dagster._record import IHaveNew, copy, record_custom
+from dagster._record import IHaveNew, copy, record_custom, replace
 from dagster._utils.cached_method import cached_method
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -719,3 +721,77 @@ class Definitions(IHaveNew):
                 **normalized_metadata,
             },
         )
+
+    @public
+    @preview
+    def map_asset_specs(
+        self,
+        *,
+        func: Callable[[AssetSpec], AssetSpec],
+        selection: Optional[CoercibleToAssetSelection] = None,
+    ) -> "Definitions":
+        """Map a function over the included AssetSpecs or AssetsDefinitions in this Definitions object, replacing specs in the sequence
+        or specs in an AssetsDefinitions with the result of the function.
+
+        Args:
+            func (Callable[[AssetSpec], AssetSpec]): The function to apply to each AssetSpec.
+            selection (Optional[Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]]): An asset selection to narrow down the set of assets to apply the function to. If not provided, applies to all assets.
+
+        Returns:
+            Definitions: A Definitions object where the AssetSpecs have been replaced with the result of the function where the selection applies.
+
+        Examples:
+            .. code-block:: python
+
+                import dagster as dg
+
+                my_spec = dg.AssetSpec("asset1")
+
+                @dg.asset
+                def asset2(_): ...
+
+
+                defs = Definitions(
+                    assets=[asset1, asset2]
+                )
+
+                # Applies to asset1 and asset2
+                mapped_defs = defs.map_asset_specs(
+                    func=lambda s: s.merge_attributes(metadata={"new_key": "new_value"}),
+                )
+
+                # Applies only to asset1
+                mapped_defs = defs.map_asset_specs(
+                    func=lambda s: s.replace_attributes(metadata={"new_key": "new_value"}),
+                    selection="asset1",
+                )
+
+        """
+        selection = selection or AssetSelection.all(include_sources=True)
+        if isinstance(selection, str):
+            selection = AssetSelection.from_string(selection, include_sources=True)
+        else:
+            selection = AssetSelection.from_coercible(selection)
+        target_keys = selection.resolve(self.get_asset_graph())
+        non_spec_asset_types = {
+            type(d) for d in self.assets or [] if not isinstance(d, (AssetsDefinition, AssetSpec))
+        }
+        if non_spec_asset_types:
+            raise DagsterInvariantViolationError(
+                "Can only map over AssetSpec or AssetsDefinition objects. "
+                "Received objects of types: "
+                f"{non_spec_asset_types}."
+            )
+        mappable = iter(
+            d for d in self.assets or [] if isinstance(d, (AssetsDefinition, AssetSpec))
+        )
+        mapped_assets = map_asset_specs(
+            lambda spec: func(spec) if spec.key in target_keys else spec,
+            mappable,
+        )
+
+        assets = [
+            *mapped_assets,
+            *[d for d in self.assets or [] if not isinstance(d, (AssetsDefinition, AssetSpec))],
+        ]
+        return replace(self, assets=assets)

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -7,15 +7,12 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.asset_spec import AssetSpec, map_asset_specs
-from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._record import replace
 from dagster.components.resolved.base import Resolvable, resolve_fields
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.model import Injectable, Injected, Model, Resolver
@@ -167,22 +164,9 @@ def apply_post_processor_to_spec(
 def apply_post_processor_to_defs(
     model: AssetPostProcessorModel, defs: Definitions, context: ResolutionContext
 ) -> Definitions:
-    target_selection = AssetSelection.from_string(model.target, include_sources=True)
-    target_keys = target_selection.resolve(defs.get_asset_graph())
-
-    mappable = [d for d in defs.assets or [] if isinstance(d, (AssetsDefinition, AssetSpec))]
-    mapped_assets = map_asset_specs(
-        lambda spec: apply_post_processor_to_spec(model, spec, context)
-        if spec.key in target_keys
-        else spec,
-        mappable,
+    return defs.map_asset_specs(
+        selection=model.target, func=lambda spec: apply_post_processor_to_spec(model, spec, context)
     )
-
-    assets = [
-        *mapped_assets,
-        *[d for d in defs.assets or [] if not isinstance(d, (AssetsDefinition, AssetSpec))],
-    ]
-    return replace(defs, assets=assets)
 
 
 def resolve_schema_to_post_processor(


### PR DESCRIPTION
## Summary & Motivation
Adds a top-level "map_asset_specs" method to Definitions, which takes in an optional asset selection and an AssetSpec -> AssetSpec transformation function.

The idea is to enable last-mile transformation of asset specs on a Definitions object; similar to what `asset_post_processors` does, but for non-components Definitions. In fact, most of this implementation is ripped directly from the asset_post_processors code path, and we reimplement that on top of this functionality.

## How I Tested These Changes
- Additional test_definitions_class.py tests.
## Changelog
- A `Definitions.map_asset_specs` method, which allows for transforming asset specs from any passed in AssetSpec or AssetsDefinition objects which match an asset selection.
