### PR TITLE
[docs] fix typo in Automation conditions operands and operators page

### DIFF
--- a/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/automation-condition-operands-and-operators.md
+++ b/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/automation-condition-operands-and-operators.md
@@ -97,7 +97,7 @@ The [operands](#operands) can be built into more complex expressions using the f
     </tr>
     <tr>
       <td>
-        <code>AutomationCondition.any_downstream_condition()</code>
+        <code>AutomationCondition.any_downstream_conditions()</code>
       </td>
       <td>
         Any <PyObject section="assets" module="dagster" object="AutomationCondition" /> on a downstream asset evaluates


### PR DESCRIPTION
## Summary & Motivation
Should be any_downstream_condition**s**() as per https://github.com/dagster-io/dagster/blob/f0e405e3184d5fb12eaa3b8c1373aa33721388bf/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py#L717

## How I Tested These Changes
👀