### PR TITLE
[dg] Make `dg check` and `dg dev` work without assuming `uv`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -119,11 +119,12 @@ def check_definitions_command(
         *(["--verbose"] if verbose else []),
     ]
 
-    run_cmds = (
-        ["uv", "run", "dagster", "definitions", "validate"]
-        if dg_context.is_project
-        else ["uv", "tool", "run", "dagster", "definitions", "validate"]
-    )
+    if dg_context.use_dg_managed_environment:
+        run_cmds = ["uv", "run", "dagster", "definitions", "validate"]
+    elif dg_context.is_project:
+        run_cmds = ["dagster", "definitions", "validate"]
+    else:
+        run_cmds = ["uv", "tool", "run", "dagster", "definitions", "validate"]
 
     with (
         pushd(dg_context.root_path),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -111,11 +111,12 @@ def dev_command(
     # In a workspace context, dg dev will construct a temporary
     # workspace file that points at all defined code locations and invoke:
     #     uv tool run --with dagster-webserver dagster dev
-    run_cmds = (
-        ["uv", "run", "dagster", "dev"]
-        if dg_context.is_project
-        else ["uv", "tool", "run", "--with", "dagster-webserver", "dagster", "dev"]
-    )
+    if dg_context.use_dg_managed_environment:
+        run_cmds = ["uv", "run", "dagster", "dev"]
+    elif dg_context.is_project:
+        run_cmds = ["dagster", "dev"]
+    else:
+        run_cmds = ["uv", "tool", "run", "--with", "dagster-webserver", "dagster", "dev"]
 
     with (
         pushd(dg_context.root_path),


### PR DESCRIPTION
## Summary & Motivation

Currently, `dg check` and `dg dev` always use `uv run` in a project context. This changes them to make them use the ambient environment if we're not using dg management.

## How I Tested These Changes

Manually by running in a project not using `uv`. Will need to add automated tests in a followup.