### PR TITLE
[asset health] asset check health status calculations

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -602,7 +602,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         # if SLA violated with error, degraded
         return GrapheneAssetHealthStatus.UNKNOWN
 
-    def resolve_assetHealth(self, graphene_info: ResolveInfo):
+    async def resolve_assetHealth(self, graphene_info: ResolveInfo):
         if not graphene_info.context.instance.dagster_observe_supported():
             return None
         return GrapheneAssetHealth(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -605,9 +605,8 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_assetHealth(self, graphene_info: ResolveInfo):
         if not graphene_info.context.instance.dagster_observe_supported():
             return None
-        check_status = await self.get_asset_check_status_for_asset_health(graphene_info)
         return GrapheneAssetHealth(
-            asset_check_status=check_status,
+            asset_check_status=await self.get_asset_check_status_for_asset_health(graphene_info),
             materializationStatus=self.get_materialization_status_for_asset_health(graphene_info),
             freshnessStatus=self.get_freshness_status_for_asset_health(graphene_info),
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -606,7 +606,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         if not graphene_info.context.instance.dagster_observe_supported():
             return None
         return GrapheneAssetHealth(
-            asset_check_status=await self.get_asset_check_status_for_asset_health(graphene_info),
+            assetChecksStatus=await self.get_asset_check_status_for_asset_health(graphene_info),
             materializationStatus=self.get_materialization_status_for_asset_health(graphene_info),
             freshnessStatus=self.get_freshness_status_for_asset_health(graphene_info),
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -578,7 +578,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             )
             for summary_record in asset_check_summary_records:
                 if summary_record is None or summary_record.last_check_execution_record is None:
-                    # the check has never been executed
+                    # the check has never been executed.
                     all_checks_executed = False
                     continue
 
@@ -628,7 +628,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                     # degraded health anyway.
                     check_failure_severities.append(AssetCheckSeverity.ERROR)
 
-            if len(check_statuses) == 0 or not all_checks_executed:
+            if len(check_statuses) == 0:
                 # checks have never been executed
                 return GrapheneAssetHealthStatus.UNKNOWN
 
@@ -646,6 +646,11 @@ class GrapheneAssetNode(graphene.ObjectType):
                 return GrapheneAssetHealthStatus.DEGRADED
             # since we are only looking at the latest completed execution for each check, if there
             # are no failed checks, then all checks must have succeeded
+            if not all_checks_executed:
+                # if any check has never been executed, we report this as unknown, even if other checks
+                # have passed
+                return GrapheneAssetHealthStatus.UNKNOWN
+            # all checks must have executed and passed
             return GrapheneAssetHealthStatus.HEALTHY
 
     def get_freshness_status_for_asset_health(self, graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -551,6 +551,18 @@ class GrapheneAssetNode(graphene.ObjectType):
         return GrapheneAssetHealthStatus.UNKNOWN
 
     async def get_asset_check_status_for_asset_health(self, graphene_info: ResolveInfo):
+        """Computes the health indicator for the asset checks for the assets. Follows these rules:
+        HEALTHY - the latest completed execution for every check is a success.
+        WARNING - the latest completed execution for any asset check failed with severity WARN
+            (and no checks failed with severity ERROR). Or some checks have been successfully
+            executed, but others have never been executed.
+        DEGRADED - the latest completed execution for any asset check failed with severity ERROR.
+        UNKNOWN - the asset checks have never been executed.
+        NOT_APPLICABLE - the asset has no asset checks defined.
+
+        Note: the latest completed execution for each check may not have executed based on the
+        most recent materialization of the asset.
+        """
         remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(
             self._asset_node_snap.asset_key
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -554,10 +554,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         """Computes the health indicator for the asset checks for the assets. Follows these rules:
         HEALTHY - the latest completed execution for every check is a success.
         WARNING - the latest completed execution for any asset check failed with severity WARN
-            (and no checks failed with severity ERROR). Or some checks have been successfully
-            executed, but others have never been executed.
+            (and no checks failed with severity ERROR).
         DEGRADED - the latest completed execution for any asset check failed with severity ERROR.
-        UNKNOWN - the asset checks have never been executed.
+        UNKNOWN - any asset checks has never been executed.
         NOT_APPLICABLE - the asset has no asset checks defined.
 
         Note: the latest completed execution for each check may not have executed based on the
@@ -629,7 +628,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                     # degraded health anyway.
                     check_failure_severities.append(AssetCheckSeverity.ERROR)
 
-            if len(check_statuses) == 0:
+            if len(check_statuses) == 0 or not all_checks_executed:
                 # checks have never been executed
                 return GrapheneAssetHealthStatus.UNKNOWN
 
@@ -647,11 +646,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 return GrapheneAssetHealthStatus.DEGRADED
             # since we are only looking at the latest completed execution for each check, if there
             # are no failed checks, then all checks must have succeeded
-            if not all_checks_executed:
-                # all executed checks succeeded, but some checks have never been executed, so we consider this a warning
-                return GrapheneAssetHealthStatus.WARNING
-            else:
-                return GrapheneAssetHealthStatus.HEALTHY
+            return GrapheneAssetHealthStatus.HEALTHY
 
     def get_freshness_status_for_asset_health(self, graphene_info: ResolveInfo):
         # if SLA is met, healthy

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -602,16 +602,9 @@ class GrapheneAssetNode(graphene.ObjectType):
             if not all_checks_executed:
                 # if some checks have no planned execution for the latest materialization, we show that as an warning
                 return GrapheneAssetHealthStatus.WARNING
-            if all(
-                status == AssetCheckExecutionResolvedStatus.IN_PROGRESS
-                or status == AssetCheckExecutionResolvedStatus.SKIPPED
-                for status in check_statuses
-            ):
-                return GrapheneAssetHealthStatus.UNKNOWN
-            else:
-                # some asset checks have succeeded. Some checks may be skipped or still in progress,
-                # but we show the more descriptive status in the meantime
-                return GrapheneAssetHealthStatus.HEALTHY
+            # the checks are some combination of IN_PROGRESS, SKIPPED, and SUCCEEDED
+            # we display this as HEALTHY in the UI since no checks are in a failed state
+            return GrapheneAssetHealthStatus.HEALTHY
 
     def get_freshness_status_for_asset_health(self, graphene_info: ResolveInfo):
         # if SLA is met, healthy

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -23,6 +23,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
     class Meta:
         name = "AssetHealth"
 
+    def __init__(self, asset_check_status: GrapheneAssetHealthStatus):
+        self.assetChecksStatus = asset_check_status
+
     def resolve_assetHealth(self, graphene_info: ResolveInfo):
         if not graphene_info.context.instance.dagster_observe_supported():
             return GrapheneAssetHealthStatus.UNKNOWN

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -23,9 +23,6 @@ class GrapheneAssetHealth(graphene.ObjectType):
     class Meta:
         name = "AssetHealth"
 
-    def __init__(self, asset_check_status: GrapheneAssetHealthStatus):
-        self.assetChecksStatus = asset_check_status
-
     def resolve_assetHealth(self, graphene_info: ResolveInfo):
         if not graphene_info.context.instance.dagster_observe_supported():
             return GrapheneAssetHealthStatus.UNKNOWN

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -489,56 +489,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.2db9cd385a1c02ba97b38cd51002d65fef8593f2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_with_automation_condition\": {}, \"asset_with_compute_storage_kinds\": {\"config\": {}}, \"asset_with_custom_automation_condition\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"concurrency_asset\": {}, \"concurrency_graph_asset\": {\"ops\": {\"concurrency_op_1\": {}, \"concurrency_op_2\": {}}}, \"concurrency_multi_asset\": {\"config\": {}}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"integers_asset\": {}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"multi_asset_with_kinds\": {\"config\": {}}, \"multi_run_backfill_policy_asset\": {}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"not_included_asset\": {}, \"output_then_hang_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}, \"upstream_static_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}, \"yield_partition_materialization\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.c71ef76e3de43bf6c3f361fbe08a4075e718a568"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.2db9cd385a1c02ba97b38cd51002d65fef8593f2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.31ebade63b77a8095e9f78414e75445567b90463": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -823,30 +773,57 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+        "Shape.a4a835ae2795d4165e07afe5917f852d14e0d66d": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
           "fields": [
             {
               "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_3_asset_3_check\": {}, \"asset_3_asset_3_other_check\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_with_automation_condition\": {}, \"asset_with_compute_storage_kinds\": {\"config\": {}}, \"asset_with_custom_automation_condition\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"concurrency_asset\": {}, \"concurrency_graph_asset\": {\"ops\": {\"concurrency_op_1\": {}, \"concurrency_op_2\": {}}}, \"concurrency_multi_asset\": {\"config\": {}}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"integers_asset\": {}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"multi_asset_with_kinds\": {\"config\": {}}, \"multi_run_backfill_policy_asset\": {}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"not_included_asset\": {}, \"output_then_hang_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}, \"upstream_static_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}, \"yield_partition_materialization\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.a67285ee387ede3835e15c3dec165c9d63bd54fb"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
               "default_provided": false,
               "default_value_as_json_str": null,
-              "description": null,
+              "description": "Configure how shared resources are implemented within a run.",
               "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
             }
           ],
           "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "key": "Shape.a4a835ae2795d4165e07afe5917f852d14e0d66d",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.c71ef76e3de43bf6c3f361fbe08a4075e718a568": {
+        "Shape.a67285ee387ede3835e15c3dec165c9d63bd54fb": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -885,6 +862,24 @@
               "description": null,
               "is_required": false,
               "name": "asset_3",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3_asset_3_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3_asset_3_other_check",
               "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
             },
             {
@@ -1429,7 +1424,30 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.c71ef76e3de43bf6c3f361fbe08a4075e718a568",
+          "key": "Shape.a67285ee387ede3835e15c3dec165c9d63bd54fb",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -1706,6 +1724,48 @@
           "is_dynamic_mapped": false,
           "solid_def_name": "asset_3",
           "solid_name": "asset_3",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_3",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_3"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_3_asset_3_check",
+          "solid_name": "asset_3_asset_3_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_3",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_3"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_3_asset_3_other_check",
+          "solid_name": "asset_3_asset_3_other_check",
           "tags": {}
         },
         {
@@ -2590,7 +2650,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.2db9cd385a1c02ba97b38cd51002d65fef8593f2"
+        "root_config_key": "Shape.a4a835ae2795d4165e07afe5917f852d14e0d66d"
       }
     ],
     "name": "__ASSET_JOB",
@@ -2870,6 +2930,74 @@
             }
           ],
           "name": "asset_3",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_3"
+            }
+          ],
+          "name": "asset_3_asset_3_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_3"
+            }
+          ],
+          "name": "asset_3_asset_3_other_check",
           "output_def_snaps": [
             {
               "__class__": "OutputDefSnap",
@@ -35352,7 +35480,7 @@
   'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
 # ---
 # name: test_all_snapshot_ids[1]
-  '8484c9f8574994fa288e354ed57a67102974452b'
+  '35491f28517bc6d696caaa82881cafd410837925'
 # ---
 # name: test_all_snapshot_ids[20]
   '''
@@ -49529,56 +49657,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.3862a2262e4d580a2557af8c0dd5b11482e407da": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.614a7cc3a33bd941ce0721f63eb229cc6e7a1719"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.3862a2262e4d580a2557af8c0dd5b11482e407da",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -49651,56 +49729,6 @@
           ],
           "given_name": null,
           "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.614a7cc3a33bd941ce0721f63eb229cc6e7a1719": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1_my_check",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_3",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.614a7cc3a33bd941ce0721f63eb229cc6e7a1719",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -49794,6 +49822,56 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.a5d7e8f66f2b2df236d1ac251b1056c59fc0b60a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_3_asset_3_check\": {}, \"asset_3_asset_3_other_check\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.f2130943a0dc381df93f3fd16fa0cfc38f5e565b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.a5d7e8f66f2b2df236d1ac251b1056c59fc0b60a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -49847,6 +49925,74 @@
           ],
           "given_name": null,
           "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f2130943a0dc381df93f3fd16fa0cfc38f5e565b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3_asset_3_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3_asset_3_other_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f2130943a0dc381df93f3fd16fa0cfc38f5e565b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -50059,6 +50205,48 @@
           "solid_def_name": "asset_3",
           "solid_name": "asset_3",
           "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_3",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_3"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_3_asset_3_check",
+          "solid_name": "asset_3_asset_3_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_3",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_3"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_3_asset_3_other_check",
+          "solid_name": "asset_3_asset_3_other_check",
+          "tags": {}
         }
       ]
     },
@@ -50130,7 +50318,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.3862a2262e4d580a2557af8c0dd5b11482e407da"
+        "root_config_key": "Shape.a5d7e8f66f2b2df236d1ac251b1056c59fc0b60a"
       }
     ],
     "name": "failure_assets_job",
@@ -50273,6 +50461,74 @@
           ],
           "required_resource_keys": [],
           "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_3"
+            }
+          ],
+          "name": "asset_3_asset_3_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_3"
+            }
+          ],
+          "name": "asset_3_asset_3_other_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
         }
       ]
     },
@@ -50281,7 +50537,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[45]
-  'f07b5f3e9fe1aaec2d455ef01bac50f38db70300'
+  '797927dc38e2e944aa962af5ee2558cd34ff7ed5'
 # ---
 # name: test_all_snapshot_ids[46]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
@@ -246,6 +246,54 @@
         dict({
           '__typename': 'UsedSolid',
           'definition': dict({
+            'name': 'asset_3_asset_3_check',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_3_asset_3_check',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': 'failure_assets_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_3_asset_3_check',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
+            'name': 'asset_3_asset_3_other_check',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_3_asset_3_other_check',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': 'failure_assets_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'asset_3_asset_3_other_check',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
             'name': 'asset_one',
           }),
           'invocations': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1963,6 +1963,28 @@ def my_check(asset_1):
     )
 
 
+@asset_check(asset=asset_3, description="asset_3 check", blocking=True)
+def asset_3_check(asset_3):
+    return AssetCheckResult(
+        passed=True,
+        metadata={
+            "foo": "baz",
+            "baz": "bar",
+        },
+    )
+
+
+@asset_check(asset=asset_3, description="asset_3 second check", blocking=True)
+def asset_3_other_check(asset_3):
+    return AssetCheckResult(
+        passed=True,
+        metadata={
+            "foo": "baz",
+            "baz": "bar",
+        },
+    )
+
+
 @asset(check_specs=[AssetCheckSpec(asset="check_in_op_asset", name="my_check")])
 def check_in_op_asset():
     yield Output(1)
@@ -2193,9 +2215,7 @@ def define_resources():
 
 
 def define_asset_checks():
-    return [
-        my_check,
-    ]
+    return [my_check, asset_3_check, asset_3_other_check]
 
 
 asset_jobs = define_asset_jobs()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -376,9 +376,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
             },
             {
                 "assetKey": {"path": ["asset_3"]},
-                "assetChecksOrError": {
-                    "checks": [{"name": "asset_3_check"}, {"name": "asset_3_other_check"}]
-                },
+                "assetChecksOrError": {"checks": [{"name": "asset_3_check"}]},
             },
             {
                 "assetKey": {"path": ["check_in_op_asset"]},

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -346,6 +346,12 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 "assetChecksOrError": {"checks": [{"name": "my_check"}]},
             },
             {
+                "assetKey": {"path": ["asset_3"]},
+                "assetChecksOrError": {
+                    "checks": [{"name": "asset_3_check"}, {"name": "asset_3_other_check"}]
+                },
+            },
+            {
                 "assetKey": {"path": ["check_in_op_asset"]},
                 "assetChecksOrError": {"checks": [{"name": "my_check"}]},
             },
@@ -367,6 +373,12 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
             {
                 "assetKey": {"path": ["asset_1"]},
                 "assetChecksOrError": {"checks": [{"name": "my_check"}]},
+            },
+            {
+                "assetKey": {"path": ["asset_3"]},
+                "assetChecksOrError": {
+                    "checks": [{"name": "asset_3_check"}, {"name": "asset_3_other_check"}]
+                },
             },
             {
                 "assetKey": {"path": ["check_in_op_asset"]},

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -2829,7 +2829,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result.data["assetNodes"]
 
         for a in result.data["assetNodes"]:
-            if a["assetKey"]["path"] in [["asset_1"], ["one"], ["check_in_op_asset"]]:
+            if a["assetKey"]["path"] in [["asset_1"], ["one"], ["check_in_op_asset"], ["asset_3"]]:
                 assert a["hasAssetChecks"] is True
             else:
                 assert a["hasAssetChecks"] is False, f"Asset {a['assetKey']} has asset checks"


### PR DESCRIPTION
## Summary & Motivation
Computes the health status for the asset checks for an asset
Rules:
- `HEALTHY` - the latest completed execution for every check is a success. Note the latest completed execution for each check may not have executed based on the most recent materialization of the asset
- `WARNING` -  the latest completed execution for any asset check failed with severity `WARN`(and no checks failed with severity `ERROR`). Note the latest completed execution for each check may not have executed based on the most recent materialization of the asset
- `DEGRADED` - the latest completed execution for any asset check failed with severity `ERROR`. Note the latest completed execution for each check may not have executed based on the most recent materialization of the asset    
- `UNKNOWN` - any asset checks have never been executed (unless some checks have failed, then `WARNING` or `DEGRADED` status applies)
- `NOT_APPLICABLE` - the asset has no asset checks defined

tests in https://github.com/dagster-io/internal/pull/14690

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
