### PR TITLE
Allow dg deploy to run in a workspace or project context

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
@@ -122,7 +122,7 @@ def deploy_group(
     commit_hash: Optional[str],
     use_editable_dagster: Optional[str],
     skip_confirmation_prompt: bool,
-    location_names: list[str],
+    location_names: tuple[str],
     **global_options: object,
 ) -> None:
     """Deploy a project or workspace to Dagster Plus. Handles all state management for the deploy
@@ -183,7 +183,7 @@ def deploy_group(
 
 
 def _validate_location_names(
-    dg_context: DgContext, location_names: list[str], cli_config: DgRawCliConfig
+    dg_context: DgContext, location_names: tuple[str], cli_config: DgRawCliConfig
 ):
     if not location_names:
         return
@@ -235,7 +235,7 @@ def start_deploy_session_command(
     skip_confirmation_prompt: bool,
     git_url: Optional[str],
     commit_hash: Optional[str],
-    location_names: list[str],
+    location_names: tuple[str],
     **global_options: object,
 ) -> None:
     """Start a new deploy session. Determines which code locations will be deployed and what
@@ -294,7 +294,7 @@ def build_and_push_command(
     agent_type_str: str,
     python_version: Optional[str],
     use_editable_dagster: Optional[str],
-    location_names: list[str],
+    location_names: tuple[str],
     **global_options: object,
 ) -> None:
     """Builds a Docker image to be deployed, and pushes it to the registry
@@ -338,7 +338,7 @@ def build_and_push_command(
 @dg_global_options
 @cli_telemetry_wrapper
 def set_build_output_command(
-    image_tag: str, location_names: list[str], **global_options: object
+    image_tag: str, location_names: tuple[str], **global_options: object
 ) -> None:
     """If building a Docker image was built outside of the `dg` CLI, configures the deploy session
     to indicate the correct tag to use when the session is finished.
@@ -354,7 +354,7 @@ def set_build_output_command(
 
     set_build_output(
         statedir=str(statedir),
-        location_name=location_names,
+        location_name=list(location_names),
         image_tag=image_tag,
     )
 
@@ -369,7 +369,7 @@ def set_build_output_command(
 )
 @dg_global_options
 @cli_telemetry_wrapper
-def finish_deploy_session_command(location_names: list[str], **global_options: object) -> None:
+def finish_deploy_session_command(location_names: tuple[str], **global_options: object) -> None:
     """Once all needed images have been built and pushed, completes the deploy session, signaling
     to the Dagster+ API that the deployment can be updated to the newly built and pushed code.
     """

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
@@ -17,7 +17,7 @@ from dagster_dg.cli.shared_options import (
     dg_global_options,
     make_option_group,
 )
-from dagster_dg.config import normalize_cli_config
+from dagster_dg.config import DgRawCliConfig, normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.utils import DgClickCommand, DgClickGroup, not_none
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
@@ -102,6 +102,13 @@ org_and_deploy_option_group = make_option_group(
 )
 @click.option("--git-url", "git_url")
 @click.option("--commit-hash", "commit_hash")
+@click.option(
+    "--location-name",
+    "location_names",
+    help="Name of the code location to set the build output for. Defaults to the current project's code location, or every project's code location when run in a workspace.",
+    required=False,
+    multiple=True,
+)
 @dg_editable_dagster_options
 @dg_global_options
 @cli_telemetry_wrapper
@@ -115,6 +122,7 @@ def deploy_group(
     commit_hash: Optional[str],
     use_editable_dagster: Optional[str],
     skip_confirmation_prompt: bool,
+    location_names: list[str],
     **global_options: object,
 ) -> None:
     """Deploy a project or workspace to Dagster Plus. Handles all state management for the deploy
@@ -140,8 +148,8 @@ def deploy_group(
     organization = _get_organization(organization, plus_config)
     deployment = _get_deployment(deployment, plus_config)
 
-    # TODO This command should work in a workspace context too and apply to multiple projects
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    _validate_location_names(dg_context, location_names, cli_config)
 
     # TODO Confirm that dagster-cloud is packaged in the project
 
@@ -159,6 +167,7 @@ def deploy_group(
         skip_confirmation_prompt,
         git_url,
         commit_hash,
+        location_names,
     )
 
     build_artifact(
@@ -167,9 +176,30 @@ def deploy_group(
         statedir,
         bool(use_editable_dagster),
         python_version,
+        location_names,
     )
 
-    finish_deploy_session(dg_context, statedir)
+    finish_deploy_session(dg_context, statedir, location_names)
+
+
+def _validate_location_names(
+    dg_context: DgContext, location_names: list[str], cli_config: DgRawCliConfig
+):
+    if not location_names:
+        return
+
+    if dg_context.is_project:
+        existing_location_names = {dg_context.code_location_name}
+    else:
+        existing_location_names = {
+            dg_context.for_project_environment(project_spec.path, cli_config).code_location_name
+            for project_spec in dg_context.project_specs
+        }
+    nonexistent_location_names = set(location_names) - existing_location_names
+    if nonexistent_location_names:
+        raise click.UsageError(
+            f"The following requested locations do not exist: {', '.join(nonexistent_location_names)}"
+        )
 
 
 @deploy_group.command(name="start", cls=DgClickCommand)
@@ -189,6 +219,13 @@ def deploy_group(
 )
 @click.option("--git-url", "git_url")
 @click.option("--commit-hash", "commit_hash")
+@click.option(
+    "--location-name",
+    "location_names",
+    help="Name of the code location to set the build output for. Defaults to the current project's code location, or every project's code location when run in a workspace.",
+    required=False,
+    multiple=True,
+)
 @dg_global_options
 @cli_telemetry_wrapper
 def start_deploy_session_command(
@@ -198,6 +235,7 @@ def start_deploy_session_command(
     skip_confirmation_prompt: bool,
     git_url: Optional[str],
     commit_hash: Optional[str],
+    location_names: list[str],
     **global_options: object,
 ) -> None:
     """Start a new deploy session. Determines which code locations will be deployed and what
@@ -209,9 +247,8 @@ def start_deploy_session_command(
     organization = _get_organization(organization, plus_config)
     deployment = _get_deployment(deployment, plus_config)
 
-    # TODO This command should work in a workspace context too and apply to multiple projects
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
-
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    _validate_location_names(dg_context, location_names, cli_config)
     statedir = _get_statedir()
 
     init_deploy_session(
@@ -223,6 +260,7 @@ def start_deploy_session_command(
         skip_confirmation_prompt,
         git_url,
         commit_hash,
+        location_names,
     )
 
 
@@ -242,6 +280,13 @@ def start_deploy_session_command(
         "Python version used to deploy the project. If not set, defaults to the calling process's Python minor version."
     ),
 )
+@click.option(
+    "--location-name",
+    "location_names",
+    help="Name of the code location to set the build output for. Defaults to the current project's code location, or every project's code location when run in a workspace.",
+    required=False,
+    multiple=True,
+)
 @dg_editable_dagster_options
 @dg_global_options
 @cli_telemetry_wrapper
@@ -249,6 +294,7 @@ def build_and_push_command(
     agent_type_str: str,
     python_version: Optional[str],
     use_editable_dagster: Optional[str],
+    location_names: list[str],
     **global_options: object,
 ) -> None:
     """Builds a Docker image to be deployed, and pushes it to the registry
@@ -256,8 +302,9 @@ def build_and_push_command(
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    # TODO This command should work in a workspace context too and apply to multiple projects
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    _validate_location_names(dg_context, location_names, cli_config)
 
     # TODO derive this from graphql if it is not set
     agent_type = DgPlusAgentType(agent_type_str)
@@ -270,6 +317,7 @@ def build_and_push_command(
         statedir,
         bool(use_editable_dagster),
         python_version,
+        location_names,
     )
 
 
@@ -280,39 +328,55 @@ def build_and_push_command(
     help="Tag for the built docker image.",
     required=True,
 )
+@click.option(
+    "--location-name",
+    "location_names",
+    help="Name of the code location to set the build output for. Defaults to the current project's code location, or every project's code location when run in a workspace.",
+    required=False,
+    multiple=True,
+)
 @dg_global_options
 @cli_telemetry_wrapper
-def set_build_output_command(image_tag: str, **global_options: object) -> None:
-    from dagster_cloud_cli.commands.ci import set_build_output
-
+def set_build_output_command(
+    image_tag: str, location_names: list[str], **global_options: object
+) -> None:
     """If building a Docker image was built outside of the `dg` CLI, configures the deploy session
     to indicate the correct tag to use when the session is finished.
     """
+    from dagster_cloud_cli.commands.ci import set_build_output
+
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
     # TODO This command should work in a workspace context too and apply to multiple projects
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
     statedir = _get_statedir()
+    _validate_location_names(dg_context, location_names, cli_config)
 
     set_build_output(
         statedir=str(statedir),
-        location_name=[dg_context.code_location_name],
+        location_name=location_names,
         image_tag=image_tag,
     )
 
 
 @deploy_group.command(name="finish", cls=DgClickCommand)
+@click.option(
+    "--location-name",
+    "location_names",
+    help="Name of the code location to set the build output for. Defaults to the current project's code location, or every project's code location when run in a workspace.",
+    required=False,
+    multiple=True,
+)
 @dg_global_options
 @cli_telemetry_wrapper
-def finish_deploy_session_command(**global_options: object) -> None:
+def finish_deploy_session_command(location_names: list[str], **global_options: object) -> None:
     """Once all needed images have been built and pushed, completes the deploy session, signaling
     to the Dagster+ API that the deployment can be updated to the newly built and pushed code.
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    # TODO This command should work in a workspace context too and apply to multiple projects
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
-
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    _validate_location_names(dg_context, location_names, cli_config)
     statedir = _get_statedir()
 
-    finish_deploy_session(dg_context, statedir)
+    finish_deploy_session(dg_context, statedir, location_names)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -138,7 +138,7 @@ def init_deploy_session(
     skip_confirmation_prompt: bool,
     git_url: Optional[str],
     commit_hash: Optional[str],
-    location_names: list[str],
+    location_names: tuple[str],
 ):
     from dagster_cloud_cli.commands.ci import init_impl
 
@@ -171,7 +171,7 @@ def init_deploy_session(
         status_url=None,
         snapshot_base_condition=None,
         clean_statedir=False,
-        location_name=location_names,
+        location_name=list(location_names),
     )
 
 
@@ -181,7 +181,7 @@ def build_artifact(
     statedir: str,
     use_editable_dagster: bool,
     python_version: Optional[str],
-    location_names: list[str],
+    location_names: tuple[str],
 ):
     if not python_version:
         python_version = f"3.{sys.version_info.minor}"
@@ -224,7 +224,7 @@ def _build_artifact_for_project(
     agent_type: DgPlusAgentType,
     statedir: str,
     use_editable_dagster: bool,
-    python_version: Optional[str],
+    python_version: str,
     workspace_context: Optional[DgContext],
 ):
     from dagster_cloud_cli.commands.ci import BuildStrategy, build_impl
@@ -277,7 +277,7 @@ def _build_artifact_for_project(
         )
 
 
-def finish_deploy_session(dg_context: DgContext, statedir: str, location_names: list[str]):
+def finish_deploy_session(dg_context: DgContext, statedir: str, location_names: tuple[str]):
     from dagster_cloud_cli.commands.ci import deploy_impl
     from dagster_cloud_cli.config_utils import (
         get_agent_heartbeat_timeout,
@@ -286,7 +286,7 @@ def finish_deploy_session(dg_context: DgContext, statedir: str, location_names: 
 
     deploy_impl(
         statedir=str(statedir),
-        location_name=location_names,
+        location_name=list(location_names),
         location_load_timeout=get_location_load_timeout(),
         agent_heartbeat_timeout=get_agent_heartbeat_timeout(),
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -13,7 +13,7 @@ from dagster_shared.serdes.objects import PluginObjectKey
 
 from dagster_dg.cli.shared_options import dg_global_options
 from dagster_dg.component import RemotePluginRegistry, all_components_schema_from_dg_context
-from dagster_dg.config import normalize_cli_config
+from dagster_dg.config import DgRawBuildConfig, merge_build_configs, normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.utils import (
     DgClickCommand,
@@ -176,15 +176,19 @@ def create_temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
         yield temp_workspace_file.name
 
 
-def _dagster_cloud_entry_for_project(dg_context: DgContext) -> dict[str, Any]:
-    build_config = dg_context.build_config
+def _dagster_cloud_entry_for_project(
+    dg_context: DgContext, workspace_build_config: Optional[DgRawBuildConfig]
+) -> dict[str, Any]:
+    merged_build_config: DgRawBuildConfig = merge_build_configs(
+        workspace_build_config, dg_context.build_config
+    )
 
     return {
         "location_name": dg_context.code_location_name,
         "code_source": {
             "module_name": str(dg_context.code_location_target_module_name),
         },
-        **({"build": build_config} if build_config else {}),
+        **({"build": merged_build_config} if merged_build_config else {}),
     }
 
 
@@ -193,12 +197,16 @@ def create_temp_dagster_cloud_yaml_file(dg_context: DgContext, statedir: str) ->
     with open(dagster_cloud_yaml_path, "w+") as temp_dagster_cloud_yaml_file:
         entries = []
         if dg_context.is_project:
-            entries.append(_dagster_cloud_entry_for_project(dg_context))
+            entries.append(_dagster_cloud_entry_for_project(dg_context, {}))
         elif dg_context.is_workspace:
+            workspace_build_config = dg_context.build_config
+
             for spec in dg_context.project_specs:
                 project_root = dg_context.root_path / spec.path
                 project_context: DgContext = dg_context.with_root_path(project_root)
-                entries.append(_dagster_cloud_entry_for_project(project_context))
+                entries.append(
+                    _dagster_cloud_entry_for_project(project_context, workspace_build_config)
+                )
         yaml.dump({"locations": entries}, temp_dagster_cloud_yaml_file)
         temp_dagster_cloud_yaml_file.flush()
         return temp_dagster_cloud_yaml_file.name

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -197,7 +197,7 @@ def create_temp_dagster_cloud_yaml_file(dg_context: DgContext, statedir: str) ->
     with open(dagster_cloud_yaml_path, "w+") as temp_dagster_cloud_yaml_file:
         entries = []
         if dg_context.is_project:
-            entries.append(_dagster_cloud_entry_for_project(dg_context, {}))
+            entries.append(_dagster_cloud_entry_for_project(dg_context, None))
         elif dg_context.is_workspace:
             workspace_build_config = dg_context.build_config
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -22,7 +22,9 @@ import click
 import tomlkit
 import tomlkit.items
 from click.core import ParameterSource
+from dagster_shared.merger import deep_merge_dicts
 from dagster_shared.plus.config import load_config
+from dagster_shared.utils import remove_none_recursively
 from dagster_shared.utils.config import get_dg_config_path
 from typing_extensions import Never, NotRequired, Required, Self, TypeAlias, TypeGuard
 
@@ -262,6 +264,19 @@ class DgRawProjectPythonEnvironment(TypedDict, total=False):
 class DgRawBuildConfig(TypedDict):
     registry: Optional[str]
     directory: Optional[str]
+
+
+def merge_build_configs(
+    workspace_build_config: Optional[DgRawBuildConfig],
+    project_build_config: Optional[DgRawBuildConfig],
+) -> DgRawBuildConfig:
+    project_dict = remove_none_recursively(project_build_config or {})
+    workspace_dict = remove_none_recursively(workspace_build_config or {})
+
+    return cast(
+        "DgRawBuildConfig",
+        deep_merge_dicts(workspace_dict, project_dict),
+    )
 
 
 @dataclass

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -348,7 +348,15 @@ class DgContext:
             return None
 
         with open(build_yaml_path) as f:
-            return yaml.safe_load(f)
+            build_config_dict = yaml.safe_load(f)
+            build_directory = build_config_dict.get("directory")
+            if build_directory:
+                build_directory_path = Path(build_directory)
+                if not build_directory_path.is_absolute():
+                    build_directory_path = (build_yaml_path.parent / build_directory_path).resolve()
+                build_config_dict["directory"] = str(build_directory_path.resolve())
+
+            return build_config_dict
 
     @cached_property
     def defs_module_name(self) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -258,7 +258,7 @@ def isolated_example_project_foo_bar(
                 components_dir = Path.cwd() / "src" / "foo_bar" / "defs" / component_name
                 components_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(src_dir, components_dir, dirs_exist_ok=True)
-            yield project_path
+            yield Path.cwd()
 
 
 @contextmanager


### PR DESCRIPTION
Summary:
- each command can now be run in either a workspace or project context. if you run in a workspace context you can pass in a list of location names to filter it down to specific projects.
- workspace-level defaults for the build.yaml file
