### PR TITLE
Fix asset events filtering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -79,13 +79,9 @@ export const AssetEvents = ({
     }
     if (filterState.status) {
       if (filterState.status.length === 1) {
-        if (filterState.status[0] === 'Materialization') {
-          combinedParams.status = MaterializationHistoryEventTypeSelector.MATERIALIZATION;
-        } else if (filterState.status[0] === 'FailedToMaterialize') {
-          combinedParams.status = MaterializationHistoryEventTypeSelector.FAILED_TO_MATERIALIZE;
-        } else {
-          combinedParams.status = MaterializationHistoryEventTypeSelector.ALL;
-        }
+        combinedParams.status = filterState.status[0] as MaterializationHistoryEventTypeSelector;
+      } else {
+        combinedParams.status = MaterializationHistoryEventTypeSelector.ALL;
       }
     }
     return combinedParams;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -77,8 +77,19 @@ export const AssetEvents = ({
         combinedParams.after = filterState.dateRange.start;
       }
     }
+    if (filterState.status) {
+      if (filterState.status.length === 1) {
+        if (filterState.status[0] === 'Materialization') {
+          combinedParams.status = MaterializationHistoryEventTypeSelector.MATERIALIZATION;
+        } else if (filterState.status[0] === 'FailedToMaterialize') {
+          combinedParams.status = MaterializationHistoryEventTypeSelector.FAILED_TO_MATERIALIZE;
+        } else {
+          combinedParams.status = MaterializationHistoryEventTypeSelector.ALL;
+        }
+      }
+    }
     return combinedParams;
-  }, [params, filterState.dateRange]);
+  }, [params, filterState.dateRange, filterState.status]);
 
   const {materializations, observations, loadedPartitionKeys, fetchMore, fetchLatest, loading} =
     usePaginatedAssetEvents(assetKey, combinedParams);


### PR DESCRIPTION
## Summary & Motivation

We were passing an array to the query but it expects an enum. Convert from array to enum.

## How I Tested These Changes
local host cloud

## Changelog
[ui] Fixed a bug preventing filtering on the asset events page.