### PR TITLE
[Docs] Only create version dropdown entries for minor versions

### DIFF
--- a/docs/dagsterVersions.json
+++ b/docs/dagsterVersions.json
@@ -1,16 +1,3 @@
 {
-  "1.10.9": "https://release-1-10-9.archive.dagster-docs.io/",
-  "1.10.8": "https://release-1-10-8.archive.dagster-docs.io/",
-  "1.10.7": "https://release-1-10-7.archive.dagster-docs.io/",
-  "1.10.6": "https://release-1-10-6.archive.dagster-docs.io/",
-  "1.10.5": "https://release-1-10-5.archive.dagster-docs.io/",
-  "1.10.4": "https://release-1-10-4.archive.dagster-docs.io/",
-  "1.10.3": "https://release-1-10-3.archive.dagster-docs.io/",
-  "1.10.2": "https://release-1-10-2.archive.dagster-docs.io/",
-  "1.10.1": "https://release-1-10-1.archive.dagster-docs.io/",
-  "1.10.0": "https://release-1-10-0.archive.dagster-docs.io/",
-  "1.9.13": "https://release-1-9-13.archive.dagster-docs.io/",
-  "1.9.12": "https://release-1-9-12.archive.dagster-docs.io/",
-  "1.9.11": "https://release-1-9-11.archive.dagster-docs.io/",
-  "1.9.10": "https://release-1-9-10.archive.dagster-docs.io/"
+  "Version 1.9 (1.9.13)": "https://release-1-9-13.archive.dagster-docs.io/"
 }

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -185,7 +185,7 @@ const config: Config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: 'Latest (1.10.10)',
+              label: 'Latest (1.10.11)',
               path: '/',
             },
           },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -185,7 +185,7 @@ const config: Config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.10.10',
+              label: 'Latest (1.10.10)',
               path: '/',
             },
           },


### PR DESCRIPTION
## Summary & Motivation

See title -- to keep the version switcher from getting super long, only create new entries in the version picker for minor versions.

Since the 1.10.10 release branch has already been cut, I set the most recent release to 1.10.11.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
