### PR TITLE
[source-checks][RFC] Allow unselected checks to be yielded with a warning.

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -210,8 +210,11 @@ def execute_core_compute(
                 handle = AssetCheckKey(step_output.asset_key, step_output.check_name)
             else:
                 handle = step_output.to_asset_check_evaluation(step_context).asset_check_key
-            output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(handle)
-            emitted_result_names.add(output_name)
+            handle = step_context.job_def.asset_layer.node_output_handles_by_asset_check_key.get(
+                handle
+            )
+            if handle:
+                emitted_result_names.add(handle.output_name)
 
     expected_op_output_names = {
         output.name

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -110,21 +110,27 @@ def _process_user_event(
             )
     elif isinstance(user_event, AssetCheckResult):
         asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
+        assets_def = _get_assets_def_for_step(step_context, user_event)
         spec = check.not_none(
-            step_context.job_def.asset_layer.asset_graph.get_check_spec(
-                asset_check_evaluation.asset_check_key
-            ),
+            assets_def.get_spec_for_check_key(asset_check_evaluation.asset_check_key),
             "If we were able to create an AssetCheckEvaluation from the AssetCheckResult, then"
             " there should be a spec for the check",
         )
-
-        output_name = step_context.job_def.asset_layer.get_output_name_for_asset_check(
-            asset_check_evaluation.asset_check_key
-        )
-        output = Output(value=None, output_name=output_name)
-
+        # If the check is explicitly selected, we need to yield an Output event for it.
+        if spec.key in assets_def.check_keys:
+            output_name = check.not_none(
+                step_context.job_def.asset_layer.get_output_name_for_asset_check(
+                    asset_check_key=spec.key
+                ),
+                f"No output name found for check key {spec.key} in step {step_context.step.key}. This likely indicates that the currently executing AssetsDefinition has no check specified for the key.",
+            )
+            output = Output(value=None, output_name=output_name)
+            yield output
+        else:
+            step_context.log.warning(
+                f"AssetCheckResult for check '{spec.name}' for asset '{spec.asset_key.to_user_string()}' was yielded which is not selected. Letting it through."
+            )
         yield asset_check_evaluation
-
         if (
             not asset_check_evaluation.passed
             and asset_check_evaluation.severity == AssetCheckSeverity.ERROR
@@ -134,7 +140,6 @@ def _process_user_event(
                 f"Blocking check '{spec.name}' for asset '{spec.asset_key.to_user_string()}' failed with"
                 " ERROR severity."
             )
-        yield output
     else:
         yield user_event
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -26,6 +26,7 @@ from dagster import (
     mem_io_manager,
     op,
 )
+from dagster._check import CheckError
 from dagster._config.field import Field
 from dagster._core.definitions.dependency import DependencyDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
@@ -1694,6 +1695,7 @@ def test_bare_asset_check_result() -> None:
 
     # test execution - we correctly raise an error here
     with pytest.raises(
-        dg.DagsterInvariantViolationError, match="Received unexpected AssetCheckResult."
+        CheckError,
+        match="expected to find an AssetsDefinition object that could be associated back to the currently executing NodeHandle",
     ):
         execute_op_in_graph(the_op)


### PR DESCRIPTION
## Summary & Motivation
Part of a stack to enable dbt sources as asset checks.

Right now in the system, we throw an explicit error if the user emits an asset check result for an asset check that is not part of the selection. This PR proposes _allowing_ unselected checks to be executed; and instead throw a warning.

There are two reasons to add support for this:
- I think it's a reasonable default behavior to warn instead of error here. Leave it up to the user to determine the severity.
- It helps enable dbt source checks - our asset check default selection semantics make it very difficult to select an asset check that doesn't directly target an asset part of the underlying assets definition. And somewhat impossible to do it by default without breaking changes. The way forward is to enable dbt source checks to be executed despite being unselected.

## How I Tested These Changes
- Tests which exercise the "unselected" behavior.
## Changelog
- A behavioral change has been made to asset check executions: if an unselected check is executed during a run, the system will now warn instead of throwing a hard error.
