### PR TITLE
derive dagster core version from dagster-shared version in telemetry

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/libraries/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/libraries/__init__.py
@@ -77,7 +77,7 @@ def core_version_from_library_version(library_version: str) -> str:
     parsed_version = parse_package_version(library_version)
 
     release = parsed_version.release
-    if release[0] < 1:
+    if release[0] < 1 and len(release) > 1:
         core_version = ".".join(["1", str(release[1] - 16), str(release[2])])
 
         if parsed_version.is_prerelease:

--- a/python_modules/libraries/dagster-shared/dagster_shared/telemetry/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/telemetry/__init__.py
@@ -12,6 +12,9 @@ from typing import Callable, NamedTuple, Optional
 import click
 import yaml
 
+from dagster_shared.libraries import core_version_from_library_version
+from dagster_shared.version import __version__
+
 OS_DESC = platform.platform()
 OS_PLATFORM = platform.system()
 
@@ -32,15 +35,6 @@ KNOWN_CI_ENV_VAR_KEYS = {
     "TRAVIS",  # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     "BUILDKITE",  # https://buildkite.com/docs/pipelines/environment-variables
 }
-
-
-def _get_dagster_module_version() -> Optional[str]:
-    try:
-        from dagster.version import __version__ as dagster_module_version
-
-        return dagster_module_version
-    except ImportError:
-        return None
 
 
 def get_python_version() -> str:
@@ -194,7 +188,7 @@ class TelemetryEntry(
             instance_id=instance_id,
             python_version=get_python_version(),
             metadata=metadata or {},
-            dagster_version=_get_dagster_module_version() or "None",
+            dagster_version=core_version_from_library_version(__version__) or "None",
             os_desc=OS_DESC,
             os_platform=OS_PLATFORM,
             run_storage_id=run_storage_id or "",

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_libraries.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_libraries.py
@@ -91,9 +91,11 @@ def test_library_version_from_core_version():
     assert library_version_from_core_version("1.1.16pre0") == "0.17.16rc0"
     assert library_version_from_core_version("1.1.16rc0") == "0.17.16rc0"
     assert library_version_from_core_version("1.1.16post0") == "0.17.16post0"
+    assert library_version_from_core_version("1!0+dev") == "1!0+dev"
 
 
 def test_core_version_from_library_version():
+    assert core_version_from_library_version("1!0+dev") == "1!0+dev"
     assert core_version_from_library_version("0.17.16") == "1.1.16"
     assert core_version_from_library_version("1.1.16") == "1.1.16"
     assert core_version_from_library_version("0.17.16pre0") == "1.1.16rc0"


### PR DESCRIPTION
Summary:
This way we get a consistent dagster version logged in telemetry even from dg (and don't have to worry about a rogue dagster import sneaking in)

Test Plan: BK
