### PR TITLE
[ui] Add “Copy tags” option to tags modals, unify copy behavior

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -1,15 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
-import {
-  Box,
-  Colors,
-  Heading,
-  Icon,
-  IconWrapper,
-  MiddleTruncate,
-  PageHeader,
-  Tooltip,
-} from '@dagster-io/ui-components';
+import {Box, Colors, Heading, Icon, MiddleTruncate, PageHeader} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useContext} from 'react';
 import {Link, useHistory, useLocation} from 'react-router-dom';
@@ -17,9 +8,8 @@ import {getAssetFilterStateQueryString} from 'shared/assets/useAssetDefinitionFi
 import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
-import {showSharedToaster} from '../app/DomUtils';
-import {useCopyToClipboard} from '../app/browser';
 import {AnchorButton} from '../ui/AnchorButton';
+import {CopyIconButton} from '../ui/CopyButton';
 
 type Props = Partial<React.ComponentProps<typeof PageHeader>> & {
   assetKey: {path: string[]};
@@ -40,28 +30,7 @@ export const AssetPageHeader = ({
   const history = useHistory();
   const {basePath} = useContext(AppContext);
 
-  const copy = useCopyToClipboard();
   const copyableString = assetKey.path.join('/');
-  const [didCopy, setDidCopy] = React.useState(false);
-  const iconTimeout = React.useRef<ReturnType<typeof setTimeout>>();
-
-  const performCopy = React.useCallback(async () => {
-    if (iconTimeout.current) {
-      clearTimeout(iconTimeout.current);
-    }
-
-    copy(copyableString);
-    setDidCopy(true);
-    await showSharedToaster({
-      icon: 'done',
-      intent: 'primary',
-      message: 'Copied asset key!',
-    });
-
-    iconTimeout.current = setTimeout(() => {
-      setDidCopy(false);
-    }, 2000);
-  }, [copy, copyableString]);
 
   const location = useLocation();
   const filterStateQueryString = getAssetFilterStateQueryString(location.search);
@@ -130,16 +99,7 @@ export const AssetPageHeader = ({
                 popoverClassName: 'dagster-popover',
               }}
             />
-            {copyableString ? (
-              <Tooltip placement="bottom" content="Copy asset key">
-                <CopyButton onClick={performCopy}>
-                  <Icon
-                    name={didCopy ? 'copy_to_clipboard_done' : 'copy_to_clipboard'}
-                    color={Colors.accentGray()}
-                  />
-                </CopyButton>
-              </Tooltip>
-            ) : undefined}
+            {copyableString ? <CopyIconButton value={copyableString} /> : undefined}
           </Title>
         </Box>
       }
@@ -151,26 +111,6 @@ export const AssetPageHeader = ({
 const TruncatedHeading = styled(Heading)`
   max-width: 300px;
   overflow: hidden;
-`;
-
-const CopyButton = styled.button`
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  padding: 3px;
-  margin-top: 2px;
-
-  :focus {
-    outline: none;
-  }
-
-  ${IconWrapper} {
-    transition: background-color 100ms linear;
-  }
-
-  :hover ${IconWrapper} {
-    background-color: ${Colors.accentGrayHover()};
-  }
 `;
 
 export const AssetGlobalLineageLink = () => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
@@ -6,18 +6,14 @@ import {
   Icon,
   MiddleTruncate,
   Tag,
-  Tooltip,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
-import React from 'react';
 import {Link} from 'react-router-dom';
 import {UserDisplay} from 'shared/runs/UserDisplay.oss';
 import styled from 'styled-components';
 
 import {AssetDefinedInMultipleReposNotice} from '../AssetDefinedInMultipleReposNotice';
 import {AttributeAndValue} from './Common';
-import {showSharedToaster} from '../../app/DomUtils';
-import {useCopyToClipboard} from '../../app/browser';
 import {CodeLink, getCodeReferenceKey} from '../../code-links/CodeLink';
 import {AssetKind, isCanonicalStorageKindTag, isSystemTag} from '../../graph/KindTags';
 import {useStateWithStorage} from '../../hooks/useStateWithStorage';
@@ -27,6 +23,7 @@ import {
   isCanonicalUriEntry,
 } from '../../metadata/TableSchema';
 import {RepositoryLink} from '../../nav/RepositoryLink';
+import {CopyIconButton} from '../../ui/CopyButton';
 import {buildTagString} from '../../ui/tagAsString';
 import {WorkspaceLocationNodeFragment} from '../../workspace/WorkspaceContext/types/WorkspaceQueries.types';
 import {RepoAddress} from '../../workspace/types';
@@ -129,7 +126,7 @@ export const DefinitionSection = ({
             {tableNameMetadata && (
               <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
                 <MiddleTruncate text={tableNameMetadata.text} />
-                <CopyButton value={tableNameMetadata.text} />
+                <CopyIconButton value={tableNameMetadata.text} />
               </Box>
             )}
             {uriMetadata && (
@@ -141,7 +138,7 @@ export const DefinitionSection = ({
                     {uriMetadata.url}
                   </a>
                 )}
-                <CopyButton
+                <CopyIconButton
                   value={
                     uriMetadata.__typename === 'TextMetadataEntry'
                       ? uriMetadata?.text
@@ -217,26 +214,6 @@ const SystemTagsToggle = ({tags}: {tags: Array<{key: string; value: string}>}) =
       </Box>
     );
   }
-};
-
-const CopyButton = ({value}: {value: string}) => {
-  const copy = useCopyToClipboard();
-  const onCopy = async () => {
-    copy(value);
-    await showSharedToaster({
-      intent: 'success',
-      icon: 'copy_to_clipboard_done',
-      message: 'Copied!',
-    });
-  };
-
-  return (
-    <Tooltip content="Copy" placement="bottom" display="block">
-      <div onClick={onCopy} style={{cursor: 'pointer'}}>
-        <Icon name="content_copy" />
-      </div>
-    </Tooltip>
-  );
 };
 
 const UserAssetOwnerWrapper = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -5,11 +5,9 @@ import {
   Button,
   ButtonLink,
   Caption,
-  Colors,
   CursorHistoryControls,
   FontFamily,
   Icon,
-  IconWrapper,
   Menu,
   MenuItem,
   MiddleTruncate,
@@ -34,11 +32,9 @@ import {HistoryTickFragment} from './types/InstigationUtils.types';
 import {TickHistoryQuery, TickHistoryQueryVariables} from './types/TickHistory.types';
 import {countPartitionsAddedOrDeleted, isStuckStartedTick} from './util';
 import {gql, useQuery} from '../apollo-client';
-import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {useCopyToClipboard} from '../app/browser';
 import {
   DynamicPartitionsRequestType,
   InstigationSelector,
@@ -51,6 +47,7 @@ import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {TickLogDialog} from '../ticks/TickLogDialog';
 import {TickResultType, TickStatusTag} from '../ticks/TickStatusTag';
+import {CopyIconButton} from '../ui/CopyButton';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -432,8 +429,6 @@ function TickRow({
   onShowDetails: (tick: HistoryTickFragment) => void;
   onShowLogs: (tick: HistoryTickFragment) => void;
 }) {
-  const copyToClipboard = useCopyToClipboard();
-
   const [addedPartitions, deletedPartitions] = React.useMemo(() => {
     const requests = tick.dynamicPartitionsRequestResults;
     const added = countPartitionsAddedOrDeleted(
@@ -488,17 +483,7 @@ function TickRow({
               >
                 <MiddleTruncate text={tick.cursor || ''} />
               </div>
-              <CopyButton
-                onClick={async () => {
-                  copyToClipboard(tick.cursor || '');
-                  await showSharedToaster({
-                    message: <div>Copied value</div>,
-                    intent: 'success',
-                  });
-                }}
-              >
-                <Icon name="assignment" />
-              </CopyButton>
+              <CopyIconButton value={tick.cursor || ''} />
             </Box>
           ) : (
             <>&mdash;</>
@@ -591,28 +576,6 @@ const TICK_HISTORY_QUERY = gql`
   ${PYTHON_ERROR_FRAGMENT}
   ${TICK_TAG_FRAGMENT}
   ${HISTORY_TICK_FRAGMENT}
-`;
-
-const CopyButton = styled.button`
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  padding: 8px;
-  margin: -6px;
-  outline: none;
-
-  ${IconWrapper} {
-    background-color: ${Colors.accentGray()};
-    transition: background-color 100ms;
-  }
-
-  :hover ${IconWrapper} {
-    background-color: ${Colors.accentGrayHover()};
-  }
-
-  :focus ${IconWrapper} {
-    background-color: ${Colors.linkDefault()};
-  }
 `;
 
 const TableWrapper = styled(Table)`

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -24,7 +24,7 @@ import {DeletionDialog} from './DeletionDialog';
 import {ReexecutionDialog} from './ReexecutionDialog';
 import {RunConfigDialog} from './RunConfigDialog';
 import {doneStatuses, failedStatuses} from './RunStatuses';
-import {RunTags} from './RunTags';
+import {RunTags, tagsAsYamlString} from './RunTags';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {RunFilterToken} from './RunsFilterInput';
 import {TerminationDialog} from './TerminationDialog';
@@ -38,12 +38,11 @@ import {useJobReexecution} from './useJobReExecution';
 import {gql, useLazyQuery} from '../apollo-client';
 import {DagsterTag} from './RunTag';
 import {AppContext} from '../app/AppContext';
-import {showSharedToaster} from '../app/DomUtils';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
-import {useCopyToClipboard} from '../app/browser';
 import {ReexecutionStrategy} from '../graphql/types';
 import {getPipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
 import {AnchorButton} from '../ui/AnchorButton';
+import {CopyButton} from '../ui/CopyButton';
 import {MenuLink} from '../ui/MenuLink';
 import {isThisThingAJob} from '../workspace/WorkspaceContext/util';
 import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
@@ -62,16 +61,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
   >('none');
 
   const {rootServerURI} = React.useContext(AppContext);
-
-  const copyConfig = useCopyToClipboard();
-  const onCopy = async () => {
-    copyConfig(runConfigYaml || '');
-    await showSharedToaster({
-      intent: 'success',
-      icon: 'copy_to_clipboard_done',
-      message: 'Copied!',
-    });
-  };
 
   const reexecute = useJobReexecution({onCompleted: refetch});
 
@@ -289,6 +278,7 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
           />
         </DialogBody>
         <DialogFooter topBorder>
+          <CopyButton value={() => tagsAsYamlString(run.tags)}>Copy tags</CopyButton>
           <Button intent="primary" onClick={closeDialogs}>
             Close
           </Button>
@@ -297,7 +287,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
       <RunConfigDialog
         isOpen={visibleDialog === 'config'}
         onClose={closeDialogs}
-        copyConfig={onCopy}
         mode={run.mode}
         runConfigYaml={runConfigYaml || ''}
         isJob={isJob}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -2,18 +2,18 @@ import {Box, Button, Dialog, DialogFooter, Icon, Subheading} from '@dagster-io/u
 import {StyledRawCodeMirror} from '@dagster-io/ui-components/editor';
 import styled from 'styled-components';
 
-import {RunTags} from './RunTags';
+import {RunTags, tagsAsYamlString} from './RunTags';
 import {RunTagsFragment} from './types/RunTagsFragment.types';
 import {applyCreateSession, useExecutionSessionStorage} from '../app/ExecutionSessionStorage';
 import {useOpenInNewTab} from '../hooks/useOpenInNewTab';
 import {RunRequestFragment} from '../ticks/types/RunRequestFragment.types';
+import {CopyButton} from '../ui/CopyButton';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  copyConfig: () => void;
   runConfigYaml: string;
   mode: string | null;
   isJob: boolean;
@@ -27,18 +27,7 @@ interface Props {
 }
 
 export const RunConfigDialog = (props: Props) => {
-  const {
-    isOpen,
-    onClose,
-    copyConfig,
-    runConfigYaml,
-    tags,
-    mode,
-    isJob,
-    jobName,
-    request,
-    repoAddress,
-  } = props;
+  const {isOpen, onClose, runConfigYaml, tags, mode, isJob, jobName, request, repoAddress} = props;
   const hasTags = !!tags && tags.length > 0;
 
   return (
@@ -98,9 +87,9 @@ export const RunConfigDialog = (props: Props) => {
             )
           }
         >
-          <Button onClick={() => copyConfig()} intent="none">
-            Copy config
-          </Button>
+          {hasTags ? <CopyButton value={() => tagsAsYamlString(tags)}>Copy tags</CopyButton> : null}
+          <CopyButton value={runConfigYaml}>Copy config</CopyButton>
+
           <Button onClick={onClose} intent="primary">
             OK
           </Button>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -15,7 +15,6 @@ import {useMutation} from '../apollo-client';
 import {RunFragment} from './types/RunFragments.types';
 import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';
-import {useCopyToClipboard} from '../app/browser';
 import {RunStatus} from '../graphql/types';
 import {FREE_CONCURRENCY_SLOTS_MUTATION} from '../instance/InstanceConcurrencyKeyInfo';
 import {
@@ -36,7 +35,6 @@ type VisibleDialog =
   | null;
 
 export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean}) => {
-  const {runConfigYaml} = run;
   const runMetricsEnabled = run.hasRunMetricsEnabled;
 
   const [visibleDialog, setVisibleDialog] = useState<VisibleDialog>(null);
@@ -44,22 +42,12 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
   const {rootServerURI} = useContext(AppContext);
   const {refetch} = useContext(RunsQueryRefetchContext);
 
-  const copy = useCopyToClipboard();
   const history = useHistory();
 
   const [freeSlots] = useMutation<
     FreeConcurrencySlotsMutation,
     FreeConcurrencySlotsMutationVariables
   >(FREE_CONCURRENCY_SLOTS_MUTATION);
-
-  const copyConfig = async () => {
-    copy(runConfigYaml);
-    await showSharedToaster({
-      intent: 'success',
-      icon: 'copy_to_clipboard_done',
-      message: 'Copied!',
-    });
-  };
 
   const freeConcurrencySlots = async () => {
     const resp = await freeSlots({variables: {runId: run.id}});
@@ -160,7 +148,6 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
       <RunConfigDialog
         isOpen={visibleDialog === 'config'}
         onClose={() => setVisibleDialog(null)}
-        copyConfig={() => copyConfig()}
         mode={run.mode}
         runConfigYaml={run.runConfigYaml}
         tags={run.tags}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRowTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRowTags.tsx
@@ -11,13 +11,14 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import {DagsterTag, TagType} from './RunTag';
-import {RunTags} from './RunTags';
+import {RunTags, tagsAsYamlString} from './RunTags';
 import {getBackfillPath} from './RunsFeedUtils';
 import {RunFilterToken} from './RunsFilterInput';
 import {RunTableRunFragment} from './types/RunTableRunFragment.types';
 import {useTagPinning} from './useTagPinning';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {PipelineTag} from '../graphql/types';
+import {CopyButton} from '../ui/CopyButton';
 
 export const RunRowTags = ({
   run,
@@ -125,12 +126,8 @@ export const RunRowTags = ({
           <RunTags tags={allTagsWithPinned} onAddTag={onAddTag} onToggleTagPin={onToggleTagPin} />
         </DialogBody>
         <DialogFooter topBorder>
-          <Button
-            intent="primary"
-            onClick={() => {
-              setShowRunTags(false);
-            }}
-          >
+          <CopyButton value={() => tagsAsYamlString(run.tags)}>Copy tags</CopyButton>
+          <Button intent="primary" onClick={() => setShowRunTags(false)}>
             Close
           </Button>
         </DialogFooter>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTags.tsx
@@ -1,5 +1,6 @@
 import {Box} from '@dagster-io/ui-components';
 import {memo, useMemo} from 'react';
+import * as yaml from 'yaml';
 
 import {DagsterTag, RunTag, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
@@ -119,6 +120,7 @@ export const RunTags = memo((props: Props) => {
   const modeTag = mode ? (
     <RunTag tag={{key: 'mode', value: mode}} actions={actionsForTag({key: 'mode', value: mode})} />
   ) : null;
+
   return (
     <Box flex={{direction: 'row', wrap: 'wrap', gap: 4}}>
       {modeTag}
@@ -128,3 +130,9 @@ export const RunTags = memo((props: Props) => {
     </Box>
   );
 });
+
+export function tagsAsYamlString(displayedTags: TagType[]): string {
+  return yaml.stringify(
+    Object.fromEntries(displayedTags.map((d) => [d.originalKey || d.key, d.value])),
+  );
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
@@ -33,13 +33,12 @@ import {
   ScheduleTickConfigQuery,
   ScheduleTickConfigQueryVariables,
 } from './types/SchedulesNextTicks.types';
-import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {useCopyToClipboard} from '../app/browser';
 import {InstigationStatus} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunTags} from '../runs/RunTags';
+import {CopyButton} from '../ui/CopyButton';
 import {MenuLink} from '../ui/MenuLink';
 import {
   findRepositoryAmongOptions,
@@ -340,8 +339,6 @@ const NextTickDialog = ({
         : null,
     );
 
-  const copy = useCopyToClipboard();
-
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, schedule.pipelineName);
 
@@ -476,19 +473,7 @@ const NextTickDialog = ({
       {body}
       <DialogFooter topBorder>
         {selectedRunRequest ? (
-          <Button
-            autoFocus={false}
-            onClick={async () => {
-              copy(selectedRunRequest.runConfigYaml);
-              await showSharedToaster({
-                intent: 'success',
-                icon: 'copy_to_clipboard_done',
-                message: 'Copied!',
-              });
-            }}
-          >
-            Copy config
-          </Button>
+          <CopyButton value={selectedRunRequest.runConfigYaml}>Copy config</CopyButton>
         ) : null}
         <Button intent="primary" autoFocus={true} onClick={() => close()}>
           OK

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
@@ -3,8 +3,6 @@ import {useState} from 'react';
 
 import {RunConfigDialog} from '../runs/RunConfigDialog';
 import {RunRequestFragment} from './types/RunRequestFragment.types';
-import {showSharedToaster} from '../app/DomUtils';
-import {useCopyToClipboard} from '../app/browser';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {testId} from '../testing/testId';
 import {useRepository} from '../workspace/WorkspaceContext/util';
@@ -23,16 +21,6 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
   const repo = useRepository(repoAddress);
   const [selectedRequest, setSelectedRequest] = useState<RunRequestFragment | null>(null);
   const [visibleDialog, setVisibleDialog] = useState<'config' | null>(null);
-  const copy = useCopyToClipboard();
-
-  const copyConfig = async () => {
-    copy(selectedRequest?.runConfigYaml || '');
-    await showSharedToaster({
-      intent: 'success',
-      icon: 'copy_to_clipboard_done',
-      message: 'Copied!',
-    });
-  };
 
   const body = (
     <tbody data-testid={testId('table-body')}>
@@ -66,7 +54,6 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
         <RunConfigDialog
           isOpen={visibleDialog === 'config'}
           onClose={() => setVisibleDialog(null)}
-          copyConfig={() => copyConfig()}
           mode={mode || null}
           runConfigYaml={selectedRequest.runConfigYaml}
           tags={selectedRequest.tags}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/CopyButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/CopyButton.tsx
@@ -1,0 +1,64 @@
+import {Button, Colors, Icon, UnstyledButton} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {showSharedToaster} from '../app/DomUtils';
+import {useCopyToClipboard} from '../app/browser';
+
+export const CopyIconButton = ({value}: {value: string | (() => string)}) => {
+  const copyToClipboard = useCopyToClipboard();
+  const [didCopy, setDidCopy] = React.useState(false);
+  const iconTimeout = React.useRef<ReturnType<typeof setTimeout>>();
+
+  const performCopy = React.useCallback(async () => {
+    if (iconTimeout.current) {
+      clearTimeout(iconTimeout.current);
+    }
+
+    copyToClipboard(value instanceof Function ? value() : value);
+
+    await showSharedToaster({
+      icon: 'copy_to_clipboard_done',
+      message: 'Copied!',
+      intent: 'success',
+    });
+
+    setDidCopy(true);
+    iconTimeout.current = setTimeout(() => {
+      setDidCopy(false);
+    }, 2000);
+  }, [value, copyToClipboard]);
+
+  return (
+    <UnstyledButton $expandedClickPx={6} onClick={performCopy}>
+      <Icon
+        name={didCopy ? 'copy_to_clipboard_done' : 'copy_to_clipboard'}
+        color={Colors.accentGray()}
+      />
+    </UnstyledButton>
+  );
+};
+
+export const CopyButton = ({
+  value,
+  children,
+}: {
+  value: string | (() => string);
+  children: React.ReactNode;
+}) => {
+  const copyToClipboard = useCopyToClipboard();
+  return (
+    <Button
+      autoFocus={false}
+      onClick={async () => {
+        copyToClipboard(value instanceof Function ? value() : value);
+        await showSharedToaster({
+          icon: 'copy_to_clipboard_done',
+          intent: 'success',
+          message: 'Copied!',
+        });
+      }}
+    >
+      {children}
+    </Button>
+  );
+};


### PR DESCRIPTION
related: https://linear.app/dagster-labs/issue/FE-637/add-button-to-copy-all-tags-in-tags-modal

## Summary & Motivation

This PR adds a “Copy Tags” button to the run tags modal and the run “view configuration” modal  (which also shows the tags) which copies all the tags as a yaml block.

In building this I realized we have a handful of copy buttons and their behaviors (icons, toasts, etc) differ slightly, so I consolidated them down to two - an icon and a standard button. We could alternatively keep different buttons and push more toaster behavior into the hook, but I think it’s nice to standardize on a single icon + behavior. The version in the asset header is quite nice and I moved them all to that, but with the larger click target.

There is one that I didn't touch, which is pulled in from dagster dg - maybe we move this component to the new shared package and use it there too 👀 

## How I Tested These Changes

![image](https://github.com/user-attachments/assets/d68f9411-060b-4f47-8b00-7c5b729de749)
![image](https://github.com/user-attachments/assets/98171e96-5b06-4a3d-9696-2a0b8d55e7a0)

## Impacted

![image](https://github.com/user-attachments/assets/b8cbd4a7-648a-4c64-b73c-b9fced7e8925)
![image](https://github.com/user-attachments/assets/7538424d-11ac-413b-a565-4d4e843086ab)
![image](https://github.com/user-attachments/assets/25e2ba24-3da1-4f86-b5c1-b1632a2cc1cb)

## Changelog

[ui] Dagster's UI now allows you to copy run tags as a yaml block from the Tags and Configuration modals
