### PR TITLE
[ui] Fix padding on headers when they wrap

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -25,8 +25,9 @@ export const PageHeader = (props: Props) => {
     >
       {title && (
         <Box
+          padding={{vertical: 8}}
           style={{minHeight: 52, alignContent: 'center'}}
-          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 8}}
         >
           <Box flex={{direction: 'row', alignItems: 'center', gap: 12, wrap: 'wrap'}}>
             {title}


### PR DESCRIPTION
This is the same fix from https://github.com/dagster-io/dagster/pull/25752 back in November, it looks like it got squashed out on the same day i what I think was a merge conflict mishap.

## Summary & Motivation

Before:
![Screenshot 2025-03-27 at 11 44 30 PM](https://github.com/user-attachments/assets/ad5d4db5-7e3e-491e-8889-cb2db8c76dfe)

After:
![image](https://github.com/user-attachments/assets/8c76e286-991e-4096-b7fc-3bb15ac2cfc5)


## How I Tested These Changes

Also tested this on the job page, which has the same problem, and verified that this additional padding does not impact other pages like the asset header, because 52-(8px x 2) leaves enough room for buttons.
 
![image](https://github.com/user-attachments/assets/34ce32c1-e7f7-4408-b7a1-15c9af633d1a)
