### PR TITLE
[dg] Rename DefsModuleComponent

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/18-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/18-dg-list-component-types.txt
@@ -8,7 +8,7 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                                                                      │ arbitrary set   │
 │                                                                      │ of Dagster      │
 │                                                                      │ definitions.    │
-│ dagster_components.dagster.DefsModuleComponent                       │ Wraps a         │
+│ dagster_components.dagster.DefsFolderComponent                       │ Wraps a         │
 │                                                                      │ DefsModule to   │
 │                                                                      │ allow the       │
 │                                                                      │ addition of     │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-component-types.txt
@@ -7,7 +7,7 @@ dg list component-type
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
-│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│ dagster_components.dagster.DefsFolderComponent                      │ Wraps a          │
 │                                                                     │ DefsModule to    │
 │                                                                     │ allow the        │
 │                                                                     │ addition of      │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-component-types.txt
@@ -8,7 +8,7 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                                                                      │ arbitrary set   │
 │                                                                      │ of Dagster      │
 │                                                                      │ definitions.    │
-│ dagster_components.dagster.DefsModuleComponent                       │ Wraps a         │
+│ dagster_components.dagster.DefsFolderComponent                       │ Wraps a         │
 │                                                                      │ DefsModule to   │
 │                                                                      │ allow the       │
 │                                                                      │ addition of     │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
@@ -8,7 +8,7 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
-│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│ dagster_components.dagster.DefsFolderComponent                      │ Wraps a          │
 │                                                                     │ DefsModule to    │
 │                                                                     │ allow the        │
 │                                                                     │ addition of      │

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/8-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/8-dg-list-component-types.txt
@@ -8,7 +8,7 @@ Using /.../my-existing-project/.venv/bin/dagster-components
 │                                                                     │ arbitrary set of │
 │                                                                     │ Dagster          │
 │                                                                     │ definitions.     │
-│ dagster_components.dagster.DefsModuleComponent                      │ Wraps a          │
+│ dagster_components.dagster.DefsFolderComponent                      │ Wraps a          │
 │                                                                     │ DefsModule to    │
 │                                                                     │ allow the        │
 │                                                                     │ addition of      │

--- a/python_modules/libraries/dagster-components/dagster_components/dagster.py
+++ b/python_modules/libraries/dagster-components/dagster_components/dagster.py
@@ -1,7 +1,7 @@
 from dagster_components.lib.definitions_component.component import (
     DefinitionsComponent as DefinitionsComponent,
 )
-from dagster_components.lib.defs_module.component import DefsModuleComponent as DefsModuleComponent
+from dagster_components.lib.defs_module.component import DefsFolderComponent as DefsFolderComponent
 from dagster_components.lib.pipes_subprocess_script_collection import (
     PipesSubprocessScriptCollectionComponent as PipesSubprocessScriptCollectionComponent,
 )

--- a/python_modules/libraries/dagster-components/dagster_components/lib/defs_module/component.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/defs_module/component.py
@@ -26,7 +26,7 @@ class ResolvedDefsModuleArgs(ResolvedFrom[DefsModuleArgsModel]):
     asset_post_processors: Annotated[Sequence[AssetPostProcessor], Resolver.from_annotation()]
 
 
-class DefsModuleComponent(Component):
+class DefsFolderComponent(Component):
     """Wraps a DefsModule to allow the addition of arbitrary attributes."""
 
     def __init__(

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dagster.DefsModuleComponent
+type: dagster_components.dagster.DefsFolderComponent
 
 attributes:
   asset_post_processors:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/defs_object/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dagster.DefsModuleComponent
+type: dagster_components.dagster.DefsFolderComponent
 
 attributes:
   asset_post_processors:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dagster.DefsModuleComponent
+type: dagster_components.dagster.DefsFolderComponent
 
 attributes:
   asset_post_processors:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/component.yaml
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/integration_test_defs/definitions_autoload/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/component.yaml
@@ -1,4 +1,4 @@
-type: dagster_components.dagster.DefsModuleComponent
+type: dagster_components.dagster.DefsFolderComponent
 
 attributes:
   asset_post_processors:


### PR DESCRIPTION
## Summary & Motivation

As title

## How I Tested These Changes

## Changelog

The `DefsModuleComponent` has been renamed to `DefsFolderComponent`.
