### PR TITLE
Update run status sensor docs for get_job_success_event and get_job_failure_event

### DIFF
--- a/docs/docs/guides/automate/sensors/testing-run-status-sensors.md
+++ b/docs/docs/guides/automate/sensors/testing-run-status-sensors.md
@@ -30,7 +30,7 @@ Then we can execute this job and pull the attributes we need to build the `conte
 />
 
 {/* TODO the methods and statuses below do not exist in API docs */}
-{/* We have provided convenience functions <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_run_success_event" /> and <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_run_failure_event" /> for retrieving `DagsterRunStatus.SUCCESS` and `DagsterRunStatus.FAILURE` events, respectively. If you have a run status sensor triggered on another status, you can retrieve all events from `result` and filter based on your event type. */}
+We have provided convenience functions <PyObject section="execution" module="dagster" object="ExecuteInProcessResult.get_run_success_event" /> and <PyObject section="execution" module="dagster" object="ExecuteInProcessResult.get_run_failure_event" /> for retrieving `DagsterRunStatus.SUCCESS` and `DagsterRunStatus.FAILURE` events, respectively. If you have a run status sensor triggered on another status, you can retrieve all events from `result` and filter based on your event type.
 
 We can use the same pattern to build the context for <PyObject section="schedules-sensors" module="dagster" object="run_failure_sensor" />. If we wanted to test this run failure sensor:
 

--- a/docs/docs/guides/automate/sensors/testing-run-status-sensors.md
+++ b/docs/docs/guides/automate/sensors/testing-run-status-sensors.md
@@ -30,7 +30,7 @@ Then we can execute this job and pull the attributes we need to build the `conte
 />
 
 {/* TODO the methods and statuses below do not exist in API docs */}
-{/* We have provided convenience functions <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_job_success_event" /> and <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_job_failure_event" /> for retrieving `DagsterRunStatus.SUCCESS` and `DagsterRunStatus.FAILURE` events, respectively. If you have a run status sensor triggered on another status, you can retrieve all events from `result` and filter based on your event type. */}
+{/* We have provided convenience functions <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_run_success_event" /> and <PyObject section="execution" module="dagster" object="ExecuteInProcessResult" method="get_run_failure_event" /> for retrieving `DagsterRunStatus.SUCCESS` and `DagsterRunStatus.FAILURE` events, respectively. If you have a run status sensor triggered on another status, you can retrieve all events from `result` and filter based on your event type. */}
 
 We can use the same pattern to build the context for <PyObject section="schedules-sensors" module="dagster" object="run_failure_sensor" />. If we wanted to test this run failure sensor:
 

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -365,7 +365,7 @@ def build_run_status_sensor_context(
             result = my_job.execute_in_process(instance=instance)
 
             dagster_run = result.dagster_run
-            dagster_event = result.get_job_success_event() # or get_job_failure_event()
+            dagster_event = result.get_run_success_event() # or get_run_failure_event()
 
             context = build_run_status_sensor_context(
                 sensor_name="run_status_sensor_to_invoke",


### PR DESCRIPTION
## Summary & Motivation

The docs for `build_run_status_sensor_context` referred to methods (`get_job_success_event` and `get_job_failure_event`) that don't exist anymore and have been renamed (`get_run_success_event` and `get_run_failure_event`)

## How I Tested These Changes

n/a

## Changelog


