### PR TITLE
[docs] add note that PagerDuty Alerts are Pro plan feature

### DIFF
--- a/docs/docs/dagster-plus/features/alerts/configuring-an-alert-notification-service.md
+++ b/docs/docs/dagster-plus/features/alerts/configuring-an-alert-notification-service.md
@@ -26,7 +26,7 @@ This will provide you with a **workflow URL** which will be required when config
   </TabItem>
   <TabItem value='pagerduty' label='PagerDuty'>
     :::note
-You will need sufficient permissions in PagerDuty to add or edit services.
+A Dagster+ Pro plan is required to use this feature. You will also need sufficient permissions in PagerDuty to add or edit services.
 :::
 
 In PagerDuty, you can either:


### PR DESCRIPTION
## Summary & Motivation
Add the note that "A Pro plan is required to use this feature." from [in our legacy doc](https://legacy-docs.dagster.io/dagster-plus/managing-deployments/alerts/pagerduty) that didn't get ported over. 

## How I Tested These Changes
👀