### PR TITLE
[dg check yaml] walk nested subdirs, not just top level dirs in defs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - `dg`-scaffolded workspaces now include a `dg.toml` instead of `pyproject.toml` file.
 - `dg`-scaffolded projects now place the root package in an `src/` directory and use `hatchling` as the build backend rather than `setuptools`.
 - Fixed a bug where `dg` would crash when working with Python packages with an src-based layout.
+- `dg check yaml` now properly validates component files in nested subdirectories of the `defs/` folder.
 
 ## 1.10.8 (core) / 0.26.8 (libraries)
 

--- a/python_modules/dagster/dagster/components/test/test_cases.py
+++ b/python_modules/dagster/dagster/components/test/test_cases.py
@@ -75,6 +75,16 @@ COMPONENT_VALIDATION_TEST_CASES = [
         ),
     ),
     ComponentValidationTestCase(
+        component_path="validation/basic_component_extra_value_in_a_subfolder",
+        component_type_filepath=None,
+        should_error=True,
+        validate_error_msg=msg_includes_all_of("component.yaml:4", "attributes.path"),
+        check_error_msg=msg_includes_all_of(
+            "component.yaml:4",
+            "attributes.path",
+        ),
+    ),
+    ComponentValidationTestCase(
         component_path="validation/nested_component_invalid_values",
         component_type_filepath=BASIC_COMPONENT_TYPE_FILEPATH,
         should_error=True,

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_extra_value_in_a_subfolder/subfolder/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_extra_value_in_a_subfolder/subfolder/component.yaml
@@ -1,0 +1,4 @@
+type: dagster.components.DefinitionsComponent
+
+attributes:
+  path: {}

--- a/python_modules/libraries/dagster-dg/dagster_dg/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/check.py
@@ -58,7 +58,7 @@ def check_yaml(
 
     component_contents_by_key: dict[LibraryObjectKey, Any] = {}
     modules_to_fetch = set()
-    for component_dir in dg_context.defs_path.iterdir():
+    for component_dir in dg_context.defs_path.rglob("*"):
         if resolved_paths and not any(
             path == component_dir or path in component_dir.parents for path in resolved_paths
         ):


### PR DESCRIPTION
## Summary
Now that we allow for more flexible `defs` structure, let `dg check yaml` walk all `defs` subfolders to find components.


## How I Tested These Changes

 unit test

