### PR TITLE
[dg] Correctly display sensors in the sensors section of dg list

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -209,8 +209,8 @@ def list_defs_command(output_json: bool, **global_options: object) -> None:
             table = Table(border_style="dim")
             table.add_column("Name")
 
-            for schedule in schedules:
-                table.add_row(schedule.name)
+            for sensor in sensors:
+                table.add_row(sensor.name)
             console.print(table)
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -186,11 +186,11 @@ _EXPECTED_DEFS = textwrap.dedent("""
     └─────────────┴───────────────┘
 
     Sensors
-    ┏━━━━━━━━━━━━━┓
-    ┃ Name        ┃
-    ┡━━━━━━━━━━━━━┩
-    │ my_schedule │
-    └─────────────┘
+    ┏━━━━━━━━━━━┓
+    ┃ Name      ┃
+    ┡━━━━━━━━━━━┩
+    │ my_sensor │
+    └───────────┘
 """).strip()
 
 _EXPECTED_DEFS_JSON = textwrap.dedent("""


### PR DESCRIPTION
## Summary & Motivation

We were displaying schedules in the sensors section. This fixes that.

## How I Tested These Changes

Manual

## Changelog

- Fixed bug where schedules were displayed in the sensors section of `dg list defs`.