### PR TITLE
[dagster-fivetran] Move connector selection to state-backed defs

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -11,13 +11,13 @@ from dagster_fivetran.ops import (
     fivetran_sync_op as fivetran_sync_op,
 )
 from dagster_fivetran.resources import (
-    ConnectorSelectorFn as ConnectorSelectorFn,
     FivetranResource as FivetranResource,
     FivetranWorkspace as FivetranWorkspace,
     fivetran_resource as fivetran_resource,
     load_fivetran_asset_specs as load_fivetran_asset_specs,
 )
 from dagster_fivetran.translator import (
+    ConnectorSelectorFn as ConnectorSelectorFn,
     DagsterFivetranTranslator as DagsterFivetranTranslator,
     FivetranConnectorTableProps as FivetranConnectorTableProps,
 )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -3,8 +3,12 @@ from typing import Any, Callable, Optional
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import beta
 
-from dagster_fivetran.resources import ConnectorSelectorFn, FivetranWorkspace
-from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
+from dagster_fivetran.resources import FivetranWorkspace
+from dagster_fivetran.translator import (
+    ConnectorSelectorFn,
+    DagsterFivetranTranslator,
+    FivetranMetadataSet,
+)
 
 
 @beta

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -32,13 +32,9 @@ from dagster._core.utils import imap
 from dagster._utils.log import get_dagster_logger
 
 from dagster_fivetran.asset_decorator import fivetran_assets
-from dagster_fivetran.resources import (
-    DEFAULT_POLL_INTERVAL,
-    ConnectorSelectorFn,
-    FivetranResource,
-    FivetranWorkspace,
-)
+from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource, FivetranWorkspace
 from dagster_fivetran.translator import (
+    ConnectorSelectorFn,
     DagsterFivetranTranslator,
     FivetranConnectorTableProps,
     FivetranMetadataSet,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1169,7 +1169,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]
     def defs_from_state(self, state: FivetranWorkspaceData) -> Definitions:  # pyright: ignore[reportIncompatibleMethodOverride]
         all_asset_specs = [
             self.translator.get_asset_spec(props)
-            for props in state.to_workpsace_data_selection(
+            for props in state.to_workspace_data_selection(
                 connector_selector_fn=self.connector_selector_fn
             ).to_fivetran_connector_table_props_data()
         ]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -11,12 +11,13 @@ from dagster._record import as_dict, record
 from dagster._utils.cached_method import cached_method
 from dagster._vendored.dateutil import parser
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import TypeAlias
 
 from dagster_fivetran.utils import get_fivetran_connector_table_name, metadata_for_table
 
 MIN_TIME_STR = "0001-01-01 00:00:00+00"
 
-ConnectorSelectorFn = Callable[["FivetranConnector"], bool]
+ConnectorSelectorFn: TypeAlias = Callable[["FivetranConnector"], bool]
 
 
 class FivetranConnectorTableProps(NamedTuple):
@@ -254,9 +255,9 @@ class FivetranWorkspaceData:
                             )
         return data
 
-    # Cache workspace data selection for a specific connector_selector_fn.
+    # Cache workspace data selection for a specific connector_selector_fn
     @cached_method
-    def to_workpsace_data_selection(
+    def to_workspace_data_selection(
         self, connector_selector_fn: Optional[ConnectorSelectorFn]
     ) -> "FivetranWorkspaceData":
         if not connector_selector_fn:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -36,15 +36,15 @@ def test_fetch_fivetran_workspace_data(
 
 
 @pytest.mark.parametrize(
-    "attribute, value, expected_result",
+    "attribute, value, expected_result_before_selection, expected_result_after_selection",
     [
-        (None, None, 1),
-        ("name", TEST_CONNECTOR_NAME, 1),
-        ("id", TEST_CONNECTOR_ID, 1),
-        ("service", TEST_DESTINATION_SERVICE, 1),
-        ("name", "non_matching_name", 0),
-        ("id", "non_matching_id", 0),
-        ("service", "non_matching_service", 0),
+        (None, None, 1, 1),
+        ("name", TEST_CONNECTOR_NAME, 1, 1),
+        ("id", TEST_CONNECTOR_ID, 1, 1),
+        ("service", TEST_DESTINATION_SERVICE, 1, 1),
+        ("name", "non_matching_name", 1, 0),
+        ("id", "non_matching_id", 1, 0),
+        ("service", "non_matching_service", 1, 0),
     ],
     ids=[
         "no_selector_present_connector",
@@ -59,7 +59,8 @@ def test_fetch_fivetran_workspace_data(
 def test_fivetran_connector_selector(
     attribute: str,
     value: str,
-    expected_result: int,
+    expected_result_before_selection: int,
+    expected_result_after_selection: int,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     resource = FivetranWorkspace(
@@ -69,10 +70,13 @@ def test_fivetran_connector_selector(
     connector_selector_fn = (
         (lambda connector: getattr(connector, attribute) == value) if attribute else None
     )
-    actual_workspace_data = resource.fetch_fivetran_workspace_data(
+    workspace_data = resource.fetch_fivetran_workspace_data()
+    assert len(workspace_data.connectors_by_id) == expected_result_before_selection
+
+    workspace_data_selection = workspace_data.to_workpsace_data_selection(
         connector_selector_fn=connector_selector_fn
     )
-    assert len(actual_workspace_data.connectors_by_id) == expected_result
+    assert len(workspace_data_selection.connectors_by_id) == expected_result_after_selection
 
 
 def test_missing_schemas_fivetran_workspace_data(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_asset_specs.py
@@ -73,7 +73,7 @@ def test_fivetran_connector_selector(
     workspace_data = resource.fetch_fivetran_workspace_data()
     assert len(workspace_data.connectors_by_id) == expected_result_before_selection
 
-    workspace_data_selection = workspace_data.to_workpsace_data_selection(
+    workspace_data_selection = workspace_data.to_workspace_data_selection(
         connector_selector_fn=connector_selector_fn
     )
     assert len(workspace_data_selection.connectors_by_id) == expected_result_after_selection


### PR DESCRIPTION
## Summary & Motivation

This PR moves the logic to select Fivetran connector using the connector_selector_fn from `fetch_fivetran_workspace_data()` to `defs_from_state()` in the state-backed defs.

The main motivation here is that the workspace data should include all connectors that are active and valid, then we should create definitions for a subset of connectors based on the logic in `connector_selector_fn` when users are using the spec loader. This way, the users can create multiple assets with different `connector_selector_fns` in the same workspace.

## How I Tested These Changes

Updated tests with BK
