### PR TITLE
update model fields access

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -193,7 +193,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         modified_data_by_config_key = {}
         field_info_by_config_key = {
             field.alias if field.alias else field_key: (field_key, field)
-            for field_key, field in model_fields(self).items()
+            for field_key, field in model_fields(self.__class__).items()
         }
         for config_key, value in config_dict.items():
             field_info = field_info_by_config_key.get(config_key)
@@ -241,7 +241,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             else:
                 modified_data_by_config_key[config_key] = value
 
-        for field_key, field in model_fields(self).items():
+        for field_key, field in model_fields(self.__class__).items():
             config_key = field.alias if field.alias else field_key
             if field.is_required() and config_key not in modified_data_by_config_key:
                 modified_data_by_config_key[config_key] = (
@@ -267,7 +267,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
         """
         public_fields = self._get_non_default_public_field_values(keep_if_not_none=True)
         return {
-            k: _config_value_to_dict_representation(model_fields(self).get(k), v)
+            k: _config_value_to_dict_representation(model_fields(self.__class__).get(k), v)
             for k, v in public_fields.items()
         }
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
@@ -58,7 +58,7 @@ class NamespacedKVSet(ABC, DagsterModel):
     def keys(self) -> Iterable[str]:
         return [
             self._namespaced_key(key)
-            for key in model_fields(self).keys()
+            for key in model_fields(self.__class__).keys()
             # getattr returns the pydantic property on the subclass
             if getattr(self, key) is not None
         ]
@@ -130,7 +130,7 @@ class NamespacedMetadataSet(NamespacedKVSet):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        for field_name in model_fields(self).keys():
+        for field_name in model_fields(self.__class__).keys():
             annotation_types = self._get_accepted_types_for_field(field_name)
             invalid_annotation_types = {
                 annotation_type

--- a/python_modules/dagster/dagster/_core/definitions/tags/tag_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/tags/tag_set.py
@@ -27,7 +27,7 @@ class NamespacedTagSet(NamespacedKVSet):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        for field_name, field in model_fields(self).items():
+        for field_name, field in model_fields(self.__class__).items():
             annotation_type = field.annotation
 
             is_optional = is_closed_python_optional_type(annotation_type)

--- a/python_modules/libraries/dagster-shared/dagster_shared/dagster_model/pydantic_compat_layer.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/dagster_model/pydantic_compat_layer.py
@@ -61,7 +61,7 @@ class ModelFieldCompat:
             return self.field.discriminator if hasattr(self.field, "discriminator") else None
 
 
-def model_fields(model) -> dict[str, ModelFieldCompat]:
+def model_fields(model: type[BaseModel]) -> dict[str, ModelFieldCompat]:
     """Returns a dictionary of fields for a given pydantic model, wrapped
     in a compat class to provide a consistent interface between Pydantic 1 and 2.
     """


### PR DESCRIPTION
fix up some callsite where we are calling `model_fields` on the instance instead of the class generating new warnings

```
pydantic.warnings.PydanticDeprecatedSince211: Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
```

## How I Tested These Changes

bk
