### PR TITLE
[asset health] include freshness in asset health

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -750,6 +750,7 @@ type AssetHealth {
   assetChecksStatus: AssetHealthStatus!
   assetChecksStatusMetadata: AssetHealthCheckMeta
   freshnessStatus: AssetHealthStatus!
+  freshnessStatusMetadata: AssetHealthFreshnessMeta
 }
 
 enum AssetHealthStatus {
@@ -799,6 +800,10 @@ type AssetHealthCheckWarningMeta {
 type AssetHealthCheckUnknownMeta {
   numNotExecutedChecks: Int!
   totalNumChecks: Int!
+}
+
+type AssetHealthFreshnessMeta {
+  lastMaterializedTimestamp: Float!
 }
 
 type MaterializationUpstreamDataVersion {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -803,7 +803,7 @@ type AssetHealthCheckUnknownMeta {
 }
 
 type AssetHealthFreshnessMeta {
-  lastMaterializedTimestamp: Float!
+  lastMaterializedTimestamp: Float
 }
 
 type MaterializationUpstreamDataVersion {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -416,7 +416,7 @@ export type AssetHealthCheckWarningMeta = {
 
 export type AssetHealthFreshnessMeta = {
   __typename: 'AssetHealthFreshnessMeta';
-  lastMaterializedTimestamp: Scalars['Float']['output'];
+  lastMaterializedTimestamp: Maybe<Scalars['Float']['output']>;
 };
 
 export type AssetHealthMaterializationDegradedNotPartitionedMeta = {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -385,6 +385,7 @@ export type AssetHealth = {
   assetChecksStatusMetadata: Maybe<AssetHealthCheckMeta>;
   assetHealth: AssetHealthStatus;
   freshnessStatus: AssetHealthStatus;
+  freshnessStatusMetadata: Maybe<AssetHealthFreshnessMeta>;
   materializationStatus: AssetHealthStatus;
   materializationStatusMetadata: Maybe<AssetHealthMaterializationMeta>;
 };
@@ -411,6 +412,11 @@ export type AssetHealthCheckWarningMeta = {
   __typename: 'AssetHealthCheckWarningMeta';
   numWarningChecks: Scalars['Int']['output'];
   totalNumChecks: Scalars['Int']['output'];
+};
+
+export type AssetHealthFreshnessMeta = {
+  __typename: 'AssetHealthFreshnessMeta';
+  lastMaterializedTimestamp: Scalars['Float']['output'];
 };
 
 export type AssetHealthMaterializationDegradedNotPartitionedMeta = {
@@ -6681,6 +6687,12 @@ export const buildAssetHealth = (
       overrides && overrides.hasOwnProperty('freshnessStatus')
         ? overrides.freshnessStatus!
         : AssetHealthStatus.DEGRADED,
+    freshnessStatusMetadata:
+      overrides && overrides.hasOwnProperty('freshnessStatusMetadata')
+        ? overrides.freshnessStatusMetadata!
+        : relationshipsToOmit.has('AssetHealthFreshnessMeta')
+          ? ({} as AssetHealthFreshnessMeta)
+          : buildAssetHealthFreshnessMeta({}, relationshipsToOmit),
     materializationStatus:
       overrides && overrides.hasOwnProperty('materializationStatus')
         ? overrides.materializationStatus!
@@ -6744,6 +6756,21 @@ export const buildAssetHealthCheckWarningMeta = (
         : 4025,
     totalNumChecks:
       overrides && overrides.hasOwnProperty('totalNumChecks') ? overrides.totalNumChecks! : 9768,
+  };
+};
+
+export const buildAssetHealthFreshnessMeta = (
+  overrides?: Partial<AssetHealthFreshnessMeta>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetHealthFreshnessMeta'} & AssetHealthFreshnessMeta => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetHealthFreshnessMeta');
+  return {
+    __typename: 'AssetHealthFreshnessMeta',
+    lastMaterializedTimestamp:
+      overrides && overrides.hasOwnProperty('lastMaterializedTimestamp')
+        ? overrides.lastMaterializedTimestamp!
+        : 5.66,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -16,6 +16,7 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionSnapshot,
 )
+from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.remote_asset_graph import RemoteAssetNode, RemoteWorkspaceAssetNode
@@ -71,6 +72,7 @@ from dagster_graphql.schema.asset_health import (
     GrapheneAssetHealthCheckMeta,
     GrapheneAssetHealthCheckUnknownMeta,
     GrapheneAssetHealthCheckWarningMeta,
+    GrapheneAssetHealthFreshnessMeta,
     GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta,
     GrapheneAssetHealthMaterializationDegradedPartitionedMeta,
     GrapheneAssetHealthMaterializationMeta,
@@ -803,10 +805,43 @@ class GrapheneAssetNode(graphene.ObjectType):
             # all checks must have executed and passed
             return GrapheneAssetHealthStatus.HEALTHY, None
 
-    def get_freshness_status_for_asset_health(self, graphene_info: ResolveInfo) -> tuple[str, None]:
-        # if SLA is met, healthy
-        # if SLA violated with warning, warning
-        # if SLA violated with error, degraded
+    async def get_freshness_status_for_asset_health(
+        self, graphene_info: ResolveInfo
+    ) -> tuple[str, GrapheneAssetHealthFreshnessMeta]:
+        """Computes the health indicator for the freshness for an asset. Follows these rules:
+        HEALTHY - the freshness policy is in a PASS-ing state
+        WARNING - the freshness policy is in a WARN-ing state
+        DEGRADED - the freshness policy is in a FAIL-ing state
+        UNKNOWN - the freshness policy has never been evaluated or is in an UNKNOWN state
+        NOT_APPLICABLE - the asset does not have a freshness policy defined.
+        """
+        if self._asset_node_snap.internal_freshness_policy is None:
+            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+
+        freshness_state_record = graphene_info.context.instance.get_entity_freshness_state(
+            self._asset_node_snap.asset_key
+        )
+        if freshness_state_record is None:
+            return GrapheneAssetHealthStatus.UNKNOWN, None
+        state = freshness_state_record.freshness_state
+        if state == FreshnessState.PASS:
+            return GrapheneAssetHealthStatus.HEALTHY, None
+
+        asset_record = await AssetRecord.gen(graphene_info.context, self._asset_node_snap.asset_key)
+        last_materialization = (
+            asset_record.asset_entry.last_materialization.timestamp
+            if asset_record and asset_record.asset_entry.last_materialization
+            else None
+        )
+        if state == FreshnessState.WARN:
+            return GrapheneAssetHealthStatus.WARNING, GrapheneAssetHealthFreshnessMeta(
+                lastMaterializedTimestamp=last_materialization,
+            )
+        if state == FreshnessState.FAIL:
+            return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthFreshnessMeta(
+                lastMaterializedTimestamp=last_materialization,
+            )
+
         return GrapheneAssetHealthStatus.UNKNOWN, None
 
     async def resolve_assetHealth(
@@ -819,13 +854,16 @@ class GrapheneAssetNode(graphene.ObjectType):
             materialization_status,
             materialization_meta,
         ) = await self.get_materialization_status_for_asset_health(graphene_info)
-        freshness_status, freshness_meta = self.get_freshness_status_for_asset_health(graphene_info)
+        freshness_status, freshness_meta = await self.get_freshness_status_for_asset_health(
+            graphene_info
+        )
         return GrapheneAssetHealth(
             assetChecksStatus=check_status,
             assetChecksStatusMetadata=check_meta,
             materializationStatus=materialization_status,
             materializationStatusMetadata=materialization_meta,
             freshnessStatus=freshness_status,
+            freshnessStatusMetadata=freshness_meta,
         )
 
     def resolve_hasMaterializePermission(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -807,7 +807,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     async def get_freshness_status_for_asset_health(
         self, graphene_info: ResolveInfo
-    ) -> tuple[str, GrapheneAssetHealthFreshnessMeta]:
+    ) -> tuple[str, Optional[GrapheneAssetHealthFreshnessMeta]]:
         """Computes the health indicator for the freshness for an asset. Follows these rules:
         HEALTHY - the freshness policy is in a PASS-ing state
         WARNING - the freshness policy is in a WARN-ing state

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -83,6 +83,13 @@ class GrapheneAssetHealthMaterializationMeta(graphene.Union):
         name = "AssetHealthMaterializationMeta"
 
 
+class GrapheneAssetHealthFreshnessMeta(graphene.ObjectType):
+    lastMaterializedTimestamp = graphene.NonNull(graphene.Float)
+
+    class Meta:
+        name = "AssetHealthFreshnessMeta"
+
+
 class GrapheneAssetHealth(graphene.ObjectType):
     assetHealth = graphene.NonNull(GrapheneAssetHealthStatus)
     materializationStatus = graphene.NonNull(GrapheneAssetHealthStatus)
@@ -90,6 +97,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     assetChecksStatus = graphene.NonNull(GrapheneAssetHealthStatus)
     assetChecksStatusMetadata = graphene.Field(GrapheneAssetHealthCheckMeta)
     freshnessStatus = graphene.NonNull(GrapheneAssetHealthStatus)
+    freshnessStatusMetadata = graphene.Field(GrapheneAssetHealthFreshnessMeta)
 
     class Meta:
         name = "AssetHealth"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -84,7 +84,7 @@ class GrapheneAssetHealthMaterializationMeta(graphene.Union):
 
 
 class GrapheneAssetHealthFreshnessMeta(graphene.ObjectType):
-    lastMaterializedTimestamp = graphene.NonNull(graphene.Float)
+    lastMaterializedTimestamp = graphene.Field(graphene.Float)
 
     class Meta:
         name = "AssetHealthFreshnessMeta"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -2829,6 +2829,17 @@
               "description": null,
               "is_dynamic": false,
               "is_required": true,
+              "metadata_entries": [
+                {
+                  "__class__": "EventMetadataEntry",
+                  "description": null,
+                  "entry_data": {
+                    "__class__": "TextMetadataEntryData",
+                    "text": "{\"__class__\": \"TimeWindowFreshnessPolicy\", \"fail_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 600}, \"warn_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 300}}"
+                  },
+                  "label": "dagster/internal_freshness_policy"
+                }
+              ],
               "name": "result"
             }
           ],
@@ -35480,7 +35491,7 @@
   'd9f6d85793df3d9df94d4aedb21bb659c1202bda'
 # ---
 # name: test_all_snapshot_ids[1]
-  '35491f28517bc6d696caaa82881cafd410837925'
+  '666e6e1cd555c8e7ea0878980de5fcd356110156'
 # ---
 # name: test_all_snapshot_ids[20]
   '''
@@ -50348,6 +50359,17 @@
               "description": null,
               "is_dynamic": false,
               "is_required": true,
+              "metadata_entries": [
+                {
+                  "__class__": "EventMetadataEntry",
+                  "description": null,
+                  "entry_data": {
+                    "__class__": "TextMetadataEntryData",
+                    "text": "{\"__class__\": \"TimeWindowFreshnessPolicy\", \"fail_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 600}, \"warn_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 300}}"
+                  },
+                  "label": "dagster/internal_freshness_policy"
+                }
+              ],
               "name": "result"
             }
           ],
@@ -50537,7 +50559,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[45]
-  '797927dc38e2e944aa962af5ee2558cd34ff7ed5'
+  '27aa1c25caf492245ba26705514d968ddfbb675b'
 # ---
 # name: test_all_snapshot_ids[46]
   '''
@@ -65053,6 +65075,17 @@
               "description": null,
               "is_dynamic": false,
               "is_required": true,
+              "metadata_entries": [
+                {
+                  "__class__": "EventMetadataEntry",
+                  "description": null,
+                  "entry_data": {
+                    "__class__": "TextMetadataEntryData",
+                    "text": "{\"__class__\": \"TimeWindowFreshnessPolicy\", \"fail_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 600}, \"warn_window\": {\"__class__\": \"SerializableTimeDelta\", \"days\": 0, \"microseconds\": 0, \"seconds\": 300}}"
+                  },
+                  "label": "dagster/internal_freshness_policy"
+                }
+              ],
               "name": "result"
             }
           ],
@@ -69737,7 +69770,7 @@
   '68f90c6bc3483e01ab1317573d90e23d0efe14a9'
 # ---
 # name: test_all_snapshot_ids[7]
-  '8023256507d183317343a2f6c4703a5ac3800eaf'
+  '9af25dcd5c69c820935d9b67163dfff2f3bd9519'
 # ---
 # name: test_all_snapshot_ids[80]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -97,7 +97,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import Failure
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.external_asset import external_asset_from_spec
-from dagster._core.definitions.freshness import TimeWindowFreshnessPolicy
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
@@ -1681,7 +1681,7 @@ def req_config_job():
 
 @asset(
     owners=["user@dagsterlabs.com", "team:team1"],
-    internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
+    internal_freshness_policy=InternalFreshnessPolicy.time_window(
         fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
     ),
 )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
+from datetime import timedelta
 from typing import Optional, TypeVar, Union
 
 from dagster import (
@@ -96,6 +97,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import Failure
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.external_asset import external_asset_from_spec
+from dagster._core.definitions.freshness import TimeWindowFreshnessPolicy
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
@@ -1695,6 +1697,15 @@ def asset_3():
 failure_assets_job = define_asset_job("failure_assets_job", [asset_1, asset_2, asset_3])
 
 
+@asset(
+    internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
+        fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+    )
+)
+def asset_with_internal_freshness_policy():
+    pass
+
+
 @asset
 def foo(context: AssetExecutionContext):
     assert context.job_def.asset_selection_data is not None
@@ -2187,6 +2198,7 @@ def define_assets():
         asset_1,
         asset_2,
         asset_3,
+        asset_with_internal_freshness_policy,
         foo,
         bar,
         foo_bar,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1679,7 +1679,12 @@ def req_config_job():
     the_op()
 
 
-@asset(owners=["user@dagsterlabs.com", "team:team1"])
+@asset(
+    owners=["user@dagsterlabs.com", "team:team1"],
+    internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
+        fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+    ),
+)
 def asset_1():
     yield Output(3)
 
@@ -1695,15 +1700,6 @@ def asset_3():
 
 
 failure_assets_job = define_asset_job("failure_assets_job", [asset_1, asset_2, asset_3])
-
-
-@asset(
-    internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
-        fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
-    )
-)
-def asset_with_internal_freshness_policy():
-    pass
 
 
 @asset
@@ -2198,7 +2194,6 @@ def define_assets():
         asset_1,
         asset_2,
         asset_3,
-        asset_with_internal_freshness_policy,
         foo,
         bar,
         foo_bar,

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any, Optional
 
 from dagster_shared.serdes.utils import SerializableTimeDelta
-from sqlalchemy import Row
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._record import IHaveNew, record
@@ -86,7 +85,7 @@ class FreshnessStateRecord:
     record_body: FreshnessStateRecordBody
 
     @staticmethod
-    def from_db_row(db_row: Row):
+    def from_db_row(db_row):
         return FreshnessStateRecord(
             entity_key=check.not_none(AssetKey.from_db_string(db_row[0])),
             freshness_state=FreshnessState(db_row[3]),

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -1,6 +1,6 @@
-import datetime
 from abc import ABC
 from collections.abc import Mapping
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Optional
 
@@ -43,7 +43,7 @@ class InternalFreshnessPolicy(ABC):
 
     @staticmethod
     def time_window(
-        fail_window: datetime.timedelta, warn_window: Optional[datetime.timedelta] = None
+        fail_window: timedelta, warn_window: Optional[timedelta] = None
     ) -> "TimeWindowFreshnessPolicy":
         return TimeWindowFreshnessPolicy.from_timedeltas(fail_window, warn_window)
 
@@ -55,9 +55,7 @@ class TimeWindowFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
     warn_window: Optional[SerializableTimeDelta] = None
 
     @classmethod
-    def from_timedeltas(
-        cls, fail_window: datetime.timedelta, warn_window: Optional[datetime.timedelta] = None
-    ):
+    def from_timedeltas(cls, fail_window: timedelta, warn_window: Optional[timedelta] = None):
         if warn_window:
             check.invariant(warn_window < fail_window, "warn_window must be less than fail_window")
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3396,6 +3396,7 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
     def get_entity_freshness_state(self, entity_key: AssetKey) -> Optional[FreshnessStateRecord]:
+        warnings.warn("`get_entity_freshness_state` is not yet implemented for OSS.")
         return None
 
     def get_asset_check_support(self) -> "AssetCheckInstanceSupport":

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -37,7 +37,7 @@ from dagster._core.definitions.asset_check_evaluation import (
 )
 from dagster._core.definitions.data_version import extract_data_provenance_from_entry
 from dagster._core.definitions.events import AssetKey, AssetObservation
-from dagster._core.definitions.freshness import FreshnessStateEvaluation
+from dagster._core.definitions.freshness import FreshnessStateEvaluation, FreshnessStateRecord
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.errors import (
     DagsterHomeNotSetError,
@@ -3394,6 +3394,9 @@ class DagsterInstance(DynamicPartitionsStore):
                 job_name=RUNLESS_JOB_NAME,
             ),
         )
+
+    def get_entity_freshness_state(self, entity_key: AssetKey) -> Optional[FreshnessStateRecord]:
+        return None
 
     def get_asset_check_support(self) -> "AssetCheckInstanceSupport":
         from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport


### PR DESCRIPTION
## Summary & Motivation
Includes the freshness status of each asset in asset health. Follows these rules:
- `HEALTHY` - the freshness policy is in a PASS-ing state
- `WARNING` - the freshness policy is in a WARN-ing state
- `DEGRADED` - the freshness policy is in a FAIL-ing state
- `UNKNOWN` - the freshness policy has never been evaluated or is in an UNKNOWN state
- `NOT_APPLICABLE` - the asset does not have a freshness policy defined.


I need to access the freshness getter function from OSS, so i added an instance method for it. This could also be solved by moving the storage methods to a shared storage class (Run or EventLog probably). I don't have a preference and picked adding the Instance method for no specific reason. Similarly, I needed to move `FreshnessRecord` and `FreshnessRecordBody` to OSS so that I could use them as type hints 

## How I Tested These Changes
tests in https://github.com/dagster-io/internal/pull/15022
