### PR TITLE
use uuid for runID in test

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from dagster._core.definitions.reconstruct import ReconstructableRepository
@@ -368,8 +369,9 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             assert run and run.status == DagsterRunStatus.CANCELED
 
     def test_run_not_found(self, graphql_context: WorkspaceRequestContext):
+        random_run_id = str(uuid4())
         result = execute_dagster_graphql(
-            graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": "nope"}
+            graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": random_run_id}
         )
         assert result.data["terminatePipelineExecution"]["__typename"] == "RunNotFoundError"
 


### PR DESCRIPTION
## Summary & Motivation

instead of "nope" for a non-existent runID, just uses a UUID instead

## How I Tested These Changes

unit tests