### PR TITLE
[ui] Fix backfill toast URL

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -16,7 +16,6 @@ import {
 } from '@dagster-io/ui-components';
 import reject from 'lodash/reject';
 import {useEffect, useMemo, useState} from 'react';
-import {useHistory} from 'react-router-dom';
 import {useLaunchWithTelemetry} from 'shared/launchpad/useLaunchWithTelemetry.oss';
 
 import {partitionCountString} from './AssetNodePartitionCounts';
@@ -213,7 +212,6 @@ const LaunchAssetChoosePartitionsDialogBody = ({
   }, [missingFailedOnly, selections, displayedHealth]);
 
   const client = useApolloClient();
-  const history = useHistory();
 
   const launchWithTelemetry = useLaunchWithTelemetry();
   const launchAsBackfill =
@@ -351,11 +349,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
     });
 
     if (launchBackfillData?.launchPartitionBackfill.__typename === 'LaunchBackfillSuccess') {
-      showBackfillSuccessToast(
-        history,
-        launchBackfillData?.launchPartitionBackfill.backfillId,
-        true,
-      );
+      showBackfillSuccessToast(launchBackfillData?.launchPartitionBackfill.backfillId, true);
       setOpen(false);
     } else {
       showBackfillErrorToast(launchBackfillData);

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/useReexecuteBackfill.tsx
@@ -1,5 +1,4 @@
 import {Group} from '@dagster-io/ui-components';
-import {useHistory} from 'react-router-dom';
 
 import {gql, useMutation} from '../../apollo-client';
 import {BackfillActionsBackfillFragment} from './types/BackfillFragments.types';
@@ -18,7 +17,6 @@ export function useReexecuteBackfill(
   backfill: BackfillActionsBackfillFragment,
   refetch: () => void,
 ) {
-  const history = useHistory();
   const [reexecuteBackfill] = useMutation<
     ReexecuteBackfillMutation,
     ReexecuteBackfillMutationVariables
@@ -29,7 +27,7 @@ export function useReexecuteBackfill(
       variables: {reexecutionParams: {parentRunId: backfill.id, strategy}},
     });
     if (data && data.reexecutePartitionBackfill.__typename === 'LaunchBackfillSuccess') {
-      showBackfillSuccessToast(history, data.reexecutePartitionBackfill.backfillId, true);
+      showBackfillSuccessToast(data.reexecutePartitionBackfill.backfillId, true);
       refetch();
     } else if (data && data.reexecutePartitionBackfill.__typename === 'UnauthorizedError') {
       await showSharedToaster({

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
@@ -1,5 +1,4 @@
 import {Alert, ButtonLink, Colors, Group, Mono} from '@dagster-io/ui-components';
-import {History} from 'history';
 import * as React from 'react';
 
 import {gql, useQuery} from '../apollo-client';
@@ -68,13 +67,8 @@ export async function showBackfillErrorToast(
   });
 }
 
-export async function showBackfillSuccessToast(
-  history: History<unknown>,
-  backfillId: string,
-  isAssetBackfill: boolean,
-) {
+export async function showBackfillSuccessToast(backfillId: string, isAssetBackfill: boolean) {
   const url = getBackfillPath(backfillId, isAssetBackfill);
-  const [pathname, search] = url.split('?');
   await showSharedToaster({
     intent: 'success',
     message: (
@@ -84,7 +78,7 @@ export async function showBackfillSuccessToast(
     ),
     action: {
       type: 'custom',
-      element: <AnchorButton to={history.createHref({pathname, search})}>View</AnchorButton>,
+      element: <AnchorButton to={url}>View</AnchorButton>,
     },
   });
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useHistory} from 'react-router-dom';
 
 import {
   DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT,
@@ -76,7 +75,6 @@ export const BackfillPartitionSelector = ({
   onSubmit: () => void;
   repoAddress: RepoAddress;
 }) => {
-  const history = useHistory();
   const [range, _setRange] = React.useState<string[]>(
     Object.keys(runStatusData).filter(
       (k) => !runStatusData[k] || runStatusData[k] === RunStatus.FAILURE,
@@ -122,7 +120,7 @@ export const BackfillPartitionSelector = ({
   }, [onLaunch]);
 
   const onSuccess = (backfillId: string) => {
-    showBackfillSuccessToast(history, backfillId, false);
+    showBackfillSuccessToast(backfillId, false);
     onLaunch?.(backfillId, query);
   };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -187,15 +187,15 @@ export async function handleLaunchMultipleResult(
   const params = new URLSearchParams();
   successfulRunIds.forEach((id) => params.append('q[]', `id:${id}`));
 
-  const queryString = `/runs?${params.toString()}`;
-  history.push(queryString);
+  const pathAndQueryString = `/runs?${params.toString()}`;
+  history.push(pathAndQueryString);
 
   await showSharedToaster({
     intent: 'success',
     message: <div>Launched {successfulRunIds.length} runs</div>,
     action: {
       type: 'custom',
-      element: <AnchorButton to={history.createHref({pathname: queryString})}>View</AnchorButton>,
+      element: <AnchorButton to={pathAndQueryString}>View</AnchorButton>,
     },
   });
 


### PR DESCRIPTION
## Summary & Motivation

Now that toasts are within the scope of the top-level `BrowserRouter`, they no longer need special link behavior, and `history.createHref` will in fact double the base path in the URL if used in conjunction with react-router links like `AnchorButton`.

This change fixes broken toast links when launching backfills.

## How I Tested These Changes

Launch a backfill in cloud, verify that the link in the resulting toast goes to the correct backfill page.

## Changelog

[ui] Fix link in toast messages that appear when launching backfills.
