### PR TITLE
storage endpoint to order assets by materialization timestamp

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -638,12 +638,6 @@ class GrapheneQuery(graphene.ObjectType):
         description="Retrieve the executions for a given asset check.",
     )
 
-    orderAssetsByLastMaterializedTime = graphene.Field(
-        non_null_list(GrapheneAssetKey),
-        assetKeys=graphene.Argument(non_null_list(GrapheneAssetKeyInput)),
-        description="Retrieve a list of asset keys sorted by their last materialized or observed time. Includes materialization attempts that failed to materialize the asset.",
-    )
-
     @capture_error
     def resolve_repositoriesOrError(
         self,
@@ -1363,6 +1357,3 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
             cursor=cursor,
         )
-
-    def resolve_orderAssetsByLastMaterializedTime(self, graphene_info, assetKeys: Sequence[GrapheneAssetKeyInput]) -> Sequence[GrapheneAssetKeyInput]:
-        

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -638,6 +638,12 @@ class GrapheneQuery(graphene.ObjectType):
         description="Retrieve the executions for a given asset check.",
     )
 
+    orderAssetsByLastMaterializedTime = graphene.Field(
+        non_null_list(GrapheneAssetKey),
+        assetKeys=graphene.Argument(non_null_list(GrapheneAssetKeyInput)),
+        description="Retrieve a list of asset keys sorted by their last materialized or observed time. Includes materialization attempts that failed to materialize the asset.",
+    )
+
     @capture_error
     def resolve_repositoriesOrError(
         self,
@@ -1357,3 +1363,6 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
             cursor=cursor,
         )
+
+    def resolve_orderAssetsByLastMaterializedTime(self, graphene_info, assetKeys: Sequence[GrapheneAssetKeyInput]) -> Sequence[GrapheneAssetKeyInput]:
+        

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -735,6 +735,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return self._instance.get_concurrency_config().pool_config
 
     def order_assets_by_last_materialized_time(
-        self, asset_keys: Sequence[AssetKey], descending: bool = False
+        self, asset_keys: Optional[Sequence[AssetKey]], descending: bool = False
     ) -> Sequence[AssetKey]:
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -733,3 +733,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         # Base implementation of fetching pool config.  To be overriden for remote storage
         # implementations where the local instance might not match the remote instance.
         return self._instance.get_concurrency_config().pool_config
+
+    def order_assets_by_last_materialized_time(
+        self, asset_keys: Sequence[AssetKey], descending: bool = False
+    ) -> Sequence[AssetKey]:
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -3282,6 +3282,9 @@ class SqlEventLogStorage(EventLogStorage):
             rows = db_fetch_mappings(conn, query)
 
         ordered_asset_keys = [AssetKey.from_db_string(cast(str, row["asset_key"])) for row in rows]
+        ordered_asset_keys = [
+            asset_key for asset_key in ordered_asset_keys if asset_key is not None
+        ]
 
         never_materialized_assets = [
             asset_key for asset_key in asset_keys if asset_key not in ordered_asset_keys

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6829,3 +6829,19 @@ class TestEventLogStorage:
                 )
                 == expected_order.reverse()
             )
+
+            # query for all assets. Since asset_5 has never been materialized, and asset_1 has
+            # been wiped, they will not be returned
+
+            expected_order = [
+                AssetKey("asset_4"),
+                AssetKey("asset_2"),
+                AssetKey("asset_3"),
+            ]
+
+            assert storage.order_assets_by_last_materialized_time() == expected_order
+
+            assert (
+                storage.order_assets_by_last_materialized_time(descending=True)
+                == expected_order.reverse()
+            )


### PR DESCRIPTION
## Summary & Motivation
From the FE we want to be able to order the assets in the Asset Catalog by the time they were most recently materialized/observed/failed to materialize. 

Existing query pattern in the FE:
- fetch and cache 10000 asset nodes
- display whichever assets are in the selected catalog view, fetching more asset nodes if needed

Rather than modifying the query that fetches all assets from the DB to return in time-sorted order (which would require updating cursor logic, etc) this PR adds an endpoint that takes a list of asset keys and returns that list of asset keys in sorted order. This way we don't have to refetch the asset nodes when a user switches from time-ordered to alphabetical sorting.

New query pattern would be:
- fetch and cache 10000 asset nodes
- if doing time-sorted order, query to get the asset keys in time-sorted order
- display the assets, fetching more asset nodes if needed

The endpoint also has an option to sort all asset nodes to cover the case when no catalog view is selected. 

Sorting caveat:
- right now the `latest_materialization_timestamp` doesn't get updated on `FAILED_TO_MATERIALIZE` events, which means the asset would be sorted by the corresponding `PLANNED` event. We'll likely want to change this in the future so that the failure events are used in the sorting, but are fine with this inconsistency for the internal observe release

internal pr https://github.com/dagster-io/internal/pull/14946

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
