### PR TITLE
DOC-1002 Remove `logo` prop from integrations docs metadata

### DIFF
--- a/docs/docs/integrations/libraries/airbyte/airbyte-cloud.md
+++ b/docs/docs/integrations/libraries/airbyte/airbyte-cloud.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-airbyte
 docslink: https://docs.dagster.io/integrations/libraries/airbyte/airbyte-cloud
 partnerlink: https://airbyte.com/tutorials/orchestrate-data-ingestion-and-transformation-pipelines
-logo: /integrations/airbyte.svg
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/airlift.md
+++ b/docs/docs/integrations/libraries/airlift.md
@@ -9,7 +9,6 @@ date:
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-airlift
 docslink: https://docs.dagster.io/integrations/libraries/airlift/
 partnerlink:
-logo:
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/aws/glue.md
+++ b/docs/docs/integrations/libraries/aws/glue.md
@@ -9,7 +9,6 @@ date: 2024-08-20
 apireflink: https://docs.dagster.io/integrations/libraries/aws/glue
 docslink:
 partnerlink: https://aws.amazon.com/
-logo: /integrations/aws-glue.svg
 categories:
   - Compute
 enabledBy:

--- a/docs/docs/integrations/libraries/aws/lambda.md
+++ b/docs/docs/integrations/libraries/aws/lambda.md
@@ -9,7 +9,6 @@ date: 2024-06-21
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-aws
 docslink:
 partnerlink: https://aws.amazon.com/
-logo: /integrations/aws-lambda.svg
 categories:
   - Compute
 enabledBy:

--- a/docs/docs/integrations/libraries/aws/redshift.md
+++ b/docs/docs/integrations/libraries/aws/redshift.md
@@ -9,7 +9,6 @@ date: 2024-06-21
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-aws
 docslink:
 partnerlink: https://aws.amazon.com/
-logo: /integrations/aws-redshift.svg
 categories:
   - Storage
 enabledBy:

--- a/docs/docs/integrations/libraries/aws/s3.md
+++ b/docs/docs/integrations/libraries/aws/s3.md
@@ -9,7 +9,6 @@ date: 2024-06-21
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-aws
 docslink:
 partnerlink: https://aws.amazon.com/
-logo: /integrations/aws-s3.svg
 categories:
   - Storage
 enabledBy:

--- a/docs/docs/integrations/libraries/azure-adls2.md
+++ b/docs/docs/integrations/libraries/azure-adls2.md
@@ -8,7 +8,6 @@ date: 2022-11-07
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-azure
 docslink:
 partnerlink: https://azure.microsoft.com/
-logo: /integrations/Azure.svg
 categories:
   - Storage
 enabledBy:

--- a/docs/docs/integrations/libraries/census.md
+++ b/docs/docs/integrations/libraries/census.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 apireflink: http://docs.dagster.io/api/python-api/libraries/dagster-census
 partnerlink: https://www.getcensus.com/
 communityIntegration: true
-logo: /integrations/Census.svg
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/chroma.md
+++ b/docs/docs/integrations/libraries/chroma.md
@@ -6,7 +6,6 @@ title: Dagster & Chroma
 sidebar_label: Chroma
 excerpt: 'Integrate Chroma vector database capabilities into your AI pipelines powered by Dagster.'
 partnerlink: https://docs.trychroma.com/
-logo: /integrations/chroma.svg
 categories:
   - Storage
 enabledBy:

--- a/docs/docs/integrations/libraries/cube.md
+++ b/docs/docs/integrations/libraries/cube.md
@@ -9,7 +9,6 @@ date: 2023-08-30
 apireflink: https://cube.dev/docs/orchestration-api/dagster
 partnerlink: https://cube.dev/
 communityIntegration: true
-logo: /integrations/cube.svg
 categories:
   - Other
 enabledBy:

--- a/docs/docs/integrations/libraries/databricks.md
+++ b/docs/docs/integrations/libraries/databricks.md
@@ -9,7 +9,6 @@ date: 2024-08-20
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-databricks
 docslink: https://docs.dagster.io/integrations/libraries/databricks
 partnerlink: https://databricks.com/
-logo: /integrations/databricks.svg
 categories:
   - Compute
 enabledBy:

--- a/docs/docs/integrations/libraries/datadog.md
+++ b/docs/docs/integrations/libraries/datadog.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-datadog
 docslink:
 partnerlink: https://www.datadoghq.com/
-logo: /integrations/Datadog.svg
 categories:
   - Monitoring
 enabledBy:

--- a/docs/docs/integrations/libraries/dlt/index.md
+++ b/docs/docs/integrations/libraries/dlt/index.md
@@ -9,7 +9,6 @@ date: 2024-08-30
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-dlt
 docslink: https://docs.dagster.io/integrations/libraries/dlt/
 partnerlink: https://dlthub.com/
-logo: /integrations/dlthub.jpeg
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/docker.md
+++ b/docs/docs/integrations/libraries/docker.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-docker
 docslink:
 partnerlink: https://www.docker.com/
-logo: /integrations/Docker.svg
 categories:
   - Compute
 enabledBy:

--- a/docs/docs/integrations/libraries/fivetran.md
+++ b/docs/docs/integrations/libraries/fivetran.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 apireflink: https://docs.dagster.io/api/python-api/libraries/dagster-fivetran
 docslink: https://docs.dagster.io/integrations/libraries/fivetran
 partnerlink: https://www.fivetran.com/
-logo: /integrations/Fivetran.svg
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/hashicorp.md
+++ b/docs/docs/integrations/libraries/hashicorp.md
@@ -10,7 +10,6 @@ apireflink:
 docslink: https://github.com/silentsokolov/dagster-hashicorp
 partnerlink: https://www.vaultproject.io/
 communityIntegration: true
-logo: /integrations/Hashicorp.svg
 categories:
   - Other
 enabledBy:

--- a/docs/docs/integrations/libraries/hightouch.md
+++ b/docs/docs/integrations/libraries/hightouch.md
@@ -9,7 +9,6 @@ date: 2022-11-07
 docslink: https://github.com/hightouchio/dagster-hightouch
 partnerlink: https://hightouch.com/
 communityIntegration: true
-logo: /integrations/Hightouch.svg
 categories:
   - ETL
 enabledBy:

--- a/docs/docs/integrations/libraries/java.md
+++ b/docs/docs/integrations/libraries/java.md
@@ -9,7 +9,6 @@ date: 2025-03-14
 apireflink:
 docslink: https://docs.dagster.io/integrations/libraries/java
 partnerlink: https://www.java.com/en/
-logo: /integrations/java.svg
 categories:
 enabledBy:
 enables:

--- a/docs/docs/integrations/libraries/qdrant.md
+++ b/docs/docs/integrations/libraries/qdrant.md
@@ -6,7 +6,6 @@ title: Dagster & Qdrant
 sidebar_label: Qdrant
 excerpt: 'Integrate Qdrant vector search features into your workflows powered by Dagster.'
 partnerlink: https://qdrant.tech/
-logo: /integrations/qdrant.svg
 categories:
   - Storage
 enabledBy:

--- a/docs/docs/integrations/libraries/rust.md
+++ b/docs/docs/integrations/libraries/rust.md
@@ -9,7 +9,6 @@ date: 2025-03-14
 apireflink:
 docslink: https://docs.dagster.io/integrations/libraries/rust
 partnerlink: https://www.rust-lang.org/
-logo: /integrations/rust.svg
 categories:
 enabledBy:
 enables:

--- a/docs/docs/integrations/libraries/typescript.md
+++ b/docs/docs/integrations/libraries/typescript.md
@@ -9,7 +9,6 @@ date: 2025-03-14
 apireflink:
 docslink: https://docs.dagster.io/integrations/libraries/typescript
 partnerlink: https://www.typescriptlang.org/
-logo: /integrations/typescript.svg
 categories:
 enabledBy:
 enables:

--- a/docs/docs/integrations/libraries/weaviate.md
+++ b/docs/docs/integrations/libraries/weaviate.md
@@ -6,7 +6,6 @@ title: Dagster & Weaviate
 sidebar_label: Weaviate
 excerpt: 'Using this integration, you can seamlessly integrate Weaviate into your Dagster workflows, leveraging Weaviates data warehousing capabilities for your data pipelines.'
 partnerlink: https://weaviate.io/
-logo: /integrations/weaviate.png
 categories:
   - Storage
 enabledBy:


### PR DESCRIPTION
## Summary & Motivation

Addresses https://linear.app/dagster-labs/issue/DOC-1002/delete-logo-from-integrations-docs-metadata -- removes `logo` from integrations docs metadata, since it's been deprecated in favor of `sidebar_custom_props > logo`

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
