### PR TITLE
[dagster-fivetran] Leverage state-backed defs in FivetranWorkspace.fetch_fivetran_workspace_data()

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -886,70 +886,6 @@ class FivetranWorkspace(ConfigurableResource):
             disable_schedule_on_trigger=self.disable_schedule_on_trigger,
         )
 
-    def _fetch_fivetran_workspace_data(
-        self,
-    ) -> FivetranWorkspaceData:
-        """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
-
-        Returns:
-            FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
-        """
-        connectors_by_id = {}
-        destinations_by_id = {}
-        schema_configs_by_connector_id = {}
-
-        client = self.get_client()
-        groups = client.get_groups()["items"]
-
-        for group in groups:
-            group_id = group["id"]
-
-            destination_details = client.get_destination_details(destination_id=group_id)
-            destination = FivetranDestination.from_destination_details(
-                destination_details=destination_details
-            )
-
-            destinations_by_id[destination.id] = destination
-
-            connectors_details = client.get_connectors_for_group(group_id=group_id)["items"]
-            for connector_details in connectors_details:
-                connector = FivetranConnector.from_connector_details(
-                    connector_details=connector_details,
-                )
-                if not connector.is_connected:
-                    self._log.warning(
-                        f"Ignoring incomplete or broken connector `{connector.name}`. "
-                        f"Dagster requires a connector to be connected before fetching its data."
-                    )
-                    continue
-
-                schema_config_details = client.get_schema_config_for_connector(
-                    connector_id=connector.id
-                )
-                schema_config = FivetranSchemaConfig.from_schema_config_details(
-                    schema_config_details=schema_config_details
-                )
-
-                # A connector that has not been synced yet has no `schemas` field in its schema config.
-                # Schemas are required for creating the asset definitions,
-                # so connectors for which the schemas are missing are discarded.
-                if not schema_config.has_schemas:
-                    self._log.warning(
-                        f"Ignoring connector `{connector.name}`. "
-                        f"Dagster requires connector schema information to represent this connector, "
-                        f"which is not available until this connector has been run for the first time."
-                    )
-                    continue
-
-                connectors_by_id[connector.id] = connector
-                schema_configs_by_connector_id[connector.id] = schema_config
-
-        return FivetranWorkspaceData(
-            connectors_by_id=connectors_by_id,
-            destinations_by_id=destinations_by_id,
-            schema_configs_by_connector_id=schema_configs_by_connector_id,
-        )
-
     def fetch_fivetran_workspace_data(
         self,
     ) -> FivetranWorkspaceData:
@@ -1192,7 +1128,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[FivetranWorkspace
         return f"{FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX}/{self.workspace.account_id}"
 
     def fetch_state(self) -> FivetranWorkspaceData:
-        return self.workspace._fetch_fivetran_workspace_data()  # noqa
+        return self.fetch_fivetran_workspace_data()
 
     def defs_from_state(self, state: FivetranWorkspaceData) -> Definitions:
         all_asset_specs = [
@@ -1203,3 +1139,67 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[FivetranWorkspace
         ]
 
         return Definitions(assets=all_asset_specs)
+
+    def fetch_fivetran_workspace_data(
+        self,
+    ) -> FivetranWorkspaceData:
+        """Retrieves all Fivetran content from the workspace and returns it as a FivetranWorkspaceData object.
+
+        Returns:
+            FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
+        """
+        connectors_by_id = {}
+        destinations_by_id = {}
+        schema_configs_by_connector_id = {}
+
+        client = self.workspace.get_client()
+        groups = client.get_groups()["items"]
+
+        for group in groups:
+            group_id = group["id"]
+
+            destination_details = client.get_destination_details(destination_id=group_id)
+            destination = FivetranDestination.from_destination_details(
+                destination_details=destination_details
+            )
+
+            destinations_by_id[destination.id] = destination
+
+            connectors_details = client.get_connectors_for_group(group_id=group_id)["items"]
+            for connector_details in connectors_details:
+                connector = FivetranConnector.from_connector_details(
+                    connector_details=connector_details,
+                )
+                if not connector.is_connected:
+                    self.workspace._log.warning(  # noqa
+                        f"Ignoring incomplete or broken connector `{connector.name}`. "
+                        f"Dagster requires a connector to be connected before fetching its data."
+                    )
+                    continue
+
+                schema_config_details = client.get_schema_config_for_connector(
+                    connector_id=connector.id
+                )
+                schema_config = FivetranSchemaConfig.from_schema_config_details(
+                    schema_config_details=schema_config_details
+                )
+
+                # A connector that has not been synced yet has no `schemas` field in its schema config.
+                # Schemas are required for creating the asset definitions,
+                # so connectors for which the schemas are missing are discarded.
+                if not schema_config.has_schemas:
+                    self.workspace._log.warning(  # noqa
+                        f"Ignoring connector `{connector.name}`. "
+                        f"Dagster requires connector schema information to represent this connector, "
+                        f"which is not available until this connector has been run for the first time."
+                    )
+                    continue
+
+                connectors_by_id[connector.id] = connector
+                schema_configs_by_connector_id[connector.id] = schema_config
+
+        return FivetranWorkspaceData(
+            connectors_by_id=connectors_by_id,
+            destinations_by_id=destinations_by_id,
+            schema_configs_by_connector_id=schema_configs_by_connector_id,
+        )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_reconstruction.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_reconstruction.py
@@ -1,0 +1,56 @@
+import pytest
+import responses
+from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.reconstruct import (
+    initialize_repository_def_from_pointer,
+    reconstruct_repository_def_from_pointer,
+)
+from dagster._utils.test.definitions import lazy_definitions
+from dagster_fivetran import FivetranWorkspace
+
+from dagster_fivetran_tests.beta.conftest import TEST_ACCOUNT_ID, TEST_API_KEY, TEST_API_SECRET
+
+
+@lazy_definitions
+def cacheable_fivetran_workspace_data():
+    workspace = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    workspace.fetch_fivetran_workspace_data()
+
+    return Definitions(
+        resources={"fivetran": workspace},
+    )
+
+
+@pytest.mark.order("last")
+def test_cacheable_fivetran_workspace_data(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    assert len(fetch_workspace_data_api_mocks.calls) == 0
+
+    # first, we resolve the repository to generate our cached metadata
+    pointer = CodePointer.from_python_file(
+        __file__,
+        "cacheable_fivetran_workspace_data",
+        None,
+    )
+    init_repository_def = initialize_repository_def_from_pointer(
+        pointer,
+    )
+
+    # 4 call to creates the defs
+    assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+    repository_load_data = init_repository_def.repository_load_data
+
+    # We use a separate file here just to ensure we get a fresh load
+    _ = reconstruct_repository_def_from_pointer(
+        pointer,
+        repository_load_data,
+    )
+
+    # no additional calls after a fresh load
+    assert len(fetch_workspace_data_api_mocks.calls) == 4

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_reconstruction.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_reconstruction.py
@@ -6,13 +6,13 @@ from dagster._core.definitions.reconstruct import (
     initialize_repository_def_from_pointer,
     reconstruct_repository_def_from_pointer,
 )
-from dagster._utils.test.definitions import lazy_definitions
+from dagster._utils.test.definitions import definitions
 from dagster_fivetran import FivetranWorkspace
 
 from dagster_fivetran_tests.beta.conftest import TEST_ACCOUNT_ID, TEST_API_KEY, TEST_API_SECRET
 
 
-@lazy_definitions
+@definitions
 def cacheable_fivetran_workspace_data():
     workspace = FivetranWorkspace(
         account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -44,5 +44,8 @@ setup(
         "managed": [
             f"dagster-managed-elements{pin}",
         ],
+        "test": [
+            "pytest-order",
+        ],
     },
 )

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -14,7 +14,7 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-shared
   -e ../dagster-managed-elements
-  -e .
+  -e .[test]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary & Motivation

Updates `fetch_fivetran_workspace_data` to use the state loader. The goal is to avoid reloading the workspace data more than once when using the method. The workspace data should be loaded only once.

## How I Tested These Changes

New tests with bk
