### PR TITLE
[ui] Restore __typename to tag filtering on automations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -114,12 +114,8 @@ export const MergedAutomationRoot = () => {
       repoBuckets,
       useCallback((repoBucket) => {
         return [
-          ...repoBucket.schedules.flatMap((schedule) =>
-            schedule.tags.map(({key, value}) => ({key, value})),
-          ),
-          ...repoBucket.sensors.flatMap((sensor) =>
-            sensor.tags.map(({key, value}) => ({key, value})),
-          ),
+          ...repoBucket.schedules.flatMap((schedule) => schedule.tags),
+          ...repoBucket.sensors.flatMap((sensor) => sensor.tags),
         ];
       }, []),
     ),


### PR DESCRIPTION
## Summary & Motivation

In automation tag filtering, we're depending on the `__typename` key/value pair that I discarded in https://github.com/dagster-io/dagster/pull/28583. Tag filtering is currently broken because of its removal. Revert that change.

I think I missed this because the tag set that I was checking appeared to result in an expected empty set.

## How I Tested These Changes

View automations with a tag filter, verify that it works correctly. Add multiple tags to filter, verify that this continues to work correctly.

## Changelog

[ui] Fix tag filtering on automations list.
