### PR TITLE
[dg] Get cli plumbing working for new --format argument

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py
@@ -19,7 +19,17 @@ def scaffold_cli() -> None:
 @click.argument("typename", type=str)
 @click.argument("path", type=Path)
 @click.option("--json-params", type=str, default=None)
-def scaffold_object_command(typename: str, path: Path, json_params: Optional[str]) -> None:
+@click.option(
+    "--scaffold-format",
+    type=click.Choice(["yaml", "python"], case_sensitive=False),
+    help="Format of the component configuration (yaml or python)",
+)
+def scaffold_object_command(
+    typename: str,
+    path: Path,
+    json_params: Optional[str],
+    scaffold_format: str,
+) -> None:
     key = LibraryObjectKey.from_typename(typename)
     obj = load_library_object(key)
 
@@ -33,4 +43,4 @@ def scaffold_object_command(typename: str, path: Path, json_params: Optional[str
     else:
         scaffold_params = {}
 
-    scaffold_object(path, obj, typename, scaffold_params)
+    scaffold_object(path, obj, typename, scaffold_params, scaffold_format)

--- a/python_modules/libraries/dagster-components/dagster_components/scaffold/scaffold.py
+++ b/python_modules/libraries/dagster-components/dagster_components/scaffold/scaffold.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 from dagster import _check as check
 from dagster._record import record
 from pydantic import BaseModel
+from typing_extensions import TypeAlias
 
 # Type variable for generic class handling
 T = TypeVar("T")
@@ -72,12 +73,17 @@ class ScaffolderUnavailableReason:
     message: str
 
 
+ScaffoldFormatOptions: TypeAlias = Literal["yaml", "python"]
+
+
 @record
 class ScaffoldRequest:
     # fully qualified class name of the decorated object
     type_name: str
     # target path for the scaffold request. Typically used to construct absolute paths
     target_path: Path
+    # yaml or python
+    scaffold_format: ScaffoldFormatOptions
 
 
 class Scaffolder:

--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -229,6 +229,8 @@ def test_scaffold_component_command():
                 "bar/components/qux",
                 "--json-params",
                 '{"asset_key": "my_asset", "filename": "my_asset.py"}',
+                "--scaffold-format",
+                "yaml",
             ],
         )
         assert_runner_result(result)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/integration_tests/test_sling_integration_test.py
@@ -323,6 +323,8 @@ def test_scaffold_sling():
                 "object",
                 "dagster_components.dagster_sling.SlingReplicationCollectionComponent",
                 "bar/components/qux",
+                "--scaffold-format",
+                "yaml",
             ],
         )
         assert result.exit_code == 0

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -1,10 +1,11 @@
 from collections.abc import Mapping
 from copy import copy
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import click
 from click.core import ParameterSource
+from dagster_shared import check
 from dagster_shared.serdes.objects import LibraryObjectKey, LibraryObjectSnap
 from typer.rich_utils import rich_format_help
 
@@ -26,6 +27,7 @@ from dagster_dg.config import (
 )
 from dagster_dg.context import DgContext
 from dagster_dg.scaffold import (
+    ScaffoldFormatOptions,
     scaffold_component_type,
     scaffold_library_object,
     scaffold_project,
@@ -283,6 +285,7 @@ def _core_scaffold(
     instance_name: str,
     key_value_params,
     json_params,
+    scaffold_format: ScaffoldFormatOptions,
 ) -> None:
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemoteLibraryObjectRegistry.from_dg_context(dg_context)
@@ -316,6 +319,7 @@ def _core_scaffold(
         object_key.to_typename(),
         scaffold_params,
         dg_context,
+        scaffold_format,
     )
 
 
@@ -335,12 +339,19 @@ def _create_scaffold_subcommand(key: LibraryObjectKey, obj: LibraryObjectSnap) -
         help="JSON string of component parameters.",
         callback=parse_json_option,
     )
+    @click.option(
+        "--format",
+        type=click.Choice(["yaml", "python"], case_sensitive=False),
+        default="yaml",
+        help="Format of the component configuration (yaml or python)",
+    )
     @click.pass_context
     @cli_telemetry_wrapper
     def scaffold_command(
         cli_context: click.Context,
         instance_name: str,
         json_params: Mapping[str, Any],
+        format: str,  # noqa: A002 "format" name required for click magic
         **key_value_params: Any,
     ) -> None:
         f"""Scaffold a {key.name} object.
@@ -360,8 +371,20 @@ def _create_scaffold_subcommand(key: LibraryObjectKey, obj: LibraryObjectSnap) -
 
         It is an error to pass both --json-params and key-value pairs as options.
         """
+        check.invariant(
+            format in ["yaml", "python"],
+            "format must be either 'yaml' or 'python'",
+        )
         cli_config = get_config_from_cli_context(cli_context)
-        _core_scaffold(cli_context, cli_config, key, instance_name, key_value_params, json_params)
+        _core_scaffold(
+            cli_context,
+            cli_config,
+            key,
+            instance_name,
+            key_value_params,
+            json_params,
+            cast(ScaffoldFormatOptions, format),
+        )
 
     # If there are defined scaffold params, add them to the command
     if obj.scaffolder_schema:

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -2,11 +2,12 @@ import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import click
 import tomlkit
 import tomlkit.items
+from typing_extensions import TypeAlias
 
 from dagster_dg.component import RemoteLibraryObjectRegistry
 from dagster_dg.config import (
@@ -25,6 +26,7 @@ from dagster_dg.utils import (
     set_toml_node,
 )
 
+ScaffoldFormatOptions: TypeAlias = Literal["yaml", "python"]
 # ########################
 # ##### WORKSPACE
 # ########################
@@ -256,7 +258,11 @@ def scaffold_component_type(dg_context: DgContext, class_name: str, module_name:
 
 
 def scaffold_library_object(
-    path: Path, typename: str, scaffold_params: Optional[Mapping[str, Any]], dg_context: "DgContext"
+    path: Path,
+    typename: str,
+    scaffold_params: Optional[Mapping[str, Any]],
+    dg_context: "DgContext",
+    scaffold_format: ScaffoldFormatOptions,
 ) -> None:
     scaffold_command = [
         "scaffold",
@@ -264,5 +270,6 @@ def scaffold_library_object(
         typename,
         str(path),
         *(["--json-params", json.dumps(scaffold_params)] if scaffold_params else []),
+        *(["--scaffold-format", scaffold_format]),
     ]
     dg_context.external_components_command(scaffold_command)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -189,21 +189,22 @@ def test_dynamic_subcommand_help_message():
         assert match_terminal_box_output(
             output.strip(),
             textwrap.dedent("""
-                 Usage: dg scaffold [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] INSTANCE_NAME 
+Usage: dg scaffold [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] INSTANCE_NAME
 
-                ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ *    instance_name      TEXT  [required]                                                                             │
-                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-                ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ --json-params          TEXT  JSON string of component parameters.                                                    │
-                │ --asset-key            TEXT  asset_key                                                                               │
-                │ --filename             TEXT  filename                                                                                │
-                │ --help         -h            Show this message and exit.                                                             │
-                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-                ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ --cache-dir            TEXT  Specify a directory to use for the cache.                                               │
-                │ --disable-cache              Disable the cache..                                                                     │
-                │ --verbose                    Enable verbose output for debugging.                                                    │
-                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-        """).strip(),
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    instance_name      TEXT  [required]                                                                             │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --json-params          TEXT           JSON string of component parameters.                                           │
+│ --format               [yaml|python]  Format of the component configuration (yaml or python)                         │
+│ --asset-key            TEXT           asset_key                                                                      │
+│ --filename             TEXT           filename                                                                       │
+│ --help         -h                     Show this message and exit.                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --cache-dir            TEXT  Specify a directory to use for the cache.                                               │
+│ --disable-cache              Disable the cache..                                                                     │
+│ --verbose                    Enable verbose output for debugging.                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                            """).strip(),
         )


### PR DESCRIPTION
## Summary & Motivation

Just getting the double layer cli layering working before implementing the business logic.

* `dg` has a flag (`--format`) that defaults to `yaml`)
* `dagster_componets` has a non-optional flag (`--scaffold-format`). Renamed to avoid collision with python built-in `format`.

## How I Tested These Changes

```
(dagster-dev-3.11.11-2024-12-08) ➜  standalone_project dg scaffold dagster_components.dagster.DefinitionsComponent test_component_1 --format python
Using /Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/bin/dagster-components
Traceback (most recent call last):
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/bin/dagster-components", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/schrockn/code/dagster/python_modules/libraries/dagster-components/dagster_components/cli/__init__.py", line 35, in main
    cli(auto_envvar_prefix=ENV_PREFIX)
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/schrockn/code/dagster/python_modules/libraries/dagster-components/dagster_components/cli/scaffold.py", line 47, in scaffold_object_command
    scaffold_object(path, obj, typename, scaffold_params, scaffold_format)
  File "/Users/schrockn/code/dagster/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py", line 65, in scaffold_object
    scaffolder.scaffold(
  File "/Users/schrockn/code/dagster/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/scaffolder.py", line 33, in scaffold
    scaffold_component(
  File "/Users/schrockn/code/dagster/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py", line 37, in scaffold_component
    raise NotImplementedError("Python scaffolding not yet implemented.")
NotImplementedError: Python scaffolding not yet implemented.
An error occurred while executing a `dagster-components` command in the Python environment at /Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv.

`uv run dagster-components scaffold object dagster_components.dagster.DefinitionsComponent /Users/schrockn/code/scratch/dg-workspaces/standalone_project/standalone_project/defs/test_component_1 --scaffold-format python` exited with code 1. Aborting.
(dagster-dev-3.11.11-2024-12-08) ➜  standalone_project
```
## Changelog

> Insert changelog entry or delete this section.
