### PR TITLE
[dg] make temp workspace creation work on Windows

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -150,7 +150,7 @@ MIN_ENV_VAR_INJECTION_VERSION = "1.10.8"
 
 @contextmanager
 def create_temp_workspace_file(dg_context: DgContext) -> Iterator[str]:
-    with NamedTemporaryFile(mode="w+", delete=True) as temp_workspace_file:
+    with NamedTemporaryFile(mode="w+", delete=True, delete_on_close=False) as temp_workspace_file:
         entries = []
         if dg_context.is_project:
             entries.append(_workspace_entry_for_project(dg_context))


### PR DESCRIPTION
## Summary & Motivation

Currently, "dg dev" fails on Windows, due to a Permission Denied error when attempting to open a temporary workspace. This PR fixes this.

On Windows, the NamedTemporaryFile function requires that delete_on_close=False if delete=True, otherwise a Permission denied error will occur.

This addresses issue #28681
