### PR TITLE
[ui] Show levels fraction on run page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
@@ -89,7 +89,9 @@ export const LogFilterSelect = ({options, onSetFilter}: Props) => {
         icon={<Icon name="filter_alt" />}
         rightIcon={<Icon name="expand_more" />}
       >
-        Levels ({enabledCount})
+        <span style={{fontVariantNumeric: 'tabular-nums'}}>
+          Levels ({enabledCount}/{levels.length})
+        </span>
       </FilterButton>
     </Popover>
   );


### PR DESCRIPTION
## Summary & Motivation

On the run page, show `X/Y` instead of just `X` for the number of level types selected for the logs display filtering.

<img width="214" alt="Screenshot 2025-04-11 at 12 22 58" src="https://github.com/user-attachments/assets/4b743268-659d-4966-9b86-e91115a3f168" />

## How I Tested These Changes

Materialize an asset, view the run. Verify that the button label has the full `X/Y` string.

## Changelog

[ui] On the run page, show the number of log levels selected as well as the number of log levels available.
