### PR TITLE
Clean up COVERAGE_ARGS in tox.ini

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
@@ -25,9 +25,6 @@ def _get_latest_dagster_release() -> str:
 
 LATEST_DAGSTER_RELEASE = _get_latest_dagster_release()
 
-# https://github.com/dagster-io/dagster/issues/1662
-DO_COVERAGE = True
-
 GCP_CREDS_FILENAME = "gcp-key-elementl-dev.json"
 
 # GCP tests need appropriate credentials

--- a/python_modules/dagster-pipes/tox.ini
+++ b/python_modules/dagster-pipes/tox.ini
@@ -8,9 +8,6 @@ deps =
   -e ../dagster[test]
   -e ../libraries/dagster-shared
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -4,8 +4,6 @@ skipsdist = True
 [testenv]
 download = True
 setenv =
-  !windows: COVERAGE_ARGS =  --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 passenv =
     CI_*
@@ -42,32 +40,32 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
 
-  api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  asset_defs_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/asset_defs_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests {env:COVERAGE_ARGS} --durations 10 {posargs}
-  components_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/components_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  declarative_automation_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/declarative_automation_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  execution_tests__context_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/context_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__dynamic_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/dynamic_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__engine_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/engine_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__execute_job_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/execute_job_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__execution_plan_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/execution_plan_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__misc_execution_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/misc_execution_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__pipes_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/pipes_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests__versioning_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/versioning_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  general_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  general_tests_old_protobuf: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  launcher_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/launcher_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  logging_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/logging_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  model_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  scheduler_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  scheduler_tests_pendulum_1: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  scheduler_tests_pendulum_2: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  storage_tests_sqlalchemy_1_3: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  storage_tests_sqlalchemy_1_4: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs} -m 'typesignature'
+  api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests --durations 10 {posargs}
+  asset_defs_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/asset_defs_tests --durations 10 {posargs}
+  cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests --durations 10 {posargs}
+  components_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/components_tests --durations 10 {posargs}
+  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --durations 10 {posargs}
+  daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests --durations 10 {posargs}
+  daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests --durations 10 {posargs}
+  declarative_automation_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/declarative_automation_tests --durations 10 {posargs}
+  definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests --durations 10 {posargs}
+  execution_tests__context_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/context_tests --durations 10  {posargs}
+  execution_tests__dynamic_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/dynamic_tests --durations 10  {posargs}
+  execution_tests__engine_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/engine_tests --durations 10  {posargs}
+  execution_tests__execute_job_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/execute_job_tests --durations 10  {posargs}
+  execution_tests__execution_plan_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/execution_plan_tests --durations 10  {posargs}
+  execution_tests__misc_execution_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/misc_execution_tests --durations 10  {posargs}
+  execution_tests__pipes_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/pipes_tests --durations 10  {posargs}
+  execution_tests__versioning_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/versioning_tests --durations 10  {posargs}
+  general_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests --durations 10  {posargs}
+  general_tests_old_protobuf: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests --durations 10  {posargs}
+  launcher_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/launcher_tests --durations 10 {posargs}
+  logging_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/logging_tests --durations 10 {posargs}
+  model_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests --durations 10 {posargs}
+  scheduler_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests --durations 10 {posargs}
+  scheduler_tests_pendulum_1: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests --durations 10  {posargs}
+  scheduler_tests_pendulum_2: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests --durations 10  {posargs}
+  storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests --durations 10 {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests --durations 10 {posargs}
+  storage_tests_sqlalchemy_1_4: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests --durations 10 {posargs}
+  type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --durations 10 {posargs} -m 'typesignature'

--- a/python_modules/libraries/dagster-gcp-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pyspark/tox.ini
@@ -5,9 +5,6 @@ skipsdist = True
 extras =
   test
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN

--- a/python_modules/libraries/dagster-polars/tox.ini
+++ b/python_modules/libraries/dagster-polars/tox.ini
@@ -4,9 +4,6 @@ skipsdist = True
 [testenv]
 install_command = uv pip install {opts} {packages}
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN

--- a/python_modules/libraries/dagster-shared/tox.ini
+++ b/python_modules/libraries/dagster-shared/tox.ini
@@ -3,9 +3,6 @@ skipsdist = true
 
 [testenv]
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN

--- a/python_modules/libraries/dagster-wandb/tox.ini
+++ b/python_modules/libraries/dagster-wandb/tox.ini
@@ -5,9 +5,6 @@ skipsdist = True
 extras =
   test
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN

--- a/scripts/templates_create_dagster_package/tox.ini.tmpl
+++ b/scripts/templates_create_dagster_package/tox.ini.tmpl
@@ -2,9 +2,6 @@
 
 [testenv]
 download = True
-setenv =
-  !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
-  windows: COVERAGE_ARGS =
 passenv =
     CI_*
     COVERALLS_REPO_TOKEN


### PR DESCRIPTION
We stopped running coveralls years ago but never cleaned up the remaining cruft in our tox.ini files.