### PR TITLE
[components] rename `ComponentSpec` to `ComponentTypeSpec`

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -5,7 +5,7 @@ from dagster.components import (
     Component,
     ComponentLoadContext,
     # highlight-start
-    ComponentSpec,
+    ComponentTypeSpec,
     # highlight-end
     Resolvable,
     ResolvedAssetSpec,
@@ -18,7 +18,7 @@ class ShellCommand(Component, Resolvable):
     # highlight-start
     @classmethod
     def get_spec(cls):
-        return ComponentSpec(
+        return ComponentTypeSpec(
             owners=["John Dagster"],
             tags=["shell", "script"],
         )

--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -2,7 +2,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components import Component, ComponentLoadContext, ComponentSpec, Model, Resolvable
+from dagster.components import Component, ComponentLoadContext, ComponentTypeSpec, Model, Resolvable
 
 
 class SimpleAssetComponent(Component, Resolvable, Model):
@@ -17,7 +17,7 @@ class SimpleAssetComponent(Component, Resolvable, Model):
 
     @classmethod
     def get_spec(cls):
-        return ComponentSpec(
+        return ComponentTypeSpec(
             owners=["john@dagster.io", "jane@dagster.io"],
             tags=["a", "b", "c"],
         )

--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -1,6 +1,6 @@
 from dagster.components.component.component import (
     Component as Component,
-    ComponentSpec as ComponentSpec,
+    ComponentTypeSpec as ComponentTypeSpec,
 )
 from dagster.components.component.component_loader import component as component
 from dagster.components.component.component_scaffolder import (

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 @record_custom
-class ComponentSpec(IHaveNew):
+class ComponentTypeSpec(IHaveNew):
     """Specifies the core attributes of a component.
 
     Args:
@@ -70,8 +70,8 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_spec(cls) -> ComponentSpec:
-        return ComponentSpec()
+    def get_spec(cls) -> ComponentTypeSpec:
+        return ComponentTypeSpec()
 
     @classmethod
     def get_model_cls(cls) -> Optional[type[BaseModel]]:


### PR DESCRIPTION
## Summary & Motivation

After chatting with Ben it was determined that `ComponentTypeSpec` is more appropriate.

## How I Tested These Changes

N/A

## Changelog

NOCHANGELOG
