### PR TITLE
[docs] remove unlisting of change tracking doc

### DIFF
--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/change-tracking.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/change-tracking.md
@@ -1,7 +1,6 @@
 ---
 title: 'Change tracking in branch deployments'
 sidebar_position: 200
-unlisted: true
 ---
 
 :::note


### PR DESCRIPTION
## Summary & Motivation

I think it's probably just an oversight from the docs migration that this one is still unlisted. Content seems good to me. 

## How I Tested These Changes
👀