### PR TITLE
[ui] If no steps have started, disable the stdout/stderr tabs of the run page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/ButtonGroup.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ButtonGroup.tsx
@@ -11,6 +11,7 @@ export type ButtonGroupItem<T> = {
   label?: React.ReactNode;
   icon?: IconName;
   tooltip?: string;
+  disabled?: boolean;
 };
 
 interface Props<T> {
@@ -24,7 +25,7 @@ export const ButtonGroup = <T extends string | number>(props: Props<T>) => {
   return (
     <JoinedButtons>
       {buttons.map((button) => {
-        const {id, icon, label, tooltip} = button;
+        const {id, icon, label, tooltip, disabled} = button;
         const isActive = activeItems?.has(id);
         const {fillColor, fillColorHover, iconColor, strokeColor, strokeColorHover} = buildColorSet(
           {intent: undefined, outlined: false},
@@ -43,6 +44,7 @@ export const ButtonGroup = <T extends string | number>(props: Props<T>) => {
             icon={icon ? <Icon name={icon} /> : null}
             label={label}
             onClick={(e) => onClick(id, e)}
+            disabled={disabled}
           />
         );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -77,14 +77,19 @@ export const LogsToolbar = (props: ILogsToolbarProps | WithExpandCollapseProps) 
 
   const activeItems = React.useMemo(() => new Set([logType]), [logType]);
 
+  const noStepsStarted = React.useMemo(
+    () => Object.values(metadata.steps).every((step) => !step.start),
+    [metadata],
+  );
+
   return (
     <OptionsContainer style={{gap: 12}}>
       <ButtonGroup
         activeItems={activeItems}
         buttons={[
           {id: LogType.structured, icon: 'logs_structured', label: 'Events'},
-          {id: LogType.stdout, icon: 'logs_stdout', label: 'stdout'},
-          {id: LogType.stderr, icon: 'logs_stderr', label: 'stderr'},
+          {id: LogType.stdout, icon: 'logs_stdout', label: 'stdout', disabled: noStepsStarted},
+          {id: LogType.stderr, icon: 'logs_stderr', label: 'stderr', disabled: noStepsStarted},
         ]}
         onClick={(id) => onSetLogType(id)}
       />


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-97/disable-stdoutstderr-tab-if-no-steps-were-run

## How I Tested These Changes

I tested that these are disabled for a queued run and immediately become available when the run starts executing the first 

(Rendering with disabled state below)

![image](https://github.com/user-attachments/assets/95f1bc07-f0fb-4060-bea4-5e4b7511fe44)
