### PR TITLE
RFC [dg] set DAGSTER_IS_DEV_CLI

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import click
@@ -75,6 +76,8 @@ def create_dg_cli():
         **global_options: object,
     ):
         """CLI for managing Dagster projects."""
+        os.environ["DAGSTER_IS_DEV_CLI"] = "1"
+
         context = click.get_current_context()
         if install_completion:
             import dagster_dg.completion


### PR DESCRIPTION
We could do another env var, but wanted to float just having this one.

Line of thought here is that `IS_DEV_CLI` -> "is development cli" and `dg` is our local development CLI 


## How I Tested These Changes


tbd