### PR TITLE
[dg] Default dagster.components.Model instead of @dataclass

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -36,7 +36,7 @@ This will add a new file to your project in the `lib` directory:
 This file contains the basic structure for the new component type. Our goal is to implement the `build_defs` method to return a `Definitions`. This will require some input which we will define as what our component class is instantiated with.
 
 :::note
-The use of `@dataclass` is optional. If you wish to implement an `__init__` method for your class, you can provide the `--no-dataclass` flag to the `dg scaffold` command.
+The use of `Model` is optional if you only want a Pythonic interface to the component. If you wish to implement an `__init__` method for your class (manually or using using `@dataclasses.dataclass`), you can provide the `--no-model` flag to the `dg scaffold` command.
 :::
 
 ## Defining the Python class

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -36,7 +36,7 @@ This will add a new file to your project in the `lib` directory:
 This file contains the basic structure for the new component type. Our goal is to implement the `build_defs` method to return a `Definitions`. This will require some input which we will define as what our component class is instantiated with.
 
 :::note
-The use of `Model` is optional if you only want a Pythonic interface to the component. If you wish to implement an `__init__` method for your class (manually or using using `@dataclasses.dataclass`), you can provide the `--no-model` flag to the `dg scaffold` command.
+The use of `Model` is optional if you only want a Pythonic interface to the component. If you wish to implement an `__init__` method for your class (manually or using `@dataclasses.dataclass`), you can provide the `--no-model` flag to the `dg scaffold` command.
 :::
 
 ## Defining the Python class

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass
-
 import dagster as dg
-from dagster.components import Component, ComponentLoadContext, Resolvable
+from dagster.components import Component, ComponentLoadContext, Model, Resolvable
 
 
 @dataclass
-class ShellCommand(Component, Resolvable):
+class ShellCommand(Component, Model, Resolvable):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/2-shell-command-empty.py
@@ -2,14 +2,13 @@ import dagster as dg
 from dagster.components import Component, ComponentLoadContext, Model, Resolvable
 
 
-@dataclass
 class ShellCommand(Component, Model, Resolvable):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.
     """
 
-    # added fields here will define yaml schema via Resolvable
+    # added fields here will define yaml schema via Model
 
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         # Add definition construction logic here.

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -403,17 +403,17 @@ def _create_scaffold_subcommand(key: LibraryObjectKey, obj: LibraryObjectSnap) -
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 @click.option(
-    "--dataclass/--no-dataclass",
+    "--model/--no-model",
     is_flag=True,
     default=True,
-    help="Whether to automatically annotate the generated class with @dataclass.",
+    help="Whether to automatically make the generated class inherit from dagster.components.Model.",
 )
 @click.argument("name", type=str)
 @dg_global_options
 @click.pass_context
 @cli_telemetry_wrapper
 def scaffold_component_type_command(
-    context: click.Context, name: str, dataclass: bool, **global_options: object
+    context: click.Context, name: str, model: bool, **global_options: object
 ) -> None:
     """Scaffold of a custom Dagster component type.
 
@@ -432,5 +432,5 @@ def scaffold_component_type_command(
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
     scaffold_component_type(
-        dg_context=dg_context, class_name=name, module_name=module_name, dataclass=dataclass
+        dg_context=dg_context, class_name=name, module_name=module_name, model=model
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -232,7 +232,7 @@ def _gather_dagster_packages(editable_dagster_root: Path) -> list[Path]:
 
 
 def scaffold_component_type(
-    *, dg_context: DgContext, class_name: str, module_name: str, dataclass: bool
+    *, dg_context: DgContext, class_name: str, module_name: str, model: bool
 ) -> None:
     root_path = Path(dg_context.default_component_library_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{module_name}.py.")
@@ -243,7 +243,7 @@ def scaffold_component_type(
         templates_path=str(Path(__file__).parent / "templates" / "COMPONENT_TYPE"),
         project_name=module_name,
         name=class_name,
-        dataclass=dataclass,
+        model=model,
     )
 
     with open(root_path / "__init__.py", "a") as f:

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -1,23 +1,26 @@
-{% if dataclass -%}
-from dataclasses import dataclass
-
-{% endif -%}
 import dagster as dg
+{% if model -%}
+from dagster.components import Component, ComponentLoadContext, Model, Resolvable
+{% else -%}
 from dagster.components import Component, ComponentLoadContext, Resolvable
+{% endif %}
 
+{% if model -%}
+class {{ name }}(Component, Model, Resolvable):
+    """COMPONENT SUMMARY HERE.
 
-{% if dataclass -%}
-@dataclass
-{% endif -%}
+    COMPONENT DESCRIPTION HERE.
+    """
+{% else -%}
 class {{ name }}(Component, Resolvable):
     """COMPONENT SUMMARY HERE.
 
     COMPONENT DESCRIPTION HERE.
     """
-{% if dataclass %}
-    # added fields here will define yaml schema via Resolvable
-{%- endif %}
-{% if not dataclass %}
+{% endif -%}
+{% if model %}
+    # added fields here will define yaml schema via Model
+{% else %}
     def __init__(
         self,
         # added arguments here will define yaml schema via Resolvable

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -566,12 +566,12 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
         assert "type: foo_bar.lib.Baz" in component_yaml_path.read_text()
 
 
-def test_scaffold_component_succeeds_scaffolded_no_dataclass() -> None:
+def test_scaffold_component_succeeds_scaffolded_no_model() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "component-type", "Baz", "--no-dataclass")
+        result = runner.invoke("scaffold", "component-type", "Baz", "--no-model")
         assert_runner_result(result)
         assert Path("src/foo_bar/lib/baz.py").exists()
 
@@ -584,7 +584,6 @@ class Baz(Component, Resolvable):
 
     COMPONENT DESCRIPTION HERE.
     """
-
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary & Motivation

On reflection it was a bit silly to default to `dataclass` since we want the full YAML system (including Resolved things) to work out of the box.

## How I Tested These Changes

BK

## Changelog

* Scaffolding a component type defaults to inheriting from `dagster.components.Model` instead of getting decorated by `@dataclasses.dataclass`