### PR TITLE
add elapsed time to last materialization / observation / failure

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/MaterializationTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/MaterializationTag.tsx
@@ -2,10 +2,10 @@
 import {Box, Colors, Tag} from '@dagster-io/ui-components';
 
 import {AssetKey} from './types';
-import {Timestamp} from '../app/time/Timestamp';
 import {StatusCase} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {StatusCaseDot} from '../asset-graph/sidebar/util';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 export const MaterializationTag = ({
   assetKey,
@@ -15,19 +15,22 @@ export const MaterializationTag = ({
   assetKey: AssetKey;
   event: {timestamp: string; runId: string};
   stepKey: string | null;
-}) => (
-  <Tag intent="success">
-    <Box flex={{gap: 4, alignItems: 'center'}}>
-      <StatusCaseDot statusCase={StatusCase.MATERIALIZED} />
-      <AssetRunLink
-        assetKey={assetKey}
-        runId={event.runId}
-        event={{timestamp: event.timestamp, stepKey}}
-      >
-        <Box style={{color: Colors.textGreen()}} flex={{gap: 4}}>
-          <Timestamp timestamp={{ms: Number(event.timestamp)}} />
-        </Box>
-      </AssetRunLink>
-    </Box>
-  </Tag>
-);
+}) => {
+  const timestamp = Number(event.timestamp) / 1000;
+  return (
+    <Tag intent="success">
+      <Box flex={{gap: 4, alignItems: 'center'}}>
+        <StatusCaseDot statusCase={StatusCase.MATERIALIZED} />
+        <AssetRunLink
+          assetKey={assetKey}
+          runId={event.runId}
+          event={{timestamp: event.timestamp, stepKey}}
+        >
+          <Box style={{color: Colors.textGreen()}} flex={{gap: 4}}>
+            <TimeFromNow unixTimestamp={timestamp} />
+          </Box>
+        </AssetRunLink>
+      </Box>
+    </Tag>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -4,13 +4,13 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 
 import {MaterializationTag} from './MaterializationTag';
-import {Timestamp} from '../app/time/Timestamp';
 import {StatusCase} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {StatusCaseDot} from '../asset-graph/sidebar/util';
 import {titleForRun} from '../runs/RunUtils';
 import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 /** We explicitly don't want to share partition-level information with stakeholders,
  * so this status component exposes only basic "materializing, success, failed, missing"
@@ -39,21 +39,29 @@ export const SimpleStakeholderAssetStatus = ({
   }
 
   if (liveData.runWhichFailedToMaterialize) {
+    const timestamp = liveData.runWhichFailedToMaterialize.endTime;
     return (
-      <Tag intent="danger">
-        <Box flex={{gap: 4, alignItems: 'center'}}>
-          <StatusCaseDot statusCase={StatusCase.FAILED_MATERIALIZATION} />
-          Failed in
-          <AssetRunLink
-            assetKey={assetNode.assetKey}
-            runId={liveData.runWhichFailedToMaterialize.id}
-          >
-            <Box style={{color: Colors.textRed()}}>
-              {titleForRun(liveData.runWhichFailedToMaterialize)}
-            </Box>
-          </AssetRunLink>
-        </Box>
-      </Tag>
+      <Box flex={{gap: 4}}>
+        <Tag intent="danger">
+          <Box flex={{gap: 4, alignItems: 'center'}}>
+            <StatusCaseDot statusCase={StatusCase.FAILED_MATERIALIZATION} />
+            Failed in
+            <AssetRunLink
+              assetKey={assetNode.assetKey}
+              runId={liveData.runWhichFailedToMaterialize.id}
+            >
+              <Box style={{color: Colors.textRed()}}>
+                {titleForRun(liveData.runWhichFailedToMaterialize)}
+              </Box>
+            </AssetRunLink>
+          </Box>
+        </Tag>
+        {timestamp ? (
+          <Box style={{color: Colors.textLighter(), minWidth: 400}} flex={{alignItems: 'center'}}>
+            <TimeFromNow unixTimestamp={timestamp} showTooltip={false} />
+          </Box>
+        ) : null}
+      </Box>
     );
   }
   const partitionTag = partition ? (
@@ -77,10 +85,11 @@ export const SimpleStakeholderAssetStatus = ({
     );
   }
   if (liveData.lastObservation && assetNode.isObservable) {
+    const timestamp = Number(liveData.lastObservation.timestamp) / 1000.0;
     return (
       <Box flex={{gap: 4}}>
         <Tag intent="none">
-          <Timestamp timestamp={{ms: Number(liveData.lastObservation.timestamp)}} />
+          <TimeFromNow unixTimestamp={timestamp} />
         </Tag>
         {partitionTag}
       </Box>


### PR DESCRIPTION
## Summary & Motivation
Helpful to contextualize the last materialization time.

## How I Tested These Changes
<img width="1186" alt="Screenshot 2025-04-08 at 9 48 29 AM" src="https://github.com/user-attachments/assets/86428d32-07d7-47ef-a572-7fb44b605d63" />


## Changelog
- [ui] Added elapsed time to last materialization tags on asset overview pages