### PR TITLE
use historic step key vs current step key for asset materialization link

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -170,7 +170,7 @@
   "TypeExplorerContainerQuery": "40bdf55720a8542ddb727910ef82280a8e8e2300d3cc1fb9df11a7d8d957ee06",
   "TypeListContainerQuery": "c92c874af7b1e7be221281fa265743a9c426f909ffc7500f302540ef9a6cf8f2",
   "GraphExplorerRootQuery": "b8a935a406d27b367c31c8249726895899d43782b7557928faaaf86e6b686d7a",
-  "SingleNonSDAAssetQuery": "a7ef9ca5f114adee47bc5361112b16a2f00b70ae06eb6ab65a9f312bbae7625c",
+  "SingleNonSDAAssetQuery": "29857d908046c996dc1d44a6b08b20d025aa63a0cd689a5962d29cca71d12894",
   "SingleJobQuery": "5ff8f070e59507f5369f1a19abb9a72cfa12439ab04a08dc340866885f6e4702",
   "SingleScheduleQuery": "508a47e32ce04ba5be52c66cd592b74147bf98ec85b9f5d0e4db45172bd9a897",
   "SingleSensorQuery": "dbda5ba47d4ba10f8c527c9a7cd45fba0811276441a17a8ac6f173ed588f025b",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -1,7 +1,7 @@
 {
   "PermissionsQuery": "505a351d43369bd83e7d4ff2d974368d2a754a85661dfb077a26d1a11ff2f714",
   "LogTelemetryMutation": "b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3",
-  "AssetGraphLiveQuery": "d65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497",
+  "AssetGraphLiveQuery": "9f875017c08597b0fa017a17fa40813c255d13e3f92eb98992772f4c8ae42e52",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "724ef0733b9b187ffd012e40c02c3b3a5e32967dbcae46e2024b15dfd5bf0271",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -161,11 +161,13 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
   fragment AssetNodeLiveMaterialization on MaterializationEvent {
     timestamp
     runId
+    stepKey
   }
 
   fragment AssetNodeLiveObservation on ObservationEvent {
     timestamp
     runId
+    stepKey
   }
 
   fragment AssetCheckLiveFragment on AssetCheck {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
@@ -33,8 +33,14 @@ export type AssetNodeLiveFragment = {
     __typename: 'MaterializationEvent';
     timestamp: string;
     runId: string;
+    stepKey: string | null;
   }>;
-  assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+  assetObservations: Array<{
+    __typename: 'ObservationEvent';
+    timestamp: string;
+    runId: string;
+    stepKey: string | null;
+  }>;
   assetChecksOrError:
     | {__typename: 'AssetCheckNeedsAgentUpgradeError'}
     | {__typename: 'AssetCheckNeedsMigrationError'}
@@ -72,12 +78,14 @@ export type AssetNodeLiveMaterializationFragment = {
   __typename: 'MaterializationEvent';
   timestamp: string;
   runId: string;
+  stepKey: string | null;
 };
 
 export type AssetNodeLiveObservationFragment = {
   __typename: 'ObservationEvent';
   timestamp: string;
   runId: string;
+  stepKey: string | null;
 };
 
 export type AssetCheckLiveFragment = {
@@ -111,8 +119,14 @@ export type AssetGraphLiveQuery = {
       __typename: 'MaterializationEvent';
       timestamp: string;
       runId: string;
+      stepKey: string | null;
     }>;
-    assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+    assetObservations: Array<{
+      __typename: 'ObservationEvent';
+      timestamp: string;
+      runId: string;
+      stepKey: string | null;
+    }>;
     assetChecksOrError:
       | {__typename: 'AssetCheckNeedsAgentUpgradeError'}
       | {__typename: 'AssetCheckNeedsMigrationError'}
@@ -179,6 +193,6 @@ export type AssetNodeLiveFreshnessInfoFragment = {
   currentMinutesLate: number | null;
 };
 
-export const AssetGraphLiveQueryVersion = 'd65025ff4ff394938e261d28393a15fa2c5095afb19bdbf6171bdda29e762497';
+export const AssetGraphLiveQueryVersion = '9f875017c08597b0fa017a17fa40813c255d13e3f92eb98992772f4c8ae42e52';
 
 export const AssetsFreshnessInfoQueryVersion = '1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -458,6 +458,7 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNodeWithStaleData
   lastObservation: {
     __typename: 'ObservationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   runWhichFailedToMaterialize: null,
@@ -476,6 +477,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNodeWithStaleData
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,
@@ -501,6 +503,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNodeWithStaleData 
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,
@@ -526,6 +529,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNodeWithStaleData
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,
@@ -593,6 +597,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNodeWithStaleData = {
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,
@@ -618,6 +623,7 @@ export const LiveDataForNodePartitionedOverdue: LiveDataForNodeWithStaleData = {
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,
@@ -646,6 +652,7 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNodeWithStaleData = {
   lastMaterialization: {
     __typename: 'MaterializationEvent',
     runId: 'ABCDEF',
+    stepKey: 'asset1',
     timestamp: TIMESTAMP,
   },
   lastMaterializationRunStatus: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/MaterializationTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/MaterializationTag.tsx
@@ -2,10 +2,10 @@
 import {Box, Colors, Tag} from '@dagster-io/ui-components';
 
 import {AssetKey} from './types';
-import {Timestamp} from '../app/time/Timestamp';
 import {StatusCase} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {StatusCaseDot} from '../asset-graph/sidebar/util';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 export const MaterializationTag = ({
   assetKey,
@@ -15,19 +15,22 @@ export const MaterializationTag = ({
   assetKey: AssetKey;
   event: {timestamp: string; runId: string};
   stepKey: string | null;
-}) => (
-  <Tag intent="success">
-    <Box flex={{gap: 4, alignItems: 'center'}}>
-      <StatusCaseDot statusCase={StatusCase.MATERIALIZED} />
-      <AssetRunLink
-        assetKey={assetKey}
-        runId={event.runId}
-        event={{timestamp: event.timestamp, stepKey}}
-      >
-        <Box style={{color: Colors.textGreen()}} flex={{gap: 4}}>
-          <Timestamp timestamp={{ms: Number(event.timestamp)}} />
-        </Box>
-      </AssetRunLink>
-    </Box>
-  </Tag>
-);
+}) => {
+  const timestamp = Number(event.timestamp) / 1000;
+  return (
+    <Tag intent="success">
+      <Box flex={{gap: 4, alignItems: 'center'}}>
+        <StatusCaseDot statusCase={StatusCase.MATERIALIZED} />
+        <AssetRunLink
+          assetKey={assetKey}
+          runId={event.runId}
+          event={{timestamp: event.timestamp, stepKey}}
+        >
+          <Box style={{color: Colors.textGreen()}} flex={{gap: 4}}>
+            <TimeFromNow unixTimestamp={timestamp} />
+          </Box>
+        </AssetRunLink>
+      </Box>
+    </Tag>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -78,7 +78,7 @@ export const SimpleStakeholderAssetStatus = ({
         <MaterializationTag
           assetKey={assetNode.assetKey}
           event={liveData.lastMaterialization}
-          stepKey={liveData.stepKey}
+          stepKey={liveData.lastMaterialization.stepKey}
         />
         {partitionTag}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -4,13 +4,13 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 
 import {MaterializationTag} from './MaterializationTag';
-import {Timestamp} from '../app/time/Timestamp';
 import {StatusCase} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {StatusCaseDot} from '../asset-graph/sidebar/util';
 import {titleForRun} from '../runs/RunUtils';
 import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 /** We explicitly don't want to share partition-level information with stakeholders,
  * so this status component exposes only basic "materializing, success, failed, missing"
@@ -39,21 +39,29 @@ export const SimpleStakeholderAssetStatus = ({
   }
 
   if (liveData.runWhichFailedToMaterialize) {
+    const timestamp = liveData.runWhichFailedToMaterialize.endTime;
     return (
-      <Tag intent="danger">
-        <Box flex={{gap: 4, alignItems: 'center'}}>
-          <StatusCaseDot statusCase={StatusCase.FAILED_MATERIALIZATION} />
-          Failed in
-          <AssetRunLink
-            assetKey={assetNode.assetKey}
-            runId={liveData.runWhichFailedToMaterialize.id}
-          >
-            <Box style={{color: Colors.textRed()}}>
-              {titleForRun(liveData.runWhichFailedToMaterialize)}
-            </Box>
-          </AssetRunLink>
-        </Box>
-      </Tag>
+      <Box flex={{gap: 4}}>
+        <Tag intent="danger">
+          <Box flex={{gap: 4, alignItems: 'center'}}>
+            <StatusCaseDot statusCase={StatusCase.FAILED_MATERIALIZATION} />
+            Failed in
+            <AssetRunLink
+              assetKey={assetNode.assetKey}
+              runId={liveData.runWhichFailedToMaterialize.id}
+            >
+              <Box style={{color: Colors.textRed()}}>
+                {titleForRun(liveData.runWhichFailedToMaterialize)}
+              </Box>
+            </AssetRunLink>
+          </Box>
+        </Tag>
+        {timestamp ? (
+          <Box style={{color: Colors.textLighter(), minWidth: 400}} flex={{alignItems: 'center'}}>
+            <TimeFromNow unixTimestamp={timestamp} showTooltip={false} />
+          </Box>
+        ) : null}
+      </Box>
     );
   }
   const partitionTag = partition ? (
@@ -77,10 +85,11 @@ export const SimpleStakeholderAssetStatus = ({
     );
   }
   if (liveData.lastObservation && assetNode.isObservable) {
+    const timestamp = Number(liveData.lastObservation.timestamp) / 1000.0;
     return (
       <Box flex={{gap: 4}}>
         <Tag intent="none">
-          <Timestamp timestamp={{ms: Number(liveData.lastObservation.timestamp)}} />
+          <TimeFromNow unixTimestamp={timestamp} />
         </Tag>
         {partitionTag}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -351,6 +351,7 @@ export const SINGLE_NON_SDA_ASSET_QUERY = gql`
         id
         assetMaterializations(limit: 1) {
           runId
+          stepKey
           timestamp
         }
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedAssetRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedAssetRow.types.ts
@@ -15,6 +15,7 @@ export type SingleNonSdaAssetQuery = {
         assetMaterializations: Array<{
           __typename: 'MaterializationEvent';
           runId: string;
+          stepKey: string | null;
           timestamp: string;
         }>;
       }


### PR DESCRIPTION
## Summary & Motivation
Especially for multi-assets with asset selections, the stepKey can change across runs and cannot be trusted.  This results in broken experience when using the materialization tag to link to runs.

Should be able to satisfy without doing any extra data fetching (although it is passing an extra string per node).

## How I Tested These Changes

https://github.com/user-attachments/assets/401a5ce4-5e39-4004-965c-eb18bceb78b2


## Changelog

- [ui] Fixed a bug where the materialization status tag would sometimes deep link to the wrong step key in the materializing run.