### PR TITLE
Reapply partition key pagination APIs

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -616,6 +616,7 @@ from dagster._core.types.dagster_type import (
     make_python_type_usable_as_dagster_type as make_python_type_usable_as_dagster_type,
 )
 from dagster._core.types.decorator import usable_as_dagster_type as usable_as_dagster_type
+from dagster._core.types.pagination import PaginatedResults as PaginatedResults
 from dagster._core.types.python_dict import Dict as Dict
 from dagster._core.types.python_set import Set as Set
 from dagster._core.types.python_tuple import Tuple as Tuple

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionsDefinition,
     PartitionDimensionDefinition,
 )
-from dagster._core.definitions.partition import AllPartitionsSubset
+from dagster._core.definitions.partition import AllPartitionsSubset, TemporalContext
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
@@ -51,31 +51,6 @@ if TYPE_CHECKING:
 
 
 U_EntityKey = TypeVar("U_EntityKey", AssetKey, AssetCheckKey, EntityKey)
-
-
-class TemporalContext(NamedTuple):
-    """TemporalContext represents an effective time, used for business logic, and last_event_id
-    which is used to identify that state of the event log at some point in time. Put another way,
-    the value of a TemporalContext represents a point in time and a snapshot of the event log.
-
-    Effective time: This is the effective time of the computation in terms of business logic,
-    and it impacts the behavior of partitioning and partition mapping. For example,
-    the "last" partition window of a given partitions definition, it is with
-    respect to the effective time.
-
-    Last event id: Our event log has a monotonically increasing event id. This is used to
-    cursor the event log. This event_id is also propogated to derived tables to indicate
-    when that record is valid.  This allows us to query the state of the event log
-    at a given point in time.
-
-    Note that insertion time of the last_event_id is not the same as the effective time.
-
-    A last_event_id of None indicates that the reads will be volatile will immediately
-    reflect any subsequent writes.
-    """
-
-    effective_dt: datetime
-    last_event_id: Optional[int]
 
 
 class AssetGraphView(LoadingContext):

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -1,5 +1,7 @@
+import base64
 import hashlib
 import itertools
+import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from functools import lru_cache, reduce
@@ -10,6 +12,7 @@ from dagster._annotations import public
 from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
     DynamicPartitionsDefinition,
+    PartitionLoadingContext,
     PartitionsDefinition,
     PartitionsSubset,
     StaticPartitionsDefinition,
@@ -29,6 +32,8 @@ from dagster._core.storage.tags import (
     MULTIDIMENSIONAL_PARTITION_PREFIX,
     get_multidimensional_partition_tag,
 )
+from dagster._core.types.pagination import PaginatedResults
+from dagster._record import record
 from dagster._time import get_current_datetime
 
 INVALID_STATIC_PARTITIONS_KEY_CHARACTERS = set(["|", ",", "[", "]"])
@@ -334,6 +339,48 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
             current_time or get_current_datetime(), dynamic_partitions_store
         )
 
+    def get_paginated_partition_keys(
+        self,
+        context: PartitionLoadingContext,
+        limit: int,
+        ascending: bool,
+        cursor: Optional[str] = None,
+    ) -> PaginatedResults[str]:
+        """Returns a connection object that contains a list of partition keys and all the necessary
+        information to paginate through them.
+
+        Args:
+            cursor: (Optional[str]): A cursor to track the progress paginating through the returned partition key results.
+            limit: (Optional[int]): The maximum number of partition keys to return.
+
+        Returns:
+            PaginatedResults[MultiPartitionKey]
+        """
+        partition_keys = []
+        iterator = MultiDimensionalPartitionKeyIterator(
+            context=context,
+            partition_defs=self._partitions_defs,
+            cursor=MultiPartitionCursor.from_cursor(cursor),
+            ascending=ascending,
+        )
+        next_cursor = cursor
+        while iterator.has_next():
+            partition_key = next(iterator)
+            if not partition_key:
+                break
+
+            partition_keys.append(partition_key)
+            next_cursor = iterator.cursor().to_string()
+            if len(partition_keys) >= limit:
+                break
+
+        if not next_cursor:
+            next_cursor = MultiPartitionCursor(last_seen_key=None).to_string()
+
+        return PaginatedResults(
+            results=partition_keys, cursor=next_cursor, has_more=iterator.has_next()
+        )
+
     def filter_valid_partition_keys(
         self, partition_keys: set[str], dynamic_partitions_store: DynamicPartitionsStore
     ) -> set[MultiPartitionKey]:
@@ -555,3 +602,154 @@ def get_multipartition_key_from_tags(tags: Mapping[str, str]) -> str:
             partitions_by_dimension[dimension] = tags[tag]
 
     return MultiPartitionKey(partitions_by_dimension)
+
+
+@record
+class MultiPartitionCursor:
+    """A cursor for MultiPartitionsDefinition that tracks last seen keys for each dimension."""
+
+    last_seen_key: Optional[MultiPartitionKey]
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        raw = json.dumps(
+            {
+                "last_seen_key": self.last_seen_key.keys_by_dimension if self.last_seen_key else {},
+            }
+        )
+        return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
+
+    @classmethod
+    def from_cursor(cls, cursor: Optional[str]):
+        if cursor is None:
+            return MultiPartitionCursor(last_seen_key=None)
+
+        raw = json.loads(base64.b64decode(cursor).decode("utf-8"))
+        if "last_seen_key" not in raw:
+            raise ValueError(f"Invalid cursor: {cursor}")
+        return MultiPartitionCursor(last_seen_key=MultiPartitionKey(raw["last_seen_key"]))
+
+
+class MultiDimensionalPartitionKeyIterator:
+    """Helper class to iterate through all the partition keys in a MultiPartitionsDefinition."""
+
+    def __init__(
+        self,
+        context: PartitionLoadingContext,
+        partition_defs: list[PartitionDimensionDefinition],
+        cursor: MultiPartitionCursor,
+        ascending: bool,
+    ):
+        self._ascending = ascending
+        self._dimension_names = [dim.name for dim in partition_defs]
+        self._dimension_keys = self._initialize_dimension_keys(context, partition_defs)
+        if cursor and cursor.last_seen_key:
+            self._last_seen_state = self._initialize_state_to_last_seen_key(
+                self._dimension_keys, ascending, cursor.last_seen_key
+            )
+        else:
+            self._last_seen_state = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        current_state = self.next_state()
+        if self._is_state_invalid(current_state, self._dimension_keys):
+            raise StopIteration
+        self._last_seen_state = current_state
+        return self._partition_key_from_state(current_state, self._dimension_keys)
+
+    def next_state(self):
+        if self._last_seen_state is None:
+            return self._get_initial_state(self._dimension_keys, self._ascending)
+
+        advanced = False
+        next_state = {}
+        # Iterate through dimensions in reverse order to advance the state by dimension, from the
+        # least significant to the most significant dimension.  State is represented by the indices
+        # of the cross-product of the keys for each dimension.
+        for idx, dim_name in enumerate(reversed(self._dimension_names)):
+            if advanced:
+                # we've already advanced in the lower dimension, so copy the current dimension index as is
+                next_state[dim_name] = self._last_seen_state[dim_name]
+                continue
+            is_most_significant_dim = idx == len(self._dimension_names) - 1
+            delta = 1 if self._ascending else -1
+            next_state[dim_name] = self._last_seen_state[dim_name] + delta
+            if (self._ascending and next_state[dim_name] < len(self._dimension_keys[dim_name])) or (
+                not self._ascending and next_state[dim_name] >= 0
+            ):
+                advanced = True
+            elif not is_most_significant_dim:
+                next_state[dim_name] = (
+                    0 if self._ascending else len(self._dimension_keys[dim_name]) - 1
+                )
+
+        return next_state
+
+    def has_next(self):
+        next_state = self.next_state()
+        return not self._is_state_invalid(next_state, self._dimension_keys)
+
+    def cursor(self):
+        last_partition_key = self._partition_key_from_state(
+            self._last_seen_state, self._dimension_keys
+        )
+        return MultiPartitionCursor(last_seen_key=last_partition_key)
+
+    def _initialize_dimension_keys(self, context, partition_defs):
+        dimension_keys = {}
+        for dimension in partition_defs:
+            dimension_keys[dimension.name] = dimension.partitions_def.get_partition_keys(
+                current_time=context.temporal_context.effective_dt,
+                dynamic_partitions_store=context.dynamic_partitions_store,
+            )
+
+        return dimension_keys
+
+    def _get_initial_state(self, dimension_keys, ascending: bool):
+        state = {}
+        for dim_name, results in dimension_keys.items():
+            if ascending:
+                state[dim_name] = 0
+            else:
+                state[dim_name] = len(results) - 1
+        return state
+
+    def _initialize_state_to_last_seen_key(
+        self, dimension_keys, ascending: bool, last_seen_key: MultiPartitionKey
+    ):
+        state = {}
+        for dim_name, results in dimension_keys.items():
+            if dim_name in last_seen_key.keys_by_dimension:
+                dimension_value = last_seen_key.keys_by_dimension[dim_name]
+                if dimension_value in results:
+                    # the cursor dimension value is in the set of valid values for that dimension
+                    state[dim_name] = results.index(dimension_value)
+                elif ascending:
+                    state[dim_name] = 0
+                else:
+                    state[dim_name] = len(results) - 1
+            elif ascending:
+                state[dim_name] = 0
+            else:
+                state[dim_name] = len(results) - 1
+        return state
+
+    def _is_state_invalid(self, state, dimension_keys):
+        return any(state[dim_name] >= len(dimension_keys[dim_name]) for dim_name in state) or any(
+            state[dim_name] < 0 for dim_name in state
+        )
+
+    def _partition_key_from_state(self, state, dimension_keys) -> Optional[MultiPartitionKey]:
+        if self._is_state_invalid(state, dimension_keys):
+            return None
+
+        partition_tuple = {}
+        for dim_name, idx in state.items():
+            partition_tuple[dim_name] = dimension_keys[dim_name][idx]
+
+        return MultiPartitionKey(partition_tuple)

--- a/python_modules/dagster/dagster/_core/definitions/temporal_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/temporal_context.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Optional
+
+from dagster._record import record
+
+
+@record
+class TemporalContext:
+    """TemporalContext represents an effective time, used for business logic, and last_event_id
+    which is used to identify that state of the event log at some point in time. Put another way,
+    the value of a TemporalContext represents a point in time and a snapshot of the event log.
+
+    Effective time: This is the effective time of the computation in terms of business logic,
+    and it impacts the behavior of partitioning and partition mapping. For example,
+    the "last" partition window of a given partitions definition, it is with
+    respect to the effective time.
+
+    Last event id: Our event log has a monotonically increasing event id. This is used to
+    cursor the event log. This event_id is also propogated to derived tables to indicate
+    when that record is valid.  This allows us to query the state of the event log
+    at a given point in time.
+
+    Note that insertion time of the last_event_id is not the same as the effective time.
+
+    A last_event_id of None indicates that the reads will be volatile and will immediately
+    reflect any subsequent writes.
+    """
+
+    effective_dt: datetime
+    last_event_id: Optional[int]

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -854,53 +854,18 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
 
     @functools.lru_cache(maxsize=5)
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
-        paginated_results = self.get_paginated_partition_keys_in_time_window(time_window)
-        return paginated_results.results
-
-    @functools.lru_cache(maxsize=5)
-    def get_paginated_partition_keys_in_time_window(
-        self,
-        time_window: TimeWindow,
-        limit: Optional[int] = None,
-        ascending: bool = True,
-        cursor: Optional[str] = None,
-    ) -> PaginatedResults[str]:
         result: list[str] = []
-        if cursor:
-            start_ts = TimeWindowCursor.from_cursor(cursor).start_timestamp
-        else:
-            start_ts = time_window.start.timestamp()
-
-        has_more = False
-        new_cursor = str(
-            TimeWindowCursor(
-                start_timestamp=int(start_ts),
-                end_timestamp=int(start_ts),
-                offset_partition_count=0,
-            )
-        )
-
         time_window_end_timestamp = time_window.end.timestamp()
-        for partition_time_window in self._iterate_time_windows(start_ts):
+        for partition_time_window in self._iterate_time_windows(time_window.start.timestamp()):
             if partition_time_window.start.timestamp() < time_window_end_timestamp:
                 result.append(
                     dst_safe_strftime(
                         partition_time_window.start, self.timezone, self.fmt, self.cron_schedule
                     )
                 )
-                new_cursor = str(
-                    TimeWindowCursor(
-                        start_timestamp=int(partition_time_window.end.timestamp()),
-                        end_timestamp=int(time_window.start.timestamp()),
-                        offset_partition_count=0,
-                    )
-                )
-                if limit and len(result) >= limit:
-                    has_more = True
-                    break
             else:
                 break
-        return PaginatedResults(results=result, cursor=new_cursor, has_more=has_more)
+        return result
 
     def get_partition_subset_in_time_window(
         self, time_window: TimeWindow

--- a/python_modules/dagster/dagster/_core/types/pagination.py
+++ b/python_modules/dagster/dagster/_core/types/pagination.py
@@ -1,0 +1,85 @@
+import base64
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    Sequence,
+)
+from dagster._record import record
+from dagster._serdes import whitelist_for_serdes, deserialize_value, serialize_value
+
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+
+
+@record
+class PaginatedResults(Generic[T]):
+    results: Sequence[T]
+    cursor: str
+    has_more: bool
+
+    """
+    A wrapper for paginated connection results of type T.
+
+    Attributes:
+        results (Sequence[T]): The sequence of returned objects
+        cursor (Optional[str]): Pagination cursor for fetching next page
+        has_more (bool): Whether more results are available
+    """
+
+    @classmethod
+    def create_from_sequence(
+        cls, seq: Sequence[T], limit: int, ascending: bool, cursor: Optional[str] = None
+    ) -> "PaginatedResults[T]":
+        """
+        Create a PaginatedResults from a sequence of objects.
+
+        Args:
+            seq (Sequence[T]): The sequence of objects to paginate
+
+        Returns:
+            PaginatedResults[T]: A PaginatedResults object with the given sequence
+        """
+        seq = seq if ascending else list(reversed(seq))
+        if cursor:
+            value = ValueIndexCursor.from_cursor(cursor).value
+            if value is None or value not in seq:
+                offset = 0
+            else:
+                offset = seq.index(value) + 1
+
+            seq = seq[offset:]
+        else:
+            value = None
+
+        has_more = len(seq) > limit
+        seq = seq[:limit]
+
+        last_seen_value = seq[-1] if seq else value
+        new_cursor = ValueIndexCursor(value=last_seen_value).to_string()
+
+        return PaginatedResults(results=seq, cursor=new_cursor, has_more=has_more)
+
+
+@whitelist_for_serdes
+@record
+class ValueIndexCursor:
+    """
+    Cursor class useful for paginating results based on a last seen value.
+    """
+
+    value: Any
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        string_serialized = serialize_value(self)
+        return base64.b64encode(bytes(string_serialized, encoding="utf-8")).decode(
+            "utf-8"
+        )
+
+    @classmethod
+    def from_cursor(cls, cursor: str):
+        return deserialize_value(base64.b64decode(cursor).decode("utf-8"), cls)

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -15,7 +15,7 @@ from dagster import (
     job,
 )
 from dagster._check import CheckError
-from dagster._core.test_utils import instance_for_test
+from dagster._core.test_utils import get_paginated_partition_keys, instance_for_test
 from dagster._serdes import serialize_value
 
 
@@ -27,6 +27,10 @@ def test_static_partitions(partition_keys: Sequence[str]):
     static_partitions = StaticPartitionsDefinition(partition_keys)
 
     assert static_partitions.get_partition_keys() == partition_keys
+    assert get_paginated_partition_keys(static_partitions) == partition_keys
+    assert get_paginated_partition_keys(static_partitions, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
 
 def test_static_partition_string_input() -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -14,7 +14,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.partition import DynamicPartitionsDefinition, Partition
-from dagster._core.test_utils import instance_for_test
+from dagster._core.test_utils import get_paginated_partition_keys, instance_for_test
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,10 @@ def test_dynamic_partitions_partitions(
 ):
     partitions = DynamicPartitionsDefinition(partition_fn)
 
-    assert partitions.get_partition_keys() == [p.name for p in partition_fn(None)]
+    all_keys = [p.name for p in partition_fn(None)]
+    assert partitions.get_partition_keys() == all_keys
+    assert get_paginated_partition_keys(partitions) == all_keys
+    assert get_paginated_partition_keys(partitions, ascending=False) == list(reversed(all_keys))
 
 
 @pytest.mark.parametrize(
@@ -42,21 +45,28 @@ def test_dynamic_partitions_partitions(
 def test_dynamic_partitions_keys(partition_fn: Callable[[Optional[datetime]], Sequence[str]]):
     partitions = DynamicPartitionsDefinition(partition_fn)
 
-    assert partitions.get_partition_keys() == partition_fn(None)
+    all_keys = partition_fn(None)
+    assert partitions.get_partition_keys() == all_keys
+    assert get_paginated_partition_keys(partitions) == all_keys
+    assert get_paginated_partition_keys(partitions, ascending=False) == list(reversed(all_keys))
 
 
 def test_dynamic_partitions_def_methods():
-    foo = DynamicPartitionsDefinition(name="foo")
+    partitions = DynamicPartitionsDefinition(name="foo")
     with instance_for_test() as instance:
         instance.add_dynamic_partitions("foo", ["a", "b"])
-        assert set(foo.get_partition_keys(dynamic_partitions_store=instance)) == {
-            "a",
-            "b",
-        }
+        all_keys = ["a", "b"]
+        assert partitions.get_partition_keys(dynamic_partitions_store=instance) == all_keys
+        assert (
+            get_paginated_partition_keys(partitions, dynamic_partitions_store=instance) == all_keys
+        )
+        assert get_paginated_partition_keys(
+            partitions, dynamic_partitions_store=instance, ascending=False
+        ) == list(reversed(all_keys))
         assert instance.has_dynamic_partition("foo", "a")
 
         instance.delete_dynamic_partition("foo", "a")
-        assert set(foo.get_partition_keys(dynamic_partitions_store=instance)) == {"b"}
+        assert partitions.get_partition_keys(dynamic_partitions_store=instance) == ["b"]
         assert instance.has_dynamic_partition("foo", "a") is False
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -19,6 +19,7 @@ from dagster import (
     weekly_partitioned_config,
 )
 from dagster._check import CheckError
+from dagster._core.definitions.partition import PartitionLoadingContext, TemporalContext
 from dagster._core.definitions.time_window_partitions import (
     PersistedTimeWindow,
     ScheduleType,
@@ -27,7 +28,7 @@ from dagster._core.definitions.time_window_partitions import (
     dst_safe_strptime,
 )
 from dagster._core.definitions.timestamp import TimestampWithTimezone
-from dagster._core.test_utils import freeze_time
+from dagster._core.test_utils import freeze_time, get_paginated_partition_keys
 from dagster._record import copy
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import create_datetime, parse_time_string
@@ -75,13 +76,19 @@ def test_daily_partitions():
     )
     assert partitions_def.schedule_type == ScheduleType.DAILY
 
+    current_time = datetime.strptime("2021-05-07", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-07", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-05", "2021-05-06"),
         time_window("2021-05-06", "2021-05-07"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
     assert partitions_def.time_window_for_partition_key("2021-05-08") == time_window(
         "2021-05-08", "2021-05-09"
@@ -94,15 +101,21 @@ def test_daily_partitions_with_end_offset():
         return {}
 
     partitions_def = my_partitioned_config.partitions_def
+    current_time = datetime.strptime("2021-05-07", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-07", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-05", "2021-05-06"),
         time_window("2021-05-06", "2021-05-07"),
         time_window("2021-05-07", "2021-05-08"),
         time_window("2021-05-08", "2021-05-09"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
 
 def test_daily_partitions_with_negative_end_offset():
@@ -111,15 +124,21 @@ def test_daily_partitions_with_negative_end_offset():
         return {}
 
     partitions_def = my_partitioned_config.partitions_def
+    current_time = datetime.strptime("2021-05-07", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-07", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-01", "2021-05-02"),
         time_window("2021-05-02", "2021-05-03"),
         time_window("2021-05-03", "2021-05-04"),
         time_window("2021-05-04", "2021-05-05"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
 
 def test_daily_partitions_with_time_offset():
@@ -129,9 +148,13 @@ def test_daily_partitions_with_time_offset():
 
     partitions_def = my_partitioned_config.partitions_def
     assert partitions_def == DailyPartitionsDefinition(start_date="2021-05-05", minute_offset=15)
-
-    partition_keys = partitions_def.get_partition_keys(datetime.strptime("2021-05-07", DATE_FORMAT))
+    current_time = datetime.strptime("2021-05-07", DATE_FORMAT)
+    partition_keys = partitions_def.get_partition_keys(current_time)
     assert partition_keys == ["2021-05-05"]
+    assert get_paginated_partition_keys(partitions_def, current_time) == partition_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
     assert [partitions_def.time_window_for_partition_key(key) for key in partition_keys] == [
         time_window("2021-05-05T00:15:00", "2021-05-06T00:15:00"),
@@ -151,13 +174,19 @@ def test_monthly_partitions():
     assert partitions_def == MonthlyPartitionsDefinition(start_date="2021-05-01")
     assert copy(partitions_def) == MonthlyPartitionsDefinition(start_date="2021-05-01")
 
+    current_time = datetime.strptime("2021-07-03", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-07-03", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-01", "2021-06-01"),
         time_window("2021-06-01", "2021-07-01"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
     assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
         "2021-05-01", "2021-06-01"
@@ -170,15 +199,21 @@ def test_monthly_partitions_with_end_offset():
         return {}
 
     partitions_def = my_partitioned_config.partitions_def
+    current_time = datetime.strptime("2021-07-03", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-07-03", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-01", "2021-06-01"),
         time_window("2021-06-01", "2021-07-01"),
         time_window("2021-07-01", "2021-08-01"),
         time_window("2021-08-01", "2021-09-01"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
 
 def test_monthly_partitions_with_time_offset():
@@ -195,12 +230,16 @@ def test_monthly_partitions_with_time_offset():
     assert partitions_def == MonthlyPartitionsDefinition(
         start_date="2021-05-01", minute_offset=15, hour_offset=3, day_offset=12
     )
-
-    partition_keys = partitions_def.get_partition_keys(datetime.strptime("2021-07-13", DATE_FORMAT))
+    current_time = datetime.strptime("2021-07-13", DATE_FORMAT)
+    partition_keys = partitions_def.get_partition_keys(current_time)
     assert partition_keys == [
         "2021-05-12",
         "2021-06-12",
     ]
+    assert get_paginated_partition_keys(partitions_def, current_time) == partition_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
     assert [partitions_def.time_window_for_partition_key(key) for key in partition_keys] == [
         time_window("2021-05-12T03:15:00", "2021-06-12T03:15:00"),
@@ -221,13 +260,16 @@ def test_hourly_partitions():
     assert partitions_def == HourlyPartitionsDefinition(start_date="2021-05-05-01:00")
     assert copy(partitions_def) == HourlyPartitionsDefinition(start_date="2021-05-05-01:00")
 
-    partition_keys = partitions_def.get_partition_keys(
-        datetime.strptime("2021-05-05-03:00", DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE)
-    )
+    current_time = datetime.strptime("2021-05-05-03:00", DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE)
+    partition_keys = partitions_def.get_partition_keys(current_time)
     assert partition_keys == [
         "2021-05-05-01:00",
         "2021-05-05-02:00",
     ]
+    assert get_paginated_partition_keys(partitions_def, current_time) == partition_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
     assert [partitions_def.time_window_for_partition_key(key) for key in partition_keys] == [
         time_window("2021-05-05T01:00:00", "2021-05-05T02:00:00"),
@@ -249,13 +291,16 @@ def test_hourly_partitions_with_time_offset():
         start_date="2021-05-05-01:00", minute_offset=15
     )
 
-    partition_keys = partitions_def.get_partition_keys(
-        datetime.strptime("2021-05-05-03:30", DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE)
-    )
+    current_time = datetime.strptime("2021-05-05-03:30", DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE)
+    partition_keys = partitions_def.get_partition_keys(current_time)
     assert partition_keys == [
         "2021-05-05-01:15",
         "2021-05-05-02:15",
     ]
+    assert get_paginated_partition_keys(partitions_def, current_time) == partition_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
     assert [partitions_def.time_window_for_partition_key(key) for key in partition_keys] == [
         time_window("2021-05-05T01:15:00", "2021-05-05T02:15:00"),
@@ -277,13 +322,19 @@ def test_weekly_partitions():
     assert copy(partitions_def) == WeeklyPartitionsDefinition(start_date="2021-05-01")
 
     partitions_def = my_partitioned_config.partitions_def
+    current_time = datetime.strptime("2021-05-18", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-18", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-02", "2021-05-09"),
         time_window("2021-05-09", "2021-05-16"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
     assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
         "2021-05-02", "2021-05-09"
@@ -301,12 +352,16 @@ def test_weekly_partitions_with_time_offset():
     assert partitions_def == WeeklyPartitionsDefinition(
         start_date="2021-05-01", minute_offset=15, hour_offset=4, day_offset=3
     )
-
-    partition_keys = partitions_def.get_partition_keys(datetime.strptime("2021-05-20", DATE_FORMAT))
+    current_time = datetime.strptime("2021-05-20", DATE_FORMAT)
+    partition_keys = partitions_def.get_partition_keys(current_time)
     assert partition_keys == [
         "2021-05-05",
         "2021-05-12",
     ]
+    assert get_paginated_partition_keys(partitions_def, current_time) == partition_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(partition_keys)
+    )
 
     assert [partitions_def.time_window_for_partition_key(key) for key in partition_keys] == [
         time_window("2021-05-05T04:15:00", "2021-05-12T04:15:00"),
@@ -446,6 +501,14 @@ def test_time_partitions_daily_partitions(
         partitions_def.get_partition_keys(current_time=current_time),
         expected_partition_keys,
     )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time),
+        expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time, ascending=False),
+        list(reversed(expected_partition_keys)),
+    )
 
 
 @pytest.mark.parametrize(
@@ -508,6 +571,14 @@ def test_time_partitions_monthly_partitions(
     assert_expected_partition_keys(
         partitions_def.get_partition_keys(current_time=current_time),
         expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time),
+        expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time, ascending=False),
+        list(reversed(expected_partition_keys)),
     )
 
 
@@ -576,6 +647,14 @@ def test_time_partitions_weekly_partitions(
     assert_expected_partition_keys(
         partitions_def.get_partition_keys(current_time=current_time),
         expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time),
+        expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time, ascending=False),
+        list(reversed(expected_partition_keys)),
     )
 
 
@@ -712,6 +791,14 @@ def test_time_partitions_hourly_partitions(
         partitions_def.get_partition_keys(current_time=current_time),
         expected_partition_keys,
     )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time),
+        expected_partition_keys,
+    )
+    assert_expected_partition_keys(
+        get_paginated_partition_keys(partitions_def, current_time, ascending=False),
+        list(reversed(expected_partition_keys)),
+    )
 
 
 @pytest.mark.parametrize(
@@ -758,15 +845,21 @@ def test_twice_daily_partitions():
         fmt=DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE,
     )
 
+    current_time = datetime.strptime("2021-05-07", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-07", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-05T00:00:00", "2021-05-05T11:00:00"),
         time_window("2021-05-05T11:00:00", "2021-05-06T00:00:00"),
         time_window("2021-05-06T00:00:00", "2021-05-06T11:00:00"),
         time_window("2021-05-06T11:00:00", "2021-05-07T00:00:00"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
     assert partitions_def.time_window_for_partition_key("2021-05-08-00:00") == time_window(
         "2021-05-08T00:00:00", "2021-05-08T11:00:00"
@@ -783,13 +876,19 @@ def test_start_not_aligned():
         fmt=DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE,
     )
 
+    current_time = datetime.strptime("2021-05-08", DATE_FORMAT)
     assert [
         partitions_def.time_window_for_partition_key(key)
-        for key in partitions_def.get_partition_keys(datetime.strptime("2021-05-08", DATE_FORMAT))
+        for key in partitions_def.get_partition_keys(current_time)
     ] == [
         time_window("2021-05-05T07:00:00", "2021-05-06T07:00:00"),
         time_window("2021-05-06T07:00:00", "2021-05-07T07:00:00"),
     ]
+    all_keys = partitions_def.get_partition_keys(current_time)
+    assert get_paginated_partition_keys(partitions_def, current_time) == all_keys
+    assert get_paginated_partition_keys(partitions_def, current_time, ascending=False) == list(
+        reversed(all_keys)
+    )
 
 
 @pytest.mark.parametrize(
@@ -1831,3 +1930,161 @@ def test_persisted_time_window_serdes():
     deserialized_time_window = deserialize_value(serialized_time_window, PersistedTimeWindow)
     assert isinstance(deserialized_time_window, PersistedTimeWindow)
     assert serialize_value(deserialized_time_window) == serialized_time_window
+
+
+def test_daily_pagination():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=current_time,
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    paginated_results = partitions_def.get_paginated_partition_keys(
+        context=partition_context, limit=3, ascending=True, cursor=None
+    )
+
+    assert len(paginated_results.results) == 3
+    assert paginated_results.has_more
+    assert [
+        partitions_def.time_window_for_partition_key(key) for key in paginated_results.results
+    ] == [
+        time_window("2021-05-05", "2021-05-06"),
+        time_window("2021-05-06", "2021-05-07"),
+        time_window("2021-05-07", "2021-05-08"),
+    ]
+
+    paginated_results = partitions_def.get_paginated_partition_keys(
+        context=partition_context, limit=3, ascending=True, cursor=paginated_results.cursor
+    )
+    assert len(paginated_results.results) == 3
+    assert paginated_results.has_more
+    assert [
+        partitions_def.time_window_for_partition_key(key) for key in paginated_results.results
+    ] == [
+        time_window("2021-05-08", "2021-05-09"),
+        time_window("2021-05-09", "2021-05-10"),
+        time_window("2021-05-10", "2021-05-11"),
+    ]
+
+    assert get_paginated_partition_keys(
+        partitions_def, current_time=current_time
+    ) == partitions_def.get_partition_keys(current_time)
+
+
+def test_empty_pagination():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=datetime.strptime("2021-05-01", DATE_FORMAT),
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    paginated_results = partitions_def.get_paginated_partition_keys(
+        context=partition_context, limit=10, ascending=True, cursor=None
+    )
+    assert len(paginated_results.results) == 0
+    assert not paginated_results.has_more
+
+
+def test_pagination_limit():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=current_time,
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    all_keys = partitions_def.get_partition_keys(current_time)
+
+    for limit in [1, 3, 5, 7, 11, 50]:
+        paginated_results = partitions_def.get_paginated_partition_keys(
+            context=partition_context, limit=limit, ascending=True, cursor=None
+        )
+        assert len(paginated_results.results) == min(limit, len(all_keys))
+        assert paginated_results.has_more == (len(all_keys) > limit)
+        assert paginated_results.results == all_keys[:limit]
+
+
+def test_reverse_pagination():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=current_time,
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    all_keys = partitions_def.get_partition_keys(current_time)
+
+    for limit in [1, 3, 5, 7, 11, 50]:
+        paginated_results = partitions_def.get_paginated_partition_keys(
+            context=partition_context, limit=limit, ascending=False, cursor=None
+        )
+        assert len(paginated_results.results) == min(limit, len(all_keys))
+        assert paginated_results.has_more == (len(all_keys) > limit)
+        assert paginated_results.results == list(reversed(all_keys[-1 * limit :]))
+
+
+def test_reverse_pagination_end_offset():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05", end_offset=2)
+    current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=current_time,
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    all_keys = partitions_def.get_partition_keys(current_time)
+
+    paginated_results = partitions_def.get_paginated_partition_keys(
+        context=partition_context, limit=5, ascending=False, cursor=None
+    )
+
+    assert paginated_results.results == [
+        "2021-06-06",
+        "2021-06-05",
+        "2021-06-04",
+        "2021-06-03",
+        "2021-06-02",
+    ]
+
+    assert get_paginated_partition_keys(
+        partitions_def, current_time=current_time, ascending=False
+    ) == list(reversed(all_keys))
+
+
+def test_reverse_pagination_negative_end_offset():
+    partitions_def = DailyPartitionsDefinition(start_date="2021-05-05", end_offset=-2)
+    current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
+    partition_context = PartitionLoadingContext(
+        temporal_context=TemporalContext(
+            effective_dt=current_time,
+            last_event_id=None,
+        ),
+        dynamic_partitions_store=None,
+    )
+    all_keys = partitions_def.get_partition_keys(current_time)
+
+    paginated_results = partitions_def.get_paginated_partition_keys(
+        context=partition_context, limit=5, ascending=False, cursor=None
+    )
+
+    assert paginated_results.results == [
+        "2021-06-02",
+        "2021-06-01",
+        "2021-05-31",
+        "2021-05-30",
+        "2021-05-29",
+    ]
+
+    assert get_paginated_partition_keys(
+        partitions_def, current_time=current_time, ascending=False
+    ) == list(reversed(all_keys))


### PR DESCRIPTION
## Summary & Motivation
Reapplies #28311, but with the time_window based pagination ripped out because it was unnecessary and changed the underlying non-paginated implementation.

## How I Tested These Changes
BK - ran the automaterialization perf tests locally and saw a 30% increase in perf.
