### PR TITLE
Enforce global pytest timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ filterwarnings = [
   "ignore::pytest.PytestCollectionWarning",
 ]
 
+timeout = 240
+
 # ########################
 # ##### RUFF
 # ########################

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -123,6 +123,7 @@ setup(
             "pytest-xdist==3.6.1",
             "pytest>=8",
             "pytest-asyncio",
+            "pytest-timeout",
             "responses<=0.23.1",  # https://github.com/getsentry/responses/issues/654
             "syrupy>=4.0.0",
             "tox>=4",


### PR DESCRIPTION
To avoid hanging tests like we ran into here:

https://dagsterlabs.slack.com/archives/C03EQ628RS7/p1744219888323539

We might need to tune this actual number a bit although the longest avg
test duration I see in Test Engine this week is ~3.5 minutes:

https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/70058306-3987-85dc-8cbf-8da39d8ebaad?period=7days&tags=scm.branch%3Amaster