### PR TITLE
Remove selection syntax feature flag part 1

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -4,7 +4,7 @@ export enum FeatureFlag {
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
   flagLegacyRunsPage = 'flagLegacyRunsPage',
-  flagSelectionSyntax = 'flagSelectionSyntax',
+  flagSelectionSyntax = 'flagSelectionSyntax-always-on',
   flagAssetSelectionWorker = 'flagAssetSelectionWorker',
   flagUseNewObserveUIs = 'flagUseNewObserveUIs',
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -33,21 +33,4 @@ export const useVisibleFeatureFlagRows = () => [
       </>
     ),
   },
-  {
-    key: 'Enable new selection syntax for Asset/Op/Run graphs',
-    flagType: FeatureFlag.flagSelectionSyntax,
-    label: (
-      <>
-        Enable new selection syntax for Asset/Op/Run graphs (
-        <a
-          href="https://github.com/dagster-io/dagster/discussions/26849"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Learn more
-        </a>
-        )
-      </>
-    ),
-  },
 ];


### PR DESCRIPTION
## Summary & Motivation

Disable turning off the selection syntax flag for now. In a follow-up PR i remove all of the code but for now just want to remove the flag so that new features I'm working on don't need to consider the case when the 
flag is off.

## How I Tested These Changes
BK, open feature flags dialog.

