### PR TITLE
[dagster-dbt] Update DbtCloudCliInvocation to accept manifest

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -259,8 +259,16 @@ class DbtCloudWorkspace(ConfigurableResource):
     ) -> DbtCloudCliInvocation:
         """Creates a dbt cli invocation with the dbt Cloud client."""
         dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
+        workspace_data = self.fetch_workspace_data()
+        # We pass the manifest instead of the workspace data
+        # because we use the manifest included in the asset definitions
+        # when this method is called inside a function decorated with `@dbt_cloud_assets`
         return DbtCloudCliInvocation.run(
-            args=args, workspace=self, dagster_dbt_translator=dagster_dbt_translator
+            job_id=workspace_data.job_id,
+            args=args,
+            client=self.get_client(),
+            manifest=workspace_data.manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
         )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -96,7 +96,8 @@ def materializations_from_batch_iter(
                 run_results_json=client.get_run_results_json(run_id=run.id)
             )
             events = run_results.to_default_asset_events(
-                workspace=workspace,
+                client=workspace.get_client(),
+                manifest=workspace.fetch_workspace_data().manifest,
                 dagster_dbt_translator=dagster_dbt_translator,
             )
             # Currently, only materializations are tracked

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -13,7 +13,12 @@ def test_default_asset_events_from_run_results(
         run_results_json=get_sample_run_results_json()
     )
 
-    events = [event for event in run_results.to_default_asset_events(workspace=workspace)]
+    events = [
+        event
+        for event in run_results.to_default_asset_events(
+            client=workspace.get_client(), manifest=workspace.fetch_workspace_data().manifest
+        )
+    ]
 
     asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
     asset_check_evaluations = [event for event in events if isinstance(event, AssetCheckEvaluation)]


### PR DESCRIPTION
## Summary & Motivation

This PR updated `DbtCloudCliInvocation` to accept manifest objects instead of the workspace.

This is required for the subsequent PR - when `DbtCloudWorkspace.cli(...)` is called in the asset decorator, we need to pass the manifest used to create the asset definitions to the `DbtCloudJobRunHandler` object, not the manifest of the workspace. Because of that, we need to pass a manifest object instead of the workspace object.

Other parameters like `job_id` and `client` also added because we are not passing the workspace anymore.

## How I Tested These Changes

Updated tests with BK.
