### PR TITLE
[ui] Append a dagster/from_ui tag to every run launched from the UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -60,6 +60,7 @@ import {
 } from '../instance/backfill/types/BackfillUtils.types';
 import {fetchTagsAndConfigForAssetJob} from '../launchpad/ConfigFetch';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
+import {tagsWithUIExecutionTags} from '../launchpad/uiExecutionTags';
 import {
   DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT,
   DaemonNotRunningAlert,
@@ -311,10 +312,11 @@ const LaunchAssetChoosePartitionsDialogBody = ({
   };
 
   const onLaunchAsBackfill = async () => {
+    const backfillTags = tagsWithUIExecutionTags(tags);
     const backfillParams: LaunchBackfillParams =
       target.type === 'job' && !isHiddenAssetGroupJob(target.jobName)
         ? {
-            tags,
+            tags: backfillTags,
             assetSelection: assets.map(asAssetKeyInput),
             partitionNames: keysFiltered,
             fromFailure: false,
@@ -329,12 +331,12 @@ const LaunchAssetChoosePartitionsDialogBody = ({
           }
         : target.type === 'pureAll'
           ? {
-              tags,
+              tags: backfillTags,
               assetSelection: assets.map(asAssetKeyInput),
               allPartitions: true,
             }
           : {
-              tags,
+              tags: backfillTags,
               assetSelection: assets.map(asAssetKeyInput),
               partitionNames: keysFiltered,
               fromFailure: false,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -7,6 +7,7 @@ import {CustomAlertProvider} from '../../app/CustomAlertProvider';
 import {CustomConfirmationProvider} from '../../app/CustomConfirmationProvider';
 import {displayNameForAssetKey} from '../../asset-graph/Utils';
 import {LaunchPartitionBackfillMutation} from '../../instance/backfill/types/BackfillUtils.types';
+import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
 import {LaunchPipelineExecutionMutation} from '../../runs/types/RunUtils.types';
 import {TestProvider} from '../../testing/TestProvider';
 import {buildWorkspaceMocks} from '../../workspace/WorkspaceContext/__fixtures__/Workspace.fixtures';
@@ -190,7 +191,7 @@ describe('LaunchAssetExecutionButton', () => {
       const launchMock = buildExpectedLaunchSingleRunMutation({
         mode: 'default',
         executionMetadata: {
-          tags: [],
+          tags: [...UI_EXECUTION_TAGS],
         },
         runConfigData: '{}',
         selector: {
@@ -214,7 +215,7 @@ describe('LaunchAssetExecutionButton', () => {
       it('should not include checks if the job in context is marked without_checks', async () => {
         const launchMock = buildExpectedLaunchSingleRunMutation({
           mode: 'default',
-          executionMetadata: {tags: []},
+          executionMetadata: {tags: [...UI_EXECUTION_TAGS]},
           runConfigData: '{}',
           selector: {
             repositoryLocationName: 'test.py',
@@ -236,7 +237,7 @@ describe('LaunchAssetExecutionButton', () => {
       it('should include checks if the job in context includes them', async () => {
         const launchMock = buildExpectedLaunchSingleRunMutation({
           mode: 'default',
-          executionMetadata: {tags: []},
+          executionMetadata: {tags: [...UI_EXECUTION_TAGS]},
           runConfigData: '{}',
           selector: {
             repositoryLocationName: 'test.py',
@@ -275,7 +276,7 @@ describe('LaunchAssetExecutionButton', () => {
       const launchMock = buildExpectedLaunchSingleRunMutation({
         mode: 'default',
         executionMetadata: {
-          tags: [],
+          tags: [...UI_EXECUTION_TAGS],
         },
         runConfigData: '{}',
         selector: {
@@ -327,6 +328,7 @@ describe('LaunchAssetExecutionButton', () => {
           tags: [
             {key: 'dagster/partition', value: '2023-02-22'},
             {key: 'dagster/partition_set', value: 'my_asset_job_partition_set'},
+            ...UI_EXECUTION_TAGS,
           ],
         },
         mode: 'default',
@@ -360,7 +362,7 @@ describe('LaunchAssetExecutionButton', () => {
         assetSelection: [{path: ['asset_daily']}],
         partitionNames: ASSET_DAILY_PARTITION_KEYS,
         fromFailure: false,
-        tags: [],
+        tags: [...UI_EXECUTION_TAGS],
       });
       renderButton({
         scope: {all: [ASSET_DAILY]},
@@ -400,7 +402,7 @@ describe('LaunchAssetExecutionButton', () => {
         assetSelection: [{path: ['asset_daily']}],
         partitionNames: ASSET_DAILY_PARTITION_KEYS_MISSING,
         fromFailure: false,
-        tags: [],
+        tags: [...UI_EXECUTION_TAGS],
       });
       renderButton({
         scope: {all: [ASSET_DAILY]},
@@ -437,6 +439,7 @@ describe('LaunchAssetExecutionButton', () => {
           tags: [
             {key: 'dagster/partition', value: '2023-02-22'},
             {key: 'dagster/partition_set', value: '__ASSET_JOB_partition_set'},
+            ...UI_EXECUTION_TAGS,
           ],
         },
         mode: 'default',
@@ -472,7 +475,7 @@ describe('LaunchAssetExecutionButton', () => {
           assetSelection: [{path: ['asset_daily']}],
           partitionNames: ASSET_DAILY_PARTITION_KEYS,
           fromFailure: false,
-          tags: [],
+          tags: [...UI_EXECUTION_TAGS],
         });
         renderButton({
           scope: {all: [ASSET_DAILY]},
@@ -503,6 +506,7 @@ describe('LaunchAssetExecutionButton', () => {
             tags: [
               {key: 'dagster/asset_partition_range_start', value: '2020-01-02'},
               {key: 'dagster/asset_partition_range_end', value: '2023-02-22'},
+              ...UI_EXECUTION_TAGS,
             ],
           },
           runConfigData: '{}\n',
@@ -540,6 +544,7 @@ describe('LaunchAssetExecutionButton', () => {
             tags: [
               {key: 'dagster/asset_partition_range_start', value: '2020-01-02'},
               {key: 'dagster/asset_partition_range_end', value: '2023-02-22'},
+              ...UI_EXECUTION_TAGS,
             ],
           },
           runConfigData: '{}\n',
@@ -572,7 +577,7 @@ describe('LaunchAssetExecutionButton', () => {
         assetSelection: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
         partitionNames: ASSET_DAILY_PARTITION_KEYS,
         fromFailure: false,
-        tags: [],
+        tags: [...UI_EXECUTION_TAGS],
       });
 
       renderButton({
@@ -604,7 +609,7 @@ describe('LaunchAssetExecutionButton', () => {
         assetSelection: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
         partitionNames: ASSET_DAILY_PARTITION_KEYS,
         fromFailure: false,
-        tags: [],
+        tags: [...UI_EXECUTION_TAGS],
       });
 
       renderButton({
@@ -624,7 +629,7 @@ describe('LaunchAssetExecutionButton', () => {
 
     it('should offer to materialize all partitions if roots have different partition defintions ("pureAll" case)', async () => {
       const LaunchPureAllMutationMock = buildExpectedLaunchBackfillMutation({
-        tags: [],
+        tags: [...UI_EXECUTION_TAGS],
         assetSelection: [
           {path: ['asset_daily']},
           {path: ['asset_weekly']},
@@ -658,7 +663,7 @@ describe('LaunchAssetExecutionButton', () => {
     it('should present a warning if pre-flight check indicates other asset keys are required', async () => {
       const launchMock = buildExpectedLaunchSingleRunMutation({
         mode: 'default',
-        executionMetadata: {tags: []},
+        executionMetadata: {tags: [...UI_EXECUTION_TAGS]},
         runConfigData: '{}',
         selector: {
           repositoryLocationName: 'test.py',

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/uiExecutionTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/uiExecutionTags.tsx
@@ -1,0 +1,21 @@
+import {ExecutionParams, ExecutionTag} from '../graphql/types';
+import {DagsterTag} from '../runs/RunTag';
+
+export const UI_EXECUTION_TAGS: ExecutionTag[] = [{key: DagsterTag.FromUI, value: 'true'}];
+
+export function tagsWithUIExecutionTags(tags: ExecutionTag[] | null | undefined) {
+  return [
+    ...(tags || []).filter((t) => !UI_EXECUTION_TAGS.some((a) => a.key === t.key)),
+    ...UI_EXECUTION_TAGS,
+  ];
+}
+
+export function paramsWithUIExecutionTags(params: ExecutionParams) {
+  return {
+    ...params,
+    executionMetadata: {
+      ...params.executionMetadata,
+      tags: tagsWithUIExecutionTags(params.executionMetadata?.tags),
+    },
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -3,6 +3,7 @@ import {useHistory} from 'react-router-dom';
 
 import {showLaunchError} from './showLaunchError';
 import {useMutation} from '../apollo-client';
+import {paramsWithUIExecutionTags} from './uiExecutionTags';
 import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
 import {
   LAUNCH_MULTIPLE_RUNS_MUTATION,
@@ -49,7 +50,15 @@ export function useLaunchMultipleRunsWithTelemetry() {
           opSelection: undefined,
         };
 
-        const result = (await launchMultipleRuns({variables})).data?.launchMultipleRuns;
+        const finalized = {
+          ...variables,
+          executionParamsList: Array.isArray(variables.executionParamsList)
+            ? variables.executionParamsList.map(paramsWithUIExecutionTags)
+            : paramsWithUIExecutionTags(variables.executionParamsList),
+        };
+
+        const result = (await launchMultipleRuns({variables: finalized})).data?.launchMultipleRuns;
+
         if (result) {
           handleLaunchMultipleResult(result, history, {behavior});
           logTelemetry(

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -43,6 +43,7 @@ import {
 } from '../instance/backfill/types/BackfillUtils.types';
 import {LaunchButton} from '../launchpad/LaunchButton';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
+import {tagsWithUIExecutionTags} from '../launchpad/uiExecutionTags';
 import {explodeCompositesInHandleGraph} from '../pipelines/CompositeSupport';
 import {GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT} from '../pipelines/GraphExplorer';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
@@ -388,7 +389,7 @@ const LaunchBackfillButton = ({
           partitionNames,
           reexecutionSteps,
           fromFailure,
-          tags,
+          tags: tagsWithUIExecutionTags(tags),
         },
       },
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
@@ -23,6 +23,7 @@ import {
   LaunchPipelineReexecutionMutationVariables,
 } from './types/RunUtils.types';
 import {ExecutionTag, ReexecutionStrategy} from '../graphql/types';
+import {tagsWithUIExecutionTags} from '../launchpad/uiExecutionTags';
 
 export interface ReexecutionDialogProps {
   isOpen: boolean;
@@ -179,7 +180,7 @@ export const ReexecutionDialog = (props: ReexecutionDialogProps) => {
     dispatch({type: 'start'});
 
     const runList = Object.keys(state.frozenRuns);
-    const extraTags = extraTagsValidated.toSave.length ? extraTagsValidated.toSave : undefined;
+    const extraTags = tagsWithUIExecutionTags(extraTagsValidated.toSave);
 
     for (const runId of runList) {
       const {data} = await reexecute({

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -33,6 +33,7 @@ export enum DagsterTag {
   AssetEvaluationID = 'dagster/asset_evaluation_id',
   SnapshotID = 'dagster/snapshot_id', // This only exists on the client, not the server.
   ReportingUser = 'dagster/reporting_user',
+  FromUI = 'dagster/from_ui',
   User = 'user',
 
   // Hidden tags (using ".dagster" HIDDEN_TAG_PREFIX)

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/ReexecutionDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/ReexecutionDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter} from 'react-router-dom';
 
 import {ReexecutionStrategy} from '../../graphql/types';
+import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
 import {ReexecutionDialog} from '../ReexecutionDialog';
 import {
   buildLaunchPipelineReexecutionErrorMock,
@@ -49,7 +50,7 @@ describe('ReexecutionDialog', () => {
         mocks={Object.keys(selectedMap).map((parentRunId) =>
           buildLaunchPipelineReexecutionSuccessMock({
             parentRunId,
-            extraTags: [{key: 'test_key', value: 'test_value'}],
+            extraTags: [{key: 'test_key', value: 'test_value'}, ...UI_EXECUTION_TAGS],
           }),
         )}
       />,
@@ -74,7 +75,7 @@ describe('ReexecutionDialog', () => {
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
         mocks={Object.keys(selectedMap).map((parentRunId) =>
-          buildLaunchPipelineReexecutionSuccessMock({parentRunId}),
+          buildLaunchPipelineReexecutionSuccessMock({parentRunId, extraTags: UI_EXECUTION_TAGS}),
         )}
       />,
     );
@@ -101,7 +102,10 @@ describe('ReexecutionDialog', () => {
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
         mocks={Object.keys(selectedMap).map((parentRunId) =>
-          buildLaunchPipelineReexecutionSuccessMock({parentRunId}),
+          buildLaunchPipelineReexecutionSuccessMock({
+            parentRunId,
+            extraTags: UI_EXECUTION_TAGS,
+          }),
         )}
       />,
     );
@@ -121,9 +125,18 @@ describe('ReexecutionDialog', () => {
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
         mocks={[
-          buildLaunchPipelineReexecutionErrorMock({parentRunId: 'abcd-1234'}),
-          buildLaunchPipelineReexecutionSuccessMock({parentRunId: 'efgh-5678'}),
-          buildLaunchPipelineReexecutionErrorMock({parentRunId: 'ijkl-9012'}),
+          buildLaunchPipelineReexecutionErrorMock({
+            parentRunId: 'abcd-1234',
+            extraTags: UI_EXECUTION_TAGS,
+          }),
+          buildLaunchPipelineReexecutionSuccessMock({
+            parentRunId: 'efgh-5678',
+            extraTags: UI_EXECUTION_TAGS,
+          }),
+          buildLaunchPipelineReexecutionErrorMock({
+            parentRunId: 'ijkl-9012',
+            extraTags: UI_EXECUTION_TAGS,
+          }),
         ]}
       />,
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter, useLocation} from 'react-router-dom';
 
 import {ReexecutionStrategy} from '../../graphql/types';
+import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
 import {testId} from '../../testing/testId';
 import {buildLaunchPipelineReexecutionSuccessMock} from '../__fixtures__/Reexecution.fixtures';
 import {useJobReexecution} from '../useJobReExecution';
@@ -33,6 +34,7 @@ describe('useJobReexecution', () => {
           buildLaunchPipelineReexecutionSuccessMock({
             parentRunId: '1',
             strategy: ReexecutionStrategy.FROM_FAILURE,
+            extraTags: UI_EXECUTION_TAGS,
           }),
         ]}
       >
@@ -54,7 +56,7 @@ describe('useJobReexecution', () => {
         mocks={[
           buildLaunchPipelineReexecutionSuccessMock({
             parentRunId: '1',
-            extraTags: [{key: 'test_key', value: 'test_value'}],
+            extraTags: [{key: 'test_key', value: 'test_value'}, ...UI_EXECUTION_TAGS],
           }),
         ]}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useJobReExecution.tsx
@@ -16,6 +16,7 @@ import {
   CheckBackfillStatusQuery,
   CheckBackfillStatusQueryVariables,
 } from './types/useJobReExecution.types';
+import {UI_EXECUTION_TAGS, paramsWithUIExecutionTags} from '../launchpad/uiExecutionTags';
 
 /**
  * This hook gives you a mutation method that you can use to re-execute runs.
@@ -91,8 +92,14 @@ export const useJobReexecution = (opts?: {onCompleted?: () => void}) => {
         const result = await launchPipelineReexecution({
           variables:
             typeof param === 'string'
-              ? {reexecutionParams: {parentRunId: run.id, strategy: param}}
-              : {executionParams: param},
+              ? {
+                  reexecutionParams: {
+                    parentRunId: run.id,
+                    strategy: param,
+                    extraTags: UI_EXECUTION_TAGS,
+                  },
+                }
+              : {executionParams: paramsWithUIExecutionTags(param)},
         });
         handleLaunchResult(run.pipelineName, result.data?.launchPipelineReexecution, history, {
           preserveQuerystring: true,

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/EvaluateScheduleDialog.fixtures.tsx
@@ -14,6 +14,7 @@ import {
   buildSchedule,
   buildTickEvaluation,
 } from '../../graphql/types';
+import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
 import {LAUNCH_MULTIPLE_RUNS_MUTATION} from '../../runs/RunUtils';
 import {LaunchMultipleRunsMutation} from '../../runs/types/RunUtils.types';
 import {GET_SCHEDULE_QUERY, SCHEDULE_DRY_RUN_MUTATION} from '../EvaluateScheduleDialog';
@@ -260,6 +261,7 @@ export const ScheduleLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutatio
                 key: 'okay_t2',
                 value: 'okay',
               },
+              ...UI_EXECUTION_TAGS,
             ],
           },
         },
@@ -344,6 +346,7 @@ export const ScheduleLaunchAllMutationWithUndefinedName: MockedResponse<LaunchMu
                   key: 'okay_t2',
                   value: 'okay',
                 },
+                ...UI_EXECUTION_TAGS,
               ],
             },
           },

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
@@ -18,6 +18,7 @@ import {
   buildSensorData,
   buildTickEvaluation,
 } from '../../graphql/types';
+import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
 import {LAUNCH_MULTIPLE_RUNS_MUTATION} from '../../runs/RunUtils';
 import {LaunchMultipleRunsMutation} from '../../runs/types/RunUtils.types';
 import {SET_CURSOR_MUTATION} from '../../sensors/EditCursorDialog';
@@ -252,6 +253,7 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
                 key: 'marco2',
                 value: 'salazar2',
               },
+              ...UI_EXECUTION_TAGS,
             ],
           },
         },
@@ -277,6 +279,7 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
                 key: 'marco3',
                 value: 'salazar3',
               },
+              ...UI_EXECUTION_TAGS,
             ],
           },
         },
@@ -302,6 +305,7 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
                 key: 'marco6',
                 value: 'salazar6',
               },
+              ...UI_EXECUTION_TAGS,
             ],
           },
         },
@@ -404,6 +408,7 @@ export const SensorLaunchAllMutation1JobWithUndefinedJobName: MockedResponse<Lau
                   key: 'marco2',
                   value: 'salazar2',
                 },
+                ...UI_EXECUTION_TAGS,
               ],
             },
           },


### PR DESCRIPTION
This is a small change but it applies to:

- Job execution / materialization
- Job backfills
- Asset graph materialization
- Asset graph backfills
- Run re-execution (via extraTags)
- Multiple-run launching
- Evaluating schedules
- Sensor dry runs

## Summary & Motivation

Context: https://dagsterlabs.slack.com/archives/C058CBEL230/p1743459307738509

https://linear.app/dagster-labs/issue/FE-828/add-a-tag-that-indicates-that-a-run-was-triggered-by-a-user-via-the-ui

Allows filtering for runs created from the UI:

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/66fb89fa-5107-454a-93ce-d8867a79d1eb" />


## How I Tested These Changes

I manually tested most of the workflows above, and I also made changes to the tests I placed this code very close to the mutations to make sure it's always sent.

## Changelog

[ui] Runs launched from the Dagster UI get a `dagster/from_ui = true` tag, making it easy to filter for them.