### PR TITLE
Always use graphAssetKeys in `useAssetSelectionFiltering`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -55,9 +55,6 @@ export const useAssetSelectionFiltering = <
   );
 
   const filtered = useMemo(() => {
-    if (!assetSelection) {
-      return assets ?? [];
-    }
     return (
       graphAssetKeys
         .map((key) => {
@@ -66,7 +63,7 @@ export const useAssetSelectionFiltering = <
         .filter((a) => a)
         .sort((a, b) => COMMON_COLLATOR.compare(a.key.path.join(''), b.key.path.join(''))) ?? []
     );
-  }, [assetSelection, graphAssetKeys, assets, assetsByKey]);
+  }, [graphAssetKeys, assetsByKey]);
 
   const filteredByKey = useMemo(
     () => Object.fromEntries(filtered.map((asset) => [tokenForAssetKey(asset.key), asset])),


### PR DESCRIPTION
## Summary & Motivation

I added this logic to side step using the results from selection filtering if there is no asset selection but overlooked that the favorites feature in cloud hooks into the selection filtering (via useAssetGraphData) in order to affect which assets are shown. I will add a test case in internal for this.

## How I Tested These Changes
used favorites locally.
