### PR TITLE
[ui] Break up LeftNavRepositorySection.test

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import {RepoNavItem} from './RepoNavItem';
 import {SectionedLeftNav} from '../ui/SectionedLeftNav';
 import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
-import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
+import {DagsterRepoOption, SetVisibleOrHiddenFn} from '../workspace/WorkspaceContext/util';
 import {RepoAddress} from '../workspace/types';
 
 const LoadedRepositorySection = ({
@@ -21,7 +21,7 @@ const LoadedRepositorySection = ({
     if (visibleRepos.length) {
       return (
         <div style={{overflow: 'hidden'}}>
-          <SectionedLeftNav />
+          <SectionedLeftNav visibleRepos={visibleRepos} />
         </div>
       );
     }
@@ -79,11 +79,28 @@ const EmptyState = styled.div`
 
 export const LeftNavRepositorySection = memo(() => {
   const {allRepos, loading, visibleRepos, toggleVisible} = useContext(WorkspaceContext);
-
   if (loading && !visibleRepos) {
     return <div style={{flex: 1}} />;
   }
 
+  return (
+    <LeftNavRepositorySectionInner
+      allRepos={allRepos}
+      visibleRepos={visibleRepos}
+      toggleVisible={toggleVisible}
+    />
+  );
+});
+
+export const LeftNavRepositorySectionInner = ({
+  allRepos,
+  visibleRepos,
+  toggleVisible,
+}: {
+  allRepos: DagsterRepoOption[];
+  visibleRepos: DagsterRepoOption[];
+  toggleVisible: SetVisibleOrHiddenFn;
+}) => {
   return (
     <LoadedRepositorySection
       allRepos={allRepos}
@@ -91,4 +108,4 @@ export const LeftNavRepositorySection = memo(() => {
       toggleVisible={toggleVisible}
     />
   );
-});
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__fixtures__/LeftNavRepositorySection.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__fixtures__/LeftNavRepositorySection.fixtures.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
 import {buildWorkspaceMocks} from '../../workspace/WorkspaceContext/__fixtures__/Workspace.fixtures';
+import {DagsterRepoOption} from '../../workspace/WorkspaceContext/util';
 import {DUNDER_REPO_NAME} from '../../workspace/buildRepoAddress';
 import {INSTIGATION_STATES_QUERY} from '../InstigationStatesQuery';
 import {
@@ -46,84 +47,156 @@ const buildRepo = ({
 
 export const buildWorkspaceQueryWithZeroLocations = () => buildWorkspaceMocks([]);
 
-const locationEntries = [
-  buildWorkspaceLocationEntry({
-    id: 'ipsum-entry',
-    name: 'ipsum-entry',
-    locationOrLoadError: buildRepositoryLocation({
+const loremRepo = buildRepo({
+  id: 'lorem',
+  name: 'lorem',
+  jobNames: ['my_pipeline', 'other_pipeline'],
+});
+
+const ipsumLocation = buildRepositoryLocation({
+  id: 'ipsum',
+  name: 'ipsum',
+  repositories: [loremRepo],
+});
+
+export const loremIpsumOption: DagsterRepoOption = {
+  repository: loremRepo,
+  repositoryLocation: ipsumLocation,
+};
+
+const fooRepo = buildRepo({
+  id: 'foo',
+  name: 'foo',
+  jobNames: ['bar_job', 'd_job', 'e_job', 'f_job'],
+});
+
+const barLocation = buildRepositoryLocation({
+  id: 'bar',
+  name: 'bar',
+  repositories: [fooRepo],
+});
+
+export const fooBarOption: DagsterRepoOption = {
+  repository: fooRepo,
+  repositoryLocation: barLocation,
+};
+
+const abcRepo = buildRepo({
+  id: 'abc_location_repo_id',
+  name: DUNDER_REPO_NAME,
+  jobNames: ['abc_job', 'def_job', 'ghi_job', 'jkl_job', 'mno_job', 'pqr_job'],
+});
+
+const abcLocation = buildRepositoryLocation({
+  id: 'abc_location',
+  name: 'abc_location',
+  repositories: [abcRepo],
+});
+
+export const abcLocationOption: DagsterRepoOption = {
+  repository: abcRepo,
+  repositoryLocation: abcLocation,
+};
+
+const entryRepo = buildRepo({
+  id: 'entry',
+  name: 'entry',
+  jobNames: ['my_pipeline', 'other_pipeline'],
+  assetGroupNames: ['my_asset_group'],
+});
+
+const uniqueLocation = buildRepositoryLocation({
+  id: 'unique',
+  name: 'unique',
+  repositories: [entryRepo],
+});
+
+export const uniqueOption: DagsterRepoOption = {
+  repository: entryRepo,
+  repositoryLocation: uniqueLocation,
+};
+
+const locationEntries = () =>
+  [
+    buildWorkspaceLocationEntry({
       id: 'ipsum',
       name: 'ipsum',
-      repositories: [
-        buildRepo({id: 'lorem', name: 'lorem', jobNames: ['my_pipeline', 'other_pipeline']}),
-      ],
+      locationOrLoadError: buildRepositoryLocation({
+        id: 'ipsum',
+        name: 'ipsum',
+        repositories: [
+          buildRepo({id: 'lorem', name: 'lorem', jobNames: ['my_pipeline', 'other_pipeline']}),
+        ],
+      }),
     }),
-  }),
-  buildWorkspaceLocationEntry({
-    id: 'bar-entry',
-    name: 'bar-entry',
-    locationOrLoadError: buildRepositoryLocation({
+    buildWorkspaceLocationEntry({
       id: 'bar',
       name: 'bar',
-      repositories: [
-        buildRepo({id: 'foo', name: 'foo', jobNames: ['bar_job', 'd_job', 'e_job', 'f_job']}),
-      ],
+      locationOrLoadError: buildRepositoryLocation({
+        id: 'bar',
+        name: 'bar',
+        repositories: [
+          buildRepo({id: 'foo', name: 'foo', jobNames: ['bar_job', 'd_job', 'e_job', 'f_job']}),
+        ],
+      }),
     }),
-  }),
-  buildWorkspaceLocationEntry({
-    id: 'abc_location-entry',
-    name: 'abc_location-entry',
-    locationOrLoadError: buildRepositoryLocation({
+    buildWorkspaceLocationEntry({
       id: 'abc_location',
       name: 'abc_location',
-      repositories: [
-        buildRepo({
-          id: 'abc_location_repo_id',
-          name: DUNDER_REPO_NAME,
-          jobNames: ['abc_job', 'def_job', 'ghi_job', 'jkl_job', 'mno_job', 'pqr_job'],
-        }),
-      ],
+      locationOrLoadError: buildRepositoryLocation({
+        id: 'abc_location',
+        name: 'abc_location',
+        repositories: [
+          buildRepo({
+            id: 'abc_location_repo_id',
+            name: DUNDER_REPO_NAME,
+            jobNames: ['abc_job', 'def_job', 'ghi_job', 'jkl_job', 'mno_job', 'pqr_job'],
+          }),
+        ],
+      }),
     }),
-  }),
-] as [WorkspaceLocationEntry, WorkspaceLocationEntry, WorkspaceLocationEntry];
+  ] as [WorkspaceLocationEntry, WorkspaceLocationEntry, WorkspaceLocationEntry];
 
 export const buildWorkspaceQueryWithOneLocation = () => {
-  return buildWorkspaceMocks([locationEntries[0]]);
+  return buildWorkspaceMocks([locationEntries()[0]]);
 };
 
 export const buildWorkspaceQueryWithThreeLocations = () => {
-  return buildWorkspaceMocks(locationEntries);
+  return buildWorkspaceMocks(locationEntries());
 };
 
-const entryWithOneLocationAndAssetGroup = buildWorkspaceLocationEntry({
-  id: 'unique-entry',
-  name: 'unique-entry',
-  locationOrLoadError: buildRepositoryLocation({
+const entryWithOneLocationAndAssetGroup = () =>
+  buildWorkspaceLocationEntry({
     id: 'unique',
     name: 'unique',
-    repositories: [
-      buildRepo({
-        id: 'entry',
-        name: 'entry',
-        jobNames: ['my_pipeline', 'other_pipeline'],
-        assetGroupNames: ['my_asset_group'],
-      }),
-    ],
-  }),
-});
+    locationOrLoadError: buildRepositoryLocation({
+      id: 'unique',
+      name: 'unique',
+      repositories: [
+        buildRepo({
+          id: 'entry',
+          name: 'entry',
+          jobNames: ['my_pipeline', 'other_pipeline'],
+          assetGroupNames: ['my_asset_group'],
+        }),
+      ],
+    }),
+  });
 
 export const buildWorkspaceQueryWithOneLocationAndAssetGroup = () =>
-  buildWorkspaceMocks([entryWithOneLocationAndAssetGroup]);
+  buildWorkspaceMocks([entryWithOneLocationAndAssetGroup()]);
 
-export const buildInstigationStateQueryForLocation = (locationName: string) => {
+export const buildInstigationStateQueryForLocation = (repoId: string) => {
   return buildQueryMock<InstigationStatesQuery, InstigationStatesQueryVariables>({
     query: INSTIGATION_STATES_QUERY,
     variables: {
-      repositoryID: locationName,
+      repositoryID: repoId,
     },
     data: {
       instigationStatesOrError: buildInstigationStates({
         results: [],
       }),
     },
+    maxUsageCount: 1000,
   });
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -1,354 +1,86 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {useContext} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {__resetForJest} from '../../search/useIndexedDBCachedQuery';
 import {mockViewportClientRect, restoreViewportClientRect} from '../../testing/mocking';
+import {LeftNavRepositorySectionInner} from '../LeftNavRepositorySection';
 import {
-  HIDDEN_REPO_KEYS,
-  WorkspaceContext,
-  WorkspaceProvider,
-} from '../../workspace/WorkspaceContext/WorkspaceContext';
-import {DUNDER_REPO_NAME} from '../../workspace/buildRepoAddress';
-import {LeftNavRepositorySection} from '../LeftNavRepositorySection';
-import {
+  abcLocationOption,
   buildInstigationStateQueryForLocation,
-  buildWorkspaceQueryWithOneLocation,
-  buildWorkspaceQueryWithOneLocationAndAssetGroup,
-  buildWorkspaceQueryWithThreeLocations,
-  buildWorkspaceQueryWithZeroLocations,
+  fooBarOption,
+  loremIpsumOption,
+  uniqueOption,
 } from '../__fixtures__/LeftNavRepositorySection.fixtures';
 
-describe('Repository options', () => {
-  const locationOne = 'ipsum';
-  const repoOne = 'lorem';
-
+describe('LeftNavRepositorySection', () => {
   beforeEach(() => {
-    window.localStorage.clear();
     mockViewportClientRect();
   });
 
   afterEach(() => {
     restoreViewportClientRect();
-    window.localStorage.clear();
-    __resetForJest();
-    jest.resetModules();
-    jest.resetAllMocks();
   });
 
   it('Correctly displays the current repository state', async () => {
-    window.localStorage.removeItem(`:${HIDDEN_REPO_KEYS}`);
     const user = userEvent.setup();
     const {findByRole} = render(
-      <MemoryRouter initialEntries={['/locations/foo@bar/etc']}>
-        <MockedProvider
-          mocks={[
-            ...buildWorkspaceQueryWithOneLocation(),
-            buildInstigationStateQueryForLocation('lorem'),
-          ]}
-        >
-          <WorkspaceProvider>
-            <LeftNavRepositorySection />
-          </WorkspaceProvider>
+      <MemoryRouter initialEntries={['/locations/lorem@ipsum/etc']}>
+        <MockedProvider mocks={[buildInstigationStateQueryForLocation('lorem')]}>
+          <LeftNavRepositorySectionInner
+            allRepos={[loremIpsumOption, fooBarOption, abcLocationOption]}
+            visibleRepos={[loremIpsumOption]}
+            toggleVisible={jest.fn()}
+          />
         </MockedProvider>
       </MemoryRouter>,
     );
 
-    const repoHeader = await findByRole('button', {name: /lorem/i});
+    const repoHeader = await findByRole('button', {name: /lorem@ipsum/i});
     await user.click(repoHeader);
 
     expect(await findByRole('link', {name: /my_pipeline/i})).toBeVisible();
   });
 
-  describe('localStorage', () => {
-    it('initializes with first repo option, if one option and no localStorage', async () => {
-      window.localStorage.removeItem(`:${HIDDEN_REPO_KEYS}`);
-      const user = userEvent.setup();
-      const {findByRole, findAllByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithOneLocation(),
-              buildInstigationStateQueryForLocation('lorem'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
+  it('initializes with first repo option', async () => {
+    const {findByRole, findAllByRole} = render(
+      <MemoryRouter initialEntries={['/runs']}>
+        <MockedProvider mocks={[buildInstigationStateQueryForLocation('lorem')]}>
+          <LeftNavRepositorySectionInner
+            allRepos={[loremIpsumOption]}
+            visibleRepos={[loremIpsumOption]}
+            toggleVisible={jest.fn()}
+          />
+        </MockedProvider>
+      </MemoryRouter>,
+    );
 
-      const repoHeader = await findByRole('button', {name: /lorem/i});
-      await user.click(repoHeader);
+    const repoHeader = await findByRole('button', {name: /lorem@ipsum/i});
+    expect(repoHeader).toBeVisible();
 
-      // Three links. Two jobs, one repo name at the bottom.
-      expect(await findAllByRole('link')).toHaveLength(3);
-    });
-
-    it(`initializes with one repo if it's the only one, even though it's hidden`, async () => {
-      window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, `["${repoOne}:${locationOne}"]`);
-      const user = userEvent.setup();
-      const {findByRole, findAllByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithOneLocation(),
-              buildInstigationStateQueryForLocation('lorem'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
-
-      const repoHeader = await findByRole('button', {name: /lorem/i});
-      await user.click(repoHeader);
-
-      expect(await findAllByRole('link')).toHaveLength(3);
-    });
-
-    it('initializes with all repos visible, if multiple options and no localStorage', async () => {
-      window.localStorage.removeItem(`:${HIDDEN_REPO_KEYS}`);
-      const {findByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithThreeLocations(),
-              buildInstigationStateQueryForLocation('lorem'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
-
-      const loremHeader = await findByRole('button', {name: /lorem/i});
-      expect(loremHeader).toBeVisible();
-      const fooHeader = await findByRole('button', {name: /foo/i});
-      expect(fooHeader).toBeVisible();
-      const dunderHeader = await findByRole('button', {name: /abc_location/i});
-      expect(dunderHeader).toBeVisible();
-    });
-
-    it('initializes with correct repo option, if `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(
-        `:${HIDDEN_REPO_KEYS}`,
-        `["lorem:ipsum","${DUNDER_REPO_NAME}:abc_location"]`,
-      );
-
-      const user = userEvent.setup();
-      const {findByRole, findAllByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithThreeLocations(),
-              buildInstigationStateQueryForLocation('foo'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
-
-      const fooHeader = await findByRole('button', {name: /foo/i});
-      await user.click(fooHeader);
-
-      // `foo@bar` is visible, and has four jobs. Plus one for repo link at bottom.
-      expect(await findAllByRole('link')).toHaveLength(5);
-    });
-
-    it('initializes with all repo options, no matching `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, '["hello:world"]');
-
-      const {findByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithThreeLocations(),
-              buildInstigationStateQueryForLocation('lorem'),
-              buildInstigationStateQueryForLocation('foo'),
-              buildInstigationStateQueryForLocation('abc_location_repo_id'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
-
-      const loremHeader = await findByRole('button', {name: /lorem/i});
-      expect(loremHeader).toBeVisible();
-      const fooHeader = await findByRole('button', {name: /foo/i});
-      expect(fooHeader).toBeVisible();
-      const dunderHeader = await findByRole('button', {name: /abc_location/i});
-      expect(dunderHeader).toBeVisible();
-    });
-
-    it('initializes empty, if all items in `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(
-        `:${HIDDEN_REPO_KEYS}`,
-        `["lorem:ipsum", "foo:bar", "${DUNDER_REPO_NAME}:abc_location"]`,
-      );
-
-      const {findByText, queryByRole, queryAllByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider mocks={buildWorkspaceQueryWithThreeLocations()}>
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
-
-      expect(await findByText(/select a code location to see a list of jobs/i)).toBeVisible();
-      const loremHeader = queryByRole('button', {name: /lorem/i});
-      expect(loremHeader).toBeNull();
-      const fooHeader = queryByRole('button', {name: /foo/i});
-      expect(fooHeader).toBeNull();
-      const dunderHeader = queryByRole('button', {name: /abc_location/i});
-      expect(dunderHeader).toBeNull();
-
-      // No linked jobs or repos. Everything is hidden.
-      expect(queryAllByRole('link')).toHaveLength(0);
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('initializes empty, then shows options when they are added', async () => {
-      const ReloadableTest = () => {
-        const {refetch} = useContext(WorkspaceContext);
-        return (
-          <>
-            <button onClick={() => refetch()}>Refetch workspace</button>
-            <LeftNavRepositorySection />
-          </>
-        );
-      };
-
-      const mocks = [
-        ...buildWorkspaceQueryWithZeroLocations(),
-        ...buildWorkspaceQueryWithThreeLocations(),
-      ];
-
-      await act(() =>
-        render(
-          <MemoryRouter initialEntries={['/runs']}>
-            <MockedProvider mocks={mocks}>
-              <WorkspaceProvider>
-                <ReloadableTest />
-              </WorkspaceProvider>
-            </MockedProvider>
-          </MemoryRouter>,
-        ),
-      );
-
-      // Zero repositories, so zero pipelines.
-      expect(screen.queryAllByRole('link')).toHaveLength(0);
-
-      const reloadButton = screen.getByRole('button', {name: /refetch workspace/i});
-      await userEvent.click(reloadButton);
-
-      const loremHeader = await waitFor(() => screen.findByRole('button', {name: /lorem/i}));
-      await waitFor(() => {
-        expect(loremHeader).toBeVisible();
-      });
-
-      const fooHeader = screen.getByRole('button', {name: /foo/i});
-      expect(fooHeader).toBeVisible();
-      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
-      expect(dunderHeader).toBeVisible();
-
-      await act(async () => {
-        await userEvent.click(loremHeader);
-        await userEvent.click(fooHeader);
-        await userEvent.click(dunderHeader);
-      });
-
-      // After repositories are added and expanded, all become visible.
-      await waitFor(() => {
-        expect(screen.getAllByRole('link')).toHaveLength(12);
-      });
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('initializes with options, then shows empty if they are removed', async () => {
-      const ReloadableTest = () => {
-        const {refetch} = useContext(WorkspaceContext);
-        return (
-          <>
-            <button onClick={() => refetch()}>Refetch workspace</button>
-            <LeftNavRepositorySection />
-          </>
-        );
-      };
-
-      const mocks = [
-        ...buildWorkspaceQueryWithOneLocation(),
-        ...buildWorkspaceQueryWithZeroLocations(),
-      ];
-
-      await act(() =>
-        render(
-          <MemoryRouter initialEntries={['/runs']}>
-            <MockedProvider mocks={mocks}>
-              <WorkspaceProvider>
-                <ReloadableTest />
-              </WorkspaceProvider>
-            </MockedProvider>
-          </MemoryRouter>,
-        ),
-      );
-
-      const loremHeader = await screen.findByRole('button', {name: /lorem/i});
-      expect(loremHeader).toBeVisible();
-      await userEvent.click(loremHeader);
-
-      // Three links: two jobs, one repo link at bottom.
-      expect(screen.queryAllByRole('link')).toHaveLength(3);
-
-      const reloadButton = screen.getByRole('button', {name: /refetch workspace/i});
-      await userEvent.click(reloadButton);
-
-      await waitFor(() => {
-        // After repositories are removed, there are none displayed.
-        expect(screen.queryAllByRole('link')).toHaveLength(0);
-      });
-    });
+    // Three links. Two jobs, one repo name at the bottom.
+    expect(await findAllByRole('link')).toHaveLength(3);
   });
 
-  describe('Asset groups', () => {
-    it('renders asset groups alongside jobs', async () => {
-      window.localStorage.removeItem(`:${HIDDEN_REPO_KEYS}`);
-      const user = userEvent.setup();
-      const {findByRole} = render(
-        <MemoryRouter initialEntries={['/runs']}>
-          <MockedProvider
-            mocks={[
-              ...buildWorkspaceQueryWithOneLocationAndAssetGroup(),
-              buildInstigationStateQueryForLocation('entry'),
-            ]}
-          >
-            <WorkspaceProvider>
-              <LeftNavRepositorySection />
-            </WorkspaceProvider>
-          </MockedProvider>
-        </MemoryRouter>,
-      );
+  it('renders asset groups alongside jobs', async () => {
+    const user = userEvent.setup();
 
-      const repoHeader = await findByRole('button', {name: /unique/i});
-      await user.click(repoHeader);
+    const {findByRole} = render(
+      <MemoryRouter initialEntries={['/runs']}>
+        <MockedProvider mocks={[buildInstigationStateQueryForLocation('entry')]}>
+          <LeftNavRepositorySectionInner
+            allRepos={[uniqueOption]}
+            visibleRepos={[uniqueOption]}
+            toggleVisible={jest.fn()}
+          />
+        </MockedProvider>
+      </MemoryRouter>,
+    );
 
-      expect(await findByRole('link', {name: /my_pipeline/i})).toBeVisible();
-      expect(await findByRole('link', {name: /my_asset_group/i})).toBeVisible();
-    });
+    const repoHeader = await findByRole('button', {name: /unique/i});
+    await user.click(repoHeader);
+
+    expect(await findByRole('link', {name: /my_pipeline/i})).toBeVisible();
+    expect(await findByRole('link', {name: /my_asset_group/i})).toBeVisible();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/RepoOptionVisibility.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/RepoOptionVisibility.test.tsx
@@ -1,0 +1,128 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, waitFor} from '@testing-library/react';
+import {useContext} from 'react';
+
+import {testId} from '../../testing/testId';
+import {
+  HIDDEN_REPO_KEYS,
+  WorkspaceContext,
+  WorkspaceProvider,
+} from '../../workspace/WorkspaceContext/WorkspaceContext';
+import {DUNDER_REPO_NAME} from '../../workspace/buildRepoAddress';
+import {
+  buildWorkspaceQueryWithOneLocation,
+  buildWorkspaceQueryWithThreeLocations,
+} from '../__fixtures__/LeftNavRepositorySection.fixtures';
+
+describe('Repo option visibility', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const Test = () => {
+    const {visibleRepos, loading} = useContext(WorkspaceContext);
+    return (
+      <div data-testid={testId('target')}>
+        {loading
+          ? 'loading…'
+          : visibleRepos
+              .map((repo) => `${repo.repository.name}@${repo.repositoryLocation.name}`)
+              .join(', ')}
+      </div>
+    );
+  };
+
+  it(`initializes with one repo if it's the only one, even though it's hidden`, async () => {
+    window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, `["lorem:ipsum"]`);
+
+    const {findByTestId} = render(
+      <MockedProvider mocks={[...buildWorkspaceQueryWithOneLocation()]}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    const element = await findByTestId('target');
+    expect(element).toHaveTextContent('loading…');
+    await waitFor(async () => {
+      expect(element).toHaveTextContent('lorem@ipsum');
+    });
+  });
+
+  it('initializes with all repos visible, if multiple options and no localStorage', async () => {
+    window.localStorage.removeItem(`:${HIDDEN_REPO_KEYS}`);
+
+    const {findByTestId} = render(
+      <MockedProvider mocks={[...buildWorkspaceQueryWithThreeLocations()]}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    const element = await findByTestId('target');
+    await waitFor(async () => {
+      expect(element).toHaveTextContent('__repository__@abc_location, foo@bar, lorem@ipsum');
+    });
+  });
+
+  it('initializes with correct repo option, if `HIDDEN_REPO_KEYS` localStorage', async () => {
+    window.localStorage.setItem(
+      `:${HIDDEN_REPO_KEYS}`,
+      `["lorem:ipsum","${DUNDER_REPO_NAME}:abc_location"]`,
+    );
+
+    const {findByTestId} = render(
+      <MockedProvider mocks={[...buildWorkspaceQueryWithThreeLocations()]}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    const element = await findByTestId('target');
+    await waitFor(async () => {
+      expect(element).toHaveTextContent('foo@bar');
+    });
+  });
+
+  it('initializes with all repo options, no matching `HIDDEN_REPO_KEYS` localStorage', async () => {
+    window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, '["hello:world"]');
+
+    const {findByTestId} = render(
+      <MockedProvider mocks={[...buildWorkspaceQueryWithThreeLocations()]}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    const element = await findByTestId('target');
+    await waitFor(async () => {
+      expect(element).toHaveTextContent('__repository__@abc_location, foo@bar, lorem@ipsum');
+    });
+  });
+
+  it('initializes empty, if all items in `HIDDEN_REPO_KEYS` localStorage', async () => {
+    window.localStorage.setItem(
+      `:${HIDDEN_REPO_KEYS}`,
+      `["lorem:ipsum", "foo:bar", "${DUNDER_REPO_NAME}:abc_location"]`,
+    );
+
+    const {findByTestId} = render(
+      <MockedProvider mocks={buildWorkspaceQueryWithThreeLocations()}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    const element = await findByTestId('target');
+    await waitFor(async () => {
+      expect(element).not.toHaveTextContent('loading…');
+    });
+
+    expect(element).toHaveTextContent('');
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
@@ -25,14 +25,14 @@ import {
   getTopLevelResourceDetailsItemsForOption,
 } from '../nav/getLeftNavItemsForOption';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
-import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
+import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
 import {DUNDER_REPO_NAME, buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString, repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
 const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
-const EXPANDED_REPO_KEYS = 'dagster.expanded-repo-keys';
+export const EXPANDED_REPO_KEYS = 'dagster.expanded-repo-keys';
 
 type ItemType = 'asset-group' | 'job' | 'resource';
 
@@ -48,8 +48,11 @@ type RowType =
       isLast: boolean;
     };
 
-export const SectionedLeftNav = () => {
-  const {visibleRepos} = React.useContext(WorkspaceContext);
+interface Props {
+  visibleRepos: DagsterRepoOption[];
+}
+
+export const SectionedLeftNav = ({visibleRepos}: Props) => {
   const {basePath} = React.useContext(AppContext);
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__stories__/SectionedLeftNav.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__stories__/SectionedLeftNav.stories.tsx
@@ -1,8 +1,11 @@
 import {Meta} from '@storybook/react';
 
 import {LEFT_NAV_WIDTH} from '../../nav/LeftNav';
-import {StorybookProvider} from '../../testing/StorybookProvider';
-import {defaultMocks, hyphenatedName} from '../../testing/defaultMocks';
+import {
+  abcLocationOption,
+  fooBarOption,
+  loremIpsumOption,
+} from '../../nav/__fixtures__/LeftNavRepositorySection.fixtures';
 import {SectionedLeftNav} from '../SectionedLeftNav';
 
 // eslint-disable-next-line import/no-default-export
@@ -11,82 +14,18 @@ export default {
   component: SectionedLeftNav,
 } as Meta;
 
-const names = [hyphenatedName(4), hyphenatedName(4), hyphenatedName(4), hyphenatedName(4)];
-let repoIndex = 0;
-let nameIndex = 0;
-
 export const Default = () => {
-  const mocks = {
-    Pipeline: () => ({
-      name: () => names[nameIndex++ % 4],
-      modes: () => [...new Array(1)],
-      isAssetJob: () => false,
-    }),
-    Schedule: () => ({
-      id: hyphenatedName,
-      name: hyphenatedName,
-      pipelineName: () => names[0],
-      results: () => [...new Array(1)],
-    }),
-    Sensor: () => ({
-      id: hyphenatedName,
-      name: hyphenatedName,
-      targets: () => [
-        {
-          pipelineName: names[1],
-          mode: 'mistmatching_mode',
-        },
-      ],
-      results: () => [...new Array(1)],
-    }),
-    Repository: () => ({
-      ...defaultMocks.Repository(),
-      name: () => (repoIndex++ % 2 === 0 ? 'default' : hyphenatedName(4)),
-      sensors: () => (repoIndex === 1 ? [...new Array(2)] : []),
-      schedules: () => (repoIndex === 1 ? [...new Array(2)] : []),
-    }),
-    RepositoryLocation: () => ({
-      ...defaultMocks.RepositoryLocation(),
-      name: () => hyphenatedName(6),
-    }),
-    Workspace: () => ({
-      ...defaultMocks.Workspace(),
-      locationEntries: () => [...new Array(2)],
-    }),
-  };
-
   return (
-    <StorybookProvider apolloProps={{mocks}}>
-      <div style={{position: 'absolute', left: 0, top: 0, height: '100%', width: LEFT_NAV_WIDTH}}>
-        <SectionedLeftNav />
-      </div>
-    </StorybookProvider>
+    <div style={{position: 'absolute', left: 0, top: 0, height: '100%', width: LEFT_NAV_WIDTH}}>
+      <SectionedLeftNav visibleRepos={[loremIpsumOption, fooBarOption, abcLocationOption]} />
+    </div>
   );
 };
 
 export const SingleRepo = () => {
-  const mocks = {
-    Repository: () => ({
-      ...defaultMocks.Repository(),
-      pipelines: () => [...new Array(15)],
-    }),
-    RepositoryLocation: () => ({
-      environmentPath: () => 'what then',
-      id: () => 'my_location',
-      name: () => 'my_location',
-      repositories: () => [...new Array(1)],
-    }),
-    Workspace: () => ({
-      ...defaultMocks.Workspace(),
-      locationEntries: () => [...new Array(1)],
-    }),
-  };
-
   return (
-    <StorybookProvider apolloProps={{mocks}}>
-      <div style={{position: 'absolute', left: 0, top: 0, height: '100%', width: LEFT_NAV_WIDTH}}>
-        <SectionedLeftNav />
-      </div>
-    </StorybookProvider>
+    <div style={{position: 'absolute', left: 0, top: 0, height: '100%', width: LEFT_NAV_WIDTH}}>
+      <SectionedLeftNav visibleRepos={[loremIpsumOption]} />
+    </div>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Break apart `LeftNavRepositorySection.test`, which is demonstrating some maddening heisenbugs and may just be putting too much under test at once given what we're actually trying to look at here.

I'm creating two separate tests that I think effectively cover what we wanted to test, which is that a) the rendering of the left nav reflects the hidden/visible state tracked in localStorage, and b) the left nav shows expanded states with jobs and asset groups.

- Make `LeftNavRepositorySection.test` test that visible `DagsterRepoOption` items are in fact visible as expected, including expansion of the contained jobs and asset groups.
  - This is now independent of `WorkspaceProvider`, and the supplied repo options are mocked and passed in as props.
- To test the existing localStorage behavior used in `WorkspaceProvider` to track the hidden/visible state of repos, add `RepoOptionVisibility.test`.
  - This tests that the localStorage values used by `WorkspaceProvider` lead to the correct set of `visibleRepos` for rendering.
  - I am not trying to render a full left nav, just a plaintext list of the visible repos.

I haven't been able to pin down the timing issues of the current test, and I can't continue investing the time in the rabbit hole right now. My goal here is to keep testing the behavior we actually care about testing, and get our builds unblocked.

## How I Tested These Changes

yarn jest

Load app, sanity check that hiding/showing and expanding/collapsing in left nav continues to work. Introduce an error to code location, reload code location, verify that the left nav is cleared out. Fix the error, reload code location, verify that the left nav is restored.