### PR TITLE
Fix bug when executing a run using CacheableAssetData when the code has changed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import update_wrapper
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
@@ -211,9 +212,12 @@ def _resolve_cacheable_asset_data(
     # cacheable data is available, we expect all of it to be available. This
     # is to match previous behavior of PendingRepositoryDefinition.
     elif context.load_type == DefinitionsLoadType.RECONSTRUCTION and context.cacheable_asset_data:
-        check.failed(
-            f"No metadata found for CacheableAssetsDefinition with unique_id {definition.unique_id}."
+        warnings.warn(
+            f"No cached metadata found for CacheableAssetsDefinition with unique_id {definition.unique_id}."
+            " This can occur when executing a run that was created against an older version of the code"
+            " in the current process, because the `unique_id` may change between code versions. Recomputing metadata."
         )
+        return definition.compute_cacheable_data()
     else:
         return definition.compute_cacheable_data()
 


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where a redeploy of code using state-backed definitions can lead to job failures due to the `CacheableAssetData` storage key changing.

Current situation:

* Both the code server and the run worker independently compute the `cacheable_asset_data` key
* The run and `ExecutionPlanSnapshot` get created in the host process using the reconstruction metadata fetched from the code server
* Let’s say we have code state A with `cacheable_asset_data` key K
* A run gets created. The `ExecutionPlanSnapshot` for the run has some cacheable asset data stored under K.
* Before the run is launched, the code is redeployed and state changes from A -> A’, key changes from K -> K’
* Now when the run starts, the run worker pulls the `ExecutionPlanSnapshot` from the instance, where the cacheable asset data is stored under K. But the run worker computes the key as K’ and looks under the wrong key. It throws an error.

Change:

Instead of throwing an error when there is some cacheable asset data present but not the expected key, print a warning and recompute the data.

## How I Tested These Changes

Existing test suite.

## Changelog

Fixes an issue where a redeploy of code using state-backed definitions can lead to failures on runs created before the redeploy.
