### PR TITLE
Use docs team for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically request docs team for docs PR review
-/docs/              @neverett
+/docs/              @dagster-io/docs


### PR DESCRIPTION
## Summary & Motivation

Use @dagster-io/docs instead of @neverett for CODEOWNERS. This way, we can add/remove people from the docs team as needed.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
