### PR TITLE
[dg] definitions_component

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components/component/component_loader.py
+++ b/python_modules/libraries/dagster-components/dagster_components/component/component_loader.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
+from typing_extensions import TypeAlias
+
 if TYPE_CHECKING:
     from dagster_components.component.component import Component
     from dagster_components.core.context import ComponentLoadContext
@@ -9,10 +11,10 @@ COMPONENT_LOADER_FN_ATTR = "__dagster_component_loader_fn"
 
 T_Component = TypeVar("T_Component", bound="Component")
 
+ComponentLoadFn: TypeAlias = Callable[["ComponentLoadContext"], T_Component]
 
-def component(
-    fn: Callable[["ComponentLoadContext"], T_Component],
-) -> Callable[["ComponentLoadContext"], T_Component]:
+
+def component(fn: ComponentLoadFn) -> ComponentLoadFn:
     setattr(fn, COMPONENT_LOADER_FN_ATTR, True)
     return fn
 

--- a/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components/lib/definitions_component/decorator.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from dagster._core.definitions.definitions_class import Definitions
+from typing_extensions import TypeAlias
+
+from dagster_components.component.component import Component
+from dagster_components.component.component_loader import ComponentLoadFn, component
+from dagster_components.core.context import ComponentLoadContext
+
+DefinitionsLoadFn: TypeAlias = Callable[[ComponentLoadContext], Definitions]
+
+
+@dataclass(frozen=True)
+class DecoratorDefinitionsComponent(Component):
+    fn: DefinitionsLoadFn
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return self.fn(context)
+
+
+def definitions_component(fn: DefinitionsLoadFn) -> ComponentLoadFn:
+    @component
+    def load(context: ComponentLoadContext) -> DecoratorDefinitionsComponent:
+        return DecoratorDefinitionsComponent(fn)
+
+    return load

--- a/python_modules/libraries/dagster-components/dagster_components/test/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/utils.py
@@ -9,22 +9,6 @@ from dagster_components.component.component_loader import ComponentLoadFn, is_co
 TComponent = TypeVar("TComponent", bound=Component)
 
 
-# def load_direct(
-#     component_type: type[TComponent],
-#     attribute_yaml: str,
-# ) -> TComponent:
-#     decl_node = DirectForTestComponentDecl(
-#         path=Path("/"),
-#         component_type=component_type,
-#         attributes_yaml=attribute_yaml,
-#     )
-#     context = ComponentLoadContext.for_test(
-#         decl_node=decl_node,
-#     )
-#     components = decl_node.load(context)
-#     return components[0]  # type: ignore
-
-
 def load_component_defs(
     *,
     context: Optional["ComponentLoadContext"] = None,

--- a/python_modules/libraries/dagster-components/dagster_components/test/utils.py
+++ b/python_modules/libraries/dagster-components/dagster_components/test/utils.py
@@ -1,0 +1,40 @@
+from typing import Optional, TypeVar
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_shared import check
+
+from dagster_components import Component, ComponentLoadContext
+from dagster_components.component.component_loader import ComponentLoadFn, is_component_loader
+
+TComponent = TypeVar("TComponent", bound=Component)
+
+
+# def load_direct(
+#     component_type: type[TComponent],
+#     attribute_yaml: str,
+# ) -> TComponent:
+#     decl_node = DirectForTestComponentDecl(
+#         path=Path("/"),
+#         component_type=component_type,
+#         attributes_yaml=attribute_yaml,
+#     )
+#     context = ComponentLoadContext.for_test(
+#         decl_node=decl_node,
+#     )
+#     components = decl_node.load(context)
+#     return components[0]  # type: ignore
+
+
+def load_component_defs(
+    *,
+    context: Optional["ComponentLoadContext"] = None,
+    component_fn: ComponentLoadFn,
+) -> Definitions:
+    check.param_invariant(
+        is_component_loader(component_fn),
+        "component_fn",
+        "Component function must be decorated with @component.",
+    )
+    context = context or ComponentLoadContext.for_test()
+    component_inst = component_fn(context)
+    return component_inst.build_defs(context)

--- a/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_definitions_component_decorator.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/unit_tests/test_definitions_component_decorator.py
@@ -1,0 +1,22 @@
+from dagster import asset
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_components import Component
+from dagster_components.core.context import ComponentLoadContext
+from dagster_components.lib.definitions_component.decorator import definitions_component
+from dagster_components.test.utils import load_component_defs
+
+
+def test_basic_definitions_component() -> None:
+    @definitions_component
+    def an_asset_component(context):
+        @asset
+        def an_asset() -> None: ...
+
+        return Definitions([an_asset])
+
+    assert isinstance(an_asset_component(ComponentLoadContext.for_test()), Component)
+    defs = load_component_defs(component_fn=an_asset_component)
+    assert isinstance(defs, Definitions)
+    assert len(defs.get_all_asset_specs())
+    assert defs.get_all_asset_specs()[0].key == AssetKey("an_asset")


### PR DESCRIPTION
## Summary & Motivation

When using Pythonic Components, it's a fairly common pattern to want to create a basket of definitions in the component hierarchy.

For a lot of operations (e.g. attaching a resource) it feels heavy to create an entire component, and creating a Definitions leads to a potential import-time construction.

Here I propose a decorator, `definitions_component`, that enables the creation a `Definitions` in decorated function, but it creates a component loader on the users behalf.

```python
@definitions_component
def my_definitions_component(context):
    @asset
    def an_asset() -> None: ...
    
    return Definitions([an_asset], resources={"a_resource", AResource())
```

The decorator implementation is quite minimal, and transforms the function into a component loader

```python
def definitions_component(
    fn: DefinitionsLoadFn,
) -> Callable[[ComponentLoadContext], DecoratorDefinitionsComponent]:
    @component
    def load(context: ComponentLoadContext) -> DecoratorDefinitionsComponent:
        return DecoratorDefinitionsComponent(fn)
    return load
```

I think this will be a common pattern to make Pythonic components feel lighter.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG