### PR TITLE
[component] remove DefsModuleComponent

### DIFF
--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -39,13 +39,13 @@ def load_defs(defs_root: ModuleType) -> Definitions:
         resources (Optional[Mapping[str, object]]): A mapping of resource keys to resources
             to apply to the definitions.
     """
-    from dagster.components.core.defs_module import DefsModuleComponent
+    from dagster.components.core.defs_module import get_component
     from dagster.components.core.package_entry import discover_entry_point_package_objects
     from dagster.components.core.snapshot import get_package_entry_snap
 
     # create a top-level DefsModule component from the root module
     context = ComponentLoadContext.for_module(defs_root)
-    root_component = DefsModuleComponent.from_context(context)
+    root_component = get_component(context)
     if root_component is None:
         raise DagsterInvalidDefinitionError("Could not resolve root module to a component.")
 

--- a/python_modules/dagster/dagster/components/lib/definitions_component/__init__.py
+++ b/python_modules/dagster/dagster/components/lib/definitions_component/__init__.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Optional
 
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.defs_module import DagsterDefsComponent
@@ -20,10 +19,5 @@ class DefinitionsComponent(Component, Model, Resolvable):
     path: Optional[str]
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        inner_context = context.for_path(Path(self.path)) if self.path else context
-        component = DagsterDefsComponent.from_context(inner_context)
-        if component is None:
-            raise DagsterInvalidDefinitionError(
-                f"Could not resolve {self.path} to a DagsterDefsComponent."
-            )
+        component = DagsterDefsComponent(Path(self.path) if self.path else context.path)
         return component.build_defs(context)

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -22,7 +22,7 @@ from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components import ComponentLoadContext
 from dagster.components.cli import cli
-from dagster.components.core.defs_module import DefsModuleComponent, WrappedYamlComponent
+from dagster.components.core.defs_module import get_component
 from dagster.components.resolved.context import ResolutionException
 from dagster.components.resolved.core_models import AssetAttributesModel
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
@@ -80,10 +80,9 @@ def temp_sling_component_instance(
                 data["attributes"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
 
             context = ComponentLoadContext.for_test().for_path(component_path)
-            defs_module = DefsModuleComponent.from_context(context)
-            assert isinstance(defs_module, WrappedYamlComponent)
-            assert isinstance(defs_module.wrapped, SlingReplicationCollectionComponent)
-            yield defs_module.wrapped, defs_module.build_defs(context)
+            component = get_component(context)
+            assert isinstance(component, SlingReplicationCollectionComponent)
+            yield component, component.build_defs(context)
 
 
 def test_python_attributes() -> None:


### PR DESCRIPTION
The wrapped components were confusing me so I took a spin at refactoring to try to simplify things.

`get_component()` for (maybe) getting a `Component` at `context.path` 
`DefsFolderComponent.get()` for expecting to get a `DefsFolderComponent` like for `defs` folder 

## How I Tested These Changes

existing coverage
