### PR TITLE
[dg] Default to dataclass in component type generation with an opt-out

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -1,10 +1,7 @@
-from dagster import Definitions
-from dagster.components import (
-    Component,
-    ComponentLoadContext,
-    Resolvable,
-)
 from dataclasses import dataclass
+
+import dagster as dg
+from dagster.components import Component, ComponentLoadContext, Resolvable
 
 
 @dataclass
@@ -14,6 +11,6 @@ class ShellCommand(Component, Resolvable):
     COMPONENT DESCRIPTION HERE.
     """
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         # Add definition construction logic here.
-        return Definitions()
+        return dg.Definitions()

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -4,18 +4,15 @@ from dagster.components import (
     ComponentLoadContext,
     Resolvable,
 )
+from dataclasses import dataclass
 
+
+@dataclass
 class ShellCommand(Component, Resolvable):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.
     """
-
-    def __init__(
-        self,
-        # added arguments here will define yaml schema via Resolvable
-    ):
-        pass
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         # Add definition construction logic here.

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -1,4 +1,3 @@
-from ast import mod
 from collections.abc import Mapping
 from copy import copy
 from pathlib import Path

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -1,3 +1,4 @@
+from ast import mod
 from collections.abc import Mapping
 from copy import copy
 from pathlib import Path
@@ -401,12 +402,18 @@ def _create_scaffold_subcommand(key: LibraryObjectKey, obj: LibraryObjectSnap) -
     cls=ScaffoldSubCommand,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+@click.option(
+    "--dataclass/--no-dataclass",
+    is_flag=True,
+    default=True,
+    help="Where to automatically annotated the generated class with @dataclass.",
+)
 @click.argument("name", type=str)
 @dg_global_options
 @click.pass_context
 @cli_telemetry_wrapper
 def scaffold_component_type_command(
-    context: click.Context, name: str, **global_options: object
+    context: click.Context, name: str, dataclass: bool, **global_options: object
 ) -> None:
     """Scaffold of a custom Dagster component type.
 
@@ -424,4 +431,6 @@ def scaffold_component_type_command(
     if registry.has(component_key):
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
-    scaffold_component_type(dg_context, name, module_name)
+    scaffold_component_type(
+        dg_context=dg_context, class_name=name, module_name=module_name, dataclass=dataclass
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -405,7 +405,7 @@ def _create_scaffold_subcommand(key: LibraryObjectKey, obj: LibraryObjectSnap) -
     "--dataclass/--no-dataclass",
     is_flag=True,
     default=True,
-    help="Where to automatically annotated the generated class with @dataclass.",
+    help="Whether to automatically annotate the generated class with @dataclass.",
 )
 @click.argument("name", type=str)
 @dg_global_options

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -231,7 +231,9 @@ def _gather_dagster_packages(editable_dagster_root: Path) -> list[Path]:
 # ########################
 
 
-def scaffold_component_type(dg_context: DgContext, class_name: str, module_name: str) -> None:
+def scaffold_component_type(
+    *, dg_context: DgContext, class_name: str, module_name: str, dataclass: bool
+) -> None:
     root_path = Path(dg_context.default_component_library_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{module_name}.py.")
 
@@ -241,6 +243,7 @@ def scaffold_component_type(dg_context: DgContext, class_name: str, module_name:
         templates_path=str(Path(__file__).parent / "templates" / "COMPONENT_TYPE"),
         project_name=module_name,
         name=class_name,
+        dataclass=dataclass,
     )
 
     with open(root_path / "__init__.py", "a") as f:

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -4,19 +4,25 @@ from dagster.components import (
     ComponentLoadContext,
     Resolvable,
 )
+{% if dataclass -%}
+from dataclasses import dataclass
+{% endif %}
 
+{% if dataclass -%}
+@dataclass
+{% endif -%}
 class {{ name }}(Component, Resolvable):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.
     """
-
+{% if not dataclass %}
     def __init__(
         self,
         # added arguments here will define yaml schema via Resolvable
     ):
         pass
-
+{% endif %}
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         # Add definition construction logic here.
         return Definitions()

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -1,12 +1,9 @@
-from dagster import Definitions
-from dagster.components import (
-    Component,
-    ComponentLoadContext,
-    Resolvable,
-)
 {% if dataclass -%}
 from dataclasses import dataclass
 {% endif %}
+import dagster as dg
+from dagster.components import Component, ComponentLoadContext, Resolvable
+
 
 {% if dataclass -%}
 @dataclass
@@ -23,6 +20,6 @@ class {{ name }}(Component, Resolvable):
     ):
         pass
 {% endif %}
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         # Add definition construction logic here.
-        return Definitions()
+        return dg.Definitions()

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -1,6 +1,7 @@
 {% if dataclass -%}
 from dataclasses import dataclass
-{% endif %}
+
+{% endif -%}
 import dagster as dg
 from dagster.components import Component, ComponentLoadContext, Resolvable
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -156,6 +156,7 @@ PROJECT_NAME_PLACEHOLDER = "PROJECT_NAME_PLACEHOLDER"
 
 # Copied from dagster._generate.generate
 def scaffold_subtree(
+    *,
     path: Path,
     excludes: Optional[list[str]] = None,
     name_placeholder: str = PROJECT_NAME_PLACEHOLDER,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -570,6 +570,39 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
         assert "type: foo_bar.lib.Baz" in component_yaml_path.read_text()
 
 
+def test_scaffold_component_succeeds_scaffolded_no_dataclass() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke("scaffold", "component-type", "Baz", "--no-dataclass")
+        assert_runner_result(result)
+        assert Path("foo_bar/lib/baz.py").exists()
+
+        output = '''import dagster as dg
+from dagster.components import Component, ComponentLoadContext, Resolvable
+
+
+class Baz(Component, Resolvable):
+    """COMPONENT SUMMARY HERE.
+
+    COMPONENT DESCRIPTION HERE.
+    """
+
+    def __init__(
+        self,
+        # added arguments here will define yaml schema via Resolvable
+    ):
+        pass
+
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
+        # Add definition construction logic here.
+        return dg.Definitions()
+'''
+
+        assert Path("foo_bar/lib/baz.py").read_text() == output
+
+
 # ##### SHIMS
 
 


### PR DESCRIPTION
## Summary & Motivation

While `Component` itself is agnostic to what framework is used to define properties (e.g. they could Pydantic or their own handrolled system) but that shouldn't prevent us from providing an easy path in the default case. So we are going to default to use `@dataclass` but allow an opt-out.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG