### PR TITLE
Deprecate/remove 'should_materiailze' field on StepOutput

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -76,7 +76,7 @@ def create_step_outputs(
                     is_required=output_def.is_required,
                     is_dynamic=output_def.is_dynamic,
                     is_asset=asset_key is not None,
-                    should_materialize=output_def.name in config_output_names,
+                    should_materialize_DEPRECATED=output_def.name in config_output_names,
                     asset_key=asset_node.key
                     if asset_node and asset_node.key in asset_layer.asset_keys_for_node(handle)
                     else None,

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -15,7 +15,7 @@ from dagster._core.execution.plan.objects import TypeCheckData
 from dagster._serdes import whitelist_for_serdes
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_field_names={"should_materialize_DEPRECATED": "should_materialize"})
 class StepOutputProperties(
     NamedTuple(
         "_StepOutputProperties",
@@ -23,7 +23,7 @@ class StepOutputProperties(
             ("is_required", bool),
             ("is_dynamic", bool),
             ("is_asset", bool),
-            ("should_materialize", bool),
+            ("should_materialize_DEPRECATED", bool),
             ("asset_key", Optional[AssetKey]),
             ("is_asset_partitioned", bool),
             ("asset_check_key", Optional[AssetCheckKey]),
@@ -35,7 +35,7 @@ class StepOutputProperties(
         is_required: bool,
         is_dynamic: bool,
         is_asset: bool,
-        should_materialize: bool,
+        should_materialize_DEPRECATED: bool,
         asset_key: Optional[AssetKey] = None,
         is_asset_partitioned: bool = False,
         asset_check_key: Optional[AssetCheckKey] = None,
@@ -45,7 +45,7 @@ class StepOutputProperties(
             check.bool_param(is_required, "is_required"),
             check.bool_param(is_dynamic, "is_dynamic"),
             check.bool_param(is_asset, "is_asset"),
-            check.bool_param(should_materialize, "should_materialize"),
+            check.bool_param(should_materialize_DEPRECATED, "should_materialize_DEPRECATED"),
             check.opt_inst_param(asset_key, "asset_key", AssetKey),
             check.bool_param(is_asset_partitioned, "is_asset_partitioned"),
             check.opt_inst_param(asset_check_key, "asset_check_key", AssetCheckKey),
@@ -92,10 +92,6 @@ class StepOutput(
     @property
     def is_asset(self) -> bool:
         return self.properties.is_asset
-
-    @property
-    def should_materialize(self) -> bool:
-        return self.properties.should_materialize
 
     @property
     def asset_key(self) -> Optional[AssetKey]:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_old_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_old_execution_plan_snapshot.py
@@ -3,7 +3,7 @@ from dagster import job
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
-from dagster_shared.serdes import deserialize_value
+from dagster_shared.serdes import deserialize_value, serialize_value
 
 OLD_EXECUTION_PLAN_SNAPSHOT = """{
   "__class__": "ExecutionPlanSnapshot",
@@ -197,4 +197,11 @@ PRE_CACHE_EXECUTION_PLAN_SNAPSHOT = """{
 
 def test_rebuild_pre_cached_key_execution_plan_snapshot():
     snapshot = deserialize_value(PRE_CACHE_EXECUTION_PLAN_SNAPSHOT, ExecutionPlanSnapshot)
-    ExecutionPlan.rebuild_from_snapshot("noop_job", snapshot)
+    plan = ExecutionPlan.rebuild_from_snapshot("noop_job", snapshot)
+
+    assert (
+        next(iter(plan.steps[0].step_output_dict.values())).properties.should_materialize_DEPRECATED
+        is False
+    )
+
+    assert snapshot == deserialize_value(serialize_value(snapshot))


### PR DESCRIPTION
## Summary & Motivation
This appears to be unused in 2025. Retain the serialized field for any old versions that might still be using it, but make the name clearer that it is unused.

## How I Tested These Changes
New back-compat test case
