### PR TITLE
[dg] Thread project path into ComponentLoadContext

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
@@ -140,6 +140,10 @@ def test_components_docs_index(update_snippets: bool) -> None:
         )
 
         create_file(
+            Path("my_existing_project") / "defs" / "__init__.py",
+            contents="",
+        )
+        create_file(
             Path("my_existing_project") / "defs" / "autoloaded_asset.py",
             contents=format_multiline("""
                 import dagster as dg

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -22,6 +22,7 @@ class ComponentLoadContext:
     """Context for loading a single component."""
 
     path: Path
+    project_path: Path
     defs_module_path: Path
     defs_module_name: str
     resolution_context: ResolutionContext
@@ -36,10 +37,11 @@ class ComponentLoadContext:
         return context
 
     @staticmethod
-    def for_module(defs_module: ModuleType) -> "ComponentLoadContext":
+    def for_module(defs_module: ModuleType, project_path: Path) -> "ComponentLoadContext":
         path = get_path_from_module(defs_module)
         return ComponentLoadContext(
             path=path,
+            project_path=project_path,
             defs_module_path=path,
             defs_module_name=defs_module.__name__,
             resolution_context=ResolutionContext.default(),
@@ -49,6 +51,7 @@ class ComponentLoadContext:
     def for_test() -> "ComponentLoadContext":
         return ComponentLoadContext(
             path=Path.cwd(),
+            project_path=Path.cwd(),
             defs_module_path=Path.cwd(),
             defs_module_name="test",
             resolution_context=ResolutionContext.default(),
@@ -60,7 +63,11 @@ class ComponentLoadContext:
         return dataclasses.replace(self, resolution_context=resolution_context)
 
     def with_rendering_scope(self, rendering_scope: Mapping[str, Any]) -> "ComponentLoadContext":
-        return self._with_resolution_context(self.resolution_context.with_scope(**rendering_scope))
+        return self._with_resolution_context(
+            self.resolution_context.with_scope(
+                **rendering_scope, **{"project_path": self.project_path}
+            )
+        )
 
     def with_source_position_tree(
         self, source_position_tree: SourcePositionTree
@@ -105,7 +112,7 @@ class ComponentLoadContext:
         # loaded. This is just a temporary hack to keep tests passing.
         from dagster.components.core.load_defs import load_defs
 
-        return load_defs(module)
+        return load_defs(module, self.project_path)
 
     def load_defs_relative_python_module(self, path: Path) -> ModuleType:
         """Load a python module relative to the defs's context path. This is useful for loading code

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -65,7 +65,7 @@ class ComponentLoadContext:
     def with_rendering_scope(self, rendering_scope: Mapping[str, Any]) -> "ComponentLoadContext":
         return self._with_resolution_context(
             self.resolution_context.with_scope(
-                **rendering_scope, **{"project_path": self.project_path}
+                **rendering_scope, **{"project_path": str(self.project_path.absolute())}
             )
         )
 

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -1,6 +1,7 @@
 import importlib
 from pathlib import Path
 from types import ModuleType
+from typing import Optional
 
 from dagster_shared.serdes.objects.package_entry import json_for_all_components
 
@@ -26,16 +27,46 @@ def build_component_defs(components_root: Path) -> Definitions:
         f"{Path(components_root).parent.name}.{Path(components_root).name}"
     )
 
-    return load_defs(defs_root=defs_root)
+    return load_defs(defs_root=defs_root, project_path=components_root.parent.parent)
+
+
+def get_project_path(defs_root: ModuleType) -> Path:
+    """Find the project root directory containing pyproject.yaml or setup.py.
+
+    Args:
+        defs_root: A module object from which to start the search.
+
+    Returns:
+        The absolute path to the project root directory.
+
+    Raises:
+        FileNotFoundError: If no project root with pyproject.yaml or setup.py is found.
+    """
+    # Get the module's file path
+
+    module_path = getattr(defs_root, "__file__", None)
+    if not module_path:
+        raise FileNotFoundError("Module has no __file__ attribute")
+
+    # Start with the directory containing the module
+    current_dir = Path(module_path).parent
+
+    # Traverse up until we find pyproject.yaml or setup.py
+    while current_dir != current_dir.parent:  # Stop at root
+        if (current_dir / "pyproject.toml").exists() or (current_dir / "setup.py").exists():
+            return current_dir
+        current_dir = current_dir.parent
+
+    raise FileNotFoundError("No project root with pyproject.yaml or setup.py found")
 
 
 # Public method so optional Nones are fine
 @suppress_dagster_warnings
-def load_defs(defs_root: ModuleType) -> Definitions:
+def load_defs(defs_root: ModuleType, project_path: Optional[Path] = None) -> Definitions:
     """Constructs a Definitions object, loading all Dagster defs in the given module.
 
     Args:
-        defs_root (Path): The path to the defs root, typically `package.defs`.
+        defs_root (Path): The path to the defs root, typically `package.defs`.)
         resources (Optional[Mapping[str, object]]): A mapping of resource keys to resources
             to apply to the definitions.
     """
@@ -43,8 +74,10 @@ def load_defs(defs_root: ModuleType) -> Definitions:
     from dagster.components.core.package_entry import discover_entry_point_package_objects
     from dagster.components.core.snapshot import get_package_entry_snap
 
+    project_path = project_path if project_path else get_project_path(defs_root)
+
     # create a top-level DefsModule component from the root module
-    context = ComponentLoadContext.for_module(defs_root)
+    context = ComponentLoadContext.for_module(defs_root, project_path)
     root_component = get_component(context)
     if root_component is None:
         raise DagsterInvalidDefinitionError("Could not resolve root module to a component.")

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
@@ -20,12 +20,13 @@ def load_test_component_defs(
     """Loads a component from a test component project, making the provided local component defn
     available in that component's __init__.py.
     """
+    src_path = Path(src_path)
     with create_project_from_components(
         str(src_path), local_component_defn_to_inject=local_component_defn_to_inject
     ) as (_, project_name):
-        module = importlib.import_module(f"{project_name}.defs.{Path(src_path).stem}")
+        module = importlib.import_module(f"{project_name}.defs.{src_path.stem}")
 
-        yield load_defs(defs_root=module)
+        yield load_defs(defs_root=module, project_path=src_path.parent.parent)
 
 
 def sync_load_test_component_defs(

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
@@ -26,7 +26,7 @@ def load_test_component_defs(
     ) as (_, project_name):
         module = importlib.import_module(f"{project_name}.defs.{src_path.stem}")
 
-        yield load_defs(defs_root=module, project_path=src_path.parent.parent)
+        yield load_defs(defs_root=module, project_root=src_path.parent.parent)
 
 
 def sync_load_test_component_defs(

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 from dagster import AssetSpec, AutomationCondition
 from dagster.components.core.load_defs import load_defs
@@ -8,7 +9,7 @@ def test_custom_scope() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.resolution_tests.custom_scope_component"
     )
-    defs = load_defs(module)
+    defs = load_defs(module, project_path=Path(__file__).parent)
 
     assets = list(defs.assets or [])
     assert len(assets) == 1

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
@@ -9,7 +9,7 @@ def test_custom_scope() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.resolution_tests.custom_scope_component"
     )
-    defs = load_defs(module, project_path=Path(__file__).parent)
+    defs = load_defs(module, project_root=Path(__file__).parent)
 
     assets = list(defs.assets or [])
     assert len(assets) == 1

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -11,7 +11,7 @@ def test_load_from_path() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.code_locations.python_script_location.defs"
     )
-    defs = load_defs(module, project_path=Path(__file__).parent)
+    defs = load_defs(module, project_root=Path(__file__).parent)
 
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),
@@ -28,7 +28,7 @@ def test_load_from_location_path() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.code_locations.python_script_location.defs.scripts"
     )
-    defs = load_defs(module, project_path=Path(__file__).parent)
+    defs = load_defs(module, project_root=Path(__file__).parent)
 
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -11,7 +11,7 @@ def test_load_from_path() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.code_locations.python_script_location.defs"
     )
-    defs = load_defs(module)
+    defs = load_defs(module, project_path=Path(__file__).parent)
 
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),
@@ -28,7 +28,7 @@ def test_load_from_location_path() -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.code_locations.python_script_location.defs.scripts"
     )
-    defs = load_defs(module)
+    defs = load_defs(module, project_path=Path(__file__).parent)
 
     assert defs.get_asset_graph().get_all_asset_keys() == {
         AssetKey("a"),


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

Manually tested.

```python
import dagster as dg
from dagster.components import Component, ComponentLoadContext, Model, Resolvable


class TakesStringComponent(Component, Model, Resolvable):
    value: str

    # added fields here will define yaml schema via Model

    def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
        # Add definition construction logic here.
        print("**********")
        print(self.value)
        print("**********")
        return dg.Definitions()
```

and then

```yaml
type: project_path_test.lib.TakesStringComponent

attributes:
  value: "{{project_root}}"
```

## Changelog

NOCHANGELOG