### PR TITLE
[dagster-dbt][rfc] core system changes required to automatically allow dbt sources to work

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -137,13 +137,17 @@ class AssetCheckResult(
     def to_asset_check_evaluation(
         self, step_context: "StepExecutionContext"
     ) -> AssetCheckEvaluation:
-        check_names_by_asset_key = (
-            step_context.job_def.asset_layer.check_names_by_asset_key_by_node_handle.get(
-                step_context.node_handle.root
-            )
+        assets_def_for_check = check.not_none(
+            step_context.job_def.asset_layer.assets_def_for_node(
+                node_handle=step_context.node_handle
+            ),
+            f"While resolving asset check result {self}, expected to find an AssetsDefinition object that could be associated back to the currently executing NodeHandle {step_context.node_handle}.",
         )
-
-        check_key = self.resolve_target_check_key(check_names_by_asset_key)
+        all_check_keys = set(assets_def_for_check._computation.check_keys_by_output_name.values())
+        all_check_names_by_asset_key = {}
+        for check_key in all_check_keys:
+            all_check_names_by_asset_key.setdefault(check_key.asset_key, set()).add(check_key.name)
+        check_key = self.resolve_target_check_key(all_check_names_by_asset_key)
 
         input_asset_info = step_context.maybe_fetch_and_get_input_asset_version_info(
             check_key.asset_key

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -64,6 +64,8 @@ class AssetLayer(NamedTuple):
         assets_defs_by_op_handle: dict[NodeHandle, AssetsDefinition] = {}
 
         for node_handle, assets_def in assets_defs_by_outer_node_handle.items():
+            print("OUTPUT BY CHECK KEY")
+            print(assets_def.check_specs_by_output_name)
             computation = check.not_none(assets_def.computation)
             full_node_def = computation.full_node_def
             for input_name, input_asset_key in assets_def.node_keys_by_input_name.items():
@@ -122,6 +124,12 @@ class AssetLayer(NamedTuple):
                 for op_handle in computation.node_def.get_op_handles(parent=node_handle):
                     assets_defs_by_op_handle[op_handle] = assets_def
 
+        print("CHECK NAMES BY ASSET KEY BY NODE HANDLE")
+        print(check_names_by_asset_key_by_node_handle)
+        print("CHECK KEYS BY NODE OUTPUT HANDLE")
+        print(check_key_by_output)
+        print("NODE OUTPUT HANDLES BY ASSET CHECK KEY")
+        print(node_output_handles_by_asset_check_key)
         return AssetLayer(
             asset_graph=asset_graph,
             asset_keys_by_node_input_handle=asset_key_by_input,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -148,6 +148,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         execution_type: Optional[AssetExecutionType] = None,
         # TODO: FOU-243
         auto_materialize_policies_by_key: Optional[Mapping[AssetKey, AutoMaterializePolicy]] = None,
+        # for dbt source tests; we want to auto select the checks which apply to
+        # any upstreams of the asset being selected if no check selection is provided.
+        # this is very overspecified; but there's not really another use case for it.
         # if adding new fields, make sure to handle them in the with_attributes, from_graph,
         # from_op, and get_attributes_dict methods
     ):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -570,6 +570,8 @@ def multi_asset(
     specs: Optional[Sequence[AssetSpec]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     pool: Optional[str] = None,
+    # scope this down to only allow targeting upstreams
+    # and then it's reasonable default behavior?
     _disable_check_specs_target_relevant_asset_keys: bool = False,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -171,6 +171,7 @@ class RepositorySnap(IHaveNew):
         repository_def: RepositoryDefinition,
         defer_snapshots: bool = False,
     ) -> Self:
+        print("I AM IN THE REPOSITORY SNAP CLASS")
         check.inst_param(repository_def, "repository_def", RepositoryDefinition)
 
         jobs = repository_def.get_all_jobs()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -861,9 +861,9 @@ def test_dbt_source_tests_checks_enabled(
         [my_dbt_assets],
         resources={"dbt": DbtCliResource(project_dir=os.fspath(test_asset_checks_path))},
         raise_on_error=False,
-        selection=AssetSelection.keys(*all_asset_keys).__or__(
-            AssetSelection.checks(*all_check_keys)
-        ),
+        # selection=AssetSelection.keys(*all_asset_keys).__or__(
+        #     AssetSelection.checks(*all_check_keys)
+        # ),
     )
     assert not result.success
     asset_check_results = [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/dagster_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/dagster_defs.py
@@ -17,10 +17,25 @@ project.prepare_if_dev()
 @dg_dbt.dbt_assets(
     project=project,
     manifest=project.manifest_path,
+    dagster_dbt_translator=dg_dbt.DagsterDbtTranslator(
+        dg_dbt.DagsterDbtTranslatorSettings(enable_source_tests_as_checks=True)
+    ),
 )
 def my_dbt_assets(context: dg.AssetExecutionContext, dbt: dg_dbt.DbtCliResource):
     yield from dbt.cli(["build"], context=context).stream()
 
+
+# @dg.multi_asset(specs=[dg.AssetSpec(key="abc", deps=["upstream"])], check_specs=[dg.AssetCheckSpec(name="my_check", asset="upstream")], _disable_check_specs_target_relevant_asset_keys=True)
+# def my_asset():
+#     pass
+
+# # simulates having a check targeting an upstream asset
+# @dg.multi_asset(specs=[dg.AssetSpec(key="unrelated", deps=["upstream"])], check_specs=[dg.AssetCheckSpec(name="my_check", asset="upstream")], _disable_check_specs_target_relevant_asset_keys=True)
+# def my_unrelated_asset():
+#     pass
+
+
+print(" I AM LOADING THE DAGSTER DEFS")
 
 defs = dg.Definitions(
     assets=[my_dbt_assets],


### PR DESCRIPTION
## Summary & Motivation
This PR scopes out all the core framework changes required to get dbt source tests to run automatically when represented as asset checks.
Note that the core code might not be a perfect representation of everythigng that I've stated here. For example; we need to narrow the "allowance of asset checks which don't targeted included assets" further in a few places.

Excalidraw laying out the state of the world: https://link.excalidraw.com/l/1JeNdKlWvm5/7MxN7I6MrF0

**Tl;dr:**
- Allow asset checks to be defined on an AssetsDefinition which target upstreams of the assets defined within.
- If I select an asset, and the AssetsDefinition for that asset contains a check on an upstream, automatically select that check as well (only if the upstream is not part of the underlying AssetsDefinition)
- When a multi asset is cleaved in two due to cycle resolution; smack this "upstream check" on only one of the cleaved multi assets
- Don't error when an asset check result is yielded for an unselected asset check. Instead,  yield a warning.


**Explanation**
**Part 1: Allowing asset checks defined on upstreams**
The data model for a dbt source is as follows:
- When a model which requires a dbt source is run; and tests are configured to run in general, the tests for that dbt source will be automatically run as well.
Think of it like the following asset:
```python
@multi_asset(
        specs=[AssetSpec("b", deps=["a"])],
        check_specs=[AssetCheckSpec("a_is_good", asset="a")],
    )
    def foo(context: AssetExecutionContext):
        ...
```

This is currently unmodel-able in Dagster; because the system expects that any check in an assetsdefinition _only_ targets assets within that definition (unless there are no assets within the definition).

Our solution is to relax this constraint to explicitly allow for the "upstream source check" behavior we want: allow upstream source checks. If an asset check targets a _dep_ of any assets within; allow that.

**Part 2: Inclusion of upstream checks**
In the previous PR; we allow dbt source tests to run as asset checks. However, because of how the default asset resolution logic works; those checks never get executed. Take the following code as an example:
```python
@dg_dbt.dbt_assets(...)
def my_dbt_assets(context: dg.AssetExecutionContext, dbt: dg_dbt.DbtCliResource):
    yield from dbt.cli(["build"], context=context).stream()

materialize([my_dbt_assets])
```
Here's the resolution path:
1. If my_dbt_assets contains dbt sources, they render as asset checks which target the _upstream_ dbt sources; not any of the actual assets in the `AssetsDefinition`.
2. Create a job which targets all assets. This resolves down to the explicit set of asset keys which comprise all assets
3. From that full set of asset keys, select the check keys which target those asset keys.

The crucial bit here is that dbt sources are "autogenerated stub" external assets, generated from the existence of a dep; and thus are not part of the asset key list for _any_ materializable asset. So when we define a check for them; there's no way for that check to get selected except explicitly doing so.

To fix this; we make a net new behavioral change: if there's a check present on an asset that's upstream of any selected asset, and the asset targeted by the check is not part of the AssetsDefinition; automatically select that check as well. While it sounds complicated at first; we think this is actually a sensible behavior change. The idea is that; you're basically performing some data quality check upon loading an upstream. In which case, it makes sense that the check would also be selected. This doesn't break any existing functionality, because it was previously impossible for checks to be defined on anything but the assets contained within the AssetsDefinition (if any assets are defined). And of course; it enables the expected dbt source test behavior which runs tests on sources whenever the downstreams of a source are selected (and tests are configured to be run).

**Part 3: cycle resolution** 
There's a complex edge case where a multi asset results in an asset graph that must be "cleaved". Imagine the following dependency graph:

![Screenshot 2025-03-28 at 5.20.54 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BNzu24Bttry3X3xg41kv/dc670141-4af4-4a64-846d-b2e0a1747de8.png)

If "b" and "d" are included within the same assets definition, then the system will need to "cleave" that assets definition apart to avoid cycles. This results in a nasty edge case if the cleaved assets share a source; and there's a check on that source. In the dbt case; the source test will run automatically in both "cleaved" asset computations; but including the same asset check in multiple computations is disallowed. It is also disallowed to yield unselected asset check evaluations.

Our workaround here is to _only_ include the upstream source check in _one_ of the cleaved assetsdefinitions; but then relax the constriction that unselected asset check evaluations result in an error. We yield the asset check result without yielding an output, and fire off a warning. We think this is a reasonable end state for what is ostensibly a pretty hard edge case to hit.

**Part 4: (currently unhandled) Launchpad**
The launchpad independently resolves the set of asset checks to use when executing the "materialize all" button by retrieving all check keys from the graphene layer. We could use the same "inclusion of upstream checks" logic above; or just explicitly defer the resolution of which checks to run to the backend (unless checks are explicitly selected)

## How I Tested These Changes
A new test for the cycle resolution behavior + automatic inclusion of upstream checks.

## Changelog
- To support execution of dbt sources as asset checks; we've made the following core framework enhancements:
 1. asset checks can be defined on deps of assets:
```python
@multi_asset(
        specs=[AssetSpec("b", deps=["a"])],
        check_specs=[AssetCheckSpec("a_is_good", asset="a")],
    )
    def foo(context: AssetExecutionContext):
        ...
```

 2. when an asset is selected to be executed and the same computation includes a check on an upstream; it will automatically be selected as well if the upstream is not part of the same computation.
    - Ie; in `foo` above, selecting `b` for execution without specifying which asset checks to execute, will also execute `a_is_good` automatically. This can be disabled with asset selections.
 3. We have relaxed the hard requirement that you only yield check results for selected checks. Instead; we will emit a warning. This is to semi-peacefully resolve the scenario where dagster is forced to split apart an AssetsDefinition due to complex cycle resolution logic; but the underlying check logic always executes anyway. 

