### PR TITLE
Pin dagster/dagster-cloud version used by dg when using uv tool run

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -15,6 +15,7 @@ from dagster_dg.context import DgContext
 from dagster_dg.utils import DgClickCommand, DgClickGroup, pushd
 from dagster_dg.utils.filesystem import watch_paths
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
+from dagster_dg.utils.version import get_uv_tool_core_pin_string
 
 
 @click.group(name="check", cls=DgClickGroup)
@@ -133,7 +134,14 @@ def check_definitions_command(
     elif dg_context.is_project:
         run_cmds = ["dagster", "definitions", "validate"]
     else:
-        run_cmds = ["uv", "tool", "run", "dagster", "definitions", "validate"]
+        run_cmds = [
+            "uv",
+            "tool",
+            "run",
+            f"dagster{get_uv_tool_core_pin_string()}",
+            "definitions",
+            "validate",
+        ]
 
     with (
         pushd(dg_context.root_path),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -19,6 +19,7 @@ from dagster_dg.error import DgError
 from dagster_dg.utils import DgClickCommand, pushd, strip_activated_venv_from_env_vars
 from dagster_dg.utils.cli import format_forwarded_option
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
+from dagster_dg.utils.version import get_uv_tool_core_pin_string
 
 T = TypeVar("T")
 
@@ -133,7 +134,18 @@ def dev_command(
     elif dg_context.is_project:
         run_cmds = ["dagster", "dev"]
     else:
-        run_cmds = ["uv", "tool", "run", "--with", "dagster-webserver", "dagster", "dev"]
+        uv_tool_core_pin_string = get_uv_tool_core_pin_string()
+        run_cmds = [
+            "uv",
+            "tool",
+            "run",
+            "--from",
+            f"dagster{uv_tool_core_pin_string}",
+            "--with",
+            f"dagster-webserver{uv_tool_core_pin_string}",
+            "dagster",
+            "dev",
+        ]
 
     with (
         pushd(dg_context.root_path),

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -44,6 +44,7 @@ from dagster_dg.utils import (
     strip_activated_venv_from_env_vars,
 )
 from dagster_dg.utils.filesystem import hash_paths
+from dagster_dg.utils.version import get_uv_tool_core_pin_string
 
 # Project
 _DEFAULT_PROJECT_DEFS_SUBMODULE: Final = "defs"
@@ -445,8 +446,15 @@ class DgContext:
     def external_dagster_cloud_cli_command(
         self, command: list[str], log: bool = True, env: Optional[dict[str, str]] = None
     ):
-        # TODO Match dagster-cloud-cli version with calling dg version
-        command = ["uv", "tool", "run", "--from", "dagster-cloud-cli", "dagster-cloud", *command]
+        command = [
+            "uv",
+            "tool",
+            "run",
+            "--from",
+            f"dagster-cloud-cli{get_uv_tool_core_pin_string()}",
+            "dagster-cloud",
+            *command,
+        ]
         with pushd(self.root_path):
             result = subprocess.run(command, check=False, env={**os.environ, **(env or {})})
             if result.returncode != 0:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/version.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/version.py
@@ -1,0 +1,10 @@
+from dagster_shared.libraries import core_version_from_library_version
+
+from dagster_dg.version import __version__
+
+
+def get_uv_tool_core_pin_string() -> str:
+    if __version__ == "1!0+dev":
+        return ""
+    else:
+        return f"=={core_version_from_library_version(__version__)}"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_versions.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils_tests/test_versions.py
@@ -1,0 +1,10 @@
+from unittest import mock
+
+from dagster_dg.utils.version import get_uv_tool_core_pin_string
+
+
+def test_get_uv_tool_core_pin_string():
+    assert get_uv_tool_core_pin_string() == ""
+
+    with mock.patch("dagster_dg.utils.version.__version__", "0.26.3"):
+        assert get_uv_tool_core_pin_string() == "==1.10.3"


### PR DESCRIPTION
## Summary & Motivation
This helps avoid back-compat issues when dg is running a different dagster version than the underlying uv tool run command. The main target is for dg deploy, which always invokes uv tool run currently, but I figured it could be useful for the other places we run uv tool run too.

## How I Tested These Changes
new test case, locally batch __version for dg and run dg dev and dg deploy and dg check

