### PR TITLE
[components] fix AssetPostProcessor

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -172,10 +172,15 @@ class AssetPostProcessorModel(Resolvable, Model):
 
 
 def apply_post_processor_to_spec(
-    model: AssetPostProcessorModel, spec: AssetSpec, context: ResolutionContext
+    model,
+    spec: AssetSpec,
+    context: ResolutionContext,
 ) -> AssetSpec:
-    attributes = (
-        context.with_scope(asset=spec).at_path("attributes").resolve_value(model.attributes)
+    check.inst(model, AssetPostProcessorModel.model())
+
+    attributes = resolve_asset_attributes_to_mapping(
+        context.with_scope(asset=spec).at_path("attributes"),
+        model.attributes,
     )
     if model.operation == "merge":
         mergeable_attributes = {"metadata", "tags"}
@@ -189,16 +194,24 @@ def apply_post_processor_to_spec(
 
 
 def apply_post_processor_to_defs(
-    model: AssetPostProcessorModel, defs: Definitions, context: ResolutionContext
+    model,
+    defs: Definitions,
+    context: ResolutionContext,
 ) -> Definitions:
+    check.inst(model, AssetPostProcessorModel.model())
+
     return defs.map_asset_specs(
-        selection=model.target, func=lambda spec: apply_post_processor_to_spec(model, spec, context)
+        selection=model.target,
+        func=lambda spec: apply_post_processor_to_spec(model, spec, context),
     )
 
 
 def resolve_schema_to_post_processor(
-    context, model: AssetPostProcessorModel
+    context: ResolutionContext,
+    model,
 ) -> Callable[[Definitions], Definitions]:
+    check.inst(model, AssetPostProcessorModel.model())
+
     return lambda defs: apply_post_processor_to_defs(model, defs, context)
 
 
@@ -206,6 +219,6 @@ AssetPostProcessor: TypeAlias = Annotated[
     PostProcessorFn,
     Resolver(
         resolve_schema_to_post_processor,
-        model_field_type=AssetPostProcessorModel,
+        model_field_type=AssetPostProcessorModel.model(),
     ),
 ]

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -5,6 +5,7 @@ import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components import Component, Model, Resolvable, ResolvedAssetSpec
+from dagster.components.resolved.core_models import AssetPostProcessor
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Resolver
 from pydantic import BaseModel, ConfigDict, Field
@@ -226,3 +227,19 @@ def test_nested_not_resolvable():
 
     with pytest.raises(ResolutionException, match="Resolvable subclass"):
         Parent.resolve_from_yaml("")
+
+
+def test_post_process():
+    @dataclass
+    class Test(Resolvable):
+        post_process: AssetPostProcessor
+
+    with pytest.raises(Exception, match="junk_extra_input"):
+        Test.resolve_from_yaml(
+            """
+post_process:
+  target: '*'
+  attributes:
+    junk_extra_input: hi
+    """
+        )

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_spec_processing.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_spec_processing.py
@@ -24,7 +24,7 @@ defs = Definitions(
 
 
 def test_replace_attributes() -> None:
-    op = AssetPostProcessorModel(
+    op = AssetPostProcessorModel.model()(
         operation="replace",
         target="group:g2",
         attributes={"tags": {"newtag": "newval"}},
@@ -38,7 +38,7 @@ def test_replace_attributes() -> None:
 
 
 def test_merge_attributes() -> None:
-    op = AssetPostProcessorModel(
+    op = AssetPostProcessorModel.model()(
         operation="merge",
         target="group:g2",
         attributes={"tags": {"newtag": "newval"}},
@@ -52,7 +52,7 @@ def test_merge_attributes() -> None:
 
 
 def test_render_attributes_asset_context() -> None:
-    op = AssetPostProcessorModel(
+    op = AssetPostProcessorModel.model()(
         attributes={"tags": {"group_name_tag": "group__{{ asset.group_name }}"}}
     )
 
@@ -64,7 +64,7 @@ def test_render_attributes_asset_context() -> None:
 
 
 def test_render_attributes_custom_context() -> None:
-    op = AssetPostProcessorModel(
+    op = AssetPostProcessorModel.model()(
         operation="replace",
         target="group:g2",
         attributes={
@@ -103,11 +103,11 @@ def test_render_attributes_custom_context() -> None:
         # default to merge and a * target
         (
             {"attributes": {"tags": {"a": "b"}}},
-            AssetPostProcessorModel(target="*", attributes={"tags": {"a": "b"}}),
+            AssetPostProcessorModel.model()(target="*", attributes={"tags": {"a": "b"}}),
         ),
         (
             {"operation": "replace", "attributes": {"tags": {"a": "b"}}},
-            AssetPostProcessorModel(
+            AssetPostProcessorModel.model()(
                 operation="replace",
                 target="*",
                 attributes={"tags": {"a": "b"}},
@@ -116,14 +116,14 @@ def test_render_attributes_custom_context() -> None:
         # explicit target
         (
             {"attributes": {"tags": {"a": "b"}}, "target": "group:g2"},
-            AssetPostProcessorModel(
+            AssetPostProcessorModel.model()(
                 target="group:g2",
                 attributes={"tags": {"a": "b"}},
             ),
         ),
         (
             {"operation": "replace", "attributes": {"tags": {"a": "b"}}, "target": "group:g2"},
-            AssetPostProcessorModel(
+            AssetPostProcessorModel.model()(
                 operation="replace",
                 target="group:g2",
                 attributes={"tags": {"a": "b"}},
@@ -132,6 +132,6 @@ def test_render_attributes_custom_context() -> None:
     ],
 )
 def test_load_attributes(python, expected) -> None:
-    loaded = TypeAdapter(Sequence[AssetPostProcessorModel]).validate_python([python])
+    loaded = TypeAdapter(Sequence[AssetPostProcessorModel.model()]).validate_python([python])
     assert len(loaded) == 1
     assert loaded[0] == expected


### PR DESCRIPTION
we set `model_field_type` to the underlying model instead of the `Resolvable` derived one which has the actual strict validation for asset attributes

## How I Tested These Changes

added test that was previously failing