### PR TITLE
[dagster-dbt] Support total_count in DbtCloudWorkspaceClient.get_runs_batch

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -110,7 +110,11 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 )
                 response.raise_for_status()
                 resp_dict = response.json()
-                return resp_dict["data"] if "data" in resp_dict and not include_full_response else resp_dict
+                return (
+                    resp_dict["data"]
+                    if "data" in resp_dict and not include_full_response
+                    else resp_dict
+                )
             except RequestException as e:
                 self._log.error(
                     f"Request to dbt Cloud API failed for url {url} with method {method} : {e}"
@@ -279,12 +283,9 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 "finished_at__range": f"""["{finished_at_start.isoformat()}", "{finished_at_end.isoformat()}"]""",
                 "order_by": "finished_at",
             },
-            include_full_response=True
+            include_full_response=True,
         )
-        data = cast(
-            Sequence[Mapping[str, Any]],
-            resp["data"]
-        )
+        data = cast(Sequence[Mapping[str, Any]], resp["data"])
         total_count = resp["extra"]["pagination"]["total_count"]
         return data, total_count
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -254,7 +254,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
         finished_at_end: datetime.datetime,
         offset: int = 0,
     ) -> tuple[Sequence[Mapping[str, Any]], int]:
-        """Retrieves a batch of dbt cloud runs from a dbt Cloud workspace for a given project and environment.
+        """Retrieves a batch of dbt Cloud runs from a dbt Cloud workspace for a given project and environment.
 
         Args:
             project_id (str): The dbt Cloud Project ID. You can retrieve this value from the
@@ -268,7 +268,9 @@ class DbtCloudWorkspaceClient(DagsterModel):
             offset (str): The pagination offset for this request.
 
         Returns:
-            List[Dict[str, Any]]: A List of parsed json data from the response to this request
+            tuple[List[Dict[str, Any]], int]: A tuple containing:
+                - a list of run details as parsed json data from the response to this request;
+                - the total number of runs for the given parameters.
         """
         resp = self._make_request(
             method="get",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -93,6 +93,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
         data: Optional[Mapping[str, Any]] = None,
         params: Optional[Mapping[str, Any]] = None,
         session_attr: str = "_get_session",
+        include_full_response: bool = False,
     ) -> Mapping[str, Any]:
         url = f"{base_url}/{endpoint}"
 
@@ -109,7 +110,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 )
                 response.raise_for_status()
                 resp_dict = response.json()
-                return resp_dict["data"] if "data" in resp_dict else resp_dict
+                return resp_dict["data"] if "data" in resp_dict and not include_full_response else resp_dict
             except RequestException as e:
                 self._log.error(
                     f"Request to dbt Cloud API failed for url {url} with method {method} : {e}"
@@ -248,7 +249,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
         finished_at_start: datetime.datetime,
         finished_at_end: datetime.datetime,
         offset: int = 0,
-    ) -> Sequence[Mapping[str, Any]]:
+    ) -> tuple[Sequence[Mapping[str, Any]], int]:
         """Retrieves a batch of dbt cloud runs from a dbt Cloud workspace for a given project and environment.
 
         Args:
@@ -265,23 +266,27 @@ class DbtCloudWorkspaceClient(DagsterModel):
         Returns:
             List[Dict[str, Any]]: A List of parsed json data from the response to this request
         """
-        return cast(
-            Sequence[Mapping[str, Any]],
-            self._make_request(
-                method="get",
-                endpoint="runs",
-                base_url=self.api_v2_url,
-                params={
-                    "account_id": self.account_id,
-                    "environment_id": environment_id,
-                    "project_id": project_id,
-                    "limit": DAGSTER_DBT_CLOUD_BATCH_RUNS_REQUEST_LIMIT,
-                    "offset": offset,
-                    "finished_at__range": f"""["{finished_at_start.isoformat()}", "{finished_at_end.isoformat()}"]""",
-                    "order_by": "finished_at",
-                },
-            ),
+        resp = self._make_request(
+            method="get",
+            endpoint="runs",
+            base_url=self.api_v2_url,
+            params={
+                "account_id": self.account_id,
+                "environment_id": environment_id,
+                "project_id": project_id,
+                "limit": DAGSTER_DBT_CLOUD_BATCH_RUNS_REQUEST_LIMIT,
+                "offset": offset,
+                "finished_at__range": f"""["{finished_at_start.isoformat()}", "{finished_at_end.isoformat()}"]""",
+                "order_by": "finished_at",
+            },
+            include_full_response=True
         )
+        data = cast(
+            Sequence[Mapping[str, Any]],
+            resp["data"]
+        )
+        total_count = resp["extra"]["pagination"]["total_count"]
+        return data, total_count
 
     def get_run_details(self, run_id: int) -> Mapping[str, Any]:
         """Retrieves the details of a given dbt Cloud Run.

--- a/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/dagster_dbt_cloud_kitchen_sink_tests/test_client_methods.py
@@ -61,12 +61,13 @@ def test_cloud_job_apis(
     assert run.id == polled_run.id
     assert polled_run.status == DbtCloudJobRunStatusType.SUCCESS
 
-    batched_runs = client.get_runs_batch(
+    batched_runs, total_count = client.get_runs_batch(
         project_id=project_id,
         environment_id=environment_id,
         finished_at_start=start_run_process,
         finished_at_end=end_run_process,
     )
+    assert total_count == 1
     assert len(batched_runs) == 1
 
     batched_run = DbtCloudRun.from_run_details(run_details=next(iter(batched_runs)))


### PR DESCRIPTION
## Summary & Motivation

Updates the `get_runs_batch` method to return the total count of runs. `_make_request` is also updated to support this feature. This is required for the polling sensor.

## How I Tested These Changes

Updated test with BK.

