### PR TITLE
Don't use the root logger in get_local_branch_name

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/git.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/git.py
@@ -15,5 +15,5 @@ def get_local_branch_name(project_dir: str) -> Optional[str]:
             .strip()
         )
     except subprocess.SubprocessError:
-        logging.debug("Failed to determine git branch", exc_info=True)
+        logging.getLogger("dg").debug("Failed to determine git branch", exc_info=True)
         return None


### PR DESCRIPTION
## Summary & Motivation
Probably a longer-term fix we should make here, but in the short-term, calling logging.debug instead of a particular causes it to lazily initialize the root logger and change the default log level for every logger(!)

## How I Tested These Changes
dg plus deploy start no longer emits surprising INFO logs
