### PR TITLE
Fix test_available_examples_in_sync_with_example_folder

### DIFF
--- a/python_modules/dagster/dagster/_generate/download.py
+++ b/python_modules/dagster/dagster/_generate/download.py
@@ -10,7 +10,9 @@ from dagster._generate.generate import _should_skip_file
 
 # Examples aren't that can't be downloaded from the dagster project CLI
 EXAMPLES_TO_IGNORE = [
+    "components_yaml_checks_dsl",
     "deploy_k8s_beta",
+    "docs_beta_snippets",
     "docs_projects",
     "docs_snippets",
     "experimental",


### PR DESCRIPTION
Summary:
New example added in https://github.com/dagster-io/dagster/pull/29001 is presumably not ready for download as a public scaffolded example yet by dagster project from-example (exact future of that command unclear in a post-dg world anyway)

Not positive when docs_beta_snippets became eligible here but presumably that is not eligible as well

Test Plan:
BK
