### PR TITLE
[dagster-dbt] Support context in default asset events for dbt Cloud

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -321,6 +321,7 @@ class DbtCloudWorkspace(ConfigurableResource):
             client=client,
             manifest=manifest,
             dagster_dbt_translator=dagster_dbt_translator,
+            context=context,
         )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -209,6 +209,10 @@ def test_cli_invocation_in_asset_decorator(
     asset_materialization_events = result.get_asset_materialization_events()
     asset_check_evaluation = result.get_asset_check_evaluations()
 
+    # materializations are successful outputs, asset check evaluations are not outputs
+    outputs = [event for event in result.all_events if event.is_successful_output]
+    assert len(outputs) == 8
+
     # 8 asset materializations
     assert len(asset_materialization_events) == 8
     # 20 asset check evaluations


### PR DESCRIPTION
## Summary & Motivation

This PR leverages the context in `DbtCloudJobRunResults.to_default_asset_events`. Now, when assets events are yielded in an asset definition, e.g. in the `dbt_cloud_assets` asset decorator, an output is yielded instead of an asset materialization for materialized assets.

## How I Tested These Changes

Updated test with BK
