### PR TITLE
Fix a bug in the pyspark guide example code

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/pyspark/dagster_code.py
@@ -78,7 +78,7 @@ def pipes_spark_asset(context: dg.AssetExecutionContext):
             check=True,
         )
 
-        return session.get_results()
+    return session.get_results()
 
 
 # start_definitions_marker


### PR DESCRIPTION
## Summary & Motivation

It's important to return the result after closing the session, to avoid [this race condition](https://github.com/dagster-io/dagster/blob/b985d57aadc7d9bf88d8dcbd32b16d3487e433cc/python_modules/dagster/dagster/_core/pipes/utils.py#L706-L713)

## How I Tested These Changes

## Changelog

Fix a bug in example code for pyspark
