### PR TITLE
[dagster-fivetran] Support limit and pagination cursor in FivetranClient.list_connectors_for_group

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -475,7 +475,8 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
 # Reworked resources
 # ------------------
 
-
+# The upper limit is 1000 according to the Fivetran API documentation
+# https://fivetran.com/docs/rest-api/getting-started/pagination#queryparameters
 DAGSTER_FIVETRAN_LIST_CONNECTIONS_FOR_GROUP_INDIVIDUAL_REQUEST_LIMIT = int(
     os.getenv("DAGSTER_FIVETRAN_LIST_CONNECTIONS_FOR_GROUP_INDIVIDUAL_REQUEST_LIMIT", "1000")
 )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1257,7 +1257,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[FivetranWorkspace
 
             destinations_by_id[destination.id] = destination
 
-            connectors_details = client.get_connectors_for_group(group_id=group_id)["items"]
+            connectors_details = client.list_connectors_for_group(group_id=group_id)
             for connector_details in connectors_details:
                 connector = FivetranConnector.from_connector_details(
                     connector_details=connector_details,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/conftest.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Mapping
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import patch
 
 import pytest
@@ -53,7 +53,9 @@ SAMPLE_GROUPS = {
 
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/groups/list-all-connectors-in-group
-def get_connectors_for_group(setup_state: str) -> Mapping[str, Any]:
+def list_connectors_for_group_sample(
+    setup_state: str, next_cursor: Optional[str] = None
+) -> Mapping[str, Any]:
     return {
         "code": "Success",
         "message": "Operation performed.",
@@ -123,12 +125,12 @@ def get_connectors_for_group(setup_state: str) -> Mapping[str, Any]:
                     "hybrid_deployment_agent_id": "string",
                 }
             ],
-            "nextCursor": "cursor_value",
+            **({"nextCursor": next_cursor} if next_cursor else {}),
         },
     }
 
 
-SAMPLE_CONNECTORS_FOR_GROUP = get_connectors_for_group(
+SAMPLE_CONNECTORS_FOR_GROUP = list_connectors_for_group_sample(
     setup_state=FivetranConnectorSetupStateType.CONNECTED.value
 )
 
@@ -565,7 +567,9 @@ def incomplete_connector_fetch_workspace_data_api_mocks_fixture(
     fetch_workspace_data_api_mocks.replace(
         method_or_response=responses.GET,
         url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
-        json=get_connectors_for_group(setup_state=FivetranConnectorSetupStateType.INCOMPLETE.value),
+        json=list_connectors_for_group_sample(
+            setup_state=FivetranConnectorSetupStateType.INCOMPLETE.value
+        ),
         status=200,
     )
     fetch_workspace_data_api_mocks.remove(
@@ -587,7 +591,9 @@ def broken_connector_fetch_workspace_data_api_mocks_fixture(
     fetch_workspace_data_api_mocks.replace(
         method_or_response=responses.GET,
         url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
-        json=get_connectors_for_group(setup_state=FivetranConnectorSetupStateType.BROKEN.value),
+        json=list_connectors_for_group_sample(
+            setup_state=FivetranConnectorSetupStateType.BROKEN.value
+        ),
         status=200,
     )
     fetch_workspace_data_api_mocks.remove(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
@@ -142,7 +142,7 @@ def test_list_connectors_for_group_cursor(connector_id: str, group_id: str):
 
     setup_state = FivetranConnectorSetupStateType.CONNECTED.value
 
-    # Create mock responses to mock API behiavor for the "list connectors for group" endpoint
+    # Create mock responses to mock API behavior for the "list connectors for group" endpoint
     def _mock_interaction():
         with responses.RequestsMock() as response:
             # initial state, a cursor is returned, we will do a second call

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/beta/test_resources.py
@@ -1,4 +1,5 @@
 import re
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,9 +10,11 @@ from dagster._core.definitions.materialize import materialize
 from dagster._core.test_utils import environ
 from dagster._vendored.dateutil import parser
 from dagster_fivetran import FivetranOutput, FivetranWorkspace, fivetran_assets
-from dagster_fivetran.translator import MIN_TIME_STR
+from dagster_fivetran.translator import MIN_TIME_STR, FivetranConnectorSetupStateType
 
 from dagster_fivetran_tests.beta.conftest import (
+    FIVETRAN_API_BASE,
+    FIVETRAN_API_VERSION,
     SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR,
     SAMPLE_SUCCESS_MESSAGE,
     TEST_ACCOUNT_ID,
@@ -23,6 +26,7 @@ from dagster_fivetran_tests.beta.conftest import (
     TEST_TABLE_NAME,
     get_fivetran_connector_api_url,
     get_sample_connection_details,
+    list_connectors_for_group_sample,
 )
 
 
@@ -38,7 +42,7 @@ def test_basic_resource_request(
     client = resource.get_client()
 
     # fetch workspace data calls
-    client.get_connectors_for_group(group_id=group_id)
+    client.list_connectors_for_group(group_id=group_id)
     client.get_destination_details(destination_id=destination_id)
     client.get_groups()
     client.get_schema_config_for_connector(connector_id=connector_id)
@@ -128,6 +132,38 @@ def test_basic_resource_request(
             poll_timeout=2,
             poll_interval=1,
         )
+
+
+def test_list_connectors_for_group_cursor(connector_id: str, group_id: str):
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+    client = resource.get_client()
+
+    setup_state = FivetranConnectorSetupStateType.CONNECTED.value
+
+    # Create mock responses to mock API behiavor for the "list connectors for group" endpoint
+    def _mock_interaction():
+        with responses.RequestsMock() as response:
+            # initial state, a cursor is returned, we will do a second call
+            response.add(
+                method=responses.GET,
+                url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
+                json=list_connectors_for_group_sample(
+                    setup_state=setup_state, next_cursor="some_cursor"
+                ),
+                status=200,
+            )
+            # final state, no cursor so we break after the second call
+            response.add(
+                method=responses.GET,
+                url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups/{group_id}/connectors",
+                json=list_connectors_for_group_sample(setup_state=setup_state, next_cursor=None),
+                status=200,
+            )
+            return client.list_connectors_for_group(group_id=group_id)
+
+    assert len(cast(list, _mock_interaction())) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-1026

Previously, we were fetching connections for a group without iterating using the cursor and passing a maximum limit for the number of connectors to fetch - the default limit per call which is set to 100, see [here](https://fivetran.com/docs/rest-api/api-reference/groups/list-all-connections-in-group#limit), so we were fetching a maximum of 100 connectors per group ID (destination ID). This poses serious limitations for organizations with large numbers of connectors per destination.

This PR implement the code to support passing a limit and iterate on the pages of the responses for that endpoint.

## How I Tested These Changes

BK, dagster dev

## Changelog

[dagster-fivetran] A bug causing the Fivetran integration to fetch only 100 connectors per destination has been fixed, all connectors are now fetched for a given destination.
