### PR TITLE
[ez] backtick to single quotes in dg init

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -121,4 +121,4 @@ def init_command(
         python_environment=project_python_environment,
     )
 
-    click.echo("You can create additional projects later by running `dg scaffold project`.")
+    click.echo("You can create additional projects later by running 'dg scaffold project'.")


### PR DESCRIPTION
Summary:
Noticed this in the DSL demo - backticks make sense for markdown but not in this context. Not sure what the proper formatting is here, but single quotes seems better.

How I Tested These Changes:
eyes
