### PR TITLE
[docs] extend dynamic job code snippets with full example

### DIFF
--- a/docs/docs/guides/build/ops/dynamic-graphs.md
+++ b/docs/docs/guides/build/ops/dynamic-graphs.md
@@ -49,6 +49,10 @@ Within our `@job` decorated composition function, the object representing the dy
 
 `collect` creates a fan-in dependency over all the dynamic copies. The dependent op will receive a list containing all the values.
 
+Below is a full example that extends the above concepts and uses a mocked large dataset for simulating chunked processing:
+
+<CodeExample path="docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dynamic.py" startAfter="dyn_job_full_example_start" endBefore="dyn_job_full_example_end" />
+
 ## Advanced mapping examples
 
 ### Returning dynamic outputs


### PR DESCRIPTION
## Summary & Motivation
Our current doc for a dynamic job uses two small code snippets as examples, but these stub necessary methods/ops and it isn't clear how to use them. I extended these snippets by using them in a full working example.

## How I Tested These Changes
👀