### PR TITLE
Only use favorites in global asset graph and catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -123,7 +123,19 @@ export const AssetGraphExplorer = React.memo((props: Props) => {
   } = useAssetGraphData(
     props.explorerPath.opsQuery,
     useMemo(
-      () => ({...props.fetchOptions, hideNodesMatching}),
+      () => ({
+        ...props.fetchOptions,
+        hideNodesMatching: (node) => {
+          let hide = false;
+          if (props.fetchOptions.hideNodesMatching?.(node)) {
+            hide = true;
+          }
+          if (hideNodesMatching(node)) {
+            hide = true;
+          }
+          return hide;
+        },
+      }),
       [props.fetchOptions, hideNodesMatching],
     ),
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -83,7 +83,6 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
     () => [...(nodes ?? []), ...externalAssetNodes],
     [nodes, externalAssetNodes],
   );
-  const queryItems = useMemo(() => buildGraphQueryItems(allNodes), [allNodes]);
 
   const [fullAssetGraphData, setFullAssetGraphData] = useState<GraphData | null>(null);
   useBlockTraceUntilTrue('FullAssetGraphData', !!fullAssetGraphData);
@@ -113,7 +112,7 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
         // buildGraphData is throttled and rejects promises when another call is made before the throttle delay.
         console.warn(e);
       });
-  }, [allNodes, options.loading, options.useWorker, queryItems, spawnBuildGraphDataWorker]);
+  }, [allNodes, options.loading, options.useWorker, spawnBuildGraphDataWorker]);
 
   return {fullAssetGraphData, loading: !fetchResult.data || fetchResult.loading || options.loading};
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -3,7 +3,6 @@ import reject from 'lodash/reject';
 import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {useAssetGraphSupplementaryData} from 'shared/asset-graph/useAssetGraphSupplementaryData.oss';
-import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 import {Worker} from 'shared/workers/Worker.oss';
 
 import {ASSET_NODE_FRAGMENT} from './AssetNode';
@@ -76,17 +75,15 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
   }, [spawnBuildGraphDataWorker]);
 
   const externalAssetNodes = useMemo(
-    () => (options.externalAssets ?? []).map((a) => buildExternalAssetQueryItem(a).node),
+    () => (options.externalAssets ?? []).map((a) => buildExternalAssetQueryItem(a)),
     [options.externalAssets],
   );
   const nodes = fetchResult.data?.assetNodes;
-  const queryItems = useMemo(
-    () => [
-      ...(nodes ? buildGraphQueryItems(nodes) : []).map(({node}) => node),
-      ...externalAssetNodes,
-    ],
+  const allNodes = useMemo(
+    () => [...(nodes ?? []), ...externalAssetNodes],
     [nodes, externalAssetNodes],
   );
+  const queryItems = useMemo(() => buildGraphQueryItems(allNodes), [allNodes]);
 
   const [fullAssetGraphData, setFullAssetGraphData] = useState<GraphData | null>(null);
   useBlockTraceUntilTrue('FullAssetGraphData', !!fullAssetGraphData);
@@ -101,7 +98,7 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
     const requestId = ++currentRequestRef.current;
     buildGraphData(
       {
-        nodes: queryItems,
+        nodes: allNodes,
       },
       spawnBuildGraphDataWorker,
       options.useWorker ?? true,
@@ -116,7 +113,7 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
         // buildGraphData is throttled and rejects promises when another call is made before the throttle delay.
         console.warn(e);
       });
-  }, [options.loading, options.useWorker, queryItems, spawnBuildGraphDataWorker]);
+  }, [allNodes, options.loading, options.useWorker, queryItems, spawnBuildGraphDataWorker]);
 
   return {fullAssetGraphData, loading: !fetchResult.data || fetchResult.loading || options.loading};
 }
@@ -161,43 +158,27 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
   });
 
   const nodes = fetchResult.data?.assetNodes;
+  const externalAssetNodes = useMemo(
+    () => (options.externalAssets ?? []).map(buildExternalAssetQueryItem),
+    [options.externalAssets],
+  );
 
-  const favoriteAssets = useFavoriteAssets();
+  const allNodes = useMemo(
+    () => [...(nodes ?? []), ...externalAssetNodes],
+    [nodes, externalAssetNodes],
+  );
 
   const repoFilteredNodes = useMemo(() => {
-    // Apply any filters provided by the caller
-    let matching = nodes;
-
-    // Apply favorites filtering if enabled
-    if (favoriteAssets) {
-      matching = matching?.filter((node) => favoriteAssets.has(tokenForAssetKey(node.assetKey)));
-    }
-
-    // Apply repository filtering
+    let matching = allNodes;
     if (options.hideNodesMatching) {
       matching = reject(matching, options.hideNodesMatching);
     }
-
     return matching;
-  }, [nodes, options.hideNodesMatching, favoriteAssets]);
-
-  const externalAssetNodes = useMemo(
-    () =>
-      (options.externalAssets ?? [])
-        .filter((asset) => {
-          const token = tokenForAssetKey(asset.key);
-          return !favoriteAssets || favoriteAssets.has(token);
-        })
-        .map(buildExternalAssetQueryItem),
-    [options.externalAssets, favoriteAssets],
-  );
+  }, [allNodes, options.hideNodesMatching]);
 
   const graphQueryItems = useMemo(
-    () => [
-      ...(repoFilteredNodes ? buildGraphQueryItems(repoFilteredNodes) : []),
-      ...externalAssetNodes,
-    ],
-    [repoFilteredNodes, externalAssetNodes],
+    () => buildGraphQueryItems(repoFilteredNodes),
+    [repoFilteredNodes],
   );
 
   const [state, setState] = useState<GraphDataState>(INITIAL_STATE);
@@ -300,6 +281,7 @@ const computeGraphData = indexedDBAsyncMemoize<GraphDataState, typeof computeGra
 );
 
 const buildGraphQueryItems = (nodes: AssetNode[]) => {
+  console.log('buildGraphQueryItems', nodes);
   const items: {[name: string]: AssetGraphQueryItem} = {};
 
   for (const node of nodes) {
@@ -508,46 +490,41 @@ async function buildGraphDataWrapper(
 const buildExternalAssetQueryItem = (asset: {
   id: string;
   key: {path: string[]};
-}): AssetGraphQueryItem => {
+}): AssetNodeForGraphQueryFragment => {
   return {
-    name: tokenForAssetKey(asset.key),
-    inputs: [],
-    outputs: [],
-    node: {
-      __typename: 'AssetNode',
-      id: asset.id,
-      assetKey: {
-        __typename: 'AssetKey',
-        ...asset.key,
-      },
-      groupName: '',
-      isExecutable: false,
-      changedReasons: [],
-      tags: [],
-      owners: [],
-      hasMaterializePermission: false,
-      repository: {
-        __typename: 'Repository',
+    __typename: 'AssetNode',
+    changedReasons: [],
+    kinds: [],
+    hasMaterializePermission: false,
+    opVersion: null,
+    isMaterializable: false,
+    tags: [],
+    owners: [],
+    id: asset.id,
+    groupName: '',
+    isExecutable: false,
+    isPartitioned: false,
+    opNames: [],
+    jobNames: [],
+    computeKind: null,
+    isObservable: false,
+    description: null,
+    repository: {
+      __typename: 'Repository',
+      id: '',
+      name: '',
+      location: {
+        __typename: 'RepositoryLocation',
         id: '',
         name: '',
-        location: {
-          __typename: 'RepositoryLocation',
-          id: '',
-          name: '',
-        },
       },
-      dependencyKeys: [],
-      dependedByKeys: [],
-      graphName: null,
-      jobNames: [],
-      opNames: [],
-      opVersion: null,
-      description: null,
-      computeKind: null,
-      isPartitioned: false,
-      isObservable: false,
-      isMaterializable: false,
-      kinds: [],
     },
+    assetKey: {
+      __typename: 'AssetKey',
+      ...asset.key,
+    },
+    graphName: null,
+    dependencyKeys: [],
+    dependedByKeys: [],
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -280,7 +280,6 @@ const computeGraphData = indexedDBAsyncMemoize<GraphDataState, typeof computeGra
 );
 
 const buildGraphQueryItems = (nodes: AssetNode[]) => {
-  console.log('buildGraphQueryItems', nodes);
   const items: {[name: string]: AssetGraphQueryItem} = {};
 
   for (const node of nodes) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
@@ -2,6 +2,7 @@ import {Page} from '@dagster-io/ui-components';
 import {useCallback, useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 import {AssetsGraphHeader} from 'shared/assets/AssetsGraphHeader.oss';
+import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
@@ -10,14 +11,13 @@ import {
 } from './globalAssetGraphPathToString';
 import {useTrackPageView} from '../app/analytics';
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
-import {AssetGraphViewType} from '../asset-graph/Utils';
+import {AssetGraphViewType, tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useOpenInNewTab} from '../hooks/useOpenInNewTab';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
-
 interface AssetGroupRootParams {
   0: string;
 }
@@ -62,12 +62,19 @@ export const AssetsGlobalGraphRoot = () => {
     },
   );
 
+  const favorites = useFavoriteAssets();
+
+  console.log({favorites});
+
   const fetchOptions = useMemo(() => {
     const options: AssetGraphFetchScope = {
       hideEdgesToNodesOutsideQuery,
+      hideNodesMatching: favorites
+        ? (node) => !favorites.has(tokenForAssetKey(node.assetKey))
+        : undefined,
     };
     return options;
-  }, [hideEdgesToNodesOutsideQuery]);
+  }, [hideEdgesToNodesOutsideQuery, favorites]);
 
   return (
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
@@ -64,8 +64,6 @@ export const AssetsGlobalGraphRoot = () => {
 
   const favorites = useFavoriteAssets();
 
-  console.log({favorites});
-
   const fetchOptions = useMemo(() => {
     const options: AssetGraphFetchScope = {
       hideEdgesToNodesOutsideQuery,

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -9,6 +9,7 @@ import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
 import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 import {workerSpawner} from '../workers/workerSpawner';
 
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
@@ -37,41 +38,43 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
   });
 }, _opLayoutCacheKey);
 
-const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
-  // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
-  // both the displayed nodes and the displayed edges.
+const _assetLayoutCacheKey = weakMapMemoize(
+  (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
+    // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
+    // both the displayed nodes and the displayed edges.
 
-  // Make the cache key deterministic by alphabetically sorting all of the keys since the order
-  // of the keys is not guaranteed to be consistent even when the graph hasn't changed.
+    // Make the cache key deterministic by alphabetically sorting all of the keys since the order
+    // of the keys is not guaranteed to be consistent even when the graph hasn't changed.
 
-  function recreateObjectWithKeysSorted(obj: Record<string, Record<string, boolean>>) {
-    const newObj: Record<string, Record<string, boolean>> = {};
-    Object.keys(obj)
-      .sort()
-      .forEach((key) => {
-        newObj[key] = Object.keys(obj[key]!)
-          .sort()
-          .reduce(
-            (acc, k) => {
-              acc[k] = obj[key]![k]!;
-              return acc;
-            },
-            {} as Record<string, boolean>,
-          );
-      });
-    return newObj;
-  }
+    function recreateObjectWithKeysSorted(obj: Record<string, Record<string, boolean>>) {
+      const newObj: Record<string, Record<string, boolean>> = {};
+      Object.keys(obj)
+        .sort()
+        .forEach((key) => {
+          newObj[key] = Object.keys(obj[key]!)
+            .sort()
+            .reduce(
+              (acc, k) => {
+                acc[k] = obj[key]![k]!;
+                return acc;
+              },
+              {} as Record<string, boolean>,
+            );
+        });
+      return newObj;
+    }
 
-  return `${JSON.stringify(opts)}${JSON.stringify({
-    version: 4,
-    downstream: recreateObjectWithKeysSorted(graphData.downstream),
-    upstream: recreateObjectWithKeysSorted(graphData.upstream),
-    nodes: Object.keys(graphData.nodes)
-      .sort()
-      .map((key) => graphData.nodes[key]),
-    expandedGroups: graphData.expandedGroups,
-  })}`;
-};
+    return `${JSON.stringify(opts)}${JSON.stringify({
+      version: 4,
+      downstream: recreateObjectWithKeysSorted(graphData.downstream),
+      upstream: recreateObjectWithKeysSorted(graphData.upstream),
+      nodes: Object.keys(graphData.nodes)
+        .sort()
+        .map((key) => graphData.nodes[key]),
+      expandedGroups: graphData.expandedGroups,
+    })}`;
+  },
+);
 
 const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 


### PR DESCRIPTION
## Summary & Motivation

Only take favorites into account when on the global asset graph and catalog.

If you're visiting the lineage of a specific asset (even if its from within the favorites view), do not limit the lineage by favorites.


## How I Tested These Changes

locally:
<img width="1390" alt="Screenshot 2025-04-07 at 9 56 13 PM" src="https://github.com/user-attachments/assets/f9ba6120-2670-416f-99c6-127f8e1a4640" />


