### PR TITLE
[components,docs] add explanation of overridden `get_spec` on `Component`

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -58,7 +58,7 @@ We can define the schema for our component and add it to our class as follows:
   title="my_component_library/lib/shell_command.py"
   />
 
-Additionally, it's possible to include metadata for your Component by overriding the `get_metadata` method. This allows you to set fields like `author` and `tags` that will be visible in the generated documentation.
+Additionally, it's possible to include metadata for your Component by overriding the `get_component_type_metadata` method. This allows you to set fields like `owners` and `tags` that will be visible in the generated documentation.
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py"

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -58,6 +58,14 @@ We can define the schema for our component and add it to our class as follows:
   title="my_component_library/lib/shell_command.py"
   />
 
+Additionally, it's possible to include metadata for your Component by overriding the `get_metadata` method. This allows you to set fields like `author` and `tags` that will be visible in the generated documentation.
+
+<CodeExample
+  path="docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py"
+  language="python"
+  title="my_component_library/lib/shell_command.py"
+  />
+
 :::tip
 
 When defining a field on a component that isn't on the schema, or is of a different type, the components system allows you to provide custom resolution logic for that field. See the [Providing resolution logic for non-standard types](#advanced-providing-resolution-logic-for-non-standard-types) section for more information.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -5,7 +5,7 @@ from dagster.components import (
     Component,
     ComponentLoadContext,
     # highlight-start
-    ComponentMetadata,
+    ComponentSpec,
     # highlight-end
     Resolvable,
     ResolvedAssetSpec,
@@ -17,8 +17,8 @@ class ShellCommand(Component, Resolvable):
 
     # highlight-start
     @classmethod
-    def get_component_type_metadata(cls):
-        return ComponentMetadata(
+    def get_spec(cls):
+        return ComponentSpec(
             owners=["John Dagster"],
             tags=["shell", "script"],
         )

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -17,9 +17,9 @@ class ShellCommand(Component, Resolvable):
 
     # highlight-start
     @classmethod
-    def get_metadata(cls):
+    def get_component_type_metadata(cls):
         return ComponentMetadata(
-            author="John Dagster",
+            owners=["John Dagster"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -1,0 +1,36 @@
+from collections.abc import Sequence
+
+import dagster as dg
+from dagster.components import (
+    Component,
+    ComponentLoadContext,
+    # highlight-start
+    ComponentMetadata,
+    # highlight-end
+    Resolvable,
+    ResolvedAssetSpec,
+)
+
+
+class ShellCommand(Component, Resolvable):
+    """Models a shell script as a Dagster asset."""
+
+    # highlight-start
+    @classmethod
+    def get_metadata(cls):
+        return ComponentMetadata(
+            author="John Dagster",
+            tags=["shell", "script"],
+        )
+
+    # highlight-end
+
+    def __init__(
+        self,
+        script_path: str,
+        asset_specs: Sequence[ResolvedAssetSpec],
+    ):
+        self.script_path = script_path
+        self.asset_specs = asset_specs
+
+    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions: ...


### PR DESCRIPTION
## Summary & Motivation

Explains how to set `owners` and `tags` on Component using `get_spec`.

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
