### PR TITLE
[perf] Share cache manager and add global cache for `useAllAssets`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -36,7 +36,7 @@ import {AssetGroupSelector} from '../graphql/types';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {fetchPaginatedData} from '../runs/fetchPaginatedBucketData';
-import {CacheManager} from '../search/useIndexedDBCachedQuery';
+import {getCacheManager} from '../search/useIndexedDBCachedQuery';
 import {SyntaxError} from '../selection/CustomErrorListener';
 import {LoadingSpinner} from '../ui/Loading';
 
@@ -54,7 +54,7 @@ export function useCachedAssets({
 }) {
   const {localCacheIdPrefix} = useContext(AppContext);
   const cacheManager = useMemo(
-    () => new CacheManager<AssetTableFragment[]>(`${localCacheIdPrefix}/allAssetNodes`),
+    () => getCacheManager<AssetTableFragment[]>(`${localCacheIdPrefix}/allAssetNodes`),
     [localCacheIdPrefix],
   );
 
@@ -69,6 +69,11 @@ export function useCachedAssets({
   return {cacheManager};
 }
 
+// Module-level cache variables
+let globalAssetsPromise: Promise<Asset[]> | null = null;
+let cachedAllAssets: Asset[] | null = null;
+let cachedAssetsFetchTime: number = 0;
+
 export function useAllAssets({
   batchLimit = DEFAULT_BATCH_LIMIT,
   groupSelector,
@@ -77,14 +82,16 @@ export function useAllAssets({
   const [{error, assets}, setErrorAndAssets] = useState<{
     error: PythonErrorFragment | undefined;
     assets: Asset[] | undefined;
-  }>({error: undefined, assets: undefined});
+  }>({error: undefined, assets: cachedAllAssets || undefined});
 
   const assetsRef = useUpdatingRef(assets);
 
   const {cacheManager} = useCachedAssets({
     onAssetsLoaded: useCallback(
       (data) => {
+        console.log('onAssetsLoaded', data);
         if (!assetsRef.current) {
+          console.log('onAssetsLoaded', data);
           setErrorAndAssets({
             error: undefined,
             assets: data,
@@ -95,69 +102,57 @@ export function useAllAssets({
     ),
   });
 
-  const allAssetsQuery = useCallback(async () => {
-    if (groupSelector) {
-      return;
+  // Query function for all assets
+  const fetchAllAssets = useCallback(async () => {
+    if (cachedAllAssets && Date.now() - cachedAssetsFetchTime < 6000) {
+      return cachedAllAssets;
     }
-    try {
-      const data = await fetchPaginatedData({
-        async fetchData(cursor: string | null | undefined) {
-          const {data} = await client.query<
-            AssetCatalogTableQuery,
-            AssetCatalogTableQueryVariables
-          >({
-            query: ASSET_CATALOG_TABLE_QUERY,
-            fetchPolicy: 'no-cache',
-            variables: {
-              cursor,
-              limit: batchLimit,
-            },
-          });
-
-          if (data.assetsOrError.__typename === 'PythonError') {
-            return {
-              data: [],
-              cursor: undefined,
-              hasMore: false,
-              error: data.assetsOrError,
-            };
-          }
-          const assets = data.assetsOrError.nodes;
-          const hasMoreData = assets.length === batchLimit;
-          const nextCursor = data.assetsOrError.cursor;
-          return {
-            data: assets,
-            cursor: nextCursor,
-            hasMore: hasMoreData,
-            error: undefined,
-          };
-        },
-      });
-      cacheManager.set(data, AssetCatalogTableQueryVersion);
-      setErrorAndAssets({error: undefined, assets: data});
-    } catch (e: any) {
-      if (e.__typename === 'PythonError') {
-        setErrorAndAssets(({assets}) => ({
-          error: e,
-          assets,
-        }));
-      }
+    if (!globalAssetsPromise) {
+      globalAssetsPromise = (async () => {
+        const allAssets = await fetchPaginatedData({
+          async fetchData(cursor: string | null | undefined) {
+            const {data} = await client.query<
+              AssetCatalogTableQuery,
+              AssetCatalogTableQueryVariables
+            >({
+              query: ASSET_CATALOG_TABLE_QUERY,
+              fetchPolicy: 'no-cache',
+              variables: {cursor, limit: batchLimit},
+            });
+            if (data.assetsOrError.__typename === 'PythonError') {
+              return {
+                data: [],
+                cursor: undefined,
+                hasMore: false,
+                error: data.assetsOrError,
+              };
+            }
+            const assets = data.assetsOrError.nodes;
+            const hasMoreData = assets.length === batchLimit;
+            const nextCursor = data.assetsOrError.cursor;
+            return {data: assets, cursor: nextCursor, hasMore: hasMoreData, error: undefined};
+          },
+        });
+        cachedAssetsFetchTime = Date.now();
+        cachedAllAssets = allAssets;
+        cacheManager.set(allAssets, AssetCatalogTableQueryVersion);
+        globalAssetsPromise = null;
+        return allAssets;
+      })();
     }
-  }, [batchLimit, cacheManager, client, groupSelector]);
+    return globalAssetsPromise;
+  }, [batchLimit, cacheManager, client]);
 
+  // Query function for group assets
   const groupQuery = useCallback(async () => {
-    if (!groupSelector) {
-      return;
-    }
-    function onData(queryData: typeof data) {
-      setErrorAndAssets({
-        error: undefined,
-        assets: queryData.assetNodes?.map(definitionToAssetTableFragment),
-      });
-    }
     const cacheKey = JSON.stringify(groupSelector);
     if (groupTableCache.has(cacheKey)) {
-      onData(groupTableCache.get(cacheKey));
+      const cachedData = groupTableCache.get(cacheKey);
+      setErrorAndAssets({
+        error: undefined,
+        assets: cachedData.assetNodes?.map(definitionToAssetTableFragment),
+      });
+      return;
     }
     const {data} = await client.query<
       AssetCatalogGroupTableQuery,
@@ -168,23 +163,43 @@ export function useAllAssets({
       fetchPolicy: 'no-cache',
     });
     groupTableCache.set(cacheKey, data);
-    onData(data);
-  }, [groupSelector, client]);
+    setErrorAndAssets({
+      error: undefined,
+      assets: data.assetNodes?.map(definitionToAssetTableFragment),
+    });
+  }, [client, groupSelector]);
 
-  const query = groupSelector ? groupQuery : allAssetsQuery;
+  const query = groupSelector ? groupQuery : fetchAllAssets;
 
   useEffect(() => {
-    query();
-  }, [query]);
+    if (groupSelector) {
+      groupQuery();
+    } else {
+      fetchAllAssets()
+        .then((allAssets) => setErrorAndAssets({error: undefined, assets: allAssets}))
+        .catch((e: any) => {
+          if (e.__typename === 'PythonError') {
+            setErrorAndAssets((prev) => ({error: e, assets: prev.assets}));
+          }
+        });
+    }
+  }, [fetchAllAssets, groupQuery, groupSelector]);
 
-  return useMemo(() => {
-    return {
+  const assetsByAssetKey = useMemo(
+    () => Object.fromEntries(assets?.map((asset) => [tokenForAssetKey(asset.key), asset]) ?? []),
+    [assets],
+  );
+
+  return useMemo(
+    () => ({
       assets,
+      assetsByAssetKey,
       error,
       loading: !assets && !error,
       query,
-    };
-  }, [assets, error, query]);
+    }),
+    [assets, assetsByAssetKey, error, query],
+  );
 }
 
 interface AssetCatalogTableProps {
@@ -253,7 +268,7 @@ export const AssetsCatalogTable = ({
     [filtered, prefixPath, view],
   );
 
-  const refreshState = useRefreshAtInterval({
+  const refreshState = useRefreshAtInterval<any>({
     refresh: query,
     intervalMs: 4 * FIFTEEN_SECONDS,
     leading: true,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
@@ -113,9 +113,6 @@ describe('useAllAssets', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.assets?.length).toBe(1);
-    });
-    await waitFor(() => {
       expect(result.current.assets?.length).toBe(5);
     });
   });


### PR DESCRIPTION
## Summary & Motivation

Currently when there are multiple `useAllAssets` hooks on the page they each end up handling indexeddb separately because they create separate cache managers. To fix this make `getCacheManager` the only way to obtain one so that we reuse them and don't pull from indexeddb multiple times.

Secondly add a global in memory cache to make sure we're not fetching more than once and not fetching too often. This is a stop-gap for now, long term we're going to get rid of this logic and fold everything into a generalized WorkspaceContext  abstraction.

## How I Tested These Changes

Use the app and everything works. Foregoing complicated testing for now since we will be folding this into the WorkspaceContext soon.
