### PR TITLE
Enable removing networkConfiguration from AWS ECS Run Task API call

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/executor.py
@@ -277,6 +277,13 @@ class EcsStepHandler(StepHandler):
             run_task_kwargs.get("overrides", {}), task_overrides
         )
 
+        # Remove networkConfiguration if it is set to None
+        if (
+            "networkConfiguration" in run_task_kwargs
+            and run_task_kwargs.get("networkConfiguration") is None
+        ):
+            del run_task_kwargs["networkConfiguration"]
+
         return run_task_kwargs
 
     def _get_task_overrides(self, step_tags: Mapping[str, str]) -> dict[str, Any]:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/executor_tests/test_executor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/executor_tests/test_executor.py
@@ -114,6 +114,7 @@ def test_executor_init(instance_cm: Callable[..., ContextManager[DagsterInstance
                         }
                     ],
                 },
+                "run_task_kwargs": {"networkConfiguration": None},
             },
         )
 
@@ -153,6 +154,8 @@ def test_executor_init(instance_cm: Callable[..., ContextManager[DagsterInstance
             )
 
             assert run_task_kwargs["launchType"] == "FARGATE"  # this comes from the Run Launcher
+
+            assert "networkConfiguration" not in run_task_kwargs
 
             overrides = run_task_kwargs["overrides"]
 


### PR DESCRIPTION
## Summary & Motivation

The summary and motivation here are the same as for https://github.com/dagster-io/dagster/pull/26893. All credit for the fix to @markgrin and the other contributors there, I have only ported the same fix to the ECS executor as well.

## How I Tested These Changes

I have included a minimal change to the existing test suite that failed before the code change and passes afterwards.

## Changelog

- [dagster-aws] Fixed an issue handling null `networkConfiguration` parameters for the ECS executor

