### PR TITLE
[dg] Add test for installation that an isolated dg can execute

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_integrity.py
@@ -1,5 +1,10 @@
+import shutil
+import subprocess
+
 from dagster_dg.cli import cli
 from dagster_dg.utils import DgClickCommand, DgClickGroup
+
+from dagster_dg_tests.utils import ProxyRunner, isolated_dg_venv
 
 
 # Important that all nodes of the command tree inherit from one of our customized click
@@ -28,3 +33,15 @@ def test_all_commands_have_global_options():
                 crawl(command)
 
     crawl(cli)
+
+
+# Install dagster-dg in an isolated venv and make sure that it can execute. Without this test, it is
+# easy to accidentally leave an import of a dependency present in the test environment inside
+# dagster-dg, which causes the executable to fail when it is installed from pypi without those test
+# dependencies.
+def test_isolated_dg_executes():
+    with ProxyRunner.test() as runner, isolated_dg_venv(runner) as venv_path:
+        dg_path = shutil.which("dg")
+        assert dg_path is not None, "dg executable not found in PATH"
+        assert dg_path.startswith(str(venv_path)), "dg executable not resolving to local venv"
+        assert subprocess.check_output(["dg", "--help"])


### PR DESCRIPTION
## Summary & Motivation

This adds a test to make sure that `dg` successfully executes in an isolated environment. This prevents accidentally depending on packages only present in the test env in runtime code.

## How I Tested These Changes

New test, made sure it fails when there is a test dependency import in runtime code.