### PR TITLE
Make the unique_id on a CacheableAssetsDefinition when you run it through with_resources more stable

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
@@ -226,13 +226,21 @@ def test_resolve_with_resources():
         def foo_resource():
             return 3
 
+        cacheable_assets = define_uncacheable_and_resource_dependent_cacheable_assets()
+        cacheable_assets_with_resources = with_resources(
+            define_uncacheable_and_resource_dependent_cacheable_assets(),
+            {"foo": foo_resource},
+        )
+
+        assert (
+            cacheable_assets_with_resources[0].unique_id
+            == f"{cacheable_assets[0].unique_id}_with_resources"
+        )
+
         @repository
         def resource_dependent_repo_with_resources():
             return [
-                with_resources(
-                    define_uncacheable_and_resource_dependent_cacheable_assets(),
-                    {"foo": foo_resource},
-                ),
+                cacheable_assets_with_resources,
                 define_asset_job(
                     "all_asset_job",
                 ),


### PR DESCRIPTION
## Summary & Motivation
Sending this out for discussion. The problem with the implementation here is that if there is any non-determinism in the resource config, the ID here changes on each deploy, causing various problems and race conditions. For example, the dbt cli resource is currently non-deterministic since it sets an absolute path as one of its fields that can change on each deploy.

I can't think of a situation where a CacheableAssetsDefinition would ever need to co-exist with itself with with_resources called on it (unless there is some odd case i'm not thinking of?) so I would expect it to be safe to keep the same unique ID after with_resources is applied to it.

## How I Tested These Changes
New test case

## Changelog
[dagster-fivetran] Fixed an issue where new runs of code locations using fivetran assets would sometimes raise a "Failure condition: No metadata found for CacheableAssetsDefinition" error if the run was started immediately after a new version of the code location was deployed.