### PR TITLE
[docs] Components concepts page

### DIFF
--- a/docs/docs/getting-started/concepts.md
+++ b/docs/docs/getting-started/concepts.md
@@ -69,7 +69,7 @@ Dagster provides a variety of abstractions for building and orchestrating data p
 
     Job ==> Schedule
     Job ==> Sensor
-    Job ==> Definitions
+    Job ==> Component
 
     Partition ==> Asset
     IoManager ==> Asset
@@ -78,7 +78,7 @@ Dagster provides a variety of abstractions for building and orchestrating data p
     Resource ==> Schedule
     Resource ==> Sensor
 
-    AssetCheck ==> Definitions
+    AssetCheck ==> Component
     AssetCheck ==> Asset
 
     Config ==> Schedule
@@ -90,13 +90,17 @@ Dagster provides a variety of abstractions for building and orchestrating data p
     Asset ==> Schedule
     Asset ==> Sensor
 
-    Asset ==> Definitions
-    Schedule ==> Definitions
-    Sensor ==> Definitions
-    IoManager ==> Definitions
-    Resource ==> Definitions
+    subgraph Component
+    Definitions
+    end
 
-    Definitions ==> CodeLocation
+    Asset ==> Component
+    Schedule ==> Component
+    Sensor ==> Component
+    IoManager ==> Component
+    Resource ==> Component
+
+    Component ==> CodeLocation
 ```
 
 ### Asset
@@ -219,6 +223,34 @@ A `code location` is a collection of <PyObject section="definitions" module="dag
 | ----------------------------------- | ------------------------------------------------------- |
 | [definitions](concepts#definitions) | `code location` must contain at least one `definitions` |
 
+### Component
+
+```mermaid
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#4F43DD',
+      'primaryTextColor': '#FFFFFF',
+      'primaryBorderColor': '#231F1B',
+      'lineColor': '#DEDDFF',
+      'secondaryColor': '#BDBAB7',
+      'tertiaryColor': '#FFFFFF'
+    }
+  }
+}%%
+  graph LR
+    subgraph Component
+    Definitions(Definitions)
+    end
+```
+
+A `Component` is an opinionated project layout built around a <PyObject section="definitions" module="dagster" object="Definitions" />. The `Definitions` contains Dagster objects used to accomplish a specific task—such as a standard workflow or an integration. Components are designed to help you quickly bootstrap parts of your Dagster project and serve as templates for repeatable patterns.
+
+| Concept                             | Relationship                         |
+| ----------------------------------- | ------------------------------------ |
+| [definitions](concepts#definitions) | `component` produces a `definitions` |
+
 ### Config
 
 ```mermaid
@@ -285,17 +317,19 @@ A <PyObject section="config" module="dagster" object="RunConfig" /> is a set sch
     style CodeLocation fill:#BDBAB7,stroke:#BDBAB7,stroke-width:2px
 
 
-    Asset -.-> Definitions
-    AssetCheck -.-> Definitions
-    IOManager -.-> Definitions
-    Job -.-> Definitions
-    Resource -.-> Definitions
-    Schedule -.-> Definitions
-    Sensor -.-> Definitions
+    Asset -.-> Component
+    AssetCheck -.-> Component
+    IOManager -.-> Component
+    Job -.-> Component
+    Resource -.-> Component
+    Schedule -.-> Component
+    Sensor -.-> Component
 
+    subgraph Component
     Definitions(Definitions)
+    end
 
-    Definitions ==> CodeLocation
+    Component ==> CodeLocation
 ```
 
 <PyObject section="definitions" module="dagster" object="Definitions" /> is a top-level construct that contains
@@ -314,6 +348,7 @@ in the definitions will be deployed and visible within the Dagster UI.
 | [resource](concepts#resource)           | `definitions` may contain one or more `resources`    |
 | [schedule](concepts#schedule)           | `definitions` may contain one or more `schedules`    |
 | [sensor](concepts#sensor)               | `definitions` may contain one or more `sensors`      |
+| [component](concepts#component)       | `definitions` may exist as part of a `component`     |
 | [code location](concepts#code-location) | `definitions` must be deployed in a `code location`  |
 
 ### Graph


### PR DESCRIPTION
## Summary & Motivation

Add components to the concepts page. Trying not to overcomplicate things too much and just show that a `definitions` is the output of a `component`. Updating the main diagram, definitions diagram and new components diagram.

**Main Diagram**
![Screenshot 2025-04-04 at 12 22 40 PM](https://github.com/user-attachments/assets/fd742772-0686-4e7a-b991-dd5fdd3ae2a3)

Don't love that the arrows go to components box rather than the definition but the mermaid diagram looks really weird when pointing to the definitions.

**Definitions Diagram**
![Screenshot 2025-04-04 at 12 22 19 PM](https://github.com/user-attachments/assets/c1fde36a-b2e5-4dc0-8606-9e6ac2dfaa97)

**Component Diagram**
![Screenshot 2025-04-04 at 12 22 27 PM](https://github.com/user-attachments/assets/f8975ae9-6be8-4c21-ba46-555bd7be88d8)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
