### PR TITLE
[ui] Clean up rendering of serialized cursor tuples on sensor details page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -49,6 +49,7 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {TimeElapsed} from '../runs/TimeElapsed';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {humanizeSensorCursor} from '../sensors/SensorDetails';
 import {TickLogDialog} from '../ticks/TickLogDialog';
 import {TickResultType, TickStatusTag} from '../ticks/TickStatusTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -486,7 +487,7 @@ function TickRow({
                   overflow: 'hidden',
                 }}
               >
-                <MiddleTruncate text={tick.cursor || ''} />
+                <MiddleTruncate text={humanizeSensorCursor(tick.cursor) || ''} />
               </div>
               <CopyButton
                 onClick={async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/__tests__/SensorDetails.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/__tests__/SensorDetails.test.tsx
@@ -1,0 +1,23 @@
+import {humanizeSensorCursor} from '../SensorDetails';
+
+describe('SensorDetails', () => {
+  describe('humanizeSensorCursor', () => {
+    it('displays populated fields in a minimal format', () => {
+      expect(
+        humanizeSensorCursor(
+          '{"__class__": "AirflowPollingSensorCursor", "dag_query_offset": 0, "end_date_gte": 1743134332.087687, "end_date_lte": null}',
+        ),
+      ).toEqual('end_date_gte=1743134332.087687');
+
+      expect(
+        humanizeSensorCursor(
+          '{"__class__": "RunStatusSensorCursor", "record_id": 1234, "update_timestamp": "1743134332", "record_timestamp": null}',
+        ),
+      ).toEqual('record_id=1234,update_timestamp=1743134332');
+
+      expect(humanizeSensorCursor('1234')).toEqual('1234');
+      expect(humanizeSensorCursor(false)).toEqual(false);
+      expect(humanizeSensorCursor(null)).toEqual(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/OPER-1581/improve-cursor-display-for-run-status-sensor-in-ui-and-disallow

## How I Tested These Changes

New test, manual testing against impacted sensors

Before:
![image](https://github.com/user-attachments/assets/51a3549b-df60-429b-9a33-e292f85c00be)

After:

![image](https://github.com/user-attachments/assets/193d3329-9ded-4aab-bbc8-34553b33f611)
