### PR TITLE
[dg] Make dagster scaffold project definitions.py pass ruff formatting

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/5-definitions.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/5-definitions.py
@@ -1,6 +1,6 @@
-import jaffle_platform.defs
-
 from dagster.components import definitions, load_defs
+
+import jaffle_platform.defs
 
 
 @definitions

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/PROJECT_NAME_PLACEHOLDER/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/PROJECT_NAME_PLACEHOLDER/PROJECT_NAME_PLACEHOLDER/definitions.py.jinja
@@ -1,6 +1,6 @@
-import {{ project_name }}.defs
-
 from dagster.components import definitions, load_defs
+
+import {{ project_name }}.defs
 
 
 @definitions


### PR DESCRIPTION
## Summary & Motivation

We were generating definitions.py file that did not abide by ruff formating

## How I Tested These Changes

`dg scaffold project np`
`make ruff`
observe no changes

## Changelog

NOCHANGELOG

