### PR TITLE
[dagster-dbt] Support asset checks in dbt_cloud_assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
@@ -61,5 +61,5 @@ def dbt_cloud_assets(
             dagster_dbt_translator=dagster_dbt_translator,
             select=select,
             exclude=exclude,
-        )
+        ),
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
@@ -57,4 +57,9 @@ def dbt_cloud_assets(
             exclude=exclude,
         ),
         op_tags=op_tags,
+        check_specs=workspace.load_check_specs(
+            dagster_dbt_translator=dagster_dbt_translator,
+            select=select,
+            exclude=exclude,
+        )
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
@@ -1,7 +1,13 @@
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Optional, Union
 
-from dagster import AssetCheckEvaluation, AssetExecutionContext, AssetMaterialization, Output
+from dagster import (
+    AssetCheckEvaluation,
+    AssetCheckResult,
+    AssetExecutionContext,
+    AssetMaterialization,
+    Output,
+)
 from dagster._annotations import preview
 from dagster._record import record
 
@@ -46,7 +52,9 @@ class DbtCloudCliInvocation:
             context=context,
         )
 
-    def wait(self) -> Iterator[Union[AssetMaterialization, AssetCheckEvaluation, Output]]:
+    def wait(
+        self,
+    ) -> Iterator[Union[AssetCheckEvaluation, AssetCheckResult, AssetMaterialization, Output]]:
         self.run_handler.wait_for_success()
         if "run_results.json" not in self.run_handler.list_run_artifacts():
             return

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -214,7 +214,7 @@ class DbtCloudJobRunResults:
                             else AssetCheckSeverity.ERROR
                         ),
                     )
-                elif asset_check_key is not None:
+                elif not has_asset_def and asset_check_key is not None:
                     yield AssetCheckEvaluation(
                         passed=result_status == TestStatus.Pass,
                         asset_key=asset_check_key.asset_key,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -98,7 +98,7 @@ class DbtCloudJobRunResults:
         manifest: Mapping[str, Any],
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
         context: Optional[AssetExecutionContext] = None,
-    ) -> Iterator[Union[AssetMaterialization, AssetCheckEvaluation, Output]]:
+    ) -> Iterator[Union[AssetCheckEvaluation, AssetCheckResult, AssetMaterialization, Output]]:
         """Convert the run results of a dbt Cloud job run to a set of corresponding Dagster events.
 
         Args:
@@ -109,12 +109,12 @@ class DbtCloudJobRunResults:
             context (Optional[AssetExecutionContext]): The execution context.
 
         Returns:
-            Iterator[Union[AssetMaterialization, AssetCheckEvaluation, Output]]:
+            Iterator[Union[AssetCheckEvaluation, AssetCheckResult, AssetMaterialization, Output]]:
                 A set of corresponding Dagster events.
 
                 In a Dagster asset definition, the following are yielded:
                 - Output for refables (e.g. models, seeds, snapshots.)
-                - AssetCheckEvaluation for dbt tests.
+                - AssetCheckResult for dbt tests.
 
                 For ad hoc usage, the following are yielded:
                 - AssetMaterialization for refables (e.g. models, seeds, snapshots.)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -3,12 +3,12 @@ from typing import Any, Optional, Union
 
 from dagster import (
     AssetCheckEvaluation,
+    AssetCheckResult,
     AssetCheckSeverity,
     AssetExecutionContext,
     AssetMaterialization,
     MetadataValue,
     Output,
-    AssetCheckResult,
 )
 from dagster._annotations import preview
 from dagster._record import record

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -209,9 +209,13 @@ def test_cli_invocation_in_asset_decorator(
     asset_materialization_events = result.get_asset_materialization_events()
     asset_check_evaluation = result.get_asset_check_evaluations()
 
-    # materializations are successful outputs, asset check evaluations are not outputs
+    # materializations and check results are successful outputs
     outputs = [event for event in result.all_events if event.is_successful_output]
-    assert len(outputs) == 8
+    assert len(outputs) == 28
+
+    # materialization outputs have metadata, asset check outputs don't
+    outputs_with_metadata = [output for output in outputs if output.step_output_data.metadata]
+    assert len(outputs_with_metadata) == 8
 
     # 8 asset materializations
     assert len(asset_materialization_events) == 8

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -223,6 +223,10 @@ def test_cli_invocation_in_asset_decorator(
     assert len(asset_check_evaluation) == 20
 
     # Sanity check
+    first_output_with_metadata = next(output for output in sorted(outputs_with_metadata))
+    assert first_output_with_metadata.step_output_data.output_name == "customers"
+    assert first_output_with_metadata.step_output_data.metadata["run_url"].value == TEST_RUN_URL
+
     first_mat = next(event.materialization for event in sorted(asset_materialization_events))
     assert first_mat.asset_key.path == ["customers"]
     assert first_mat.metadata["run_url"].value == TEST_RUN_URL


### PR DESCRIPTION
## Summary & Motivation

This PR updates the `dbt_cloud_assets` decorator to pass the check specs to the multi-asset definition, and updates `DbtCloudJobRunResults.to_default_asset_events` to yield AssetCheckResults when asset check are executed in an asset execution context.

## How I Tested These Changes

Updated test with BK

