### PR TITLE
Print muted tests at end of test run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ filterwarnings = [
 ]
 
 timeout = 240
+addopts = "-ra"
 
 # ########################
 # ##### RUFF


### PR DESCRIPTION
```
-r chars              Show extra test summary info as specified by chars:
                      (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed,
                      (p)assed, (P)assed with output, (a)ll except passed
                      (p/P), or (A)ll. (w)arnings are enabled by default (see
                      --disable-warnings), 'N' can be used to reset the list.
                      (default: 'fE').
```

Historically we've only printed errors. But this changes it to print summaries of:

- failures
- errors
- skips (and their reason)
- xfailed (expected to fail and their reasons - this should show muted tests that actually fail)
- xpassed (expected to fail but actually passed and their reasons - this should show tests that are muted but maybe shouldn't be anymore)