### PR TITLE
Skip hanging dagit test

### DIFF
--- a/python_modules/dagit/dagit_tests/test_cli.py
+++ b/python_modules/dagit/dagit_tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import time
 
+import pytest
 from dagster import asset
 
 
@@ -20,6 +21,7 @@ def foo(bar):
     return 1
 
 
+@pytest.mark.skip("This test is hanging indefinitely")
 def test_cli_logs_to_dagit():
     defs_path = os.path.realpath(__file__)
     process = subprocess.Popen(


### PR DESCRIPTION
When we investigate while it's hanging. Ideally we'd just mute this in Buildkite, but since it still runs under xfail, we still hit our hang.