### PR TITLE
[ui] Repair TextInput focus/hover styles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -148,10 +148,13 @@ const StyledInput = styled.input<StyledInputProps>`
   padding: ${({$hasIcon}) => ($hasIcon ? '6px 6px 6px 28px' : '6px 6px 6px 12px')};
 
   :hover:not(:disabled) {
-    box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px;
+    box-shadow: ${({$strokeColor}) =>
+        $strokeColor === Colors.borderDefault() ? Colors.borderHover() : $strokeColor}
+      inset 0px 0px 0px 1px;
   }
 
-  :focus {
+  :focus,
+  :hover:focus:not(:disabled) {
     box-shadow:
       ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px,
       ${Colors.focusRing()} 0 0 0 2px;


### PR DESCRIPTION
## Summary & Motivation

I recently introduced a bug in text input styles, where hovering on a focused input causes the focus ring to disappear. It should remain visible.

Fix this by adding an additional selector to the focus rule.

Also fix the hover stroke color for the default, since `$strokeColor` always has a value and we currently never fall back to `borderHover`. If the stroke color is `borderDefault`, use `borderHover` as the stroke color on hover. Otherwise, just keep the specified stroke color.

## How I Tested These Changes

`ui-components` storybook

## Changelog

[ui] Fix hover state on focused inputs.
