### PR TITLE
[dg] Remove dg list component-type

### DIFF
--- a/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
+++ b/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
@@ -64,7 +64,7 @@ To learn more about the files, directories, and default settings in a project sc
 
 To ingest data, you must set up [Sling](https://slingdata.io/). However, if you list the available component types in your environment at this point, the Sling component won't appear, since the `dagster` package doesn't contain components for specific integrations (like Sling):
 
-<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/7-dg-list-component-types.txt" />
+<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt" />
 
 To make the Sling component available in your environment, install the `dagster-sling` package:
 
@@ -82,7 +82,7 @@ When you run commands like `dg list component-type` , `dg` obtains the results b
 
 To confirm that the `dagster_sling.SlingReplicationCollectionComponent` component type is now available, run the `dg list component-type` command again:
 
-<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/8-dg-list-component-types.txt" />
+<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/8-dg-list-plugins.txt" />
 
 ### 3. Create a new instance of the Sling component
 
@@ -162,7 +162,7 @@ To interface with the dbt project, you will need to instantiate a Dagster dbt pr
 
 To confirm that the `dagster_dbt.DbtProjectComponent` component type is now available, run `dg list component-type`:
 
-<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/17-dg-list-component-types.txt" />
+<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/17-dg-list-plugins.txt" />
 
 ### 3. Scaffold a new instance of the dbt project component
 

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -89,7 +89,7 @@ Our `build_defs` method will create a single `@asset` that executes the provided
 
 Following the steps above will automatically register your component type in your environment. You can now run:
 
-<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-component-types.txt" />
+<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt" />
 
 and see your new component type in the list of available component types.
 

--- a/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-plugins.txt
@@ -1,4 +1,4 @@
-dg list component-type
+dg list plugins
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
 ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -7,6 +7,11 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │ dagster       │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓ │
 │               │ ┃ Symbol                                                      ┃ Summary          ┃ Features        ┃ │
 │               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster.asset                                               │ Create a         │ [scaffold-targ… │ │
+│               │ │                                                             │ definition for   │                 │ │
+│               │ │                                                             │ how to compute   │                 │ │
+│               │ │                                                             │ an asset.        │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set │ [component,     │ │
 │               │ │                                                             │ of dagster       │ scaffold-targe… │ │
 │               │ │                                                             │ definitions.     │                 │ │
@@ -23,7 +28,30 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ executed with    │                 │ │
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
+│               │ │                                                             │ schedule         │                 │ │
+│               │ │                                                             │ following the    │                 │ │
+│               │ │                                                             │ provided cron    │                 │ │
+│               │ │                                                             │ schedule and     │                 │ │
+│               │ │                                                             │ requests runs    │                 │ │
+│               │ │                                                             │ for the provided │                 │ │
+│               │ │                                                             │ job.             │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.sensor                                              │ Creates a sensor │ [scaffold-targ… │ │
+│               │ │                                                             │ where the        │                 │ │
+│               │ │                                                             │ decorated        │                 │ │
+│               │ │                                                             │ function is used │                 │ │
+│               │ │                                                             │ as the sensor's  │                 │ │
+│               │ │                                                             │ evaluation       │                 │ │
+│               │ │                                                             │ function.        │                 │ │
 │               │ └─────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┘ │
+│ dagster_dbt   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
+│               │ ┃ Symbol                          ┃ Summary                         ┃ Features                     ┃ │
+│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster_dbt.DbtProjectComponent │ Expose a DBT project to Dagster │ [component, scaffold-target] │ │
+│               │ │                                 │ as a set of assets.             │                              │ │
+│               │ └─────────────────────────────────┴─────────────────────────────────┴──────────────────────────────┘ │
 │ dagster_sling │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓ │
 │               │ ┃ Symbol                                            ┃ Summary              ┃ Features              ┃ │
 │               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
@@ -1,4 +1,4 @@
-dg list component-type
+dg list plugins
 
 ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Plugin  ┃ Objects                                                                                                    ┃
@@ -6,6 +6,11 @@ dg list component-type
 │ dagster │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓ │
 │         │ ┃ Symbol                                                      ┃ Summary            ┃ Features            ┃ │
 │         │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩ │
+│         │ │ dagster.asset                                               │ Create a           │ [scaffold-target]   │ │
+│         │ │                                                             │ definition for how │                     │ │
+│         │ │                                                             │ to compute an      │                     │ │
+│         │ │                                                             │ asset.             │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
 │         │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set   │ [component,         │ │
 │         │ │                                                             │ of dagster         │ scaffold-target]    │ │
 │         │ │                                                             │ definitions.       │                     │ │
@@ -21,5 +26,20 @@ dg list component-type
 │         │ │                                                             │ executed with      │                     │ │
 │         │ │                                                             │ Dagster's          │                     │ │
 │         │ │                                                             │ PipesSubprocessCl… │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.schedule                                            │ Creates a schedule │ [scaffold-target]   │ │
+│         │ │                                                             │ following the      │                     │ │
+│         │ │                                                             │ provided cron      │                     │ │
+│         │ │                                                             │ schedule and       │                     │ │
+│         │ │                                                             │ requests runs for  │                     │ │
+│         │ │                                                             │ the provided job.  │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.sensor                                              │ Creates a sensor   │ [scaffold-target]   │ │
+│         │ │                                                             │ where the          │                     │ │
+│         │ │                                                             │ decorated function │                     │ │
+│         │ │                                                             │ is used as the     │                     │ │
+│         │ │                                                             │ sensor's           │                     │ │
+│         │ │                                                             │ evaluation         │                     │ │
+│         │ │                                                             │ function.          │                     │ │
 │         │ └─────────────────────────────────────────────────────────────┴────────────────────┴─────────────────────┘ │
 └─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/8-dg-list-plugins.txt
@@ -1,4 +1,4 @@
-dg list component-type
+dg list plugins
 
 Using /.../jaffle-platform/.venv/bin/dagster-components
 ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -7,6 +7,11 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │ dagster       │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓ │
 │               │ ┃ Symbol                                                      ┃ Summary          ┃ Features        ┃ │
 │               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩ │
+│               │ │ dagster.asset                                               │ Create a         │ [scaffold-targ… │ │
+│               │ │                                                             │ definition for   │                 │ │
+│               │ │                                                             │ how to compute   │                 │ │
+│               │ │                                                             │ an asset.        │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.components.DefinitionsComponent                     │ An arbitrary set │ [component,     │ │
 │               │ │                                                             │ of dagster       │ scaffold-targe… │ │
 │               │ │                                                             │ definitions.     │                 │ │
@@ -23,13 +28,24 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ executed with    │                 │ │
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
+│               │ │                                                             │ schedule         │                 │ │
+│               │ │                                                             │ following the    │                 │ │
+│               │ │                                                             │ provided cron    │                 │ │
+│               │ │                                                             │ schedule and     │                 │ │
+│               │ │                                                             │ requests runs    │                 │ │
+│               │ │                                                             │ for the provided │                 │ │
+│               │ │                                                             │ job.             │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.sensor                                              │ Creates a sensor │ [scaffold-targ… │ │
+│               │ │                                                             │ where the        │                 │ │
+│               │ │                                                             │ decorated        │                 │ │
+│               │ │                                                             │ function is used │                 │ │
+│               │ │                                                             │ as the sensor's  │                 │ │
+│               │ │                                                             │ evaluation       │                 │ │
+│               │ │                                                             │ function.        │                 │ │
 │               │ └─────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┘ │
-│ dagster_dbt   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
-│               │ ┃ Symbol                          ┃ Summary                         ┃ Features                     ┃ │
-│               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
-│               │ │ dagster_dbt.DbtProjectComponent │ Expose a DBT project to Dagster │ [component, scaffold-target] │ │
-│               │ │                                 │ as a set of assets.             │                              │ │
-│               │ └─────────────────────────────────┴─────────────────────────────────┴──────────────────────────────┘ │
 │ dagster_sling │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓ │
 │               │ ┃ Symbol                                            ┃ Summary              ┃ Features              ┃ │
 │               │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩ │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
@@ -1,4 +1,4 @@
-dg list component-type
+dg list plugins
 
 Using /.../my-component-library/.venv/bin/dagster-components
 ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -7,6 +7,12 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │ dagster              │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓ │
 │                      │ ┃ Symbol                                                      ┃ Summary      ┃ Features     ┃ │
 │                      │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩ │
+│                      │ │ dagster.asset                                               │ Create a     │ [scaffold-t… │ │
+│                      │ │                                                             │ definition   │              │ │
+│                      │ │                                                             │ for how to   │              │ │
+│                      │ │                                                             │ compute an   │              │ │
+│                      │ │                                                             │ asset.       │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
 │                      │ │ dagster.components.DefinitionsComponent                     │ An arbitrary │ [component,  │ │
 │                      │ │                                                             │ set of       │ scaffold-ta… │ │
 │                      │ │                                                             │ dagster      │              │ │
@@ -28,6 +34,27 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                      │ │                                                             │ with         │              │ │
 │                      │ │                                                             │ Dagster's    │              │ │
 │                      │ │                                                             │ PipesSubpro… │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.schedule                                            │ Creates a    │ [scaffold-t… │ │
+│                      │ │                                                             │ schedule     │              │ │
+│                      │ │                                                             │ following    │              │ │
+│                      │ │                                                             │ the provided │              │ │
+│                      │ │                                                             │ cron         │              │ │
+│                      │ │                                                             │ schedule and │              │ │
+│                      │ │                                                             │ requests     │              │ │
+│                      │ │                                                             │ runs for the │              │ │
+│                      │ │                                                             │ provided     │              │ │
+│                      │ │                                                             │ job.         │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.sensor                                              │ Creates a    │ [scaffold-t… │ │
+│                      │ │                                                             │ sensor where │              │ │
+│                      │ │                                                             │ the          │              │ │
+│                      │ │                                                             │ decorated    │              │ │
+│                      │ │                                                             │ function is  │              │ │
+│                      │ │                                                             │ used as the  │              │ │
+│                      │ │                                                             │ sensor's     │              │ │
+│                      │ │                                                             │ evaluation   │              │ │
+│                      │ │                                                             │ function.    │              │ │
 │                      │ └─────────────────────────────────────────────────────────────┴──────────────┴──────────────┘ │
 │ my_component_library │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
 │                      │ ┃ Symbol                                ┃ Summary                 ┃ Features                ┃ │

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -99,9 +99,9 @@ def test_components_docs_index(update_snippets: bool) -> None:
         )
 
         run_command_and_snippet_output(
-            cmd="dg list component-type",
+            cmd="dg list plugins",
             snippet_path=COMPONENTS_SNIPPETS_DIR
-            / f"{next_snip_no()}-dg-list-component-types.txt",
+            / f"{next_snip_no()}-dg-list-plugins.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[MASK_JAFFLE_PLATFORM],
         )
@@ -111,9 +111,9 @@ def test_components_docs_index(update_snippets: bool) -> None:
         )
         _run_command("uv tree")
         run_command_and_snippet_output(
-            cmd="dg list component-type",
+            cmd="dg list plugins",
             snippet_path=COMPONENTS_SNIPPETS_DIR
-            / f"{next_snip_no()}-dg-list-component-types.txt",
+            / f"{next_snip_no()}-dg-list-plugins.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[MASK_JAFFLE_PLATFORM],
         )
@@ -240,9 +240,9 @@ def test_components_docs_index(update_snippets: bool) -> None:
                 f"uv add --editable '{EDITABLE_DIR / 'dagster-dbt'!s}'; uv add dbt-duckdb"
             )
             run_command_and_snippet_output(
-                cmd="dg list component-type",
+                cmd="dg list plugins",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
-                / f"{next_snip_no()}-dg-list-component-types.txt",
+                / f"{next_snip_no()}-dg-list-plugins.txt",
                 update_snippets=update_snippets,
                 snippet_replace_regex=[MASK_JAFFLE_PLATFORM],
             )

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -66,7 +66,7 @@ def test_components_docs_index(
             contents=(COMPONENTS_SNIPPETS_DIR / "with-config-schema.py").read_text(),
         )
         # Sanity check that the component type is registered properly
-        _run_command("dg list component-type")
+        _run_command("dg list plugins")
 
         # Add build defs
         create_file(
@@ -79,9 +79,9 @@ def test_components_docs_index(
         #########################################################
 
         run_command_and_snippet_output(
-            cmd="dg list component-type",
+            cmd="dg list plugins",
             snippet_path=COMPONENTS_SNIPPETS_DIR
-            / f"{get_next_snip_number()}-dg-list-component-types.txt",
+            / f"{get_next_snip_number()}-dg-list-plugins.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[MASK_MY_COMPONENT_LIBRARY],
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -346,7 +346,7 @@ def format_multiline_str(message: str) -> str:
 
 def generate_missing_component_type_error_message(component_key_str: str) -> str:
     return f"""
-        No component type `{component_key_str}` is registered. Use 'dg list component-type'
+        No component type `{component_key_str}` is registered. Use `dg list plugins --feature component`
         to see the registered component types in your environment. You may need to install a package
         that provides `{component_key_str}` into your environment.
     """

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -55,7 +55,7 @@ COMPONENT_LIBRARY_CONTEXT_COMMANDS = [
 REGISTRY_CONTEXT_COMMANDS = [
     CommandSpec(tuple(), "--rebuild-component-registry"),
     CommandSpec(("docs", "serve")),
-    CommandSpec(("list", "component-type")),
+    CommandSpec(("list", "plugins")),
     CommandSpec(("utils", "inspect-component-type"), DEFAULT_COMPONENT_TYPE),
 ]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -102,44 +102,60 @@ _EXPECTED_COMPONENT_TYPES_JSON = textwrap.dedent("""
     [
         {
             "key": "dagster_test.components.AllMetadataEmptyComponent",
-            "summary": null
+            "summary": null,
+            "features": [
+                "component",
+                "scaffold-target"
+            ]
         },
         {
             "key": "dagster_test.components.ComplexAssetComponent",
-            "summary": "An asset that has a complex schema."
+            "summary": "An asset that has a complex schema.",
+            "features": [
+                "component",
+                "scaffold-target"
+            ]
         },
         {
             "key": "dagster_test.components.SimpleAssetComponent",
-            "summary": "A simple asset that returns a constant string value."
+            "summary": "A simple asset that returns a constant string value.",
+            "features": [
+                "component",
+                "scaffold-target"
+            ]
         },
         {
             "key": "dagster_test.components.SimplePipesScriptComponent",
-            "summary": "A simple asset that runs a Python script with the Pipes subprocess client."
+            "summary": "A simple asset that runs a Python script with the Pipes subprocess client.",
+            "features": [
+                "component",
+                "scaffold-target"
+            ]
         }
     ]
 
 """).strip()
 
 
-def test_list_component_types_success():
+def test_list_plugins_success():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),
     ):
         with fixed_panel_width(width=120):
-            result = runner.invoke("list", "component-type")
+            result = runner.invoke("list", "plugins")
             assert_runner_result(result)
             # strip the first line of logging output
             output = "\n".join(result.output.split("\n")[1:])
             match_terminal_box_output(output.strip(), _EXPECTED_COMPONENT_TYPES)
 
 
-def test_list_component_type_json_success():
+def test_list_plugins_json_success():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),
     ):
-        result = runner.invoke("list", "component-type", "--json")
+        result = runner.invoke("list", "plugins", "--json")
         assert_runner_result(result)
         # strip the first line of logging output
         output = "\n".join(result.output.split("\n")[1:])
@@ -149,7 +165,7 @@ def test_list_component_type_json_success():
 # Need to use capfd here to capture stderr from the subprocess invoked by the `list component-type`
 # command. This subprocess inherits stderr from the parent process, for whatever reason `capsys` does
 # not work.
-def test_list_component_type_bad_entry_point_fails(capfd):
+def test_list_plugins_bad_entry_point_fails(capfd):
     with (
         ProxyRunner.test() as runner,
         isolated_example_component_library_foo_bar(runner),
@@ -158,7 +174,7 @@ def test_list_component_type_bad_entry_point_fails(capfd):
         shutil.rmtree("src/foo_bar/lib")
 
         # Disable cache to force re-discovery of deleted entry point
-        result = runner.invoke("list", "component-type", "--disable-cache", "--json")
+        result = runner.invoke("list", "plugins", "--disable-cache")
         assert_runner_result(result, exit_0=False)
 
         expected_error_message = format_error_message("""

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -123,13 +123,13 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
 
         # Populate cache
         with pushd("projects/foo-bar"):
-            result = runner.invoke("list", "component-type", "--verbose")
+            result = runner.invoke("list", "plugins", "--verbose")
             assert_runner_result(result)
             assert "CACHE [miss]" in result.output
 
         # Check cache was populated
         with pushd("projects/foo-bar"):
-            result = runner.invoke("list", "component-type", "--verbose")
+            result = runner.invoke("list", "plugins", "--verbose")
             assert_runner_result(result)
             assert "CACHE [hit]" in result.output
 
@@ -308,7 +308,7 @@ def test_scaffold_project_no_populate_cache_success(monkeypatch) -> None:
         assert Path("foo-bar/uv.lock").exists()
 
         with pushd("foo-bar"):
-            result = runner.invoke("list", "component-type", "--verbose")
+            result = runner.invoke("list", "plugins", "--verbose")
             assert_runner_result(result)
             assert "CACHE [miss]" in result.output
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -20,32 +20,32 @@ cache_runner_args = {"verbose": True}
 
 def test_load_from_cache():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [hit]" in result.output
 
 
 def test_cache_invalidation_uv_lock():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
         subprocess.run(["uv", "add", "dagster-dbt"], check=True)
 
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
 
 
 def test_cache_invalidation_modified_lib():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
@@ -53,21 +53,21 @@ def test_cache_invalidation_modified_lib():
         result = runner.invoke("scaffold", "component-type", "my_component")
         assert_runner_result(result)
 
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
 
 
 def test_cache_no_invalidation_modified_pkg():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
 
         Path("src/foo_bar/submodule.py").write_text("print('hello')")
 
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [hit]" in result.output
 
@@ -75,7 +75,7 @@ def test_cache_no_invalidation_modified_pkg():
 @pytest.mark.parametrize("clear_outside_project", [True, False])
 def test_clear_cache(clear_outside_project: bool):
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
         assert "CACHE [write]" in result.output
@@ -85,7 +85,7 @@ def test_clear_cache(clear_outside_project: bool):
             assert_runner_result(result)
             assert "CACHE [clear-all]" in result.output
 
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [miss]" in result.output
 
@@ -100,7 +100,7 @@ def test_rebuild_component_registry_success():
         assert_runner_result(result)
         assert "CACHE [clear-key]" in result.output
 
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE [hit]" in result.output
 
@@ -110,7 +110,7 @@ def test_rebuild_component_registry_fails_with_subcommand():
         ProxyRunner.test(**cache_runner_args) as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("--rebuild-component-registry", "list", "component-type")
+        result = runner.invoke("--rebuild-component-registry", "list", "plugins")
         assert_runner_result(result, exit_0=False)
         assert "Cannot specify --rebuild-component-registry with a subcommand." in result.output
 
@@ -134,6 +134,6 @@ def test_cache_disabled():
         ProxyRunner.test(**cache_runner_args, disable_cache=True) as runner,
         example_project(runner),
     ):
-        result = runner.invoke("list", "component-type")
+        result = runner.invoke("list", "plugins")
         assert_runner_result(result)
         assert "CACHE" not in result.output


### PR DESCRIPTION
## Summary & Motivation

Remove `dg list component-type`. Convert `dg list component-type` tests to use `dg list plugins` instead.

## How I Tested These Changes

Modified existing tests.

## Changelog

The `dg list component-type` command has been removed. There is a new `dg list plugins` with output that is a superset of `dg list component-type`.