### PR TITLE
[dagster-dbt][source-checks] source tests as checks

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -363,4 +363,5 @@ def dbt_assets(
         backfill_policy=backfill_policy,
         retry_policy=retry_policy,
         pool=pool,
+        allow_arbitrary_check_specs=True,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -737,6 +737,22 @@ def build_dbt_specs(
                 upstream_id,
                 project,
             ).key
+            if (
+                upstream_id.startswith("source")
+                and translator.settings.enable_source_tests_as_checks
+            ):
+                for child_unique_id in manifest["child_map"][upstream_id]:
+                    if not child_unique_id.startswith("test"):
+                        continue
+                    check_spec = default_asset_check_fn(
+                        manifest=manifest,
+                        dagster_dbt_translator=translator,
+                        asset_key=key_by_unique_id[upstream_id],
+                        test_unique_id=child_unique_id,
+                        project=project,
+                    )
+                    if check_spec:
+                        check_specs.append(check_spec)
 
     _validate_asset_keys(translator, manifest, key_by_unique_id)
     return specs, check_specs
@@ -852,6 +868,13 @@ def get_asset_check_key_for_test(
     )
 
 
+def get_checks_on_sources_upstream_of_selected_assets(
+    assets_def: AssetsDefinition, selected_asset_keys: AbstractSet[AssetKey]
+) -> AbstractSet[AssetCheckKey]:
+    upstream_source_keys = assets_def.get_upstream_input_keys(frozenset(selected_asset_keys))
+    return assets_def.get_checks_targeting_keys(frozenset(upstream_source_keys))
+
+
 def get_subset_selection_for_context(
     context: Union[OpExecutionContext, AssetExecutionContext],
     manifest: Mapping[str, Any],
@@ -923,20 +946,27 @@ def get_subset_selection_for_context(
         dagster_dbt_translator, manifest, assets_def, context.selected_asset_keys
     )
 
+    # We explicitly use node_check_specs_by_output_name because it contains every single check spec, not just those selected in the currently
+    # executing subset.
+    checks_targeting_selected_sources = get_checks_on_sources_upstream_of_selected_assets(
+        assets_def=assets_def, selected_asset_keys=context.selected_asset_keys
+    )
+    selected_check_keys = {*context.selected_asset_check_keys, *checks_targeting_selected_sources}
+
     # if all asset checks for the subsetted assets are selected, then we can just select the
     # assets and use indirect selection for the tests. We verify that
     # 1. all the selected checks are for selected assets
     # 2. no checks for selected assets are excluded
     # This also means we'll run any singular tests.
-    checks_on_non_selected_assets = [
+    selected_checks_on_non_selected_assets = {
         check_key
-        for check_key in context.selected_asset_check_keys
+        for check_key in selected_check_keys
         if check_key.asset_key not in context.selected_asset_keys
-    ]
+    }
     all_check_keys = {
         check_spec.key for check_spec in assets_def.node_check_specs_by_output_name.values()
     }
-    excluded_checks = all_check_keys.difference(context.selected_asset_check_keys)
+    excluded_checks = all_check_keys.difference(selected_check_keys)
     excluded_checks_on_selected_assets = [
         check_key
         for check_key in excluded_checks
@@ -961,10 +991,10 @@ def get_subset_selection_for_context(
             "Overriding default `DBT_INDIRECT_SELECTION` "
             f"{current_dbt_indirect_selection_env or 'eager'} with "
             f"`{indirect_selection_override}` due to additional checks "
-            f"{', '.join([c.to_user_string() for c in checks_on_non_selected_assets])} "
+            f"{', '.join([c.to_user_string() for c in selected_checks_on_non_selected_assets])} "
             f"and excluded checks {', '.join([c.to_user_string() for c in excluded_checks_on_selected_assets])}."
         )
-    elif checks_on_non_selected_assets:
+    elif selected_checks_on_non_selected_assets:
         # explicitly select the tests that won't be run via indirect selection
         selected_dbt_resources = [
             *selected_asset_resources,
@@ -972,7 +1002,7 @@ def get_subset_selection_for_context(
                 dagster_dbt_translator,
                 manifest,
                 assets_def,
-                checks_on_non_selected_assets,
+                selected_checks_on_non_selected_assets,
             ),
         ]
         indirect_selection_override = None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -58,12 +58,15 @@ class DagsterDbtTranslatorSettings:
             Defaults to False.
         enable_dbt_selection_by_name (bool): Whether to enable selecting dbt resources by name,
             rather than fully qualified name. Defaults to False.
+        enable_source_tests_as_checks (bool): Whether to load dbt source tests as Dagster asset checks.
+            Defaults to False. If False, asset observations will be emitted for source tests.
     """
 
     enable_asset_checks: bool = True
     enable_duplicate_source_asset_keys: bool = False
     enable_code_references: bool = False
     enable_dbt_selection_by_name: bool = False
+    enable_source_tests_as_checks: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -36,6 +36,9 @@ dagster_dbt_translator_with_checks = DagsterDbtTranslator(
 dagster_dbt_translator_without_checks = DagsterDbtTranslator(
     settings=DagsterDbtTranslatorSettings(enable_asset_checks=False)
 )
+dagster_dbt_translator_with_checks_and_source_checks = DagsterDbtTranslator(
+    settings=DagsterDbtTranslatorSettings(enable_source_tests_as_checks=True)
+)
 
 
 @pytest.fixture(params=[[["build"]], [["seed"], ["run"], ["test"]]], ids=["build", "seed-run-test"])
@@ -835,3 +838,38 @@ def test_dbt_source_tests(
         )
         == 1
     )
+
+
+@pytest.mark.parametrize(
+    "selection,expected_num_source_test_execs,success",
+    [(None, 2, False), ("stg_customers", 2, True), ("stg_orders", 0, True)],
+    ids=["select_all", "select_downstream_of_source", "select_non_source"],
+)
+def test_dbt_source_tests_checks_enabled(
+    test_asset_checks_manifest: dict[str, Any],
+    selection: Optional[str],
+    expected_num_source_test_execs: int,
+    success: bool,
+) -> None:
+    """Test behavior when dbt source tests are configured, but checks are disabled."""
+
+    @dbt_assets(
+        manifest=test_asset_checks_manifest,
+        dagster_dbt_translator=dagster_dbt_translator_with_checks_and_source_checks,
+    )
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_asset_checks_path))},
+        raise_on_error=False,
+        selection=selection,
+    )
+    assert result.success == success
+    asset_check_results = [
+        eval_result.asset_key
+        for eval_result in result.get_asset_check_evaluations()
+        if eval_result.asset_key == AssetKey(["jaffle_shop", "raw_customers"])
+    ]
+    assert len(asset_check_results) == expected_num_source_test_execs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/sources.yml
@@ -9,7 +9,7 @@ sources:
           schema: false
           identifier: false
         columns:
-          - name: id 
+          - name: id
             tests:
               - unique
               - not_null


### PR DESCRIPTION
## Summary & Motivation
This enables dbt source tests to run as asset checks instead of just yielding observations as we currently do. The behavior is hidden behind a flag by default so as not to break existing users.

It relies on the core behavioral changes from downstack PRs. We haven't been able to come up with a satisfactory way to "select" the dbt source checks by default whenever a model downstream of the targeted source is selected; so instead; we create a "composite selection" of checks which automatically adds the source checks to the tests which will actually be executed.

This mirrors the existing behavior; where source tests are run whenever the source is loaded and indirect selection does not disable tests.

## How I Tested These Changes
Adds tests for the following scenarios:
- Explicitly select downstream model
- No selection
- Select model not downstream of source.

## Changelog
- [dagster-dbt] you can now enable dbt source tests as asset checks by using the flag DagsterDbtTranslatorSettings.enable_source_tests_as_checks. We plan to eventually turn this behavior on by default.
