### PR TITLE
Enable Buildkite Test Engine muting

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -87,6 +87,7 @@ class CommandStepBuilder:
         buildkite_envvars.append("BUILDKITE_ANALYTICS_TOKEN")
         buildkite_envvars.append("PYTEST_ADDOPTS")
         buildkite_envvars.append("BUILDKITE_TEST_QUARANTINE_TOKEN")
+        buildkite_envvars.append("BUILDKITE_ORGANIZATION_SLUG")
         buildkite_envvars.append("BUILDKITE_TEST_SUITE_SLUG")
         buildkite_envvars.append("BUILDKITE_BRANCH")
         buildkite_envvars.append("BUILDKITE_COMMIT")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -86,6 +86,9 @@ class CommandStepBuilder:
         ]
         buildkite_envvars.append("BUILDKITE_ANALYTICS_TOKEN")
         buildkite_envvars.append("PYTEST_ADDOPTS")
+        buildkite_envvars.append("BUILDKITE_TEST_QUARANTINE_TOKEN")
+        buildkite_envvars.append("BUILDKITE_BRANCH")
+        buildkite_envvars.append("BUILDKITE_COMMIT")
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary

--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -89,6 +89,7 @@ class CommandStepBuilder:
         buildkite_envvars.append("BUILDKITE_TEST_QUARANTINE_TOKEN")
         buildkite_envvars.append("BUILDKITE_BRANCH")
         buildkite_envvars.append("BUILDKITE_COMMIT")
+        buildkite_envvars.append("BUILDKITE_PIPELINE_SLUG")
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary

--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -87,9 +87,9 @@ class CommandStepBuilder:
         buildkite_envvars.append("BUILDKITE_ANALYTICS_TOKEN")
         buildkite_envvars.append("PYTEST_ADDOPTS")
         buildkite_envvars.append("BUILDKITE_TEST_QUARANTINE_TOKEN")
+        buildkite_envvars.append("BUILDKITE_TEST_SUITE_SLUG")
         buildkite_envvars.append("BUILDKITE_BRANCH")
         buildkite_envvars.append("BUILDKITE_COMMIT")
-        buildkite_envvars.append("BUILDKITE_PIPELINE_SLUG")
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,4 +3,5 @@ set -eu
 . ./.buildkite/scripts/docker_prune.sh
 
 export BUILDKITE_ANALYTICS_TOKEN=$DAGSTER_BUILDKITE_TEST_ANALYTICS_TOKEN
+export BUILDKITE_TEST_SUITE_SLUG=$DAGSTER_BUILDKITE_TEST_SUITE_SLUG
 export PYTEST_ADDOPTS="-c /workdir/pyproject.toml"

--- a/conftest.py
+++ b/conftest.py
@@ -35,10 +35,10 @@ def buildkite_quarantined_tests() -> set[TestId]:
 
             token = os.getenv("BUILDKITE_TEST_QUARANTINE_TOKEN")
             org_slug = os.getenv("BUILDKITE_ORGANIZATION_SLUG")
-            pipeline_slug = os.getenv("BUILDKITE_PIPELINE_SLUG")
+            suite_slug = os.getenv("BUILDKITE_TEST_SUITE_SLUG")
 
             headers = {"Authorization": f"Bearer {token}"}
-            url = f"https://api.buildkite.com/v2/analytics/organizations/{org_slug}/suites/{pipeline_slug}/tests/muted"
+            url = f"https://api.buildkite.com/v2/analytics/organizations/{org_slug}/suites/{suite_slug}/tests/muted"
 
             response = requests.get(url, headers=headers)
             response.raise_for_status()

--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,7 @@ class TestId:
 def buildkite_quarantined_tests() -> set[TestId]:
     quarantined_tests = set()
 
-    if os.getenv("BUILDKITE"):
+    if os.getenv("BUILDKITE") or os.getenv("LOCAL_BUILDKITE_QUARANTINE"):
         # Run our full test suite - warts and all - on the release branch
         if os.getenv("BUILDKITE_BRANCH", "").startswith("release-"):
             return quarantined_tests
@@ -76,8 +76,10 @@ def pytest_runtest_setup(item):
     # quarantined test.
     try:
         if buildkite_quarantined_tests():
-            scope = item.location[0]
-            name = item.location[2]
+            # https://github.com/buildkite/test-collector-python/blob/6fba081a2844d6bdec8607942eee48a03d60cd40/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py#L22-L27
+            chunks = item.nodeid.split("::")
+            scope = "::".join(chunks[:-1])
+            name = chunks[-1]
 
             test = TestId(scope, name)
 


### PR DESCRIPTION
This checks the Buildkite API for a list of test cases that have been "muted" via the Buildkite UI. On every branch but the release branch, it annotates muted tests with a pytest "skip" annotation. That way, we can quarantine and triage broken or flaky tests without our build staying broken while we work on a fix.

Future versions of the buildkite-test-collector plan to support this use case more directly so we might be able to remove this custom implementation in the near future.

https://buildkite.com/docs/test-engine/flaky-test-management

A version of this is already running on our internal repo but this sets it up for this repo before I start evangelizing this functionality more broadly.