### PR TITLE
[dg] Fix missing `dagster-components` error messages

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -28,14 +28,13 @@ from dagster_dg.config import (
 )
 from dagster_dg.error import DgError
 from dagster_dg.utils import (
-    MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE,
     NO_LOCAL_VENV_ERROR_MESSAGE,
     NOT_COMPONENT_LIBRARY_ERROR_MESSAGE,
     NOT_PROJECT_ERROR_MESSAGE,
     NOT_WORKSPACE_ERROR_MESSAGE,
     NOT_WORKSPACE_OR_PROJECT_ERROR_MESSAGE,
     exit_with_error,
-    generate_missing_dagster_components_in_local_venv_error_message,
+    generate_missing_dagster_components_error_message,
     generate_tool_dg_cli_in_project_in_workspace_error_message,
     get_toml_node,
     get_venv_executable,
@@ -572,9 +571,7 @@ def _validate_dagster_components_availability(context: DgContext) -> None:
             exit_with_error(NO_LOCAL_VENV_ERROR_MESSAGE)
         elif not get_venv_executable(context.venv_path, "dagster-components").exists():
             exit_with_error(
-                generate_missing_dagster_components_in_local_venv_error_message(
-                    str(context.venv_path)
-                )
+                generate_missing_dagster_components_error_message(str(context.venv_path))
             )
     elif not context.has_executable("dagster-components"):
-        exit_with_error(MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE)
+        exit_with_error(generate_missing_dagster_components_error_message())

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -352,12 +352,15 @@ def generate_missing_component_type_error_message(component_key_str: str) -> str
     """
 
 
-def generate_missing_dagster_components_in_local_venv_error_message(venv_path: str) -> str:
+def generate_missing_dagster_components_error_message(
+    venv_path: Optional[str] = None,
+) -> str:
+    env_qualifier = f" for the virtual environment at {venv_path}" if venv_path else ""
     return f"""
-        Could not find the `dagster-components` executable in the virtual environment at {venv_path}.
-        The `dagster-components` executable is necessary for `dg` to interface with Python environments
-        containing Dagster definitions. Ensure that the virtual environment has the `dagster-components`
-        package installed.
+        Could not resolve the `dagster-components` executable{env_qualifier}.
+        The `dagster-components` is included with `dagster>=1.10.8`. It is necessary for `dg` to
+        interface with Python environments. Ensure that your Python environment has
+        `dagster>=1.10.8` installed.
     """
 
 
@@ -389,17 +392,6 @@ nearest pyproject.toml has `tool.dg.directory_type = "project"` or `tool.dg.dire
 NOT_COMPONENT_LIBRARY_ERROR_MESSAGE = """
 This command must be run inside a Dagster component library directory. Ensure that the nearest
 pyproject.toml has an entry point defined under the `dagster_dg.library` group.
-"""
-
-MISSING_DAGSTER_COMPONENTS_ERROR_MESSAGE = """
-Could not find the `dagster-components` executable on the system path.
-
-The `dagster-components` executable is installed with the `dagster-components` PyPI package and is
-necessary for `dg` to interface with Python environments containing Dagster definitions.
-`dagster-components` is installed by default when a project is scaffolded by `dg`. However, if
-you are using `dg` in a non-managed environment (either outside of a Dagster project or using the
-`--no-use-dg-managed-environment` flag), you need to independently ensure `dagster-components` is
-installed.
 """
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -358,7 +358,7 @@ def generate_missing_dagster_components_error_message(
     env_qualifier = f" for the virtual environment at {venv_path}" if venv_path else ""
     return f"""
         Could not resolve the `dagster-components` executable{env_qualifier}.
-        The `dagster-components` is included with `dagster>=1.10.8`. It is necessary for `dg` to
+        The `dagster-components` executable is included with `dagster>=1.10.8`. It is necessary for `dg` to
         interface with Python environments. Ensure that your Python environment has
         `dagster>=1.10.8` installed.
     """

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -151,7 +151,7 @@ def test_no_ambient_dagster_components_failure(spec: CommandSpec) -> None:
         # Set $PATH to /dev/null to ensure that the `dagster-components` executable is not found
         result = runner.invoke(*cli_args, env={"PATH": "/dev/null"})
         assert_runner_result(result, exit_0=False)
-        assert "Could not find the `dagster-components` executable" in result.output
+        assert "Could not resolve the `dagster-components` executable" in result.output
 
 
 @pytest.mark.parametrize("spec", PROJECT_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command))


### PR DESCRIPTION
## Summary & Motivation

Update error messages for a missing `dagster-components` executable (they still referenced the `dagster-components` package).

## How I Tested These Changes

Modified existing tests.