### PR TITLE
[components] Second attempt at adding requirements bloc to components

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -22,6 +22,7 @@ from dagster.components.core.defs import (
     DgScheduleMetadata,
     DgSensorMetadata,
 )
+from dagster.components.core.defs_module import ComponentRequirementsModel
 from dagster.components.core.library_object import (
     discover_entry_point_library_objects,
     discover_library_objects,
@@ -70,6 +71,7 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
                     key.name,
                     type=(Literal[key_string], key_string),
                     attributes=(model_cls, None),
+                    requirements=(Optional[ComponentRequirementsModel], None),
                     __config__=ConfigDict(extra="forbid"),
                 )
             )

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -6,6 +6,7 @@ from dagster._annotations import deprecated
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.warnings import suppress_dagster_warnings
+from dagster.components.component.component import ComponentRequirements
 from dagster.components.core.context import ComponentLoadContext, use_component_load_context
 
 
@@ -45,3 +46,15 @@ def load_defs(defs_root: ModuleType) -> Definitions:
 
     with use_component_load_context(context):
         return root_component.build_defs(context)
+
+
+def load_component_requirements(defs_root: ModuleType) -> ComponentRequirements:
+    """Loads the requirements for components in the given module."""
+    from dagster.components.core.defs_module import DefsModuleComponent
+
+    context = ComponentLoadContext.for_module(defs_root)
+    root_component = DefsModuleComponent.from_context(context)
+    if root_component is None:
+        raise DagsterInvalidDefinitionError("Could not resolve root module to a component.")
+
+    return root_component.get_requirements(context)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
@@ -8,7 +8,8 @@ from typing import Optional, Union
 import pytest
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
-from dagster.components.core.load_defs import load_defs
+from dagster.components.component.component import ComponentRequirements
+from dagster.components.core.load_defs import load_component_requirements, load_defs
 
 from dagster_tests.components_tests.utils import create_project_from_components
 
@@ -26,6 +27,17 @@ def load_test_component_defs(
         module = importlib.import_module(f"{project_name}.defs.{Path(src_path).stem}")
 
         yield load_defs(defs_root=module)
+
+
+def load_test_component_requirements(
+    src_path: Union[str, Path], local_component_defn_to_inject: Optional[Path] = None
+) -> ComponentRequirements:
+    with create_project_from_components(
+        str(src_path), local_component_defn_to_inject=local_component_defn_to_inject
+    ) as (_, project_name):
+        module = importlib.import_module(f"{project_name}.defs.{Path(src_path).stem}")
+
+        return load_component_requirements(defs_root=module)
 
 
 def sync_load_test_component_defs(

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/conftest.py
@@ -1,7 +1,9 @@
 import pytest
+from dagster.components.component.component import ComponentRequirements
 
 from dagster_tests.components_tests.integration_tests.component_loader import (
     load_test_component_defs,
+    load_test_component_requirements,
 )
 
 
@@ -10,3 +12,9 @@ def defs(request):
     component_path = request.param
     with load_test_component_defs(component_path) as defs:
         yield defs
+
+
+@pytest.fixture
+def requirements(request) -> ComponentRequirements:
+    component_path = request.param
+    return load_test_component_requirements(component_path)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/component.yaml
@@ -10,3 +10,7 @@ attributes:
       attributes:
         tags:
           added_to_defs_tag: "true"
+
+requirements:
+  env:
+    - "TOP_LEVEL_ENV"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs_object/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs_object/component.yaml
@@ -6,3 +6,7 @@ attributes:
       attributes:
         tags:
           defs_object_tag: "true"
+
+requirements:
+  env:
+    - "DEFS_OBJECT_ENV"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/component.yaml
@@ -6,3 +6,7 @@ attributes:
       attributes:
         tags:
           loose_defs_tag: "true"
+
+requirements:
+  env:
+    - "LOOSE_DEFS_ENV"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_object_relative_imports/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_object_relative_imports/component.yaml
@@ -2,3 +2,7 @@ type: dagster.components.DefinitionsComponent
 
 attributes:
   path: definitions_other_name.py
+
+requirements:
+  env:
+    - "DEFS_OBJECT_ENV"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/many_env_vars_sample/__init__.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/many_env_vars_sample/__init__.py
@@ -1,0 +1,10 @@
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components import Component, ComponentLoadContext
+
+
+class MyComponent(Component):
+    a_string: str
+    an_int: int
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions()

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/many_env_vars_sample/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/many_env_vars_sample/component.yaml
@@ -1,0 +1,9 @@
+type: .MyComponent
+
+attributes:
+  a_string: "{{ env('MY_ENV_VAR') }}"
+  an_int: "{{ env('MY_INT_ENV_VAR') }}"
+
+requirements:
+  env:
+    - "MY_UNLISTED_ENV_VAR"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -150,7 +150,7 @@ def test_autoload_definitions_nested_with_config() -> None:
     "requirements", ["definitions/definitions_at_levels_with_config"], indirect=True
 )
 def test_autoload_definitions_nested_requirements(requirements: ComponentRequirements) -> None:
-    # 3 env vars explicitly declared at each leve, one implicit (from UDF)
+    # 3 env vars explicitly declared at each level, one implicit (from UDF)
     assert set(requirements.env.keys()) == {
         "TOP_LEVEL_ENV",
         "DEFS_OBJECT_ENV",

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/editor/__init__.py
@@ -59,7 +59,7 @@ def install_or_update_yaml_schema_extension(
     template_package_json_path = Path(__file__).parent / "vscode_extension_package.json"
     template_package_json = json.loads(template_package_json_path.read_text())
     template_package_json["contributes"]["yamlValidation"] = [
-        {"fileMatch": f"{yaml_dir}/**/*.y*ml", "url": f"{schema_path}"}
+        {"fileMatch": f"{yaml_dir}/**/component.y*ml", "url": f"{schema_path}"}
     ]
 
     extension_working_dir.mkdir(parents=True, exist_ok=True)
@@ -73,7 +73,7 @@ def install_or_update_yaml_schema_extension(
             template_package_json["contributes"]["yamlValidation"].extend(
                 entry
                 for entry in existing_yaml_validation
-                if entry["fileMatch"] != f"{yaml_dir}/**/*.y*ml"
+                if entry["fileMatch"] != f"{yaml_dir}/**/component.y*ml"
             )
 
     extension_package_json_path.write_text(json.dumps(template_package_json, indent=2))


### PR DESCRIPTION
## Summary

More deep-seated impl of #28749, which adds a new `requirements` field to `components.yaml`, which can be requested and merged up the components chain by calling `get_requirements()` on a `Component` object.



This builds and returns a `ComponentRequirements` object, which currently maps the list of used env vars to the component paths which specify those requirements.

This will be used to power some env var related tooling in a stacked PR.


`defs/my_component/component.yaml`
```yaml
type: ...

attributes:
  foo: "{{ env('FOO_ENV') }}"

requirements:
  env:
    - BAR_ENV
```
Produces
`ComponentRequirements(env={"FOO_ENV": {Path("my_component")}, "BAR_ENV": {Path("my_component")}})`

## How I Tested These Changes

Updated existing loader tests, added a few more tests.

