### PR TITLE
Fix regression when creating nested ConfigurableResource with pydantic >= v.2.5.0

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -696,12 +696,12 @@ class PartialResource(
 
     def __init__(
         self,
-        resource_cls: type[ConfigurableResourceFactory[TResValue]] | None = None,
-        data: dict[str, Any] | None = None,
-        **kwargs: Any,
+        resource_cls: type[ConfigurableResourceFactory[TResValue]],
+        data: dict[str, Any],
     ):
-        super().__init__(data=data, resource_cls=resource_cls)  # type: ignore  # extends BaseModel, takes kwargs
         resource_pointers, _data_without_resources = separate_resource_params(resource_cls, data)
+
+        super().__init__(data=data, resource_cls=resource_cls)  # type: ignore  # extends BaseModel, takes kwargs
 
         def resource_fn(context: InitResourceContext):
             to_populate = resource_cls._get_non_default_public_field_values_cls(  # noqa: SLF001
@@ -834,7 +834,7 @@ def _is_annotated_as_resource_type(annotation: type, metadata: list[str]) -> boo
     """Determines if a field in a structured config class is annotated as a resource type or not."""
     from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 
-    if metadata and metadata[0] == "resource_dependency":
+    if metadata and any(m == "resource_dependency" for m in metadata):
         return True
 
     if is_closed_python_optional_type(annotation):

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -696,12 +696,12 @@ class PartialResource(
 
     def __init__(
         self,
-        resource_cls: type[ConfigurableResourceFactory[TResValue]],
-        data: dict[str, Any],
+        resource_cls: type[ConfigurableResourceFactory[TResValue]] | None = None,
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
     ):
-        resource_pointers, _data_without_resources = separate_resource_params(resource_cls, data)
-
         super().__init__(data=data, resource_cls=resource_cls)  # type: ignore  # extends BaseModel, takes kwargs
+        resource_pointers, _data_without_resources = separate_resource_params(resource_cls, data)
 
         def resource_fn(context: InitResourceContext):
             to_populate = resource_cls._get_non_default_public_field_values_cls(  # noqa: SLF001

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -105,6 +105,8 @@ class BaseResourceMeta(BaseConfigMeta):
     """
 
     def __new__(cls, name, bases, namespaces, **kwargs) -> Any:
+        from pydantic.fields import FieldInfo
+
         # Gather all type annotations from the class and its base classes
         annotations = namespaces.get("__annotations__", {})
         for field in annotations:
@@ -128,11 +130,20 @@ class BaseResourceMeta(BaseConfigMeta):
                     base = annotations[field]
                     annotations[field] = Annotated[
                         Union[
-                            LateBoundTypesForResourceTypeChecking.get_partial_resource_type(base),
                             base,
+                            LateBoundTypesForResourceTypeChecking.get_partial_resource_type(base),
                         ],
                         "resource_dependency",
                     ]
+                    # Pydantic 2.5.0 changed the default union mode to "smart", which causes
+                    # partial resource initialization to fail, since Pydantic would attempt to
+                    # initialize a PartialResource with parameters which are invalid.
+                    # https://github.com/pydantic/pydantic-core/pull/867
+                    # Here, we explicitly set the union mode to "left_to_right".
+                    # https://docs.pydantic.dev/latest/concepts/unions/#left-to-right-mode
+                    namespaces[field] = FieldInfo(
+                        union_mode="left_to_right", annotation=annotations[field]
+                    )
 
         namespaces["__annotations__"] = annotations
         return super().__new__(cls, name, bases, namespaces, **kwargs)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1030,3 +1030,24 @@ def test_nested_resources_runtime_config_fully_populated() -> None:
         .success
     )
     assert completed["yes"]
+
+
+def test_nested_resources_direct_config_fully_populated() -> None:
+    """Covers regression introduced in pydantic v2.5.0 where union validation changed to Smart
+    and direct initialization of nested ConfigurableResources stopped working.
+    """
+
+    class Inner(ConfigurableResource):
+        b: str
+
+    class Outer(ConfigurableResource):
+        a: str
+        inner: Inner
+
+    # model_validate() on NESTED ConfigurableResource worked with pydantic v2.4.2, but stopped working on v2.5.0.
+    result = Outer.model_validate(dict(a="a", inner=dict(b="b")))
+    # >> TypeError: PartialResource.__init__() got an unexpected keyword argument 'b'
+    assert isinstance(result, Outer)
+    assert result.a == "a"
+    assert isinstance(result.inner, Inner)
+    assert result.inner.b == "b"

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1036,12 +1036,13 @@ def test_nested_resources_direct_config_fully_populated() -> None:
     """Covers regression introduced in pydantic v2.5.0 where union validation changed to Smart
     and direct initialization of nested ConfigurableResources stopped working.
     """
+    import pydantic
 
     class Inner(ConfigurableResource):
         b: str
 
     class Outer(ConfigurableResource):
-        a: str
+        a: str = pydantic.Field(default="a")
         inner: Inner
 
     # model_validate() on NESTED ConfigurableResource worked with pydantic v2.4.2, but stopped working on v2.5.0.


### PR DESCRIPTION
## Summary

Slight tweak of @HynekBlaha's contribution in #28836 - this version adjusts our Pydantic union behavior for resources to account for a change in Pydantic 2.5.0 which uses 'smart unions' (https://github.com/pydantic/pydantic-core/pull/867). This smart union behavior attempted to initialize each member of the union using the input data, which called the constructor for `PartialResource` with invalid inputs.

This PR enforces left-to-right union evaluation, similar to what occurred pre-Pydantic 2.5.0.

## Test Plan

Unit test introduced in #28836.

## Changelog

Fixed an issue where using partial resources in Pydantic >= 2.5.0 could result in an unexpected keyword argument TypeError. (Thanks [@HynekBlaha](https://github.com/HynekBlaha)!)


