### PR TITLE
Use StaticFiles for directories in static routes

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -1,6 +1,7 @@
 import gzip
 import io
 import mimetypes
+import os
 import uuid
 from os import path, walk
 from typing import Generic, Optional, TypeVar
@@ -32,6 +33,7 @@ from starlette.responses import (
     StreamingResponse,
 )
 from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
 from starlette.types import Message
 
 from dagster_webserver.external_assets import (
@@ -258,12 +260,24 @@ class DagsterWebserver(
 
         routes = []
         base_dir = self.relative_path("webapp/build/")
-        for subdir, _, files in walk(base_dir):
-            for file in files:
-                full_path = path.join(subdir, file)
-                # Replace path.sep to make sure our routes use forward slashes on windows
-                mount_path = "/" + full_path[len(base_dir) :].replace(path.sep, "/")
-                routes.append(_static_file(mount_path, full_path))
+        with os.scandir(base_dir) as entries:
+            for entry in entries:
+                if entry.is_symlink():
+                    continue
+                relative_path = "/" + path.relpath(entry.path, base_dir).replace(path.sep, "/")
+                if entry.is_file():
+                    routes.append(_static_file(relative_path, entry.path))
+                elif entry.is_dir():
+                    routes.append(
+                        Mount(
+                            relative_path,
+                            StaticFiles(
+                                directory=entry.path,
+                                check_dir=False,
+                            ),
+                            name="root_static",
+                        )
+                    )
 
         # No build directory, this happens in a test environment. Don't fail loudly since we already have other tests that will fail loudly if
         # there is in fact no build


### PR DESCRIPTION
## Summary & Motivation

Adding routes for each individual static resource makes for quite alot of routes in the webserver, depending on the JS build. This PR changes the logic for the static routes so that root level static resources (like favicon) maintain their individual route, while directories for CSS etc now use a Mount + StaticFiles to reduce the number of route comparisons.

## How I Tested These Changes

Running dagster-webserver locally
