### PR TITLE
Remove components check from DgContext.for_project_environment

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -90,10 +90,6 @@ class DgContext:
     def for_project_environment(cls, path: Path, command_line_config: DgRawCliConfig) -> Self:
         context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
-        # Commands that operate on a project need to be run (a) with dagster-components
-        # available; and (b) inside a Dagster project context.
-        _validate_dagster_components_availability(context)
-
         if not context.is_project:
             exit_with_error(NOT_PROJECT_ERROR_MESSAGE)
         return context


### PR DESCRIPTION
Summary:
There are now many commands in dg that run in a project but do not need to have dagster-components installed.

Run 'dg deploy' in a folder without dagster-components installed.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
