### PR TITLE
[dg] Make DgContext work with src-based layout

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-tree.txt
@@ -1,20 +1,20 @@
 cd dagster-workspace && tree
 
 .
+├── dg.toml
 ├── libraries
-├── projects
-│   └── project-1
-│       ├── project_1
-│       │   ├── __init__.py
-│       │   ├── definitions.py
-│       │   ├── defs
-│       │   │   └── __init__.py
-│       │   └── lib
-│       │       └── __init__.py
-│       ├── project_1_tests
-│       │   └── __init__.py
-│       ├── pyproject.toml
-│       └── uv.lock
-└── pyproject.toml
+└── projects
+    └── project-1
+        ├── project_1
+        │   ├── __init__.py
+        │   ├── definitions.py
+        │   ├── defs
+        │   │   └── __init__.py
+        │   └── lib
+        │       └── __init__.py
+        ├── project_1_tests
+        │   └── __init__.py
+        ├── pyproject.toml
+        └── uv.lock
 
 ...

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/3-dg.toml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/3-dg.toml
@@ -1,0 +1,7 @@
+directory_type = "workspace"
+
+[workspace]
+[workspace.scaffold_project_options]
+use_editable_dagster = true
+[[workspace.projects]]
+path = "projects/project-1"

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
@@ -64,8 +64,8 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
             custom_comparison_fn=compare_tree_output,
         )
         check_file(
-            "pyproject.toml",
-            DG_SNIPPETS_DIR / f"{get_next_snip_number()}-pyproject.toml",
+            "dg.toml",
+            DG_SNIPPETS_DIR / f"{get_next_snip_number()}-dg.toml",
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 re_ignore_before("[tool.dagster]"),

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -101,4 +101,4 @@ commands =
   docs_snapshot_test: sh ./docs_snippets_tests/ensure_snapshot_deps.sh
   docs_snapshot_test: pytest -c ../../pyproject.toml -vv {posargs} docs_snippets_tests/snippet_checks
   docs_snapshot_update: sh ./docs_snippets_tests/ensure_snapshot_deps.sh
-  docs_snapshot_update: pytest -c ../../pyproject.toml -vv {posargs} docs_snippets_tests/snippet_checks --update-snippets {env:EXTRA_PARAMS}
+  docs_snapshot_update: pytest -c ../../pyproject.toml -vv {posargs} docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py --update-snippets {env:EXTRA_PARAMS}

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -110,7 +110,9 @@ def dev_command(
     if dg_context.is_workspace:
         os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
             {
-                dg_context.with_root_path(project.path).code_location_name: str(project.path)
+                dg_context.with_root_path(
+                    dg_context.workspace_root_path / project.path
+                ).code_location_name: str(project.path)
                 for project in dg_context.project_specs
             }
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -199,7 +199,7 @@ class DgContext:
 
     # Use to derive a new context for a project while preserving existing settings
     def with_root_path(self, root_path: Path) -> Self:
-        if not root_path / "pyproject.toml":
+        if not ((root_path / "pyproject.toml").exists() or (root_path / "dg.toml").exists()):
             raise DgError(f"Cannot find `pyproject.toml` at {root_path}")
         return self.__class__.from_file_discovery_and_command_line_config(
             root_path, self.cli_opts or {}

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -550,13 +550,19 @@ class DgContext:
             )
         if not module_name.startswith(self.root_module_name):
             raise DgError(f"Module `{module_name}` is not part of the current project.")
-        path = self.root_path / Path(*module_name.split("."))
-        if path.exists():
-            return path
-        elif path.with_suffix(".py").exists():
-            return path.with_suffix(".py")
-        else:
-            raise DgError(f"Cannot find module `{module_name}` in the current project.")
+
+        # Attempt to resolve the path for a local module by looking in both `src` and the root
+        # level. Unfortunately there is no setting reliably present in pyproject.toml or setup.py
+        # that can be relied on to know in advance the package root (src or root level).
+        for path in [
+            self.root_path / "src" / Path(*module_name.split(".")),
+            self.root_path / Path(*module_name.split(".")),
+        ]:
+            if path.exists():
+                return path
+            elif path.with_suffix(".py").exists():
+                return path.with_suffix(".py")
+        raise DgError(f"Cannot find module `{module_name}` in the current project.")
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -56,7 +56,7 @@ def scaffold_workspace(
     )
 
     if workspace_config is not None:
-        with modify_dg_toml_config(new_workspace_path / "pyproject.toml") as toml:
+        with modify_dg_toml_config(new_workspace_path / "dg.toml") as toml:
             for k, v in workspace_config.items():
                 # Ignore empty collections and None, but not False
                 if v != {} and v != [] and v is not None:

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/WORKSPACE_NAME_PLACEHOLDER/dg.toml.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/WORKSPACE_NAME_PLACEHOLDER/dg.toml.jinja
@@ -1,4 +1,3 @@
-[tool.dg]
 directory_type = "workspace"
 
-[tool.dg.workspace]
+[workspace]

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -548,8 +548,8 @@ def set_toml_node(doc: TomlDoc, path: TomlPath, value: object) -> None:
     """Given a tomlkit-parsed document/table (`doc`),set a nested value at `path` to `value`. Raises
     an error if the leading keys do not already lead to a TOML container node.
     """
-    container = _gather_toml_nodes(doc, path[:-1])[-1]
-    key_or_index = path[-1]
+    container = _gather_toml_nodes(doc, path[:-1])[-1] if len(path) > 1 else doc
+    key_or_index = path[-1]  # type: ignore  # pyright bug
     if isinstance(container, dict):
         if not isinstance(key_or_index, str):
             raise TypeError(f"Expected key to be a string, but got {type(key_or_index).__name__}")

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -44,7 +44,7 @@ def test_init_command_success_with_workspace_name(monkeypatch) -> None:
         )
         assert_runner_result(result)
         assert Path("dagster-workspace").exists()
-        assert Path("dagster-workspace/pyproject.toml").exists()
+        assert Path("dagster-workspace/dg.toml").exists()
         assert Path("dagster-workspace/projects").exists()
         assert Path("dagster-workspace/libraries").exists()
         assert Path("dagster-workspace/projects/helloworld").exists()
@@ -53,10 +53,9 @@ def test_init_command_success_with_workspace_name(monkeypatch) -> None:
         assert Path("dagster-workspace/projects/helloworld/helloworld_tests").exists()
 
         # Check workspace TOML content
-        toml = tomlkit.parse(Path("dagster-workspace/pyproject.toml").read_text())
+        toml = tomlkit.parse(Path("dagster-workspace/dg.toml").read_text())
         assert (
-            get_toml_node(toml, ("tool", "dg", "workspace", "projects", 0, "path"), str)
-            == "projects/helloworld"
+            get_toml_node(toml, ("workspace", "projects", 0, "path"), str) == "projects/helloworld"
         )
 
 
@@ -73,7 +72,7 @@ def test_init_override_project_name_prompt_with_workspace(monkeypatch) -> None:
         )
         assert_runner_result(result)
         assert Path("my-workspace").exists()
-        assert Path("my-workspace/pyproject.toml").exists()
+        assert Path("my-workspace/dg.toml").exists()
         assert Path("my-workspace/projects").exists()
         assert Path("my-workspace/libraries").exists()
         assert Path("my-workspace/projects/goodbyeworld").exists()
@@ -144,7 +143,7 @@ def test_init_use_editable_dagster(option: EditableOption, value_source: str, mo
 
         assert Path("dagster-workspace").exists()
 
-        workspace_config = Path("dagster-workspace/pyproject.toml")
+        workspace_config = Path("dagster-workspace/dg.toml")
         with workspace_config.open() as f:
             toml = tomlkit.parse(f.read())
             option_key = option[2:].replace("-", "_")
@@ -152,7 +151,7 @@ def test_init_use_editable_dagster(option: EditableOption, value_source: str, mo
             assert (
                 get_toml_node(
                     toml,
-                    ("tool", "dg", "workspace", "scaffold_project_options", option_key),
+                    ("workspace", "scaffold_project_options", option_key),
                     (bool, str),
                 )
                 == option_value

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -44,7 +44,7 @@ def test_scaffold_workspace_command_success(monkeypatch) -> None:
         result = runner.invoke("scaffold", "workspace")
         assert_runner_result(result)
         assert Path("dagster-workspace").exists()
-        assert Path("dagster-workspace/pyproject.toml").exists()
+        assert Path("dagster-workspace/dg.toml").exists()
         assert Path("dagster-workspace/projects").exists()
         assert Path("dagster-workspace/libraries").exists()
 
@@ -58,7 +58,7 @@ def test_scaffold_workspace_command_name_override_success(monkeypatch) -> None:
         result = runner.invoke("scaffold", "workspace", "my-workspace")
         assert_runner_result(result)
         assert Path("my-workspace").exists()
-        assert Path("my-workspace/pyproject.toml").exists()
+        assert Path("my-workspace/dg.toml").exists()
         assert Path("my-workspace/projects").exists()
         assert Path("my-workspace/libraries").exists()
 
@@ -107,11 +107,8 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert get_toml_node(toml, ("tool", "dg", "project", "root_module"), str) == "foo_bar"
 
         # Check workspace TOML content
-        toml = tomlkit.parse(Path("pyproject.toml").read_text())
-        assert (
-            get_toml_node(toml, ("tool", "dg", "workspace", "projects", 0, "path"), str)
-            == "projects/foo-bar"
-        )
+        toml = tomlkit.parse(Path("dg.toml").read_text())
+        assert get_toml_node(toml, ("workspace", "projects", 0, "path"), str) == "projects/foo-bar"
 
         # Check venv created
         assert Path("projects/foo-bar/.venv").exists()
@@ -142,10 +139,9 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert_runner_result(result)
 
         # Check workspace TOML content
-        toml = tomlkit.parse(Path("pyproject.toml").read_text())
+        toml = tomlkit.parse(Path("dg.toml").read_text())
         assert (
-            get_toml_node(toml, ("tool", "dg", "workspace", "projects", 1, "path"), str)
-            == "other_projects/baz"
+            get_toml_node(toml, ("workspace", "projects", 1, "path"), str) == "other_projects/baz"
         )
 
 
@@ -156,10 +152,10 @@ def test_scaffold_project_inside_workspace_applies_scaffold_project_options(monk
         ProxyRunner.test() as runner,
         isolated_example_workspace(runner, use_editable_dagster=False),
     ):
-        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+        with modify_toml_as_dict(Path("dg.toml")) as toml_dict:
             create_toml_node(
                 toml_dict,
-                ("tool", "dg", "workspace", "scaffold_project_options", "use_editable_dagster"),
+                ("workspace", "scaffold_project_options", "use_editable_dagster"),
                 True,
             )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -21,6 +21,7 @@ from dagster_dg.utils import (
 from dagster_dg_tests.utils import (
     ConfigFileType,
     ProxyRunner,
+    assert_runner_result,
     isolated_components_venv,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
@@ -137,6 +138,20 @@ def test_context_with_user_config():
         context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
         assert context.root_path == Path.cwd()
         assert context.config.cli.verbose is True
+
+
+# Temporary test until we switch src layout to the default.
+def test_context_with_src_layout():
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False, package_layout="src"),
+    ):
+        context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
+        assert context.root_path == Path.cwd()
+        assert context.defs_path == Path.cwd() / "src" / "foo_bar" / "defs"
+
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
 
 
 # ########################


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, `dg` would crash when working with projects with an `src`-based layout. This makes it compatible with `src`-layout projects.

The implementation is a little rough-- we just look for packages in both `src` and in root. The reason for this is that there's not an otherwise reliable great way to detect `src`-based layout. You could try reading `pyproject.toml` and looking for config of well-known build tools, but that's a can of worms. I suspect this solution will work well.

Upstack we are actually going to change the default new project layout to be src-based.

## How I Tested These Changes

New unit test.

## Changelog

Fixed a bug where `dg` would crash when working with Python packages with an src-based layout.