### PR TITLE
add configurable client-side timeout to k8s API calls

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -15,6 +15,8 @@ from dagster._core.storage.dagster_run import DagsterRunStatus
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.models import V1Job, V1JobStatus
 
+from dagster_k8s.utils import TimeoutConfigurableK8sAPIClient
+
 try:
     from kubernetes.client.models import EventsV1Event  # noqa
 
@@ -238,7 +240,7 @@ class KubernetesWaitingReasons:
 class DagsterKubernetesClient:
     def __init__(self, batch_api, core_api, logger, sleeper, timer):
         self.batch_api = batch_api
-        self.core_api = core_api
+        self.core_api = TimeoutConfigurableK8sAPIClient(core_api)
         self.logger = logger
         self.sleeper = sleeper
         self.timer = timer

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -29,6 +29,7 @@ T = TypeVar("T")
 DEFAULT_WAIT_TIMEOUT = 86400.0  # 1 day
 DEFAULT_WAIT_BETWEEN_ATTEMPTS = 10.0  # 10 seconds
 DEFAULT_JOB_POD_COUNT = 1  # expect job:pod to be 1:1 by default
+DEFAULT_DAGSTER_K8S_REQUEST_TIMEOUT = 60
 
 
 class WaitForPodState(Enum):
@@ -97,7 +98,9 @@ WHITELISTED_TRANSIENT_K8S_STATUS_CODES = [
 class PatchedApiClient(ApiClient):
     def __init__(self, *args, **kwargs):
         try:
-            timeout_str = os.getenv("KUBERNETES_API_REQUEST_TIMEOUT")
+            timeout_str = os.getenv(
+                "DAGSTER_KUBERNETES_API_REQUEST_TIMEOUT", str(DEFAULT_DAGSTER_K8S_REQUEST_TIMEOUT)
+            )
             self.__dagster_request_timeout = int(timeout_str) if timeout_str else None
         except ValueError:
             self.__dagster_request_timeout = None

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,5 +1,8 @@
+import functools
+import os
 import re
 
+import kubernetes
 from dagster import __version__ as dagster_version
 
 
@@ -18,3 +21,40 @@ def get_common_labels():
         "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
         "app.kubernetes.io/part-of": "dagster",
     }
+
+
+class TimeoutConfigurableK8sAPIClient(kubernetes.client.CoreV1Api):
+    def __init__(self, base_client):
+        # explicitly do not call the super constructor, since we're just wrapping the base client
+        pass
+
+    def __new__(cls, base_client: kubernetes.client.CoreV1Api):
+        instance = super().__new__(cls)
+
+        try:
+            timeout_str = os.getenv("KUBERNETES_API_REQUEST_TIMEOUT")
+            timeout = int(timeout_str) if timeout_str else None
+        except ValueError:
+            timeout = None
+
+        for attr_name in dir(base_client):
+            if not attr_name.startswith("_"):
+                attr = getattr(base_client, attr_name)
+                if callable(attr) and timeout is not None:
+
+                    @functools.wraps(attr)
+                    def wrapped_method(method_name=attr_name):
+                        original_method = getattr(base_client, method_name)
+
+                        def method_with_timeout(*args, **kwargs):
+                            if "_request_timeout" not in kwargs:
+                                kwargs["_request_timeout"] = timeout
+                            return original_method(*args, **kwargs)
+
+                        return method_with_timeout
+
+                    setattr(instance, attr_name, wrapped_method())
+                else:
+                    setattr(instance, attr_name, attr)
+
+        return instance

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,8 +1,5 @@
-import functools
-import os
 import re
 
-import kubernetes
 from dagster import __version__ as dagster_version
 
 
@@ -21,40 +18,3 @@ def get_common_labels():
         "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
         "app.kubernetes.io/part-of": "dagster",
     }
-
-
-class TimeoutConfigurableK8sAPIClient(kubernetes.client.CoreV1Api):
-    def __init__(self, base_client):
-        # explicitly do not call the super constructor, since we're just wrapping the base client
-        pass
-
-    def __new__(cls, base_client: kubernetes.client.CoreV1Api):
-        instance = super().__new__(cls)
-
-        try:
-            timeout_str = os.getenv("KUBERNETES_API_REQUEST_TIMEOUT")
-            timeout = int(timeout_str) if timeout_str else None
-        except ValueError:
-            timeout = None
-
-        for attr_name in dir(base_client):
-            if not attr_name.startswith("_"):
-                attr = getattr(base_client, attr_name)
-                if callable(attr) and timeout is not None:
-
-                    @functools.wraps(attr)
-                    def wrapped_method(method_name=attr_name):
-                        original_method = getattr(base_client, method_name)
-
-                        def method_with_timeout(*args, **kwargs):
-                            if "_request_timeout" not in kwargs:
-                                kwargs["_request_timeout"] = timeout
-                            return original_method(*args, **kwargs)
-
-                        return method_with_timeout
-
-                    setattr(instance, attr_name, wrapped_method())
-                else:
-                    setattr(instance, attr_name, attr)
-
-        return instance

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -14,7 +14,7 @@ from dagster_k8s.client import (
     KubernetesWaitingReasons,
     WaitForPodState,
 )
-from dagster_k8s.utils import TimeoutConfigurableK8sAPIClient
+from kubernetes.client.api_client import ApiClient
 from kubernetes.client.models import (
     V1ContainerState,
     V1ContainerStateRunning,
@@ -1236,15 +1236,13 @@ def test_wait_for_ready_pod_is_deleted():
     assert str(exc_info.value).startswith(f'Pod "{pod_name}" was unexpectedly killed')
 
 
-def test_wrapped_client():
-    core_api = mock.MagicMock(kubernetes.client.CoreV1Api)
-    core_api.read_namespaced_pod_log = mock.MagicMock(return_value=("a_string", 200, {}))
-    core_api.api_client = mock.MagicMock()
-
-    with environ({"KUBERNETES_API_REQUEST_TIMEOUT": "60"}):
-        wrapper = TimeoutConfigurableK8sAPIClient(core_api)
-        result = wrapper.read_namespaced_pod_log("default", "default_namespace")
-        core_api.read_namespaced_pod_log.assert_called_once_with(
-            "default", "default_namespace", _request_timeout=60
-        )
-        assert result == ("a_string", 200, {})
+def test_patched_client():
+    with (
+        mock.patch.object(ApiClient, "call_api") as call_api,
+        environ({"KUBERNETES_API_REQUEST_TIMEOUT": "60"}),
+    ):
+        client = DagsterKubernetesClient.production_client()
+        client.core_api.read_namespaced_pod_log("name", "namespace")
+        assert call_api.call_count == 1
+        _args, kwargs = call_api.call_args
+        assert kwargs["_request_timeout"] == 60


### PR DESCRIPTION
## Summary & Motivation
k8s api calls can sometimes hang when there are network blips.  Setting a client side timeout will cause the client api calls  to fail instead of hang.

## How I Tested These Changes
BK

## Changelog
- [dagster-k8s] adds a client-side request timeout configurable by a `KUBERNETES_API_REQUEST_TIMEOUT` env var to prevent network blips to hang runs