### PR TITLE
[dg] Add `dagster` dep to scaffolded project

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -174,7 +174,7 @@ EDITABLE_DAGSTER_DEPENDENCIES = (
     "dagster-test[components]",  # we include dagster-test for testing purposes
 )
 EDITABLE_DAGSTER_DEV_DEPENDENCIES = ("dagster-webserver", "dagster-graphql")
-PYPI_DAGSTER_DEPENDENCIES = tuple()
+PYPI_DAGSTER_DEPENDENCIES = ("dagster",)
 PYPI_DAGSTER_DEV_DEPENDENCIES = ("dagster-webserver",)
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -362,6 +362,15 @@ def test_scaffold_project_already_exists_fails() -> None:
         assert "already specifies a project at" in result.output
 
 
+def test_scaffold_project_non_editable_dagster_dagster_components_executable_exists() -> None:
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke("scaffold", "project", "bar")
+        assert_runner_result(result)
+        with pushd("bar"):
+            result = runner.invoke("list", "plugins", "--verbose")
+            assert_runner_result(result)
+
+
 # ########################
 # ##### COMPONENT
 # ########################


### PR DESCRIPTION
## Summary & Motivation

Fix bug in `dg scaffold project` when not using editable dagster-- scaffolded project did not have `dagster` as a dependency.

## How I Tested These Changes

New unit test.

## Changelog

Fixed a bug where new projects scaffolded with `dg scaffold project` were lacking `dagster` as a dependency.
