### PR TITLE
[BCOR-56] Make multi_assets recombine when possible

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -255,10 +255,10 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         return assets_defs
 
     @classmethod
-    def from_assets(
+    def key_mappings_from_assets(
         cls,
         assets: Iterable[Union[AssetsDefinition, SourceAsset]],
-    ) -> "AssetGraph":
+    ) -> tuple[Mapping[AssetKey, AssetNode], Mapping[AssetCheckKey, AssetsDefinition]]:
         assets_defs = cls.normalize_assets(assets)
 
         # Build the set of AssetNodes. Each node holds key rather than object references to parent
@@ -284,6 +284,14 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
             for key in ad.keys
         }
 
+        return (asset_nodes_by_key, assets_defs_by_check_key)
+
+    @classmethod
+    def from_assets(
+        cls,
+        assets: Iterable[Union[AssetsDefinition, SourceAsset]],
+    ) -> "AssetGraph":
+        asset_nodes_by_key, assets_defs_by_check_key = cls.key_mappings_from_assets(assets)
         return AssetGraph(
             asset_nodes_by_key=asset_nodes_by_key,
             assets_defs_by_check_key=assets_defs_by_check_key,
@@ -379,6 +387,10 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
 
     def get_check_spec(self, key: AssetCheckKey) -> AssetCheckSpec:
         return self._assets_defs_by_check_key[key].get_spec_for_check_key(key)
+
+    @property
+    def source_asset_graph(self) -> "AssetGraph":
+        return self
 
 
 def executable_in_same_run(

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -877,7 +877,9 @@ class JobDefinition(IHasInternalInit):
             )
 
         job_asset_graph = get_asset_graph_for_job(
-            self.asset_layer.asset_graph, selection, allow_different_partitions_defs=True
+            self.asset_layer.asset_graph.source_asset_graph,
+            selection,
+            allow_different_partitions_defs=True,
         )
 
         return build_asset_job(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -2918,18 +2918,63 @@ def test_subset_cycle_dependencies():
 
     # now create a job that just executes a and b
     job = job.get_subset(asset_selection={AssetKey("a"), AssetKey("b")})
-    # should produce a job with foo -> foo_2
-    assert len(list(job.graph.iterate_op_defs())) == 2
-    assert job.graph.dependencies == {
-        NodeInvocation(name="foo"): {},
-        # the second node must have a dependency on the first
-        NodeInvocation(name="foo", alias="foo_2"): {
-            "__subset_input__a": DependencyDefinition(node="foo", output="a"),
-        },
-    }
+    # can satisfy this with just a single op
+    assert len(list(job.graph.iterate_op_defs())) == 1
+    assert job.graph.dependencies == {NodeInvocation(name="foo"): {}}
     result = job.execute_in_process()
     assert result.success
     assert _all_asset_keys(result) == {AssetKey("a"), AssetKey("b")}
+
+
+def test_subset_recongeal() -> None:
+    # In this test, we create a job that requires multi-asset `acd` to be broken up into two pieces
+    # in order to accomodate the inclusion of `b` in the job, as `b` depends on `a`, but is depended
+    # on by `c` and `d`.
+    #
+    # We ensure that this subsetting happens, and then ensure that when we subset this job to include
+    # only `a` and `c`, the resulting graph "recongeals", and puts the multi-asset back together again,
+    # as it is no longer necessary to break it apart.
+    import dagster as dg
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("a", skippable=True),
+            dg.AssetSpec("c", deps="b", skippable=True),
+            dg.AssetSpec("d", deps=["a", "b"], skippable=True),
+        ],
+        can_subset=True,
+    )
+    def acd(context: dg.AssetExecutionContext):
+        context.log.info(f"{context.selected_asset_keys}")
+        for selected in sorted(context.op_execution_context.selected_output_names):
+            yield dg.Output(None, selected)
+
+    @dg.asset(deps=["a"])
+    def b() -> None: ...
+
+    defs = dg.Definitions(assets=[acd, b])
+    all_job = defs.get_implicit_global_asset_job_def()
+    subset_job = all_job.get_subset(asset_selection={dg.AssetKey("a"), dg.AssetKey("c")})
+    assert len(list(subset_job.graph.iterate_op_defs())) == 1
+    assert all_job.graph.dependencies == {
+        NodeInvocation(name="acd"): {},
+        NodeInvocation(name="b"): {
+            "a": DependencyDefinition(node="acd", output="a"),
+        },
+        NodeInvocation(name="acd", alias="acd_2"): {
+            "__subset_input__a": DependencyDefinition(node="acd", output="a"),
+            "b": DependencyDefinition(node="b", output="result"),
+        },
+    }
+    result = all_job.execute_in_process()
+    assert result.success
+    assert _all_asset_keys(result) == {AssetKey("a"), AssetKey("b"), AssetKey("c"), AssetKey("d")}
+    # only need a single op to make this work
+    assert len(list(subset_job.graph.iterate_op_defs())) == 1
+    assert subset_job.graph.dependencies == {NodeInvocation(name="acd"): {}}
+    result = subset_job.execute_in_process()
+    assert result.success
+    assert _all_asset_keys(result) == {AssetKey("a"), AssetKey("c")}
 
 
 def test_exclude_assets_without_keys():


### PR DESCRIPTION
## Summary & Motivation

I believe this restores the originally-intended behavior of these codepaths, although it's been like 4 years since I've looked at this.

Regardless, this allows the system to have more flexibility when generating a JobDefinition for a subset (asset selection) of an existing JobDefinition.

Previously, we would use the job-scoped AssetGraph from the parent job, which meant that any multi-assets which were cleaved within that parent job would remain as separate ops in the child job.

Now, when we create a job-scoped AssetGraph, we retain a reference to the original global asset graph, which allows us to access that at the appropriate time.

This means that creating a subset job from an existing job will result in an identical job structure to just creating that job directly on the Definitions object.

## How I Tested These Changes

## Changelog

Fixed an issue which caused multi assets that were automatically broken apart in some contexts to remain separated even in cases where this was not necessary to maintain execution dependencies.