### PR TITLE
[Performance] Skeleton - use css contain + isolate

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
@@ -11,6 +11,8 @@ export const Skeleton = styled.div<{$height?: string | number; $width?: string |
   background: ${Colors.backgroundLight()};
   position: relative;
   overflow: hidden;
+  contain: layout style size;
+  isolation: isolate;
 
   &::after {
     content: '';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -49,7 +49,7 @@ export const VirtualizedAssetTable = (props: Props) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
   const rows: Row[] = React.useMemo(() => {
-    if (isLoading && !Object.keys(groups).length) {
+    if (true || (isLoading && !Object.keys(groups).length)) {
       return new Array(5).fill({type: 'shimmer'});
     }
     return Object.entries(groups).map(([displayKey, assets]) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -49,7 +49,7 @@ export const VirtualizedAssetTable = (props: Props) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
   const rows: Row[] = React.useMemo(() => {
-    if (true || (isLoading && !Object.keys(groups).length)) {
+    if (isLoading && !Object.keys(groups).length) {
       return new Array(5).fill({type: 'shimmer'});
     }
     return Object.entries(groups).map(([displayKey, assets]) => {


### PR DESCRIPTION
## Summary & Motivation
 
as titled

## How I Tested These Changes

With only 1 tab open compare cpu/gpu usage

Before vs after
<img width="377" alt="Screenshot 2025-04-10 at 11 52 30 AM" src="https://github.com/user-attachments/assets/6654a97e-45b3-4f7b-8efc-b9906f831267" /><img width="365" alt="Screenshot 2025-04-10 at 12 15 46 PM" src="https://github.com/user-attachments/assets/ef21d552-0eda-4348-a709-33a17525b91f" />




## Changelog

> Insert changelog entry or delete this section.
