### PR TITLE
[dagster-dbt cli] add ability to target components

### DIFF
--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -4,8 +4,9 @@ import os
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from pathlib import Path
 from types import ModuleType
-from typing import Callable, NamedTuple, Optional, cast
+from typing import Callable, NamedTuple, Optional, Union, cast
 
 from dagster_shared.seven import get_import_error_message, import_module_from_path
 from dagster_shared.utils.hash import hash_collection
@@ -66,9 +67,9 @@ def rebase_file(relative_path_in_file: str, file_path_resides_in: str) -> str:
     )
 
 
-def load_python_file(python_file: str, working_directory: Optional[str]) -> ModuleType:
+def load_python_file(python_file: Union[str, Path], working_directory: Optional[str]) -> ModuleType:
     """Takes a path to a python file and returns a loaded module."""
-    check.str_param(python_file, "python_file")
+    check.inst_param(python_file, "python_file", (str, Path))
     check.opt_str_param(working_directory, "working_directory")
 
     # First verify that the file exists

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -78,12 +78,13 @@ def generate_component_lib_pyproject_toml(name: str, is_project: bool = False) -
         "dagster_dg.plugin" = {{ {pkg_name} = "{pkg_name}.lib" }}
     """)
     if is_project:
-        return base + textwrap.dedent("""
-        is_project = true
+        return base + textwrap.dedent(f"""
+        [tool.dg]
+        directory_type = "project"
 
-        [tool.dagster]
-        module_name = "{ pkg_name }.definitions"
-        code_location_name = "{ pkg_name }"
+        [tool.dg.project]
+        root_module = "{pkg_name}"
+        code_location_name = "{pkg_name}"
         """)
     else:
         return base

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -18,6 +18,8 @@ deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e ../dagster-shared
+  -e ../dagster-dg
+  -e ../dagster-cloud-cli
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
   dbt17: dbt-core==1.7.*,>=1.7.10 # first release protobuf upper bound pin was added

--- a/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
@@ -6,8 +6,9 @@ import shlex
 import sys
 import time
 from collections.abc import Sequence
+from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, List, Type  # noqa: F401, UP035
+from typing import Any, Callable, List, Type, Union  # noqa: F401, UP035
 
 from typing_extensions import TypeGuard
 
@@ -26,7 +27,7 @@ IS_PYTHON_3_12 = (sys.version_info[0], sys.version_info[1]) == (3, 12)
 
 
 # https://stackoverflow.com/a/67692/324449
-def import_module_from_path(module_name: str, path_to_file: str) -> ModuleType:
+def import_module_from_path(module_name: str, path_to_file: Union[str, Path]) -> ModuleType:
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(module_name, path_to_file)


### PR DESCRIPTION
add a flag to process all `DbtProjectComponent` in the target project directory

part of #28546

## How I Tested These Changes

added test

## Changelog

[dagster-dbt] the `dagster-dbt project prepare-and-package` cli now supports `--components` for handling `DbtProjectComponent`
