### PR TITLE
[components] bring back field docs for core models

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -77,22 +77,83 @@ ResolvedAssetKey = Annotated[
     Resolver(
         _resolve_asset_key,
         model_field_type=str,
+        description="A unique identifier for the asset.",
     ),
 ]
 
 
 @record
 class SharedAssetKwargs(Resolvable):
-    deps: Optional[Sequence[ResolvedAssetKey]] = None
-    description: Optional[str] = None
-    metadata: Injectable[Mapping[str, Any]] = {}
-    group_name: Optional[str] = None
-    skippable: Optional[bool] = None
-    code_version: Optional[str] = None
-    owners: Optional[Sequence[str]] = None
-    tags: Injectable[Mapping[str, str]] = {}
-    kinds: Sequence[str] = []
-    automation_condition: Optional[Injected[AutomationCondition]] = None
+    deps: Annotated[
+        Optional[Sequence[ResolvedAssetKey]],
+        Resolver.default(
+            description="The asset keys for the upstream assets that this asset depends on.",
+            examples=[["my_database/my_schema/upstream_table"]],
+        ),
+    ] = None
+    description: Annotated[
+        Optional[str],
+        Resolver.default(
+            description="Human-readable description of the asset.",
+            examples=["Refined sales data"],
+        ),
+    ] = None
+    metadata: Annotated[
+        Mapping[str, Any],
+        Resolver.default(
+            can_inject=True,
+            description="Additional metadata for the asset.",
+        ),
+    ] = {}
+    group_name: Annotated[
+        Optional[str],
+        Resolver.default(
+            description="Used to organize assets into groups, defaults to 'default'.",
+            examples=["staging"],
+        ),
+    ] = None
+    skippable: Annotated[
+        Optional[bool],
+        Resolver.default(
+            description="Whether this asset can be omitted during materialization, causing downstream dependencies to skip.",
+        ),
+    ] = None
+    code_version: Annotated[
+        Optional[str],
+        Resolver.default(
+            description="A version representing the code that produced the asset. Increment this value when the code changes.",
+            examples=["3"],
+        ),
+    ] = None
+    owners: Annotated[
+        Optional[Sequence[str]],
+        Resolver.default(
+            description="A list of strings representing owners of the asset. Each string can be a user's email address, or a team name prefixed with `team:`, e.g. `team:finops`.",
+            examples=[["team:analytics", "nelson@hooli.com"]],
+        ),
+    ] = None
+    tags: Annotated[
+        Mapping[str, str],
+        Resolver.default(
+            can_inject=True,
+            description="Tags for filtering and organizing.",
+            examples=[{"tier": "prod", "team": "analytics"}],
+        ),
+    ] = {}
+    kinds: Annotated[
+        Sequence[str],
+        Resolver.default(
+            description="A list of strings representing the kinds of the asset. These will be made visible in the Dagster UI.",
+            examples=[["snowflake"]],
+        ),
+    ] = []
+    automation_condition: Annotated[
+        Optional[AutomationCondition],
+        Resolver.default(
+            model_field_type=Optional[str],
+            description="The condition under which the asset will be automatically materialized.",
+        ),
+    ] = None
 
 
 @record

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -5,7 +5,7 @@ import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components import Component, Model, Resolvable, ResolvedAssetSpec
-from dagster.components.resolved.core_models import AssetPostProcessor
+from dagster.components.resolved.core_models import AssetPostProcessor, AssetSpecKwargs
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Resolver
 from pydantic import BaseModel, ConfigDict, Field
@@ -243,3 +243,9 @@ post_process:
     junk_extra_input: hi
     """
         )
+
+
+def test_desc():
+    asset_model = AssetSpecKwargs.model()
+    for field_name, field_info in asset_model.model_fields.items():
+        assert field_info.description, f"{field_name} must have description"


### PR DESCRIPTION
These got dropped in the Resolved v2 changes. 
Bring them back by adding arguments to `Resolver` to use on non-pydantic `Resolvable` classes.

## How I Tested These Changes

## Changelog

[components] descriptions and examples have been restored for core models such as `ResolvedAssetSpec`. `description` and `examples` arguments have been added to `Resolver` for documenting fields on non-pydantic model based `Resolvable` classes.
