### PR TITLE
[1/2][Favorites] wait for favorites to load

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -221,7 +221,7 @@ export const AssetsCatalogTable = ({
     enabled: !featureEnabled(FeatureFlag.flagSelectionSyntax),
   });
 
-  const favorites = useFavoriteAssets();
+  const {favorites, loading: favoritesLoading} = useFavoriteAssets();
   const penultimateAssets = useMemo(() => {
     if (!favorites) {
       return partiallyFiltered;
@@ -235,7 +235,7 @@ export const AssetsCatalogTable = ({
   const {filterInput, filtered, loading, assetSelection, setAssetSelection} =
     useAssetSelectionInput({
       assets: penultimateAssets,
-      assetsLoading: !assets || filteredAssetsLoading,
+      assetsLoading: !assets || filteredAssetsLoading || favoritesLoading,
       onErrorStateChange: (errors) => {
         if (errors !== errorState) {
           setErrorState(errors);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx
@@ -62,7 +62,7 @@ export const AssetsGlobalGraphRoot = () => {
     },
   );
 
-  const favorites = useFavoriteAssets();
+  const {favorites, loading: favoritesLoading} = useFavoriteAssets();
 
   const fetchOptions = useMemo(() => {
     const options: AssetGraphFetchScope = {
@@ -70,9 +70,10 @@ export const AssetsGlobalGraphRoot = () => {
       hideNodesMatching: favorites
         ? (node) => !favorites.has(tokenForAssetKey(node.assetKey))
         : undefined,
+      loading: favoritesLoading,
     };
     return options;
-  }, [hideEdgesToNodesOutsideQuery, favorites]);
+  }, [hideEdgesToNodesOutsideQuery, favorites, favoritesLoading]);
 
   return (
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useFavoriteAssets.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useFavoriteAssets.oss.tsx
@@ -1,1 +1,4 @@
-export const useFavoriteAssets = (): null | Set<string> => null;
+export const useFavoriteAssets = (): {
+  loading: boolean;
+  favorites: null | Set<string>;
+} => ({loading: false, favorites: null});


### PR DESCRIPTION
## Summary & Motivation

Pass loading state down so that we don't flash all asssets.

## How I Tested These Changes
Added a skip: true to the favorites query and observed we stayed in a loading state.