### PR TITLE
[dg] Add dg.toml support (BUILD-878)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -526,6 +526,14 @@ class DgContext:
             return "active Python environment"
 
     @property
+    def config_file_path(self) -> Path:
+        return self.dg_toml_path if self.dg_toml_path.exists() else self.pyproject_toml_path
+
+    @property
+    def dg_toml_path(self) -> Path:
+        return self.root_path / "dg.toml"
+
+    @property
     def pyproject_toml_path(self) -> Path:
         return self.root_path / "pyproject.toml"
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -14,7 +14,6 @@ from typing import Any, Literal, Optional, TypeVar, Union, overload
 import click
 import jinja2
 import tomlkit
-import tomlkit.items
 from typer.rich_utils import rich_format_help
 from typing_extensions import Never, TypeAlias
 
@@ -257,7 +256,7 @@ def modify_toml_as_dict(path: Path) -> Iterator[dict[str, Any]]:  # unwrap gets 
     values in the file without worrying about the details of the TOML syntax (it has multiple kinds of
     dict-like objects, for instance).
     """
-    toml_dict = tomlkit.parse(path.read_text()).unwrap()
+    toml_dict = load_toml_as_dict(path)
     yield toml_dict
     path.write_text(tomlkit.dumps(toml_dict))
 
@@ -495,6 +494,10 @@ TomlPath: TypeAlias = tuple[Union[str, int], ...]
 TomlDoc: TypeAlias = Union[tomlkit.TOMLDocument, dict[str, Any]]
 
 
+def load_toml_as_dict(path: Path) -> dict[str, Any]:
+    return tomlkit.parse(path.read_text()).unwrap()
+
+
 def get_toml_node(
     doc: TomlDoc,
     path: TomlPath,
@@ -525,10 +528,14 @@ def delete_toml_node(doc: TomlDoc, path: TomlPath) -> None:
     an error if the leading keys do not already lead to a TOML container node.
     """
     nodes = _gather_toml_nodes(doc, path)
-    container = nodes[-2]
+    container = nodes[-2] if len(nodes) > 1 else doc
     key_or_index = path[-1]
     if isinstance(container, dict):
-        del container[path[-1]]
+        assert isinstance(key_or_index, str)  # We already know this from _traverse_toml_path
+        del container[key_or_index]
+    elif isinstance(container, tomlkit.TOMLDocument):
+        assert isinstance(key_or_index, str)  # We already know this from _traverse_toml_path
+        container.remove(key_or_index)
     elif isinstance(container, list):
         assert isinstance(key_or_index, int)  # We already know this from _traverse_toml_path
         container.pop(key_or_index)
@@ -592,19 +599,24 @@ def _gather_toml_nodes(
 
 
 def toml_path_to_str(path: TomlPath) -> str:
-    first, rest = path[0], path[1:]
+    if len(path) == 0:
+        return ""
+    first = path[0]
     if not isinstance(first, str):
         raise TypeError(f"Expected first element of path to be a string, but got {type(first)}")
-    str_path = first
-    for item in rest:
-        if isinstance(item, int):
-            str_path += f"[{item}]"
-        elif isinstance(item, str):
-            str_path += f".{item}"
-        else:
-            raise TypeError(
-                f"Expected path elements to be strings or integers, but got {type(item)}"
-            )
+    elif len(path) == 1:
+        return first
+    else:
+        str_path = first
+        for item in path[1:]:
+            if isinstance(item, int):
+                str_path += f"[{item}]"
+            elif isinstance(item, str):
+                str_path += f".{item}"
+            else:
+                raise TypeError(
+                    f"Expected path elements to be strings or integers, but got {type(item)}"
+                )
     return str_path
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -13,23 +13,30 @@ from dagster_dg.utils import (
     TomlPath,
     create_toml_node,
     delete_toml_node,
-    modify_toml_as_dict,
     pushd,
     toml_path_from_str,
     toml_path_to_str,
 )
 
 from dagster_dg_tests.utils import (
+    ConfigFileType,
     ProxyRunner,
     isolated_components_venv,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
+    modify_dg_toml_config_as_dict,
     set_env_var,
 )
 
+# These tests also handle making sure config is properly read and config inheritance
 
-def test_context_in_workspace():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner):
+
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_context_in_workspace(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(runner, workspace_config_file_type=config_file),
+    ):
         # go into a subdirectory to make sure root resolution works
         path_arg = Path.cwd() / "libraries"
 
@@ -38,14 +45,26 @@ def test_context_in_workspace():
         assert context.workspace_root_path == Path.cwd()
 
         # Test config properly set
-        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
-            create_toml_node(toml_dict, ("tool", "dg", "cli", "verbose"), True)
+        with modify_dg_toml_config_as_dict(Path(config_file)) as toml_dict:
+            create_toml_node(toml_dict, ("cli", "verbose"), True)
         context = DgContext.for_workspace_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
 
-def test_context_in_project_in_workspace():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner, project_name="foo-bar"):
+@pytest.mark.parametrize("project_config_file", ["dg.toml", "pyproject.toml"])
+@pytest.mark.parametrize("workspace_config_file", ["dg.toml", "pyproject.toml"])
+def test_context_in_project_in_workspace(
+    project_config_file: ConfigFileType, workspace_config_file: ConfigFileType
+):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(
+            runner,
+            project_name="foo-bar",
+            workspace_config_file_type=workspace_config_file,
+            project_config_file_type=project_config_file,
+        ),
+    ):
         project_path = Path.cwd() / "projects" / "foo-bar"
         # go into a project subdirectory to make sure root resolution works
         path_arg = project_path / "foo_bar_tests"
@@ -56,21 +75,28 @@ def test_context_in_project_in_workspace():
         assert context.config.cli.verbose is False  # default
 
         # Test config inheritance from workspace
-        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
-            create_toml_node(toml_dict, ("tool", "dg", "cli", "verbose"), True)
+        with modify_dg_toml_config_as_dict(Path(workspace_config_file)) as toml_dict:
+            create_toml_node(toml_dict, ("cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
         # Test cli config in project is ignored and generates warning
-        with pushd(project_path), modify_toml_as_dict(Path("pyproject.toml")) as pyproject_toml:
-            create_toml_node(pyproject_toml, ("tool", "dg", "cli", "verbose"), False)
-        with pytest.warns(match="`tool.dg.cli` section detected in project"):
+        with (
+            pushd(project_path),
+            modify_dg_toml_config_as_dict(Path(project_config_file)) as project_toml,
+        ):
+            create_toml_node(project_toml, ("cli", "verbose"), False)
+        with pytest.warns(match="cli` section detected in project"):
             context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
 
-def test_context_in_project_outside_workspace():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner, in_workspace=False):
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_context_in_project_outside_workspace(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False, config_file_type=config_file),
+    ):
         project_path = Path.cwd()
         # go into a project subdirectory to make sure root resolution works
         path_arg = project_path / "foo_tests"
@@ -81,8 +107,8 @@ def test_context_in_project_outside_workspace():
         assert context.config.cli.verbose is False
 
         # Test CLI setting is used in project outside of workspace
-        with modify_toml_as_dict(Path("pyproject.toml")) as pyproject_toml:
-            create_toml_node(pyproject_toml, ("tool", "dg", "cli", "verbose"), True)
+        with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
+            create_toml_node(toml, ("cli", "verbose"), True)
         context = DgContext.for_project_environment(path_arg, {})
         assert context.config.cli.verbose is True
 
@@ -119,104 +145,125 @@ def test_context_with_user_config():
 
 # Combine the many cases inside each test function for each speed, we don't want to set up
 # isolated projects etc for every case.
+#
+# These all use pyproject.toml instead of dg.toml but validation happens after loading which is
+# tested above, so this applies to dg.toml also.
 
 
-def test_invalid_config_type():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner):
-        with _reset_pyproject_toml():
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_invalid_config_type(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(runner, workspace_config_file_type=config_file),
+    ):
+        with _reset_config_file(config_file):
             _set_and_detect_missing_required_key(
-                ("tool.dg.directory_type"), DgFileConfigDirectoryType
+                config_file, "directory_type", DgFileConfigDirectoryType
             )
-        with _reset_pyproject_toml():
-            _set_and_detect_mistyped_value(("tool.dg.directory_type"), DgFileConfigDirectoryType, 1)
+        with _reset_config_file(config_file):
+            _set_and_detect_mistyped_value(
+                config_file, "directory_type", DgFileConfigDirectoryType, 1
+            )
 
 
-def test_invalid_config_workspace():
-    with ProxyRunner.test() as runner, isolated_example_workspace(runner, project_name="foo-bar"):
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_invalid_config_workspace(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_workspace(
+            runner, project_name="foo-bar", workspace_config_file_type=config_file
+        ),
+    ):
         cases = [
-            "tool.dg.invalid_key",
-            "tool.dg.project",
-            "tool.dg.cli.invalid_key",
-            "tool.dg.workspace.invalid_key",
-            "tool.dg.workspace.projects[0].invalid_key",
-            "tool.dg.workspace.scaffold_project_options.invalid_key",
+            "invalid_key",
+            "project",
+            "cli.invalid_key",
+            "workspace.invalid_key",
+            "workspace.projects[0].invalid_key",
+            "workspace.scaffold_project_options.invalid_key",
         ]
         for path in cases:
-            with _reset_pyproject_toml():
-                _set_and_detect_invalid_key(path)
+            with _reset_config_file(config_file):
+                _set_and_detect_invalid_key(config_file, path)
 
         cases = [
-            ["tool.dg.cli.disable_cache", bool, 1],
-            ["tool.dg.cli.cache_dir", str, 1],
-            ["tool.dg.cli.verbose", bool, 1],
-            ["tool.dg.cli.use_component_modules", Sequence[str], 1],
-            ["tool.dg.workspace.projects", list, 1],
-            ["tool.dg.workspace.projects[1]", dict, 1],
-            ["tool.dg.workspace.projects[0].path", str, 1],
-            ["tool.dg.workspace.scaffold_project_options", dict, 1],
+            ["cli.disable_cache", bool, 1],
+            ["cli.cache_dir", str, 1],
+            ["cli.verbose", bool, 1],
+            ["cli.use_component_modules", Sequence[str], 1],
+            ["workspace.projects", list, 1],
+            ["workspace.projects[1]", dict, 1],
+            ["workspace.projects[0].path", str, 1],
+            ["workspace.scaffold_project_options", dict, 1],
             [
-                "tool.dg.workspace.scaffold_project_options.use_editable_dagster",
+                "workspace.scaffold_project_options.use_editable_dagster",
                 Union[bool, str],
                 1,
             ],
         ]
         for path, expected_type, val in cases:
-            with _reset_pyproject_toml():
-                _set_and_detect_mistyped_value(path, expected_type, val)
+            with _reset_config_file(config_file):
+                _set_and_detect_mistyped_value(config_file, path, expected_type, val)
 
         cases = [
-            ["tool.dg.workspace.projects[0].path", str],
+            ["workspace.projects[0].path", str],
         ]
         for path, expected_type in cases:
-            with _reset_pyproject_toml():
-                _set_and_detect_missing_required_key(path, expected_type)
+            with _reset_config_file(config_file):
+                _set_and_detect_missing_required_key(config_file, path, expected_type)
 
 
-def test_invalid_config_project():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_invalid_config_project(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, config_file_type=config_file),
+    ):
         paths = [
-            "tool.dg.invalid_key",
-            "tool.dg.project.invalid_key",
-            "tool.dg.cli.invalid_key",
+            "invalid_key",
+            "project.invalid_key",
+            "cli.invalid_key",
         ]
         for case in paths:
-            with _reset_pyproject_toml():
-                _set_and_detect_invalid_key(case)
+            with _reset_config_file(config_file):
+                _set_and_detect_invalid_key(config_file, case)
 
         cases = [
-            [("tool.dg.cli.verbose"), bool, 1],
-            [("tool.dg.project.root_module"), str, 1],
-            [("tool.dg.project.defs_module"), str, 1],
-            [("tool.dg.project.code_location_name"), str, 1],
-            [("tool.dg.project.code_location_target_module"), str, 1],
+            ["cli.verbose", bool, 1],
+            ["project.root_module", str, 1],
+            ["project.defs_module", str, 1],
+            ["project.code_location_name", str, 1],
+            ["project.code_location_target_module", str, 1],
         ]
         for path, expected_type, val in cases:
-            with _reset_pyproject_toml():
-                _set_and_detect_mistyped_value(path, expected_type, val)
+            with _reset_config_file(config_file):
+                _set_and_detect_mistyped_value(config_file, path, expected_type, val)
 
         cases = [
-            ["tool.dg.project.root_module", str],
+            ["project.root_module", str],
         ]
         for path, expected_type in cases:
-            with _reset_pyproject_toml():
-                _set_and_detect_missing_required_key(path, expected_type)
+            with _reset_config_file(config_file):
+                _set_and_detect_missing_required_key(config_file, path, expected_type)
 
 
-def test_code_location_config():
-    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+@pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
+def test_code_location_config(config_file: ConfigFileType):
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, config_file_type=config_file),
+    ):
         context = DgContext.for_project_environment(Path.cwd(), {})
         assert context.code_location_target_module_name == "foo_bar.definitions"
         assert context.code_location_name == "foo-bar"
 
-        with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+        with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
             create_toml_node(
                 toml,
-                ("tool", "dg", "project", "code_location_target_module"),
+                ("project", "code_location_target_module"),
                 "foo_bar._definitions",
             )
-            create_toml_node(
-                toml, ("tool", "dg", "project", "code_location_name"), "my-code_location"
-            )
+            create_toml_node(toml, ("project", "code_location_name"), "my-code_location")
 
         context = DgContext.for_project_environment(Path.cwd(), {})
         assert context.code_location_target_module_name == "foo_bar._definitions"
@@ -229,42 +276,60 @@ def test_code_location_config():
 
 
 @contextmanager
-def _reset_pyproject_toml():
-    original = Path("pyproject.toml").read_text()
+def _reset_config_file(config_file: ConfigFileType):
+    original = Path(config_file).read_text()
     yield
-    Path("pyproject.toml").write_text(original)
+    Path(config_file).write_text(original)
 
 
-def _set_and_detect_error(path: TomlPath, config_value: object, error_message: str):
-    with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+def _get_full_str_path(config_file: ConfigFileType, str_path: str) -> str:
+    if config_file == "pyproject.toml":
+        return f"tool.dg.{str_path}" if str_path else "tool.dg"
+    else:
+        return str_path if str_path else "<root>"
+
+
+def _set_and_detect_error(
+    config_file: ConfigFileType, path: TomlPath, config_value: object, error_message: str
+):
+    with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
         create_toml_node(toml, path, config_value)
     with pytest.raises(DgError, match=re.escape(error_message)):
         DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
 
 
-def _set_and_detect_invalid_key(str_path: str, config_value: object = True):
+def _set_and_detect_invalid_key(
+    config_file: ConfigFileType, str_path: str, config_value: object = True
+):
     path = toml_path_from_str(str_path)
     leading_str_path, key = toml_path_to_str(path[:-1]), path[-1]
-    error_message = rf"Unrecognized fields in `{leading_str_path}`: ['{key}']"
-    _set_and_detect_error(path, config_value, error_message)
+    full_leading_str_path = _get_full_str_path(config_file, leading_str_path)
+    error_message = rf"Unrecognized fields at `{full_leading_str_path}`: ['{key}']"
+    _set_and_detect_error(config_file, path, config_value, error_message)
 
 
 # expected_type Any to handle typing constructs (`Literal` etc)
-def _set_and_detect_mistyped_value(str_path: str, expected_type: Any, config_value: object):
+def _set_and_detect_mistyped_value(
+    config_file: ConfigFileType, str_path: str, expected_type: Any, config_value: object
+):
     path = toml_path_from_str(str_path)
     expected_str = get_type_str(expected_type)
+    full_str_path = _get_full_str_path(config_file, str_path)
     error_message = (
-        rf"Invalid value for `{str_path}`. Expected {expected_str}, got `{config_value}`"
+        rf"Invalid value for `{full_str_path}`. Expected {expected_str}, got `{config_value}`"
     )
-    _set_and_detect_error(path, config_value, error_message)
+    _set_and_detect_error(config_file, path, config_value, error_message)
 
 
 # expected_type Any to handle typing constructs (`Literal` etc)
-def _set_and_detect_missing_required_key(str_path: str, expected_type: Any):
+def _set_and_detect_missing_required_key(
+    config_file: ConfigFileType, str_path: str, expected_type: Any
+):
     path = toml_path_from_str(str_path)
     expected_str = get_type_str(expected_type)
-    error_message = rf"Missing required value for `{str_path}`. Expected {expected_str}"
-    with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+    full_str_path = _get_full_str_path(config_file, str_path)
+    error_message = rf"Missing required value for `{full_str_path}`. Expected {expected_str}"
+    with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
         delete_toml_node(toml, path)
     with pytest.raises(DgError, match=re.escape(error_message)):
         DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})


### PR DESCRIPTION
## Summary & Motivation

Adds support for `dg.toml` in place of `pyproject.toml`. Settings in `pyproject.toml` are set under `tool.dg`, but in `dg.toml` they are set directly at the top level. `pyproject.toml` and `dg.toml` may both be used either in a project or workspace.

Switching the default config for workspace to `dg.toml` will be added upstack.

## How I Tested These Changes

New unit tests.

## Changelog

Add support for `dg.toml` files. `dg` settings in `pyproject.toml` are set under `tool.dg`, but in `dg.toml` they are set at the top level. A `dg.toml` may be used in place of `pyproject.toml` at either the project or workspace level.
