### PR TITLE
docs: Update concurrency-no-more-than-1-job.py to add more statuses

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/operate/concurrency-no-more-than-1-job.py
+++ b/examples/docs_snippets/docs_snippets/guides/operate/concurrency-no-more-than-1-job.py
@@ -22,7 +22,15 @@ def my_schedule(context):
     # Find runs of the same job that are currently running
     # highlight-start
     run_records = context.instance.get_run_records(
-        dg.RunsFilter(job_name="my_job", statuses=[dg.DagsterRunStatus.STARTED])
+        dg.RunsFilter(
+            job_name="my_job",
+            statuses=[
+                dg.DagsterRunStatus.QUEUED,
+                dg.DagsterRunStatus.NOT_STARTED,
+                dg.DagsterRunStatus.STARTING,
+                dg.DagsterRunStatus.STARTED,
+            ],
+        )
     )
     # skip a schedule run if another run of the same job is already running
     if len(run_records) > 0:


### PR DESCRIPTION
## Summary & Motivation
On page https://docs.dagster.io/guides/operate/managing-concurrency#prevent-runs-from-starting-if-another-run-is-already-occurring-advanced in the "advanced" example only the `STARTED` status is mentioned, which is not always enough in real (production) use-cases.

It would be great to have a more complete example ;-)

## How I Tested These Changes
We already use it this way to avoid overloading the queue.

Note: not sure how the dark-gray background (highlighted part of the example code) is done on the docs page... I hope it will work.
