### PR TITLE
[dg] Better logging message for asset check evals

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1098,6 +1098,13 @@ class DagsterEvent(
             event_type=DagsterEventType.ASSET_CHECK_EVALUATION,
             step_context=step_context,
             event_specific_data=asset_check_evaluation,
+            message=f"Asset check '{asset_check_evaluation.check_name}' on '{asset_check_evaluation.asset_key.to_user_string()}' "
+            + ("passed." if asset_check_evaluation.passed else "did not pass.")
+            + (
+                ""
+                if asset_check_evaluation.description is None
+                else f" Description: '{asset_check_evaluation.description}'"
+            ),
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary & Motivation

Noticed this while preparing a demo. Improve the logging for asset check evaluations to actually include if they passed or not.

## How I Tested These Changes

```
2025-04-06 16:56:11 -0400 - dagster - DEBUG - __ASSET_JOB - 5eddbb3a-1dbc-4b72-b033-53069b2483e5 - 48173 - orders_min_user_id_test - STEP_INPUT - Got input "df" of type "DataFrame". (Type check passed).
2025-04-06 16:56:11 -0400 - dagster - DEBUG - __ASSET_JOB - 5eddbb3a-1dbc-4b72-b033-53069b2483e5 - 48173 - orders_min_user_id_test - ASSET_CHECK_EVALUATION - Asset check 'min_user_id_test' on 'orders' did not pass. Description: 'Minimum value of 1000 not met for column user_id. Found 1'
2025-04-06 16:56:11 -0400 - dagster - DEBUG - __ASSET_JOB - 5eddbb3a-1dbc-4b72-b033-53069b2483e5 - 48173 - orders_min_user_id_test - STEP_OUTPUT - Yielded output "result" of type "Any". (Type check passed).
```
## Changelog

* Improved logging message on asset checks.