### PR TITLE
[dg][refactor] Update LibraryEntry type system

### DIFF
--- a/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
+++ b/python_modules/libraries/dagster-components/dagster_components_tests/cli_tests/test_commands.py
@@ -7,12 +7,8 @@ from dagster._core.test_utils import new_cwd
 from dagster_components.cli import cli
 from dagster_components.utils import ensure_dagster_components_tests_import
 from dagster_shared import check
-from dagster_shared.serdes.objects import (
-    ComponentTypeSnap,
-    LibraryEntryKey,
-    LibraryEntrySnap,
-    ScaffolderSnap,
-)
+from dagster_shared.serdes.objects import LibraryEntryKey, LibraryEntrySnap
+from dagster_shared.serdes.objects.library_object import ComponentTypeData, ScaffoldTargetTypeData
 from dagster_shared.serdes.serdes import deserialize_value
 from jsonschema import Draft202012Validator, ValidationError
 
@@ -52,21 +48,25 @@ def test_list_library_objects_from_module():
         "dagster_test.components.scaffoldable_fn",
     ]
 
-    assert result[2] == ComponentTypeSnap(
+    assert result[2] == LibraryEntrySnap(
         key=LibraryEntryKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
-        schema={
-            "additionalProperties": False,
-            "properties": {
-                "asset_key": {"title": "Asset Key", "type": "string"},
-                "value": {"title": "Value", "type": "string"},
-            },
-            "required": ["asset_key", "value"],
-            "title": "SimpleAssetComponentModel",
-            "type": "object",
-        },
         description="A simple asset that returns a constant string value.",
         summary="A simple asset that returns a constant string value.",
-        scaffolder=ScaffolderSnap(schema=None),
+        type_data=[
+            ComponentTypeData(
+                schema={
+                    "additionalProperties": False,
+                    "properties": {
+                        "asset_key": {"title": "Asset Key", "type": "string"},
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                    "required": ["asset_key", "value"],
+                    "title": "SimpleAssetComponentModel",
+                    "type": "object",
+                }
+            ),
+            ScaffoldTargetTypeData(schema=None),
+        ],
     )
 
     pipes_script_params_schema = {
@@ -79,12 +79,14 @@ def test_list_library_objects_from_module():
         "type": "object",
     }
 
-    assert result[3] == ComponentTypeSnap(
+    assert result[3] == LibraryEntrySnap(
         key=LibraryEntryKey(namespace="dagster_test.components", name="SimplePipesScriptComponent"),
-        schema=pipes_script_params_schema,
         description="A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
         summary="A simple asset that runs a Python script with the Pipes subprocess client.",
-        scaffolder=ScaffolderSnap(schema=pipes_script_params_schema),
+        type_data=[
+            ComponentTypeData(schema=pipes_script_params_schema),
+            ScaffoldTargetTypeData(schema=pipes_script_params_schema),
+        ],
     )
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/check.py
@@ -117,7 +117,8 @@ def check_yaml(
     )
     for key, component_doc_tree in component_contents_by_key.items():
         try:
-            json_schema = component_registry.get_component_type(key).schema or {}
+            type_data = component_registry.get(key).get_type_data("component")
+            json_schema = (type_data.schema if type_data else None) or {}
 
             v = Draft202012Validator(json_schema)
             for err in v.iter_errors(component_doc_tree.value["attributes"]):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -91,36 +91,36 @@ def inspect_component_type_command(
             "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."
         )
 
-    component_type_snap = registry.get_component_type(component_key)
+    entry_snap = registry.get(component_key)
 
     if description:
-        if component_type_snap.description:
-            click.echo(component_type_snap.description)
+        if entry_snap.description:
+            click.echo(entry_snap.description)
         else:
             click.echo("No description available.")
     elif scaffold_params_schema:
-        if component_type_snap.scaffolder_schema:
-            click.echo(_serialize_json_schema(component_type_snap.scaffolder_schema))
+        if entry_snap.scaffolder_schema:
+            click.echo(_serialize_json_schema(entry_snap.scaffolder_schema))
         else:
             click.echo("No scaffold params schema defined.")
     elif component_schema:
-        if component_type_snap.schema:
-            click.echo(_serialize_json_schema(component_type_snap.schema))
+        if entry_snap.component_schema:
+            click.echo(_serialize_json_schema(entry_snap.component_schema))
         else:
             click.echo("No component schema defined.")
 
     # print all available metadata
     else:
         click.echo(component_type)
-        if component_type_snap.description:
+        if entry_snap.description:
             click.echo("\nDescription:\n")
-            click.echo(component_type_snap.description)
-        if component_type_snap.scaffolder_schema:
+            click.echo(entry_snap.description)
+        if entry_snap.scaffolder_schema:
             click.echo("\nScaffold params schema:\n")
-            click.echo(_serialize_json_schema(component_type_snap.scaffolder_schema))
-        if component_type_snap.schema:
+            click.echo(_serialize_json_schema(entry_snap.scaffolder_schema))
+        if entry_snap.component_schema:
             click.echo("\nComponent schema:\n")
-            click.echo(_serialize_json_schema(component_type_snap.schema))
+            click.echo(_serialize_json_schema(entry_snap.component_schema))
 
 
 def _serialize_json_schema(schema: Mapping[str, Any]) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import dagster_shared.check as check
 from dagster_shared.serdes import deserialize_value, serialize_value
-from dagster_shared.serdes.objects import ComponentTypeSnap, LibraryEntryKey, LibraryEntrySnap
+from dagster_shared.serdes.objects import LibraryEntryKey, LibraryEntrySnap
 
 from dagster_dg.utils import is_valid_json
 
@@ -47,13 +47,6 @@ class RemoteLibraryEntryRegistry:
     def get(self, key: LibraryEntryKey) -> LibraryEntrySnap:
         """Resolves a library object within the scope of a given component directory."""
         return self._objects[key]
-
-    def get_component_type(self, key: LibraryEntryKey) -> ComponentTypeSnap:
-        """Resolves a component type within the scope of a given component directory."""
-        obj = self.get(key)
-        if not isinstance(obj, ComponentTypeSnap):
-            raise ValueError(f"Expected component type, got {obj}")
-        return obj
 
     def has(self, key: LibraryEntryKey) -> bool:
         return key in self._objects

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -5,11 +5,11 @@ from itertools import groupby
 from typing import Any, Optional, TypedDict, Union
 
 import yaml
-from dagster_shared.serdes.objects import LibraryEntryKey
+from dagster_shared.serdes.objects import ComponentTypeData, LibraryEntryKey, LibraryEntrySnap
 from dagster_shared.yaml_utils import parse_yaml_with_source_positions
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
 
-from dagster_dg.component import ComponentTypeSnap, RemoteLibraryEntryRegistry
+from dagster_dg.component import RemoteLibraryEntryRegistry
 
 REF_BASE = "#/$defs/"
 JSON_SCHEMA_EXTRA_REQUIRED_SCOPE_KEY = "dagster_required_scope"
@@ -175,11 +175,16 @@ def json_for_all_components(
     registry: RemoteLibraryEntryRegistry,
 ) -> list[ComponentTypeNamespaceJson]:
     """Returns a list of JSON representations of all component types in the registry."""
-    component_json = [
-        (key.namespace.split(".")[0], json_for_component_type(key, library_obj))
-        for key, library_obj in registry.items()
-        if isinstance(library_obj, ComponentTypeSnap) and library_obj.schema is not None
-    ]
+    component_json = []
+    for key, library_obj in registry.items():
+        component_type_data = library_obj.get_type_data("component")
+        if component_type_data and component_type_data.schema:
+            component_json.append(
+                (
+                    key.namespace.split(".")[0],
+                    json_for_component_type(key, library_obj, component_type_data),
+                )
+            )
     return [
         ComponentTypeNamespaceJson(
             name=namespace,
@@ -190,15 +195,15 @@ def json_for_all_components(
 
 
 def json_for_component_type(
-    key: LibraryEntryKey, remote_component_type: ComponentTypeSnap
+    key: LibraryEntryKey, library_entry: LibraryEntrySnap, component_type_data: ComponentTypeData
 ) -> ComponentTypeJson:
     typename = key.to_typename()
-    sample_yaml = generate_sample_yaml(typename, remote_component_type.schema or {})
+    sample_yaml = generate_sample_yaml(typename, component_type_data.schema or {})
     return ComponentTypeJson(
         name=typename,
         author="",
         tags=[],
         example=sample_yaml,
-        schema=json.dumps(remote_component_type.schema),
-        description=remote_component_type.description,
+        schema=json.dumps(component_type_data.schema),
+        description=library_entry.description,
     )

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/__init__.py
@@ -1,6 +1,6 @@
 from dagster_shared.serdes.objects.library_object import (
-    ComponentTypeSnap as ComponentTypeSnap,
+    ComponentTypeData as ComponentTypeData,
     LibraryEntryKey as LibraryEntryKey,
     LibraryEntrySnap as LibraryEntrySnap,
-    ScaffolderSnap as ScaffolderSnap,
+    ScaffoldTargetTypeData as ScaffoldTargetTypeData,
 )


### PR DESCRIPTION
## Summary & Motivation

This refactors our type system for representing LibraryEntries. Now, each snapshot can have an arbitrary set of types, which each specify their own type-specific data. This makes it easier to add new types in the future, and also removes an artificial hierarchy that the previous system contained.

## How I Tested These Changes

## Changelog

NOCHANGELOG
