### PR TITLE
Update databricks-sdk version for supporting new dbt-databricks V1.10.0

### DIFF
--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk==0.46.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk>=0.41,<0.48.0",  # dbt-databricks is pinned to this version
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk<=0.17.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk==0.46.0",  # dbt-databricks is pinned to this version
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
With the new version of dbt-databricks, the required databricks-sdk is set to 0.46.0.
https://github.com/databricks/dbt-databricks/releases/tag/v1.10.0

## How I Tested These Changes
Used in our local setup for executing an asset at databricks

## Changelog
Update required databricks-sdk from 0.17.0 to 0.46.0
