### PR TITLE
[dagster-dbt] Support dbt selections for dbt Cloud

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
@@ -3,7 +3,15 @@ from typing import Any, Callable, Optional
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import preview
 
-from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
+from dagster_dbt.asset_utils import (
+    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
+    DAGSTER_DBT_SELECT_METADATA_KEY,
+)
+from dagster_dbt.cloud_v2.resources import (
+    DBT_CLOUD_DEFAULT_EXCLUDE,
+    DBT_CLOUD_DEFAULT_SELECT,
+    DbtCloudWorkspace,
+)
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 
@@ -11,6 +19,8 @@ from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 def dbt_cloud_assets(
     *,
     workspace: DbtCloudWorkspace,
+    select: str = DBT_CLOUD_DEFAULT_SELECT,
+    exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     name: Optional[str] = None,
     group_name: Optional[str] = None,
     dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
@@ -20,6 +30,10 @@ def dbt_cloud_assets(
 
     Args:
         workspace (DbtCloudWorkspace): The dbt Cloud workspace.
+        select (str): A dbt selection string for the models in a project that you want
+            to include. Defaults to ``fqn:*``.
+        exclude (str): A dbt selection string for the models in a project that you want
+            to exclude. Defaults to "".
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
         dagster_dbt_translator (Optional[DagsterDbtTranslator], optional): The translator to use
@@ -28,11 +42,19 @@ def dbt_cloud_assets(
     """
     dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
+    op_tags = {
+        **({DAGSTER_DBT_SELECT_METADATA_KEY: select} if select else {}),
+        **({DAGSTER_DBT_EXCLUDE_METADATA_KEY: exclude} if exclude else {}),
+    }
+
     return multi_asset(
         name=name,
         group_name=group_name,
         can_subset=True,
         specs=workspace.load_asset_specs(
             dagster_dbt_translator=dagster_dbt_translator,
+            select=select,
+            exclude=exclude,
         ),
+        op_tags=op_tags,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
@@ -43,8 +43,8 @@ def dbt_cloud_assets(
     dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
     op_tags = {
-        **({DAGSTER_DBT_SELECT_METADATA_KEY: select} if select else {}),
-        **({DAGSTER_DBT_EXCLUDE_METADATA_KEY: exclude} if exclude else {}),
+        DAGSTER_DBT_SELECT_METADATA_KEY: select,
+        DAGSTER_DBT_EXCLUDE_METADATA_KEY: exclude,
     }
 
     return multi_asset(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -24,6 +24,8 @@ from dagster._utils.cached_method import cached_method
 from pydantic import Field
 
 from dagster_dbt.asset_utils import (
+    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
+    DAGSTER_DBT_SELECT_METADATA_KEY,
     DBT_INDIRECT_SELECTION_ENV,
     build_dbt_specs,
     get_manifest_and_translator_from_dbt_assets,
@@ -43,6 +45,9 @@ from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_op
 
 DAGSTER_ADHOC_PREFIX = "DAGSTER_ADHOC_JOB__"
 DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
+
+DBT_CLOUD_DEFAULT_SELECT = "fqn:*"
+DBT_CLOUD_DEFAULT_EXCLUDE = ""
 
 
 def get_dagster_adhoc_job_name(
@@ -217,13 +222,19 @@ class DbtCloudWorkspace(ConfigurableResource):
 
     def fetch_workspace_data(self) -> DbtCloudWorkspaceData:
         return DbtCloudWorkspaceDefsLoader(
-            workspace=self, translator=DagsterDbtTranslator()
+            workspace=self,
+            translator=DagsterDbtTranslator(),
+            select=DBT_CLOUD_DEFAULT_SELECT,
+            exclude=DBT_CLOUD_DEFAULT_EXCLUDE,
         ).get_or_fetch_state()
 
     # Cache spec retrieval for a specific translator class.
     @lru_cache(maxsize=1)
     def load_specs(
-        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+        self,
+        dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+        select: str = DBT_CLOUD_DEFAULT_SELECT,
+        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[Union[AssetSpec, AssetCheckSpec]]:
         dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
@@ -231,6 +242,8 @@ class DbtCloudWorkspace(ConfigurableResource):
             defs = DbtCloudWorkspaceDefsLoader(
                 workspace=initialized_workspace,
                 translator=dagster_dbt_translator,
+                select=select,
+                exclude=exclude,
             ).build_defs()
             asset_specs = check.is_list(
                 defs.assets,
@@ -247,20 +260,32 @@ class DbtCloudWorkspace(ConfigurableResource):
             return [*asset_specs, *asset_check_specs]
 
     def load_asset_specs(
-        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+        self,
+        dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+        select: str = DBT_CLOUD_DEFAULT_SELECT,
+        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[AssetSpec]:
         return [
             spec
-            for spec in self.load_specs(dagster_dbt_translator=dagster_dbt_translator)
+            for spec in self.load_specs(
+                dagster_dbt_translator=dagster_dbt_translator,
+                select=select,
+                exclude=exclude,
+            )
             if isinstance(spec, AssetSpec)
         ]
 
     def load_check_specs(
-        self, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+        self,
+        dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+        select: str = DBT_CLOUD_DEFAULT_SELECT,
+        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[AssetCheckSpec]:
         return [
             spec
-            for spec in self.load_specs(dagster_dbt_translator=dagster_dbt_translator)
+            for spec in self.load_specs(
+                dagster_dbt_translator=dagster_dbt_translator, select=select, exclude=exclude
+            )
             if isinstance(spec, AssetCheckSpec)
         ]
 
@@ -295,8 +320,8 @@ class DbtCloudWorkspace(ConfigurableResource):
             selection_args, indirect_selection_override = get_subset_selection_for_context(
                 context=context,
                 manifest=manifest,
-                select="fqn:*",
-                exclude=None,
+                select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
+                exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
                 dagster_dbt_translator=dagster_dbt_translator,
                 current_dbt_indirect_selection_env=indirect_selection,
             )
@@ -327,16 +352,26 @@ class DbtCloudWorkspace(ConfigurableResource):
 
 @preview
 def load_dbt_cloud_asset_specs(
-    workspace: DbtCloudWorkspace, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+    workspace: DbtCloudWorkspace,
+    dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+    select: str = DBT_CLOUD_DEFAULT_SELECT,
+    exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
 ) -> Sequence[AssetSpec]:
-    return workspace.load_asset_specs(dagster_dbt_translator=dagster_dbt_translator)
+    return workspace.load_asset_specs(
+        dagster_dbt_translator=dagster_dbt_translator, select=select, exclude=exclude
+    )
 
 
 @preview
 def load_dbt_cloud_check_specs(
-    workspace: DbtCloudWorkspace, dagster_dbt_translator: Optional[DagsterDbtTranslator] = None
+    workspace: DbtCloudWorkspace,
+    dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
+    select: str = DBT_CLOUD_DEFAULT_SELECT,
+    exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
 ) -> Sequence[AssetCheckSpec]:
-    return workspace.load_check_specs(dagster_dbt_translator=dagster_dbt_translator)
+    return workspace.load_check_specs(
+        dagster_dbt_translator=dagster_dbt_translator, select=select, exclude=exclude
+    )
 
 
 @preview
@@ -344,6 +379,8 @@ def load_dbt_cloud_check_specs(
 class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspaceData]):
     workspace: DbtCloudWorkspace
     translator: DagsterDbtTranslator
+    select: str
+    exclude: str
 
     @property
     def defs_key(self) -> str:
@@ -356,8 +393,8 @@ class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspace
         all_asset_specs, all_check_specs = build_dbt_specs(
             manifest=state.manifest,
             translator=self.translator,
-            select="fqn:*",
-            exclude="",
+            select=self.select,
+            exclude=self.exclude,
             io_manager_key=None,
             project=None,
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -232,9 +232,9 @@ class DbtCloudWorkspace(ConfigurableResource):
     @lru_cache(maxsize=1)
     def load_specs(
         self,
+        select: str,
+        exclude: str,
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
-        select: str = DBT_CLOUD_DEFAULT_SELECT,
-        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[Union[AssetSpec, AssetCheckSpec]]:
         dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
@@ -261,9 +261,9 @@ class DbtCloudWorkspace(ConfigurableResource):
 
     def load_asset_specs(
         self,
+        select: str,
+        exclude: str,
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
-        select: str = DBT_CLOUD_DEFAULT_SELECT,
-        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[AssetSpec]:
         return [
             spec
@@ -277,9 +277,9 @@ class DbtCloudWorkspace(ConfigurableResource):
 
     def load_check_specs(
         self,
+        select: str,
+        exclude: str,
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
-        select: str = DBT_CLOUD_DEFAULT_SELECT,
-        exclude: str = DBT_CLOUD_DEFAULT_EXCLUDE,
     ) -> Sequence[AssetCheckSpec]:
         return [
             spec

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -25,7 +25,7 @@ from dagster_dbt.cloud_v2.resources import (
     DbtCloudCredentials,
     DbtCloudWorkspace,
     get_dagster_adhoc_job_name,
-load_dbt_cloud_asset_specs
+    load_dbt_cloud_asset_specs,
 )
 from dagster_dbt.cloud_v2.sensor_builder import build_dbt_cloud_polling_sensor
 from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -25,6 +25,7 @@ from dagster_dbt.cloud_v2.resources import (
     DbtCloudCredentials,
     DbtCloudWorkspace,
     get_dagster_adhoc_job_name,
+load_dbt_cloud_asset_specs
 )
 from dagster_dbt.cloud_v2.sensor_builder import build_dbt_cloud_polling_sensor
 from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType
@@ -995,7 +996,7 @@ def load_dbt_cloud_definitions() -> Definitions:
         )
 
         return Definitions(
-            assets=workspace.load_asset_specs(),
+            assets=load_dbt_cloud_asset_specs(workspace=workspace),
             sensors=[build_dbt_cloud_polling_sensor(workspace=workspace)],
         )
     finally:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -1,10 +1,15 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
+import pytest
 import responses
+from dagster import AssetKey
+from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.cloud_v2.asset_decorator import dbt_cloud_assets
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+from dagster_dbt_tests.cloud_v2.conftest import get_sample_manifest_json
 
 
 def test_asset_defs(
@@ -55,3 +60,162 @@ def test_asset_defs_with_custom_metadata(
 
     # Clearing cache for other tests
     workspace.load_specs.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ["select", "exclude", "expected_dbt_resource_names"],
+    [
+        (
+            None,
+            None,
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "raw_customers stg_customers",
+            None,
+            {
+                "raw_customers",
+                "stg_customers",
+            },
+        ),
+        (
+            "raw_customers+",
+            None,
+            {
+                "raw_customers",
+                "stg_customers",
+                "customers",
+            },
+        ),
+        (
+            "resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "raw_customers+,resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "customers",
+            },
+        ),
+        (
+            None,
+            "orders",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+            },
+        ),
+        (
+            None,
+            "raw_customers+",
+            {
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "orders",
+            },
+        ),
+        (
+            None,
+            "raw_customers stg_customers",
+            {
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            None,
+            "resource_type:model",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+            },
+        ),
+        (
+            None,
+            "tag:does-not-exist",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+    ],
+    ids=[
+        "--select fqn:*",
+        "--select raw_customers stg_customers",
+        "--select raw_customers+",
+        "--select resource_type:model",
+        "--select raw_customers+,resource_type:model",
+        "--exclude orders",
+        "--exclude raw_customers+",
+        "--exclude raw_customers stg_customers",
+        "--exclude resource_type:model",
+        "--exclude tag:does-not-exist",
+    ],
+)
+def test_selections(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+    select: Optional[str],
+    exclude: Optional[str],
+    expected_dbt_resource_names: set[str],
+) -> None:
+    select = select or "fqn:*"
+
+    expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
+    expected_specs, _ = build_dbt_specs(
+        manifest=get_sample_manifest_json(),
+        translator=DagsterDbtTranslator(),
+        select=select,
+        exclude=exclude or "",
+        io_manager_key=None,
+        project=None,
+    )
+
+    @dbt_cloud_assets(
+        workspace=workspace,
+        select=select,
+        exclude=exclude or "",
+    )
+    def my_dbt_assets(): ...
+
+    assert len(my_dbt_assets.keys) == len(expected_specs)
+    assert my_dbt_assets.keys == {spec.key for spec in expected_specs}
+    assert my_dbt_assets.keys == expected_asset_keys
+    assert my_dbt_assets.op.tags.get("dagster_dbt/select") == select
+    assert my_dbt_assets.op.tags.get("dagster_dbt/exclude") == exclude

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -196,13 +196,14 @@ def test_selections(
     expected_dbt_resource_names: set[str],
 ) -> None:
     select = select or "fqn:*"
+    exclude = exclude or ""
 
     expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
     expected_specs, _ = build_dbt_specs(
         manifest=get_sample_manifest_json(),
         translator=DagsterDbtTranslator(),
         select=select,
-        exclude=exclude or "",
+        exclude=exclude,
         io_manager_key=None,
         project=None,
     )
@@ -210,7 +211,7 @@ def test_selections(
     @dbt_cloud_assets(
         workspace=workspace,
         select=select,
-        exclude=exclude or "",
+        exclude=exclude,
     )
     def my_dbt_assets(): ...
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
@@ -1,5 +1,9 @@
 import responses
-from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace, load_dbt_cloud_asset_specs, load_dbt_cloud_check_specs
+from dagster_dbt.cloud_v2.resources import (
+    DbtCloudWorkspace,
+    load_dbt_cloud_asset_specs,
+    load_dbt_cloud_check_specs,
+)
 
 from dagster_dbt_tests.cloud_v2.conftest import (
     TEST_ENVIRONMENT_ID,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
@@ -1,5 +1,5 @@
 import responses
-from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
+from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace, load_dbt_cloud_asset_specs, load_dbt_cloud_check_specs
 
 from dagster_dbt_tests.cloud_v2.conftest import (
     TEST_ENVIRONMENT_ID,
@@ -24,7 +24,7 @@ def test_load_asset_specs(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_assets = workspace.load_asset_specs()
+    all_assets = load_dbt_cloud_asset_specs(workspace=workspace)
     all_assets_keys = [asset.key for asset in all_assets]
 
     # 8 dbt models
@@ -46,7 +46,7 @@ def test_load_asset_specs_selection(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_assets = workspace.load_asset_specs(select="raw_customers+")
+    all_assets = load_dbt_cloud_asset_specs(workspace=workspace, select="raw_customers+")
     all_assets_keys = [asset.key for asset in all_assets]
 
     # 3 dbt models
@@ -68,7 +68,7 @@ def test_load_asset_specs_exclusion(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_assets = workspace.load_asset_specs(exclude="raw_customers+")
+    all_assets = load_dbt_cloud_asset_specs(workspace=workspace, exclude="raw_customers+")
     all_assets_keys = [asset.key for asset in all_assets]
 
     # 5 dbt models
@@ -90,7 +90,7 @@ def test_load_check_specs(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_checks = workspace.load_check_specs()
+    all_checks = load_dbt_cloud_check_specs(workspace=workspace)
     all_checks_keys = [check.key for check in all_checks]
 
     # 20 dbt tests
@@ -110,7 +110,7 @@ def test_load_check_specs_selection(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_checks = workspace.load_check_specs(select="raw_customers+")
+    all_checks = load_dbt_cloud_check_specs(workspace=workspace, select="raw_customers+")
     all_checks_keys = [check.key for check in all_checks]
 
     # 4 dbt tests
@@ -130,7 +130,7 @@ def test_load_check_specs_exclusion(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    all_checks = workspace.load_check_specs(exclude="raw_customers+")
+    all_checks = load_dbt_cloud_check_specs(workspace=workspace, exclude="raw_customers+")
     all_checks_keys = [check.key for check in all_checks]
 
     # 16 dbt tests

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
@@ -42,6 +42,50 @@ def test_load_asset_specs(
     workspace.load_specs.cache_clear()
 
 
+def test_load_asset_specs_selection(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_assets = workspace.load_asset_specs(select="raw_customers+")
+    all_assets_keys = [asset.key for asset in all_assets]
+
+    # 3 dbt models
+    assert len(all_assets) == 3
+    assert len(all_assets_keys) == 3
+
+    # Sanity check outputs
+    first_asset_key = next(key for key in sorted(all_assets_keys))
+    assert first_asset_key.path == ["customers"]
+    first_asset_kinds = next(spec.kinds for spec in sorted(all_assets))
+    assert "dbtcloud" in first_asset_kinds
+    assert "dbt" not in first_asset_kinds
+
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()
+
+
+def test_load_asset_specs_exclusion(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_assets = workspace.load_asset_specs(exclude="raw_customers+")
+    all_assets_keys = [asset.key for asset in all_assets]
+
+    # 5 dbt models
+    assert len(all_assets) == 5
+    assert len(all_assets_keys) == 5
+
+    # Sanity check outputs
+    first_asset_key = next(key for key in sorted(all_assets_keys))
+    assert first_asset_key.path == ["orders"]
+    first_asset_kinds = next(spec.kinds for spec in sorted(all_assets))
+    assert "dbtcloud" in first_asset_kinds
+    assert "dbt" not in first_asset_kinds
+
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()
+
+
 def test_load_check_specs(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
@@ -49,7 +93,7 @@ def test_load_check_specs(
     all_checks = workspace.load_check_specs()
     all_checks_keys = [check.key for check in all_checks]
 
-    # 8 dbt models
+    # 20 dbt tests
     assert len(all_checks) == 20
     assert len(all_checks_keys) == 20
 
@@ -57,6 +101,49 @@ def test_load_check_specs(
     first_check_key = next(key for key in sorted(all_checks_keys))
     assert first_check_key.name == "not_null_customers_customer_id"
     assert first_check_key.asset_key.path == ["customers"]
+
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()
+
+
+def test_load_check_specs_selection(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_checks = workspace.load_check_specs(select="raw_customers+")
+    all_checks_keys = [check.key for check in all_checks]
+
+    # 4 dbt tests
+    assert len(all_checks) == 4
+    assert len(all_checks_keys) == 4
+
+    # Sanity check outputs
+    first_check_key = next(key for key in sorted(all_checks_keys))
+    assert first_check_key.name == "not_null_customers_customer_id"
+    assert first_check_key.asset_key.path == ["customers"]
+
+    # Clearing cache for other tests
+    workspace.load_specs.cache_clear()
+
+
+def test_load_check_specs_exclusion(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    all_checks = workspace.load_check_specs(exclude="raw_customers+")
+    all_checks_keys = [check.key for check in all_checks]
+
+    # 16 dbt tests
+    assert len(all_checks) == 16
+    assert len(all_checks_keys) == 16
+
+    # Sanity check outputs
+    first_check_key = next(key for key in sorted(all_checks_keys))
+    assert (
+        first_check_key.name
+        == "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
+    )
+    assert first_check_key.asset_key.path == ["orders"]
 
     # Clearing cache for other tests
     workspace.load_specs.cache_clear()


### PR DESCRIPTION
## Summary & Motivation

This PR updates the code to allow users to pass `select` and `exclude` strings to the `dbt_cloud_assets` decorator, and the spec loader functions for dbt Cloud.

## How I Tested These Changes

Additional tests with BK
