### PR TITLE
Downgrade logs on CPU quota fetch failures from errors to debug

### DIFF
--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -325,7 +325,7 @@ def _retrieve_containerized_cpu_cfs_quota_us_v1(
             return float(f.read())
     except:
         if logger:
-            logger.exception("Failed to retrieve CPU quota from cgroup")
+            logger.debug("Failed to retrieve CPU quota from cgroup", exc_info=True)
         return None
 
 
@@ -339,7 +339,8 @@ def _retrieve_containerized_cpu_cfs_quota_us_v2(
             return float(line.split()[0])
     except:
         if logger:
-            logger.exception(
-                "Failed to retrieve CPU quota from cgroup. There might be not limit set on the container."
+            logger.debug(
+                "Failed to retrieve CPU quota from cgroup. There might not be a limit set on the container.",
+                exc_info=True,
             )
         return None


### PR DESCRIPTION
## Summary & Motivation
This appears to be an expected case in common scenarios, so make the logger about failing to fetch it much less noisy.

## How I Tested These Changes
Confirmed existing test coverage for this case

## Changelog
Fixed an issue where Dagster run metrics produced large amounts of error lines when running in containers without a CPU limit set on the container.