### PR TITLE
[dagster-fivetran] Handle paused connector in FivetranWorkspace.sync_and_poll

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1084,8 +1084,8 @@ class FivetranWorkspace(ConfigurableResource):
         # The FivetranOutput is None if the connector hasn't been synced
         if not fivetran_output:
             context.log.warning(
-                f"The connector with ID {connector_id} has not been synced."
-                f"Make sure that your connector is enabled before syncing it."
+                f"The connector with ID {connector_id} is currently paused and so it has not been synced. "
+                f"Make sure that your connector is enabled before syncing it with Dagster."
             )
             return
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
@@ -185,7 +185,9 @@ SAMPLE_DESTINATION_DETAILS = {
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/connectors/connector-details
 # The sample is parameterized to test the poll method
-def get_sample_connection_details(succeeded_at: str, failed_at: str) -> Mapping[str, Any]:
+def get_sample_connection_details(
+    succeeded_at: str, failed_at: str, paused: bool = False
+) -> Mapping[str, Any]:
     return {
         "code": "Success",
         "message": "Operation performed.",
@@ -193,7 +195,7 @@ def get_sample_connection_details(succeeded_at: str, failed_at: str) -> Mapping[
             "id": TEST_CONNECTOR_ID,
             "service": "15five",
             "schema": "schema.table",
-            "paused": False,
+            "paused": paused,
             "status": {
                 "tasks": [
                     {
@@ -666,5 +668,11 @@ def sync_and_poll_fixture():
             )["data"],
             schema_config=ALTERED_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR["data"],
         )
-        mocked_function.side_effect = [expected_fivetran_output, unexpected_fivetran_output]
+        # sync_and_poll returns None if the connector is paused
+        paused_connector_output = None
+        mocked_function.side_effect = [
+            expected_fivetran_output,
+            unexpected_fivetran_output,
+            paused_connector_output,
+        ]
         yield mocked_function


### PR DESCRIPTION
## Summary & Motivation

This PR handles paused connectors in `FivetranWorkspace.sync_and_poll` - methods `FivetranClient.sync_and_poll` and `FivetranClient.resync_and_poll` return None if the sync is paused and log a warning.


Before this PR, syncing a paused connector raised an exception, caused by `connector.validate_syncable()` in `FivetranClient.start_sync`. We keep that behavior here - users can call that method directly in their code, and will raise an exception if the connector is paused.

The difference between `FivetranClient.sync_and_poll` and `FivetranClient.start_sync` is that the former is responsible for returning a `FivetranOutput` when a connector is synced, and he latter is a wrapper around the Fivetran API endpoint to start a sync.

```
dagster._core.definitions.events.Failure: Connector 'incubation_commutation' cannot be synced as it is currently paused.

...
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 1082, in _sync_and_poll
    fivetran_output = client.sync_and_poll(
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 781, in sync_and_poll
    return self._sync_and_poll(
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 829, in _sync_and_poll
    sync_fn(connector_id=connector_id)
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 668, in start_sync
    self._start_sync(request_fn=request_fn, connector_id=connector_id)
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py", line 697, in _start_sync
    connector.validate_syncable()
  File "/Users/smackesey/stm/code/elementl/oss/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py", line 107, in validate_syncable
    raise Failure(f"Connector '{self.id}' cannot be synced as it is currently paused.")
```


## How I Tested These Changes

Updated and new tests with BK.

## Changelog

[dagster-fivetran] Paused connectors no longer raise an exception in `FivetranWorkspace.sync_and_poll(...)` - paused connectors are now skipped and a warning messages is logged.