### PR TITLE
Ensure uri and tablename show up in asset overview

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -138,7 +138,12 @@ export const AssetEventMetadataEntriesTable = ({
     () =>
       allRows
         .filter((row) => !filter || row.entry.label.toLowerCase().includes(filter.toLowerCase()))
-        .filter((row) => !isEntryHidden(row.entry, {hideEntriesShownOnOverview})),
+        .filter(
+          (row) =>
+            !isEntryHidden(row.entry, {hideEntriesShownOnOverview}) ||
+            row.entry.label === 'dagster/uri' ||
+            row.entry.label === 'dagster/table_name',
+        ),
     [allRows, filter, hideEntriesShownOnOverview],
   );
 


### PR DESCRIPTION
## Summary & Motivation
           In issues #27705 and #27706, a similar problem related to metadata related to URI and tablename not appearing in the asset overview. Originally, my teams were only supposed to work on issue #27705, but we found that the two issues are similar, so we decided to do both fixes.
## How I Tested These Changes
          We just have a test dagster definition file and check if the URI metadata appear in the metadata section of asset overview. We checked the localhost of the make dev_webapp command. 
## Changelog
         We change the AssetEveneMetadataEntriesTable.tsx to make the URI and tablename show up.
> Insert changelog entry or delete this section.
