### PR TITLE
[docs] fix ResolvedAssetSpec imports in component authoring tutorial

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/26-component-ingest-automation.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/26-component-ingest-automation.yaml
@@ -1,0 +1,11 @@
+type: dagster_components.dagster_sling.SlingReplicationCollectionComponent
+
+attributes:
+  replications:
+    - path: replication.yaml
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        automation_condition: "{{ automation_condition.on_cron('@daily') }}"
+        metadata:
+          automation_condition: "on_cron(@daily)"

--- a/examples/docs_snippets/docs_snippets/guides/components/index/27-component-jdbt-automation.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/27-component-jdbt-automation.yaml
@@ -1,0 +1,13 @@
+type: dagster_components.dagster_dbt.DbtProjectComponent
+
+attributes:
+  dbt:
+    project_dir: ../../../dbt/jdbt
+  asset_attributes:
+    key: "target/main/{{ node.name }}"
+  asset_post_processors:
+    - target: "*"
+      attributes:
+        automation_condition: "{{ automation_condition.eager() }}"
+        metadata:
+            automation_condition: "eager"

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-build-defs.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-build-defs.py
@@ -3,8 +3,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from dagster_components import Component, ComponentLoadContext, Resolvable
-from dagster_components.resolved.core_models import ResolvedAssetSpec
+from dagster_components import (
+    Component,
+    ComponentLoadContext,
+    Resolvable,
+    ResolvedAssetSpec,
+)
 
 import dagster as dg
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-custom-scope.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-custom-scope.py
@@ -10,7 +10,6 @@ from dagster_components import (
     Resolvable,
     ResolvedAssetSpec,
 )
-from dagster_components.resolved.core_models import ResolvedAssetSpec
 
 import dagster as dg
 

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/1-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/1-tree.txt
@@ -5,8 +5,8 @@ tree
 ├── my_existing_project
 │   ├── __init__.py
 │   ├── assets.py
-│   └── definitions.py
-├── py.typed
+│   ├── definitions.py
+│   └── py.typed
 └── setup.py
 
 2 directories, 6 files


### PR DESCRIPTION
## Summary & Motivation

- Current version of _master_ expects `ResolvedAssetSpec` to be imported from root `dagster_components`
    * Updates docs to align with that in preparation for this weeks release.

## How I Tested These Changes

- `yarn start` and walk through tutorial

## Changelog

NOCHANGELOG
