### PR TITLE
[ui] Allow overriding run tags when performing re-execution

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3881,7 +3881,6 @@ type Mutation {
 input ReexecutionParams {
   parentRunId: String!
   strategy: ReexecutionStrategy!
-  runConfigData: RunConfigData
   extraTags: [ExecutionTag!]
   useParentRunTags: Boolean
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3881,6 +3881,9 @@ type Mutation {
 input ReexecutionParams {
   parentRunId: String!
   strategy: ReexecutionStrategy!
+  runConfigData: RunConfigData
+  extraTags: [ExecutionTag!]
+  useParentRunTags: Boolean
 }
 
 enum ReexecutionStrategy {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4189,7 +4189,6 @@ export type QueryWorkspaceLocationEntryOrErrorArgs = {
 export type ReexecutionParams = {
   extraTags?: InputMaybe<Array<ExecutionTag>>;
   parentRunId: Scalars['String']['input'];
-  runConfigData?: InputMaybe<Scalars['RunConfigData']['input']>;
   strategy: ReexecutionStrategy;
   useParentRunTags?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -12734,8 +12733,6 @@ export const buildReexecutionParams = (
     extraTags: overrides && overrides.hasOwnProperty('extraTags') ? overrides.extraTags! : [],
     parentRunId:
       overrides && overrides.hasOwnProperty('parentRunId') ? overrides.parentRunId! : 'sunt',
-    runConfigData:
-      overrides && overrides.hasOwnProperty('runConfigData') ? overrides.runConfigData! : 'et',
     strategy:
       overrides && overrides.hasOwnProperty('strategy')
         ? overrides.strategy!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4187,8 +4187,11 @@ export type QueryWorkspaceLocationEntryOrErrorArgs = {
 };
 
 export type ReexecutionParams = {
+  extraTags?: InputMaybe<Array<ExecutionTag>>;
   parentRunId: Scalars['String']['input'];
+  runConfigData?: InputMaybe<Scalars['RunConfigData']['input']>;
   strategy: ReexecutionStrategy;
+  useParentRunTags?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ReexecutionStrategy {
@@ -12728,12 +12731,19 @@ export const buildReexecutionParams = (
   const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
   relationshipsToOmit.add('ReexecutionParams');
   return {
+    extraTags: overrides && overrides.hasOwnProperty('extraTags') ? overrides.extraTags! : [],
     parentRunId:
       overrides && overrides.hasOwnProperty('parentRunId') ? overrides.parentRunId! : 'sunt',
+    runConfigData:
+      overrides && overrides.hasOwnProperty('runConfigData') ? overrides.runConfigData! : 'et',
     strategy:
       overrides && overrides.hasOwnProperty('strategy')
         ? overrides.strategy!
         : ReexecutionStrategy.ALL_STEPS,
+    useParentRunTags:
+      overrides && overrides.hasOwnProperty('useParentRunTags')
+        ? overrides.useParentRunTags!
+        : false,
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
@@ -34,7 +34,7 @@ export const JobMenu = (props: Props) => {
   };
 
   const materialize = useMaterializationAction(job.name);
-  const onReexecute = useJobReexecution();
+  const reexecute = useJobReexecution();
 
   const {
     permissions: {canLaunchPipelineReexecution, canLaunchPipelineExecution},
@@ -84,8 +84,10 @@ export const JobMenu = (props: Props) => {
     <MenuItem
       icon="replay"
       text="Re-execute latest run"
-      onClick={() => (run ? onReexecute(run, ReexecutionStrategy.ALL_STEPS) : undefined)}
       disabled={!canLaunchPipelineReexecution || !run || !canRunAllSteps(run)}
+      onClick={(e) =>
+        run ? reexecute.onClick(run, ReexecutionStrategy.ALL_STEPS, e.shiftKey) : undefined
+      }
     />
   );
 
@@ -93,14 +95,17 @@ export const JobMenu = (props: Props) => {
     <MenuItem
       icon="sync_problem"
       text="Re-execute latest run from failure"
-      onClick={() => (run ? onReexecute(run, ReexecutionStrategy.FROM_FAILURE) : undefined)}
       disabled={!canLaunchPipelineReexecution || !run || !canRunFromFailure(run)}
+      onClick={(e) =>
+        run ? reexecute.onClick(run, ReexecutionStrategy.FROM_FAILURE, e.shiftKey) : undefined
+      }
     />
   );
 
   return (
     <>
       {materialize.launchpadElement}
+      {reexecute.launchpadElement}
       <Popover
         onOpened={() => fetchIfPossible()}
         content={

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchButton.tsx
@@ -20,7 +20,7 @@ export interface LaunchButtonConfiguration {
   disabled: boolean;
   warning?: React.ReactNode;
   scope?: string;
-  onClick: () => Promise<any>;
+  onClick: (e: React.MouseEvent | KeyboardEvent) => Promise<any>;
   icon?: IconName | JSX.Element | 'dagster-spinner';
   tooltip?: string | JSX.Element;
 }
@@ -34,9 +34,12 @@ enum LaunchButtonStatus {
 function useLaunchButtonCommonState({runCount, disabled}: {runCount: number; disabled: boolean}) {
   const [starting, setStarting] = React.useState(false);
 
-  const onConfigSelected = async (option: LaunchButtonConfiguration) => {
+  const onConfigSelected = async (
+    e: React.MouseEvent | KeyboardEvent,
+    option: LaunchButtonConfiguration,
+  ) => {
     setStarting(true);
-    await option.onClick();
+    await option.onClick(e);
     setStarting(false);
   };
 
@@ -69,9 +72,9 @@ export const LaunchButton = ({config, runCount}: LaunchButtonProps) => {
     runCount,
     disabled: config.disabled,
   });
-  const onClick = () => {
+  const onClick = (e: React.MouseEvent | KeyboardEvent) => {
     if (status === LaunchButtonStatus.Ready) {
-      onConfigSelected(config);
+      onConfigSelected(e, config);
     }
   };
   return (
@@ -120,7 +123,7 @@ export const LaunchButtonDropdown = ({
 
   return (
     <ShortcutHandler
-      onShortcut={() => onConfigSelected(primary)}
+      onShortcut={(e) => onConfigSelected(e, primary)}
       shortcutLabel="⌥L"
       shortcutFilter={(e) => e.code === 'KeyL' && e.altKey}
     >
@@ -130,7 +133,7 @@ export const LaunchButtonDropdown = ({
         joined="right"
         icon={icon}
         tooltip={tooltip}
-        onClick={() => onConfigSelected(primary)}
+        onClick={(e) => onConfigSelected(e, primary)}
         disabled={!!disabled}
         {...forced}
       />
@@ -153,7 +156,7 @@ export const LaunchButtonDropdown = ({
                 <LaunchMenuItem
                   text={option.title}
                   disabled={option.disabled}
-                  onClick={() => onConfigSelected(option)}
+                  onClick={(e) => onConfigSelected(e, option)}
                   icon={option.icon !== 'dagster-spinner' ? option.icon : undefined}
                 />
               </Tooltip>
@@ -183,7 +186,7 @@ interface ButtonWithConfigurationProps {
   icon?: IconName | JSX.Element | 'dagster-spinner';
   joined?: 'left' | 'right';
   tooltip?: string | JSX.Element;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   disabled?: boolean;
 }
 
@@ -202,7 +205,7 @@ const ButtonWithConfiguration = ({
 }: ButtonWithConfigurationProps) => {
   const confirm = useConfirmation();
 
-  const onClickWithWarning = async () => {
+  const onClickWithWarning = async (e: React.MouseEvent) => {
     if (!onClick || disabled) {
       return;
     }
@@ -213,7 +216,7 @@ const ButtonWithConfiguration = ({
         return;
       }
     }
-    onClick();
+    onClick(e);
   };
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -22,7 +22,7 @@ import {RepoAddress} from '../workspace/types';
 
 const LaunchpadStoredSessionsContainer = lazy(() => import('./LaunchpadStoredSessionsContainer'));
 
-export interface LaunchpadAllowedRootProps {
+interface Props {
   launchpadType: LaunchpadType;
   pipelinePath: string;
   repoAddress: RepoAddress;
@@ -46,7 +46,7 @@ const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<stri
   return yaml.stringify(parsedYaml);
 };
 
-export const LaunchpadAllowedRoot = (props: LaunchpadAllowedRootProps) => {
+export const LaunchpadAllowedRoot = (props: Props) => {
   useTrackPageView();
 
   const {pipelinePath, repoAddress, launchpadType, sessionPresets} = props;

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -22,7 +22,7 @@ import {RepoAddress} from '../workspace/types';
 
 const LaunchpadStoredSessionsContainer = lazy(() => import('./LaunchpadStoredSessionsContainer'));
 
-interface Props {
+export interface LaunchpadAllowedRootProps {
   launchpadType: LaunchpadType;
   pipelinePath: string;
   repoAddress: RepoAddress;
@@ -46,7 +46,7 @@ const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<stri
   return yaml.stringify(parsedYaml);
 };
 
-export const LaunchpadAllowedRoot = (props: Props) => {
+export const LaunchpadAllowedRoot = (props: LaunchpadAllowedRootProps) => {
   useTrackPageView();
 
   const {pipelinePath, repoAddress, launchpadType, sessionPresets} = props;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
@@ -17,11 +17,12 @@ import {NavigationBlock} from './NavigationBlock';
 import {LAUNCH_PIPELINE_REEXECUTION_MUTATION} from './RunUtils';
 import {useMutation} from '../apollo-client';
 import {getBackfillPath} from './RunsFeedUtils';
+import {EditableTagList, validateTagEditState} from '../launchpad/TagEditor';
 import {
   LaunchPipelineReexecutionMutation,
   LaunchPipelineReexecutionMutationVariables,
 } from './types/RunUtils.types';
-import {ReexecutionStrategy} from '../graphql/types';
+import {ExecutionTag, ReexecutionStrategy} from '../graphql/types';
 
 interface Props {
   isOpen: boolean;
@@ -79,6 +80,7 @@ type ReexecutionDialogState = {
   frozenRuns: SelectedRuns;
   step: 'initial' | 'reexecuting' | 'completed';
   reexecution: ReexecutionState;
+  extraTags: ExecutionTag[];
 };
 
 type SelectedRuns = {[id: string]: string};
@@ -88,11 +90,13 @@ const initializeState = (selectedRuns: SelectedRuns): ReexecutionDialogState => 
     frozenRuns: selectedRuns,
     step: 'initial',
     reexecution: {completed: 0, errors: {}},
+    extraTags: [],
   };
 };
 
 type ReexecutionDialogAction =
   | {type: 'reset'; frozenRuns: SelectedRuns}
+  | {type: 'set-extra-tags'; tags: ExecutionTag[]}
   | {type: 'start'}
   | {type: 'reexecution-success'}
   | {type: 'reexecution-error'; id: string; error: Error}
@@ -105,6 +109,8 @@ const reexecutionDialogReducer = (
   switch (action.type) {
     case 'reset':
       return initializeState(action.frozenRuns);
+    case 'set-extra-tags':
+      return {...prevState, extraTags: action.tags};
     case 'start':
       return {...prevState, step: 'reexecuting'};
     case 'reexecution-success': {
@@ -146,6 +152,7 @@ export const ReexecutionDialog = (props: Props) => {
     initializeState,
   );
 
+  const extraTagsValidated = validateTagEditState(state.extraTags);
   const count = Object.keys(state.frozenRuns).length;
 
   // If the dialog is newly open, update state to match the frozen list.
@@ -172,12 +179,15 @@ export const ReexecutionDialog = (props: Props) => {
     dispatch({type: 'start'});
 
     const runList = Object.keys(state.frozenRuns);
+    const extraTags = extraTagsValidated.toSave.length ? extraTagsValidated.toSave : undefined;
+
     for (const runId of runList) {
       const {data} = await reexecute({
         variables: {
           reexecutionParams: {
             parentRunId: runId,
             strategy: reexecutionStrategy,
+            extraTags,
           },
         },
       });
@@ -225,6 +235,21 @@ export const ReexecutionDialog = (props: Props) => {
         return (
           <Group direction="column" spacing={16}>
             <div>{message()}</div>
+
+            <div>
+              Re-executed runs inherit tags from the parent runs automatically. To change tag values
+              or add additional tags, add them below.
+            </div>
+            <EditableTagList
+              editState={state.extraTags}
+              setEditState={(cb) =>
+                dispatch({
+                  type: 'set-extra-tags',
+                  tags: cb instanceof Array ? cb : cb(state.extraTags),
+                })
+              }
+            />
+
             {selectedRunBackfillIds.length > 0 ? (
               <div>
                 {selectedRunBackfillIds.length > 1 ? (
@@ -275,7 +300,11 @@ export const ReexecutionDialog = (props: Props) => {
             <Button intent="none" onClick={onClose}>
               Cancel
             </Button>
-            <Button intent="primary" onClick={mutate}>
+            <Button
+              intent="primary"
+              onClick={mutate}
+              disabled={extraTagsValidated.toError.length > 0}
+            >
               {`Re-execute ${`${count} ${count === 1 ? 'run' : 'runs'}`}`}
             </Button>
           </>
@@ -350,6 +379,7 @@ export const ReexecutionDialog = (props: Props) => {
 
   return (
     <Dialog
+      style={{minWidth: 590}}
       isOpen={isOpen}
       title={
         reexecutionStrategy === ReexecutionStrategy.ALL_STEPS

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from './types/RunUtils.types';
 import {ExecutionTag, ReexecutionStrategy} from '../graphql/types';
 
-interface Props {
+export interface ReexecutionDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onComplete: (reexecutionState: ReexecutionState) => void;
@@ -138,7 +138,7 @@ const reexecutionDialogReducer = (
   }
 };
 
-export const ReexecutionDialog = (props: Props) => {
+export const ReexecutionDialog = (props: ReexecutionDialogProps) => {
   const {isOpen, onClose, onComplete, reexecutionStrategy, selectedRuns, selectedRunBackfillIds} =
     props;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -120,10 +120,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
   );
 
   const reexecute = useJobReexecution();
-  const reexecuteWithSelection = async (
-    e: React.MouseEvent | KeyboardEvent,
-    selection: StepSelection,
-  ) => {
+  const reexecuteWithSelection = async (selection: StepSelection) => {
     if (!run || !repoMatch || !run.pipelineSnapshotId) {
       return;
     }
@@ -133,7 +130,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
       repositoryLocationName: repoMatch.match.repositoryLocation.name,
       repositoryName: repoMatch.match.repository.name,
     });
-    await reexecute.onClick(run, executionParams, e.shiftKey);
+    await reexecute.onClick(run, executionParams, false);
   };
 
   const full: LaunchButtonConfiguration = {
@@ -158,10 +155,9 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
             ? 'Wait for all of the steps to finish to re-execute the same subset.'
             : 'Re-execute the same step subset used for this run:'}
         <StepSelectionDescription selection={currentRunSelection} />
-        {' Shift-click to adjust tags.'}
       </div>
     ),
-    onClick: (e) => reexecuteWithSelection(e, currentRunSelection!),
+    onClick: () => reexecuteWithSelection(currentRunSelection!),
   };
 
   const selected: LaunchButtonConfiguration = {
@@ -177,19 +173,17 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
             ? 'Wait for the steps to finish to re-execute them.'
             : 'Re-execute the selected steps with existing configuration:'}
         <StepSelectionDescription selection={selection} />
-        {' Shift-click to adjust tags.'}
       </div>
     ),
-    onClick: (e) => reexecuteWithSelection(e, selection),
+    onClick: () => reexecuteWithSelection(selection),
   };
 
   const fromSelected: LaunchButtonConfiguration = {
     icon: 'arrow_forward',
     title: 'From selected',
     disabled: !canRunAllSteps(run) || selection.keys.length !== 1,
-    tooltip:
-      'Re-execute the pipeline downstream from the selected steps. Shift-click to adjust tags.',
-    onClick: async (e) => {
+    tooltip: 'Re-execute the pipeline downstream from the selected steps.',
+    onClick: async () => {
       if (!run.executionPlan) {
         console.warn('Run execution plan must be present to launch from-selected execution');
         return Promise.resolve();
@@ -204,7 +198,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
         (node) => node.name,
       );
 
-      await reexecuteWithSelection(e, {
+      await reexecuteWithSelection({
         keys: selectionKeys,
         query: selectionForPythonFiltering,
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -116,6 +116,7 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
 
   return (
     <>
+      {reexecute.launchpadElement}
       <JoinedButtons>
         <AnchorButton to={`/runs/${run.id}`}>{anchorLabel ?? 'View run'}</AnchorButton>
         <Popover
@@ -178,9 +179,8 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                   />
                 </Tooltip>
                 <Tooltip
-                  content={reexecutionDisabledState.message || ''}
+                  content={reexecutionDisabledState.message || 'Shift-click to adjust tags.'}
                   position="left"
-                  canShow={reexecutionDisabledState.disabled}
                   targetTagName="div"
                 >
                   <MenuItem
@@ -188,8 +188,8 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                     text="Re-execute"
                     disabled={reexecutionDisabledState.disabled}
                     icon="refresh"
-                    onClick={async () => {
-                      await reexecute(run, ReexecutionStrategy.ALL_STEPS);
+                    onClick={async (e) => {
+                      await reexecute.onClick(run, ReexecutionStrategy.ALL_STEPS, e.shiftKey);
                     }}
                   />
                 </Tooltip>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__fixtures__/Reexecution.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__fixtures__/Reexecution.fixtures.tsx
@@ -1,0 +1,49 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {ReexecutionParams} from '../../graphql/types';
+import {LAUNCH_PIPELINE_REEXECUTION_MUTATION} from '../RunUtils';
+import {LaunchPipelineReexecutionMutation} from '../types/RunUtils.types';
+
+export const buildLaunchPipelineReexecutionSuccessMock = (
+  overrides: Pick<ReexecutionParams, 'parentRunId'> & Partial<ReexecutionParams>,
+): MockedResponse<LaunchPipelineReexecutionMutation> => ({
+  request: {
+    query: LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+    variables: {reexecutionParams: {strategy: 'FROM_FAILURE', ...overrides}},
+  },
+  result: {
+    data: {
+      __typename: 'Mutation',
+      launchPipelineReexecution: {
+        __typename: 'LaunchRunSuccess',
+        run: {
+          id: '1234',
+          pipelineName: '1234',
+          rootRunId: null,
+          parentRunId: overrides.parentRunId,
+          __typename: 'Run',
+        },
+      },
+    },
+  },
+});
+
+export const buildLaunchPipelineReexecutionErrorMock = (
+  overrides: Pick<ReexecutionParams, 'parentRunId'> & Partial<ReexecutionParams>,
+): MockedResponse<LaunchPipelineReexecutionMutation> => ({
+  request: {
+    query: LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+    variables: {reexecutionParams: {strategy: 'FROM_FAILURE', ...overrides}},
+  },
+  result: {
+    data: {
+      __typename: 'Mutation',
+      launchPipelineReexecution: {
+        __typename: 'PythonError',
+        errorChain: [],
+        message: 'A wild python error appeared!',
+        stack: [],
+      },
+    },
+  },
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
@@ -1,247 +1,82 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {Body, Box, Button, Dialog, DialogBody, DialogFooter} from '@dagster-io/ui-components';
-import {renderHook, waitFor} from '@testing-library/react';
-import {ReactNode, useCallback, useState} from 'react';
-import {useHistory} from 'react-router-dom';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {MemoryRouter, useLocation} from 'react-router-dom';
 
-import {LAUNCH_PIPELINE_REEXECUTION_MUTATION, handleLaunchResult} from './RunUtils';
-import {gql, useApolloClient, useMutation} from '../apollo-client';
-import {DagsterTag} from './RunTag';
-import {useConfirmation} from '../app/CustomConfirmationProvider';
-import {
-  LaunchPipelineReexecutionMutation,
-  LaunchPipelineReexecutionMutationVariables,
-} from './types/RunUtils.types';
-import {
-  BulkActionStatus,
-  ExecutionParams,
-  ExecutionTag,
-  ReexecutionStrategy,
-  Run,
-} from '../graphql/types';
-import {showLaunchError} from '../launchpad/showLaunchError';
-import {
-  CheckBackfillStatusQuery,
-  CheckBackfillStatusQueryVariables,
-} from './types/useJobReExecution.types';
+import {ReexecutionStrategy} from '../../graphql/types';
+import {testId} from '../../testing/testId';
 import {buildLaunchPipelineReexecutionSuccessMock} from '../__fixtures__/Reexecution.fixtures';
-import {EditableTagList, validateTagEditState} from '../launchpad/TagEditor';
+import {useJobReexecution} from '../useJobReExecution';
+
+const Wrapper = (props: {
+  reexecuteParams: Parameters<ReturnType<typeof useJobReexecution>['onClick']>;
+}) => {
+  const reexecute = useJobReexecution();
+  const location = useLocation();
+  return (
+    <>
+      {reexecute.launchpadElement}
+      <button onClick={() => reexecute.onClick(...props.reexecuteParams)}>Re-execute</button>
+      <div data-testid={testId('location')}>{location.pathname}</div>
+    </>
+  );
+};
 
 describe('useJobReexecution', () => {
+  const PARENT_RUN = {id: '1', pipelineName: 'abc', tags: []};
+
   it('creates the correct mutation for FROM_FAILURE', async () => {
-    const wrapper = ({children}: {children: ReactNode}) => (
+    const {findByText, findByTestId} = render(
       <MockedProvider
         addTypename={false}
         mocks={[
           buildLaunchPipelineReexecutionSuccessMock({
             parentRunId: '1',
-            extraTags: [{key: 'a', value: 'b'}],
+            strategy: ReexecutionStrategy.FROM_FAILURE,
           }),
         ]}
       >
-        {children}
-      </MockedProvider>
+        <MemoryRouter>
+          <Wrapper reexecuteParams={[PARENT_RUN, ReexecutionStrategy.FROM_FAILURE, false]} />
+        </MemoryRouter>
+      </MockedProvider>,
     );
 
-    const {result} = renderHook(() => useJobReexecution(), {wrapper});
+    await userEvent.click(await findByText('Re-execute'));
 
-    await result.current.onClick(
-      {id: '1', pipelineName: 'abc', tags: [{key: 'a', value: 'b'}]},
-      'FROM_FAILURE',
-      true,
+    expect((await findByTestId('location')).textContent).toEqual('/runs/1234');
+  });
+
+  it('shows the re-execute dialog so you can provide tags if requested', async () => {
+    const {findByText} = render(
+      <MockedProvider
+        addTypename={false}
+        mocks={[
+          buildLaunchPipelineReexecutionSuccessMock({
+            parentRunId: '1',
+            extraTags: [{key: 'test_key', value: 'test_value'}],
+          }),
+        ]}
+      >
+        <MemoryRouter>
+          <Wrapper reexecuteParams={[PARENT_RUN, ReexecutionStrategy.FROM_FAILURE, true]} />
+        </MemoryRouter>
+      </MockedProvider>,
     );
 
-    expect(screen.findByText('Re-executed runs inherit tags'));
+    await userEvent.click(await findByText('Re-execute'));
+
+    await userEvent.click(await screen.findByText('Add custom tag'));
+    await userEvent.type(await screen.findByPlaceholderText('Tag Key'), 'test_key');
+    await userEvent.type(await screen.findByPlaceholderText('Tag Value'), 'test_value');
+
+    await waitFor(async () => {
+      const button = screen.getByText(/re\-execute 1 run/i);
+      await userEvent.click(button);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Successfully requested re-execution for 1 run./i)).toBeVisible();
+    });
   });
 });
-
-/**
- * This hook gives you a mutation method that you can use to re-execute runs.
- *
- * The preferred way to re-execute runs is to pass a ReexecutionStrategy.
- * If you need to re-execute with more complex parameters, (eg: a custom subset
- * of the previous run), build the variables using `getReexecutionVariables` and
- * pass them to this hook.
- */
-export const useJobReexecution = (opts?: {onCompleted?: () => void}) => {
-  const history = useHistory();
-  const confirm = useConfirmation();
-  const client = useApolloClient();
-  const {onCompleted} = opts || {};
-
-  const [launchPipelineReexecution] = useMutation<
-    LaunchPipelineReexecutionMutation,
-    LaunchPipelineReexecutionMutationVariables
-  >(LAUNCH_PIPELINE_REEXECUTION_MUTATION);
-
-  const [dialogProps, setDialogProps] = useState<ReexecutionEditTagsDialogProps | null>(null);
-  const onClick = useCallback(
-    async (
-      run: Pick<Run, 'id' | 'pipelineName' | 'tags'>,
-      param: ReexecutionStrategy | ExecutionParams,
-      forceLaunchpad: boolean,
-    ) => {
-      const backfillTag = run.tags.find((t) => t.key === DagsterTag.Backfill);
-
-      if (backfillTag) {
-        const {data} = await client.query<
-          CheckBackfillStatusQuery,
-          CheckBackfillStatusQueryVariables
-        >({
-          query: CHECK_BACKFILL_STATUS_QUERY,
-          fetchPolicy: 'no-cache',
-          variables: {
-            backfillId: backfillTag.value,
-          },
-        });
-        const backfillRunning =
-          data.partitionBackfillOrError.__typename === 'PartitionBackfill'
-            ? data.partitionBackfillOrError.status === BulkActionStatus.REQUESTED
-            : false;
-
-        if (!backfillRunning) {
-          try {
-            await confirm({
-              title: 'Re-execution within backfill',
-              description: `This run is part of a completed backfill. Re-executing will not update the backfill status or launch runs of downstream dependencies.`,
-              intent: 'primary',
-              catchOnCancel: true,
-            });
-          } catch {
-            return;
-          }
-        }
-      }
-
-      const launch = async (variables: LaunchPipelineReexecutionMutationVariables) => {
-        try {
-          const result = await launchPipelineReexecution({variables});
-          handleLaunchResult(run.pipelineName, result.data?.launchPipelineReexecution, history, {
-            preserveQuerystring: true,
-            behavior: 'open',
-          });
-          onCompleted?.();
-        } catch (error) {
-          showLaunchError(error as Error);
-        }
-      };
-
-      if (forceLaunchpad) {
-        setDialogProps({
-          tags: run.tags,
-          onCancel: () => setDialogProps(null),
-          onContinue: async (extraTags) => {
-            setDialogProps(null);
-
-            if (typeof param === 'string') {
-              await launch({
-                reexecutionParams: {
-                  parentRunId: run.id,
-                  strategy: param,
-                  extraTags,
-                },
-              });
-            } else {
-              const em = param.executionMetadata || {};
-              const extraTagKeys = new Set(extraTags.map((t) => t.key));
-
-              await launch({
-                executionParams: {
-                  ...param,
-                  executionMetadata: {
-                    ...em,
-                    tags: [
-                      ...(em.tags || []).filter((t) => !extraTagKeys.has(t.key)),
-                      ...extraTags,
-                    ],
-                  },
-                },
-              });
-            }
-          },
-        });
-      } else {
-        await launch(
-          typeof param === 'string'
-            ? {reexecutionParams: {parentRunId: run.id, strategy: param}}
-            : {executionParams: param},
-        );
-      }
-    },
-    [client, confirm, launchPipelineReexecution, history, onCompleted],
-  );
-
-  return {
-    onClick,
-    launchpadElement: dialogProps ? <ReexecutionEditTagsDialog {...dialogProps} /> : null,
-  };
-};
-
-/** Ben Note: Wiring this into the existing launchpad is /messy/ - we only want to allow
- * editing tags (and possibly runConfigYaml in the future), and we need to disable everything
- * else. We also need to rewire the Launch button to run this mutation with the remaining args.
- */
-interface ReexecutionEditTagsDialogProps {
-  tags: ExecutionTag[];
-  onContinue: (tags: ExecutionTag[]) => Promise<void>;
-  onCancel: () => void;
-}
-
-const ReexecutionEditTagsDialog = (props: ReexecutionEditTagsDialogProps) => {
-  const parentRunCustomTags = props.tags.filter((t) => !t.key.startsWith(DagsterTag.Namespace));
-  const [tags, setTags] = useState(
-    parentRunCustomTags.length === 0 ? [{key: '', value: ''}] : parentRunCustomTags,
-  );
-  const {toError, toSave} = validateTagEditState(tags);
-
-  const onSave = () => {
-    const parentRunValues = Object.fromEntries(parentRunCustomTags.map((t) => [t.key, t.value]));
-    const toSaveModified = toSave.filter((t) => t.value !== parentRunValues[t.key]);
-    if (!toError.length) {
-      props.onContinue(toSaveModified);
-    }
-  };
-
-  const disabled = !!toError.length;
-
-  return (
-    <Dialog
-      icon="info"
-      onClose={props.onCancel}
-      style={{minWidth: 700}}
-      title="Re-execute"
-      isOpen={true}
-    >
-      <DialogBody>
-        <Box padding={{bottom: 16}}>
-          <Body>
-            Re-executed runs inherit tags from the parent run automatically. Edit existing tags to
-            override their values or add more tags below.
-          </Body>
-        </Box>
-        <EditableTagList
-          editState={tags}
-          setEditState={setTags}
-          tagsFromParentRun={parentRunCustomTags}
-        />
-      </DialogBody>
-      <DialogFooter>
-        <Button onClick={props.onCancel}>Cancel</Button>
-        <Button intent="primary" onClick={onSave} disabled={disabled}>
-          Launch Run
-        </Button>
-      </DialogFooter>
-    </Dialog>
-  );
-};
-
-const CHECK_BACKFILL_STATUS_QUERY = gql`
-  query CheckBackfillStatus($backfillId: String!) {
-    partitionBackfillOrError(backfillId: $backfillId) {
-      ... on PartitionBackfill {
-        id
-        status
-      }
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
@@ -10,7 +10,7 @@ import {
   LaunchPipelineReexecutionMutation,
   LaunchPipelineReexecutionMutationVariables,
 } from './types/RunUtils.types';
-import {BulkActionStatus, ExecutionParams, ReexecutionStrategy, Run} from '../graphql/types';
+import {BulkActionStatus, ExecutionParams, ReexecutionStrategy} from '../graphql/types';
 import {showLaunchError} from '../launchpad/showLaunchError';
 import {
   CheckBackfillStatusQuery,
@@ -39,7 +39,7 @@ export const useJobReexecution = (opts?: {onCompleted?: () => void}) => {
   const [dialogProps, setDialogProps] = useState<ReexecutionDialogProps | null>(null);
   const onClick = useCallback(
     async (
-      run: Pick<Run, 'id' | 'pipelineName' | 'tags'>,
+      run: {id: string; pipelineName: string; tags: {key: string; value: string}[]},
       param: ReexecutionStrategy | ExecutionParams,
       forceLaunchpad: boolean,
     ) => {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional, Mapping, Any, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -74,7 +75,11 @@ def _launch_pipeline_execution(
 
 
 def launch_reexecution_from_parent_run(
-    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str, extra_tags: Optional[Mapping[str, Any]] = None, use_parent_run_tags: bool = None
+    graphene_info: "ResolveInfo",
+    parent_run_id: str,
+    strategy: str,
+    extra_tags: Optional[Mapping[str, Any]] = None,
+    use_parent_run_tags: Optional[bool] = None,
 ) -> "GrapheneLaunchRunSuccess":
     """Launch a re-execution by referencing the parent run id."""
     from dagster_graphql.schema.pipelines.pipeline import GrapheneRun
@@ -111,7 +116,9 @@ def launch_reexecution_from_parent_run(
         remote_job=external_pipeline,
         strategy=ReexecutionStrategy(strategy),
         extra_tags=extra_tags,
-        use_parent_run_tags=use_parent_run_tags if use_parent_run_tags is not None else True,  # inherit whatever tags were set on the parent run at launch time
+        use_parent_run_tags=use_parent_run_tags
+        if use_parent_run_tags is not None
+        else True,  # inherit whatever tags were set on the parent run at launch time
     )
     graphene_info.context.instance.submit_run(
         run.run_id,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -74,7 +74,7 @@ def _launch_pipeline_execution(
 
 
 def launch_reexecution_from_parent_run(
-    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str
+    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str, extra_tags: Optional[Mapping[str, Any]] = None, run_config: Optional[Mapping[str, Any]] = None,
 ) -> "GrapheneLaunchRunSuccess":
     """Launch a re-execution by referencing the parent run id."""
     from dagster_graphql.schema.pipelines.pipeline import GrapheneRun
@@ -110,6 +110,8 @@ def launch_reexecution_from_parent_run(
         code_location=repo_location,
         remote_job=external_pipeline,
         strategy=ReexecutionStrategy(strategy),
+        extra_tags=extra_tags,
+        run_config=run_config,
         use_parent_run_tags=True,  # inherit whatever tags were set on the parent run at launch time
     )
     graphene_info.context.instance.submit_run(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Optional, Mapping, Any, cast
 
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -74,7 +74,7 @@ def _launch_pipeline_execution(
 
 
 def launch_reexecution_from_parent_run(
-    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str, extra_tags: Optional[Mapping[str, Any]] = None, run_config: Optional[Mapping[str, Any]] = None,
+    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str, extra_tags: Optional[Mapping[str, Any]] = None, use_parent_run_tags: bool = None
 ) -> "GrapheneLaunchRunSuccess":
     """Launch a re-execution by referencing the parent run id."""
     from dagster_graphql.schema.pipelines.pipeline import GrapheneRun
@@ -111,8 +111,7 @@ def launch_reexecution_from_parent_run(
         remote_job=external_pipeline,
         strategy=ReexecutionStrategy(strategy),
         extra_tags=extra_tags,
-        run_config=run_config,
-        use_parent_run_tags=True,  # inherit whatever tags were set on the parent run at launch time
+        use_parent_run_tags=use_parent_run_tags if use_parent_run_tags is not None else True,  # inherit whatever tags were set on the parent run at launch time
     )
     graphene_info.context.instance.submit_run(
         run.run_id,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -329,11 +329,11 @@ class GrapheneReexecutionStrategy(graphene.Enum):
 class GrapheneReexecutionParams(graphene.InputObjectType):
     parentRunId = graphene.NonNull(graphene.String)
     strategy = graphene.NonNull(GrapheneReexecutionStrategy)
-    runConfigData = graphene.InputField(GrapheneRunConfigData, 
-        description="""When re-executing a single run, pass new config YAML to override the previous YAML."""
-    )
     extraTags = graphene.List(graphene.NonNull(GrapheneExecutionTag),
         description="""When re-executing a single run, pass new tags which will upsert over tags on the parent run."""
+    )
+    useParentRunTags = graphene.Boolean(
+        description="""When re-executing a single run, pass false to avoid adding the parent run tags by default."""
     )
 
     class Meta:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -329,6 +329,12 @@ class GrapheneReexecutionStrategy(graphene.Enum):
 class GrapheneReexecutionParams(graphene.InputObjectType):
     parentRunId = graphene.NonNull(graphene.String)
     strategy = graphene.NonNull(GrapheneReexecutionStrategy)
+    runConfigData = graphene.InputField(GrapheneRunConfigData, 
+        description="""When re-executing a single run, pass new config YAML to override the previous YAML."""
+    )
+    extraTags = graphene.List(graphene.NonNull(GrapheneExecutionTag),
+        description="""When re-executing a single run, pass new tags which will upsert over tags on the parent run."""
+    )
 
     class Meta:
         name = "ReexecutionParams"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -329,8 +329,9 @@ class GrapheneReexecutionStrategy(graphene.Enum):
 class GrapheneReexecutionParams(graphene.InputObjectType):
     parentRunId = graphene.NonNull(graphene.String)
     strategy = graphene.NonNull(GrapheneReexecutionStrategy)
-    extraTags = graphene.List(graphene.NonNull(GrapheneExecutionTag),
-        description="""When re-executing a single run, pass new tags which will upsert over tags on the parent run."""
+    extraTags = graphene.List(
+        graphene.NonNull(GrapheneExecutionTag),
+        description="""When re-executing a single run, pass new tags which will upsert over tags on the parent run.""",
     )
     useParentRunTags = graphene.Boolean(
         description="""When re-executing a single run, pass false to avoid adding the parent run tags by default."""

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -523,10 +523,23 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
                 execution_params_dict=executionParams,
             )
         elif reexecutionParams:
+            run_config = None
+            if reexecutionParams.get("runConfigData"):
+                run_config = parse_run_config_input(  # pyright: ignore[reportArgumentType]
+                    reexecutionParams["runConfigData"],
+                    raise_on_error=True,
+                )
+
+            extra_tags = None
+            if reexecutionParams.get("extraTags"):
+                extra_tags={t["key"]: t["value"] for t in reexecutionParams["extraTags"]},
+
             return launch_reexecution_from_parent_run(
                 graphene_info,
-                reexecutionParams["parentRunId"],
-                reexecutionParams["strategy"],
+                parent_run_id=reexecutionParams["parentRunId"],
+                strategy=reexecutionParams["strategy"],
+                run_config=run_config,
+                extra_tags=extra_tags,
             )
         else:
             check.failed("Unreachable")

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -523,23 +523,20 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
                 execution_params_dict=executionParams,
             )
         elif reexecutionParams:
-            run_config = None
-            if reexecutionParams.get("runConfigData"):
-                run_config = parse_run_config_input(  # pyright: ignore[reportArgumentType]
-                    reexecutionParams["runConfigData"],
-                    raise_on_error=True,
-                )
-
             extra_tags = None
             if reexecutionParams.get("extraTags"):
-                extra_tags={t["key"]: t["value"] for t in reexecutionParams["extraTags"]},
+                extra_tags={t["key"]: t["value"] for t in reexecutionParams["extraTags"]}
+            print(extra_tags)
+            use_parent_run_tags = None
+            if reexecutionParams.get("useParentRunTags") is not None:
+                use_parent_run_tags= reexecutionParams["useParentRunTags"]
 
             return launch_reexecution_from_parent_run(
                 graphene_info,
                 parent_run_id=reexecutionParams["parentRunId"],
                 strategy=reexecutionParams["strategy"],
-                run_config=run_config,
                 extra_tags=extra_tags,
+                use_parent_run_tags=use_parent_run_tags
             )
         else:
             check.failed("Unreachable")

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -525,18 +525,18 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
         elif reexecutionParams:
             extra_tags = None
             if reexecutionParams.get("extraTags"):
-                extra_tags={t["key"]: t["value"] for t in reexecutionParams["extraTags"]}
-            print(extra_tags)
+                extra_tags = {t["key"]: t["value"] for t in reexecutionParams["extraTags"]}
+
             use_parent_run_tags = None
             if reexecutionParams.get("useParentRunTags") is not None:
-                use_parent_run_tags= reexecutionParams["useParentRunTags"]
+                use_parent_run_tags = reexecutionParams["useParentRunTags"]
 
             return launch_reexecution_from_parent_run(
                 graphene_info,
                 parent_run_id=reexecutionParams["parentRunId"],
                 strategy=reexecutionParams["strategy"],
                 extra_tags=extra_tags,
-                use_parent_run_tags=use_parent_run_tags
+                use_parent_run_tags=use_parent_run_tags,
             )
         else:
             check.failed("Unreachable")


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/OPER-1624/override-run-tags-when-performing-a-re-execution-from-failure

This PR exposes the `extra_tags` option on re-execution (already available in the python API) via graphql, and allows the user to put in additional tags when re-executing using one of the two core strategies (ALL_STEPS and FROM_FAILURE)

We allow re-execution from a bunch of places, and I put the new UI into the `ReexecutionDialog` which is used when you select multiple runs on the runs feed view and chose the bulk action.   For other re-execute menu items, including the individual run actions, the job page "reexecute last run" option, and the run details page options, I added menu item tooltips and made shift-clicking open the dialog so you can add tags there too.

**Q: Why not show all the existing tags and let the user edit them?**

This was what I tried at first. Adding tags to a re-execution overrides existing tags and allows you to pass new tags, but it cannot be used to remove a tag from the parent run. That can be done in the Python API by setting `use_parent_run_tags=False` and re-specifying all tags that are not `TAGS_TO_MAYBE_OMIT_ON_RETRY`, but the behavior is complicated. I chose not to expose this option to re-execute /without/ some tags because  1) it wasn't asked for and 2) it would require the UI to either ask the user to put in all their tags from scratch, or be aware of exactly what tags from the parent run would have normally used and should be specified in `extra_tags` along with `use_parent_run_tags=False`.

The backend API is specifically for for adding "extra tags", and after investigating I don't think we should try to build a "review + modify" style UI in the front-end.

## How I Tested These Changes

I tested this manually and by adding new tests! 

![image](https://github.com/user-attachments/assets/1ae6f7b0-52e6-416d-a337-b0deb3c16af7)

![image](https://github.com/user-attachments/assets/a2c9bf20-df9e-41b9-aa0f-cdbdfbd5ef0f)

![image](https://github.com/user-attachments/assets/668e7d17-4f00-45bd-b673-76ca5c3306ca)

![image](https://github.com/user-attachments/assets/cbdf3c20-b2b3-4541-9895-aa01f774fa7c)


## Changelog

[ui] The Dagster UI allows you to specify extra tags when re-executing runs from failure from the runs feed re-execute dialog, or by holding shift when clicking Re-execute menu items throughout the app.