### PR TITLE
Split out K8s integration monitoring tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -229,8 +229,8 @@ def build_k8s_suite_steps() -> List[BuildkiteTopLevelStep]:
     pytest_tox_factors = [
         "-default",
         "-subchart",
-        "-default-monitoring",
-        "-subchart-monitoring",
+        "-default_monitoring",
+        "-subchart_monitoring",
     ]
     directory = os.path.join("integration_tests", "test_suites", "k8s-test-suite")
     return build_integration_suite_steps(

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -226,7 +226,12 @@ def daemon_pytest_extra_cmds(version: AvailablePythonVersion, _):
 
 
 def build_k8s_suite_steps() -> List[BuildkiteTopLevelStep]:
-    pytest_tox_factors = ["-default", "-subchart"]
+    pytest_tox_factors = [
+        "-default",
+        "-subchart",
+        "-default-monitoring",
+        "-subchart-monitoring",
+    ]
     directory = os.path.join("integration_tests", "test_suites", "k8s-test-suite")
     return build_integration_suite_steps(
         directory,

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -38,7 +38,7 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  default: pytest --log-cli-level=INFO -m "default" --ignore ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
-  subchart: pytest --log-cli-level=INFO -m "subchart" --ignore ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
-  default-monitoring: pytest --log-cli-level=INFO -m "default" ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
-  subchart-monitoring: pytest --log-cli-level=INFO -m "subchart" ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
+  default: pytest --log-cli-level=INFO -m "default" --ignore ./tests/test_k8s_monitoring.py {posargs}
+  subchart: pytest --log-cli-level=INFO -m "subchart" --ignore ./tests/test_k8s_monitoring.py {posargs}
+  default_monitoring: pytest --log-cli-level=INFO -m "default" ./tests/test_k8s_monitoring.py {posargs}
+  subchart_monitoring: pytest --log-cli-level=INFO -m "subchart" ./tests/test_k8s_monitoring.py {posargs}

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -38,5 +38,7 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  default: pytest --log-cli-level=INFO -m "default" {posargs}
-  subchart: pytest --log-cli-level=INFO -m "subchart" {posargs}
+  default: pytest --log-cli-level=INFO -m "default" --ignore ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
+  subchart: pytest --log-cli-level=INFO -m "subchart" --ignore ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
+  default-monitoring: pytest --log-cli-level=INFO -m "default" ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}
+  subchart-monitoring: pytest --log-cli-level=INFO -m "subchart" ./k8s-test-suite/tests/test_k8s_monitoring.py {posargs}


### PR DESCRIPTION
Eyeballing this test suite, our longest runtime seem to be dominated by the monitoring tests. So let's just split them out into their own tox factors to run in parallel.

4 of the 8 longest runtimes for this test suite are monitoring related:

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/d606e9b4-ff8d-452e-9096-bf4a6f3b1ba2" />

And it's one of our longer test suites in general:

<img width="1760" alt="image" src="https://github.com/user-attachments/assets/f6b78392-15ff-4492-a357-c8dd31aaefe1" />
