### PR TITLE
[dg] Fix lib/__init__.py addition for component type scaffolding (BUILD-925)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -246,10 +246,13 @@ def scaffold_component_type(
         model=model,
     )
 
-    with open(root_path / "__init__.py", "a") as f:
-        f.write(
-            f"from {dg_context.default_component_library_module_name}.{module_name} import {class_name}\n"
-        )
+    with open(root_path / "__init__.py") as f:
+        lines = f.readlines()
+    lines.append(
+        f"from {dg_context.default_component_library_module_name}.{module_name} import {class_name} as {class_name}\n"
+    )
+    with open(root_path / "__init__.py", "w") as f:
+        f.writelines(lines)
 
     click.echo(f"Scaffolded files for Dagster component type at {root_path}/{module_name}.py.")
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 from typing import Literal, get_args
 
@@ -690,6 +691,9 @@ def test_scaffold_component_type_success() -> None:
         dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
         registry = RemotePluginRegistry.from_dg_context(dg_context)
         assert registry.has(PluginObjectKey(name="Baz", namespace="foo_bar.lib"))
+        assert Path("src/foo_bar/lib/__init__.py").read_text() == textwrap.dedent("""
+            from foo_bar.lib.baz import Baz as Baz
+        """)
 
 
 def test_scaffold_component_type_already_exists_fails() -> None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -295,7 +295,9 @@ def isolated_example_component_library_foo_bar(
                         ("project", "entry-points", "dagster_dg.library", "foo_bar"),
                         lib_module_name,
                     )
-                    Path("src", *lib_module_name.split(".")).mkdir(exist_ok=True)
+                    lib_dir = Path("src", *lib_module_name.split("."))
+                    lib_dir.mkdir(exist_ok=True)
+                    (lib_dir / "__init__.py").touch()
 
             # Install the component library into our venv
             if not skip_venv:


### PR DESCRIPTION
## Summary & Motivation

Fix line added to `<project>/lib/__init__.py`.

Formerly:

```
# extra line
from my_project.lib.shell_command import ShellCommand
```

Now:

```
from my_project.lib.shell_command import ShellCommand as ShellCommand
```

## How I Tested These Changes

Modified a test.

## Changelog

Fix formatting of line added to `project/lib/__init__.py` when scaffolding a component type.