### PR TITLE
[AssetRunLogObserver] Observe failed to materialize event

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -6,7 +6,7 @@
   "AssetHealthQuery": "564cb745963722748aeaac66dc433a44e8b6091ef60812a0bb7ec44c3fae5b1c",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "724ef0733b9b187ffd012e40c02c3b3a5e32967dbcae46e2024b15dfd5bf0271",
-  "AssetLiveRunLogsSubscription": "4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12",
+  "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",
   "SidebarAssetQuery": "5f877e6818194f30b948bda42fea8e5ef954461ce44bb45d7d201a677ec30487",
   "AssetGraphQuery": "26030b5c565bdc4d84b54b2c9a7e8172562cf7434912511768bde20875d47b44",
   "AssetForNavigationQuery": "eb695ab88044ddd7068ea0dc1e2482eaba1fcb11b83de11050ff52f55e83ed3d",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
@@ -99,7 +99,8 @@ const SingleRunLogObserver = memo(({runId, callback}: SingleRunLogObserverProps)
             if (
               m.__typename === 'AssetMaterializationPlannedEvent' ||
               m.__typename === 'MaterializationEvent' ||
-              m.__typename === 'ObservationEvent'
+              m.__typename === 'ObservationEvent' ||
+              m.__typename === 'FailedToMaterializeEvent'
             ) {
               return {assetKey: m.assetKey} as ObservedEvent;
             }
@@ -150,6 +151,11 @@ export const ASSET_LIVE_RUN_LOGS_SUBSCRIPTION = gql`
             }
           }
           ... on ObservationEvent {
+            assetKey {
+              path
+            }
+          }
+          ... on FailedToMaterializeEvent {
             assetKey {
               path
             }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
@@ -37,7 +37,10 @@ export type AssetLiveRunLogsSubscription = {
           | {__typename: 'ExecutionStepStartEvent'; stepKey: string | null}
           | {__typename: 'ExecutionStepSuccessEvent'}
           | {__typename: 'ExecutionStepUpForRetryEvent'}
-          | {__typename: 'FailedToMaterializeEvent'}
+          | {
+              __typename: 'FailedToMaterializeEvent';
+              assetKey: {__typename: 'AssetKey'; path: Array<string>} | null;
+            }
           | {__typename: 'HandledOutputEvent'}
           | {__typename: 'HookCompletedEvent'}
           | {__typename: 'HookErroredEvent'}
@@ -72,4 +75,4 @@ export type AssetLiveRunLogsSubscription = {
       };
 };
 
-export const AssetLiveRunLogsSubscriptionVersion = '4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12';
+export const AssetLiveRunLogsSubscriptionVersion = 'd3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d';


### PR DESCRIPTION
## Summary & Motivation

Observe this event to trigger refetch asset live data so that we show failed status immediately.