### PR TITLE
[resolvable] cite Resolvable subclass in error message

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -186,7 +186,7 @@ def _get_annotations(
     # * @record
     else:
         raise ResolutionException(
-            f"Invalid Resolved type {resolved_type} could not determine fields, expected:\n"
+            f"Invalid Resolvable type {resolved_type} could not determine fields, expected:\n"
             "* class with __init__\n"
             "* @dataclass\n"
             "* pydantic Model\n"
@@ -209,13 +209,13 @@ def _get_init_kwargs(target_type: type[Resolvable]):
 
         if param.kind == param.POSITIONAL_ONLY:
             raise ResolutionException(
-                f"Invalid Resolved type {target_type}: __init__ contains positional only parameter."
+                f"Invalid Resolvable type {target_type}: __init__ contains positional only parameter."
             )
         if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
             continue
         if param.annotation == param.empty:
             raise ResolutionException(
-                f"Invalid Resolved type {target_type}: __init__ parameter {name} has no type hint."
+                f"Invalid Resolvable type {target_type}: __init__ parameter {name} has no type hint."
             )
 
         fields[name] = (param.annotation, param.default is not param.empty, None)
@@ -274,11 +274,13 @@ def _get_resolver(annotation: Any, field_name: str) -> "Resolver":
     if res:
         return res
     raise ResolutionException(
-        f"Could not derive resolver for annotation {field_name}: {annotation}.\n"
+        "Could not derive resolver for annotation\n"
+        f"  {field_name}: {annotation}\n"
         "Field types are expected to be:\n"
         "* serializable types such as str, float, int, bool, list, etc\n"
+        "* Resolvable subclasses\n"
         "* pydantic Models\n"
-        "* Annotated with an appropriate Resolver."
+        "* Annotated with an appropriate Resolver"
     )
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -30,7 +30,9 @@ def test_error():
         name: str
         foo: Foo
 
-    with pytest.raises(ResolutionException, match="Could not derive resolver for annotation foo:"):
+    with pytest.raises(
+        ResolutionException, match=r"Could not derive resolver for annotation\W*foo:"
+    ):
         MyNewThing.resolve_from_yaml("")
 
 
@@ -211,3 +213,16 @@ def test_component_docs():
     json_schema = model_cls.model_json_schema()
     assert json_schema["$defs"]["RangeTest"]["properties"]["type"]["description"]
     assert json_schema["$defs"]["SumTest"]["properties"]["type"]["description"]
+
+
+def test_nested_not_resolvable():
+    @dataclass
+    class Child:
+        name: str
+
+    @dataclass
+    class Parent(Resolvable):
+        children: list[Child]
+
+    with pytest.raises(ResolutionException, match="Resolvable subclass"):
+        Parent.resolve_from_yaml("")


### PR DESCRIPTION
During use, we hit an error when a `@dataclass` used as a field in a `Resolvable` `@dataclass` was not also `Resolvable`. 

This PR makes a conservative improvement for this problem by 
* adding some newlines to highlight the problematic annotation 
* calling out explicitly that a `Resolvable` subclass is one of the expected conditions

## How I Tested These Changes

added test
