### PR TITLE
[1/n][Asset Health] Add descriptions to health summary card

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -3,7 +3,7 @@
   "LogTelemetryMutation": "b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3",
   "AssetGraphLiveQuery": "9f875017c08597b0fa017a17fa40813c255d13e3f92eb98992772f4c8ae42e52",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "f77fe5f7a3629cb0a3fb0795d4f81d0072604c31fd16cdeb3f989dc80cad5e45",
+  "AssetHealthQuery": "564cb745963722748aeaac66dc433a44e8b6091ef60812a0bb7ec44c3fae5b1c",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "724ef0733b9b187ffd012e40c02c3b3a5e32967dbcae46e2024b15dfd5bf0271",
   "AssetLiveRunLogsSubscription": "4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -70,9 +70,49 @@ export const ASSETS_HEALTH_INFO_QUERY = gql`
     assetHealth {
       assetHealth
       materializationStatus
+      materializationStatusMetadata {
+        ...AssetHealthMaterializationDegradedPartitionedMetaFragment
+        ...AssetHealthMaterializationWarningPartitionedMetaFragment
+        ...AssetHealthMaterializationDegradedNotPartitionedMetaFragment
+      }
       assetChecksStatus
+      assetChecksStatusMetadata {
+        ...AssetHealthCheckDegradedMetaFragment
+        ...AssetHealthCheckWarningMetaFragment
+        ...AssetHealthCheckUnknownMetaFragment
+      }
       freshnessStatus
     }
+  }
+
+  fragment AssetHealthMaterializationDegradedPartitionedMetaFragment on AssetHealthMaterializationDegradedPartitionedMeta {
+    numMissingPartitions
+    totalNumPartitions
+  }
+
+  fragment AssetHealthMaterializationWarningPartitionedMetaFragment on AssetHealthMaterializationWarningPartitionedMeta {
+    numMissingPartitions
+    totalNumPartitions
+  }
+
+  fragment AssetHealthMaterializationDegradedNotPartitionedMetaFragment on AssetHealthMaterializationDegradedNotPartitionedMeta {
+    failedRunId
+  }
+
+  fragment AssetHealthCheckDegradedMetaFragment on AssetHealthCheckDegradedMeta {
+    numFailedChecks
+    numWarningChecks
+    totalNumChecks
+  }
+
+  fragment AssetHealthCheckWarningMetaFragment on AssetHealthCheckWarningMeta {
+    numWarningChecks
+    totalNumChecks
+  }
+
+  fragment AssetHealthCheckUnknownMetaFragment on AssetHealthCheckUnknownMeta {
+    numNotExecutedChecks
+    totalNumChecks
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -18,6 +18,37 @@ export type AssetHealthQuery = {
       materializationStatus: Types.AssetHealthStatus;
       assetChecksStatus: Types.AssetHealthStatus;
       freshnessStatus: Types.AssetHealthStatus;
+      materializationStatusMetadata:
+        | {__typename: 'AssetHealthMaterializationDegradedNotPartitionedMeta'; failedRunId: string}
+        | {
+            __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
+            numMissingPartitions: number;
+            totalNumPartitions: number;
+          }
+        | {
+            __typename: 'AssetHealthMaterializationWarningPartitionedMeta';
+            numMissingPartitions: number;
+            totalNumPartitions: number;
+          }
+        | null;
+      assetChecksStatusMetadata:
+        | {
+            __typename: 'AssetHealthCheckDegradedMeta';
+            numFailedChecks: number;
+            numWarningChecks: number;
+            totalNumChecks: number;
+          }
+        | {
+            __typename: 'AssetHealthCheckUnknownMeta';
+            numNotExecutedChecks: number;
+            totalNumChecks: number;
+          }
+        | {
+            __typename: 'AssetHealthCheckWarningMeta';
+            numWarningChecks: number;
+            totalNumChecks: number;
+          }
+        | null;
     } | null;
   }>;
 };
@@ -31,7 +62,74 @@ export type AssetHealthFragment = {
     materializationStatus: Types.AssetHealthStatus;
     assetChecksStatus: Types.AssetHealthStatus;
     freshnessStatus: Types.AssetHealthStatus;
+    materializationStatusMetadata:
+      | {__typename: 'AssetHealthMaterializationDegradedNotPartitionedMeta'; failedRunId: string}
+      | {
+          __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
+          numMissingPartitions: number;
+          totalNumPartitions: number;
+        }
+      | {
+          __typename: 'AssetHealthMaterializationWarningPartitionedMeta';
+          numMissingPartitions: number;
+          totalNumPartitions: number;
+        }
+      | null;
+    assetChecksStatusMetadata:
+      | {
+          __typename: 'AssetHealthCheckDegradedMeta';
+          numFailedChecks: number;
+          numWarningChecks: number;
+          totalNumChecks: number;
+        }
+      | {
+          __typename: 'AssetHealthCheckUnknownMeta';
+          numNotExecutedChecks: number;
+          totalNumChecks: number;
+        }
+      | {
+          __typename: 'AssetHealthCheckWarningMeta';
+          numWarningChecks: number;
+          totalNumChecks: number;
+        }
+      | null;
   } | null;
 };
 
-export const AssetHealthQueryVersion = 'f77fe5f7a3629cb0a3fb0795d4f81d0072604c31fd16cdeb3f989dc80cad5e45';
+export type AssetHealthMaterializationDegradedPartitionedMetaFragment = {
+  __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
+  numMissingPartitions: number;
+  totalNumPartitions: number;
+};
+
+export type AssetHealthMaterializationWarningPartitionedMetaFragment = {
+  __typename: 'AssetHealthMaterializationWarningPartitionedMeta';
+  numMissingPartitions: number;
+  totalNumPartitions: number;
+};
+
+export type AssetHealthMaterializationDegradedNotPartitionedMetaFragment = {
+  __typename: 'AssetHealthMaterializationDegradedNotPartitionedMeta';
+  failedRunId: string;
+};
+
+export type AssetHealthCheckDegradedMetaFragment = {
+  __typename: 'AssetHealthCheckDegradedMeta';
+  numFailedChecks: number;
+  numWarningChecks: number;
+  totalNumChecks: number;
+};
+
+export type AssetHealthCheckWarningMetaFragment = {
+  __typename: 'AssetHealthCheckWarningMeta';
+  numWarningChecks: number;
+  totalNumChecks: number;
+};
+
+export type AssetHealthCheckUnknownMetaFragment = {
+  __typename: 'AssetHealthCheckUnknownMeta';
+  numNotExecutedChecks: number;
+  totalNumChecks: number;
+};
+
+export const AssetHealthQueryVersion = '564cb745963722748aeaac66dc433a44e8b6091ef60812a0bb7ec44c3fae5b1c';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -19,6 +19,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import updateLocale from 'dayjs/plugin/updateLocale';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
+import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
 import styled from 'styled-components';
 
 import {AssetHealthStatusString, STATUS_INFO, statusToIconAndColor} from './AssetHealthSummary';
@@ -33,7 +34,6 @@ import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {useAssetsHealthData} from '../asset-data/AssetHealthDataProvider';
 import {AssetHealthFragment} from '../asset-data/types/AssetHealthDataProvider.types';
 import {useAssetSelectionInput} from '../asset-selection/input/useAssetSelectionInput';
-import {useDebugChanged} from '../hooks/useDebugChanged';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {SyntaxError} from '../selection/CustomErrorListener';
 import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
@@ -64,8 +64,6 @@ export const AssetsCatalogTableV2Impl = React.memo(() => {
   const {liveDataByNode} = useAssetsHealthData(
     useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
   );
-
-  console.log(Object.keys(liveDataByNode).length);
 
   const healthDataLoading = useMemo(() => {
     return Object.values(liveDataByNode).length !== filtered.length;
@@ -98,27 +96,6 @@ export const AssetsCatalogTableV2Impl = React.memo(() => {
     }
   }, [selectedTab, filtered, groupedByStatus, loading]);
 
-  useDebugChanged([
-    liveDataByNode,
-    filtered,
-    assets,
-    errorState,
-    filterInput,
-    loading,
-    assetsLoading,
-    error,
-    selectedTab,
-    groupedByStatus,
-    content,
-    healthDataLoading,
-    assetsLoading,
-    loading,
-    error,
-    selectedTab,
-    groupedByStatus,
-    content,
-  ]);
-
   if (error) {
     return <PythonErrorInfo error={error} />;
   }
@@ -140,7 +117,13 @@ export const AssetsCatalogTableV2Impl = React.memo(() => {
         minHeight: 600,
       }}
     >
-      <Box padding={{vertical: 12, horizontal: 24}}>{filterInput}</Box>
+      <Box
+        flex={{direction: 'row', alignItems: 'center', gap: 8}}
+        padding={{vertical: 12, horizontal: 24}}
+      >
+        <Box flex={{grow: 1, shrink: 1}}>{filterInput}</Box>
+        <CreateCatalogViewButton />
+      </Box>
       <IndeterminateLoadingBar $loading={loading || healthDataLoading} />
       <Box border="bottom">
         <Tabs
@@ -368,7 +351,16 @@ const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
           </AssetIconWrapper>
           {asset.assetKey.path.join(' / ')}
         </Box>
-        <AssetRecentUpdatesTrend asset={asset} />
+        {/* Prevent clicks on the trend from propoagating to the row and triggering the link */}
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          className="test"
+        >
+          <AssetRecentUpdatesTrend asset={asset} />
+        </div>
       </Box>
     </RowWrapper>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -36,7 +36,8 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
   );
 
   const states = useMemo(() => {
-    return new Array(5).fill(null).map((_, index) => {
+    return new Array(5).fill(null).map((_, _index) => {
+      const index = 4 - _index;
       const materialization = materializations[index] ?? observations[index];
       if (!materialization) {
         return <Pill key={index} $index={index} $color={Colors.backgroundDisabled()} />;
@@ -95,11 +96,11 @@ const Pill = styled.div<{$index: number; $color: string}>`
 `;
 
 const OPACITIES: Record<number, number> = {
-  4: 1,
-  3: 0.8,
+  0: 1,
+  1: 0.8,
   2: 0.66,
-  1: 0.4,
-  0: 0.2,
+  3: 0.4,
+  4: 0.2,
 };
 
 const EventPopover = React.memo(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -90,9 +90,7 @@ export function useAllAssets({
   const {cacheManager} = useCachedAssets({
     onAssetsLoaded: useCallback(
       (data) => {
-        console.log('onAssetsLoaded', data);
         if (!assetsRef.current) {
-          console.log('onAssetsLoaded', data);
           setErrorAndAssets({
             error: undefined,
             assets: data,


### PR DESCRIPTION
## Summary & Motivation

1. Add descriptions.
2. Fix the order of events in the health trend.

## How I Tested These Changes
<img width="1440" alt="Screenshot 2025-04-14 at 12 09 29 PM" src="https://github.com/user-attachments/assets/fe9bccd6-aca5-4b2c-8bd4-aeeb126bfe54" />
<img width="365" alt="Screenshot 2025-04-14 at 12 09 09 PM" src="https://github.com/user-attachments/assets/73a6cb5b-a036-46bd-b62c-be206112a3e0" />
<img width="361" alt="Screenshot 2025-04-14 at 12 09 02 PM" src="https://github.com/user-attachments/assets/2dada884-07a7-4a20-a1c8-03f3d04869b8" />
<img width="375" alt="Screenshot 2025-04-14 at 12 08 57 PM" src="https://github.com/user-attachments/assets/095a5fcf-a700-4353-9d77-6d0987465980" />
<img width="375" alt="Screenshot 2025-04-14 at 12 08 50 PM" src="https://github.com/user-attachments/assets/c39d2c39-bd2c-4a00-877e-651482d2d402" />
<img width="466" alt="Screenshot 2025-04-14 at 12 22 24 PM" src="https://github.com/user-attachments/assets/50adff64-0570-4bcd-bb9b-5bee779c1b0d" />
<img width="373" alt="Screenshot 2025-04-14 at 12 22 17 PM" src="https://github.com/user-attachments/assets/b8839a4a-7a6d-4260-af7b-fec517c20b9c" />


