### PR TITLE
[dbt] fix state_path on DbtCliResource

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -171,7 +171,13 @@ class DbtProjectComponent(Component, Resolvable):
 
     @cached_property
     def project(self) -> DbtProject:
-        return DbtProject(self.dbt.project_dir)
+        return DbtProject(
+            self.dbt.project_dir,
+            state_path=self.dbt.state_path,
+            target=self.dbt.target,
+            profile=self.dbt.profile,
+            profiles_dir=self.dbt.profiles_dir,
+        )
 
     def get_asset_selection(
         self, select: str, exclude: Optional[str] = None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -267,6 +267,11 @@ class DbtProject(IHaveNew):
             dependencies_path.exists() or packages_path.exists()
         ) and not packages_install_path.exists()
 
+        if state_path:
+            state_path = Path(state_path)
+            if not state_path.is_absolute():
+                state_path = project_dir.joinpath(state_path)
+
         return super().__new__(
             cls,
             name=dbt_project_yml["name"],
@@ -276,7 +281,7 @@ class DbtProject(IHaveNew):
             profile=profile,
             target=target,
             manifest_path=manifest_path,
-            state_path=project_dir.joinpath(state_path) if state_path else None,
+            state_path=state_path,
             packaged_project_dir=packaged_project_dir,
             has_uninstalled_deps=has_uninstalled_deps,
             preparer=preparer,


### PR DESCRIPTION
We were not resolving `state_path` as documented when directly setting on `DbtCliResource`.

I think this went undetected for a while since the more common path is to set it via `DbtProject` which does the correct resolution.

This was reported as part of #28546, where we are passing to the resource directly

## How I Tested These Changes

added test

## Changelog

[dagster-dbt] the `state_path` argument to `DbtCliResource` now resolves relative to the project directory as documented
