### PR TITLE
[components] Adjust sling component to cwd to component dir before executing sync

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/14-curl.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/14-curl.txt
@@ -1,3 +1,5 @@
+pushd src/jaffle_platform/defs/ingest_files &&
 curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_customers.csv &&
 curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_orders.csv &&
-curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_payments.csv
+curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_payments.csv &&
+popd

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -188,9 +188,11 @@ def test_components_docs_index(update_snippets: bool) -> None:
             # Test sling sync
             run_command_and_snippet_output(
                 cmd=textwrap.dedent("""
+                    pushd src/jaffle_platform/defs/ingest_files &&
                     curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_customers.csv &&
                     curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_orders.csv &&
-                    curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_payments.csv
+                    curl -O https://raw.githubusercontent.com/dbt-labs/jaffle-shop-classic/refs/heads/main/seeds/raw_payments.csv &&
+                    popd
                 """).strip(),
                 snippet_path=COMPONENTS_SNIPPETS_DIR / f"{next_snip_no()}-curl.txt",
                 update_snippets=update_snippets,


### PR DESCRIPTION
## Summary

This makes it so relative paths in the `replication.yaml` resolve relative to the `replication.yaml` file, rather than to the `dg dev` cwd. This means we can e.g. load files to a db from files placed in the component folder, rather than the project root, as we do in the tutorial right now.

## How I Tested These Changes

Update tutorial + integration test.
