### PR TITLE
[components] use dagter-io/jaffle-dashboard in components ETL tutorial

### DIFF
--- a/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
+++ b/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
@@ -268,7 +268,9 @@ And that the definitions load successfully:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/31-dg-component-check-defs.txt" />
 
-Materialize the Evidence assets in the UI, and it will generate a static website for your dashboard in the `build` directory. You can view the dashboard in your browser by running `python -m http.server` in that directory, which should result in something that looks like this:
+Next, materialize the `jaffle_dashboard` asset, and it will generate a static website for your dashboard in the `jaffle_dashboard/build` directory.
+
+You can view the dashboard in your browser by running `python -m http.server` in that folder, which will show a dashboard like this!
 
 ![](/images/guides/build/projects-and-components/components/evidence.png)
 

--- a/examples/docs_snippets/docs_snippets/guides/components/index/26-jaffle-dashboard-clone.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/26-jaffle-dashboard-clone.txt
@@ -1,1 +1,1 @@
-git clone --depth=1 https://github.com/petehunt/jaffle_dashboard.git jaffle_dashboard && rm -rf jaffle_dashboard/.git
+git clone --depth=1 https://github.com/dagster-io/jaffle-dashboard.git jaffle_dashboard && rm -rf jaffle_dashboard/.git

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -332,7 +332,7 @@ def test_components_docs_index(update_snippets: bool) -> None:
             )
 
             run_command_and_snippet_output(
-                cmd="git clone --depth=1 https://github.com/petehunt/jaffle_dashboard.git jaffle_dashboard && rm -rf jaffle_dashboard/.git",
+                cmd="git clone --depth=1 https://github.com/dagster-io/jaffle-dashboard.git jaffle_dashboard && rm -rf jaffle_dashboard/.git",
                 snippet_path=COMPONENTS_SNIPPETS_DIR
                 / f"{next_snip_no()}-jaffle-dashboard-clone.txt",
                 update_snippets=update_snippets,


### PR DESCRIPTION
## Summary & Motivation

- Uses Dagster owned jaffle-dashboard repository

## How I Tested These Changes

## Changelog

NOCHANGELOG
