### PR TITLE
rework DbtProjectComponent

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/19-component-jdbt.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/19-component-jdbt.yaml
@@ -1,5 +1,4 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  dbt:
-    project_dir: ../../../dbt/jdbt
+  project: ../../../dbt/jdbt

--- a/examples/docs_snippets/docs_snippets/guides/components/index/20-project-jdbt-incorrect.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/20-project-jdbt-incorrect.yaml
@@ -1,7 +1,6 @@
 type: dagster_dt.dbt_project
 
 attributes:
-  dbt:
-    project_dir: ../../../../dbt/jdbt
-  asset_attributes:
+  project: ../../../../dbt/jdbt
+  translation:
     key: "target/main/{{ node.name }}

--- a/examples/docs_snippets/docs_snippets/guides/components/index/21-dg-component-check-error.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/21-dg-component-check-error.txt
@@ -1,8 +1,8 @@
 dg check yaml
 
-/.../jaffle-platform/src/jaffle_platform/defs/jdbt/component.yaml:7 -  Unable to parse YAML: while scanning a quoted scalar, found unexpected end of stream
+/.../jaffle-platform/src/jaffle_platform/defs/jdbt/component.yaml:6 -  Unable to parse YAML: while scanning a quoted scalar, found unexpected end of stream
      | 
-   6 |   asset_attributes:
-   7 |     key: "target/main/{{ node.name }}
+   5 |   translation:
+   6 |     key: "target/main/{{ node.name }}
      |                                      ^ Unable to parse YAML: while scanning a quoted scalar, found unexpected end of stream
      |

--- a/examples/docs_snippets/docs_snippets/guides/components/index/22-project-jdbt.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/22-project-jdbt.yaml
@@ -1,7 +1,6 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  dbt:
-    project_dir: ../../../../dbt/jdbt
-  asset_attributes:
+  project: ../../../../dbt/jdbt
+  translation:
     key: "target/main/{{ node.name }}"

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -267,9 +267,8 @@ def test_components_docs_index(update_snippets: bool) -> None:
                     type: dagster_dt.dbt_project
 
                     attributes:
-                      dbt:
-                        project_dir: ../../../../dbt/jdbt
-                      asset_attributes:
+                      project: ../../../../dbt/jdbt
+                      translation:
                         key: "target/main/{{ node.name }}
                 """),
             )
@@ -292,9 +291,8 @@ def test_components_docs_index(update_snippets: bool) -> None:
                     type: dagster_dbt.DbtProjectComponent
 
                     attributes:
-                      dbt:
-                        project_dir: ../../../../dbt/jdbt
-                      asset_attributes:
+                      project: ../../../../dbt/jdbt
+                      translation:
                         key: "target/main/{{ node.name }}"
                 """),
             )

--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -2,6 +2,7 @@ import os
 import sys
 import traceback
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any, Optional, TypeVar, Union, overload
 
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
@@ -155,3 +156,12 @@ class ResolutionContext:
             return [self.at_path(i).resolve_value(v) for i, v in enumerate(val)]
         else:
             return self._resolve_inner_value(val)
+
+    def resolve_source_relative_path(self, value: str) -> Path:
+        path = Path(value)
+        if not self.source_position_tree or path.is_absolute():
+            # no source, can't transform
+            return path
+
+        source_dir = Path(self.source_position_tree.position.filename).parent
+        return source_dir.joinpath(path).resolve()

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -148,7 +148,7 @@ def resolve_asset_attributes_to_mapping(
     context: ResolutionContext,
     model,
 ) -> Mapping[str, Any]:
-    # only include fields that are explcitly set
+    # only include fields that are explicitly set
     set_fields = model.model_dump(exclude_unset=True).keys()
     resolved_fields = resolve_fields(model, AssetAttributesKwargs, context)
     return {k: v for k, v in resolved_fields.items() if k in set_fields}

--- a/python_modules/dagster/dagster/components/utils.py
+++ b/python_modules/dagster/dagster/components/utils.py
@@ -67,6 +67,7 @@ class TranslatorResolvingInfo:
     obj_name: str
     asset_attributes: Union[str, BaseModel]
     resolution_context: ResolutionContext
+    model_key: str = "asset_attributes"
 
     def _resolve_asset_attributes(self, context: Mapping[str, Any]) -> Union[AssetSpec, BaseModel]:
         """Resolves the user-specified asset attributes into an AssetAttributesModel, or an AssetSpec
@@ -76,7 +77,7 @@ class TranslatorResolvingInfo:
             return self.asset_attributes
 
         resolved_asset_attributes = (
-            self.resolution_context.at_path("asset_attributes")
+            self.resolution_context.at_path(self.model_key)
             .with_scope(**context)
             .resolve_value(self.asset_attributes)
         )
@@ -116,7 +117,7 @@ class TranslatorResolvingInfo:
 
         resolved_attributes = resolve_asset_attributes_to_mapping(
             model=resolved_asset_attributes,
-            context=self.resolution_context.at_path("asset_attributes").with_scope(**context),
+            context=self.resolution_context.at_path(self.model_key).with_scope(**context),
         )
         if "code_version" in resolved_attributes:
             resolved_attributes = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -1,24 +1,21 @@
 from collections.abc import Iterator, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cached_property
 from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Callable, Optional, Union, cast
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components import Resolvable, Resolver
+from dagster.components import Resolvable
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.resolved.core_models import (
-    AssetAttributesModel,
-    AssetPostProcessor,
-    OpSpec,
-    ResolutionContext,
-)
+from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec, ResolutionContext
+from dagster.components.resolved.model import Resolver
 from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils import TranslatorResolvingInfo
+from typing_extensions import TypeAlias
 
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import get_asset_key_for_model, get_node
@@ -31,56 +28,75 @@ from dagster_dbt.dbt_project import DbtProject
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
 
-
-class ComponentDagsterDbtTranslator(DagsterDbtTranslator):
-    def __init__(self, *, resolving_info: TranslatorResolvingInfo):
-        super().__init__()
-        self.resolving_info = resolving_info
-        self._specs_map: dict[tuple, AssetSpec] = {}
-
-    def get_asset_spec(
-        self,
-        manifest: Mapping[str, Any],
-        unique_id: str,
-        project: Optional[DbtProject],
-    ) -> AssetSpec:
-        memo_id = (id(manifest), unique_id)
-        if memo_id not in self._specs_map:
-            base_spec = super().get_asset_spec(
-                manifest=manifest,
-                unique_id=unique_id,
-                project=project,
-            )
-            self._specs_map[memo_id] = self.resolving_info.get_asset_spec(
-                base_spec,
-                {
-                    self.resolving_info.obj_name: get_node(manifest, unique_id),
-                    "spec": base_spec,
-                },
-            )
-        return self._specs_map[memo_id]
+TranslationFn: TypeAlias = Callable[[AssetSpec, Mapping[str, Any]], AssetSpec]
 
 
-def resolve_translator(context: ResolutionContext, model) -> DagsterDbtTranslator:
-    if (
-        model.asset_attributes
-        and isinstance(model.asset_attributes, AssetAttributesModel)
-        and "deps" in model.asset_attributes.model_dump(exclude_unset=True)
-    ):
-        # TODO: Consider supporting alerting deps in the future
-        raise ValueError("deps are not supported for dbt_project component")
-
-    return ComponentDagsterDbtTranslator(
-        resolving_info=TranslatorResolvingInfo(
-            "node",
-            model.asset_attributes or AssetAttributesModel(),
-            context,
-        )
+def resolve_translation(context: ResolutionContext, model):
+    info = TranslatorResolvingInfo(
+        "node",
+        asset_attributes=model,
+        resolution_context=context,
+        model_key="translation",
+    )
+    return lambda base_asset_spec, dbt_props: info.get_asset_spec(
+        base_asset_spec,
+        {
+            "node": dbt_props,
+            "spec": base_asset_spec,
+        },
     )
 
 
-def resolve_dbt(context: ResolutionContext, dbt: DbtCliResource) -> DbtCliResource:
-    return DbtCliResource(**context.resolve_value(dbt.model_dump()))
+ResolvedTranslationFn: TypeAlias = Annotated[
+    TranslationFn,
+    Resolver(
+        resolve_translation,
+        model_field_type=Union[str, AssetAttributesModel],
+    ),
+]
+
+
+@dataclass
+class DbtProjectArgs:
+    """Aligns with DbtProject.__new__."""
+
+    project_dir: str
+    target_path: Optional[str] = None
+    profiles_dir: Optional[str] = None
+    profile: Optional[str] = None
+    target: Optional[str] = None
+    packaged_project_dir: Optional[str] = None
+    state_path: Optional[str] = None
+
+
+def resolve_dbt_project(context: ResolutionContext, model) -> DbtProject:
+    if isinstance(model, str):
+        return DbtProject(context.resolve_source_relative_path(model))
+
+    args: DbtProjectArgs = context.resolve_value(model)
+
+    kwargs = {}  # use optionally splatted kwargs to avoid redefining default value
+    if args.target_path:
+        kwargs["target_path"] = args.target_path
+
+    return DbtProject(
+        project_dir=context.resolve_source_relative_path(args.project_dir),
+        target=args.target,
+        profiles_dir=args.profiles_dir,
+        state_path=args.state_path,
+        packaged_project_dir=args.packaged_project_dir,
+        profile=args.profile,
+        **kwargs,
+    )
+
+
+ResolvedDbtProject: TypeAlias = Annotated[
+    DbtProject,
+    Resolver(
+        resolve_dbt_project,
+        model_field_type=Union[str, DbtProjectArgs],
+    ),
+]
 
 
 @scaffold_with(DbtProjectComponentScaffolder)
@@ -104,29 +120,21 @@ class DbtProjectComponent(Component, Resolvable):
     version control, modularity, portability, CI/CD, and documentation.
     """
 
-    dbt: Annotated[DbtCliResource, Resolver(resolve_dbt)]
+    project: ResolvedDbtProject
     op: Optional[OpSpec] = None
-    translator: Annotated[
-        DagsterDbtTranslator,
-        Resolver.from_model(
-            resolve_translator,
-            model_field_name="asset_attributes",
-            model_field_type=Optional[Union[str, AssetAttributesModel]],
-        ),
-    ] = field(default_factory=DagsterDbtTranslator)
-    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
+    translation: Optional[ResolvedTranslationFn] = None
     select: str = "fqn:*"
     exclude: Optional[str] = None
 
     @cached_property
-    def project(self) -> DbtProject:
-        return DbtProject(
-            self.dbt.project_dir,
-            state_path=self.dbt.state_path,
-            target=self.dbt.target,
-            profile=self.dbt.profile,
-            profiles_dir=self.dbt.profiles_dir,
-        )
+    def translator(self):
+        if self.translation:
+            return ProxyDagsterDbtTranslator(self.translation)
+        return DagsterDbtTranslator()
+
+    @cached_property
+    def cli_resource(self):
+        return DbtCliResource(self.project)
 
     def get_asset_selection(
         self, select: str, exclude: Optional[str] = None
@@ -152,11 +160,9 @@ class DbtProjectComponent(Component, Resolvable):
             backfill_policy=self.op.backfill_policy if self.op else None,
         )
         def _fn(context: AssetExecutionContext):
-            yield from self.execute(context=context, dbt=self.dbt)
+            yield from self.execute(context=context, dbt=self.cli_resource)
 
         defs = Definitions(assets=[_fn])
-        for post_processor in self.asset_post_processors or []:
-            defs = post_processor(defs)
         return defs
 
     def execute(self, context: AssetExecutionContext, dbt: DbtCliResource) -> Iterator:
@@ -192,3 +198,16 @@ def get_asset_key_for_model_from_module(
     """
     defs = context.load_defs(dbt_component_module)
     return get_asset_key_for_model(cast("Sequence[AssetsDefinition]", defs.assets), model_name)
+
+
+class ProxyDagsterDbtTranslator(DagsterDbtTranslator):
+    # get_description conflicts on Component, so cant make it directly a translator
+
+    def __init__(self, fn: TranslationFn):
+        self._fn = fn
+        super().__init__()
+
+    def get_asset_spec(self, manifest, unique_id, project):
+        base_asset_spec = super().get_asset_spec(manifest, unique_id, project)
+        dbt_props = get_node(manifest, unique_id)
+        return self._fn(base_asset_spec, dbt_props)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/scaffolder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/scaffolder.py
@@ -38,4 +38,4 @@ class DbtProjectComponentScaffolder(Scaffolder):
         else:
             relative_path = None
 
-        scaffold_component(request, {"dbt": {"project_dir": relative_path}})
+        scaffold_component(request, {"project": relative_path})

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dbt_project_location/defs/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dbt_project_location/defs/jaffle_shop_dbt/component.yaml
@@ -1,16 +1,14 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  dbt:
-    project_dir: jaffle_shop
+  project: jaffle_shop
 
-  asset_post_processors:
-    - attributes:
-        tags:
-          foo: bar
-        metadata:
-          something: 1
-        automation_condition: "{{ automation_condition.on_cron('@daily') }}"
-    - attributes:
-        tags:
-          another: one
+  translation:
+    tags:
+      foo: bar
+    metadata:
+      something: 1
+    automation_condition: "{{ automation_condition.on_cron('@daily') }}"
+    # - attributes:
+    #     tags:
+    #       another: one

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/jaffle_shop_dbt/component.yaml
@@ -1,16 +1,11 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  dbt:
-    project_dir: jaffle_shop
+  project: jaffle_shop
 
-  asset_post_processors:
-    - attributes:
-        tags:
-          foo: bar
-        metadata:
-          something: 1
-        automation_condition: "{{ automation_condition.on_cron('@daily') }}"
-    - attributes:
-        tags:
-          another: one
+  translation:
+    tags:
+      foo: bar
+    metadata:
+      something: 1
+    automation_condition: "{{ automation_condition.on_cron('@daily') }}"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/templated_custom_keys_dbt_project_location/defs/jaffle_shop_dbt/component.yaml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/templated_custom_keys_dbt_project_location/defs/jaffle_shop_dbt/component.yaml
@@ -1,8 +1,7 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  dbt:
-    project_dir: jaffle_shop
+  project: jaffle_shop
 
-  asset_attributes:
+  translation:
     key: "some_prefix/{{node.name}}"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -11,6 +11,7 @@ import pytest
 from dagster import AssetKey, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
 from dagster._core.test_utils import ensure_dagster_tests_import
+from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.load_defs import build_component_defs
 from dagster.components.resolved.core_models import AssetAttributesModel
 from dagster_dbt import DbtProject, DbtProjectComponent
@@ -67,8 +68,12 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "op": {"name": "some_op", "tags": {"tag1": "value"}, **backfill_policy_arg},
+            "project": str(dbt_path),
+            "op": {
+                "name": "some_op",
+                "tags": {"tag1": "value"},
+                **backfill_policy_arg,
+            },
         },
     )
     assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS
@@ -97,7 +102,7 @@ def test_load_from_path(dbt_path: Path) -> None:
 
         for asset_node in defs.get_asset_graph().asset_nodes:
             assert asset_node.tags["foo"] == "bar"
-            assert asset_node.tags["another"] == "one"
+
             assert asset_node.metadata["something"] == 1
 
 
@@ -111,8 +116,8 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DebugDbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "asset_attributes": {"tags": "{{ get_tags_for_node(node) }}"},
+            "project": str(dbt_path),
+            "translation": {"tags": "{{ get_tags_for_node(node) }}"},
         },
     )
     assets_def = defs.get_assets_def(AssetKey("stg_customers"))
@@ -191,8 +196,8 @@ def test_asset_attributes(
         defs = build_component_defs_for_test(
             DbtProjectComponent,
             {
-                "dbt": {"project_dir": dbt_path},
-                "asset_attributes": attributes,
+                "project": str(dbt_path),
+                "translation": attributes,
             },
         )
         assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS
@@ -220,7 +225,7 @@ def test_asset_attributes_is_comprehensive():
 def test_subselection(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
-        {"dbt": {"project_dir": dbt_path}, "select": "raw_customers"},
+        {"project": str(dbt_path), "select": "raw_customers"},
     )
     assert defs.get_asset_graph().get_all_asset_keys() == {AssetKey("raw_customers")}
 
@@ -228,7 +233,7 @@ def test_subselection(dbt_path: Path) -> None:
 def test_exclude(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
-        {"dbt": {"project_dir": dbt_path}, "exclude": "customers"},
+        {"project": str(dbt_path), "exclude": "customers"},
     )
     assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS - {AssetKey("customers")}
 
@@ -259,8 +264,8 @@ def test_spec_is_available_in_scope(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "asset_attributes": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
+            "project": str(dbt_path),
+            "translation": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
         },
     )
     assets_def = defs.get_assets_def(AssetKey("stg_customers"))
@@ -292,8 +297,8 @@ def test_udf_map_spec(dbt_path: Path, map_fn: Callable[[AssetSpec], Any]) -> Non
     defs = build_component_defs_for_test(
         DebugDbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "asset_attributes": "{{ map_spec(spec) }}",
+            "project": str(dbt_path),
+            "translation": "{{ map_spec(spec) }}",
         },
     )
     assets_def = defs.get_assets_def(AssetKey("stg_customers"))
@@ -306,17 +311,32 @@ def test_state_path(
     comp = load_component_for_test(
         DbtProjectComponent,
         {
-            "dbt": {
-                "project_dir": dbt_path,
+            "project": {
+                "project_dir": str(dbt_path),
                 "state_path": "state",
                 "profile": "profile",
                 "target": "target",
             },
         },
     )
-    state_path = comp.dbt.state_path
+    state_path = comp.cli_resource.state_path
     assert state_path
     assert Path(state_path).relative_to(dbt_path.resolve())
-    assert comp.project.state_path == Path(state_path)
+    assert comp.project.state_path
+    assert comp.project.state_path.resolve() == Path(state_path)
     assert comp.project.target == "target"
     assert comp.project.profile == "profile"
+
+
+def test_python_interface(dbt_path: Path):
+    context = ComponentLoadContext.for_test()
+    assert DbtProjectComponent(
+        project=DbtProject(dbt_path),
+    ).build_defs(context)
+
+    defs = DbtProjectComponent(
+        project=DbtProject(dbt_path),
+        translation=lambda spec, _: spec.replace_attributes(tags={"python": "rules"}),
+    ).build_defs(context)
+    assets_def = defs.get_assets_def(AssetKey("stg_customers"))
+    assert assets_def.get_asset_spec(AssetKey("stg_customers")).tags["python"] == "rules"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
@@ -61,8 +61,8 @@ def test_python_attributes_node_rename(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "asset_attributes": {"key": "some_prefix/{{ node.name }}"},
+            "project": str(dbt_path),
+            "translation": {"key": "some_prefix/{{ node.name }}"},
         },
     )
     assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS_WITH_PREFIX
@@ -72,8 +72,8 @@ def test_python_attributes_group(dbt_path: Path) -> None:
     defs = build_component_defs_for_test(
         DbtProjectComponent,
         {
-            "dbt": {"project_dir": dbt_path},
-            "asset_attributes": {"group_name": "some_group"},
+            "project": str(dbt_path),
+            "translation": {"group_name": "some_group"},
         },
     )
     assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS
@@ -91,8 +91,8 @@ def test_render_vars_root(dbt_path: Path) -> None:
         defs = build_component_defs_for_test(
             DbtProjectComponent,
             {
-                "dbt": {"project_dir": dbt_path},
-                "asset_attributes": {"group_name": "{{ env('GROUP_AS_ENV') }}"},
+                "project": str(dbt_path),
+                "translation": {"group_name": "{{ env('GROUP_AS_ENV') }}"},
             },
         )
         assert defs.get_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS
@@ -105,8 +105,8 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
         defs = build_component_defs_for_test(
             DbtProjectComponent,
             {
-                "dbt": {"project_dir": dbt_path},
-                "asset_attributes": {
+                "project": str(dbt_path),
+                "translation": {
                     "key": "{{ env('ASSET_KEY_PREFIX') }}/{{ node.name }}",
                 },
             },


### PR DESCRIPTION
Attempt to get a simpler and more python friendly API for this component. 
* Instead of taking the cli resource as `dbt`, we take `DbtProject` as `project` which also now can just be the directory string in simple cases
* `asset_attributes` and `translator` have been replaced with `translation`, which has a yaml schema similar to the previous `translator` arg but can just be a function when defined in python. 

## How I Tested These Changes
updated existing tests
added tests for pythonic instantiation 

## Changelog

[experiemental][dagster-dbt] `DbtProjectComponent` has been reworked, changing both the python api and the yaml schema. `dbt` has been replaced with `project` with a slightly different schema, and `asset_attributes` with `translation` . 
