### PR TITLE
Reintroduce hanging dagit test

### DIFF
--- a/python_modules/dagit/dagit_tests/test_cli.py
+++ b/python_modules/dagit/dagit_tests/test_cli.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import time
 
-import pytest
 from dagster import asset
 
 
@@ -21,7 +20,6 @@ def foo(bar):
     return 1
 
 
-@pytest.mark.skip("This test is hanging indefinitely")
 def test_cli_logs_to_dagit():
     defs_path = os.path.realpath(__file__)
     process = subprocess.Popen(
@@ -29,7 +27,9 @@ def test_cli_logs_to_dagit():
     )
     time.sleep(2)  # give time for dagit to start
     process.terminate()
-    process.wait()
-    stdout, _ = process.communicate()
-    assert "The `dagit` CLI command is deprecated" in stdout
-    assert "- dagit -" in stdout
+    try:
+        stdout, _ = process.communicate(timeout=10)
+        assert "The `dagit` CLI command is deprecated" in stdout
+        assert "- dagit -" in stdout
+    except subprocess.TimeoutExpired:
+        process.kill()


### PR DESCRIPTION
This adds some more safety around our subprocess calls.

I think what's happening here is that terminate is sending SIGTERM, in some cases, dagit isn't responding to it, and then wait is just blocking indefinitely.

This instead calls terminate, gives it 10 seconds, and then calls SIGKILL.

I don't have a lead on why dagit is sometimes ignoring SIGTERM (nor am I digging into it right now) but it's pretty irrelevant to this particular test case which just makes sure we're correctly redirecting folks to dagster-webserver.