### PR TITLE
[dagster-sling]: fix Asset materialization bug when some stream fail for dagster sling integration

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/conftest.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/conftest.py
@@ -103,3 +103,22 @@ def csv_to_sqlite_dataworks_replication(path_to_dataworks_folder):
         conf_streams[f"file://{file_path}"] = {"object": f"main.{table_name}"}
     conf["streams"] = conf_streams
     return conf
+
+@pytest.fixture
+def csv_to_sqlite_failed_replication(path_to_dataworks_folder):
+    with open(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/replication.yaml")
+    ) as f:
+        conf = yaml.safe_load(f)
+    conf_streams = {}
+    file_path = os.path.join(path_to_dataworks_folder, "Failed_file.txt")
+    table_name = "failed_file"
+    conf_streams[f"file://{file_path}"] = {"object": f"main.{table_name}"}
+    # datawork sling replication to represent success stream
+    for file_name in os.listdir(path_to_dataworks_folder):
+        file_path = os.path.join(path_to_dataworks_folder, file_name)
+        table_name = file_name.split(".")[0].lower()
+        conf_streams[f"file://{file_path}"] = {"object": f"main.{table_name}"}
+    # sling stream represnt failed data work
+    conf["streams"] = conf_streams
+    return conf

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/conftest.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/conftest.py
@@ -104,6 +104,7 @@ def csv_to_sqlite_dataworks_replication(path_to_dataworks_folder):
     conf["streams"] = conf_streams
     return conf
 
+
 @pytest.fixture
 def csv_to_sqlite_failed_replication(path_to_dataworks_folder):
     with open(

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -564,3 +564,91 @@ def test_pool(replication_config: SlingReplicationParam):
     def my_sling_assets(): ...
 
     assert my_sling_assets.op.pool == pool
+
+
+def test_runs_failed_sling_config(
+    csv_to_sqlite_failed_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    from dagster_sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_failed_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+        raise_on_error=False
+    )
+
+    assert res.success==False
+    asset_materializations = res.get_asset_materialization_events()
+
+    failed_key = AssetKey(["target", "main", "failed_file"])
+    failed_metadata = [
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == failed_key
+    ]
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+
+    assert all(["stream_name" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["elapsed_time" in metadata for metadata in metadatas]), str(metadatas)
+
+    failed_key = AssetKey(["target", "main", "failed_file"])
+    failed_metadata = [
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == failed_key
+    ]
+    assert failed_metadata == []
+
+    employees_key = AssetKey(["target", "main", "employees"])
+    employees_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == employees_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    employee_name_path = os.path.join(path_name, "Employees.csv")
+
+    assert employees_metadata["stream_name"].value == f"file://{employee_name_path}"
+
+    orders_key = AssetKey(["target", "main", "orders"])
+    orders_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == orders_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    order_name_path = os.path.join(path_name, "Orders.csv")
+
+    assert orders_metadata["stream_name"].value == f"file://{order_name_path}"
+
+    products_key = AssetKey(["target", "main", "products"])
+    products_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    product_name_path = os.path.join(path_name, "Products.csv")
+
+    assert products_metadata["stream_name"].value == f"file://{product_name_path}"

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -587,14 +587,10 @@ def test_runs_failed_sling_config(
             ),
         ]
     )
-    
-    res = materialize(
-        [my_sling_assets],
-        resources={"sling": sling_resource},
-        raise_on_error=False
-    )
 
-    assert res.success==False
+    res = materialize([my_sling_assets], resources={"sling": sling_resource}, raise_on_error=False)
+
+    assert not res.success
     asset_materializations = res.get_asset_materialization_events()
 
     failed_key = AssetKey(["target", "main", "failed_file"])

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
@@ -108,6 +108,7 @@ def test_streams_sling_replicate(
     counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
     assert counts == 4
 
+
 def test_stream_sling_replicate_metadata(
     csv_to_sqlite_dataworks_replication: SlingReplicationParam,
     path_to_temp_sqlite_db: str,
@@ -162,6 +163,7 @@ def test_stream_sling_replicate_metadata(
     assert products_metadata["row_count"].value == "4"
     assert products_metadata["destination_table"].value == "main.products"
 
+
 def test_failed_stream_sling_replicate(
     csv_to_sqlite_failed_replication: SlingReplicationParam,
     path_to_temp_sqlite_db: str,
@@ -183,14 +185,10 @@ def test_failed_stream_sling_replicate(
             ),
         ]
     )
-    
-    res = materialize(
-        [my_sling_assets],
-        resources={"sling": sling_resource},
-        raise_on_error=False
-    )
 
-    assert res.success==False
+    res = materialize([my_sling_assets], resources={"sling": sling_resource}, raise_on_error=False)
+
+    assert not res.success
     asset_materializations = res.get_asset_materialization_events()
     assert len(asset_materializations) == 3
 
@@ -251,5 +249,3 @@ def test_failed_stream_sling_replicate(
     assert products_metadata["stream_name"].value == f"file://{product_name_path}"
     assert products_metadata["row_count"].value == "4"
     assert products_metadata["destination_table"].value == "main.products"
-
-    

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_streaming_replicate.py
@@ -108,7 +108,6 @@ def test_streams_sling_replicate(
     counts = sqlite_connection.execute("SELECT count(1) FROM main.products").fetchone()[0]
     assert counts == 4
 
-
 def test_stream_sling_replicate_metadata(
     csv_to_sqlite_dataworks_replication: SlingReplicationParam,
     path_to_temp_sqlite_db: str,
@@ -162,3 +161,95 @@ def test_stream_sling_replicate_metadata(
     assert products_metadata["stream_name"].value == f"file://{product_name_path}"
     assert products_metadata["row_count"].value == "4"
     assert products_metadata["destination_table"].value == "main.products"
+
+def test_failed_stream_sling_replicate(
+    csv_to_sqlite_failed_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    from dagster_sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_failed_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context, stream=True)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+        raise_on_error=False
+    )
+
+    assert res.success==False
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+
+    assert all(["stream_name" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["elapsed_time" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["row_count" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["destination_table" in metadata for metadata in metadatas]), str(metadatas)
+
+    failed_key = AssetKey(["target", "main", "failed_file"])
+    failed_metadata = [
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == failed_key
+    ]
+    assert failed_metadata == []
+
+    employees_key = AssetKey(["target", "main", "employees"])
+    employees_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == employees_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    employee_name_path = os.path.join(path_name, "Employees.csv")
+
+    assert employees_metadata["stream_name"].value == f"file://{employee_name_path}"
+    assert employees_metadata["row_count"].value == "4"
+    assert employees_metadata["destination_table"].value == "main.employees"
+
+    orders_key = AssetKey(["target", "main", "orders"])
+    orders_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == orders_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    order_name_path = os.path.join(path_name, "Orders.csv")
+
+    assert orders_metadata["stream_name"].value == f"file://{order_name_path}"
+    assert orders_metadata["row_count"].value == "4"
+    assert orders_metadata["destination_table"].value == "main.orders"
+
+    products_key = AssetKey(["target", "main", "products"])
+    products_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
+    ).step_materialization_data.materialization.metadata
+
+    path_name = os.path.abspath(
+        file_relative_path(__file__, "replication_configs/csv_to_sqlite_config/dataworks/")
+    )
+    product_name_path = os.path.join(path_name, "Products.csv")
+
+    assert products_metadata["stream_name"].value == f"file://{product_name_path}"
+    assert products_metadata["row_count"].value == "4"
+    assert products_metadata["destination_table"].value == "main.products"
+
+    


### PR DESCRIPTION
## Summary & Motivation
When some streams fail Asset materialization is not sync with underlying sling execution. In batch mode, all asset show fail when some data is load. In stream mode, there are bug in regex resulting wrong asset  

This PR try to solve this bug.

## How I Tested These Changes
- unit test was created in order to test materialization result from failed execution.
- integration test was performed in local project to confirm it behavioral in real situation

## Changelog
- Pytest fixture is created for sling replication with demo failed stream.
- unit test was created to confirm execution based on created config.
- regex bug in streaming method is fixed.
- main execution method in batch mode is moved inside try-except block to correct handle case of failed execution.
- regex was employed to extract stream status from sling command to control asset materialization in batch method.
