### PR TITLE
[dg] Add `dg scaffold github-action` command support for hybrid orgs

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -22,15 +22,11 @@ def _guess_deployment_type(
 ) -> tuple[DgPlusDeploymentType, str]:
     branch_name = get_local_branch_name(str(project_dir))
     if not branch_name:
-        click.echo(
-            f"Could not determine a git branch, so deploying to {full_deployment_name}."
-        )
+        click.echo(f"Could not determine a git branch, so deploying to {full_deployment_name}.")
         return DgPlusDeploymentType.FULL_DEPLOYMENT, full_deployment_name
 
     if branch_name in {"main", "master"}:
-        click.echo(
-            f"Current branch is {branch_name}, so deploying to {full_deployment_name}."
-        )
+        click.echo(f"Current branch is {branch_name}, so deploying to {full_deployment_name}.")
         return DgPlusDeploymentType.FULL_DEPLOYMENT, full_deployment_name
 
     click.echo(
@@ -42,9 +38,7 @@ def _guess_deployment_type(
 def _guess_and_prompt_deployment_type(
     project_dir: Path, full_deployment_name: str, skip_confirmation_prompt: bool
 ) -> DgPlusDeploymentType:
-    deployment_type, branch_name = _guess_deployment_type(
-        project_dir, full_deployment_name
-    )
+    deployment_type, branch_name = _guess_deployment_type(project_dir, full_deployment_name)
 
     if not skip_confirmation_prompt and not click.confirm("Do you want to continue?"):
         click.echo("Deployment cancelled.")
@@ -149,8 +143,7 @@ def init_deploy_session(
         project_dir=str(dg_context.root_path),
         deployment=deployment,
         organization=organization,
-        require_branch_deployment=deployment_type
-        == DgPlusDeploymentType.BRANCH_DEPLOYMENT,
+        require_branch_deployment=deployment_type == DgPlusDeploymentType.BRANCH_DEPLOYMENT,
         git_url=git_url,
         commit_hash=commit_hash,
         dagster_env=None,
@@ -228,9 +221,7 @@ def _build_artifact_for_project(
 
     dockerfile_path = build_directory / "Dockerfile"
     if not os.path.exists(dockerfile_path):
-        click.echo(
-            f"No Dockerfile found - scaffolding a default one at {dockerfile_path}."
-        )
+        click.echo(f"No Dockerfile found - scaffolding a default one at {dockerfile_path}.")
         create_deploy_dockerfile(dockerfile_path, python_version, use_editable_dagster)
     else:
         click.echo(f"Building using Dockerfile at {dockerfile_path}.")
@@ -265,9 +256,7 @@ def _build_artifact_for_project(
         )
 
 
-def finish_deploy_session(
-    dg_context: DgContext, statedir: str, location_names: tuple[str]
-):
+def finish_deploy_session(dg_context: DgContext, statedir: str, location_names: tuple[str]):
     from dagster_cloud_cli.commands.ci import deploy_impl
     from dagster_cloud_cli.config_utils import (
         get_agent_heartbeat_timeout,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -49,9 +49,7 @@ from dagster_dg.utils import (
     parse_json_option,
     snakecase,
 )
-from dagster_dg.utils.plus import gql
-from dagster_dg.utils.plus.build import create_deploy_dockerfile
-from dagster_dg.utils.plus.gql_client import DagsterPlusGraphQLClient
+from dagster_dg.utils.plus.build import create_deploy_dockerfile, get_agent_type
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 DEFAULT_WORKSPACE_NAME = "dagster-workspace"
@@ -107,9 +105,7 @@ class ScaffoldSubCommand(DgClickCommand):
     def format_help(self, context: click.Context, formatter: click.HelpFormatter):
         """Customizes the help to include hierarchical usage."""
         if not isinstance(self, click.Command):
-            raise ValueError(
-                "This mixin is only intended for use with click.Command instances."
-            )
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
 
         # This is a hack. We pass the help format func a modified version of the command where the global
         # options are attached to the command itself. This will cause them to be included in the
@@ -123,9 +119,7 @@ class ScaffoldSubCommand(DgClickCommand):
 
     def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         if not isinstance(self, click.Command):
-            raise ValueError(
-                "This mixin is only intended for use with click.Command instances."
-            )
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
         arg_pieces = self.collect_usage_pieces(ctx)
         command_parts = ctx.command_path.split(" ")
         command_parts.insert(-1, "[GLOBAL OPTIONS]")
@@ -148,9 +142,7 @@ class ScaffoldSubCommand(DgClickCommand):
 @click.option("-h", "--help", "help_", is_flag=True, help="Show this message and exit.")
 @dg_global_options
 @click.pass_context
-def scaffold_group(
-    context: click.Context, help_: bool, **global_options: object
-) -> None:
+def scaffold_group(context: click.Context, help_: bool, **global_options: object) -> None:
     """Commands for scaffolding Dagster code."""
     # Click attempts to resolve subcommands BEFORE it invokes this callback.
     # Therefore we need to manually invoke this callback during subcommand generation to make sure
@@ -218,9 +210,7 @@ def _search_for_git_root(path: Path) -> Optional[Path]:
 SERVERLESS_GITHUB_ACTION_FILE = (
     Path(__file__).parent.parent / "templates" / "serverless-github-action.yaml"
 )
-HYBRID_GITHUB_ACTION_FILE = (
-    Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
-)
+HYBRID_GITHUB_ACTION_FILE = Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
 
 
 BUILD_LOCATION_FRAGMENT = (
@@ -296,14 +286,7 @@ REGISTRY_INFOS = [
 ]
 
 
-def _get_deployment_agent_type(gql_client: DagsterPlusGraphQLClient) -> str:
-    result = gql_client.execute(gql.DEPLOYMENT_INFO_QUERY)
-    return result["currentDeployment"]["agentType"]
-
-
-def _get_project_contexts(
-    dg_context: DgContext, cli_config: DgRawCliConfig
-) -> list[DgContext]:
+def _get_project_contexts(dg_context: DgContext, cli_config: DgRawCliConfig) -> list[DgContext]:
     if dg_context.is_workspace:
         return [
             dg_context.for_project_environment(project.path, cli_config)
@@ -324,9 +307,7 @@ def _generate_dagster_cloud_yaml_contents(
         "locations": [
             {
                 "location_name": project_context.code_location_name,
-                "code_source": {
-                    "module_name": project_context.code_location_target_module_name
-                },
+                "code_source": {"module_name": project_context.code_location_target_module_name},
                 "build": {
                     "directory": str(project_context.root_path.relative_to(git_root)),
                     **({"registry": registry} if registry else {}),
@@ -340,23 +321,17 @@ def _generate_dagster_cloud_yaml_contents(
 def _get_git_web_url(git_root: Path) -> Optional[str]:
     try:
         remote_origin_url = (
-            subprocess.check_output(["git", "config", "remote.origin.url"])
-            .decode("utf-8")
-            .strip()
+            subprocess.check_output(["git", "config", "remote.origin.url"]).decode("utf-8").strip()
         )
         remote_origin_url = (
-            remote_origin_url.replace(":", "/")
-            .replace(".git", "")
-            .replace("git@", "https://")
+            remote_origin_url.replace(":", "/").replace(".git", "").replace("git@", "https://")
         )
         return remote_origin_url
     except subprocess.CalledProcessError:
         return None
 
 
-def _get_build_fragment_for_locations(
-    location_ctxs: list[DgContext], git_root: Path
-) -> str:
+def _get_build_fragment_for_locations(location_ctxs: list[DgContext], git_root: Path) -> str:
     # TODO: when we cut over to dg deploy, we'll just use a single build call for the workspace
     # rather than iterating over each project
     output = []
@@ -377,9 +352,7 @@ def _get_build_fragment_for_locations(
 @click.option("--git-root", type=Path, help="Path to the git root of the repository")
 @dg_global_options
 @cli_telemetry_wrapper
-def scaffold_github_actions_command(
-    git_root: Optional[Path], **global_options: object
-) -> None:
+def scaffold_github_actions_command(git_root: Optional[Path], **global_options: object) -> None:
     """Scaffold a GitHub Actions workflow for a Dagster project.
 
     This command will create a GitHub Actions workflow in the `.github/workflows` directory
@@ -402,23 +375,17 @@ def scaffold_github_actions_command(
 
     if plus_config and plus_config.organization:
         organization_name = plus_config.organization
-        click.echo(
-            f"Using organization name {organization_name} from Dagster Plus config."
-        )
+        click.echo(f"Using organization name {organization_name} from Dagster Plus config.")
     else:
         organization_name = click.prompt("Dagster Plus organization name") or ""
 
-    if plus_config:
-        gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
-
-        agent_type = _get_deployment_agent_type(gql_client)
-
+    if plus_config and plus_config.default_deployment:
+        deployment_name = plus_config.default_deployment
+        click.echo(f"Using default deployment name {deployment_name} from Dagster Plus config.")
     else:
-        click.echo("No Dagster Plus config found.")
-        agent_type = click.prompt(
-            "Deployment agent type: ", type=click.Choice(("serverless", "hybrid"))
-        ).upper()
+        deployment_name = click.prompt("Default deployment name", default="prod")
 
+    agent_type = get_agent_type(plus_config)
     if agent_type == "SERVERLESS":
         click.echo("Using serverless workflow template.")
     else:
@@ -432,7 +399,10 @@ def scaffold_github_actions_command(
         if agent_type == "SERVERLESS"
         else HYBRID_GITHUB_ACTION_FILE.read_text()
     )
-    template = template.replace("ORGANIZATION_NAME", organization_name)
+
+    template = template.replace("ORGANIZATION_NAME", organization_name).replace(
+        "DEFAULT_DEPLOYMENT_NAME", deployment_name
+    )
 
     if agent_type == "HYBRID":
         # Attempt to read registry from registry.yaml
@@ -455,9 +425,9 @@ def scaffold_github_actions_command(
             )
         build_fragment = _get_build_fragment_for_locations(project_contexts, git_root)
 
-        template = template.replace(
-            "# BUILD_LOCATION_FRAGMENT", build_fragment
-        ).replace("IMAGE_REGISTRY_TEMPLATE", registry_url)
+        template = template.replace("# BUILD_LOCATION_FRAGMENT", build_fragment).replace(
+            "IMAGE_REGISTRY_TEMPLATE", registry_url
+        )
 
     if registry_url:
         for registry_info in REGISTRY_INFOS:
@@ -557,16 +527,12 @@ def scaffold_project_command(
     live in `src.<project_name>.lib`. These types can be created with `dg scaffold component-type`.
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.from_file_discovery_and_command_line_config(
-        Path.cwd(), cli_config
-    )
+    dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
 
     abs_path = path.resolve()
     if dg_context.is_workspace:
         if dg_context.has_project(abs_path.relative_to(dg_context.workspace_root_path)):
-            exit_with_error(
-                f"The current workspace already specifies a project at {abs_path}."
-            )
+            exit_with_error(f"The current workspace already specifies a project at {abs_path}.")
         elif abs_path.exists():
             exit_with_error(f"A file or directory already exists at {abs_path}.")
 
@@ -591,9 +557,7 @@ def _core_scaffold(
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
     if not registry.has(object_key):
-        exit_with_error(
-            f"Scaffoldable object type `{object_key.to_typename()}` not found."
-        )
+        exit_with_error(f"Scaffoldable object type `{object_key.to_typename()}` not found.")
     elif dg_context.has_component_instance(instance_name):
         exit_with_error(f"A component instance named `{instance_name}` already exists.")
 
@@ -626,9 +590,7 @@ def _core_scaffold(
     )
 
 
-def _create_scaffold_subcommand(
-    key: PluginObjectKey, obj: PluginObjectSnap
-) -> DgClickCommand:
+def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> DgClickCommand:
     # We need to "reset" the help option names to the default ones because we inherit the parent
     # value of context settings from the parent group, which has been customized.
     @click.command(
@@ -696,9 +658,7 @@ def _create_scaffold_subcommand(
         for name, field_info in obj.scaffolder_schema["properties"].items():
             # All fields are currently optional because they can also be passed under
             # `--json-params`
-            option = json_schema_property_to_click_option(
-                name, field_info, required=False
-            )
+            option = json_schema_property_to_click_option(name, field_info, required=False)
             scaffold_command.params.append(option)
 
     return scaffold_command
@@ -737,13 +697,9 @@ def scaffold_component_type_command(
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)
-    component_key = PluginObjectKey(
-        name=name, namespace=dg_context.default_plugin_module_name
-    )
+    component_key = PluginObjectKey(name=name, namespace=dg_context.default_plugin_module_name)
     if registry.has(component_key):
-        exit_with_error(
-            f"Component type`{component_key.to_typename()}` already exists."
-        )
+        exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
     scaffold_component_type(
         dg_context=dg_context, class_name=name, module_name=module_name, model=model

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -348,7 +348,7 @@ def _get_build_fragment_for_locations(
             .replace("LOCATION_PATH", str(location_ctx.root_path.relative_to(git_root)))
             .replace("IMAGE_REGISTRY_TEMPLATE", registry_url)
         )
-    return "\n".join(output)
+    return "\n" + "\n".join(output)
 
 
 @scaffold_group.command(

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -105,9 +105,7 @@ class ScaffoldSubCommand(DgClickCommand):
     def format_help(self, context: click.Context, formatter: click.HelpFormatter):
         """Customizes the help to include hierarchical usage."""
         if not isinstance(self, click.Command):
-            raise ValueError(
-                "This mixin is only intended for use with click.Command instances."
-            )
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
 
         # This is a hack. We pass the help format func a modified version of the command where the global
         # options are attached to the command itself. This will cause them to be included in the
@@ -121,9 +119,7 @@ class ScaffoldSubCommand(DgClickCommand):
 
     def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         if not isinstance(self, click.Command):
-            raise ValueError(
-                "This mixin is only intended for use with click.Command instances."
-            )
+            raise ValueError("This mixin is only intended for use with click.Command instances.")
         arg_pieces = self.collect_usage_pieces(ctx)
         command_parts = ctx.command_path.split(" ")
         command_parts.insert(-1, "[GLOBAL OPTIONS]")
@@ -146,9 +142,7 @@ class ScaffoldSubCommand(DgClickCommand):
 @click.option("-h", "--help", "help_", is_flag=True, help="Show this message and exit.")
 @dg_global_options
 @click.pass_context
-def scaffold_group(
-    context: click.Context, help_: bool, **global_options: object
-) -> None:
+def scaffold_group(context: click.Context, help_: bool, **global_options: object) -> None:
     """Commands for scaffolding Dagster code."""
     # Click attempts to resolve subcommands BEFORE it invokes this callback.
     # Therefore we need to manually invoke this callback during subcommand generation to make sure
@@ -216,9 +210,7 @@ def _search_for_git_root(path: Path) -> Optional[Path]:
 SERVERLESS_GITHUB_ACTION_FILE = (
     Path(__file__).parent.parent / "templates" / "serverless-github-action.yaml"
 )
-HYBRID_GITHUB_ACTION_FILE = (
-    Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
-)
+HYBRID_GITHUB_ACTION_FILE = Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
 
 
 BUILD_LOCATION_FRAGMENT = (
@@ -294,9 +286,7 @@ REGISTRY_INFOS = [
 ]
 
 
-def _get_project_contexts(
-    dg_context: DgContext, cli_config: DgRawCliConfig
-) -> list[DgContext]:
+def _get_project_contexts(dg_context: DgContext, cli_config: DgRawCliConfig) -> list[DgContext]:
     if dg_context.is_workspace:
         return [
             dg_context.for_project_environment(project.path, cli_config)
@@ -317,9 +307,7 @@ def _generate_dagster_cloud_yaml_contents(
         "locations": [
             {
                 "location_name": project_context.code_location_name,
-                "code_source": {
-                    "module_name": project_context.code_location_target_module_name
-                },
+                "code_source": {"module_name": project_context.code_location_target_module_name},
                 "build": {
                     "directory": str(project_context.root_path.relative_to(git_root)),
                     **({"registry": registry} if registry else {}),
@@ -333,23 +321,17 @@ def _generate_dagster_cloud_yaml_contents(
 def _get_git_web_url(git_root: Path) -> Optional[str]:
     try:
         remote_origin_url = (
-            subprocess.check_output(["git", "config", "remote.origin.url"])
-            .decode("utf-8")
-            .strip()
+            subprocess.check_output(["git", "config", "remote.origin.url"]).decode("utf-8").strip()
         )
         remote_origin_url = (
-            remote_origin_url.replace(":", "/")
-            .replace(".git", "")
-            .replace("git@", "https://")
+            remote_origin_url.replace(":", "/").replace(".git", "").replace("git@", "https://")
         )
         return remote_origin_url
     except subprocess.CalledProcessError:
         return None
 
 
-def _get_build_fragment_for_locations(
-    location_ctxs: list[DgContext], git_root: Path
-) -> str:
+def _get_build_fragment_for_locations(location_ctxs: list[DgContext], git_root: Path) -> str:
     # TODO: when we cut over to dg deploy, we'll just use a single build call for the workspace
     # rather than iterating over each project
     output = []
@@ -370,9 +352,7 @@ def _get_build_fragment_for_locations(
 @click.option("--git-root", type=Path, help="Path to the git root of the repository")
 @dg_global_options
 @cli_telemetry_wrapper
-def scaffold_github_actions_command(
-    git_root: Optional[Path], **global_options: object
-) -> None:
+def scaffold_github_actions_command(git_root: Optional[Path], **global_options: object) -> None:
     """Scaffold a GitHub Actions workflow for a Dagster project.
 
     This command will create a GitHub Actions workflow in the `.github/workflows` directory
@@ -395,17 +375,13 @@ def scaffold_github_actions_command(
 
     if plus_config and plus_config.organization:
         organization_name = plus_config.organization
-        click.echo(
-            f"Using organization name {organization_name} from Dagster Plus config."
-        )
+        click.echo(f"Using organization name {organization_name} from Dagster Plus config.")
     else:
         organization_name = click.prompt("Dagster Plus organization name") or ""
 
     if plus_config and plus_config.default_deployment:
         deployment_name = plus_config.default_deployment
-        click.echo(
-            f"Using default deployment name {deployment_name} from Dagster Plus config."
-        )
+        click.echo(f"Using default deployment name {deployment_name} from Dagster Plus config.")
     else:
         deployment_name = click.prompt("Default deployment name", default="prod")
 
@@ -430,9 +406,7 @@ def scaffold_github_actions_command(
 
     if agent_type == "HYBRID":
         # Attempt to read registry from build.yaml
-        registry_url = (
-            dg_context.build_config["registry"] if dg_context.build_config else None
-        )
+        registry_url = dg_context.build_config["registry"] if dg_context.build_config else None
         if not registry_url:
             registry_url = click.prompt("Docker registry URL, for built images")
         else:
@@ -448,9 +422,9 @@ def scaffold_github_actions_command(
             )
         build_fragment = _get_build_fragment_for_locations(project_contexts, git_root)
 
-        template = template.replace(
-            "# BUILD_LOCATION_FRAGMENT", build_fragment
-        ).replace("IMAGE_REGISTRY_TEMPLATE", registry_url)
+        template = template.replace("# BUILD_LOCATION_FRAGMENT", build_fragment).replace(
+            "IMAGE_REGISTRY_TEMPLATE", registry_url
+        )
 
     if registry_url:
         for registry_info in REGISTRY_INFOS:
@@ -550,16 +524,12 @@ def scaffold_project_command(
     live in `src.<project_name>.lib`. These types can be created with `dg scaffold component-type`.
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.from_file_discovery_and_command_line_config(
-        Path.cwd(), cli_config
-    )
+    dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
 
     abs_path = path.resolve()
     if dg_context.is_workspace:
         if dg_context.has_project(abs_path.relative_to(dg_context.workspace_root_path)):
-            exit_with_error(
-                f"The current workspace already specifies a project at {abs_path}."
-            )
+            exit_with_error(f"The current workspace already specifies a project at {abs_path}.")
         elif abs_path.exists():
             exit_with_error(f"A file or directory already exists at {abs_path}.")
 
@@ -584,9 +554,7 @@ def _core_scaffold(
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
     if not registry.has(object_key):
-        exit_with_error(
-            f"Scaffoldable object type `{object_key.to_typename()}` not found."
-        )
+        exit_with_error(f"Scaffoldable object type `{object_key.to_typename()}` not found.")
     elif dg_context.has_component_instance(instance_name):
         exit_with_error(f"A component instance named `{instance_name}` already exists.")
 
@@ -619,9 +587,7 @@ def _core_scaffold(
     )
 
 
-def _create_scaffold_subcommand(
-    key: PluginObjectKey, obj: PluginObjectSnap
-) -> DgClickCommand:
+def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> DgClickCommand:
     # We need to "reset" the help option names to the default ones because we inherit the parent
     # value of context settings from the parent group, which has been customized.
     @click.command(
@@ -689,9 +655,7 @@ def _create_scaffold_subcommand(
         for name, field_info in obj.scaffolder_schema["properties"].items():
             # All fields are currently optional because they can also be passed under
             # `--json-params`
-            option = json_schema_property_to_click_option(
-                name, field_info, required=False
-            )
+            option = json_schema_property_to_click_option(name, field_info, required=False)
             scaffold_command.params.append(option)
 
     return scaffold_command
@@ -730,13 +694,9 @@ def scaffold_component_type_command(
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)
-    component_key = PluginObjectKey(
-        name=name, namespace=dg_context.default_plugin_module_name
-    )
+    component_key = PluginObjectKey(name=name, namespace=dg_context.default_plugin_module_name)
     if registry.has(component_key):
-        exit_with_error(
-            f"Component type`{component_key.to_typename()}` already exists."
-        )
+        exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 
     scaffold_component_type(
         dg_context=dg_context, class_name=name, module_name=module_name, model=model

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -105,7 +105,9 @@ class ScaffoldSubCommand(DgClickCommand):
     def format_help(self, context: click.Context, formatter: click.HelpFormatter):
         """Customizes the help to include hierarchical usage."""
         if not isinstance(self, click.Command):
-            raise ValueError("This mixin is only intended for use with click.Command instances.")
+            raise ValueError(
+                "This mixin is only intended for use with click.Command instances."
+            )
 
         # This is a hack. We pass the help format func a modified version of the command where the global
         # options are attached to the command itself. This will cause them to be included in the
@@ -119,7 +121,9 @@ class ScaffoldSubCommand(DgClickCommand):
 
     def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         if not isinstance(self, click.Command):
-            raise ValueError("This mixin is only intended for use with click.Command instances.")
+            raise ValueError(
+                "This mixin is only intended for use with click.Command instances."
+            )
         arg_pieces = self.collect_usage_pieces(ctx)
         command_parts = ctx.command_path.split(" ")
         command_parts.insert(-1, "[GLOBAL OPTIONS]")
@@ -142,7 +146,9 @@ class ScaffoldSubCommand(DgClickCommand):
 @click.option("-h", "--help", "help_", is_flag=True, help="Show this message and exit.")
 @dg_global_options
 @click.pass_context
-def scaffold_group(context: click.Context, help_: bool, **global_options: object) -> None:
+def scaffold_group(
+    context: click.Context, help_: bool, **global_options: object
+) -> None:
     """Commands for scaffolding Dagster code."""
     # Click attempts to resolve subcommands BEFORE it invokes this callback.
     # Therefore we need to manually invoke this callback during subcommand generation to make sure
@@ -210,7 +216,9 @@ def _search_for_git_root(path: Path) -> Optional[Path]:
 SERVERLESS_GITHUB_ACTION_FILE = (
     Path(__file__).parent.parent / "templates" / "serverless-github-action.yaml"
 )
-HYBRID_GITHUB_ACTION_FILE = Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
+HYBRID_GITHUB_ACTION_FILE = (
+    Path(__file__).parent.parent / "templates" / "hybrid-github-action.yaml"
+)
 
 
 BUILD_LOCATION_FRAGMENT = (
@@ -286,7 +294,9 @@ REGISTRY_INFOS = [
 ]
 
 
-def _get_project_contexts(dg_context: DgContext, cli_config: DgRawCliConfig) -> list[DgContext]:
+def _get_project_contexts(
+    dg_context: DgContext, cli_config: DgRawCliConfig
+) -> list[DgContext]:
     if dg_context.is_workspace:
         return [
             dg_context.for_project_environment(project.path, cli_config)
@@ -307,7 +317,9 @@ def _generate_dagster_cloud_yaml_contents(
         "locations": [
             {
                 "location_name": project_context.code_location_name,
-                "code_source": {"module_name": project_context.code_location_target_module_name},
+                "code_source": {
+                    "module_name": project_context.code_location_target_module_name
+                },
                 "build": {
                     "directory": str(project_context.root_path.relative_to(git_root)),
                     **({"registry": registry} if registry else {}),
@@ -321,17 +333,23 @@ def _generate_dagster_cloud_yaml_contents(
 def _get_git_web_url(git_root: Path) -> Optional[str]:
     try:
         remote_origin_url = (
-            subprocess.check_output(["git", "config", "remote.origin.url"]).decode("utf-8").strip()
+            subprocess.check_output(["git", "config", "remote.origin.url"])
+            .decode("utf-8")
+            .strip()
         )
         remote_origin_url = (
-            remote_origin_url.replace(":", "/").replace(".git", "").replace("git@", "https://")
+            remote_origin_url.replace(":", "/")
+            .replace(".git", "")
+            .replace("git@", "https://")
         )
         return remote_origin_url
     except subprocess.CalledProcessError:
         return None
 
 
-def _get_build_fragment_for_locations(location_ctxs: list[DgContext], git_root: Path) -> str:
+def _get_build_fragment_for_locations(
+    location_ctxs: list[DgContext], git_root: Path
+) -> str:
     # TODO: when we cut over to dg deploy, we'll just use a single build call for the workspace
     # rather than iterating over each project
     output = []
@@ -352,7 +370,9 @@ def _get_build_fragment_for_locations(location_ctxs: list[DgContext], git_root: 
 @click.option("--git-root", type=Path, help="Path to the git root of the repository")
 @dg_global_options
 @cli_telemetry_wrapper
-def scaffold_github_actions_command(git_root: Optional[Path], **global_options: object) -> None:
+def scaffold_github_actions_command(
+    git_root: Optional[Path], **global_options: object
+) -> None:
     """Scaffold a GitHub Actions workflow for a Dagster project.
 
     This command will create a GitHub Actions workflow in the `.github/workflows` directory
@@ -375,13 +395,17 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
 
     if plus_config and plus_config.organization:
         organization_name = plus_config.organization
-        click.echo(f"Using organization name {organization_name} from Dagster Plus config.")
+        click.echo(
+            f"Using organization name {organization_name} from Dagster Plus config."
+        )
     else:
         organization_name = click.prompt("Dagster Plus organization name") or ""
 
     if plus_config and plus_config.default_deployment:
         deployment_name = plus_config.default_deployment
-        click.echo(f"Using default deployment name {deployment_name} from Dagster Plus config.")
+        click.echo(
+            f"Using default deployment name {deployment_name} from Dagster Plus config."
+        )
     else:
         deployment_name = click.prompt("Default deployment name", default="prod")
 
@@ -405,15 +429,14 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
     )
 
     if agent_type == "HYBRID":
-        # Attempt to read registry from registry.yaml
-        registry_file = dg_context.root_path / "registry.yaml"
-        if registry_file.exists():
-            registry_url = yaml.safe_load(registry_file.read_text()).get("registry")
-
+        # Attempt to read registry from build.yaml
+        registry_url = (
+            dg_context.build_config["registry"] if dg_context.build_config else None
+        )
         if not registry_url:
             registry_url = click.prompt("Docker registry URL, for built images")
         else:
-            click.echo(f"Using Docker registry URL {registry_url} from registry.yaml")
+            click.echo(f"Using Docker registry URL {registry_url} from build.yaml")
 
         project_contexts = _get_project_contexts(dg_context, cli_config)
 
@@ -425,9 +448,9 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
             )
         build_fragment = _get_build_fragment_for_locations(project_contexts, git_root)
 
-        template = template.replace("# BUILD_LOCATION_FRAGMENT", build_fragment).replace(
-            "IMAGE_REGISTRY_TEMPLATE", registry_url
-        )
+        template = template.replace(
+            "# BUILD_LOCATION_FRAGMENT", build_fragment
+        ).replace("IMAGE_REGISTRY_TEMPLATE", registry_url)
 
     if registry_url:
         for registry_info in REGISTRY_INFOS:
@@ -527,12 +550,16 @@ def scaffold_project_command(
     live in `src.<project_name>.lib`. These types can be created with `dg scaffold component-type`.
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(
+        Path.cwd(), cli_config
+    )
 
     abs_path = path.resolve()
     if dg_context.is_workspace:
         if dg_context.has_project(abs_path.relative_to(dg_context.workspace_root_path)):
-            exit_with_error(f"The current workspace already specifies a project at {abs_path}.")
+            exit_with_error(
+                f"The current workspace already specifies a project at {abs_path}."
+            )
         elif abs_path.exists():
             exit_with_error(f"A file or directory already exists at {abs_path}.")
 
@@ -557,7 +584,9 @@ def _core_scaffold(
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
     if not registry.has(object_key):
-        exit_with_error(f"Scaffoldable object type `{object_key.to_typename()}` not found.")
+        exit_with_error(
+            f"Scaffoldable object type `{object_key.to_typename()}` not found."
+        )
     elif dg_context.has_component_instance(instance_name):
         exit_with_error(f"A component instance named `{instance_name}` already exists.")
 
@@ -590,7 +619,9 @@ def _core_scaffold(
     )
 
 
-def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> DgClickCommand:
+def _create_scaffold_subcommand(
+    key: PluginObjectKey, obj: PluginObjectSnap
+) -> DgClickCommand:
     # We need to "reset" the help option names to the default ones because we inherit the parent
     # value of context settings from the parent group, which has been customized.
     @click.command(
@@ -658,7 +689,9 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
         for name, field_info in obj.scaffolder_schema["properties"].items():
             # All fields are currently optional because they can also be passed under
             # `--json-params`
-            option = json_schema_property_to_click_option(name, field_info, required=False)
+            option = json_schema_property_to_click_option(
+                name, field_info, required=False
+            )
             scaffold_command.params.append(option)
 
     return scaffold_command
@@ -697,9 +730,13 @@ def scaffold_component_type_command(
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)
-    component_key = PluginObjectKey(name=name, namespace=dg_context.default_plugin_module_name)
+    component_key = PluginObjectKey(
+        name=name, namespace=dg_context.default_plugin_module_name
+    )
     if registry.has(component_key):
-        exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
+        exit_with_error(
+            f"Component type`{component_key.to_typename()}` already exists."
+        )
 
     scaffold_component_type(
         dg_context=dg_context, class_name=name, module_name=module_name, model=model

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/build-location-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/build-location-fragment.yaml
@@ -1,0 +1,16 @@
+- name: Build and upload Docker image for "LOCATION_NAME"
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/build-push-action@v4
+  with:
+    context: LOCATION_PATH
+    push: true
+    tags: ${{ env.IMAGE_REGISTRY }}:${{ env.IMAGE_TAG }}-LOCATION_NAME
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+
+- name: Update build session with image tag for LOCATION_NAME
+  id: ci-set-build-output-example-location
+  if: steps.prerun.outputs.result != 'skip'
+  uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
+  with:
+    command: "ci set-build-output --location-name=LOCATION_NAME --image-tag=$IMAGE_TAG-LOCATION_NAME"

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
@@ -58,7 +58,7 @@ jobs:
           dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_YAML_PATH }}
           # A full deployment name. If this run is for a pull request, this value will be used as
           # the base deployment for the branch deployment.
-          deployment: "prod"
+          deployment: "DEFAULT_DEPLOYMENT_NAME"
 
       # Any value can be used as the docker image tag. It is recommended to use a unique value
       # for each build so that multiple builds do not overwrite each other.

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
@@ -1,0 +1,107 @@
+name: Dagster Cloud Hybrid Deployment
+on:
+  push: # For full deployments
+    branches:
+      - "main"
+      - "master"
+  pull_request: # For branch deployments
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  # Cancel in-progress deploys to the same branch
+  group: ${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+env:
+  # The organization name in Dagster Cloud
+  DAGSTER_CLOUD_ORGANIZATION: "ORGANIZATION_NAME"
+  # The API token from https://dagster.cloud/ should be stored in Secrets
+  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  # Path to the root folder containing the dagster project
+  DAGSTER_PROJECT_DIR: "."
+  # Path to dagster_cloud.yaml relative to DAGSTER_PROJECT_DIR
+  DAGSTER_CLOUD_YAML_PATH: "dagster_cloud.yaml"
+  # The IMAGE_REGISTRY should match the 'registry:'' in dagster_cloud.yaml
+  IMAGE_REGISTRY: "IMAGE_REGISTRY_TEMPLATE"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  dagster-cloud-deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      # If this is a closed PR the prerun step closes the branch deployment and returns
+      # output.result='skip' which is used to skip other steps in this workflow.
+      - name: Pre-run checks
+        id: prerun
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
+
+      # Checkout the project
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: steps.prerun.outputs.result != 'skip'
+        with:
+          ref: ${{ github.head_ref }}
+
+      # Validate dagster_cloud.yaml and the connection to dagster.cloud
+      - name: Validate configuration
+        id: ci-validate
+        if: steps.prerun.outputs.result != 'skip'
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
+        with:
+          command: "ci check --project-dir ${{ env.DAGSTER_PROJECT_DIR }} --dagster-cloud-yaml-path ${{ env.DAGSTER_CLOUD_YAML_PATH }}"
+
+      # Parse dagster_cloud.yaml, detect if this is branch deployment and initialize the build session
+      - name: Initialize build session
+        id: ci-init
+        if: steps.prerun.outputs.result != 'skip'
+        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v0.1
+        with:
+          project_dir: ${{ env.DAGSTER_PROJECT_DIR }}
+          dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_YAML_PATH }}
+          # A full deployment name. If this run is for a pull request, this value will be used as
+          # the base deployment for the branch deployment.
+          deployment: "prod"
+
+      # Any value can be used as the docker image tag. It is recommended to use a unique value
+      # for each build so that multiple builds do not overwrite each other.
+      - name: Generate docker image tag
+        id: generate-image-tag
+        if: steps.prerun.outputs.result != 'skip'
+        run: echo "IMAGE_TAG=$GITHUB_SHA-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> $GITHUB_ENV && echo $IMAGE_TAG
+
+      # Enable buildx for caching
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login to the container registry
+      # CONTAINER_REGISTRY_LOGIN_FRAGMENT
+
+      # For each code location, the "build-push-action" builds the docker
+      # image and a "set-build-output" command records the image tag for each code location.
+      # To re-use the same docker image across multiple code locations, build the docker image once
+      # and specify the same tag in multiple "set-build-output" commands. To use a different docker
+      # image for each code location, use multiple "build-push-actions" with a location specific
+      # tag.
+      # BUILD_LOCATION_FRAGMENT
+
+      # Deploy all code locations in this build session to Dagster Cloud
+      - name: Deploy to Dagster Cloud
+        id: ci-deploy
+        if: steps.prerun.outputs.result != 'skip'
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
+        with:
+          command: "ci deploy"
+
+      # Update a PR comment - this runs always() so the comment is updated on success and failure
+      - name: Update PR comment for branch deployments
+        id: ci-notify
+        if: steps.prerun.outputs.result != 'skip' && always()
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
+        with:
+          command: "ci notify --project-dir=${{ env.DAGSTER_PROJECT_DIR }}"
+
+      # Generate a summary that shows up on the Workflow Summary page
+      - name: Generate a summary
+        id: ci-summary
+        if: steps.prerun.outputs.result != 'skip' && always()
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
+        with:
+          command: "ci status --output-format=markdown >> $GITHUB_STEP_SUMMARY"

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/hybrid-github-action.yaml
@@ -20,8 +20,6 @@ env:
   DAGSTER_PROJECT_DIR: "."
   # Path to dagster_cloud.yaml relative to DAGSTER_PROJECT_DIR
   DAGSTER_CLOUD_YAML_PATH: "dagster_cloud.yaml"
-  # The IMAGE_REGISTRY should match the 'registry:'' in dagster_cloud.yaml
-  IMAGE_REGISTRY: "IMAGE_REGISTRY_TEMPLATE"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   dagster-cloud-deploy:

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/azure-container-registry-login-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/azure-container-registry-login-fragment.yaml
@@ -1,0 +1,9 @@
+# Azure Container Registry (ACR)
+# https://github.com/docker/login-action#azure-container-registry-acr
+- name: Login to Azure Container Registry
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/login-action@v3
+  with:
+    registry: "IMAGE_REGISTRY_TEMPLATE"
+    username: ${{ secrets.AZURE_CLIENT_ID }}
+    password: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/dockerhub-login-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/dockerhub-login-fragment.yaml
@@ -1,0 +1,8 @@
+# DockerHub
+# https://github.com/docker/login-action#docker-hub
+- name: Login to Docker Hub
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/login-action@v1
+  with:
+    username: ${{ secrets.DOCKERHUB_USERNAME }}
+    password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/ecr-login-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/ecr-login-fragment.yaml
@@ -1,0 +1,12 @@
+# AWS ECR
+# https://github.com/aws-actions/amazon-ecr-login
+- name: Configure AWS credentials
+  if: steps.prerun.outputs.result != 'skip'
+  uses: aws-actions/configure-aws-credentials@v2
+  with:
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    aws-region: ${{ secrets.AWS_REGION }}
+- name: Login to ECR
+  if: steps.prerun.outputs.result != 'skip'
+  uses: aws-actions/amazon-ecr-login@v1

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/gcr-login-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/gcr-login-fragment.yaml
@@ -1,0 +1,9 @@
+# GCR
+# https://github.com/docker/login-action#google-container-registry-gcr
+- name: Login to GCR
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/login-action@v1
+  with:
+    registry: gcr.io
+    username: _json_key
+    password: ${{ secrets.GCR_JSON_KEY }}

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/github-container-registry-login-fragment.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/registry_fragments/github-container-registry-login-fragment.yaml
@@ -1,0 +1,9 @@
+# GitHub Container Registry
+# https://github.com/docker/login-action#github-container-registry
+- name: Login to GitHub Container Registry
+  if: steps.prerun.outputs.result != 'skip'
+  uses: docker/login-action@v1
+  with:
+    registry: ghcr.io
+    username: ${{ github.actor }}
+    password: ${{ secrets.GITHUB_TOKEN }}

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/serverless-github-action.yaml
@@ -52,7 +52,7 @@ jobs:
           dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_FILE }}
           # A full deployment name. If this run is for a pull request, this value will be used as
           # the base deployment for the branch deployment.
-          deployment: "prod"
+          deployment: "DEFAULT_DEPLOYMENT_NAME"
 
       # If using fast build, build the PEX
       # First ensure the correct Python version is installed

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+import jinja2
+
+
+def create_deploy_dockerfile(dst_path, python_version, use_editable_dagster: bool):
+    dockerfile_template_path = (
+        Path(__file__).parent.parent.parent
+        / "templates"
+        / (
+            "deploy_uv_editable_Dockerfile.jinja"
+            if use_editable_dagster
+            else "deploy_uv_Dockerfile.jinja"
+        )
+    )
+
+    loader = jinja2.FileSystemLoader(
+        searchpath=os.path.dirname(dockerfile_template_path)
+    )
+    env = jinja2.Environment(loader=loader)
+
+    template = env.get_template(os.path.basename(dockerfile_template_path))
+
+    with open(dst_path, "w", encoding="utf8") as f:
+        f.write(template.render(python_version=python_version))
+        f.write("\n")

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -32,34 +32,6 @@ query AllSecretsQuery($onlyViewable: Boolean, $scopes: SecretScopesInput) {
 """
 
 
-SECRETS_QUERY = """
-{
-	secretsOrError {
-    __typename
-    ... on Secrets {
-      secrets {
-        id
-        localDeploymentScope
-        fullDeploymentScope
-        allBranchDeploymentsScope
-        specificBranchDeploymentScope
-        secretName
-        secretValue
-        locationNames
-      }
-    }
-    ... on UnauthorizedError {
-        message
-    }
-    ... on PythonError {
-        message
-        stack
-    }
-  }
-}
-"""
-
-
 CREATE_OR_UPDATE_SECRET_FOR_SCOPES_MUTATION = """
     mutation CreateOrUpdateSecretForScopes($secretName: String!, $secretValue: String!, $scopes: SecretScopesInput!, $locationName: String) {
         createOrUpdateSecretForScopes(secretName: $secretName, secretValue: $secretValue, scopes: $scopes, locationName: $locationName) {
@@ -97,15 +69,11 @@ query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, 
                 id
                 secretName
                 secretValue
-
                 updatedBy {
                     email
                 }
-
                 updateTimestamp
-
                 locationNames
-
                 fullDeploymentScope
                 allBranchDeploymentsScope
                 specificBranchDeploymentScope
@@ -121,6 +89,14 @@ query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, 
             message
             stack
         }
+    }
+}
+"""
+
+DEPLOYMENT_INFO_QUERY = """
+query DeploymentInfoQuery {
+	currentDeployment {
+        agentType
     }
 }
 """

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
@@ -74,14 +74,8 @@ def test_scaffold_github_actions_command_success_serverless(
     assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
     assert "hooli" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
     assert Path("dagster_cloud.yaml").exists()
-    assert (
-        yaml.safe_load(Path("dagster_cloud.yaml").read_text())
-        == EXPECTED_DAGSTER_CLOUD_YAML
-    )
-    assert (
-        "https://github.com/hooli/example-repo/settings/secrets/actions"
-        in result.output
-    )
+    assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
+    assert "https://github.com/hooli/example-repo/settings/secrets/actions" in result.output
 
 
 @responses.activate
@@ -125,24 +119,17 @@ def test_scaffold_github_actions_command_no_plus_config_serverless(
     )
     with tempfile.TemporaryDirectory() as cloud_config_dir:
         monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
-        monkeypatch.setenv(
-            "DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config")
-        )
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
 
         runner = setup_populated_git_workspace
-        result = runner.invoke(
-            "scaffold", "github-actions", input="my-org\nprod\nserverless\n"
-        )
+        result = runner.invoke("scaffold", "github-actions", input="my-org\nprod\nserverless\n")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert "Dagster Plus organization name: " in result.output
         assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
         assert "my-org" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
         assert Path("dagster_cloud.yaml").exists()
-        assert (
-            yaml.safe_load(Path("dagster_cloud.yaml").read_text())
-            == EXPECTED_DAGSTER_CLOUD_YAML
-        )
+        assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
 
 
 @responses.activate
@@ -165,18 +152,13 @@ def test_scaffold_github_actions_command_no_git_root_serverless(
         assert result.exit_code == 1, result.output + " " + str(result.exception)
         assert "No git repository found" in result.output
 
-        result = runner.invoke(
-            "scaffold", "github-actions", "--git-root", str(Path.cwd())
-        )
+        result = runner.invoke("scaffold", "github-actions", "--git-root", str(Path.cwd()))
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
         assert "hooli" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
         assert Path("dagster_cloud.yaml").exists()
-        assert (
-            yaml.safe_load(Path("dagster_cloud.yaml").read_text())
-            == EXPECTED_DAGSTER_CLOUD_YAML
-        )
+        assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
 
 
 FAKE_ECR_URL = "10000.dkr.ecr.us-east-1.amazonaws.com"
@@ -242,10 +224,7 @@ def test_scaffold_github_actions_command_success_hybrid(
     assert yaml.safe_load(
         Path("dagster_cloud.yaml").read_text()
     ) == get_expected_dagster_cloud_yaml_hybrid(registry_url)
-    assert (
-        "https://github.com/hooli/example-repo/settings/secrets/actions"
-        in result.output
-    )
+    assert "https://github.com/hooli/example-repo/settings/secrets/actions" in result.output
 
     if registry_info.secrets_hints:
         for hint in registry_info.secrets_hints:
@@ -302,9 +281,7 @@ def test_scaffold_github_actions_command_no_plus_config_hybrid(
     )
     with tempfile.TemporaryDirectory() as cloud_config_dir:
         monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
-        monkeypatch.setenv(
-            "DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config")
-        )
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
 
         runner = setup_populated_git_workspace
         result = runner.invoke(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
@@ -28,7 +28,8 @@ def setup_populated_git_workspace():
     ):
         subprocess.run(["git", "init"], check=False)
         subprocess.run(
-            ["git", "remote", "add", "origin", "git@github.com:hooli/example-repo.git"], check=False
+            ["git", "remote", "add", "origin", "git@github.com:hooli/example-repo.git"],
+            check=False,
         )
         runner.invoke("scaffold", "project", "foo")
         runner.invoke("scaffold", "project", "bar")
@@ -121,7 +122,7 @@ def test_scaffold_github_actions_command_no_plus_config_serverless(
         monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
 
         runner = setup_populated_git_workspace
-        result = runner.invoke("scaffold", "github-actions", input="my-org\nserverless\n")
+        result = runner.invoke("scaffold", "github-actions", input="my-org\nprod\nserverless\n")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert "Dagster Plus organization name: " in result.output
@@ -191,7 +192,10 @@ FAKE_REGISTRY_URLS = [
     ids=[info.name for info in REGISTRY_INFOS],
 )
 def test_scaffold_github_actions_command_success_hybrid(
-    dg_plus_cli_config, setup_populated_git_workspace: ProxyRunner, registry_url, registry_info
+    dg_plus_cli_config,
+    setup_populated_git_workspace: ProxyRunner,
+    registry_url,
+    registry_info,
 ):
     mock_gql_response(
         query=gql.DEPLOYMENT_INFO_QUERY,
@@ -281,7 +285,9 @@ def test_scaffold_github_actions_command_no_plus_config_hybrid(
 
         runner = setup_populated_git_workspace
         result = runner.invoke(
-            "scaffold", "github-actions", input=f"my-org\nhybrid\n{FAKE_ECR_URL}\n"
+            "scaffold",
+            "github-actions",
+            input=f"my-org\nprod\nhybrid\n{FAKE_ECR_URL}\n",
         )
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_github_actions_command.py
@@ -74,8 +74,14 @@ def test_scaffold_github_actions_command_success_serverless(
     assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
     assert "hooli" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
     assert Path("dagster_cloud.yaml").exists()
-    assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
-    assert "https://github.com/hooli/example-repo/settings/secrets/actions" in result.output
+    assert (
+        yaml.safe_load(Path("dagster_cloud.yaml").read_text())
+        == EXPECTED_DAGSTER_CLOUD_YAML
+    )
+    assert (
+        "https://github.com/hooli/example-repo/settings/secrets/actions"
+        in result.output
+    )
 
 
 @responses.activate
@@ -119,17 +125,24 @@ def test_scaffold_github_actions_command_no_plus_config_serverless(
     )
     with tempfile.TemporaryDirectory() as cloud_config_dir:
         monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
-        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
+        monkeypatch.setenv(
+            "DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config")
+        )
 
         runner = setup_populated_git_workspace
-        result = runner.invoke("scaffold", "github-actions", input="my-org\nprod\nserverless\n")
+        result = runner.invoke(
+            "scaffold", "github-actions", input="my-org\nprod\nserverless\n"
+        )
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert "Dagster Plus organization name: " in result.output
         assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
         assert "my-org" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
         assert Path("dagster_cloud.yaml").exists()
-        assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
+        assert (
+            yaml.safe_load(Path("dagster_cloud.yaml").read_text())
+            == EXPECTED_DAGSTER_CLOUD_YAML
+        )
 
 
 @responses.activate
@@ -152,13 +165,18 @@ def test_scaffold_github_actions_command_no_git_root_serverless(
         assert result.exit_code == 1, result.output + " " + str(result.exception)
         assert "No git repository found" in result.output
 
-        result = runner.invoke("scaffold", "github-actions", "--git-root", str(Path.cwd()))
+        result = runner.invoke(
+            "scaffold", "github-actions", "--git-root", str(Path.cwd())
+        )
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert Path(".github/workflows/dagster-plus-deploy.yml").exists()
         assert "hooli" in Path(".github/workflows/dagster-plus-deploy.yml").read_text()
         assert Path("dagster_cloud.yaml").exists()
-        assert yaml.safe_load(Path("dagster_cloud.yaml").read_text()) == EXPECTED_DAGSTER_CLOUD_YAML
+        assert (
+            yaml.safe_load(Path("dagster_cloud.yaml").read_text())
+            == EXPECTED_DAGSTER_CLOUD_YAML
+        )
 
 
 FAKE_ECR_URL = "10000.dkr.ecr.us-east-1.amazonaws.com"
@@ -224,7 +242,10 @@ def test_scaffold_github_actions_command_success_hybrid(
     assert yaml.safe_load(
         Path("dagster_cloud.yaml").read_text()
     ) == get_expected_dagster_cloud_yaml_hybrid(registry_url)
-    assert "https://github.com/hooli/example-repo/settings/secrets/actions" in result.output
+    assert (
+        "https://github.com/hooli/example-repo/settings/secrets/actions"
+        in result.output
+    )
 
     if registry_info.secrets_hints:
         for hint in registry_info.secrets_hints:
@@ -232,7 +253,7 @@ def test_scaffold_github_actions_command_success_hybrid(
 
 
 @responses.activate
-@pytest.mark.parametrize("registry_source", ["registry.yaml", "prompt"])
+@pytest.mark.parametrize("registry_source", ["build.yaml", "prompt"])
 def test_scaffold_github_actions_command_success_project_hybrid(
     dg_plus_cli_config,
     registry_source,
@@ -245,8 +266,8 @@ def test_scaffold_github_actions_command_success_project_hybrid(
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        if registry_source == "registry.yaml":
-            Path("registry.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL}))
+        if registry_source == "build.yaml":
+            Path("build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL}))
 
         subprocess.run(["git", "init"], check=False)
         result = runner.invoke(
@@ -281,7 +302,9 @@ def test_scaffold_github_actions_command_no_plus_config_hybrid(
     )
     with tempfile.TemporaryDirectory() as cloud_config_dir:
         monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
-        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
+        monkeypatch.setenv(
+            "DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config")
+        )
 
         runner = setup_populated_git_workspace
         result = runner.invoke(


### PR DESCRIPTION
## Summary

Stacks on #28962. Implements `dg scaffold github-action` for hybrid orgs.

`dg scaffold github-action` queries Plus to figure out which agent type is in use, and scaffolds the corresponding GitHub actions file. It looks for a `regsitry.yaml` file to determine which registry type to log in to, and scaffolds a build step and dockerfile (if one doesn't yet exist) for each location.


## Test Plan

Mocked unit tests.
