### PR TITLE
[dg] dg list packages

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
@@ -1,35 +1,32 @@
 dg --help
 
-Usage: dg [OPTIONS] COMMAND [ARGS]...                                                    
-                                                                                          
- CLI for managing Dagster projects.                                                       
-                                                                                          
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --clear-cache                           Clear the cache.                               │
-│ --rebuild-component-registry            Recompute and cache the set of available       │
-│                                         component types for the current environment.   │
-│                                         Note that this also happens automatically      │
-│                                         whenever the cache is detected to be stale.    │
-│ --install-completion                    Automatically detect your shell and install a  │
-│                                         completion script for the `dg` command. This   │
-│                                         will append to your shell startup file.        │
-│ --version                     -v        Show the version and exit.                     │
-│ --help                        -h        Show this message and exit.                    │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Global options ───────────────────────────────────────────────────────────────────────╮
-│ --verbose                    Enable verbose output for debugging.                      │
-│ --disable-cache              Disable the cache..                                       │
-│ --cache-dir            TEXT  Specify a directory to use for the cache.                 │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ check      Commands for checking the integrity of your Dagster code.                   │
-│ dev        Start a local instance of Dagster.                                          │
-│ docs       Commands for generating docs from your Dagster code.                        │
-│ env        Commands for managing environment variables.                                │
-│ init       Initialize a new Dagster workspace and a first project within that          │
-│            workspace.                                                                  │
-│ launch     Launch a Dagster run.                                                       │
-│ list       Commands for listing Dagster entities.                                      │
-│ scaffold   Commands for scaffolding Dagster code.                                      │
-│ utils      Assorted utility commands.                                                  │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+Usage: dg [OPTIONS] COMMAND [ARGS]...                                                                                  
+                                                                                                                        
+ CLI for managing Dagster projects.                                                                                     
+                                                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --clear-cache                           Clear the cache.                                                             │
+│ --rebuild-component-registry            Recompute and cache the set of available component types for the current     │
+│                                         environment. Note that this also happens automatically whenever the cache is │
+│                                         detected to be stale.                                                        │
+│ --install-completion                    Automatically detect your shell and install a completion script for the `dg` │
+│                                         command. This will append to your shell startup file.                        │
+│ --version                     -v        Show the version and exit.                                                   │
+│ --help                        -h        Show this message and exit.                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --verbose                    Enable verbose output for debugging.                                                    │
+│ --disable-cache              Disable the cache..                                                                     │
+│ --cache-dir            TEXT  Specify a directory to use for the cache.                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ check      Commands for checking the integrity of your Dagster code.                                                 │
+│ dev        Start a local instance of Dagster.                                                                        │
+│ docs       Commands for generating docs from your Dagster code.                                                      │
+│ env        Commands for managing environment variables.                                                              │
+│ init       Initialize a new Dagster workspace and a first project within that workspace.                             │
+│ launch     Launch a Dagster run.                                                                                     │
+│ list       Commands for listing Dagster entities.                                                                    │
+│ scaffold   Commands for scaffolding Dagster code.                                                                    │
+│ utils      Assorted utility commands.                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/examples/docs_snippets/docs_snippets/guides/components/index/18-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/18-dg-list-component-types.txt
@@ -1,21 +1,39 @@
 dg list component-type
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                              ┃ Summary                  ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster.components.DefinitionsComponent                     │ An arbitrary set of      │
-│                                                             │ dagster definitions.     │
-│ dagster.components.DefsFolderComponent                      │ A folder containing      │
-│                                                             │ multiple submodules.     │
-│ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python  │
-│                                                             │ scripts executed with    │
-│                                                             │ Dagster's                │
-│                                                             │ PipesSubprocessClient.   │
-│ dagster_dbt.DbtProjectComponent                             │ Expose a DBT project to  │
-│                                                             │ Dagster as a set of      │
-│                                                             │ assets.                  │
-│ dagster_sling.SlingReplicationCollectionComponent           │ Expose one or more Sling │
-│                                                             │ replications to Dagster  │
-│                                                             │ as assets.               │
-└─────────────────────────────────────────────────────────────┴──────────────────────────┘
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Package       ┃ Entries                                                                                              ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster       │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Key                                                         ┃ Summary          ┃ Types           ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set │ [component,     │ │
+│               │ │                                                             │ of dagster       │ scaffold-targe… │ │
+│               │ │                                                             │ definitions.     │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.components.DefsFolderComponent                      │ A folder         │ [component,     │ │
+│               │ │                                                             │ containing       │ scaffold-targe… │ │
+│               │ │                                                             │ multiple         │                 │ │
+│               │ │                                                             │ submodules.      │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap │ [component,     │ │
+│               │ │                                                             │ Python scripts   │ scaffold-targe… │ │
+│               │ │                                                             │ executed with    │                 │ │
+│               │ │                                                             │ Dagster's        │                 │ │
+│               │ │                                                             │ PipesSubprocess… │                 │ │
+│               │ └─────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┘ │
+│ dagster_dbt   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Key                             ┃ Summary                         ┃ Types                        ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster_dbt.DbtProjectComponent │ Expose a DBT project to Dagster │ [component, scaffold-target] │ │
+│               │ │                                 │ as a set of assets.             │                              │ │
+│               │ └─────────────────────────────────┴─────────────────────────────────┴──────────────────────────────┘ │
+│ dagster_sling │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Key                                               ┃ Summary              ┃ Types                 ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster_sling.SlingReplicationCollectionComponent │ Expose one or more   │ [component,           │ │
+│               │ │                                                   │ Sling replications   │ scaffold-target]      │ │
+│               │ │                                                   │ to Dagster as        │                       │ │
+│               │ │                                                   │ assets.              │                       │ │
+│               │ └───────────────────────────────────────────────────┴──────────────────────┴───────────────────────┘ │
+└───────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-component-types.txt
@@ -1,14 +1,24 @@
 dg list component-type
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                              ┃ Summary                  ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster.components.DefinitionsComponent                     │ An arbitrary set of      │
-│                                                             │ dagster definitions.     │
-│ dagster.components.DefsFolderComponent                      │ A folder containing      │
-│                                                             │ multiple submodules.     │
-│ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python  │
-│                                                             │ scripts executed with    │
-│                                                             │ Dagster's                │
-│                                                             │ PipesSubprocessClient.   │
-└─────────────────────────────────────────────────────────────┴──────────────────────────┘
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Package ┃ Entries                                                                                                    ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓ │
+│         │ ┃ Key                                                         ┃ Summary            ┃ Types               ┃ │
+│         │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩ │
+│         │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set   │ [component,         │ │
+│         │ │                                                             │ of dagster         │ scaffold-target]    │ │
+│         │ │                                                             │ definitions.       │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.components.DefsFolderComponent                      │ A folder           │ [component,         │ │
+│         │ │                                                             │ containing         │ scaffold-target]    │ │
+│         │ │                                                             │ multiple           │                     │ │
+│         │ │                                                             │ submodules.        │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap   │ [component,         │ │
+│         │ │                                                             │ Python scripts     │ scaffold-target]    │ │
+│         │ │                                                             │ executed with      │                     │ │
+│         │ │                                                             │ Dagster's          │                     │ │
+│         │ │                                                             │ PipesSubprocessCl… │                     │ │
+│         │ └─────────────────────────────────────────────────────────────┴────────────────────┴─────────────────────┘ │
+└─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-component-types.txt
@@ -1,18 +1,33 @@
 dg list component-type
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                              ┃ Summary                  ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster.components.DefinitionsComponent                     │ An arbitrary set of      │
-│                                                             │ dagster definitions.     │
-│ dagster.components.DefsFolderComponent                      │ A folder containing      │
-│                                                             │ multiple submodules.     │
-│ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python  │
-│                                                             │ scripts executed with    │
-│                                                             │ Dagster's                │
-│                                                             │ PipesSubprocessClient.   │
-│ dagster_sling.SlingReplicationCollectionComponent           │ Expose one or more Sling │
-│                                                             │ replications to Dagster  │
-│                                                             │ as assets.               │
-└─────────────────────────────────────────────────────────────┴──────────────────────────┘
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Package       ┃ Entries                                                                                              ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster       │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Key                                                         ┃ Summary          ┃ Types           ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set │ [component,     │ │
+│               │ │                                                             │ of dagster       │ scaffold-targe… │ │
+│               │ │                                                             │ definitions.     │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.components.DefsFolderComponent                      │ A folder         │ [component,     │ │
+│               │ │                                                             │ containing       │ scaffold-targe… │ │
+│               │ │                                                             │ multiple         │                 │ │
+│               │ │                                                             │ submodules.      │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap │ [component,     │ │
+│               │ │                                                             │ Python scripts   │ scaffold-targe… │ │
+│               │ │                                                             │ executed with    │                 │ │
+│               │ │                                                             │ Dagster's        │                 │ │
+│               │ │                                                             │ PipesSubprocess… │                 │ │
+│               │ └─────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┘ │
+│ dagster_sling │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Key                                               ┃ Summary              ┃ Types                 ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster_sling.SlingReplicationCollectionComponent │ Expose one or more   │ [component,           │ │
+│               │ │                                                   │ Sling replications   │ scaffold-target]      │ │
+│               │ │                                                   │ to Dagster as        │                       │ │
+│               │ │                                                   │ assets.              │                       │ │
+│               │ └───────────────────────────────────────────────────┴──────────────────────┴───────────────────────┘ │
+└───────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt
@@ -1,17 +1,34 @@
 dg list component-type
 
 Using /.../my-component-library/.venv/bin/dagster-components
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Component Type                                              ┃ Summary                  ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster.components.DefinitionsComponent                     │ An arbitrary set of      │
-│                                                             │ dagster definitions.     │
-│ dagster.components.DefsFolderComponent                      │ A folder containing      │
-│                                                             │ multiple submodules.     │
-│ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python  │
-│                                                             │ scripts executed with    │
-│                                                             │ Dagster's                │
-│                                                             │ PipesSubprocessClient.   │
-│ my_component_library.lib.ShellCommand                       │ Models a shell script as │
-│                                                             │ a Dagster asset.         │
-└─────────────────────────────────────────────────────────────┴──────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Package              ┃ Entries                                                                                       ┃
+┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster              │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓ │
+│                      │ ┃ Key                                                         ┃ Summary      ┃ Types        ┃ │
+│                      │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩ │
+│                      │ │ dagster.components.DefinitionsComponent                     │ An arbitrary │ [component,  │ │
+│                      │ │                                                             │ set of       │ scaffold-ta… │ │
+│                      │ │                                                             │ dagster      │              │ │
+│                      │ │                                                             │ definitions. │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.components.DefsFolderComponent                      │ A folder     │ [component,  │ │
+│                      │ │                                                             │ containing   │ scaffold-ta… │ │
+│                      │ │                                                             │ multiple     │              │ │
+│                      │ │                                                             │ submodules.  │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that  │ [component,  │ │
+│                      │ │                                                             │ wrap Python  │ scaffold-ta… │ │
+│                      │ │                                                             │ scripts      │              │ │
+│                      │ │                                                             │ executed     │              │ │
+│                      │ │                                                             │ with         │              │ │
+│                      │ │                                                             │ Dagster's    │              │ │
+│                      │ │                                                             │ PipesSubpro… │              │ │
+│                      │ └─────────────────────────────────────────────────────────────┴──────────────┴──────────────┘ │
+│ my_component_library │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
+│                      │ ┃ Key                                   ┃ Summary                 ┃ Types                   ┃ │
+│                      │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
+│                      │ │ my_component_library.lib.ShellCommand │ Models a shell script   │ [component,             │ │
+│                      │ │                                       │ as a Dagster asset.     │ scaffold-target]        │ │
+│                      │ └───────────────────────────────────────┴─────────────────────────┴─────────────────────────┘ │
+└──────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
@@ -39,7 +39,7 @@ EDITABLE_DIR = DAGSTER_ROOT / "python_modules" / "libraries"
 
 SNIPPET_ENV = {
     # Controls width from click/rich
-    "COLUMNS": "90",
+    "COLUMNS": "120",
     # No ansi escapes for color
     "NO_COLOR": "1",
     # Disable any activated virtualenv to prevent warning messages

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -1,14 +1,17 @@
 import json
+from collections.abc import Sequence
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
 import click
+from dagster_shared.serdes.objects import PackageEntrySnap
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from dagster_dg.cli.shared_options import dg_global_options
-from dagster_dg.component import RemotePackageRegistry
+from dagster_dg.component import PackageEntryType, RemotePackageRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.defs import (
@@ -63,42 +66,89 @@ def list_component_command(**global_options: object) -> None:
 
 
 # ########################
-# ##### COMPONENT TYPE
+# ##### PACKAGE ENTRY
 # ########################
 
 
-def _list_package_entries(
-    registry: RemotePackageRegistry, output_json: bool, entry_type: Optional[str]
+ENTRY_TYPE_COLOR_MAP = {"component": "deep_sky_blue3", "scaffold-target": "khaki1"}
+
+
+def _pretty_entry_types(entry: PackageEntrySnap) -> Text:
+    text = Text()
+    for entry_type in entry.types:
+        if len(text) > 0:
+            text += Text(", ")
+        text += Text(entry_type, style=ENTRY_TYPE_COLOR_MAP.get(entry_type, ""))
+    text = Text("[") + text + Text("]")
+    return text
+
+
+def _package_entry_table(entries: Sequence[PackageEntrySnap]) -> Table:
+    sorted_entries = sorted(entries, key=lambda x: x.key.to_typename())
+    table = Table(border_style="dim", show_lines=True)
+    table.add_column("Key", style="bold cyan", no_wrap=True)
+    table.add_column("Summary")
+    table.add_column("Types")
+    for entry in sorted_entries:
+        table.add_row(entry.key.to_typename(), entry.summary, _pretty_entry_types(entry))
+    return table
+
+
+def _all_packages_entry_table(
+    registry: RemotePackageRegistry, name_only: bool, entry_type: Optional[PackageEntryType]
+) -> Table:
+    table = Table(border_style="dim")
+
+    table.add_column("Package", style="bold")
+    if not name_only:
+        table.add_column("Entries", style="bold")
+
+    for package in sorted(registry.packages):
+        if not name_only:
+            entries = registry.get_entries(package, entry_type)
+            inner_table = _package_entry_table(entries)
+            table.add_row(package, inner_table)
+        else:
+            table.add_row(package)
+    return table
+
+
+@list_group.command(name="packages", cls=DgClickCommand)
+@click.option(
+    "--name-only",
+    is_flag=True,
+    default=False,
+    help="Only display the names of the packages.",
+)
+@click.option(
+    "--package",
+    "-p",
+    help="Filter by package name.",
+)
+@click.option(
+    "--entry-type",
+    "-t",
+    type=click.Choice(["component", "scaffold-target"]),
+    help="Filter by entry type.",
+)
+@dg_global_options
+@cli_telemetry_wrapper
+def list_packages_command(
+    name_only: bool,
+    package: Optional[str],
+    entry_type: Optional[PackageEntryType],
+    **global_options: object,
 ) -> None:
-    sorted_keys = sorted(
-        [
-            key
-            for key in registry.keys()
-            if entry_type is None or entry_type in registry.get(key).types
-        ],
-        key=lambda k: k.to_typename(),
-    )
-    # JSON
-    if output_json:
-        output: list[dict[str, object]] = []
-        for key in sorted_keys:
-            obj = registry.get(key)
-            output.append(
-                {
-                    "key": key.to_typename(),
-                    "summary": obj.summary,
-                }
-            )
-        click.echo(json.dumps(output, indent=4))
-    # TABLE
+    """List registered Dagster components in the current project environment."""
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
+    registry = RemotePackageRegistry.from_dg_context(dg_context)
+
+    if package:
+        table = _package_entry_table(registry.get_entries(package, entry_type))
     else:
-        table = Table(border_style="dim")
-        table.add_column("Package Entry", style="bold cyan", no_wrap=True)
-        table.add_column("Summary")
-        for key in sorted_keys:
-            table.add_row(key.to_typename(), registry.get(key).summary)
-        console = Console()
-        console.print(table)
+        table = _all_packages_entry_table(registry, name_only, entry_type=entry_type)
+    Console().print(table)
 
 
 @list_group.command(name="component-type", cls=DgClickCommand)
@@ -117,7 +167,15 @@ def list_component_type_command(output_json: bool, **global_options: object) -> 
     dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
     registry = RemotePackageRegistry.from_dg_context(dg_context)
 
-    _list_package_entries(registry, output_json, "component")
+    if output_json:
+        output: list[dict[str, object]] = []
+        for entry in sorted(
+            registry.get_entries(entry_type="component"), key=lambda x: x.key.to_typename()
+        ):
+            output.append({"key": entry.key.to_typename(), "summary": entry.summary})
+        click.echo(json.dumps(output, indent=4))
+    else:
+        Console().print(_all_packages_entry_table(registry, False, "component"))
 
 
 # ########################

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
@@ -22,6 +22,10 @@ class PackageEntryKey:
     namespace: str
     name: str
 
+    @property
+    def package(self) -> str:
+        return self.namespace.split(".")[0]
+
     def to_typename(self) -> str:
         return f"{self.namespace}.{self.name}"
 


### PR DESCRIPTION
## Summary & Motivation

Adds a new `dg list packages` command that outputs organized information about the contents of each dg-enabled package.

Example output (interested in feedback here!):

![Screenshot 2025-04-02 at 1.08.03 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/6299228a-2494-4cf4-b486-36d2ea635cc7.png)


![Screenshot 2025-04-02 at 1.08.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/95dcdbe6-2ba8-4b02-808a-e0733326b1a7.png)


![Screenshot 2025-04-02 at 1.08.37 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/3b154614-117e-4ff6-aa64-512e4e37773a.png)

![Screenshot 2025-04-02 at 1.56.45 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/56b8636d-7151-4e5d-a505-70b9f10a7a0c.png)

## How I Tested These Changes

## Changelog

NOCHANGELOG
