### PR TITLE
[dg] Make init command work with a dirname arg (BUILD-893) (BUILD-919)

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
@@ -23,7 +23,7 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ check      Commands for checking the integrity of your Dagster code.                                                 │
 │ dev        Start a local instance of Dagster.                                                                        │
 │ docs       Commands for generating docs from your Dagster code.                                                      │
-│ init       Initialize a new Dagster project or workspace.                                                            │
+│ init       Initialize a new Dagster project, optionally inside a workspace.                                          │
 │ launch     Launch a Dagster run.                                                                                     │
 │ list       Commands for listing Dagster entities.                                                                    │
 │ scaffold   Commands for scaffolding Dagster code.                                                                    │

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-init.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-init.txt
@@ -1,4 +1,4 @@
-dg init --workspace-name dagster-workspace
+dg init --workspace dagster-workspace
 
 Scaffolded files for Dagster workspace at /.../dagster-workspace.
 Enter the name of your Dagster project: project-1

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
@@ -32,7 +32,7 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         # Scaffold workspace
         run_command_and_snippet_output(
-            cmd='echo "project-1\n" | dg init --use-editable-dagster --workspace-name dagster-workspace',
+            cmd='echo "project-1\n" | dg init --use-editable-dagster --workspace dagster-workspace',
             snippet_path=DG_SNIPPETS_DIR / f"{get_next_snip_number()}-dg-init.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[
@@ -45,7 +45,7 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
                     "of your Dagster project: project-1\n",
                 ),
             ],
-            print_cmd="dg init --workspace-name dagster-workspace",
+            print_cmd="dg init --workspace dagster-workspace",
         )
 
         # Remove files we don't want to show up in the tree

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -71,7 +71,7 @@ def init_command(
             Scaffold a new workspace in a new directory `<workspace_name>`. Prompts for `<workspace_name>`. Scaffold a new project inside this workspace at projects/<project_name>. Prompts for `<project_name>`.
         dg init --workspace .
             Scaffold a new workspace in the CWD. Scaffold a new project inside this workspace at projects/<project_name>. Prompts for `<project_name>`.
-        dg init -workspace WORKSPACE_NAME
+        dg init --workspace WORKSPACE_NAME
             Scaffold a new workspace in a new directory WORKSPACE_NAME. Scaffold a new project inside this workspace at projects/<project_name>. Prompt for the project name.
         dg init --workspace --project-name PROJECT_NAME .
             Scaffold a new workspace in the CWD. Scaffold a new project inside this workspace at projects/PROJECT_NAME.

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -23,9 +23,10 @@ _DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
 @dg_editable_dagster_options
 @dg_global_options
 @click.option(
-    "--workspace-name",
-    type=str,
-    help="Name of the workspace folder to create. If omitted, only a standalone project will be created.",
+    "--workspace",
+    is_flag=True,
+    default=False,
+    help="Create a workspace instead of a project at the given path.",
 )
 @click.option(
     "--project-name",
@@ -38,20 +39,44 @@ _DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
     type=click.Choice(["persistent_uv", "active"]),
     help="Type of Python environment in which to launch subprocesses for the project.",
 )
+@click.argument(
+    "dirname",
+    required=False,
+)
 @cli_telemetry_wrapper
 def init_command(
+    dirname: Optional[str],
     use_editable_dagster: Optional[str],
-    workspace_name: Optional[str],
+    workspace: bool,
     project_name: Optional[str],
     project_python_environment: DgProjectPythonEnvironment,
     **global_options: object,
 ):
-    """Initialize a new Dagster project or workspace.
+    """Initialize a new Dagster project, optionally inside a workspace.
 
-    By default, only a standalone project is created. A workspace can also be created using the
-    --workspace-name option.
+    By default, only a standalone project is created. The project will be created in a new directory specified by DIRNAME. If DIRNAME is not specified, the user will be prompted for it.
 
-    If a project is created, it will have the following structure:
+    If the --workspace flag is passed, a workspace will be created in DIRNAME and a project created inside the workspace. If DIRNAME is not passed, the user will be prompted for it. The project name can be specified with the --project-name option, or the user will be prompted for it.
+
+    In either case, "." can be passed as DIRNAME to create the new project or workspace inside the existing working directory.
+
+    Examples:
+        dg init
+            Scaffold a new project in a new directory `<project_name>`. Prompts for `<project_name>`.
+        dg init .
+            Scaffold a new project in the CWD. The project name is taken from the last component of the CWD.
+        dg init PROJECT_NAME
+            Scaffold a new project in new directory PROJECT_NAME.
+        dg init --workspace
+            Scaffold a new workspace in a new directory `<workspace_name>`. Prompts for `<workspace_name>`. Scaffold a new project inside this workspace at projects/<project_name>. Prompts for `<project_name>`.
+        dg init --workspace .
+            Scaffold a new workspace in the CWD. Scaffold a new project inside this workspace at projects/<project_name>. Prompts for `<project_name>`.
+        dg init -workspace WORKSPACE_NAME
+            Scaffold a new workspace in a new directory WORKSPACE_NAME. Scaffold a new project inside this workspace at projects/<project_name>. Prompt for the project name.
+        dg init --workspace --project-name PROJECT_NAME .
+            Scaffold a new workspace in the CWD. Scaffold a new project inside this workspace at projects/PROJECT_NAME.
+
+    Created projects will have the following structure:
 
     ├── src
     │   └── <project_name>
@@ -77,39 +102,44 @@ def init_command(
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    workspace_path = None
+    workspace_dirname = None
 
-    if workspace_name:
+    if workspace:
         workspace_config = DgRawWorkspaceConfig(
             scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
                 use_editable_dagster,
             )
         )
+        workspace_dirname = dirname or click.prompt(
+            "Enter directory name for new workspace (. to use cwd)", default=".", type=str
+        )
+        workspace_dirname = scaffold_workspace(workspace_dirname, workspace_config)
+        specified_project_name = project_name
+        dg_context = DgContext.from_file_discovery_and_command_line_config(
+            workspace_dirname, cli_config
+        )
+        project_container = Path(workspace_dirname, _DEFAULT_INIT_PROJECTS_DIR)
+    else:
+        if dirname and project_name:
+            exit_with_error(
+                "Cannot specify both a DIRNAME and --project-name if --workspace is not passed."
+            )
+        specified_project_name = dirname or project_name
+        dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
+        project_container = Path.cwd()
 
-        workspace_path = scaffold_workspace(workspace_name, workspace_config)
-
-    if project_name is None:
-        project_name = click.prompt(
+    project_name = (
+        specified_project_name
+        or click.prompt(
             "Enter the name of your Dagster project",
             type=str,
             show_default=False,
         ).strip()
-        assert project_name is not None, "click.prompt returned None"
-    else:
-        project_name = project_name.strip()
+    )
+    assert project_name is not None, "click.prompt returned None"
+    project_path = project_container if project_name == "." else project_container / project_name
 
-    if workspace_path:
-        dg_context = DgContext.from_file_discovery_and_command_line_config(
-            workspace_path, cli_config
-        )
-        project_path = Path(workspace_path, _DEFAULT_INIT_PROJECTS_DIR, project_name)
-
-    else:
-        dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
-
-        project_path = Path(Path.cwd(), project_name)
-
-    if project_path.exists():
+    if project_name != "." and project_path.exists():
         exit_with_error(f"A file or directory already exists at {project_path}.")
 
     scaffold_project(

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -33,17 +33,18 @@ ScaffoldFormatOptions: TypeAlias = Literal["yaml", "python"]
 
 
 def scaffold_workspace(
-    workspace_name: str,
+    dirname: str,
     workspace_config: Optional[DgRawWorkspaceConfig] = None,
 ) -> Path:
     # Can't create a workspace that is a child of another workspace
-    new_workspace_path = Path.cwd() / workspace_name
+
+    new_workspace_path = Path.cwd() if dirname == "." else Path.cwd() / dirname
     existing_workspace_path = discover_workspace_root(new_workspace_path)
     if existing_workspace_path:
         exit_with_error(
             f"Workspace already exists at {existing_workspace_path}.  Run `dg scaffold project` to add a new project to that workspace."
         )
-    elif new_workspace_path.exists():
+    elif dirname != "." and new_workspace_path.exists():
         exit_with_error(f"Folder already exists at {new_workspace_path}.")
 
     scaffold_subtree(
@@ -52,7 +53,7 @@ def scaffold_workspace(
         templates_path=os.path.join(
             os.path.dirname(__file__), "templates", "WORKSPACE_NAME_PLACEHOLDER"
         ),
-        project_name=workspace_name,
+        project_name=dirname,
     )
 
     if workspace_config is not None:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import get_args
+from typing import Optional, get_args
 
 import pytest
 import tomlkit
@@ -17,32 +17,85 @@ ensure_dagster_dg_tests_import()
 from dagster_dg_tests.utils import ProxyRunner, assert_runner_result
 
 
-def test_init_command_success(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "cli_args,input_str",
+    [
+        (("--", "."), None),
+        (("--", "helloworld"), None),
+        (("--project-name", "helloworld"), None),
+        (tuple(), "helloworld\n"),
+    ],
+    ids=["dirname_cwd", "dirname_arg", "project_name_opt", "project_name_prompt"],
+)
+def test_init_success_no_workspace(
+    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str]
+) -> None:
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("init", "--use-editable-dagster", input="helloworld\n")
-        assert_runner_result(result)
-        assert not Path("dagster-workspace").exists()
+        if "." in cli_args:  # creating in CWD
+            os.mkdir("helloworld")
+            os.chdir("helloworld")
 
+        result = runner.invoke(
+            "init",
+            "--project-python-environment",
+            "active",
+            "--use-editable-dagster",
+            *cli_args,
+            input=input_str,
+        )
+        assert_runner_result(result)
+
+        if "." in cli_args:  # creating in CWD
+            os.chdir("..")
+
+        assert not Path("dagster-workspace").exists()
         assert Path("helloworld").exists()
         assert Path("helloworld/src/helloworld").exists()
         assert Path("helloworld/pyproject.toml").exists()
         assert Path("helloworld/tests").exists()
 
 
-def test_init_command_success_with_workspace_name(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "cli_args,input_str",
+    [
+        (("--project-name", "helloworld", "."), None),
+        (("--project-name", "helloworld", "dagster-workspace"), None),
+        (("--", "dagster-workspace"), "helloworld\n"),
+        (tuple(), "dagster-workspace\nhelloworld\n"),
+    ],
+    ids=[
+        "dirname_cwd_and_project_name",
+        "dirname_arg_and_project_name",
+        "dirname_arg_no_project_name",
+        "no_dirname_arg_no_project_name",
+    ],
+)
+def test_init_success_workspace(
+    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str]
+) -> None:
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        if "." in cli_args:  # creating in CWD
+            os.mkdir("dagster-workspace")
+            os.chdir("dagster-workspace")
+
         result = runner.invoke(
             "init",
-            "--workspace-name",
-            "dagster-workspace",
+            "--workspace",
+            "--project-python-environment",
+            "active",
             "--use-editable-dagster",
-            input="helloworld\n",
+            *cli_args,
+            input=input_str,
         )
         assert_runner_result(result)
+
+        if "." in cli_args:  # creating in CWD
+            os.chdir("..")
+
         assert Path("dagster-workspace").exists()
         assert Path("dagster-workspace/dg.toml").exists()
         assert Path("dagster-workspace/projects").exists()
@@ -59,40 +112,6 @@ def test_init_command_success_with_workspace_name(monkeypatch) -> None:
         )
 
 
-def test_init_override_project_name_prompt_with_workspace(monkeypatch) -> None:
-    with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke(
-            "init",
-            "--project-python-environment",
-            "active",
-            "--project-name",
-            "goodbyeworld",
-            "--workspace-name",
-            "my-workspace",
-        )
-        assert_runner_result(result)
-        assert Path("my-workspace").exists()
-        assert Path("my-workspace/dg.toml").exists()
-        assert Path("my-workspace/projects").exists()
-        assert Path("my-workspace/libraries").exists()
-        assert Path("my-workspace/projects/goodbyeworld").exists()
-        assert Path("my-workspace/projects/goodbyeworld/src/goodbyeworld").exists()
-        assert Path("my-workspace/projects/goodbyeworld/pyproject.toml").exists()
-        assert Path("my-workspace/projects/goodbyeworld/tests").exists()
-
-
-def test_init_override_project_name_prompt_without_workspace(monkeypatch) -> None:
-    dagster_git_repo_dir = discover_git_root(Path(__file__))
-    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
-    with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("init", "--project-name", "goodbyeworld", "--use-editable-dagster")
-        assert_runner_result(result)
-        assert Path("goodbyeworld").exists()
-        assert Path("goodbyeworld/src/goodbyeworld").exists()
-        assert Path("goodbyeworld/pyproject.toml").exists()
-        assert Path("goodbyeworld/tests").exists()
-
-
 def test_init_workspace_already_exists_failure(monkeypatch) -> None:
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
@@ -102,7 +121,7 @@ def test_init_workspace_already_exists_failure(monkeypatch) -> None:
         result = runner.invoke(
             "init",
             "--use-editable-dagster",
-            "--workspace-name",
+            "--workspace",
             "dagster-workspace",
             input="\nhelloworld\n",
         )
@@ -116,7 +135,7 @@ def test_init_project_already_exists_failure(monkeypatch) -> None:
 
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         os.mkdir("foo")
-        result = runner.invoke("init", "--use-editable-dagster", input="foo\n")
+        result = runner.invoke("init", "--use-editable-dagster", "--", "foo")
         assert_runner_result(result, exit_0=False)
         assert "already exists" in result.output
 
@@ -134,9 +153,9 @@ def test_init_use_editable_dagster(option: EditableOption, value_source: str, mo
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         result = runner.invoke(
             "init",
-            "--workspace-name",
-            "dagster-workspace",
+            "--workspace",
             *editable_args,
+            "dagster-workspace",
             input="helloworld\n",
         )
         assert_runner_result(result)


### PR DESCRIPTION
## Summary & Motivation

Change the `dg init` command in a few ways:

- a `DIRNAME` argument is added
- `--workspace-name` option is removed, replaced by `--workspace` flag
- `DIRNAME` may be set to `.` to create (either workspace or project) in the current directory
- default workspace prompt is now (`.`)

Examples:

- `dg init`: creates a project, prompts for project name
- `dg init .`: scaffold a new project in the CWD
- `dg init helloworld`: scaffold a new project in new dir `helloworld`
- `dg init -workspace dagster-workspace`: scaffold a new workspace in new dir `dagster-workspace`, prompt for project name
- `dg init --workspace .`: scaffold a new workspace in the CWD, prompt for project anme
- `dg init --workspace --project-name helloworld .`: scaffold a new workspace in the CWD, create project named helloworld

## How I Tested These Changes

Modified init unit tests.

## Changelog

The arguments/options of the `dg init` command have changed. You may pass `.` as an argument to initialize a project/workspace in the CWD. See `dg init --help` for more details.
