### PR TITLE
Sanitize step keys before using them as tags in the ECS executor

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -13,6 +13,11 @@ def sanitize_family(family):
     return re.sub(r"[^\w^\-]", "", family)[:255]
 
 
+def sanitize_tag(tag):
+    # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html
+    return re.sub("[^A-Za-z0-9_]", "-", tag)[:255].strip("-")
+
+
 def _get_family_hash(name):
     m = hashlib.sha1()
     m.update(name.encode("utf-8"))

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/executor_tests/test_executor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/executor_tests/test_executor.py
@@ -167,6 +167,55 @@ def test_executor_init(instance_cm: Callable[..., ContextManager[DagsterInstance
             assert env_var in run_container_overrides["environment"]
 
 
+def test_executor_sanitized_step_key(instance_cm: Callable[..., ContextManager[DagsterInstance]]):
+    with instance_cm() as instance:
+        recon_job = reconstructable(bar)
+        loadable_target_origin = LoadableTargetOrigin(python_file=__file__, attribute="bar_repo")
+
+        executor = _get_executor(
+            instance,
+            reconstructable(bar),
+        )
+
+        with in_process_test_workspace(
+            instance, loadable_target_origin, container_image="testing/dagster"
+        ) as workspace:
+            location = workspace.get_code_location(workspace.code_location_names[0])
+            repo_handle = RepositoryHandle.from_location(
+                repository_name="bar_repo",
+                code_location=location,
+            )
+            fake_remote_job = remote_job_from_recon_job(
+                recon_job,
+                op_selection=None,
+                repository_handle=repo_handle,
+            )
+
+            run = create_run_for_test(
+                instance,
+                job_name="bar",
+                remote_job_origin=fake_remote_job.get_remote_origin(),
+                job_code_origin=recon_job.get_python_origin(),
+            )
+            step_handler_context = _step_handler_context(
+                job_def=reconstructable(bar),
+                dagster_run=run,
+                instance=instance,
+                executor=executor,
+            )
+            run_task_kwargs = executor._step_handler._get_run_task_kwargs(  # type: ignore  # noqa: SLF001
+                run,
+                ["my-command"],
+                "foo.bar[filename_0]",
+                {},
+                step_handler_context,
+                executor._step_handler._get_container_context(step_handler_context),  # type: ignore  # noqa: SLF001
+            )
+
+            tags = {tag["key"]: tag["value"] for tag in run_task_kwargs["tags"]}
+            assert tags["dagster/step-key"] == "foo-bar-filename_0"
+
+
 def test_executor_launch(instance_cm: Callable[..., ContextManager[DagsterInstance]]):
     with instance_cm() as instance:
         recon_job = reconstructable(bar)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
@@ -4,7 +4,7 @@ from dagster._core.remote_representation.origin import (
     RemoteRepositoryOrigin,
 )
 
-from dagster_aws.ecs.utils import get_task_definition_family, sanitize_family
+from dagster_aws.ecs.utils import get_task_definition_family, sanitize_family, sanitize_tag
 
 
 def test_sanitize_family():
@@ -14,6 +14,14 @@ def test_sanitize_family():
     assert sanitize_family("abc_123") == "abc_123"
     assert sanitize_family("abc 123") == "abc123"
     assert sanitize_family("abc~123") == "abc123"
+
+
+def test_sanitize_tag():
+    assert sanitize_tag("abc") == "abc"
+    assert sanitize_tag("abc123") == "abc123"
+    assert sanitize_tag("foo.bar[filename_0]") == "foo-bar-filename_0"
+    assert sanitize_tag("AaBbCc") == "AaBbCc"
+    assert sanitize_tag("A" * 270) == "A" * 255
 
 
 def test_get_task_definition_family():


### PR DESCRIPTION
Fix for https://github.com/dagster-io/dagster/issues/28653. Sanitize the step key before using it as a tag. We don't use this tag anywhere so the sanitized value shouldn't cause any problems in the Dagster machinery.

Test Plan: New tests