### PR TITLE
[ui] Repair timezone bug in custom date selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/useTimeRangeFilter.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment-timezone';
 import {useState} from 'react';
 
+import {TimeContext} from '../../../app/time/TimeContext';
 import {
   ActiveFilterState,
   CustomTimeRangeFilterDialog,
@@ -83,6 +84,14 @@ describe('useTimeRangeFilter', () => {
 });
 
 describe('CustomTimeRangeFilterDialog', () => {
+  const MAR_1_2025_MIDNIGHT_EASTERN = 1740805200000;
+  const MAR_3_2025_MIDNIGHT_CENTRAL = 1740978000000;
+  const MAR_3_2025_END_OF_DAY_EASTERN = 1740985599000;
+
+  const MAR_1_2025_MIDNIGHT_DARWIN = 1740753000000;
+  const MAR_3_2025_MIDNIGHT_DARWIN = 1740925800000;
+  const MAR_3_2025_END_OF_DAY_DARWIN = 1741012140000;
+
   it('should render', () => {
     const {result} = renderHook(() => useTimeRangeFilterWrapper({state: [null, null]}));
     const filter = result.current;
@@ -93,16 +102,77 @@ describe('CustomTimeRangeFilterDialog', () => {
   });
 
   it('should apply custom date range', async () => {
+    const user = userEvent.setup();
     const {result} = renderHook(() => useTimeRangeFilterWrapper({state: [null, null]}));
     let filter = result.current;
+    const originalDefaultTimezone = moment.tz.guess();
+    moment.tz.setDefault('America/New_York');
 
     const {getByText} = await act(async () =>
-      render(<CustomTimeRangeFilterDialog filter={filter} close={() => {}} />),
+      render(
+        <TimeContext.Provider
+          value={{
+            timezone: ['America/New_York', () => {}, () => {}],
+            hourCycle: ['h23', () => {}, () => {}],
+          }}
+        >
+          <CustomTimeRangeFilterDialog filter={filter} close={() => {}} />
+        </TimeContext.Provider>,
+      ),
     );
 
     // Mock selecting start and end dates
-    const startDate = moment().startOf('day').subtract(10, 'days');
-    const endDate = moment().endOf('day').subtract(5, 'days');
+    const startDate = moment(MAR_1_2025_MIDNIGHT_EASTERN);
+    const endDate = moment(MAR_3_2025_MIDNIGHT_CENTRAL);
+
+    await waitFor(() => {
+      act(() => {
+        ((mockReactDates.mock.calls[0] as any)[0] as any).onDatesChange({
+          startDate,
+          endDate,
+        });
+      });
+    });
+
+    // Click apply button
+    await user.click(getByText('Apply'));
+    filter = result.current;
+
+    const expectedStart = moment
+      .tz(MAR_1_2025_MIDNIGHT_EASTERN, 'America/New_York')
+      .startOf('day')
+      .valueOf();
+    const expectedEnd = moment
+      .tz(MAR_3_2025_END_OF_DAY_EASTERN, 'America/New_York')
+      .endOf('day')
+      .valueOf();
+
+    expect(filter.state).toEqual([expectedStart, expectedEnd]);
+    moment.tz.setDefault(originalDefaultTimezone);
+  });
+
+  it('should apply custom date range with timezone', async () => {
+    const {result} = renderHook(() => useTimeRangeFilterWrapper({state: [null, null]}));
+    let filter = result.current;
+    const originalDefaultTimezone = moment.tz.guess();
+    moment.tz.setDefault('Australia/Darwin');
+
+    const {getByText} = await act(async () =>
+      render(
+        <TimeContext.Provider
+          value={{
+            timezone: ['Australia/Darwin', () => {}, () => {}],
+            hourCycle: ['h23', () => {}, () => {}],
+          }}
+        >
+          <CustomTimeRangeFilterDialog filter={filter} close={() => {}} />
+        </TimeContext.Provider>,
+      ),
+    );
+
+    // Mock selecting start and end dates
+    const startDate = moment(MAR_1_2025_MIDNIGHT_DARWIN);
+    const endDate = moment(MAR_3_2025_MIDNIGHT_DARWIN);
 
     await waitFor(() => {
       act(() => {
@@ -117,7 +187,66 @@ describe('CustomTimeRangeFilterDialog', () => {
     await userEvent.click(getByText('Apply'));
     filter = result.current;
 
-    expect(filter.state).toEqual([startDate.valueOf(), endDate.valueOf()]);
+    const expectedStart = moment
+      .tz(MAR_1_2025_MIDNIGHT_DARWIN, 'Australia/Darwin')
+      .startOf('day')
+      .valueOf();
+    const expectedEnd = moment
+      .tz(MAR_3_2025_END_OF_DAY_DARWIN, 'Australia/Darwin')
+      .endOf('day')
+      .valueOf();
+
+    expect(filter.state).toEqual([expectedStart, expectedEnd]);
+    moment.tz.setDefault(originalDefaultTimezone);
+  });
+
+  it('should apply custom date range with timezone even when browser has other default', async () => {
+    const {result} = renderHook(() => useTimeRangeFilterWrapper({state: [null, null]}));
+    let filter = result.current;
+    const originalDefaultTimezone = moment.tz.guess();
+    moment.tz.setDefault('America/New_York');
+
+    const {getByText} = await act(async () =>
+      render(
+        <TimeContext.Provider
+          value={{
+            timezone: ['Australia/Darwin', () => {}, () => {}],
+            hourCycle: ['h23', () => {}, () => {}],
+          }}
+        >
+          <CustomTimeRangeFilterDialog filter={filter} close={() => {}} />
+        </TimeContext.Provider>,
+      ),
+    );
+
+    // Mock selecting start and end dates
+    const startDate = moment(MAR_1_2025_MIDNIGHT_EASTERN);
+    const endDate = moment(MAR_3_2025_MIDNIGHT_CENTRAL);
+
+    await waitFor(() => {
+      act(() => {
+        ((mockReactDates.mock.calls[0] as any)[0] as any).onDatesChange({
+          startDate,
+          endDate,
+        });
+      });
+    });
+
+    // Click apply button
+    await userEvent.click(getByText('Apply'));
+    filter = result.current;
+
+    const expectedStart = moment
+      .tz(MAR_1_2025_MIDNIGHT_DARWIN, 'Australia/Darwin')
+      .startOf('day')
+      .valueOf();
+    const expectedEnd = moment
+      .tz(MAR_3_2025_END_OF_DAY_DARWIN, 'Australia/Darwin')
+      .endOf('day')
+      .valueOf();
+
+    expect(filter.state).toEqual([expectedStart, expectedEnd]);
+    moment.tz.setDefault(originalDefaultTimezone);
   });
 
   it('should close dialog on cancel', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
@@ -3,7 +3,9 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import isEqual from 'lodash/isEqual';
-import {useContext, useMemo, useState} from 'react';
+// eslint-disable-next-line no-restricted-imports
+import momentTZ from 'moment-timezone';
+import {useContext, useEffect, useMemo, useState} from 'react';
 import styled from 'styled-components';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
@@ -285,6 +287,19 @@ export function CustomTimeRangeFilterDialog({
   filter: TimeRangeFilter;
   close: () => void;
 }) {
+  const {
+    timezone: [_timezone],
+  } = useContext(TimeContext);
+  const targetTimezone = _timezone === 'Automatic' ? browserTimezone() : _timezone;
+
+  useEffect(() => {
+    const originalDefaultTimezone = momentTZ.tz.guess();
+    momentTZ.tz.setDefault(targetTimezone);
+    return () => {
+      momentTZ.tz.setDefault(originalDefaultTimezone);
+    };
+  }, [targetTimezone]);
+
   const [startDate, setStartDate] = useState<moment.Moment | null>(null);
   const [endDate, setEndDate] = useState<moment.Moment | null>(null);
   const [focusedInput, setFocusedInput] = useState<'startDate' | 'endDate'>('startDate');


### PR DESCRIPTION
## Summary & Motivation

There is a timezone-related issue in the Datepicker-based filter that causes date mismatches when the user's local browser timezone and their Dagster timezone (as set in User Settings) do not match.

For instance, if my local timezone is America/Chicago and my Dagster timezone is Australia/Darwin, and I choose "April 1", react-dates will take this to mean April 1 in Chicago. When I make my selection, however, the Dagster UI will see this timestamp and render it as "April 2", the current date based on my Dagster timezone selection.

To repair this, set the moment timezone globally when opening the datepicker. We currently only use `moment` or `moment-timezone` in this one use case (grepped to check) so I don't want to pull the dependency out into the top-level context provider. But changing it here to match the user's Dagster setting seems to be an appropriate fix.

## How I Tested These Changes

Added Jest specs for timezone behavior.

In the Dagster app, modified my timezone to be Australia/Darwin, then made datepicker selections in the Runs UI. Verified that the tag looks correct, and that the subsequent query has start/end times that match the correct date/time values for these dates in Australia/Darwin.

## Changelog

[ui] Fix custom time datepicker filter selection for users with custom Dagster timezone settings.