### PR TITLE
toys code location for testing asset health

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -1,0 +1,111 @@
+import random
+
+import dagster as dg
+
+
+@dg.asset
+def random_1():
+    if random.random() < 0.5:
+        raise Exception("random_1 failed")
+    return 1
+
+
+@dg.asset
+def random_2(random_1):
+    if random.random() < 0.5:
+        raise Exception("random_2 failed")
+    return 1
+
+
+@dg.asset
+def random_3(random_1):
+    if random.random() < 0.5:
+        raise Exception("random_3 failed")
+    return 1
+
+
+@dg.asset
+def always_materializes():
+    return 1
+
+
+@dg.asset
+def always_fails():
+    raise Exception("always_fails failed")
+
+
+static_partitions = dg.StaticPartitionsDefinition(
+    ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+)
+
+
+@dg.asset(partitions_def=static_partitions)
+def random_failure_partitioned_asset():
+    if random.random() < 0.5:
+        raise Exception("partitioned_asset failed")
+    return 1
+
+
+@dg.asset_check(asset=random_1)
+def random_1_check_always_warns():
+    return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.WARN)
+
+
+@dg.asset_check(asset=random_1)
+def random_1_check_always_errors():
+    return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.ERROR)
+
+
+@dg.asset_check(asset=random_1)
+def random_1_check_always_execution_fails():
+    raise Exception("failed!")
+
+
+@dg.asset_check(asset=random_2)
+def random_2_check_sometimes_warns():
+    if random.random() < 0.5:
+        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.WARN)
+    else:
+        return dg.AssetCheckResult(passed=True)
+
+
+@dg.asset_check(asset=random_2)
+def random_2_check_sometimes_errors():
+    if random.random() < 0.5:
+        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.ERROR)
+    else:
+        return dg.AssetCheckResult(passed=True)
+
+
+@dg.asset_check(asset=always_materializes)
+def always_materializes_check_sometimes_warns():
+    if random.random() < 0.5:
+        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.WARN)
+    else:
+        return dg.AssetCheckResult(passed=True)
+
+
+@dg.asset_check(asset=always_materializes)
+def always_materializes_check_sometimes_errors():
+    if random.random() < 0.5:
+        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.ERROR)
+    else:
+        return dg.AssetCheckResult(passed=True)
+
+
+def get_assets_and_checks():
+    return [
+        random_1,
+        random_2,
+        random_3,
+        always_materializes,
+        always_fails,
+        random_failure_partitioned_asset,
+        random_1_check_always_warns,
+        random_1_check_always_errors,
+        random_1_check_always_execution_fails,
+        random_2_check_sometimes_warns,
+        random_2_check_sometimes_errors,
+        always_materializes_check_sometimes_warns,
+        always_materializes_check_sometimes_errors,
+    ]

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -224,3 +224,10 @@ def data_versions_repository():
     from dagster_test.toys import data_versions
 
     return cast(Sequence[AssetsDefinition], load_assets_from_modules([data_versions]))
+
+
+@repository
+def asset_health_repository():
+    from dagster_test.toys.asset_health import get_assets_and_checks
+
+    return get_assets_and_checks()


### PR DESCRIPTION
## Summary & Motivation
starting a small code location that we can deploy to dogfood to make it easier to test asset health. Most of our assets in the toys repo always succeed or always fail, making it hard to test state transitions. We'll probably need to add some more assets+checks as testing continues, but this will get us started 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
