### PR TITLE
[dg] Add note telling users to fix broken path in components ETL tutorial DbtProjectComponent

### DIFF
--- a/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
+++ b/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
@@ -178,6 +178,11 @@ This creates a new component instance in the project at `jaffle_platform/defs/jd
 
 ### 4. Update the dbt project component configuration
 
+:::note
+A bug in the component scaffolding for `DbtProjectComponent` is currently
+causing the `project_dir` in `jaffle_platform/defs/dbt/component.yaml` path to be generated as `../../../dbt/jdbt` when it should be `../../../../dbt/jdbt`. Please update the `project_dir` to `../../../../dbt/jdbt` before proceeding. This will be fixed in the next release.
+:::
+
 Let’s see the project in the Dagster UI:
 
 <CliInvocationExample contents="dg dev" />


### PR DESCRIPTION
## Summary & Motivation

The components ETL tutorial currently breaks after generating a DBT component because the `project_dir` relative path is generated incorrectly as `../../../dbt/jdbt` when it should be `../../../../dbt/jdbt`. The necessary path changed after the change to `src`-based layout. 

I'm not sure of how the logic needs to be changed to generate the right path, but this PR just inserts a note into the tutorial warning users about this bug so they can fix the path and proceed with the tutorial. We should remove this when we fix the bug and make the next release.

This was not being caught by our tests because we don't actually load defs in the tests with the initially generated `component.yaml`, and subsequent edits silently update the path to the correct `../../../../dbt/jdbt`.

## How I Tested These Changes

Did the tutorial manually