### PR TITLE
[dg] Docs: wrap copy behavior in a try/catch

### DIFF
--- a/js_modules/dagster-ui/packages/dg-docs-components/src/CopyButton.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/CopyButton.tsx
@@ -11,12 +11,16 @@ interface Props {
 export default function CopyButton({content}: Props) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(content);
-    setCopied(true);
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (e) {
+      console.error('Failed to copy text:', e);
+    }
   };
 
   const icon = copied ? (


### PR DESCRIPTION
## Summary & Motivation

Add a try/catch to the clipboard write on the dg-docs-components CopyButton, to see if it helps surface issues seen by @schrockn.

Also added an `await` on the `writeText` call to be a bit more correct with subsequent behavior, since the function returns a Promise.

## How I Tested These Changes

`dg docs serve`, verify that copy works as expected on code blocks.