### PR TITLE
[dagster-k8s] fix: Stability improvement for AKS network issues

### DIFF
--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -82,11 +82,11 @@ spec:
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.dagsterDaemon.image.pullPolicy }}
-          image: {{ include "dagster.dagsterImage.name" (list $ .Values.dagsterDaemon.image) | quote }}
+          # Use frozen version from commit: [dagster-k8s] [5/?] Remove generic Exception
           command: [
             "/bin/bash",
             "-c",
-            "{{- template "dagster.dagsterDaemon.daemonCommand" . }}"
+            "apt update && apt install git -y && pip install git+https://github.com/HynekBlaha/dagster.git@02e00effe1822e595ca0722c011a4a3e046997fa#subdirectory=python_modules/libraries/dagster-k8s && {{- template "dagster.dagsterDaemon.daemonCommand" . }}"
           ]
           env:
             - name: DAGSTER_PG_PASSWORD

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -82,11 +82,11 @@ spec:
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.dagsterDaemon.image.pullPolicy }}
-          # Use frozen version from commit: [dagster-k8s] [5/?] Remove generic Exception
+          image: {{ include "dagster.dagsterImage.name" (list $ .Values.dagsterDaemon.image) | quote }}
           command: [
             "/bin/bash",
             "-c",
-            "apt update && apt install git -y && pip install git+https://github.com/HynekBlaha/dagster.git@02e00effe1822e595ca0722c011a4a3e046997fa#subdirectory=python_modules/libraries/dagster-k8s && {{- template "dagster.dagsterDaemon.daemonCommand" . }}"
+            "{{- template "dagster.dagsterDaemon.daemonCommand" . }}"
           ]
           env:
             - name: DAGSTER_PG_PASSWORD

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -19,7 +19,12 @@ from dagster._annotations import beta
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._utils.merger import merge_dicts
 
-from dagster_k8s.client import DEFAULT_JOB_POD_COUNT, DagsterKubernetesClient, k8s_api_retry
+from dagster_k8s.client import (
+    DEFAULT_JOB_POD_COUNT,
+    DEFAULT_K8S_REQUEST_TIMEOUT_SEC,
+    DagsterKubernetesClient,
+    k8s_api_retry,
+)
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import (
     DagsterK8sJobConfig,
@@ -382,6 +387,7 @@ def execute_k8s_job(
                 name=pod_to_watch,
                 namespace=namespace,
                 container=container_name,
+                _request_timeout=DEFAULT_K8S_REQUEST_TIMEOUT_SEC,
             )
 
             while True:


### PR DESCRIPTION
## Summary & Motivation
Since `2025-03-31T02Z` we started observing large number of `urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))` exceptions. 

At the same time, the **dagster.daemon.QueuedRunCoordinatorDaemon** got stuck and its Heartbeat was not being refreshed. To mitigate damage, we started a cronjob, that would periodically restart Dagster Controller Pod.

The same problems were reported by other Dagster users:
- [28314# K8sRunLauncher deployment on Azure AKS - intermittent dropped connections when calling create_namespaced_job causing failed jobs](https://github.com/dagster-io/dagster/issues/28314)
- [28910# Queued Run Coordinator Daemon hangs and jobs are not starting](https://github.com/dagster-io/dagster/issues/28910)

## How I Tested These Changes
[I installed this patched dagster-k8s](https://github.com/dagster-io/dagster/commit/e16660f4aa55eda08fd00ae0071372c8a4850fc1) to our staging and production environment with over 30 code deployments. 

- I can see from logs that the urllib3.exceptions are retried.
<img width="1432" alt="Screenshot 2025-04-01 at 23 28 56" src="https://github.com/user-attachments/assets/335c3ffd-f654-42d0-960d-e5dff2e1a934" />

- I don't see any new `Run FAILURE: Failed to start`
```sql
select
    timestamp, 
    run_id, 
    pipeline_name
from runs
join event_logs using (run_id)
where
    dagster_event_type = 'PIPELINE_FAILURE'
    and timestamp >= now() - interval '4 hours'
    and (event::jsonb)->'dagster_event'->>'message' like 'Run timed out%'
order by timestamp desc
>
empty
```

- The **QueuedRunCoordinatorDaemon** is working as expected again.
The reason why it got stuck was:
1) Threaded QueuedRunCoordinatorDaemon waits for all threads to finish
https://github.com/dagster-io/dagster/blob/56f2f782f64ce547e0d88fd7a49b216f00c7813d/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py#L151-L160
2) Each thread launches run
https://github.com/dagster-io/dagster/blob/56f2f782f64ce547e0d88fd7a49b216f00c7813d/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py#L397-L403
3) No API timeout was used for K8sRunLauncher - effectively blocking the Heartbeat 
https://github.com/dagster-io/dagster/blob/56f2f782f64ce547e0d88fd7a49b216f00c7813d/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py#L276

Observe 15min delay on `2025-04-02 00:30:41.544` and error log matching 2).
<img width="1664" alt="Screenshot 2025-04-02 at 0 38 07" src="https://github.com/user-attachments/assets/fbb39d6a-2f36-4366-86dd-103b1901fd76" />


## Changelog

> [dagster-k8s] Stability improvement for AKS network issues
