### PR TITLE
rename tests folder

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/3-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/3-tree.txt
@@ -1,8 +1,6 @@
 cd jaffle-platform && tree
 
 .
-├── jaffle_platform_tests
-│   └── __init__.py
 ├── pyproject.toml
 ├── src
 │   └── jaffle_platform
@@ -12,6 +10,8 @@ cd jaffle-platform && tree
 │       │   └── __init__.py
 │       └── lib
 │           └── __init__.py
+├── tests
+│   └── __init__.py
 └── uv.lock
 
 6 directories, 7 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/2-tree.txt
@@ -1,8 +1,6 @@
 tree
 
 .
-├── my_project_tests
-│   └── __init__.py
 ├── pyproject.toml
 ├── src
 │   └── my_project
@@ -14,6 +12,8 @@ tree
 │       │       └── my_asset.py
 │       └── lib
 │           └── __init__.py
+├── tests
+│   └── __init__.py
 └── uv.lock
 
 7 directories, 8 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
@@ -2,8 +2,6 @@ tree
 
 .
 └── my-project
-    ├── my_project_tests
-    │   └── __init__.py
     ├── pyproject.toml
     ├── src
     │   └── my_project
@@ -13,6 +11,8 @@ tree
     │       │   └── __init__.py
     │       └── lib
     │           └── __init__.py
+    ├── tests
+    │   └── __init__.py
     └── uv.lock
 
 7 directories, 7 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-tree.txt
@@ -5,8 +5,6 @@ cd dagster-workspace && tree
 ├── libraries
 └── projects
     └── project-1
-        ├── project_1_tests
-        │   └── __init__.py
         ├── pyproject.toml
         ├── src
         │   └── project_1
@@ -16,6 +14,8 @@ cd dagster-workspace && tree
         │       │   └── __init__.py
         │       └── lib
         │           └── __init__.py
+        ├── tests
+        │   └── __init__.py
         └── uv.lock
 
 ...

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -61,7 +61,7 @@ def init_command(
     │       │   └── __init__.py
     │       └── lib
     │           └── __init__.py
-    ├── <project_name>_tests
+    ├── tests
     │   └── __init__.py
     └── pyproject.toml
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -245,7 +245,7 @@ def scaffold_project_command(
     │       │   └── __init__.py
     │       └── lib
     │           └── __init__.py
-    ├── <project_name>_tests
+    ├── tests
     │   └── __init__.py
     └── pyproject.toml
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -28,7 +28,7 @@ def test_init_command_success(monkeypatch) -> None:
         assert Path("helloworld").exists()
         assert Path("helloworld/src/helloworld").exists()
         assert Path("helloworld/pyproject.toml").exists()
-        assert Path("helloworld/helloworld_tests").exists()
+        assert Path("helloworld/tests").exists()
 
 
 def test_init_command_success_with_workspace_name(monkeypatch) -> None:
@@ -50,7 +50,7 @@ def test_init_command_success_with_workspace_name(monkeypatch) -> None:
         assert Path("dagster-workspace/projects/helloworld").exists()
         assert Path("dagster-workspace/projects/helloworld/src/helloworld").exists()
         assert Path("dagster-workspace/projects/helloworld/pyproject.toml").exists()
-        assert Path("dagster-workspace/projects/helloworld/helloworld_tests").exists()
+        assert Path("dagster-workspace/projects/helloworld/tests").exists()
 
         # Check workspace TOML content
         toml = tomlkit.parse(Path("dagster-workspace/dg.toml").read_text())
@@ -78,7 +78,7 @@ def test_init_override_project_name_prompt_with_workspace(monkeypatch) -> None:
         assert Path("my-workspace/projects/goodbyeworld").exists()
         assert Path("my-workspace/projects/goodbyeworld/src/goodbyeworld").exists()
         assert Path("my-workspace/projects/goodbyeworld/pyproject.toml").exists()
-        assert Path("my-workspace/projects/goodbyeworld/goodbyeworld_tests").exists()
+        assert Path("my-workspace/projects/goodbyeworld/tests").exists()
 
 
 def test_init_override_project_name_prompt_without_workspace(monkeypatch) -> None:
@@ -90,7 +90,7 @@ def test_init_override_project_name_prompt_without_workspace(monkeypatch) -> Non
         assert Path("goodbyeworld").exists()
         assert Path("goodbyeworld/src/goodbyeworld").exists()
         assert Path("goodbyeworld/pyproject.toml").exists()
-        assert Path("goodbyeworld/goodbyeworld_tests").exists()
+        assert Path("goodbyeworld/tests").exists()
 
 
 def test_init_workspace_already_exists_failure(monkeypatch) -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -98,7 +98,7 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert Path("projects/foo-bar/src/foo_bar").exists()
         assert Path("projects/foo-bar/src/foo_bar/lib").exists()
         assert Path("projects/foo-bar/src/foo_bar/defs").exists()
-        assert Path("projects/foo-bar/foo_bar_tests").exists()
+        assert Path("projects/foo-bar/tests").exists()
         assert Path("projects/foo-bar/pyproject.toml").exists()
         assert Path("projects/foo-bar/.gitignore").exists()
 
@@ -182,7 +182,7 @@ def test_scaffold_project_outside_workspace_success(monkeypatch) -> None:
         assert Path("foo-bar/src/foo_bar").exists()
         assert Path("foo-bar/src/foo_bar/lib").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
-        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv created
@@ -276,7 +276,7 @@ def test_scaffold_project_skip_venv_success() -> None:
         assert Path("foo-bar/src/foo_bar").exists()
         assert Path("foo-bar/src/foo_bar/lib").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
-        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv not created
@@ -300,7 +300,7 @@ def test_scaffold_project_no_populate_cache_success(monkeypatch) -> None:
         assert Path("foo-bar/src/foo_bar").exists()
         assert Path("foo-bar/src/foo_bar/lib").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
-        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv created
@@ -330,7 +330,7 @@ def test_scaffold_project_active_venv_success(monkeypatch) -> None:
         assert Path("foo-bar/src/foo_bar").exists()
         assert Path("foo-bar/src/foo_bar/lib").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
-        assert Path("foo-bar/foo_bar_tests").exists()
+        assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
 
         # Check venv not created


### PR DESCRIPTION
## Summary & Motivation

It's also standard to have a `tests` folder rather than something with the project name in it.

## How I Tested These Changes

`dg init --project-name new_format_2`

```
pyproject.toml src            tests          uv.lock
(dagster-dev-3.11.11-2024-12-08) ➜  new_format_2 tree .
.
├── pyproject.toml
├── src
│   └── new_format_2
│       ├── __init__.py
│       ├── __pycache__
│       │   └── __init__.cpython-311.pyc
│       ├── definitions.py
│       ├── defs
│       │   └── __init__.py
│       └── lib
│           ├── __init__.py
│           └── __pycache__
│               └── __init__.cpython-311.pyc
├── tests
│   └── __init__.py
└── uv.lock
```
## Changelog

> Insert changelog entry or delete this section.
