### PR TITLE
[dg] Update docs to no longer refer to 'dg project scaffold'

### DIFF
--- a/docs/docs/guides/labs/components/building-pipelines-with-components/adding-components.md
+++ b/docs/docs/guides/labs/components/building-pipelines-with-components/adding-components.md
@@ -22,13 +22,13 @@ Before adding a component, you must either [create a project with components](/g
 You can view the available component types in your environment by running the following command:
 
 ```bash
-dg list component-type
+dg list plugins --feature component
 ```
 
 This will display a list of all the component types that are available in your project. To see more information about a specific component type, you can run:
 
 ```bash
-dg docs component-type <component-name>
+dg docs
 ```
 
 This will display a webpage containing documentation for the specified component type.
@@ -38,10 +38,10 @@ This will display a webpage containing documentation for the specified component
 Once you've decided on the component type that you'd like to use, you can instantiate it by running:
 
 ```bash
-dg scaffold component <component-type> <component-name>
+dg scaffold <component-type> <component-path>
 ```
 
-This will create a new directory inside your `components/` folder that contains a `component.yaml` file. Some component types may also generate additional files as needed.
+This will create a new directory inside your `defs/` folder that contains a `component.yaml` file. Some component types may also generate additional files as needed.
 
 ## Configuration
 
@@ -55,7 +55,7 @@ The `component.yaml` is the primary configuration file for a component. It conta
 To see a sample `component.yaml` file for your specific component, you can run:
 
 ```bash
-dg docs component-type <component-name>
+dg docs
 ```
 
 ### Component templating

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -101,7 +101,7 @@ Now, you can use this component type to create new component instances.
 
 ## Configuring custom scaffolding
 
-Once your component type is registered, instances of the component type can be scaffolded using the `dg scaffold component` command:
+Once your component type is registered, instances of the component type can be scaffolded using the `dg scaffold` command:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt" />
 
@@ -115,7 +115,7 @@ In this case, we might want to scaffold a template shell script alongside a fill
   title="my_component_library/lib/shell_command.py"
 />
 
-Now, when we run `dg scaffold component`, we'll see that a template shell script is created alongside a filled-out `component.yaml` file:
+Now, when we run `dg scaffold`, we'll see that a template shell script is created alongside a filled-out `component.yaml` file:
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/components/shell-script-component/5-scaffolded-component.yaml"

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -112,7 +112,7 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
     [Sling](https://slingdata.io/) is a Powerful Data Integration tool enabling seamless ELT
     operations as well as quality checks across files, databases, and storage systems.
 
-    dg scaffold component dagster_sling.SlingReplicationCollectionComponent {component_name} to get started.
+    dg scaffold dagster_sling.SlingReplicationCollectionComponent {component_path} to get started.
 
     This will create a component.yaml as well as a `replication.yaml` which is a Sling-specific configuration
     file. See Sling's [documentation](https://docs.slingdata.io/concepts/replication#overview) on `replication.yaml`.


### PR DESCRIPTION
## Summary & Motivation

Update documentation to no longer refer to `dg scaffold component`

## How I Tested These Changes

Read

## Changelog

NOCHANGELOG