### PR TITLE
[ui] Fix awkward messaging on the “Materialize” button when selection is empty

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -128,6 +128,38 @@ export const ERROR_INVALID_ASSET_SELECTION =
   ` the same code location and share a partition space, or form a connected` +
   ` graph in which root assets share the same partitioning.`;
 
+function materializationDisabledReason(all: Asset[], materializable: Asset[]) {
+  if (!all.length) {
+    return 'Select one or more assets to materialize';
+  }
+  if (all.some((a) => !a.hasMaterializePermission)) {
+    return 'You do not have permission to materialize assets';
+  }
+  if (all.every((a) => !a.isExecutable)) {
+    return 'External assets cannot be materialized';
+  }
+  if (all.every((a) => a.isObservable)) {
+    return 'Observable assets cannot be materialized';
+  }
+  if (materializable.length === 0) {
+    return 'No executable assets selected.';
+  }
+  return null;
+}
+
+function observationDisabledReason(all: Asset[], observable: Asset[]) {
+  if (!all.length) {
+    return 'Select one or more assets to observe';
+  }
+  if (all.some((a) => !a.hasMaterializePermission)) {
+    return 'You do not have permission to observe assets';
+  }
+  if (observable.length === 0) {
+    return 'Assets do not have observation functions';
+  }
+  return null;
+}
+
 export function optionsForExecuteButton(
   assets: Asset[],
   {skipAllTerm, isSelection}: {skipAllTerm?: boolean; isSelection?: boolean},
@@ -139,15 +171,7 @@ export function optionsForExecuteButton(
   return {
     materializeOption: {
       assetKeys: materializable.map((a) => a.assetKey),
-      disabledReason: assets.some((a) => !a.hasMaterializePermission)
-        ? 'You do not have permission to materialize assets'
-        : assets.every((a) => !a.isExecutable)
-          ? 'External assets cannot be materialized'
-          : assets.every((a) => a.isObservable)
-            ? 'Observable assets cannot be materialized'
-            : materializable.length === 0
-              ? 'No executable assets selected.'
-              : null,
+      disabledReason: materializationDisabledReason(assets, materializable),
       icon: <Icon name="materialization" />,
       label: isSelection
         ? `Materialize selected${countIfPluralOrNotAll(materializable, assets)}${ellipsis}`
@@ -157,11 +181,7 @@ export function optionsForExecuteButton(
     },
     observeOption: {
       assetKeys: observable.map((a) => a.assetKey),
-      disabledReason: assets.some((a) => !a.hasMaterializePermission)
-        ? 'You do not have permission to observe assets'
-        : observable.length === 0
-          ? 'Assets do not have observation functions'
-          : null,
+      disabledReason: observationDisabledReason(assets, observable),
       icon: <Icon name="observation" />,
       label: isSelection
         ? `Observe selected${countIfPluralOrNotAll(observable, assets)}`

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -114,6 +114,17 @@ describe('LaunchAssetExecutionButton', () => {
         'Materialize selected (1)…', // 2 instead of 3
       );
     });
+
+    it('should be disabled if the selection is empty', async () => {
+      renderButton({
+        scope: {selected: []},
+      });
+      const button = await screen.findByTestId('materialize-button');
+      expect(button).toBeDisabled();
+
+      userEvent.hover(button);
+      expect(await screen.findByText('Select one or more assets to materialize')).toBeDefined();
+    });
   });
 
   describe('observable assets', () => {


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-798/improve-tooltip-for-button-with-no-selection

Before:
![image](https://github.com/user-attachments/assets/28b0194b-9d50-4d29-94de-6a181729034a)

After:

![image](https://github.com/user-attachments/assets/1422dc2e-0909-46fc-b1f8-af8670b234ee)


## How I Tested These Changes

Other cases are unchanged, I just unwound a mega-ternary into a function  (probably my doing...)  and added a new case at the top.  Verified the other cases still work by selecting non-executable and observable assets.
