### PR TITLE
[docs] Note that DefaultSensorStatus can be STOPPED

### DIFF
--- a/docs/docs/guides/automate/sensors/index.md
+++ b/docs/docs/guides/automate/sensors/index.md
@@ -43,7 +43,7 @@ If the sensor finds new files, it starts a run of `my_job`. If not, it skips the
 :::tip
 Unless a sensor has a `default_status` of `DefaultSensorStatus.RUNNING`, it won't be enabled when first deployed to a Dagster instance. To find and enable the sensor, click **Automation > Sensors** in the Dagster UI.
 
-To explicitly set a sensor to be disabled, you can use `DefaultSensorStatus.STOPPED`. 
+To explicitly disable a sensor, you can use `DefaultSensorStatus.STOPPED`. 
 :::
 
 ## Customizing intervals between evaluations

--- a/docs/docs/guides/automate/sensors/index.md
+++ b/docs/docs/guides/automate/sensors/index.md
@@ -42,6 +42,8 @@ If the sensor finds new files, it starts a run of `my_job`. If not, it skips the
 
 :::tip
 Unless a sensor has a `default_status` of `DefaultSensorStatus.RUNNING`, it won't be enabled when first deployed to a Dagster instance. To find and enable the sensor, click **Automation > Sensors** in the Dagster UI.
+
+To explicitly set a sensor to be disabled, you can use `DefaultSensorStatus.STOPPED`. 
 :::
 
 ## Customizing intervals between evaluations


### PR DESCRIPTION
## Summary & Motivation
We don't document anywhere else what this value can also be so users would have to hunt it down in the source code: https://github.com/dagster-io/dagster/blob/23d649b22c4f60b1ee60d51d331bcb076ae20cb8/python_modules/dagster/dagster/_core/definitions/sensor_definition.py#L78

## How I Tested These Changes
👀