### PR TITLE
Add hybrid and branch deployment support to `dg plus deploy`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -177,12 +177,14 @@ def create_temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
 
 
 def _dagster_cloud_entry_for_project(dg_context: DgContext) -> dict[str, Any]:
+    build_config = dg_context.build_config
+
     return {
         "location_name": dg_context.code_location_name,
         "code_source": {
             "module_name": str(dg_context.code_location_target_module_name),
         },
-        # TODO build, container_context
+        **({"build": build_config} if build_config else {}),
     }
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -225,6 +225,11 @@ class DgRawCliConfig(TypedDict, total=False):
 DgProjectPythonEnvironment: TypeAlias = Literal["active", "persistent_uv"]
 
 
+class DgRawBuildConfig(TypedDict):
+    registry: Optional[str]
+    directory: Optional[str]
+
+
 @dataclass
 class DgProjectConfig:
     root_module: str

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -11,6 +11,7 @@ from typing import Final, Optional, Union
 
 import tomlkit
 import tomlkit.items
+import yaml
 from dagster_shared.utils.config import does_dg_config_file_exist
 from typing_extensions import Self
 
@@ -19,6 +20,7 @@ from dagster_dg.component import RemotePluginRegistry
 from dagster_dg.config import (
     DgConfig,
     DgProjectPythonEnvironment,
+    DgRawBuildConfig,
     DgRawCliConfig,
     DgWorkspaceProjectSpec,
     discover_config_file,
@@ -332,6 +334,17 @@ class DgContext:
                 "`project_python_executable` is only available in a Dagster project context"
             )
         return self.root_path / get_venv_executable(Path(".venv"))
+
+    @cached_property
+    def build_config(self) -> Optional[DgRawBuildConfig]:
+        # make filename config
+        build_yaml_path = self.root_path / "build.yaml"
+
+        if not build_yaml_path.exists():
+            return None
+
+        with open(build_yaml_path) as f:
+            return yaml.safe_load(f)
 
     @cached_property
     def defs_module_name(self) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -337,7 +337,6 @@ class DgContext:
 
     @cached_property
     def build_config(self) -> Optional[DgRawBuildConfig]:
-        # make filename config
         build_yaml_path = self.root_path / "build.yaml"
 
         if not build_yaml_path.exists():

--- a/python_modules/libraries/dagster-dg/dagster_dg/templates/deploy_uv_editable_Dockerfile.jinja
+++ b/python_modules/libraries/dagster-dg/dagster_dg/templates/deploy_uv_editable_Dockerfile.jinja
@@ -11,6 +11,11 @@ ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
+
+COPY --from=oss python_modules ../dagster/python_modules
+COPY --from=internal dagster-cloud/python_modules/dagster-cloud ../dagster-internal/dagster-cloud/python_modules/dagster-cloud
+COPY --from=internal dagster-cloud/python_modules/dagster-cloud-cli ../dagster-internal/dagster-cloud/python_modules/dagster-cloud-cli
+
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
@@ -27,6 +32,10 @@ FROM python:{{ python_version }}-slim-bookworm
 
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
+
+# And also the editable installs
+COPY --from=builder --chown=app:app /dagster /dagster
+COPY --from=builder --chown=app:app /dagster-internal /dagster-internal
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/git.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/git.py
@@ -1,0 +1,19 @@
+import logging
+import subprocess
+from typing import Optional
+
+
+def get_local_branch_name(project_dir: str) -> Optional[str]:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=project_dir,
+                stderr=subprocess.PIPE,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except subprocess.SubprocessError:
+        logging.debug("Failed to determine git branch", exc_info=True)
+        return None

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -52,11 +52,11 @@ def test_plus_deploy_command(logged_in_dg_cli_config, project, runner):
     with patch(
         "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
     ):
-        result = runner.invoke(plus_group, ["deploy"])
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
         assert result.exit_code == 0, result.output + " : " + str(result.exception)
         assert "No Dockerfile found - scaffolding a default one" in result.output
 
-        result = runner.invoke(plus_group, ["deploy"])
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
         assert "Building using Dockerfile at" in result.output
         assert result.exit_code == 0, result.output + " : " + str(result.exception)
 
@@ -65,6 +65,6 @@ def test_plus_deploy_command_no_login(empty_dg_cli_config, runner, project):
     with patch(
         "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
     ):
-        result = runner.invoke(plus_group, ["deploy"])
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
         assert result.exit_code != 0
         assert "Organization not specified" in result.output

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -37,6 +37,16 @@ def empty_dg_cli_config(monkeypatch):
         yield config_path
 
 
+@pytest.fixture
+def build_yaml_file(project):
+    build_yaml_path = "build.yaml"
+    try:
+        with open(build_yaml_path, "w") as f:
+            f.write("registry: my-repo\ndirectory: .")
+    finally:
+        Path(build_yaml_path).unlink()
+
+
 @pytest.fixture(scope="module")
 def runner():
     yield CliRunner()
@@ -44,11 +54,13 @@ def runner():
 
 @pytest.fixture(scope="module")
 def project(runner):
-    with isolated_example_project_foo_bar(runner, use_editable_dagster=False, in_workspace=False):
-        yield
+    with isolated_example_project_foo_bar(
+        runner, use_editable_dagster=False, in_workspace=False
+    ) as project_path:
+        yield project_path
 
 
-def test_plus_deploy_command(logged_in_dg_cli_config, project, runner):
+def test_plus_deploy_command_serverless(logged_in_dg_cli_config, project, runner):
     with patch(
         "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
     ):
@@ -68,3 +80,76 @@ def test_plus_deploy_command_no_login(empty_dg_cli_config, runner, project):
         result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
         assert result.exit_code != 0
         assert "Organization not specified" in result.output
+
+
+def test_plus_deploy_on_branch(logged_in_dg_cli_config, project, runner, mocker):
+    mocker.patch(
+        "dagster_dg.cli.plus.get_local_branch_name",
+        return_value="my-branch",
+    )
+    with patch(
+        "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
+    ):
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
+        assert result.exit_code == 0
+        assert (
+            "Deploying to the branch deployment for my-branch, with prod as the base deployment"
+            in result.output
+        )
+
+
+def test_plus_deploy_cant_determine_branch(logged_in_dg_cli_config, project, runner, mocker):
+    mocker.patch(
+        "dagster_dg.cli.plus.get_local_branch_name",
+        return_value=None,
+    )
+    with patch(
+        "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
+    ):
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
+        assert result.exit_code == 0
+        assert "Could not determine a git branch, so deploying to prod." in result.output
+
+
+def test_plus_deploy_main_branch(logged_in_dg_cli_config, project, runner, mocker):
+    mocker.patch(
+        "dagster_dg.cli.plus.get_local_branch_name",
+        return_value="main",
+    )
+    with patch(
+        "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
+    ):
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "serverless", "--yes"])
+        assert result.exit_code == 0
+        assert "Current branch is main, so deploying to prod." in result.output
+
+
+def test_plus_deploy_hybrid_no_build_yaml(logged_in_dg_cli_config, project, runner, mocker):
+    mocker.patch(
+        "dagster_dg.cli.plus.get_local_branch_name",
+        return_value="main",
+    )
+    with patch(
+        "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
+    ):
+        result = runner.invoke(plus_group, ["deploy", "--agent-type", "hybrid", "--yes"])
+        assert result.exit_code
+
+        assert "No build config found. Please specify a registry in build.yaml." in result.output
+
+
+def test_plus_deploy_hybrid_with_build_yaml(
+    logged_in_dg_cli_config, project, runner, mocker, build_yaml_file
+):
+    mocker.patch(
+        "dagster_dg.cli.plus.get_local_branch_name",
+        return_value="main",
+    )
+    with patch(
+        "dagster_dg.context.DgContext.external_dagster_cloud_cli_command",
+    ):
+        with patch(
+            "dagster_dg.cli.plus._build_hybrid_image",
+        ):
+            result = runner.invoke(plus_group, ["deploy", "--agent-type", "hybrid", "--yes"])
+            assert not result.exit_code


### PR DESCRIPTION
## Summary & Motivation
- Expland plus options to include both serverless and hybrid
- Hybrid pulls its config from a local build.yaml file (improved scaffolding support coming soon)
- Editable support to build the docker image using a special editable image
- Detect if you're in a branch and pass the right flag down to the underlying dagster-cloud ci commands if you are

## How I Tested These Changes
BK, run dg plus deploy on a hybrid deployment locally

