### PR TITLE
[dg] Implement actual scaffolding

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
+++ b/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
@@ -37,19 +37,21 @@ def scaffold_component(
     elif request.scaffold_format == "python":
         with open(request.target_path / "component.py", "w") as f:
             fqtn = request.type_name
+            check.invariant("." in fqtn, "Component must be a fully qualified type name")
             module_path, class_name = (
                 ".".join(fqtn.split(".")[:-1]),
-                fqtn.split(".")[-1] if "." in fqtn else ("", fqtn),
+                fqtn.split(".")[-1],
             )
             f.write(
                 textwrap.dedent(
-                    f"""from dagster_components import component, ComponentLoadContext
-from {module_path} import {class_name}
+                    f"""
+                        from dagster_components import component, ComponentLoadContext
+                        from {module_path} import {class_name}
 
-@component
-def load(context: ComponentLoadContext) -> {class_name}: ...
-            """
-                )
+                        @component
+                        def load(context: ComponentLoadContext) -> {class_name}: ...
+                """
+                ).lstrip()
             )
     else:
         check.assert_never(request.scaffold_format)

--- a/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
+++ b/python_modules/libraries/dagster-components/dagster_components/component_scaffolding.py
@@ -94,5 +94,5 @@ def scaffold_object(
         component_py_path = path / "component.py"
         if not (component_yaml_path.exists() or component_py_path.exists()):
             raise Exception(
-                f"Currently all components require a component.yaml or component.yaml file. Please ensure your implementation of scaffold writes this file at {component_yaml_path} or {component_py_path}."
+                f"Currently all components require a component.yaml or component.py file. Please ensure your implementation of scaffold writes this file at {component_yaml_path} or {component_py_path}."
             )


### PR DESCRIPTION
## Summary & Motivation

Implement `--format python` option of scaffold command.

## How I Tested These Changes

```
(dagster-dev-3.11.11-2024-12-08) ➜  standalone_project dg scaffold dagster_components.dagster.DefinitionsComponent test_component_11 --format python
Using /Users/schrockn/code/scratch/dg-workspaces/standalone_project/.venv/bin/dagster-components
(dagster-dev-3.11.11-2024-12-08) ➜  standalone_project cat standalone_project/defs/test_component_11/component.py
from dagster_components import component, ComponentLoadContext
from dagster_components.dagster import DefinitionsComponent

@component
def load(context: ComponentLoadContext) -> DefinitionsComponent: ...
```

## Changelog

Added the abiility to scaffold Python components