### PR TITLE
[ui] Fix colorblind color mapping in Insights

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/ColorName.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/ColorName.tsx
@@ -73,9 +73,7 @@ export enum ColorName {
   PopoverBackgroundHover = 'PopoverBackgroundHover',
   ShadowDefault = 'ShadowDefault',
   CheckboxUnchecked = 'CheckboxUnchecked',
-  CheckboxUncheckedHover = 'CheckboxUncheckedHover',
   CheckboxChecked = 'CheckboxChecked',
-  CheckboxCheckedHover = 'CheckboxCheckedHover',
   CheckboxDisabled = 'CheckboxDisabled',
 
   // Header

--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/colorNameToVar.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/colorNameToVar.tsx
@@ -75,9 +75,7 @@ export const colorNameToVar = {
   [ColorName.PopoverBackgroundHover]: 'var(--color-popover-background-hover)',
   [ColorName.ShadowDefault]: 'var(--color-shadow-default)',
   [ColorName.CheckboxUnchecked]: 'var(--color-checkbox-unchecked)',
-  [ColorName.CheckboxUncheckedHover]: 'var(--color-checkbox-unchecked-hover)',
   [ColorName.CheckboxChecked]: 'var(--color-checkbox-checked)',
-  [ColorName.CheckboxCheckedHover]: 'var(--color-checkbox-checked-hover)',
   [ColorName.CheckboxDisabled]: 'var(--color-checkbox-disabled)',
 
   // Header

--- a/js_modules/dagster-ui/packages/ui-components/src/theme/darkNoRedGreenThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/darkNoRedGreenThemeColors.tsx
@@ -102,8 +102,8 @@ export const darkNoRedGreenThemeColors = css`
   --color-data-viz-cyan-alt: var(--color-dataviz-cyan100);
   --color-data-viz-gray: var(--color-dataviz-gray200);
   --color-data-viz-gray-alt: var(--color-dataviz-gray100);
-  --color-data-viz-green: var(--color-dataviz-cobalt200);
-  --color-data-viz-green-alt: var(--color-dataviz-cobalt100);
+  --color-data-viz-green: var(--color-core-cobalt200);
+  --color-data-viz-green-alt: var(--color-core-cobalt100);
   --color-data-viz-lime: var(--color-dataviz-lime200);
   --color-data-viz-lime-alt: var(--color-dataviz-lime100);
   --color-data-viz-orange: var(--color-dataviz-orange200);
@@ -120,6 +120,7 @@ export const darkNoRedGreenThemeColors = css`
   --color-data-viz-yellow-alt: var(--color-dataviz-yellow100);
   --color-checkbox-unchecked: var(--color-core-gray500);
   --color-checkbox-checked: var(--color-core-cobalt500);
+  --color-checkbox-disabled: var(--color-core-gray700);
   --color-blue-gradient: linear-gradient(
     var(--color-core-gray950),
     var(--color-translucent-blue15) 100%

--- a/js_modules/dagster-ui/packages/ui-components/src/theme/lightNoRedGreenThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/lightNoRedGreenThemeColors.tsx
@@ -102,8 +102,8 @@ export const lightNoRedGreenThemeColors = css`
   --color-data-viz-cyan-alt: var(--color-dataviz-cyan300);
   --color-data-viz-gray: var(--color-dataviz-gray200);
   --color-data-viz-gray-alt: var(--color-dataviz-gray300);
-  --color-data-viz-green: var(--color-dataviz-cobalt200);
-  --color-data-viz-green-alt: var(--color-dataviz-cobalt300);
+  --color-data-viz-green: var(--color-core-cobalt200);
+  --color-data-viz-green-alt: var(--color-core-cobalt300);
   --color-data-viz-lime: var(--color-dataviz-lime200);
   --color-data-viz-lime-alt: var(--color-dataviz-lime300);
   --color-data-viz-orange: var(--color-dataviz-orange200);
@@ -121,7 +121,6 @@ export const lightNoRedGreenThemeColors = css`
   --color-checkbox-unchecked: var(--color-core-gray400);
   --color-checkbox-checked: var(--color-core-cobalt500);
   --color-checkbox-disabled: var(--color-core-gray150);
-
   --color-blue-gradient: linear-gradient(
     var(--color-core-gray10),
     var(--color-translucent-blue10) 100%

--- a/js_modules/dagster-ui/packages/ui-components/src/theme/lightThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/lightThemeColors.tsx
@@ -1,7 +1,7 @@
 import {css} from 'styled-components';
 
 export const lightThemeColors = css`
-  --browser-color-scheme: 'light';
+  --browser-color-scheme: light;
   --color-keyline-default: var(--color-translucent-gray20);
   --color-link-default: var(--color-core-blue700);
   --color-link-hover: var(--color-core-blue500);


### PR DESCRIPTION
## Summary & Motivation

The mapping on dataviz `green` colors goes to a nonexistent color in colorblind themes, which leads to a JS error when we try to extract the color for Insights line charts. Fix this by mapping to a core cobalt color instead.

Also clean up a couple of unused color names.

## How I Tested These Changes

Switch to system colorblind theme, view Insights. Verify that the chart loads, with no JS errors.

## Changelog

[ui] Fix line charts for colorblind themes.
