### PR TITLE
[components] adds ability to set `tags` and `owners` metadata on Component with `get_spec`

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -58,6 +58,14 @@ We can define the schema for our component and add it to our class as follows:
   title="my_component_library/lib/shell_command.py"
   />
 
+Additionally, it's possible to include metadata for your Component by overriding the `get_component_type_metadata` method. This allows you to set fields like `owners` and `tags` that will be visible in the generated documentation.
+
+<CodeExample
+  path="docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py"
+  language="python"
+  title="my_component_library/lib/shell_command.py"
+  />
+
 :::tip
 
 When defining a field on a component that isn't on the schema, or is of a different type, the components system allows you to provide custom resolution logic for that field. See the [Providing resolution logic for non-standard types](#advanced-providing-resolution-logic-for-non-standard-types) section for more information.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -1,0 +1,36 @@
+from collections.abc import Sequence
+
+import dagster as dg
+from dagster.components import (
+    Component,
+    ComponentLoadContext,
+    # highlight-start
+    ComponentSpec,
+    # highlight-end
+    Resolvable,
+    ResolvedAssetSpec,
+)
+
+
+class ShellCommand(Component, Resolvable):
+    """Models a shell script as a Dagster asset."""
+
+    # highlight-start
+    @classmethod
+    def get_spec(cls):
+        return ComponentSpec(
+            owners=["John Dagster"],
+            tags=["shell", "script"],
+        )
+
+    # highlight-end
+
+    def __init__(
+        self,
+        script_path: str,
+        asset_specs: Sequence[ResolvedAssetSpec],
+    ):
+        self.script_path = script_path
+        self.asset_specs = asset_specs
+
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions: ...

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
@@ -37,7 +37,7 @@ export default function ComponentHeader({config, descriptionStyle}: Props) {
           </div>
         </div>
       </div>
-      {config.tags && config.tags.length > 0 ? <ComponentTags author={config.author} tags={config.tags} /> : null}
+      {config.tags && config.tags.length > 0 ? <ComponentTags owners={config.owners} tags={config.tags} /> : null}
     </div>
   );
 }

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
@@ -37,7 +37,7 @@ export default function ComponentHeader({config, descriptionStyle}: Props) {
           </div>
         </div>
       </div>
-      {config.tags.length > 0 ? <ComponentTags author={config.author} tags={config.tags} /> : null}
+      {config.tags && config.tags.length > 0 ? <ComponentTags author={config.author} tags={config.tags} /> : null}
     </div>
   );
 }

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentTags.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentTags.tsx
@@ -2,10 +2,14 @@ import clsx from 'clsx';
 
 import styles from './css/ComponentTags.module.css';
 
-export default function ComponentTags({author, tags}: {author: string; tags: string[]}) {
+export default function ComponentTags({owners, tags}: {owners: string[]; tags: string[]}) {
   return (
     <div className={styles.tags}>
-      {author ? <div className={clsx(styles.tag, styles.authorTag)}>author: {author}</div> : null}
+      {owners.map((owner) => (
+        <div className={clsx(styles.tag, styles.authorTag)}>
+         owner: {owner}
+        </div>
+      ))}
       {tags.map((tag) => (
         <div key={tag} className={styles.tag}>
           tag: {tag}

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentTags.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentTags.tsx
@@ -6,7 +6,7 @@ export default function ComponentTags({owners, tags}: {owners: string[]; tags: s
   return (
     <div className={styles.tags}>
       {owners.map((owner) => (
-        <div className={clsx(styles.tag, styles.authorTag)}>
+        <div key={owner} className={clsx(styles.tag, styles.authorTag)}>
          owner: {owner}
         </div>
       ))}

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/types.ts
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/types.ts
@@ -9,10 +9,10 @@ export type Package = {
 
 export type ComponentType = {
   name: string;
-  author: string;
   example: string;
   schema: string;
   description: string;
+  owners: string[];
   tags: string[];
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/dg-docs/DGDocs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/dg-docs/DGDocs.tsx
@@ -2,9 +2,10 @@ import ComponentTags from '@dagster-io/dg-docs-components/ComponentTags';
 
 export const DGDocs = () => {
   const tags = ['component', 'documentation'];
+  const owners = ['foo@bar.com'];
   return (
     <div>
-      <ComponentTags author="foo@bar.com" tags={tags} />
+      <ComponentTags owners={owners} tags={tags} />
     </div>
   );
 };

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -11,6 +11,12 @@ class SimpleAssetComponent(Component, Resolvable, Model):
     asset_key: str
     value: str
 
+    def get_author():
+        return "John Smith"
+
+    def get_tags():
+        return ["a", "b", "c"]
+
     def __init__(self, asset_key: AssetKey, value: str):
         self._asset_key = asset_key
         self._value = value

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -11,9 +11,11 @@ class SimpleAssetComponent(Component, Resolvable, Model):
     asset_key: str
     value: str
 
+    @staticmethod
     def get_author():
         return "John Smith"
 
+    @staticmethod
     def get_tags():
         return ["a", "b", "c"]
 

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -15,7 +15,8 @@ class SimpleAssetComponent(Component, Resolvable, Model):
         self._asset_key = asset_key
         self._value = value
 
-    def get_metadata():
+    @classmethod
+    def get_metadata(cls):
         return ComponentMetadata(
             author="John Smith",
             tags=["a", "b", "c"],

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -2,7 +2,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components import Component, ComponentLoadContext, Model, Resolvable
+from dagster.components import Component, ComponentLoadContext, ComponentMetadata, Model, Resolvable
 
 
 class SimpleAssetComponent(Component, Resolvable, Model):
@@ -11,17 +11,15 @@ class SimpleAssetComponent(Component, Resolvable, Model):
     asset_key: str
     value: str
 
-    @staticmethod
-    def get_author():
-        return "John Smith"
-
-    @staticmethod
-    def get_tags():
-        return ["a", "b", "c"]
-
     def __init__(self, asset_key: AssetKey, value: str):
         self._asset_key = asset_key
         self._value = value
+
+    def get_metadata():
+        return ComponentMetadata(
+            author="John Smith",
+            tags=["a", "b", "c"],
+        )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         @asset(key=self._asset_key)

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -16,9 +16,9 @@ class SimpleAssetComponent(Component, Resolvable, Model):
         self._value = value
 
     @classmethod
-    def get_metadata(cls):
+    def get_component_type_metadata(cls):
         return ComponentMetadata(
-            author="John Smith",
+            owners=["John Dagster", "Jane Dagster"],
             tags=["a", "b", "c"],
         )
 

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -2,7 +2,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components import Component, ComponentLoadContext, ComponentMetadata, Model, Resolvable
+from dagster.components import Component, ComponentLoadContext, ComponentSpec, Model, Resolvable
 
 
 class SimpleAssetComponent(Component, Resolvable, Model):
@@ -16,9 +16,9 @@ class SimpleAssetComponent(Component, Resolvable, Model):
         self._value = value
 
     @classmethod
-    def get_component_type_metadata(cls):
-        return ComponentMetadata(
-            owners=["John Dagster", "Jane Dagster"],
+    def get_spec(cls):
+        return ComponentSpec(
+            owners=["john@dagster.io", "jane@dagster.io"],
             tags=["a", "b", "c"],
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -157,6 +157,14 @@ def validate_asset_owner(owner: str, key: "AssetKey") -> None:
         )
 
 
+def validate_component_owner(owner: str) -> None:
+    if not is_valid_asset_owner(owner):
+        raise DagsterInvalidDefinitionError(
+            f"Invalid owner '{owner}'. Owner must be an email address or a team "
+            "name prefixed with 'team:'."
+        )
+
+
 def is_valid_asset_owner(owner: str) -> bool:
     return is_valid_email(owner) or (owner.startswith("team:") and len(owner) > 5)
 

--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -1,6 +1,6 @@
 from dagster.components.component.component import (
     Component as Component,
-    ComponentMetadata as ComponentMetadata,
+    ComponentSpec as ComponentSpec,
 )
 from dagster.components.component.component_loader import component as component
 from dagster.components.component.component_scaffolder import (

--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -1,4 +1,7 @@
-from dagster.components.component.component import Component as Component
+from dagster.components.component.component import (
+    Component as Component,
+    ComponentMetadata as ComponentMetadata,
+)
 from dagster.components.component.component_loader import component as component
 from dagster.components.component.component_scaffolder import (
     DefaultComponentScaffolder as DefaultComponentScaffolder,

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -20,6 +20,14 @@ class Component(ABC):
     @classmethod
     def __dg_package_entry__(cls) -> None: ...
 
+    @staticmethod
+    def get_author() -> Optional[str]:
+        return None
+
+    @staticmethod
+    def get_tags() -> Optional[list[str]]:
+        return None
+
     @classmethod
     def get_schema(cls) -> Optional[type[BaseModel]]:
         return None

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -1,6 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel
@@ -15,22 +15,25 @@ if TYPE_CHECKING:
     from dagster.components.core.context import ComponentLoadContext
 
 
+class ComponentMetadata(BaseModel):
+    """Metadata assigned to the Component."""
+
+    author: Optional[str] = None
+    tags: Optional[Sequence[str]] = None
+
+
 @scaffold_with(DefaultComponentScaffolder)
 class Component(ABC):
     @classmethod
     def __dg_package_entry__(cls) -> None: ...
 
-    @staticmethod
-    def get_author() -> Optional[str]:
-        return None
-
-    @staticmethod
-    def get_tags() -> Optional[list[str]]:
-        return None
-
     @classmethod
     def get_schema(cls) -> Optional[type[BaseModel]]:
         return None
+
+    @classmethod
+    def get_metadata(cls) -> ComponentMetadata:
+        return ComponentMetadata()
 
     @classmethod
     def get_model_cls(cls) -> Optional[type[BaseModel]]:

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -3,10 +3,14 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
+from dagster_shared.record import IHaveNew, record_custom
 from pydantic import BaseModel
 from typing_extensions import Self
 
+import dagster._check as check
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.utils import validate_component_owner
 from dagster.components.component.component_scaffolder import DefaultComponentScaffolder
 from dagster.components.resolved.base import Resolvable
 from dagster.components.scaffold.scaffold import scaffold_with
@@ -15,11 +19,45 @@ if TYPE_CHECKING:
     from dagster.components.core.context import ComponentLoadContext
 
 
-class ComponentMetadata(BaseModel):
-    """Metadata assigned to the Component."""
+@record_custom
+class ComponentSpec(IHaveNew):
+    """Specifies the core attributes of a component.
 
-    owners: Optional[Sequence[str]] = None
-    tags: Optional[Sequence[str]] = None
+    Args:
+        description (Optional[str]): Human-readable description of this component.
+        metadata (Optional[Dict[str, Any]]): A dict of static metadata for this component.
+            For example, users can provide information about the database table this
+            component corresponds to.
+        owners (Optional[Sequence[str]]): A list of strings representing owners of the component. Each
+            string can be a user's email address, or a team name prefixed with `team:`,
+            e.g. `team:finops`.
+        tags (Optional[Sequence[str]]): Tags for filtering and organizing.
+
+    """
+
+    description: PublicAttr[Optional[str]]
+    tags: PublicAttr[Sequence[str]]
+    owners: PublicAttr[Sequence[str]]
+    metadata: PublicAttr[Mapping[str, Any]]
+
+    def __new__(
+        cls,
+        description: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        owners: Optional[Sequence[str]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ):
+        owners = check.opt_sequence_param(owners, "owners", of_type=str)
+        for owner in owners:
+            validate_component_owner(owner)
+
+        return super().__new__(
+            cls,
+            description=check.opt_str_param(description, "description"),
+            tags=check.opt_sequence_param(tags, "tags", of_type=str),
+            owners=owners,
+            metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
 
 
 @scaffold_with(DefaultComponentScaffolder)
@@ -32,8 +70,8 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_component_type_metadata(cls) -> ComponentMetadata:
-        return ComponentMetadata()
+    def get_spec(cls) -> ComponentSpec:
+        return ComponentSpec()
 
     @classmethod
     def get_model_cls(cls) -> Optional[type[BaseModel]]:
@@ -72,4 +110,4 @@ class Component(ABC):
 
     @classmethod
     def get_description(cls) -> Optional[str]:
-        return inspect.getdoc(cls)
+        return cls.get_spec().description or inspect.getdoc(cls)

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class ComponentMetadata(BaseModel):
     """Metadata assigned to the Component."""
 
-    author: Optional[str] = None
+    owners: Optional[Sequence[str]] = None
     tags: Optional[Sequence[str]] = None
 
 
@@ -32,7 +32,7 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_metadata(cls) -> ComponentMetadata:
+    def get_component_type_metadata(cls) -> ComponentMetadata:
         return ComponentMetadata()
 
     @classmethod

--- a/python_modules/dagster/dagster/components/core/snapshot.py
+++ b/python_modules/dagster/dagster/components/core/snapshot.py
@@ -15,7 +15,8 @@ from dagster.components.scaffold.scaffold import Scaffolder, get_scaffolder
 def _clean_docstring(docstring: str) -> str:
     lines = docstring.strip().splitlines()
     first_line = lines[0]
-    if len(lines) == 1: return first_line
+    if len(lines) == 1:
+        return first_line
     else:
         rest = textwrap.dedent("\n".join(lines[1:]))
         return f"{first_line}\n{rest}"
@@ -44,19 +45,22 @@ def _get_scaffold_target_type_data(scaffolder: Scaffolder) -> ScaffoldTargetType
 
 def get_package_entry_snap(key: PackageObjectKey, obj: object) -> PackageObjectSnap:
     type_data = []
-    summary, description = _get_summary_and_description(obj)
+    owners = []
+    tags = []
     if isinstance(obj, type) and issubclass(obj, Component):
         type_data.append(_get_component_type_data(obj))
         spec = obj.get_spec()
-        description = spec.description
         owners = spec.owners
         tags = spec.tags
     scaffolder = get_scaffolder(obj)
     if isinstance(scaffolder, Scaffolder):
         type_data.append(_get_scaffold_target_type_data(scaffolder))
-        owners = None
-        tags = None
+    summary, description = _get_summary_and_description(obj)
     return PackageObjectSnap(
-        key=key, summary=summary, owners=owners, tags=tags, description=description, feature_data=type_data
+        key=key,
+        summary=summary,
+        owners=owners,
+        tags=tags,
+        description=description,
+        feature_data=type_data,
     )
-

--- a/python_modules/dagster/dagster/components/core/snapshot.py
+++ b/python_modules/dagster/dagster/components/core/snapshot.py
@@ -15,8 +15,7 @@ from dagster.components.scaffold.scaffold import Scaffolder, get_scaffolder
 def _clean_docstring(docstring: str) -> str:
     lines = docstring.strip().splitlines()
     first_line = lines[0]
-    if len(lines) == 1:
-        return first_line
+    if len(lines) == 1: return first_line
     else:
         rest = textwrap.dedent("\n".join(lines[1:]))
         return f"{first_line}\n{rest}"
@@ -45,12 +44,19 @@ def _get_scaffold_target_type_data(scaffolder: Scaffolder) -> ScaffoldTargetType
 
 def get_package_entry_snap(key: PackageObjectKey, obj: object) -> PackageObjectSnap:
     type_data = []
+    summary, description = _get_summary_and_description(obj)
     if isinstance(obj, type) and issubclass(obj, Component):
         type_data.append(_get_component_type_data(obj))
+        spec = obj.get_spec()
+        description = spec.description
+        owners = spec.owners
+        tags = spec.tags
     scaffolder = get_scaffolder(obj)
     if isinstance(scaffolder, Scaffolder):
         type_data.append(_get_scaffold_target_type_data(scaffolder))
-    summary, description = _get_summary_and_description(obj)
+        owners = None
+        tags = None
     return PackageObjectSnap(
-        key=key, summary=summary, description=description, feature_data=type_data
+        key=key, summary=summary, owners=owners, tags=tags, description=description, feature_data=type_data
     )
+

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -50,25 +50,8 @@ def test_list_library_objects_from_module():
         "dagster_test.components.SimplePipesScriptComponent",
     ]
 
-<<<<<<< HEAD
     assert result[2] == PackageObjectSnap(
         key=PackageObjectKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
-=======
-    assert result[2] == ComponentTypeSnap(
-        key=LibraryObjectKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
-        schema={
-            "additionalProperties": False,
-            "properties": {
-                "asset_key": {"title": "Asset Key", "type": "string"},
-                "value": {"title": "Value", "type": "string"},
-            },
-            "required": ["asset_key", "value"],
-            "title": "SimpleAssetComponentModel",
-            "type": "object",
-        },
-        owners=["John Dagster", "Jane Dagster"],
-        tags=["a", "b", "c"],
->>>>>>> 51a84b75ec (allow owners, and rename get_metadata to get_component_type_metadata)
         description="A simple asset that returns a constant string value.",
         summary="A simple asset that returns a constant string value.",
         feature_data=[

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -50,8 +50,25 @@ def test_list_library_objects_from_module():
         "dagster_test.components.SimplePipesScriptComponent",
     ]
 
+<<<<<<< HEAD
     assert result[2] == PackageObjectSnap(
         key=PackageObjectKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
+=======
+    assert result[2] == ComponentTypeSnap(
+        key=LibraryObjectKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
+        schema={
+            "additionalProperties": False,
+            "properties": {
+                "asset_key": {"title": "Asset Key", "type": "string"},
+                "value": {"title": "Value", "type": "string"},
+            },
+            "required": ["asset_key", "value"],
+            "title": "SimpleAssetComponentModel",
+            "type": "object",
+        },
+        owners=["John Dagster", "Jane Dagster"],
+        tags=["a", "b", "c"],
+>>>>>>> 51a84b75ec (allow owners, and rename get_metadata to get_component_type_metadata)
         description="A simple asset that returns a constant string value.",
         summary="A simple asset that returns a constant string value.",
         feature_data=[

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -54,6 +54,8 @@ def test_list_library_objects_from_module():
         key=PackageObjectKey(namespace="dagster_test.components", name="SimpleAssetComponent"),
         description="A simple asset that returns a constant string value.",
         summary="A simple asset that returns a constant string value.",
+        owners=["john@dagster.io", "jane@dagster.io"],
+        tags=["a", "b", "c"],
         feature_data=[
             ComponentFeatureData(
                 schema={
@@ -98,6 +100,8 @@ def test_list_library_objects_from_module():
         ),
         description="A simple asset that runs a Python script with the Pipes subprocess client.\n\nBecause it is a pipes asset, no value is returned.",
         summary="A simple asset that runs a Python script with the Pipes subprocess client.",
+        owners=[],
+        tags=[],
         feature_data=[
             ComponentFeatureData(schema=pipes_script_component_model_schema),
             ScaffoldTargetTypeData(schema=pipes_script_component_scaffold_params_schema),

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -158,7 +158,7 @@ class ComponentTypeJson(TypedDict):
     """Component type JSON, used to back dg docs webapp."""
 
     name: str
-    author: Optional[str]
+    owners: Optional[Sequence[str]]
     tags: Optional[Sequence[str]]
     example: str
     schema: str
@@ -202,7 +202,7 @@ def json_for_component_type(
     sample_yaml = generate_sample_yaml(typename, component_type_data.schema or {})
     return ComponentTypeJson(
         name=typename,
-        author=remote_component_type.author or None,
+        owners=remote_component_type.owners or None,
         tags=remote_component_type.tags or None,
         example=sample_yaml,
         schema=json.dumps(component_type_data.schema),

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -158,8 +158,8 @@ class ComponentTypeJson(TypedDict):
     """Component type JSON, used to back dg docs webapp."""
 
     name: str
-    author: str
-    tags: list[str]
+    author: Optional[str]
+    tags: Optional[Sequence[str]]
     example: str
     schema: str
     description: Optional[str]
@@ -202,8 +202,8 @@ def json_for_component_type(
     sample_yaml = generate_sample_yaml(typename, component_type_data.schema or {})
     return ComponentTypeJson(
         name=typename,
-        author=remote_component_type.author or "",
-        tags=remote_component_type.tags or [],
+        author=remote_component_type.author or None,
+        tags=remote_component_type.tags or None,
         example=sample_yaml,
         schema=json.dumps(component_type_data.schema),
         description=entry.description,

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -202,8 +202,8 @@ def json_for_component_type(
     sample_yaml = generate_sample_yaml(typename, component_type_data.schema or {})
     return ComponentTypeJson(
         name=typename,
-        owners=remote_component_type.owners or None,
-        tags=remote_component_type.tags or None,
+        owners=entry.owners,
+        tags=entry.tags,
         example=sample_yaml,
         schema=json.dumps(component_type_data.schema),
         description=entry.description,

--- a/python_modules/libraries/dagster-dg/dagster_dg/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/docs.py
@@ -202,8 +202,8 @@ def json_for_component_type(
     sample_yaml = generate_sample_yaml(typename, component_type_data.schema or {})
     return ComponentTypeJson(
         name=typename,
-        author="",
-        tags=[],
+        author=remote_component_type.author or "",
+        tags=remote_component_type.tags or [],
         example=sample_yaml,
         schema=json.dumps(component_type_data.schema),
         description=entry.description,

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
@@ -83,6 +83,8 @@ class PackageObjectSnap:
     key: PackageObjectKey
     summary: Optional[str]
     description: Optional[str]
+    owners: Optional[Sequence[str]]
+    tags: Optional[Sequence[str]]
     feature_data: Sequence[PackageObjectFeatureData]
 
     @property


### PR DESCRIPTION
## Summary & Motivation

Closes BUILD-819.

Enables adding component metadata via the `get_spec` method for defining `tags`, `owners`, and overriding the `__doc__` with `description`.

- Adds `ComponentSpec`
- Adds `get_spec` to `Component`
- Updates `PackageObjectSnap` to include `owners` and `tags` for inclusion in JSON dump in `dagster-components list library` (used by `dg docs server`).

Follow-up work will support logos as we need to determine how to either encode or bundle them alongside the component metadata.

## How I Tested These Changes
 
 Unit tests, and `dg docs serve` for the screenshot above.

## Changelog

- [components] Adds `get_spec` on `Component` for defining metadata like `tags` and `owners`.
