### PR TITLE
Fix regression when creating nested ConfigurableResource with pydantic >= v.2.5.0

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -696,12 +696,12 @@ class PartialResource(
 
     def __init__(
         self,
-        resource_cls: type[ConfigurableResourceFactory[TResValue]],
-        data: dict[str, Any],
+        resource_cls: type[ConfigurableResourceFactory[TResValue]] | None = None,
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
     ):
-        resource_pointers, _data_without_resources = separate_resource_params(resource_cls, data)
-
         super().__init__(data=data, resource_cls=resource_cls)  # type: ignore  # extends BaseModel, takes kwargs
+        resource_pointers, _data_without_resources = separate_resource_params(resource_cls, data)
 
         def resource_fn(context: InitResourceContext):
             to_populate = resource_cls._get_non_default_public_field_values_cls(  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1030,3 +1030,24 @@ def test_nested_resources_runtime_config_fully_populated() -> None:
         .success
     )
     assert completed["yes"]
+
+
+def test_nested_resources_direct_config_fully_populated() -> None:
+    """Covers regression introduced in pydantic v2.5.0 where union validation changed to Smart
+    and direct initialization of nested ConfigurableResources stopped working.
+    """
+
+    class Inner(ConfigurableResource):
+        b: str
+
+    class Outer(ConfigurableResource):
+        a: str
+        inner: Inner
+
+    # model_validate() on NESTED ConfigurableResource worked with pydantic v2.4.2, but stopped working on v2.5.0.
+    result = Outer.model_validate(dict(a="a", inner=dict(b="b")))
+    # >> TypeError: PartialResource.__init__() got an unexpected keyword argument 'b'
+    assert isinstance(result, Outer)
+    assert result.a == "a"
+    assert isinstance(result.inner, Inner)
+    assert result.inner.b == "b"


### PR DESCRIPTION
## Summary & Motivation
Fixes: https://github.com/dagster-io/dagster/issues/18272

We are using pydantic [BaseSettings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#settings-management) to define dagster code deployment configurations. Our config framework dumps the config content into json, which we save to configmap for better visibility of changes in our workloads. We then create config instance from the json dict to maintain 1:1 correctness.

In pydantic v2.5.0, there was a change in validation of Unions: https://github.com/pydantic/pydantic-core/pull/867.
As PartialResource is very lax, it passes the validation, but immediately fails on TypeError.
I tried several alternatives, but this one is least invasive and works best.

Since the issue appeared, we tried to:
- reduce the number of nested ConfigurableResources in our codebase
- pin the pydantic == v2.4.2 (very old, released on [2023-09-27](https://docs.pydantic.dev/latest/changelog/#v242-2023-09-27
) )

But eventually, we needed new pydantic features in other projects and got to the point we needed to transitively upgrade pydantic in our dagster projects.

## How I Tested These Changes
First, let's verify that this piece of code used to work with pydantic v2.4.2 ✅
```
git checkout ec9048878b9f8d81e3a0bb6284df0f0de493da68
uv pip install pydantic==2.4.2
python -m pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources
```
```
================================================================================================ 121 passed, 4 deselected in 7.66s ================================================================================================
```
but doesn't work with latest pydantic version ❌

```
uv pip install pydantic --upgrade
python -m pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources
```

```
===================================================================================================== short test summary info =====================================================================================================
FAILED python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py::test_nested_resources_direct_config_fully_populated - TypeError: PartialResource.__init__() got an unexpected keyword argument 'b'
=========================================================================================== 1 failed, 120 passed, 4 deselected in 6.95s ===========================================================================================
 
```
Then checkout the second commit where I fix the PartialResource.____init____() and rerun the tests again. ✅

## Changelog

> Fix regression where nested ResourceDefinition could not be validated from fully populated dict.
