### PR TITLE
fix indentation of lists in component scaffolding

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/11-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/11-component.yaml
@@ -2,4 +2,4 @@ type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
   replications:
-  - path: replication.yaml
+    - path: replication.yaml

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/5-scaffolded-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/5-scaffolded-component.yaml
@@ -3,5 +3,5 @@ type: my_component_library.lib.ShellCommand
 attributes:
   script_path: script.sh
   asset_specs:
-  - key: my_asset
-    description: Output of running a script
+    - key: my_asset
+      description: Output of running a script

--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -22,6 +22,10 @@ class ComponentDumper(yaml.Dumper):
             super().write_line_break()
         super().write_line_break()
 
+    # Format list elements with indentation - see https://github.com/yaml/pyyaml/issues/234
+    def increase_indent(self, flow=False, *args, **kwargs):
+        return super().increase_indent(flow=flow, indentless=False)
+
 
 def scaffold_component(
     request: ScaffoldRequest,


### PR DESCRIPTION
Summary:
Noticed that our scaffolded YAML indents lists in a way that is technnically correct but offends my aesthetic sensibilities. Applying the workaround I found on https://github.com/yaml/pyyaml/issues/234 to indent lists by 2 spaces relative to their parent.

Test Plan:
Automated tests, scaffold some components locally as a sanity check -  see updated docs snippets for an example of the change
