### PR TITLE
[dagster-dbt] Implement cached properties for account, project and environment names in DbtCloudWorkspace

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -88,14 +88,14 @@ class DbtCloudWorkspaceClient(DagsterModel):
     def _make_request(
         self,
         method: str,
-        endpoint: str,
+        endpoint: Optional[str],
         base_url: str,
         data: Optional[Mapping[str, Any]] = None,
         params: Optional[Mapping[str, Any]] = None,
         session_attr: str = "_get_session",
         include_full_response: bool = False,
     ) -> Mapping[str, Any]:
-        url = f"{base_url}/{endpoint}"
+        url = f"{base_url}/{endpoint}" if endpoint else base_url
 
         num_retries = 0
         while True:
@@ -103,7 +103,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
                 session = getattr(self, session_attr)()
                 response = session.request(
                     method=method,
-                    url=f"{self.api_v2_url}/{endpoint}",
+                    url=url,
                     json=data,
                     params=params,
                     timeout=self.request_timeout,
@@ -435,7 +435,7 @@ class DbtCloudWorkspaceClient(DagsterModel):
         """
         return self._make_request(
             method="get",
-            endpoint="",
+            endpoint=None,
             base_url=self.api_v2_url,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/types.py
@@ -9,6 +9,22 @@ from dagster._serdes import whitelist_for_serdes
 
 @preview
 @record
+class DbtCloudAccount:
+    """Represents a dbt Cloud Account, based on data as returned from the API."""
+
+    id: int
+    name: Optional[str]
+
+    @classmethod
+    def from_account_details(cls, account_details: Mapping[str, Any]) -> "DbtCloudAccount":
+        return cls(
+            id=account_details["id"],
+            name=account_details.get("name"),
+        )
+
+
+@preview
+@record
 class DbtCloudProject:
     """Represents a dbt Cloud Project, based on data as returned from the API."""
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -810,9 +810,13 @@ def credentials_fixture() -> DbtCloudCredentials:
     return TEST_CREDENTIALS
 
 
-@pytest.fixture(name="workspace")
+@pytest.fixture(name="workspace", scope="function")
 def workspace_fixture() -> DbtCloudWorkspace:
-    return TEST_WORKSPACE
+    return DbtCloudWorkspace(
+        credentials=TEST_CREDENTIALS,
+        project_id=TEST_PROJECT_ID,
+        environment_id=TEST_ENVIRONMENT_ID,
+    )
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -19,6 +19,7 @@ run_results_path = tests_path.joinpath("run_results.json")
 
 
 TEST_ACCOUNT_ID = 1111
+TEST_ACCOUNT_NAME = "test_account_name"
 TEST_ACCESS_URL = "https://cloud.getdbt.com"
 TEST_TOKEN = "test_token"
 
@@ -153,6 +154,52 @@ SAMPLE_CUSTOM_CREATE_JOB_RESPONSE = {
     "data": get_sample_job_data(job_name=TEST_CUSTOM_ADHOC_JOB_NAME),
     "status": {
         "code": 201,
+        "is_success": True,
+        "user_message": "string",
+        "developer_message": "string",
+    },
+}
+
+# Taken from dbt Cloud REST API documentation
+# https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retrieve%20Account
+SAMPLE_ACCOUNT_RESPONSE = {
+    "data": {
+        "id": TEST_ACCOUNT_ID,
+        "name": TEST_ACCOUNT_NAME,
+        "plan": "cancelled",
+        "run_slots": 1,
+        "developer_seats": 0,
+        "it_seats": 0,
+        "explorer_seats": 0,
+        "read_only_seats": 0,
+        "locked": False,
+        "lock_reason": "string",
+        "lock_cause": "trial_expired",
+        "unlocked_at": "2019-08-24T14:15:22Z",
+        "pending_cancel": False,
+        "billing_email_address": "string",
+        "pod_memory_request_mebibytes": 600,
+        "develop_pod_memory_request_mebibytes": 0,
+        "run_duration_limit_seconds": 86400,
+        "queue_limit": 50,
+        "enterprise_login_slug": "string",
+        "business_critical": False,
+        "starter_repo_url": "string",
+        "git_auth_level": "string",
+        "identifier": "string",
+        "trial_end_date": "2019-08-24T14:15:22Z",
+        "static_subdomain": "string",
+        "run_locked_until": "2019-08-24T14:15:22Z",
+        "state": 1,
+        "docs_job_id": 0,
+        "freshness_job_id": 0,
+        "account_migration_events": [None],
+        "groups": [],
+        "created_at": "2019-08-24T14:15:22Z",
+        "updated_at": "2019-08-24T14:15:22Z",
+    },
+    "status": {
+        "code": 200,
         "is_success": True,
         "user_message": "string",
         "developer_message": "string",
@@ -849,6 +896,12 @@ def all_api_mocks_fixture(
         method=responses.GET,
         url=f"{TEST_REST_API_BASE_URL}/runs/{TEST_RUN_ID}/artifacts",
         json=SAMPLE_LIST_RUN_ARTIFACTS,
+        status=200,
+    )
+    fetch_workspace_data_api_mocks.add(
+        method=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}",
+        json=SAMPLE_ACCOUNT_RESPONSE,
         status=200,
     )
     yield fetch_workspace_data_api_mocks

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_reconstruction.py
@@ -7,16 +7,33 @@ from dagster._core.definitions.reconstruct import (
     reconstruct_repository_def_from_pointer,
 )
 from dagster._utils.test.definitions import lazy_definitions
+from dagster_dbt.cloud_v2.resources import DbtCloudCredentials, DbtCloudWorkspace
 
-from dagster_dbt_tests.cloud_v2.conftest import TEST_WORKSPACE
+from dagster_dbt_tests.cloud_v2.conftest import (
+    TEST_ACCESS_URL,
+    TEST_ACCOUNT_ID,
+    TEST_ENVIRONMENT_ID,
+    TEST_PROJECT_ID,
+    TEST_TOKEN,
+)
 
 
 @lazy_definitions
 def cacheable_dbt_cloud_workspace_data():
-    TEST_WORKSPACE.fetch_workspace_data()
+    workspace = DbtCloudWorkspace(
+        credentials=DbtCloudCredentials(
+            account_id=TEST_ACCOUNT_ID,
+            access_url=TEST_ACCESS_URL,
+            token=TEST_TOKEN,
+        ),
+        project_id=TEST_PROJECT_ID,
+        environment_id=TEST_ENVIRONMENT_ID,
+    )
+
+    workspace.fetch_workspace_data()
 
     return Definitions(
-        resources={"dbt_cloud": TEST_WORKSPACE},
+        resources={"dbt_cloud": workspace},
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -25,11 +25,12 @@ from dagster_dbt_tests.cloud_v2.conftest import (
 
 def assert_rest_api_call(
     call: responses.Call,
-    endpoint: str,
+    endpoint: Optional[str],
     method: Optional[str] = None,
 ):
     rest_api_url = call.request.url.split("?")[0]
-    assert rest_api_url == f"{TEST_REST_API_BASE_URL}/{endpoint}"
+    test_url = f"{TEST_REST_API_BASE_URL}/{endpoint}" if endpoint else TEST_REST_API_BASE_URL
+    assert rest_api_url == test_url
     if method:
         assert method == call.request.method
     assert call.request.headers["Authorization"] == f"Token {TEST_TOKEN}"
@@ -61,8 +62,9 @@ def test_basic_resource_request(
         finished_at_end=TEST_FINISHED_AT_END,
     )
     client.list_run_artifacts(run_id=TEST_RUN_ID)
+    client.get_account_details()
 
-    assert len(all_api_mocks.calls) == 10
+    assert len(all_api_mocks.calls) == 11
     assert_rest_api_call(call=all_api_mocks.calls[0], endpoint="jobs", method="GET")
     assert_rest_api_call(call=all_api_mocks.calls[1], endpoint="jobs", method="POST")
     assert_rest_api_call(
@@ -89,6 +91,7 @@ def test_basic_resource_request(
     assert_rest_api_call(
         call=all_api_mocks.calls[9], endpoint=f"runs/{TEST_RUN_ID}/artifacts", method="GET"
     )
+    assert_rest_api_call(call=all_api_mocks.calls[10], endpoint=None, method="GET")
 
 
 def test_get_or_create_dagster_adhoc_job(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -136,19 +136,22 @@ def test_custom_adhoc_job_name(
         json=SAMPLE_CUSTOM_CREATE_JOB_RESPONSE,
         status=201,
     )
+    # We don't fetch the project name and environment name when we use an ad hoc job name.
+    job_api_mocks.remove(
+        method_or_response=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}/projects/{TEST_PROJECT_ID}",
+    )
+    job_api_mocks.remove(
+        method_or_response=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}/environments/{TEST_ENVIRONMENT_ID}",
+    )
 
     # The expected job name is not in the initial list of jobs so a job is created
     job = workspace._get_or_create_dagster_adhoc_job()  # noqa
 
-    assert len(job_api_mocks.calls) == 4
-    assert_rest_api_call(
-        call=job_api_mocks.calls[0], endpoint=f"projects/{TEST_PROJECT_ID}", method="GET"
-    )
-    assert_rest_api_call(
-        call=job_api_mocks.calls[1], endpoint=f"environments/{TEST_ENVIRONMENT_ID}", method="GET"
-    )
-    assert_rest_api_call(call=job_api_mocks.calls[2], endpoint="jobs", method="GET")
-    assert_rest_api_call(call=job_api_mocks.calls[3], endpoint="jobs", method="POST")
+    assert len(job_api_mocks.calls) == 2
+    assert_rest_api_call(call=job_api_mocks.calls[0], endpoint="jobs", method="GET")
+    assert_rest_api_call(call=job_api_mocks.calls[1], endpoint="jobs", method="POST")
 
     assert job.id == TEST_JOB_ID
     assert job.name == TEST_CUSTOM_ADHOC_JOB_NAME


### PR DESCRIPTION
## Summary & Motivation

This PR moves project.name and environment.name to cached properties, and support account_name as a cached_property too. 

This was originally done in the polling sensor PR, but moving the changes here to prevent the other PR from getting messy.

## How I Tested These Changes

BK
