### PR TITLE
remove partition view on asset events for non-sda assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -1,17 +1,9 @@
-import {
-  Box,
-  ButtonGroup,
-  ErrorBoundary,
-  NonIdealState,
-  Spinner,
-  Subheading,
-} from '@dagster-io/ui-components';
+import {Box, ErrorBoundary, NonIdealState, Spinner} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useMemo} from 'react';
 
 import {AssetEventDetail, AssetEventDetailEmpty} from './AssetEventDetail';
 import {AssetEventList} from './AssetEventList';
-import {AssetPartitionDetail, AssetPartitionDetailEmpty} from './AssetPartitionDetail';
 import {CurrentRunsBanner} from './CurrentRunsBanner';
 import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializationBanner';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
@@ -21,7 +13,6 @@ import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
 import {useAssetDefinition} from './useAssetDefinition';
 import {useAssetEventsFilters} from './useAssetEventsFilters';
 import {usePaginatedAssetEvents} from './usePaginatedAssetEvents';
-import {getXAxisForParams} from './useRecentAssetEvents';
 import {LiveDataForNode, stepKeyForAsset} from '../asset-graph/Utils';
 import {MaterializationHistoryEventTypeSelector, RepositorySelector} from '../graphql/types';
 
@@ -49,18 +40,6 @@ export const AssetEvents = ({
   liveData,
   dataRefreshHint,
 }: Props) => {
-  /**
-   * We have a separate "Asset > Partitions" tab, but that is only available for SDAs with
-   * pre-defined partitions. For non-SDAs, this Events page still displays a "Time | Partition"
-   * picker and this xAxis can still be `partitions`!
-   *
-   * The partitions behavior in this case isn't ideal because the UI only "sees" partition names
-   * in the events it has fetched. Users should upgrade to SDAs for a better experience.
-   *
-   * To test this easily, unload / break your code location so your SDA becomes a non-SDA :-)
-   */
-  const xAxis = getXAxisForParams(params, {defaultToPartitions: false});
-
   const {filterButton, activeFiltersJsx, filterState} = useAssetEventsFilters({
     assetKey,
     assetNode,
@@ -86,8 +65,10 @@ export const AssetEvents = ({
     return combinedParams;
   }, [params, filterState.dateRange, filterState.status]);
 
-  const {materializations, observations, loadedPartitionKeys, fetchMore, fetchLatest, loading} =
-    usePaginatedAssetEvents(assetKey, combinedParams);
+  const {materializations, observations, fetchMore, fetchLatest, loading} = usePaginatedAssetEvents(
+    assetKey,
+    combinedParams,
+  );
 
   React.useEffect(() => {
     fetchLatest();
@@ -98,21 +79,19 @@ export const AssetEvents = ({
     combinedParams.after,
     combinedParams.before,
     combinedParams.status,
-    combinedParams.partitions,
   ]);
 
   const grouped = useGroupedEvents(
-    xAxis,
+    'time',
     filterState.type?.includes('Materialization') ? materializations : [],
     filterState.type?.includes('Observation') ? observations : [],
-    loadedPartitionKeys,
+    [],
   );
 
   const onSetFocused = (group: AssetEventGroup | undefined) => {
-    const updates: Partial<AssetViewParams> =
-      xAxis === 'time'
-        ? {time: group?.timestamp !== params.time ? group?.timestamp || '' : ''}
-        : {partition: group?.partition !== params.partition ? group?.partition || '' : ''};
+    const updates: Partial<AssetViewParams> = {
+      time: group?.timestamp !== params.time ? group?.timestamp || '' : '',
+    };
     setParams({...params, ...updates});
   };
 
@@ -124,16 +103,6 @@ export const AssetEvents = ({
           ? b.partition === params.partition
           : false,
     ) || grouped[0];
-
-  // Note: This page still has a LOT of logic for displaying events by partition but it's only enabled
-  // in one case -- when the asset is an old-school, non-software-defined asset with partition keys
-  // on it's materializations but no defined partition set.
-  //
-  const assetHasUndefinedPartitions =
-    !assetNode?.partitionDefinition && grouped.some((g) => g.partition);
-  const assetHasLineage = materializations.some(
-    (m) => 'assetLineage' in m && m.assetLineage.length > 0,
-  );
 
   const onKeyDown = (e: React.KeyboardEvent<any>) => {
     const shift = {ArrowDown: 1, ArrowUp: -1}[e.key];
@@ -154,8 +123,7 @@ export const AssetEvents = ({
   const hasFilter =
     combinedParams.status !== MaterializationHistoryEventTypeSelector.ALL ||
     combinedParams.before !== undefined ||
-    combinedParams.after !== undefined ||
-    combinedParams.partitions !== undefined;
+    combinedParams.after !== undefined;
   if (!loading && !materializations.length && !observations.length && !hasFilter) {
     return (
       <Box padding={{horizontal: 24, vertical: 64}}>
@@ -191,33 +159,6 @@ export const AssetEvents = ({
           {activeFiltersJsx}
         </Box>
       ) : null}
-      {assetHasUndefinedPartitions && (
-        <Box
-          flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          border="bottom"
-          padding={{vertical: 16, horizontal: 24}}
-          style={{marginBottom: -1}}
-        >
-          <Subheading>Asset Events</Subheading>
-          <div style={{margin: '-6px 0 '}}>
-            <ButtonGroup
-              activeItems={new Set([xAxis])}
-              buttons={[
-                {id: 'partition', label: 'By partition'},
-                {id: 'time', label: 'By timestamp'},
-              ]}
-              onClick={(id: string) =>
-                setParams(
-                  id === 'time'
-                    ? {...params, partition: undefined, time: focused?.timestamp || ''}
-                    : {...params, partition: focused?.partition || '', time: undefined},
-                )
-              }
-            />
-          </div>
-        </Box>
-      )}
-
       {assetNode && !assetNode.partitionDefinition && (
         <>
           <FailedRunSinceMaterializationBanner
@@ -260,7 +201,7 @@ export const AssetEvents = ({
                   </Box>
                 ) : (
                   <AssetEventList
-                    xAxis={xAxis}
+                    xAxis="time"
                     groups={grouped}
                     focused={focused}
                     setFocused={onSetFocused}
@@ -276,20 +217,7 @@ export const AssetEvents = ({
                 border="left"
               >
                 <ErrorBoundary region="event" resetErrorOnChange={[focused]}>
-                  {xAxis === 'partition' ? (
-                    focused ? (
-                      <AssetPartitionDetail
-                        group={focused}
-                        hasLineage={assetHasLineage}
-                        assetKey={assetKey}
-                        stepKey={assetNode ? stepKeyForAsset(assetNode) : undefined}
-                        latestRunForPartition={null}
-                        changedReasons={assetNode?.changedReasons}
-                      />
-                    ) : (
-                      <AssetPartitionDetailEmpty />
-                    )
-                  ) : focused?.latest ? (
+                  {focused?.latest ? (
                     <AssetEventDetail assetKey={assetKey} event={focused.latest} />
                   ) : (
                     <AssetEventDetailEmpty />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
@@ -1,16 +1,15 @@
 import min from 'lodash/min';
-import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {clipEventsToSharedMinimumTime} from './clipEventsToSharedMinimumTime';
 import {AssetKey, AssetViewParams} from './types';
 import {
-  AssetEventsQuery,
-  AssetEventsQueryVariables,
   AssetObservationFragment,
+  RecentAssetEventsQuery,
+  RecentAssetEventsQueryVariables,
 } from './types/useRecentAssetEvents.types';
-import {ASSET_EVENTS_QUERY, AssetMaterializationFragment} from './useRecentAssetEvents';
+import {AssetMaterializationFragment, RECENT_ASSET_EVENTS_QUERY} from './useRecentAssetEvents';
 import {useApolloClient} from '../apollo-client';
 import {MaterializationHistoryEventTypeSelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
@@ -31,7 +30,6 @@ export function usePaginatedAssetEvents(
   params: Pick<AssetViewParams, 'asOf'> & {
     before?: number;
     after?: number;
-    partitions?: string[];
     status?: MaterializationHistoryEventTypeSelector;
   },
 ) {
@@ -53,7 +51,7 @@ export function usePaginatedAssetEvents(
     setObservations([]);
     setMaterializations([]);
     setCursor(undefined);
-  }, [assetKey, params.before, params.after, params.partitions, params.status]);
+  }, [assetKey, params.before, params.after, params.status]);
 
   const fetch = useCallback(
     async (before = initialAsOf ?? beforeParam, cursor: string | undefined = undefined) => {
@@ -64,15 +62,14 @@ export function usePaginatedAssetEvents(
         return;
       }
       setLoading(true);
-      const {data} = await client.query<AssetEventsQuery, AssetEventsQueryVariables>({
-        query: ASSET_EVENTS_QUERY,
+      const {data} = await client.query<RecentAssetEventsQuery, RecentAssetEventsQueryVariables>({
+        query: RECENT_ASSET_EVENTS_QUERY,
         variables: {
           assetKey: {path: assetKey.path},
           limit: 100,
           cursor,
           before,
           after: afterParam,
-          partitions: params.partitions,
           eventTypeSelector: params.status ?? MaterializationHistoryEventTypeSelector.ALL,
         },
       });
@@ -95,7 +92,7 @@ export function usePaginatedAssetEvents(
       );
       setCursor(asset?.assetMaterializationHistory?.cursor);
     },
-    [initialAsOf, beforeParam, assetKey, client, afterParam, params.partitions, params.status],
+    [initialAsOf, beforeParam, assetKey, client, afterParam, params.status],
   );
 
   useBlockTraceUntilTrue('AssetEventsQuery', loaded);
@@ -103,15 +100,10 @@ export function usePaginatedAssetEvents(
   return useMemo(() => {
     const all = [...materializations, ...observations];
 
-    // Note: If we "discover" more partition keys of a non-SDA as more events are loaded, we want
-    // those to be appended to the end so things don't jump around, so there is no sort() here.
-    const loadedPartitionKeys = uniq(all.map((p) => p.partition!).filter(Boolean)).reverse();
-
     return {
       loading,
       materializations,
       observations,
-      loadedPartitionKeys,
       fetchLatest: fetch,
       fetchMore: () => fetch(`${min(all.map((e) => Number(e.timestamp)))}`, cursor),
     };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 
 import {ASSET_LINEAGE_FRAGMENT} from './AssetLineageElements';
-import {AssetKey, AssetViewParams} from './types';
+import {AssetKey} from './types';
 import {gql, useQuery} from '../apollo-client';
 import {clipEventsToSharedMinimumTime} from './clipEventsToSharedMinimumTime';
 // import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
@@ -22,29 +22,6 @@ import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 export type AssetMaterializationFragment =
   | AssetSuccessfulMaterializationFragment
   | AssetFailedToMaterializeFragment;
-
-/**
-The params behavior on this page is a bit nuanced - there are two main query
-params: ?timestamp= and ?partition= and only one is set at a time. They can
-be undefined, an empty string or a value and all three states are used.
-- If both are undefined, we expand the first item in the table by default
-- If one is present, it determines which xAxis is used (partition grouping)
-- If one is present and set to a value, that item in the table is expanded.
-- If one is present but an empty string, no items in the table is expanded.
- */
-export function getXAxisForParams(
-  params: Pick<AssetViewParams, 'asOf' | 'partition' | 'time'>,
-  {defaultToPartitions}: {defaultToPartitions: boolean},
-) {
-  const xAxisDefault = defaultToPartitions ? 'partition' : 'time';
-  const xAxis: 'partition' | 'time' =
-    params.partition !== undefined
-      ? 'partition'
-      : params.time !== undefined || params.asOf
-        ? 'time'
-        : xAxisDefault;
-  return xAxis;
-}
 
 export function useLatestAssetPartitions(assetKey: AssetKey | undefined, limit: number) {
   const queryResult = useQuery<LatestAssetPartitionsQuery, LatestAssetPartitionsQueryVariables>(


### PR DESCRIPTION
## Summary & Motivation
We have quite a bit of complicated front-end code to group recent asset events by partition.  This code only gets exercised when we're viewing an asset page for an asset whose definition has been removed from the workspace.

I posit that this view is rarely used.  The asset page itself is extremely buried - it doesn't show up in the assets view.  You have to dig it out from a historical run view.

The by-partition implementation also needs to be qualified.  This isn't fetching all events by partition.  It's fetching the last 100 events and then grouping them by partition key IF there is even a partition key on the materializations to be grouped by.

If we actually want to support this view, we could probably implement it by creating some new, different resolvers.  We could fetch all unique partitions for a given asset in storage, and then fetch the most recent materialization for each partition.

## How I Tested These Changes
Before:
<img width="861" alt="Screenshot 2025-04-02 at 9 53 08 AM" src="https://github.com/user-attachments/assets/3e573e88-3149-49d5-9249-bfd9d7f09fd8" />


After:
<img width="859" alt="Screenshot 2025-04-02 at 9 53 50 AM" src="https://github.com/user-attachments/assets/228f759a-c6a0-44e0-a607-8f73c6b779ed" />

## Changelog
- Removes the `By partition` grouping view for recent events for assets that do not have a definition in the workspace.
