### PR TITLE
DOC-927 Add params to EcsRunLauncher docstring

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -84,7 +84,7 @@ DEFAULT_RUN_TASK_RETRIES = 5
 
 class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     """RunLauncher that starts a task in ECS for each Dagster job run.
-    
+
     Args:
         inst_data (Optional[ConfigurableClassData]): If not provided, defaults to None.
         task_definition: If not provided, defaults to None.

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -83,7 +83,24 @@ DEFAULT_RUN_TASK_RETRIES = 5
 
 
 class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
-    """RunLauncher that starts a task in ECS for each Dagster job run."""
+    """RunLauncher that starts a task in ECS for each Dagster job run.
+    
+    Args:
+        inst_data (Optional[ConfigurableClassData]): If not provided, defaults to None.
+        task_definition: If not provided, defaults to None.
+        container_name (str): If not provided, defaults to "run".
+        secrets (Optional[list[str]]): If not provided, defaults to None.
+        secrets_tag (str): If not provided, defaults to "dagster".
+        env_vars (Optional[Sequence[str]]) If not provided, defaults to None.
+        include_sidecars (bool). If not provided, defaults to False.
+        use_current_ecs_task_config (bool): If not provided, defaults to True.
+        run_task_kwargs (Optional[Mapping[str, Any]]): If not provided, defaults to None.
+        run_resources (Optional[dict[str, Any]]) If not provided, defaults to None.
+        run_ecs_tags (Optional[list[dict[str, Optional[str]]]]) If not provided, defaults to None.
+        propagate_tags (Optional[dict[str, Any]]): If not provided, defaults to None.
+        task_definition_prefix (str): If not provided, defaults to "run".
+
+    """
 
     def __init__(
         self,

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -91,12 +91,12 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         container_name (str): If not provided, defaults to "run".
         secrets (Optional[list[str]]): If not provided, defaults to None.
         secrets_tag (str): If not provided, defaults to "dagster".
-        env_vars (Optional[Sequence[str]]) If not provided, defaults to None.
-        include_sidecars (bool). If not provided, defaults to False.
+        env_vars (Optional[Sequence[str]]): If not provided, defaults to None.
+        include_sidecars (bool): If not provided, defaults to False.
         use_current_ecs_task_config (bool): If not provided, defaults to True.
         run_task_kwargs (Optional[Mapping[str, Any]]): If not provided, defaults to None.
-        run_resources (Optional[dict[str, Any]]) If not provided, defaults to None.
-        run_ecs_tags (Optional[list[dict[str, Optional[str]]]]) If not provided, defaults to None.
+        run_resources (Optional[dict[str, Any]]): If not provided, defaults to None.
+        run_ecs_tags (Optional[list[dict[str, Optional[str]]]]): If not provided, defaults to None.
         propagate_tags (Optional[dict[str, Any]]): If not provided, defaults to None.
         task_definition_prefix (str): If not provided, defaults to "run".
 


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/DOC-927/ecs-run-launcher-api-docs-in-dagster-aws-are-missing

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
