### PR TITLE
[ui] Improve typechecking on qs usage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
@@ -28,10 +28,10 @@ interface ActiveSuggestionInfo {
   idx: number;
 }
 
-export interface TokenizingFieldValue {
+export type TokenizingFieldValue = {
   token?: string;
   value: string;
-}
+};
 
 interface TokenizingFieldProps {
   values: TokenizingFieldValue[];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -200,7 +200,12 @@ const AssetGraphExplorerWithData = ({
   const [expandedGroups, setExpandedGroups] = useQueryAndLocalStoragePersistedState<string[]>({
     localStorageKey: `asset-graph-open-graph-nodes-${viewType}-${explorerPath.pipelineName}`,
     encode: (arr) => ({expanded: arr.length ? arr.join(',') : undefined}),
-    decode: (qs) => (qs.expanded || '').split(',').filter(Boolean),
+    decode: (qs) => {
+      if (typeof qs.expanded === 'string') {
+        return qs.expanded.split(',').filter(Boolean);
+      }
+      return [];
+    },
     isEmptyState: (val) => val.length === 0,
   });
   const focusGroupIdAfterLayoutRef = React.useRef('');

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -102,7 +102,11 @@ export const AssetGraphExplorerSidebar = React.memo(
         return {'open-nodes': Array.from(val)};
       },
       decode: (qs) => {
-        return new Set(qs['open-nodes']);
+        const openNodes = qs['open-nodes'];
+        if (Array.isArray(openNodes)) {
+          return new Set(openNodes.map((node) => String(node)));
+        }
+        return new Set();
       },
       isEmptyState: (val) => val.size === 0,
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
@@ -311,10 +311,10 @@ export const AllIndividualEventsButton = ({
   children: React.ReactNode;
   disabled?: boolean;
 }) => {
-  const [_open, setOpen] = useQueryPersistedState({
+  const [_open, setOpen] = useQueryPersistedState<boolean>({
     queryKey: 'showAllEvents',
-    decode: (qs) => (qs.showAllEvents === 'true' ? true : false),
-    encode: (b) => ({showAllEvents: b || undefined}),
+    decode: (qs) => typeof qs.showAllEvents === 'string' && qs.showAllEvents === 'true',
+    encode: (b) => ({showAllEvents: b ? 'true' : undefined}),
   });
   const [focusedTimestamp, setFocusedTimestamp] = React.useState<string | undefined>();
   const groups = React.useMemo(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -52,7 +52,7 @@ interface Props {
   isLoadingDefinition: boolean;
 }
 
-const DISPLAYED_STATUSES = [
+const DISPLAYED_STATUSES: AssetPartitionStatus[] = [
   AssetPartitionStatus.MISSING,
   AssetPartitionStatus.MATERIALIZING,
   AssetPartitionStatus.MATERIALIZED,
@@ -88,10 +88,17 @@ export const AssetPartitions = ({
   const [statusFilters, setStatusFilters] = useQueryPersistedState<AssetPartitionStatus[]>({
     defaults: {status: [...DISPLAYED_STATUSES].sort().join(',')},
     encode: (val) => ({status: [...val].sort().join(',')}),
-    decode: (qs) =>
-      (qs.status || '')
-        .split(',')
-        .filter((s: AssetPartitionStatus) => DISPLAYED_STATUSES.includes(s)),
+    decode: (qs) => {
+      const status = qs.status;
+      if (typeof status === 'string') {
+        return status
+          .split(',')
+          .filter((s): s is AssetPartitionStatus =>
+            DISPLAYED_STATUSES.includes(s as AssetPartitionStatus),
+          );
+      }
+      return [];
+    },
   });
 
   const [searchValues, setSearchValues] = useState<string[]>([]);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -33,7 +33,7 @@ export const AssetAutomaterializePolicyPage = ({
   >({
     queryKey: 'evaluation',
     decode: (raw) => {
-      return raw.evaluation;
+      return typeof raw.evaluation === 'string' ? raw.evaluation : undefined;
     },
     encode: (raw) => {
       // Reset the selected partition

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types.tsx
@@ -11,7 +11,7 @@ export type AssetDefinition = Extract<
 
 export type AssetLineageScope = 'neighbors' | 'upstream' | 'downstream';
 
-export interface AssetViewParams {
+export type AssetViewParams = {
   view?: string;
   lineageScope?: AssetLineageScope;
   lineageDepth?: number;
@@ -23,4 +23,4 @@ export interface AssetViewParams {
   default_range?: string;
   column?: string;
   showAllEvents?: boolean;
-}
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -12,7 +12,6 @@ import {
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {doesFilterArrayMatchValueArray} from '../ui/Filters/doesFilterArrayMatchValueArray';
 import {Tag} from '../ui/Filters/useDefinitionTagFilter';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
 type Nullable<T> = {
@@ -42,6 +41,18 @@ export type AssetFilterType = AssetFilterBaseType & {
   selectAllFilters: Array<keyof AssetFilterBaseType>;
 };
 
+const parseJSONArraySafely = (value: qs.ParsedQs[string] | undefined) => {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {}
+  }
+  return [];
+};
+
 export const useAssetDefinitionFilterState = ({isEnabled = true}: {isEnabled?: boolean}) => {
   const [filters, setFilters] = useQueryPersistedState<AssetFilterType>({
     encode: isEnabled
@@ -55,20 +66,19 @@ export const useAssetDefinitionFilterState = ({isEnabled = true}: {isEnabled?: b
           selectAllFilters: selectAllFilters?.length ? JSON.stringify(selectAllFilters) : undefined,
         })
       : () => ({}),
-    decode: (qs) => ({
-      groups: qs.groups && isEnabled ? JSON.parse(qs.groups) : [],
-      kinds: qs.kinds && isEnabled ? JSON.parse(qs.kinds) : [],
-      changedInBranch: qs.changedInBranch && isEnabled ? JSON.parse(qs.changedInBranch) : [],
-      owners: qs.owners && isEnabled ? JSON.parse(qs.owners) : [],
-      tags: qs.tags && isEnabled ? JSON.parse(qs.tags) : [],
-      codeLocations:
-        qs.codeLocations && isEnabled
-          ? JSON.parse(qs.codeLocations).map((repo: RepoAddress) =>
-              buildRepoAddress(repo.name, repo.location),
-            )
-          : [],
-      selectAllFilters: qs.selectAllFilters ? JSON.parse(qs.selectAllFilters) : [],
-    }),
+    decode: (qs) => {
+      // JSON will be parsed safely, but we are not verifying the types within the arrays themselves
+      // so there could be downstream issues if the arrays are of incorrect types.
+      return {
+        groups: isEnabled ? parseJSONArraySafely(qs.groups) : [],
+        kinds: isEnabled ? parseJSONArraySafely(qs.kinds) : [],
+        changedInBranch: isEnabled ? parseJSONArraySafely(qs.changedInBranch) : [],
+        owners: isEnabled ? parseJSONArraySafely(qs.owners) : [],
+        tags: isEnabled ? parseJSONArraySafely(qs.tags) : [],
+        codeLocations: isEnabled ? parseJSONArraySafely(qs.codeLocations) : [],
+        selectAllFilters: isEnabled ? parseJSONArraySafely(qs.selectAllFilters) : [],
+      };
+    },
   });
 
   const filterFn = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
@@ -42,21 +42,30 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
           type: typeValues.map((t) => t.key),
         };
       }
+
+      let dateRange: {start: number | null; end: number | null} | undefined;
+      if (raw?.dateRange && typeof raw.dateRange !== 'string' && !Array.isArray(raw.dateRange)) {
+        dateRange = {
+          start: typeof raw.dateRange.start === 'string' ? parseInt(raw.dateRange.start) : null,
+          end: typeof raw.dateRange.end === 'string' ? parseInt(raw.dateRange.end) : null,
+        };
+      }
+
       return {
-        partitions: raw?.partitions,
-        dateRange: raw?.dateRange
-          ? {
-              start: raw.dateRange.start ? parseInt(raw.dateRange.start) : null,
-              end: raw.dateRange.end ? parseInt(raw.dateRange.end) : null,
-            }
-          : undefined,
-        status: raw?.status,
-        type: raw?.type,
+        partitions: Array.isArray(raw?.partitions) ? raw.partitions.map(String) : [],
+        dateRange,
+        status: Array.isArray(raw?.status) ? raw.status.map(String) : [],
+        type: Array.isArray(raw?.type) ? raw.type.map(String) : [],
       };
     },
     encode: (raw) => ({
       partitions: raw.partitions,
-      dateRange: raw.dateRange,
+      dateRange: raw.dateRange
+        ? {
+            start: raw.dateRange.start ? String(raw.dateRange.start) : undefined,
+            end: raw.dateRange.end ? String(raw.dateRange.end) : undefined,
+          }
+        : undefined,
       status: raw.status,
       type: raw.type,
     }),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetViewParams.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetViewParams.tsx
@@ -1,12 +1,14 @@
+import qs from 'qs';
+
 import {AssetViewParams} from './types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 
-export const decode = ({lineageDepth, showAllEvents, ...rest}: {[key: string]: any}) => {
+export const decode = ({lineageDepth, showAllEvents, ...rest}: qs.ParsedQs) => {
   const result: AssetViewParams = {...rest};
-  if (lineageDepth !== undefined) {
+  if (typeof lineageDepth === 'string') {
     result.lineageDepth = Number(lineageDepth);
   }
-  if (showAllEvents !== undefined) {
+  if (typeof showAllEvents === 'string') {
     result.showAllEvents =
       showAllEvents === 'true' ? true : showAllEvents === 'false' ? false : undefined;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionDimensionSelections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionDimensionSelections.tsx
@@ -33,15 +33,20 @@ function buildSerializer(assetHealth: Pick<PartitionHealthData, 'dimensions'>) {
       for (const key in qs) {
         if (key.endsWith('_range')) {
           const name = key.replace(/_range$/, '');
-          results[name] = {text: qs[key], isFromPartitionQueryStringParam: false};
+          const value = qs[key];
+          if (typeof value === 'string') {
+            results[name] = {text: value, isFromPartitionQueryStringParam: false};
+          }
         } else if (key === 'partition') {
-          const partitions = qs[key].split('|');
-          for (let i = 0; i < partitions.length; i++) {
-            const partitionText = partitions[i];
-            const name = assetHealth?.dimensions[i]?.name;
-            if (name) {
-              results[name] = {text: partitionText, isFromPartitionQueryStringParam: true};
-            }
+          const value = qs[key];
+          if (typeof value === 'string') {
+            const partitions = value.split('|');
+            partitions.forEach((partitionText, i) => {
+              const name = assetHealth?.dimensions[i]?.name;
+              if (name) {
+                results[name] = {text: partitionText, isFromPartitionQueryStringParam: true};
+              }
+            });
           }
         }
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -37,7 +37,10 @@ import {WorkspaceLocationNodeFragment} from '../workspace/WorkspaceContext/types
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
-type AutomationType = 'schedules' | 'sensors';
+enum AutomationType {
+  Schedules = 'schedules',
+  Sensors = 'sensors',
+}
 
 const AUTOMATION_TYPE_FILTERS = {
   schedules: {
@@ -53,6 +56,7 @@ const AUTOMATION_TYPE_FILTERS = {
 };
 
 const ALL_AUTOMATION_VALUES = Object.values(AUTOMATION_TYPE_FILTERS);
+const AUTOMATION_TYPES: Set<string> = new Set(Object.values(AutomationType));
 
 export const MergedAutomationRoot = () => {
   useTrackPageView();
@@ -73,7 +77,15 @@ export const MergedAutomationRoot = () => {
 
   const [automationTypes, setAutomationTypes] = useQueryPersistedState<Set<AutomationType>>({
     encode: (vals) => ({automationType: vals.size ? Array.from(vals).join(',') : undefined}),
-    decode: (qs) => new Set((qs.automationType?.split(',') as AutomationType[]) || []),
+    decode: (qs) => {
+      if (typeof qs.automationType === 'string') {
+        const values = qs.automationType.split(',');
+        return new Set(
+          values.filter((value) => AUTOMATION_TYPES.has(value)),
+        ) as Set<AutomationType>;
+      }
+      return new Set();
+    },
   });
 
   const automationFilterState = useMemo(() => {
@@ -144,7 +156,7 @@ export const MergedAutomationRoot = () => {
           if (runningState.size && !runningState.has(sensorState.status)) {
             return false;
           }
-          if (automationTypes.size && !automationTypes.has('sensors')) {
+          if (automationTypes.size && !automationTypes.has(AutomationType.Sensors)) {
             return false;
           }
           return true;
@@ -159,7 +171,7 @@ export const MergedAutomationRoot = () => {
           if (runningState.size && !runningState.has(scheduleState.status)) {
             return false;
           }
-          if (automationTypes.size && !automationTypes.has('schedules')) {
+          if (automationTypes.size && !automationTypes.has(AutomationType.Schedules)) {
             return false;
           }
           return true;

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryAndLocalStoragePersistedState.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryAndLocalStoragePersistedState.test.tsx
@@ -47,7 +47,10 @@ describe('useQueryAndLocalStoragePersistedState', () => {
             return {'open-nodes': Array.from(val)};
           },
           decode: (qs) => {
-            return new Set(qs['open-nodes']);
+            if (Array.isArray(qs['open-nodes'])) {
+              return new Set(qs['open-nodes'].map(String));
+            }
+            return new Set();
           },
           isEmptyState: (val) => val.size === 0,
         }),
@@ -107,7 +110,10 @@ describe('useQueryAndLocalStoragePersistedState', () => {
             return {'open-nodes': Array.from(val)};
           },
           decode: (qs) => {
-            return new Set(qs['open-nodes']);
+            if (Array.isArray(qs['open-nodes'])) {
+              return new Set(qs['open-nodes'].map(String));
+            }
+            return new Set();
           },
           isEmptyState: (val) => val.size === 0,
         }),

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
@@ -152,7 +152,12 @@ describe('useQueryPersistedState', () => {
     const TestEncoding = () => {
       const [items, setItems] = useQueryPersistedState<string[]>({
         encode: (items) => ({value: items.join(',')}),
-        decode: (q) => q.value.split(',').filter(Boolean),
+        decode: (q) => {
+          if (typeof q.value === 'string') {
+            return q.value.split(',').filter(Boolean);
+          }
+          return [];
+        },
         defaults: {value: ''},
       });
       return (
@@ -217,7 +222,7 @@ describe('useQueryPersistedState', () => {
         enableA?: boolean;
         enableB?: boolean;
       }>({
-        defaults: {enableA: true, enableB: false},
+        defaults: {enableA: 'true', enableB: 'false'},
       });
       return (
         <div onClick={() => setFilters({enableA: !filters.enableA, enableB: !filters.enableB})}>
@@ -239,7 +244,7 @@ describe('useQueryPersistedState', () => {
     });
     await userEvent.click(screen.getByText(`{"enableA":false,"enableB":true}`));
     await waitFor(() => {
-      expect(querySearch).toEqual('');
+      expect(querySearch).toEqual('?enableA=true&enableB=false');
     });
   });
 
@@ -366,7 +371,7 @@ describe('useQueryPersistedState', () => {
     it('correctly encodes arrays alongside other values, using `indices` syntax', async () => {
       const TestArray = () => {
         const [state, setState] = useQueryPersistedState<{hello: boolean; items: string[]}>({
-          defaults: {hello: false, items: []},
+          defaults: {hello: 'false', items: []},
         });
         return (
           <div
@@ -412,7 +417,7 @@ describe('useQueryPersistedState', () => {
       const arr = new Array(1001).fill(0).map((_, i) => `Added${i}`);
       const TestLargeArray = () => {
         const [state, setState] = useQueryPersistedState<{hello: boolean; items: string[]}>({
-          defaults: {hello: false, items: []},
+          defaults: {hello: 'false', items: []},
         });
         return (
           <div onClick={() => setState({hello: true, items: arr})}>{JSON.stringify(state)}</div>
@@ -450,7 +455,7 @@ describe('useQueryPersistedState', () => {
 
       const TestLargeArray = () => {
         const [state, setState] = useQueryPersistedState<{hello: boolean; items: string[]}>({
-          defaults: {hello: false, items: []},
+          defaults: {hello: 'false', items: []},
         });
         return (
           <div onClick={() => setState({hello: true, items: arr})}>{JSON.stringify(state)}</div>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
@@ -1,7 +1,5 @@
-import {
-  CodeLocationRowStatusType,
-  CodeLocationRowType,
-} from '../workspace/VirtualizedCodeLocationRow';
+import {CodeLocationRowStatusType} from '../workspace/CodeLocationRowStatusType';
+import {CodeLocationRowType} from '../workspace/VirtualizedCodeLocationRow';
 import {
   LocationStatusEntryFragment,
   WorkspaceLocationNodeFragment,
@@ -27,13 +25,13 @@ const flatten = (
     let status: CodeLocationRowStatusType;
 
     if (locationStatus.loadStatus === 'LOADING') {
-      status = 'Updating';
+      status = CodeLocationRowStatusType.Updating;
     } else if (locationEntry?.versionKey !== locationStatus.versionKey) {
-      status = 'Loading';
+      status = CodeLocationRowStatusType.Loading;
     } else if (locationEntry?.locationOrLoadError?.__typename === 'PythonError') {
-      status = 'Failed';
+      status = CodeLocationRowStatusType.Failed;
     } else {
-      status = 'Loaded';
+      status = CodeLocationRowStatusType.Loaded;
     }
 
     if (locationEntry?.locationOrLoadError?.__typename === 'RepositoryLocation') {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
@@ -7,8 +7,10 @@ import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption'
 import {codeLocationStatusAtom} from '../nav/useCodeLocationsStatus';
 import {useFilters} from '../ui/BaseFilters';
 import {useStaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
-import {CodeLocationRowStatusType} from '../workspace/VirtualizedCodeLocationRow';
+import {CodeLocationRowStatusType} from '../workspace/CodeLocationRowStatusType';
 import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
+
+const STATUS_VALUES: Set<string> = new Set(Object.values(CodeLocationRowStatusType));
 
 export const useCodeLocationPageFilters = () => {
   const {loading, locationEntries} = useContext(WorkspaceContext);
@@ -27,7 +29,11 @@ export const useCodeLocationPageFilters = () => {
     },
     decode: (qs) => {
       const status = Array.isArray(qs?.status) ? qs.status : [];
-      return {status};
+      return {
+        status: status.filter(
+          (s) => typeof s === 'string' && STATUS_VALUES.has(s),
+        ) as CodeLocationRowStatusType[],
+      };
     },
   });
 
@@ -46,7 +52,7 @@ export const useCodeLocationPageFilters = () => {
     icon: 'tag',
     allValues: useMemo(
       () =>
-        (['Failed', 'Loaded', 'Updating', 'Loading'] as const).map((value) => ({
+        Object.values(CodeLocationRowStatusType).map((value) => ({
           key: value,
           value,
           match: [value],

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -325,7 +325,7 @@ export const TickHistoryTimeline = ({
 }) => {
   const [selectedTickId, setSelectedTickId] = useQueryPersistedState<string | undefined>({
     encode: (tickId) => ({tickId}),
-    decode: (qs) => qs['tickId'] ?? undefined,
+    decode: (qs) => (typeof qs.tickId === 'string' ? qs.tickId : undefined),
   });
 
   const [pollingPaused, pausePolling] = React.useState<boolean>(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import {showSharedToaster} from '../app/DomUtils';
 import {RepositoryLocationLoadStatus} from '../graphql/types';
 import {StatusAndMessage} from '../instance/DeploymentStatusType';
-import {CodeLocationRowStatusType} from '../workspace/VirtualizedCodeLocationRow';
+import {CodeLocationRowStatusType} from '../workspace/CodeLocationRowStatusType';
 import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
 import {CodeLocationStatusQuery} from '../workspace/WorkspaceContext/types/WorkspaceQueries.types';
 
@@ -100,7 +100,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
             <div>Definitions loaded with errors</div>
             <ViewCodeLocationsButton
               onClick={() => {
-                onClickViewButton(['Failed']);
+                onClickViewButton([CodeLocationRowStatusType.Failed]);
               }}
             />
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -58,8 +58,15 @@ export const OverviewAssetsRoot = ({Header, TabButton}: Props) => {
 
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
     queryKey: 'q',
-    decode: (qs) => (qs.searchQuery ? JSON.parse(qs.searchQuery) : ''),
     encode: (searchQuery) => ({searchQuery: searchQuery ? JSON.stringify(searchQuery) : undefined}),
+    decode: (qs) => {
+      if (typeof qs.searchQuery === 'string') {
+        try {
+          return JSON.parse(qs.searchQuery);
+        } catch {}
+      }
+      return '';
+    },
   });
 
   const groupedAssets = React.useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
@@ -68,7 +68,12 @@ export const OverviewSensors = () => {
 
   const [sensorTypes, setSensorTypes] = useQueryPersistedState<Set<SensorType>>({
     encode: (vals) => ({sensorType: vals.size ? Array.from(vals).join(',') : undefined}),
-    decode: (qs) => new Set((qs.sensorType?.split(',') as SensorType[]) || []),
+    decode: (qs) => {
+      if (typeof qs.sensorType === 'string') {
+        return new Set(qs.sensorType.split(',') as SensorType[]);
+      }
+      return new Set();
+    },
   });
 
   const codeLocationFilter = useCodeLocationFilter();

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -22,10 +22,18 @@ export const useGroupTimelineRunsBy = (
 ): [GroupRunsBy, (value: GroupRunsBy) => void] => {
   const [storedValue, setStoredValue] = useStateWithStorage(GROUP_BY_KEY, validate);
 
-  const [queryValue, setQueryValue] = useQueryPersistedState({
+  const [queryValue, setQueryValue] = useQueryPersistedState<GroupRunsBy>({
     queryKey: 'groupBy',
-    decode: (pair) => validate(pair.groupBy),
     encode: (value) => ({groupBy: value}),
+    decode: (pair) => {
+      if (typeof pair.groupBy === 'string') {
+        const result = validate(pair.groupBy);
+        if (result) {
+          return result;
+        }
+      }
+      return defaultValue;
+    },
   });
 
   /**

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -2,13 +2,13 @@ import {CaptionMono, Mono} from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 import {Link, useHistory} from 'react-router-dom';
 
-export interface ExplorerPath {
+export type ExplorerPath = {
   pipelineName: string;
   snapshotId?: string;
   opsQuery: string;
   explodeComposites?: boolean;
   opNames: string[];
-}
+};
 
 export const explorerPathSeparator = '~';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -26,17 +26,17 @@ import {WebSocketContext} from '../app/WebSocketProvider';
 import {RunStatus} from '../graphql/types';
 import {CompletionType, useTraceDependency} from '../performance/TraceContext';
 
-export interface LogFilterValue extends TokenizingFieldValue {
+export type LogFilterValue = TokenizingFieldValue & {
   token?: 'step' | 'type' | 'query';
-}
+};
 
-export interface LogFilter {
+export type LogFilter = {
   logQuery: LogFilterValue[];
   levels: {[key: string]: boolean};
   focusedTime: number;
   sinceTime: number;
   hideNonMatches: boolean;
-}
+};
 
 export interface LogsProviderLogs {
   allNodeChunks: LogNode[][];

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -53,7 +53,10 @@ export const RunsFeedRoot = () => {
 
   const [view, setView] = useQueryPersistedState<RunsFeedView>({
     encode: (v) => ({view: v && v !== RunsFeedView.ROOTS ? v.toLowerCase() : undefined}),
-    decode: (qs) => (qs.view || RunsFeedView.ROOTS).toUpperCase(),
+    decode: (qs) => {
+      const value = typeof qs.view === 'string' ? qs.view : RunsFeedView.ROOTS;
+      return value.toUpperCase() as RunsFeedView;
+    },
   });
 
   const currentTab = useSelectedRunsFeedTab(filterTokens, view);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -110,11 +110,13 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
           cursor: undefined,
           [RUNS_FEED_CURSOR_KEY]: undefined,
         }),
-        decode: ({q = []}) =>
-          tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY).filter(
+        decode: ({q}) => {
+          const values = (Array.isArray(q) ? q : []).map(String);
+          return tokenizedValuesFromStringArray(values, RUN_PROVIDERS_EMPTY).filter(
             (t) =>
               !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
-          ) as RunFilterToken[],
+          ) as RunFilterToken[];
+        },
       }),
       [enabledFilters],
     ),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
@@ -27,7 +27,7 @@ describe('encodeRunPageFilters', () => {
         sinceTime: 0,
       }),
     ).toEqual({
-      focusedTime: 1611430148147,
+      focusedTime: '1611430148147',
       hideNonMatches: 'true',
       levels: 'critical|error',
       logs: 'step:bar|query:foo*',

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useQueryPersistedLogFilter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useQueryPersistedLogFilter.ts
@@ -1,4 +1,5 @@
 import {tokenizedValueFromString} from '@dagster-io/ui-components';
+import qs from 'qs';
 import {useMemo} from 'react';
 
 import {DefaultLogLevels, LogLevel} from './LogLevel';
@@ -40,11 +41,11 @@ export const DefaultQuerystring: {[key: string]: string} = {
  *   - string (unix timestamp with msec)
  *   - Scrolls directly to log with specified time, if no `logs` filter
  */
-export const decodeRunPageFilters = (qs: {[key: string]: string}) => {
-  const logsQuery = qs['logs'] || '';
-  const focusedTimeQuery = qs['focusedTime'] || '';
-  const hideNonMatchesQuery = qs['hideNonMatches'] || '';
-  const levelsQuery = qs['levels'] || '';
+export const decodeRunPageFilters = (qs: qs.ParsedQs) => {
+  const logsQuery = typeof qs['logs'] === 'string' ? qs['logs'] : '';
+  const focusedTimeQuery = typeof qs['focusedTime'] === 'string' ? qs['focusedTime'] : '';
+  const hideNonMatchesQuery = typeof qs['hideNonMatches'] === 'string' ? qs['hideNonMatches'] : '';
+  const levelsQuery = typeof qs['levels'] === 'string' ? qs['levels'] : '';
 
   const logValues = logsQuery.split(DELIMITER);
   const focusedTime = focusedTimeQuery && !logsQuery ? Number(focusedTimeQuery) : null;
@@ -80,7 +81,7 @@ export function encodeRunPageFilters(filter: LogFilter) {
 
   return {
     hideNonMatches: filter.hideNonMatches ? 'true' : 'false',
-    focusedTime: filter.focusedTime || '',
+    focusedTime: String(filter.focusedTime || ''),
     logs: logQueryTokenStrings.join(DELIMITER),
     levels: levelsToQuery(Object.keys(filter.levels).filter((key) => !!filter.levels[key])),
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useInstigationStatusFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useInstigationStatusFilter.tsx
@@ -5,7 +5,13 @@ import {useStaticSetFilter} from '../BaseFilters/useStaticSetFilter';
 export const useInstigationStatusFilter = () => {
   const [state, onStateChanged] = useQueryPersistedState<Set<InstigationStatus>>({
     encode: (vals) => ({instigationStatus: vals.size ? Array.from(vals).join(',') : undefined}),
-    decode: (qs) => new Set((qs.instigationStatus?.split(',') as InstigationStatus[]) || []),
+    decode: (qs) => {
+      const status = qs.instigationStatus;
+      if (typeof status === 'string') {
+        return new Set(status.split(',') as InstigationStatus[]);
+      }
+      return new Set();
+    },
   });
   return useStaticSetFilter<InstigationStatus>({
     name: 'Running state',

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowStatusType.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowStatusType.tsx
@@ -1,0 +1,6 @@
+export enum CodeLocationRowStatusType {
+  Failed = 'Failed',
+  Updating = 'Updating',
+  Loaded = 'Loaded',
+  Loading = 'Loading',
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {CodeLocationMenu} from './CodeLocationMenu';
 import {ImageName, LocationStatus, ModuleOrPackageOrFile, ReloadButton} from './CodeLocationRowSet';
+import {CodeLocationRowStatusType} from './CodeLocationRowStatusType';
 import {RepositoryCountTags} from './RepositoryCountTags';
 import {WorkspaceRepositoryLocationNode} from './WorkspaceContext/WorkspaceContext';
 import {
@@ -20,8 +21,6 @@ import {featureEnabled} from '../app/Flags';
 import {AnchorButton} from '../ui/AnchorButton';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
-
-export type CodeLocationRowStatusType = 'Failed' | 'Updating' | 'Loaded' | 'Loading';
 
 export type CodeLocationRowType =
   | {


### PR DESCRIPTION
## Summary & Motivation

Following the recent JS error involving parsed querystrings crashing the page, try to lock down types on our `qs` usage in `useQueryPersistedState` and similar hooks that make use of encode/decode behavior.

This PR makes use of the `qs.ParsedQs` type, which is the type returned by `qs.parse` itself. This replaces our current `{[key: string]: any}` type, which at present leaves us with no real recourse for typechecking our parsed values.

Now, encode/decode functions will have to be much more careful about the types involved. For instance, in the case of the error hotfixed by https://github.com/dagster-io/dagster/pull/28791, the `decode` function would now have to refine the value for `qs['open-nodes']` in order to satisfy the `Set<string>` type in its return value. If `qs['open-nodes']` were an object (as in the error case), the `new Set(...)` would fail typechecking, and the developer would be forced to provide it an array of strings extracted from the `qs` argument.

## How I Tested These Changes

TS, lint, jest.