### PR TITLE
[BCOR-54] Add `FROM_ASSET_FAILURE` re-execution option

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/resume_retry.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/resume_retry.py
@@ -4,3 +4,4 @@ import enum
 class ReexecutionStrategy(enum.Enum):
     ALL_STEPS = "ALL_STEPS"
     FROM_FAILURE = "FROM_FAILURE"
+    FROM_ASSET_FAILURE = "FROM_ASSET_FAILURE"

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from datetime import datetime
 from functools import cached_property
 from threading import RLock
@@ -21,6 +21,7 @@ from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import (
     InstigatorSelector,
+    JobSubsetSelector,
     RepositorySelector,
     ScheduleSelector,
     SensorSelector,
@@ -657,6 +658,19 @@ class RemoteJob(RepresentedJob):
 
     def get_remote_origin_id(self) -> str:
         return self.get_remote_origin().get_id()
+
+    def get_subset_selector(
+        self, asset_selection: Set[AssetKey], asset_check_selection: Set[AssetCheckKey]
+    ) -> JobSubsetSelector:
+        """Returns a JobSubsetSelector to select a subset of this RemoteJob."""
+        return JobSubsetSelector(
+            location_name=self.handle.location_name,
+            repository_name=self.handle.repository_name,
+            job_name=self.name,
+            op_selection=self.op_selection,
+            asset_selection=asset_selection,
+            asset_check_selection=asset_check_selection,
+        )
 
 
 class RemoteExecutionPlan:

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -39,6 +39,8 @@ ROOT_BACKFILL_ID_TAG = f"{SYSTEM_TAG_PREFIX}root_backfill_id"
 
 RESUME_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}is_resume_retry"
 
+ASSET_RESUME_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}is_asset_resume_retry"
+
 STEP_SELECTION_TAG = f"{SYSTEM_TAG_PREFIX}step_selection"
 
 OP_SELECTION_TAG = f"{SYSTEM_TAG_PREFIX}solid_selection"


### PR DESCRIPTION
## Summary & Motivation

This adds in a new `FROM_ASSET_FAILURE` re-execution option. Its functionality is quite simple, just:

- compute the set of unexecuted asset keys and asset check keys from the parent run
- create a new run request that is a subset of the original job targeting just those selected assets and checks

This causes a brand new job snapshot / execution plan to be created, allowing the asset job construction machinery to be re-invoked to satisfy the new request.

Currently, there is no do this from the UI.

## How I Tested These Changes

Added unit tests, also tested locally.

## Changelog

NOCHANGELOG
