### PR TITLE
[dbt] cutover callsites to translator.get_asset_spec

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -35,12 +35,12 @@ from dagster_dbt.asset_utils import (
     default_description_fn,
     default_freshness_policy_fn,
     default_group_from_dbt_resource_props,
+    get_node,
 )
 from dagster_dbt.cloud.resources import DbtCloudClient, DbtCloudClientResource, DbtCloudRunStatus
 from dagster_dbt.cloud.utils import result_to_events
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.errors import DagsterDbtCloudJobInvariantViolationError
-from dagster_dbt.utils import get_dbt_resource_props_by_dbt_unique_id_from_manifest
 
 DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR = "DBT_DAGSTER_COMPILE_RUN_ID"
 
@@ -333,12 +333,12 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
                 return self._node_info_to_auto_materialize_policy_fn(dbt_resource_props)
 
         # generate specs for each executed node
-        dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(manifest_json)
         specs = build_dbt_asset_specs(
             manifest=manifest_json,
             dagster_dbt_translator=CustomDagsterDbtTranslator(),
             select=" ".join(
-                f"fqn:{'.'.join(dbt_nodes[unique_id]['fqn'])}" for unique_id in executed_unique_ids
+                f"fqn:{'.'.join(get_node(manifest_json, unique_id)['fqn'])}"
+                for unique_id in executed_unique_ids
             ),
         )
 
@@ -351,7 +351,10 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             },
             metadata_by_output_name={
                 spec.key.to_python_identifier(): self._build_dbt_cloud_assets_metadata(
-                    dbt_nodes[spec.metadata[DAGSTER_DBT_UNIQUE_ID_METADATA_KEY]]
+                    get_node(
+                        manifest_json,
+                        spec.metadata[DAGSTER_DBT_UNIQUE_ID_METADATA_KEY],
+                    )
                 )
                 for spec in specs
             },
@@ -363,9 +366,10 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
                     spec.key.to_python_identifier(): spec.group_name for spec in specs
                 },
                 "fqns_by_output_name": {
-                    spec.key.to_python_identifier(): dbt_nodes[
-                        spec.metadata[DAGSTER_DBT_UNIQUE_ID_METADATA_KEY]
-                    ]["fqn"]
+                    spec.key.to_python_identifier(): get_node(
+                        manifest_json,
+                        spec.metadata[DAGSTER_DBT_UNIQUE_ID_METADATA_KEY],
+                    )["fqn"]
                     for spec in specs
                 },
             },

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -196,6 +196,7 @@ class DbtCloudJobRunResults:
                     manifest=manifest,
                     dagster_dbt_translator=dagster_dbt_translator,
                     test_unique_id=unique_id,
+                    project=None,
                 )
 
                 if (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -400,8 +400,7 @@ class DbtCliEventMessage:
                     exc_info=True,
                 )
 
-            dbt_resource_props = manifest["nodes"][unique_id]
-            asset_key = dagster_dbt_translator.get_asset_key(dbt_resource_props)
+            asset_key = dagster_dbt_translator.get_asset_spec(manifest, unique_id, None).key
             if context and has_asset_def:
                 yield Output(
                     value=None,
@@ -430,7 +429,10 @@ class DbtCliEventMessage:
                 metadata["dagster_dbt/failed_row_count"] = self.raw_event["data"]["num_failures"]
 
             asset_check_key = get_asset_check_key_for_test(
-                manifest, dagster_dbt_translator, test_unique_id=unique_id
+                manifest,
+                dagster_dbt_translator,
+                test_unique_id=unique_id,
+                project=None,
             )
 
             if (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -118,21 +118,6 @@ def select_unique_ids_from_manifest(
     return selected
 
 
-def get_dbt_resource_props_by_dbt_unique_id_from_manifest(
-    manifest: Mapping[str, Any],
-) -> Mapping[str, Mapping[str, Any]]:
-    """A mapping of a dbt node's unique id to the node's dictionary representation in the manifest."""
-    return {
-        **manifest["nodes"],
-        **manifest["sources"],
-        **manifest["exposures"],
-        **manifest["metrics"],
-        **manifest.get("semantic_models", {}),
-        **manifest.get("saved_queries", {}),
-        **manifest.get("unit_tests", {}),
-    }
-
-
 def _set_flag_attrs(kvs: dict[str, Any]):
     from dbt.flags import get_flag_dict, set_flags
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -408,7 +408,7 @@ def test_custom_groups(dbt_cloud, dbt_cloud_service):
     dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(
         dbt_cloud=dbt_cloud,
         job_id=DBT_CLOUD_JOB_ID,
-        node_info_to_group_fn=lambda node_info: node_info["tags"][0],
+        node_info_to_group_fn=lambda node_info: next(iter(node_info["tags"]), None),
     )
     dbt_assets_definition_cacheable_data = dbt_cloud_cacheable_assets.compute_cacheable_data()
     dbt_cloud_assets = dbt_cloud_cacheable_assets.build_definitions(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -127,15 +127,14 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
         ),
         ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
         (
-            {"kinds": ["snowflake"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds
-            and "dbt" in asset_spec.kinds,  # Ensure dbt-specific kind is not overwritten
+            {"kinds": ["snowflake", "dbt"]},
+            lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
             False,
         ),
         (
-            {"tags": {"foo": "bar"}, "kinds": ["snowflake"]},
+            {"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
             lambda asset_spec: "snowflake" in asset_spec.kinds
-            and "dbt" in asset_spec.kinds  # Ensure dbt-specific kind is not overwritten
+            and "dbt" in asset_spec.kinds
             and asset_spec.tags.get("foo") == "bar",
             False,
         ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_materialization_execution_duration.py
@@ -81,6 +81,7 @@ def test_microbatch_log_model_result_to_asset():
                 "alias": "order_history",
                 "path": "mart/public__orders.sql",
                 "config": {"schema": "public"},
+                "description": "",
             }
         },
     }
@@ -171,6 +172,7 @@ def test_incremental_log_model_result_to_asset():
                 "alias": "order_history",
                 "path": "mart/public__orders.sql",
                 "config": {"schema": "public"},
+                "description": "",
             }
         },
     }


### PR DESCRIPTION
Make `get_asset_spec` authoritative by moving all internal call sites to calling that to get access to properties like the key.

This changes the API signature of `get_asset_spec` from its previous set to a much more manageable `manifest: Mapping[...], unique_id: str, project: Optional[DbtProject]`. 

`project` getting thread through when needed when `enable_code_references` is on is the biggest concern. 

## How I Tested These Changes

existing coverage

