### PR TITLE
[dg] Change sure config from dg.toml -> .dg.toml

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
@@ -15,7 +15,7 @@ def _get_default_dg_cli_file() -> Path:
     if is_windows():
         return Path.home() / "AppData" / "dg" / "dg.toml"
     else:
-        return Path.home() / "dg.toml"
+        return Path.home() / ".dg.toml"
 
 
 DEFAULT_DG_CLI_FILE = _get_default_dg_cli_file()


### PR DESCRIPTION
## Summary & Motivation

Change the user dg config file from `dg.toml` to `.dg.toml` on Unix. This means that there will be no `dg.toml` file in the home directory that will be discovered as a containing workspace.

## How I Tested These Changes

Manually, by checking that settings from `~/.dg.toml` were inherited and those from `~/dg.toml` were not. Used this approach because it's hard to use an automated test when reading from the home directory.

## Changelog

The `dg` user config file on Unix is now looked for at `~/.dg.toml` instead of `~/dg.toml`.