### PR TITLE
[docs] rm "Edit this page" link for API docs

### DIFF
--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -431,6 +431,9 @@ class MdxTranslator(SphinxTranslator):
         last_update = datetime.now().strftime("%Y-%m-%d")
         frontmatter += "last_update:\n"
         frontmatter += f"  date: '{last_update}'\n"
+
+        # prevent API docs from having `Edit this page` link; in the future we may want to configure this to point to the `.rst` file
+        frontmatter += "custom_edit_url: null\n"
         frontmatter += "---\n\n"
         self.end_state()
         self.body = frontmatter


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-986.


Do not show an "Edit this page" link for API docs, as they do not have corresponding markdown files in version control.

## How I Tested These Changes

```
yarn build-api-docs && yarn start
```

## Changelog

NOCHANGELOG
