### PR TITLE
Move pipes external metadata processing to its own layer.

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
@@ -15,7 +15,7 @@ export type AssetGraphSidebarQuery = {
         id: string;
         pipelineSnapshotId: string;
         parentSnapshotId: string | null;
-        externalJobSource: Types.ExternalJobSource | null;
+        externalJobSource: string | null;
         name: string;
         description: string | null;
         metadataEntries: Array<

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1220,7 +1220,7 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   parentSnapshotId: String
   graphName: String!
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!
@@ -1232,10 +1232,6 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
     selectedAssetKeys: [AssetKeyInput!]
   ): PartitionKeys!
   partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
-}
-
-enum ExternalJobSource {
-  AIRFLOW
 }
 
 type PartitionKeys {
@@ -1528,7 +1524,7 @@ type PipelineSnapshot implements SolidContainer & IPipelineSnapshot & PipelineRe
   graphName: String!
   solidSelection: [String!]
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
 }
 
 union PipelineSnapshotOrError =
@@ -1594,7 +1590,7 @@ type Run implements PipelineRun & RunsFeedEntry {
   allPools: [String!]
   hasUnconstrainedRootNodes: Boolean!
   hasRunMetricsEnabled: Boolean!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
 }
 
 interface RunsFeedEntry {
@@ -2328,7 +2324,7 @@ type Job implements SolidContainer & IPipelineSnapshot {
   parentSnapshotId: String
   graphName: String!
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1735,10 +1735,6 @@ export type ExpectationResult = DisplayableEvent & {
   success: Scalars['Boolean']['output'];
 };
 
-export enum ExternalJobSource {
-  AIRFLOW = 'AIRFLOW',
-}
-
 export type FailedToMaterializeEvent = DisplayableEvent &
   MessageEvent &
   StepEvent & {
@@ -2257,7 +2253,7 @@ export type Job = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     isAssetJob: Scalars['Boolean']['output'];
@@ -3627,7 +3623,7 @@ export type Pipeline = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     isAssetJob: Scalars['Boolean']['output'];
@@ -3869,7 +3865,7 @@ export type PipelineSnapshot = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     metadataEntries: Array<
@@ -4752,7 +4748,7 @@ export type Run = PipelineRun &
     endTime: Maybe<Scalars['Float']['output']>;
     eventConnection: EventConnection;
     executionPlan: Maybe<ExecutionPlan>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     hasConcurrencyKeySlots: Scalars['Boolean']['output'];
     hasDeletePermission: Scalars['Boolean']['output'];
     hasReExecutePermission: Scalars['Boolean']['output'];
@@ -9881,7 +9877,7 @@ export const buildJob = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'suscipit',
     graphName:
       overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'eveniet',
     id:
@@ -12196,7 +12192,7 @@ export const buildPipeline = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'quis',
     graphName: overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'eius',
     id:
       overrides && overrides.hasOwnProperty('id')
@@ -12629,7 +12625,7 @@ export const buildPipelineSnapshot = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'ut',
     graphName:
       overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'dolorum',
     id:
@@ -13866,7 +13862,7 @@ export const buildRun = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'similique',
     hasConcurrencyKeySlots:
       overrides && overrides.hasOwnProperty('hasConcurrencyKeySlots')
         ? overrides.hasConcurrencyKeySlots!

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import {LeftNavItemType} from './LeftNavItemType';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {ExternalJobSource} from '../graphql/types';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -85,7 +84,7 @@ export const getJobItemsForOption = (option: DagsterRepoOption) => {
     const sensorsForJob = sensors.filter((sensor) =>
       sensor.targets?.map((target) => target.pipelineName).includes(name),
     );
-    const isAirflowJob = externalJobSource === ExternalJobSource.AIRFLOW;
+    const isAirflowJob = externalJobSource === 'airflow';
 
     items.push({
       name,

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
@@ -4533,7 +4533,7 @@ export type GraphExplorerFragment_PipelineSnapshot = {
   description: string | null;
   pipelineSnapshotId: string;
   parentSnapshotId: string | null;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   metadataEntries: Array<
     | {
         __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
@@ -20,7 +20,7 @@ export type PipelineExplorerRootQuery = {
         description: string | null;
         pipelineSnapshotId: string;
         parentSnapshotId: string | null;
-        externalJobSource: Types.ExternalJobSource | null;
+        externalJobSource: string | null;
         metadataEntries: Array<
           | {
               __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
@@ -4530,7 +4530,7 @@ export type SidebarRootContainerFragment_PipelineSnapshot = {
   __typename: 'PipelineSnapshot';
   pipelineSnapshotId: string;
   parentSnapshotId: string | null;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   id: string;
   name: string;
   description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
@@ -1,4 +1,4 @@
-import {ExternalJobSource, RunStatus} from '../graphql/types';
+import {RunStatus} from '../graphql/types';
 import {RepoAddress} from '../workspace/types';
 
 export type RunAutomation =
@@ -11,7 +11,7 @@ export type TimelineRun = {
   startTime: number;
   endTime: number;
   automation: null | RunAutomation;
-  externalJobSource: null | ExternalJobSource;
+  externalJobSource: null | string;
 };
 
 export type RowObjectType = 'job' | 'asset' | 'schedule' | 'sensor' | 'legacy-amp' | 'manual';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -6,7 +6,7 @@ export type RunTimelineFragment = {
   __typename: 'Run';
   id: string;
   pipelineName: string;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   status: Types.RunStatus;
   creationTime: number;
   startTime: number | null;
@@ -38,7 +38,7 @@ export type OngoingRunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          externalJobSource: Types.ExternalJobSource | null;
+          externalJobSource: string | null;
           status: Types.RunStatus;
           creationTime: number;
           startTime: number | null;
@@ -72,7 +72,7 @@ export type CompletedRunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          externalJobSource: Types.ExternalJobSource | null;
+          externalJobSource: string | null;
           status: Types.RunStatus;
           creationTime: number;
           startTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
@@ -60,7 +60,7 @@ export type LocationWorkspaceQuery = {
                   name: string;
                   isJob: boolean;
                   isAssetJob: boolean;
-                  externalJobSource: Types.ExternalJobSource | null;
+                  externalJobSource: string | null;
                   pipelineSnapshotId: string;
                 }>;
                 schedules: Array<{
@@ -224,7 +224,7 @@ export type WorkspaceLocationNodeFragment = {
             name: string;
             isJob: boolean;
             isAssetJob: boolean;
-            externalJobSource: Types.ExternalJobSource | null;
+            externalJobSource: string | null;
             pipelineSnapshotId: string;
           }>;
           schedules: Array<{
@@ -368,7 +368,7 @@ export type WorkspaceLocationFragment = {
       name: string;
       isJob: boolean;
       isAssetJob: boolean;
-      externalJobSource: Types.ExternalJobSource | null;
+      externalJobSource: string | null;
       pipelineSnapshotId: string;
     }>;
     schedules: Array<{
@@ -492,7 +492,7 @@ export type WorkspaceRepositoryFragment = {
     name: string;
     isJob: boolean;
     isAssetJob: boolean;
-    externalJobSource: Types.ExternalJobSource | null;
+    externalJobSource: string | null;
     pipelineSnapshotId: string;
   }>;
   schedules: Array<{
@@ -611,7 +611,7 @@ export type WorkspacePipelineFragment = {
   name: string;
   isJob: boolean;
   isAssetJob: boolean;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   pipelineSnapshotId: string;
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,4 +1,3 @@
-import enum
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, AbstractSet, Optional  # noqa: UP035
 
@@ -420,13 +419,6 @@ class GrapheneEventConnectionOrError(graphene.Union):
         name = "EventConnectionOrError"
 
 
-class ExternalJobSource(enum.Enum):
-    AIRFLOW = "AIRFLOW"
-
-
-GrapheneExternalJobSource = graphene.Enum.from_enum(ExternalJobSource)
-
-
 class GraphenePipelineRun(graphene.Interface):
     id = graphene.NonNull(graphene.ID)
     runId = graphene.NonNull(graphene.String)
@@ -517,7 +509,7 @@ class GrapheneRun(graphene.ObjectType):
     allPools = graphene.List(graphene.NonNull(graphene.String))
     hasUnconstrainedRootNodes = graphene.NonNull(graphene.Boolean)
     hasRunMetricsEnabled = graphene.NonNull(graphene.Boolean)
-    externalJobSource = GrapheneExternalJobSource()
+    externalJobSource = graphene.String()
 
     class Meta:
         interfaces = (GraphenePipelineRun, GrapheneRunsFeedEntry)
@@ -653,12 +645,13 @@ class GrapheneRun(graphene.ObjectType):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self.dagster_run.tags.items()
+            if get_tag_type(key) != TagType.HIDDEN
         ]
 
     def resolve_externalJobSource(self, _graphene_info: ResolveInfo):
         source_str = self.dagster_run.tags.get(EXTERNAL_JOB_SOURCE_TAG_KEY)
         if source_str:
-            return ExternalJobSource(source_str.upper())
+            return source_str.lower()
         return None
 
     def resolve_rootRunId(self, _graphene_info: ResolveInfo):
@@ -819,7 +812,7 @@ class GrapheneIPipelineSnapshotMixin:
     sensors = non_null_list(GrapheneSensor)
     parent_snapshot_id = graphene.String()
     graph_name = graphene.NonNull(graphene.String)
-    externalJobSource = GrapheneExternalJobSource()
+    externalJobSource = graphene.String()
 
     class Meta:
         name = "IPipelineSnapshotMixin"
@@ -925,7 +918,7 @@ class GrapheneIPipelineSnapshotMixin:
         represented_pipeline = self.get_represented_job()
         source_str = represented_pipeline.job_snapshot.tags.get(EXTERNAL_JOB_SOURCE_TAG_KEY)
         if source_str:
-            return ExternalJobSource(source_str.upper())
+            return source_str.lower()
         return None
 
     def resolve_run_tags(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -855,7 +855,7 @@ class Definitions(IHaveNew):
         ]
         sensors = []
         for sensor in self.sensors or []:
-            if sensor.has_jobs and any(job.name == job_name for job in sensor.jobs):
+            if has_job_defs_attached(sensor) and any(job.name == job_name for job in sensor.jobs):
                 sensors.append(
                     sensor.with_updated_jobs(
                         [job for job in sensor.jobs if job.name != job_name] + [job_def]
@@ -893,3 +893,7 @@ def get_job_from_defs(
         iter(job for job in (defs.jobs or []) if job.name == name),
         None,
     )
+
+
+def has_job_defs_attached(sensor_def: SensorDefinition) -> bool:
+    return any(target.has_job_def for target in sensor_def.targets)

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -15,6 +15,13 @@ from typing_extensions import TypeAlias, TypeVar
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated, deprecated_param
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.metadata.external_metadata import (
+    EXTERNAL_METADATA_TYPE_INFER as EXTERNAL_METADATA_TYPE_INFER,
+    ExternalMetadataType as ExternalMetadataType,
+    ExternalMetadataValue as ExternalMetadataValue,
+    metadata_map_from_external as metadata_map_from_external,
+    metadata_value_from_external as metadata_value_from_external,
+)
 from dagster._core.definitions.metadata.metadata_set import (
     NamespacedMetadataSet as NamespacedMetadataSet,
     TableMetadataSet as TableMetadataSet,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/external_metadata.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/external_metadata.py
@@ -1,0 +1,140 @@
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+
+import dagster._check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.metadata.table import (
+    TableColumn as TableColumn,
+    TableColumnConstraints as TableColumnConstraints,
+    TableColumnDep as TableColumnDep,
+    TableColumnLineage as TableColumnLineage,
+    TableConstraints as TableConstraints,
+    TableRecord as TableRecord,
+    TableSchema as TableSchema,
+)
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.metadata import MetadataValue
+
+InferrableExternalMetadataValue = Union[
+    int, float, str, Mapping[str, Any], Sequence[Any], bool, None
+]
+
+
+class ExternalMetadataValue(TypedDict):
+    type: "ExternalMetadataType"
+    raw_value: InferrableExternalMetadataValue
+
+
+# Infer the type from the raw value on the orchestration end
+EXTERNAL_METADATA_TYPE_INFER = "__infer__"
+
+ExternalMetadataType = Literal[
+    "__infer__",
+    "text",
+    "url",
+    "path",
+    "notebook",
+    "json",
+    "md",
+    "float",
+    "int",
+    "bool",
+    "dagster_run",
+    "asset",
+    "null",
+    "table",
+    "table_schema",
+    "table_column_lineage",
+    "timestamp",
+]
+
+
+def metadata_map_from_external(
+    metadata: Mapping[str, ExternalMetadataValue],
+) -> Mapping[str, "MetadataValue"]:
+    return {k: metadata_value_from_external(v["raw_value"], v["type"]) for k, v in metadata.items()}
+
+
+def metadata_value_from_external(
+    value: Any, metadata_type: ExternalMetadataType
+) -> "MetadataValue":
+    from dagster._core.definitions.metadata import MetadataValue, normalize_metadata_value
+
+    if metadata_type == EXTERNAL_METADATA_TYPE_INFER:
+        return normalize_metadata_value(value)
+    elif metadata_type == "text":
+        return MetadataValue.text(value)
+    elif metadata_type == "url":
+        return MetadataValue.url(value)
+    elif metadata_type == "path":
+        return MetadataValue.path(value)
+    elif metadata_type == "notebook":
+        return MetadataValue.notebook(value)
+    elif metadata_type == "json":
+        return MetadataValue.json(value)
+    elif metadata_type == "md":
+        return MetadataValue.md(value)
+    elif metadata_type == "float":
+        return MetadataValue.float(value)
+    elif metadata_type == "int":
+        return MetadataValue.int(value)
+    elif metadata_type == "bool":
+        return MetadataValue.bool(value)
+    elif metadata_type == "dagster_run":
+        return MetadataValue.dagster_run(value)
+    elif metadata_type == "asset":
+        return MetadataValue.asset(AssetKey.from_user_string(value))
+    elif metadata_type == "table":
+        value = check.mapping_param(value, "table_value", key_type=str)
+        return MetadataValue.table(
+            records=[TableRecord(record) for record in value["records"]],
+            schema=TableSchema(
+                columns=[
+                    TableColumn(
+                        name=column["name"],
+                        type=column["type"],
+                        description=column.get("description"),
+                        tags=column.get("tags"),
+                        constraints=TableColumnConstraints(**column["constraints"])
+                        if column.get("constraints")
+                        else None,
+                    )
+                    for column in value["schema"]
+                ]
+            ),
+        )
+    elif metadata_type == "table_schema":
+        value = check.mapping_param(value, "table_schema_value", key_type=str)
+        return MetadataValue.table_schema(
+            schema=TableSchema(
+                columns=[
+                    TableColumn(
+                        name=column["name"],
+                        type=column["type"],
+                        description=column.get("description"),
+                        tags=column.get("tags"),
+                        constraints=TableColumnConstraints(**column["constraints"])
+                        if column.get("constraints")
+                        else None,
+                    )
+                    for column in value["columns"]
+                ]
+            )
+        )
+    elif metadata_type == "table_column_lineage":
+        value = check.mapping_param(value, "table_column_value", key_type=str)
+        return MetadataValue.column_lineage(
+            lineage=TableColumnLineage(
+                deps_by_column={
+                    column: [TableColumnDep(**dep) for dep in deps]
+                    for column, deps in value["deps_by_column"].items()
+                }
+            )
+        )
+    elif metadata_type == "timestamp":
+        return MetadataValue.timestamp(float(check.numeric_param(value, "timestamp")))
+    elif metadata_type == "null":
+        return MetadataValue.null()
+    else:
+        check.failed(f"Unexpected metadata type {metadata_type}")

--- a/python_modules/dagster/dagster/_core/definitions/metadata/external_metadata.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/external_metadata.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union, get_args
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
@@ -48,6 +48,8 @@ ExternalMetadataType = Literal[
     "table_column_lineage",
     "timestamp",
 ]
+EXTERNAL_METADATA_VALUE_KEYS = frozenset(ExternalMetadataValue.__annotations__.keys())
+EXTERNAL_METADATA_TYPES = frozenset(get_args(ExternalMetadataType))
 
 
 def metadata_map_from_external(

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -44,7 +44,6 @@ from dagster._core.execution.resources_init import (
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._loggers import default_loggers, default_system_loggers
@@ -55,10 +54,16 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.outputs import StepOutputHandle
     from dagster._core.executor.base import Executor
 
+    # Import within functions so that we can mock the class in tests using freeze_time.
+    # Essentially, we want to be able to control the timestamp of the log records.
+    from dagster._core.log_manager import DagsterLogManager
+
 
 def initialize_console_manager(
     dagster_run: Optional[DagsterRun], instance: Optional[DagsterInstance] = None
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
+    from dagster._core.log_manager import DagsterLogManager
+
     # initialize default colored console logger
     loggers = []
     for logger_def, logger_config in default_system_loggers(instance):
@@ -458,7 +463,9 @@ def scoped_job_context(
 
 def create_log_manager(
     context_creation_data: ContextCreationData,
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(context_creation_data, "context_creation_data", ContextCreationData)
 
     job_def, resolved_run_config, dagster_run = (
@@ -506,7 +513,7 @@ def create_log_manager(
 
 def create_context_free_log_manager(
     instance: DagsterInstance, dagster_run: DagsterRun
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
     """In the event of pipeline initialization failure, we want to be able to log the failure
     without a dependency on the PlanExecutionContext to initialize DagsterLogManager.
 
@@ -514,6 +521,8 @@ def create_context_free_log_manager(
         dagster_run (PipelineRun)
         pipeline_def (JobDefinition)
     """
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(dagster_run, "dagster_run", DagsterRun)
 

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -26,7 +26,6 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.executor.base import Executor
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._loggers import default_system_loggers
 from dagster._utils import ensure_single_item
@@ -80,6 +79,8 @@ def host_mode_execution_context_event_generator(
     output_capture: None,
     resume_from_failure: bool = False,
 ) -> Iterator[Union[PlanOrchestrationContext, DagsterEvent]]:
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
     check.inst_param(pipeline, "pipeline", ReconstructableJob)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -7,6 +7,7 @@ import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from enum import Enum
 from tempfile import TemporaryDirectory
 from types import TracebackType
@@ -85,7 +86,7 @@ from dagster._core.storage.tags import (
 from dagster._core.types.pagination import PaginatedResults
 from dagster._serdes import ConfigurableClass
 from dagster._streamline.asset_check_health import AssetCheckHealthState
-from dagster._time import get_current_datetime, get_current_timestamp
+from dagster._time import datetime_from_timestamp, get_current_datetime, get_current_timestamp
 from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
@@ -1925,8 +1926,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.add_snapshot(snapshot)
 
     @traced
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._run_storage.handle_run_event(run_id, event)
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._run_storage.handle_run_event(run_id, event, update_timestamp)
 
     @traced
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
@@ -2668,7 +2671,9 @@ class DagsterInstance(DynamicPartitionsStore):
                 and event.is_dagster_event
                 and event.get_dagster_event().is_job_event
             ):
-                self._run_storage.handle_run_event(run_id, event.get_dagster_event())
+                self._run_storage.handle_run_event(
+                    run_id, event.get_dagster_event(), datetime_from_timestamp(event.timestamp)
+                )
                 run = self.get_run_by_id(run_id)
                 if run and event.get_dagster_event().is_run_failure and self.run_retries_enabled:
                     # Note that this tag is only applied to runs that fail. Successful runs will not
@@ -2749,6 +2754,7 @@ class DagsterInstance(DynamicPartitionsStore):
         run_id: str,
         log_level: Union[str, int] = logging.INFO,
         batch_metadata: Optional["DagsterEventBatchMetadata"] = None,
+        timestamp: Optional[float] = None,
     ) -> None:
         """Takes a DagsterEvent and stores it in persistent storage for the corresponding DagsterRun."""
         from dagster._core.events.log import EventLogEntry
@@ -2759,7 +2765,7 @@ class DagsterInstance(DynamicPartitionsStore):
             job_name=dagster_event.job_name,
             run_id=run_id,
             error_info=None,
-            timestamp=get_current_timestamp(),
+            timestamp=timestamp or get_current_timestamp(),
             step_key=dagster_event.step_key,
             dagster_event=dagster_event,
         )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Union  # noqa: UP035
 
 from dagster import _check as check
@@ -198,8 +199,15 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def add_run(self, dagster_run: "DagsterRun") -> "DagsterRun":
         return self._storage.run_storage.add_run(dagster_run)
 
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._storage.run_storage.handle_run_event(run_id, event)
+    def add_historical_run(
+        self, dagster_run: "DagsterRun", run_creation_time: datetime
+    ) -> "DagsterRun":
+        return self._storage.run_storage.add_historical_run(dagster_run, run_creation_time)
+
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._storage.run_storage.handle_run_event(run_id, event, update_timestamp)
 
     def get_runs(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Union
 
 from typing_extensions import TypedDict
@@ -55,7 +56,15 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def handle_run_event(self, run_id: str, event: DagsterEvent) -> None:
+    def add_historical_run(
+        self, dagster_run: DagsterRun, run_creation_time: datetime
+    ) -> DagsterRun:
+        """Add a historical run to storage."""
+
+    @abstractmethod
+    def handle_run_event(
+        self, run_id: str, event: DagsterEvent, update_timestamp: Optional[datetime] = None
+    ) -> None:
         """Update run storage in accordance to a pipeline run related DagsterEvent.
 
         Args:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -55,6 +55,9 @@ class TestSqliteRunStorage(TestRunStorage):
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
@@ -83,6 +86,9 @@ class TestInMemoryRunStorage(TestRunStorage):
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         with DagsterInstance.ephemeral() as the_instance:
@@ -109,6 +115,9 @@ class TestLegacyRunStorage(TestRunStorage):
         return True
 
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
     @pytest.fixture(name="instance", scope="function")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -121,7 +121,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
     MULTIDIMENSIONAL_PARTITION_PREFIX,
 )
-from dagster._core.test_utils import create_run_for_test, instance_for_test
+from dagster._core.test_utils import create_run_for_test, freeze_time, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._loggers import colored_console_logger
@@ -3097,6 +3097,44 @@ class TestEventLogStorage:
                 )
 
             assert failed_partitions_by_step_key == failed_partitions
+
+    def test_timestamp_overrides(self, storage, instance: DagsterInstance) -> None:
+        frozen_time = get_current_datetime()
+        frozen_time = get_current_datetime()
+        with freeze_time(frozen_time):
+            instance.report_dagster_event(
+                run_id="",
+                dagster_event=DagsterEvent(
+                    event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,
+                    job_name="",
+                    event_specific_data=StepMaterializationData(
+                        AssetMaterialization(asset_key="foo")
+                    ),
+                ),
+            )
+
+            record = instance.get_asset_records([AssetKey("foo")])[0]
+            assert (
+                record.asset_entry.last_materialization_record.timestamp == frozen_time.timestamp()  # type: ignore
+            )
+
+            report_date = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+
+            instance.report_dagster_event(
+                run_id="",
+                dagster_event=DagsterEvent(
+                    event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,
+                    job_name="",
+                    event_specific_data=StepMaterializationData(
+                        AssetMaterialization(asset_key="foo")
+                    ),
+                ),
+                timestamp=report_date.timestamp(),
+            )
+            record = instance.get_asset_records([AssetKey("foo")])[0]
+            assert (
+                record.asset_entry.last_materialization_record.timestamp == report_date.timestamp()  # type: ignore
+            )
 
     def test_get_latest_storage_ids_by_partition(self, storage, instance):
         a = AssetKey(["a"])

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -1,0 +1,99 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal, Optional, Union
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components import Component, ComponentLoadContext, Resolvable
+from dagster.components.component_scaffolding import scaffold_component
+from dagster.components.resolved.context import ResolutionContext
+from dagster.components.resolved.core_models import AssetPostProcessor
+from dagster.components.resolved.model import Resolver
+from dagster.components.scaffold.scaffold import Scaffolder, ScaffoldRequest, scaffold_with
+from pydantic import BaseModel
+from typing_extensions import TypeAlias
+
+import dagster_airlift.core as dg_airlift_core
+from dagster_airlift.core.airflow_instance import AirflowAuthBackend
+from dagster_airlift.core.basic_auth import AirflowBasicAuthBackend
+from dagster_airlift.core.load_defs import build_job_based_airflow_defs
+
+
+@dataclass
+class AirflowBasicAuthBackendModel(Resolvable):
+    type: Literal["basic_auth"]
+    webserver_url: str
+    username: str
+    password: str
+
+
+@dataclass
+class AirflowMwaaAuthBackendModel(Resolvable):
+    type: Literal["mwaa"]
+
+
+class AirflowInstanceScaffolderParams(BaseModel):
+    name: str
+    auth_type: Literal["basic_auth", "mwaa"]
+
+
+class AirflowInstanceScaffolder(Scaffolder):
+    @classmethod
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+        return AirflowInstanceScaffolderParams
+
+    def scaffold(self, request: ScaffoldRequest, params: AirflowInstanceScaffolderParams) -> None:
+        full_params: dict[str, Any] = {
+            "name": params.name,
+        }
+        if params.auth_type == "basic_auth":
+            full_params["auth"] = {
+                "type": "basic_auth",
+                "webserver_url": '{{ env("AIRFLOW_WEBSERVER_URL") }}',
+                "username": '{{ env("AIRFLOW_USERNAME") }}',
+                "password": '{{ env("AIRFLOW_PASSWORD") }}',
+            }
+        else:
+            raise ValueError(f"Unsupported auth type: {params.auth_type}")
+        scaffold_component(request, full_params)
+
+
+def resolve_auth(context: ResolutionContext, model) -> AirflowAuthBackend:
+    if model.auth.type == "basic_auth":
+        return AirflowBasicAuthBackend(
+            webserver_url=model.auth.webserver_url,
+            username=model.auth.username,
+            password=model.auth.password,
+        )
+    else:
+        raise ValueError(f"Unsupported auth type: {model.auth.type}")
+
+
+ResolvedAirflowAuthBackend: TypeAlias = Annotated[
+    AirflowAuthBackend,
+    Resolver.from_model(
+        resolve_auth,
+        model_field_type=Union[AirflowBasicAuthBackendModel, AirflowMwaaAuthBackendModel],
+    ),
+]
+
+
+@scaffold_with(AirflowInstanceScaffolder)
+@dataclass
+class AirflowInstanceComponent(Component, Resolvable):
+    auth: ResolvedAirflowAuthBackend
+    name: str
+    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
+
+    def _get_instance(self) -> dg_airlift_core.AirflowInstance:
+        return dg_airlift_core.AirflowInstance(
+            auth_backend=self.auth,
+            name=self.name,
+        )
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        defs = build_job_based_airflow_defs(
+            airflow_instance=self._get_instance(),
+        )
+        for post_processor in self.asset_post_processors or []:
+            defs = post_processor(defs)
+        return defs

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
@@ -1,34 +1,59 @@
-from typing import Union
+import datetime
+from typing import Optional, Union
 
-from dagster import RunRequest
+from dagster import RunRequest, sensor
 from dagster._annotations import beta
+from dagster._config.pythonic_config.config import Config
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.op_decorator import op
-from dagster._core.definitions.decorators.schedule_decorator import schedule
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.run_request import SkipReason
-from dagster._core.definitions.schedule_definition import (
-    DefaultScheduleStatus,
-    ScheduleEvaluationContext,
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    SensorDefinition,
+    SensorEvaluationContext,
 )
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
-from dagster._core.storage.dagster_run import RunsFilter
+from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster._grpc.client import DEFAULT_SENSOR_GRPC_TIMEOUT
-from dagster._time import datetime_from_timestamp, get_current_datetime
+from dagster._record import record
+from dagster._serdes import deserialize_value, serialize_value
+from dagster._time import get_current_datetime
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.monitoring_job.event_stream import persist_events
-from dagster_airlift.core.monitoring_job.utils import (
-    augment_monitor_run_with_range_tags,
-    get_range_from_run_history,
-    structured_log,
-)
+from dagster_airlift.core.monitoring_job.utils import structured_log
 from dagster_airlift.core.utils import monitoring_job_name
+from dagster_shared.serdes import whitelist_for_serdes
+from pydantic import Field
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 30
 START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
+
+
+@whitelist_for_serdes
+@record
+class AirflowMonitoringJobSensorCursor:
+    range_start: str
+    range_end: str
+
+    def to_config(self) -> "MonitoringConfig":
+        return MonitoringConfig(range_start=self.range_start, range_end=self.range_end)
+
+    def to_tags(self) -> dict[str, str]:
+        return {
+            "range_start": self.range_start,
+            "range_end": self.range_end,
+        }
+
+    def advance(self, effective_timestamp: datetime.datetime) -> "AirflowMonitoringJobSensorCursor":
+        return AirflowMonitoringJobSensorCursor(
+            range_start=self.range_end, range_end=effective_timestamp.isoformat()
+        )
 
 
 # IMPROVEME BCOR-102: We should be able to replace the sensor from the original Airlift functionality with this job.
@@ -38,39 +63,84 @@ def build_airflow_monitoring_defs(
     airflow_instance: AirflowInstance,
 ) -> Definitions:
     """The constructed job polls the Airflow instance for activity, and inserts asset events into Dagster's event log."""
-
-    @job(name=monitoring_job_name(airflow_instance.name))
-    def airflow_monitoring_job():
-        _build_monitoring_op(airflow_instance)()
-
-    @schedule(
-        job=airflow_monitoring_job,
-        cron_schedule="* * * * *",
-        name=f"{airflow_instance.name}__airflow_monitoring_job_schedule",
-        default_status=DefaultScheduleStatus.RUNNING,
-    )
-    def airflow_monitoring_job_schedule(
-        context: ScheduleEvaluationContext,
-    ) -> Union[RunRequest, SkipReason]:
-        """The schedule that runs the sensor job."""
-        # Get the last run for this job
-        last_run = next(
-            iter(
-                context.instance.get_runs(
-                    filters=RunsFilter(job_name=airflow_monitoring_job.name),
-                    limit=1,
-                )
-            ),
-            None,
-        )
-        if not last_run or last_run.is_finished:
-            return RunRequest()
-        else:
-            return SkipReason("Monitoring job is already running.")
-
     return Definitions(
-        jobs=[airflow_monitoring_job],
-        schedules=[airflow_monitoring_job_schedule],
+        jobs=[build_monitoring_job(airflow_instance=airflow_instance)],
+        sensors=[build_monitoring_sensor(airflow_instance=airflow_instance)],
+    )
+
+
+class MonitoringConfig(Config):
+    range_start: str = Field(
+        description="The start of the range to process. Should be an ISO 8601 formatted string."
+    )
+    range_end: str = Field(
+        description="The end of the range to process. Should be an ISO 8601 formatted string."
+    )
+
+    @property
+    def range_start_datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.range_start)
+
+    @property
+    def range_end_datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.range_end)
+
+
+def build_monitoring_sensor(
+    *,
+    airflow_instance: AirflowInstance,
+) -> SensorDefinition:
+    @sensor(
+        job_name=monitoring_job_name(airflow_instance.name),
+        name=f"{airflow_instance.name}__airflow_monitoring_job_sensor",
+        default_status=DefaultSensorStatus.RUNNING,
+    )
+    def airflow_monitoring_job_sensor(
+        context: SensorEvaluationContext,
+    ) -> Union[RunRequest, SkipReason]:
+        effective_timestamp = get_current_datetime()
+        if context.cursor is None:
+            cursor = AirflowMonitoringJobSensorCursor(
+                range_start=(get_current_datetime() - datetime.timedelta(seconds=30)).isoformat(),
+                range_end=effective_timestamp.isoformat(),
+            )
+        else:
+            cursor = deserialize_value(context.cursor, AirflowMonitoringJobSensorCursor)
+
+        run = _get_run_for_cursor(context, airflow_instance, cursor)
+        if run and not run.is_finished:
+            return SkipReason(
+                f"Monitoring job is still running for range {cursor.range_start} to {cursor.range_end}. Waiting to advance."
+            )
+        # We only advance the cursor if the run has finished.
+        cursor = cursor if not run else cursor.advance(effective_timestamp)
+        context.update_cursor(serialize_value(cursor))
+
+        return RunRequest(
+            run_config=RunConfig(
+                ops={monitoring_job_op_name(airflow_instance): cursor.to_config()},
+            ),
+            tags=cursor.to_tags(),
+        )
+
+    return airflow_monitoring_job_sensor
+
+
+def _get_run_for_cursor(
+    context: SensorEvaluationContext,
+    airflow_instance: AirflowInstance,
+    cursor: AirflowMonitoringJobSensorCursor,
+) -> Optional[DagsterRun]:
+    return next(
+        iter(
+            context.instance.get_runs(
+                filters=RunsFilter(
+                    job_name=monitoring_job_name(airflow_instance.name), tags=cursor.to_tags()
+                ),
+                limit=1,
+            )
+        ),
+        None,
     )
 
 
@@ -80,7 +150,7 @@ def _build_monitoring_op(
     @op(
         name=monitoring_job_op_name(airflow_instance),
     )
-    def monitor_dags(context: OpExecutionContext) -> None:
+    def monitor_dags(context: OpExecutionContext, config: MonitoringConfig) -> None:
         """The main function that runs the sensor. It polls the Airflow instance for activity and emits asset events."""
         # This is a hack to get the repository tag for the current run. It's bad because it assumes that the job we're
         # creating a run for is within the same repository; but I think that we'll have to do a second pass to get "outside of code
@@ -88,19 +158,32 @@ def _build_monitoring_op(
         airflow_data = AirflowDefinitionsData(
             airflow_instance=airflow_instance, resolved_repository=context.repository_def
         )
-        # get previously processed time range from run tags
-        current_date = get_current_datetime()
-        range_start, range_end = get_range_from_run_history(context, current_date.timestamp())
-        augment_monitor_run_with_range_tags(context, range_start, range_end)
 
         structured_log(
             context,
-            f"Processing from {datetime_from_timestamp(range_start)} to {datetime_from_timestamp(range_end)}",
+            f"Processing from {config.range_start} to {config.range_end}",
         )
-        persist_events(context, airflow_data, airflow_instance, range_start, range_end)
+        persist_events(
+            context,
+            airflow_data,
+            airflow_instance,
+            config.range_start_datetime.timestamp(),
+            config.range_end_datetime.timestamp(),
+        )
 
     return monitor_dags
 
 
 def monitoring_job_op_name(airflow_instance: AirflowInstance) -> str:
     return f"core_monitor__{airflow_instance.name}"
+
+
+def build_monitoring_job(
+    *,
+    airflow_instance: AirflowInstance,
+) -> JobDefinition:
+    @job(name=monitoring_job_name(airflow_instance.name))
+    def airflow_monitoring_job():
+        _build_monitoring_op(airflow_instance)()
+
+    return airflow_monitoring_job

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
@@ -1,9 +1,11 @@
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from itertools import chain
 from typing import Optional, Union
 
 from dagster import AssetMaterialization
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.events import (
     AssetMaterializationPlannedData,
     DagsterEvent,
@@ -26,6 +28,7 @@ from dagster_airlift.constants import (
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.monitoring_job.utils import (
+    extract_metadata_from_logs,
     get_dagster_run_for_airflow_repr,
     structured_log,
 )
@@ -71,8 +74,8 @@ class DagRunStarted(AirflowEvent):
         if not relevant_job_def:
             return
         dagster_run_id = make_new_run_id()
-        context.instance.add_run(
-            DagsterRun(
+        context.instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
                 run_id=dagster_run_id,
                 job_name=relevant_job_def.name,
                 tags={
@@ -92,7 +95,8 @@ class DagRunStarted(AirflowEvent):
                 )
                 if context.run.remote_job_origin
                 else None,
-            )
+            ),
+            run_creation_time=self.dag_run.start_date,
         )
 
         context.instance.report_dagster_event(
@@ -101,6 +105,7 @@ class DagRunStarted(AirflowEvent):
                 event_type_value="PIPELINE_START",
                 job_name=relevant_job_def.name,
             ),
+            timestamp=self.dag_run.start_date.timestamp(),
         )
 
         planned_asset_keys = {
@@ -122,12 +127,14 @@ class DagRunStarted(AirflowEvent):
                     ),
                     step_key=NO_STEP_KEY,
                 ),
+                timestamp=self.dag_run.start_date.timestamp(),
             )
 
 
 @record
 class TaskInstanceCompleted(AirflowEvent):
     task_instance: TaskInstance
+    metadata: dict[str, MetadataValue]
 
     @property
     def timestamp(self) -> float:
@@ -143,7 +150,10 @@ class TaskInstanceCompleted(AirflowEvent):
         for asset in airflow_data.mapped_asset_keys_by_task_handle[self.task_instance.task_handle]:
             # IMPROVEME: Add metadata to the materialization event.
             _report_materialization(
-                context, corresponding_run, AssetMaterialization(asset_key=asset)
+                context=context,
+                corresponding_run=corresponding_run,
+                materialization=AssetMaterialization(asset_key=asset, metadata=self.metadata),
+                airflow_event=self.task_instance,
             )
 
 
@@ -164,7 +174,10 @@ class DagRunCompleted(AirflowEvent):
         corresponding_run = get_dagster_run_for_airflow_repr(context, self.dag_run)
         for asset in airflow_data.all_asset_keys_by_dag_handle[self.dag_run.dag_handle]:
             _report_materialization(
-                context, corresponding_run, AssetMaterialization(asset_key=asset)
+                context=context,
+                corresponding_run=corresponding_run,
+                materialization=AssetMaterialization(asset_key=asset),
+                airflow_event=self.dag_run,
             )
 
         if not corresponding_run:
@@ -194,7 +207,9 @@ class DagRunCompleted(AirflowEvent):
                     error=None, failure_reason=None, first_step_failure_event=None
                 ),
             )
-        context.instance.report_dagster_event(run_id=dagster_run_id, dagster_event=event)
+        context.instance.report_dagster_event(
+            run_id=dagster_run_id, dagster_event=event, timestamp=self.dag_run.end_date.timestamp()
+        )
 
 
 def _process_started_runs(
@@ -260,6 +275,44 @@ def _process_completed_runs(
             break
 
 
+async def _retrieve_logs_for_task_instance(
+    context: OpExecutionContext,
+    airflow_instance: AirflowInstance,
+    task_instance: TaskInstance,
+) -> TaskInstanceCompleted:
+    logs = await asyncio.to_thread(
+        airflow_instance.get_task_instance_logs,
+        task_instance.dag_id,
+        task_instance.task_id,
+        task_instance.run_id,
+        task_instance.try_number,
+    )
+    try:
+        metadata = extract_metadata_from_logs(context, logs)
+    except Exception as e:
+        context.log.warning(
+            f"An unexpected error occurred while extracting metadata from logs: {e}. Skipping metadata extraction for task instance {task_instance.task_id}."
+        )
+        metadata = {}
+
+    return TaskInstanceCompleted(task_instance=task_instance, metadata=metadata)
+
+
+async def _async_process_task_instances(
+    context: OpExecutionContext,
+    airflow_instance: AirflowInstance,
+    task_instances: list[TaskInstance],
+) -> list[TaskInstanceCompleted]:
+    results = await asyncio.gather(
+        *(
+            _retrieve_logs_for_task_instance(context, airflow_instance, task_instance)
+            for task_instance in task_instances
+        )
+    )
+
+    return results
+
+
 def _process_task_instances(
     context: OpExecutionContext,
     airflow_data: AirflowDefinitionsData,
@@ -281,9 +334,7 @@ def _process_task_instances(
         context,
         f"Found {len(task_instances)} completed task instances in the time range {datetime_from_timestamp(range_start)} to {datetime_from_timestamp(range_end)}",
     )
-    yield from (
-        TaskInstanceCompleted(task_instance=task_instance) for task_instance in task_instances
-    )
+    yield from asyncio.run(_async_process_task_instances(context, airflow_instance, task_instances))
 
 
 def persist_events(
@@ -309,9 +360,11 @@ def persist_events(
 
 
 def _report_materialization(
+    *,
     context: OpExecutionContext,
     corresponding_run: Optional[DagsterRun],
     materialization: AssetMaterialization,
+    airflow_event: Union[TaskInstance, DagRun],
 ) -> None:
     if corresponding_run:
         context.instance.report_dagster_event(
@@ -321,8 +374,10 @@ def _report_materialization(
                 job_name=corresponding_run.job_name,
                 event_specific_data=StepMaterializationData(materialization=materialization),
             ),
+            timestamp=airflow_event.end_date.timestamp(),
         )
     else:
+        # Could also support timestamp override here; but would only benefit jobless Airlift.
         context.instance.report_runless_asset_event(
             asset_event=AssetMaterialization(
                 asset_key=materialization.asset_key,

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
@@ -1,44 +1,20 @@
-from typing import Optional, Union
+import json
+from collections.abc import Iterable
+from typing import Optional, TypeVar, Union, cast
 
+import dagster._check as check
+from dagster._core.definitions.metadata.external_metadata import (
+    EXTERNAL_METADATA_TYPE_INFER,
+    EXTERNAL_METADATA_TYPES,
+    EXTERNAL_METADATA_VALUE_KEYS,
+    ExternalMetadataValue,
+    metadata_map_from_external,
+)
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
+from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY
 from dagster_airlift.core.runtime_representations import DagRun, TaskInstance
-
-START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
-
-
-def get_range_from_run_history(
-    context: OpExecutionContext, effective_ts: float
-) -> tuple[float, float]:
-    prev_run = next(
-        iter(
-            context.instance.get_runs(
-                filters=RunsFilter(job_name=context.job_name, statuses=[DagsterRunStatus.SUCCESS]),
-                limit=1,
-            )
-        ),
-        None,
-    )
-    if prev_run:
-        # Start from the end of the last run
-        range_start = float(prev_run.tags_for_storage()["dagster-airlift/monitoring_job_range_end"])
-    else:
-        range_start = effective_ts - START_LOOKBACK_SECONDS
-    range_end = effective_ts
-    return range_start, range_end
-
-
-def augment_monitor_run_with_range_tags(
-    context: OpExecutionContext, range_start: float, range_end: float
-) -> None:
-    context.instance.add_run_tags(
-        run_id=context.run_id,
-        new_tags={
-            "dagster-airlift/monitoring_job_range_start": str(range_start),
-            "dagster-airlift/monitoring_job_range_end": str(range_end),
-        },
-    )
 
 
 def structured_log(context: OpExecutionContext, message: str) -> None:
@@ -61,3 +37,54 @@ def get_dagster_run_for_airflow_repr(
         ),
         None,
     )
+
+
+_T = TypeVar("_T")
+
+
+def _assert_param_value(value: _T, expected_values: Iterable[_T]) -> _T:
+    if value not in expected_values:
+        raise Exception(
+            f"Invalid value when translating metadata from logs. Expected one of"
+            f" `{expected_values}`, got `{value}`."
+        )
+    return value
+
+
+def extract_metadata_from_logs(context: OpExecutionContext, logs: str) -> dict[str, MetadataValue]:
+    metadata = {}
+    import re
+
+    matches = re.findall(r"DAGSTER_START(.*?)DAGSTER_END", logs, re.DOTALL)
+    for match in matches:
+        try:
+            raw_external_metadata_map = json.loads(match)
+        except json.JSONDecodeError as e:
+            raise Exception(f"Invalid JSON found in logs for match: {match}. JSON error: {e}")
+        check.mapping_param(raw_external_metadata_map, "raw_external_metadata_map")
+        new_external_metadata_map = {}
+        for key, value in raw_external_metadata_map.items():
+            if not isinstance(key, str):
+                raise Exception(
+                    f"Invalid type when translating metadata from logs. Expected a dict with string"
+                    f" keys, got a key `{key}` of type `{type(key)}`."
+                )
+            elif isinstance(value, dict):
+                if not {*value.keys()} == EXTERNAL_METADATA_VALUE_KEYS:
+                    raise Exception(
+                        f"Invalid type when translating metadata from logs. Expected a dict with"
+                        " string keys and values that are either raw metadata values or dictionaries"
+                        f" with schema `{{raw_value: ..., type: ...}}`. Got a value `{value}`."
+                    )
+                _assert_param_value(value["type"], EXTERNAL_METADATA_TYPES)
+                new_external_metadata_map[key] = cast("ExternalMetadataValue", value)
+            else:
+                new_external_metadata_map[key] = {
+                    "raw_value": value,
+                    "type": EXTERNAL_METADATA_TYPE_INFER,
+                }
+
+        metadata_map = metadata_map_from_external(new_external_metadata_map)
+        metadata.update(metadata_map)
+
+    return metadata

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/runtime_representations.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/runtime_representations.py
@@ -131,3 +131,7 @@ class TaskInstance:
         from dagster_airlift.core.serialization.serialized_data import DagHandle
 
         return DagHandle(dag_id=self.dag_id)
+
+    @property
+    def try_number(self) -> int:
+        return self.metadata["try_number"]

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Optional, Union
 
@@ -73,6 +73,7 @@ def create_defs_and_instance(
     dag_level_asset_overrides: Optional[dict[str, list[str]]] = None,
     seeded_runs: Optional[list[DagRun]] = None,
     seeded_task_instances: Optional[list[TaskInstance]] = None,
+    seeded_logs: Optional[Mapping[str, Mapping[str, str]]] = None,
 ) -> tuple[Definitions, AirflowInstance]:
     assets = []
     dag_and_task_structure = defaultdict(list)
@@ -132,6 +133,7 @@ def create_defs_and_instance(
         dag_runs=runs,
         dataset_construction_info=dataset_construction_info or [],
         task_instances=seeded_task_instances,
+        logs=seeded_logs,
     )
     defs = Definitions.merge(
         additional_defs,

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+
+import dagster_airlift.core as dg_airlift_core
+import pytest
+import yaml
+from click.testing import CliRunner
+from dagster._core.test_utils import ensure_dagster_tests_import
+from dagster.components.cli import cli
+from dagster_airlift.core.components.airflow_instance.component import AirflowInstanceComponent
+from dagster_airlift.test import make_instance
+from dagster_airlift.test.test_utils import asset_spec
+
+ensure_dagster_tests_import()
+from dagster_tests.components_tests.utils import (
+    build_component_defs_for_test,
+    temp_code_location_bar,
+)
+
+
+@pytest.fixture
+def component_for_test():
+    airflow_instance = make_instance(
+        {"dag_1": ["dag_1_task_1", "dag_1_task_2"], "dag_2": ["dag_2_task_1", "dag_2_task_2"]},
+        dataset_construction_info=[
+            {
+                "uri": "s3://dataset-bucket/example1.csv",
+                "producing_tasks": [
+                    {"dag_id": "dag_1", "task_id": "dag_1_task_1"},
+                ],
+                "consuming_dags": ["dag_2"],
+            },
+            {
+                "uri": "s3://dataset-bucket/example2.csv",
+                "producing_tasks": [
+                    {"dag_id": "dag_2", "task_id": "dag_2_task_1"},
+                ],
+                "consuming_dags": [],
+            },
+        ],
+    )
+
+    class DebugAirflowInstanceComponent(AirflowInstanceComponent):
+        def _get_instance(self) -> dg_airlift_core.AirflowInstance:
+            return airflow_instance
+
+    return DebugAirflowInstanceComponent
+
+
+def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> None:
+    defs = build_component_defs_for_test(
+        component_for_test,
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "asset_post_processors": [
+                {
+                    "target": "*",
+                    "attributes": {
+                        "metadata": {
+                            "foo": "bar",
+                        },
+                    },
+                }
+            ],
+        },
+    )
+
+    for asset_key in ["example1", "example2"]:
+        keyed_spec = asset_spec(asset_key, defs)
+        assert keyed_spec is not None
+        assert keyed_spec.metadata["foo"] == "bar"
+
+    assert defs.jobs
+    assert len(defs.jobs) == 3  # type: ignore # monitoring job + 2 dag jobs.
+
+
+def _scaffold_airlift(scaffold_format: str):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "scaffold",
+            "object",
+            "dagster_airlift.core.components.airflow_instance.component.AirflowInstanceComponent",
+            "bar/components/qux",
+            "--json-params",
+            json.dumps({"name": "qux", "auth_type": "basic_auth"}),
+            "--scaffold-format",
+            scaffold_format,
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_scaffold_airlift_yaml():
+    with temp_code_location_bar():
+        _scaffold_airlift("yaml")
+        assert Path("bar/components/qux/component.yaml").exists()
+        with open("bar/components/qux/component.yaml") as f:
+            assert yaml.safe_load(f) == {
+                "type": "dagster_airlift.core.components.airflow_instance.component.AirflowInstanceComponent",
+                "attributes": {
+                    "name": "qux",
+                    "auth": {
+                        "type": "basic_auth",
+                        "webserver_url": '{{ env("AIRFLOW_WEBSERVER_URL") }}',
+                        "username": '{{ env("AIRFLOW_USERNAME") }}',
+                        "password": '{{ env("AIRFLOW_PASSWORD") }}',
+                    },
+                },
+            }
+
+
+def test_scaffold_airlift_python():
+    with temp_code_location_bar():
+        _scaffold_airlift("python")
+        assert Path("bar/components/qux/component.py").exists()
+        with open("bar/components/qux/component.py") as f:
+            file_contents = f.read()
+            assert file_contents == (
+                """from dagster.components import component, ComponentLoadContext
+from dagster_airlift.core.components.airflow_instance.component import AirflowInstanceComponent
+
+@component
+def load(context: ComponentLoadContext) -> AirflowInstanceComponent: ...
+"""
+            )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
@@ -1,8 +1,14 @@
+import json
 from datetime import datetime, timedelta, timezone
 
 import dagster._check as check
+import pytest
 from dagster import AssetKey, DagsterInstance
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.run_config import RunConfig
+from dagster._core.definitions.run_request import RunRequest, SkipReason
+from dagster._core.definitions.sensor_definition import build_sensor_context
+from dagster._core.events import DagsterEvent
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG
 from dagster._core.test_utils import freeze_time
@@ -13,7 +19,11 @@ from dagster_airlift.core.load_defs import (
     build_defs_from_airflow_instance,
     build_job_based_airflow_defs,
 )
-from dagster_airlift.core.monitoring_job.builder import build_airflow_monitoring_defs
+from dagster_airlift.core.monitoring_job.builder import (
+    MonitoringConfig,
+    build_airflow_monitoring_defs,
+    monitoring_job_op_name,
+)
 from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
 from dagster_airlift.core.utils import monitoring_job_name
 from dagster_airlift.test import make_dag_run, make_task_instance
@@ -33,10 +43,15 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
     """Test that monitoring job correctly represents state in Dagster."""
     freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
+    raw_metadata = {
+        "foo": "bar",
+        "my_timestamp": {"raw_value": 111, "type": "timestamp"},
+    }
     with freeze_time(freeze_datetime):
         defs, af_instance = create_defs_and_instance(
             assets_per_task={
                 "dag": {"task": [("a", [])]},
+                "dag2": {"task": [("b", [])]},
             },
             create_runs=False,
             create_assets_defs=False,
@@ -67,6 +82,167 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     end_date=freeze_datetime,
                     state="failed",
                 ),
+                # Newly finished run that started after the last iteration, and therefore has no corresponding run on the instance.
+                make_dag_run(
+                    dag_id="dag2",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
+                    state="success",
+                ),
+            ],
+            seeded_task_instances=[
+                # Have a newly completed task instance for the newly started run.
+                make_task_instance(
+                    dag_id="dag",
+                    task_id="task",
+                    run_id="run-dag",
+                    start_date=freeze_datetime - timedelta(seconds=30),
+                    end_date=freeze_datetime,
+                ),
+                # Have a newly completed task instance for the late run.
+                make_task_instance(
+                    dag_id="dag2",
+                    task_id="task",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
+                ),
+            ],
+            seeded_logs={
+                "run-dag": {"task": f"DAGSTER_START{json.dumps(raw_metadata)}DAGSTER_END"}
+            },
+        )
+        defs = build_job_based_airflow_defs(
+            airflow_instance=af_instance,
+            mapped_defs=defs,
+        )
+        success_dagster_run_id = make_new_run_id()
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
+                job_name=job_name("dag"),
+                run_id=success_dagster_run_id,
+                tags={
+                    DAG_RUN_ID_TAG_KEY: "success-run",
+                    DAG_ID_TAG_KEY: "dag",
+                },
+                status=DagsterRunStatus.STARTED,
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
+        )
+        failure_dagster_run_id = make_new_run_id()
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
+                job_name=job_name("dag"),
+                run_id=failure_dagster_run_id,
+                tags={
+                    DAG_RUN_ID_TAG_KEY: "failure-run",
+                    DAG_ID_TAG_KEY: "dag",
+                },
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
+        )
+        result = defs.execute_job_in_process(
+            job_name=monitoring_job_name(af_instance.name),
+            instance=instance,
+            tags={REPOSITORY_LABEL_TAG: "placeholder"},
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(freeze_datetime - timedelta(seconds=30)).isoformat(),
+                        range_end=freeze_datetime.isoformat(),
+                    )
+                }
+            ),
+        )
+        assert result.success
+
+        # Expect that the success and failure runs are marked as finished.
+        success_record = check.not_none(instance.get_run_record_by_id(success_dagster_run_id))
+        assert success_record.dagster_run.status == DagsterRunStatus.SUCCESS
+        assert success_record.end_time == (freeze_datetime).timestamp()
+
+        failure_record = check.not_none(instance.get_run_record_by_id(failure_dagster_run_id))
+        assert failure_record.dagster_run.status == DagsterRunStatus.FAILURE
+        assert failure_record.end_time == (freeze_datetime).timestamp()
+
+        # Expect that we created a new run for the newly running run.
+        newly_started_run_record = next(
+            iter(instance.get_run_records(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
+        )
+        assert newly_started_run_record.dagster_run.status == DagsterRunStatus.STARTED
+        assert (
+            newly_started_run_record.start_time
+            == (freeze_datetime - timedelta(seconds=30)).timestamp()
+        )
+
+        late_run = next(
+            iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "late-run"})))
+        )
+        assert late_run.status == DagsterRunStatus.SUCCESS
+        run_record = check.not_none(instance.get_run_record_by_id(late_run.run_id))
+        assert (
+            run_record.create_timestamp.timestamp()
+            == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        )
+        assert run_record.start_time == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        assert run_record.end_time == (freeze_datetime - timedelta(seconds=10)).timestamp()
+
+        # There should be planned materialization data for the task.
+        planned_info = instance.get_latest_planned_materialization_info(AssetKey("a"))
+        assert planned_info
+        assert planned_info.run_id == newly_started_run_record.dagster_run.run_id
+        # Expect that we emitted asset materialization events for the task.
+        mapped_asset_mat = instance.get_latest_materialization_event(AssetKey("a"))
+        assert mapped_asset_mat is not None
+        assert mapped_asset_mat.run_id == newly_started_run_record.dagster_run.run_id
+
+
+def get_invalid_json_log_content() -> str:
+    raw_metadata = {
+        "foo": "bar",
+        "my_timestamp": {"raw_value": 111, "type": "timestamp"},
+    }
+    return f"DAGSTER_START{json.dumps(raw_metadata)}ijkDAGSTER_END"  # add ijk randomly at the endto make it invalid json
+
+
+def get_invalid_type_log_content() -> str:
+    raw_metadata = {
+        "foo": "bar",
+        "my_timestamp": {"raw_value": 111, "type": "not_a_type"},
+    }
+    return f"DAGSTER_START{json.dumps(raw_metadata)}DAGSTER_END"
+
+
+@pytest.mark.parametrize(
+    "log_content",
+    [
+        get_invalid_json_log_content(),
+        get_invalid_type_log_content(),
+    ],
+)
+def test_monitoring_job_log_extraction_errors(
+    init_load_context: None, instance: DagsterInstance, log_content: str
+) -> None:
+    """Test that monitoring job correctly handles log extraction errors."""
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+
+    with freeze_time(freeze_datetime):
+        defs, af_instance = create_defs_and_instance(
+            assets_per_task={
+                "dag": {"task": [("a", [])]},
+            },
+            create_runs=False,
+            create_assets_defs=False,
+            seeded_runs=[
+                # Have a newly started run.
+                make_dag_run(
+                    dag_id="dag",
+                    run_id="run-dag",
+                    start_date=freeze_datetime - timedelta(seconds=30),
+                    end_date=None,
+                    state="running",
+                ),
             ],
             seeded_task_instances=[
                 # Have a newly completed task instance for the newly started run.
@@ -78,66 +254,37 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     end_date=freeze_datetime,
                 ),
             ],
+            seeded_logs={"run-dag": {"task": log_content}},
         )
         defs = build_job_based_airflow_defs(
             airflow_instance=af_instance,
             mapped_defs=defs,
         )
-        success_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
-                job_name=job_name("dag"),
-                run_id=success_dagster_run_id,
-                tags={
-                    DAG_RUN_ID_TAG_KEY: "success-run",
-                    DAG_ID_TAG_KEY: "dag",
-                },
-                status=DagsterRunStatus.STARTED,
-            )
-        )
-        failure_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
-                job_name=job_name("dag"),
-                run_id=failure_dagster_run_id,
-                tags={
-                    DAG_RUN_ID_TAG_KEY: "failure-run",
-                    DAG_ID_TAG_KEY: "dag",
-                },
-                status=DagsterRunStatus.STARTED,
-            )
-        )
+        # Despite the invalid log content, we should still be able to execute the job.
         result = defs.execute_job_in_process(
             job_name=monitoring_job_name(af_instance.name),
             instance=instance,
             tags={REPOSITORY_LABEL_TAG: "placeholder"},
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(freeze_datetime - timedelta(seconds=30)).isoformat(),
+                        range_end=freeze_datetime.isoformat(),
+                    )
+                }
+            ),
         )
         assert result.success
-
-        # Expect that the success and failure runs are marked as finished.
-        assert (
-            check.not_none(instance.get_run_by_id(success_dagster_run_id)).status
-            == DagsterRunStatus.SUCCESS
-        )
-        assert (
-            check.not_none(instance.get_run_by_id(failure_dagster_run_id)).status
-            == DagsterRunStatus.FAILURE
-        )
-        # Expect that we created a new run for the newly running run.
         newly_started_run = next(
             iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
         )
 
-        assert newly_started_run.status == DagsterRunStatus.STARTED
-
-        # There should be planned materialization data for the task.
-        planned_info = instance.get_latest_planned_materialization_info(AssetKey("a"))
-        assert planned_info
-        assert planned_info.run_id == newly_started_run.run_id
         # Expect that we emitted asset materialization events for the task.
         mapped_asset_mat = instance.get_latest_materialization_event(AssetKey("a"))
         assert mapped_asset_mat is not None
         assert mapped_asset_mat.run_id == newly_started_run.run_id
+        # metadata should be empty
+        assert check.not_none(mapped_asset_mat.asset_materialization).metadata == {}
 
 
 def test_monitoring_job_dag_assets(init_load_context: None, instance: DagsterInstance) -> None:
@@ -201,6 +348,14 @@ def test_monitoring_job_dag_assets(init_load_context: None, instance: DagsterIns
             job_name=monitoring_job_name(af_instance.name),
             instance=instance,
             tags={REPOSITORY_LABEL_TAG: "placeholder"},
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(freeze_datetime - timedelta(seconds=30)).isoformat(),
+                        range_end=freeze_datetime.isoformat(),
+                    )
+                }
+            ),
         )
         assert result.success
         # There should be runless materializations for the dag asset corresponding to run-dag,
@@ -213,3 +368,64 @@ def test_monitoring_job_dag_assets(init_load_context: None, instance: DagsterIns
         mapped_asset_mat = instance.get_latest_materialization_event(AssetKey("a"))
         assert mapped_asset_mat is not None
         assert mapped_asset_mat.run_id == ""
+
+
+def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstance) -> None:
+    """Test that monitoring job correctly represents state in Dagster."""
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+
+    with freeze_time(freeze_datetime):
+        defs, af_instance = create_defs_and_instance(
+            assets_per_task={
+                "dag": {"task": [("a", [])]},
+            },
+            create_runs=False,
+            create_assets_defs=False,
+        )
+        defs = build_job_based_airflow_defs(
+            airflow_instance=af_instance,
+            mapped_defs=defs,
+        )
+        context = build_sensor_context(
+            instance=instance,
+            repository_def=defs.get_repository_def(),
+        )
+        result = defs.sensors[0](context)  # type: ignore
+        assert isinstance(result, RunRequest)
+        assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
+            "config": {
+                "range_start": (freeze_datetime - timedelta(seconds=30)).isoformat(),
+                "range_end": freeze_datetime.isoformat(),
+            }
+        }
+        assert result.tags["range_start"] == (freeze_datetime - timedelta(seconds=30)).isoformat()
+        assert result.tags["range_end"] == freeze_datetime.isoformat()
+        # Create an actual run for the monitoring job that is not finished.
+        run = instance.create_run_for_job(
+            job_def=defs.get_job_def(monitoring_job_name(af_instance.name)),
+            run_id=make_new_run_id(),
+            tags=result.tags,
+            status=DagsterRunStatus.STARTED,
+            run_config=result.run_config,
+        )
+        result = defs.sensors[0](context)  # type: ignore
+        assert isinstance(result, SkipReason)
+        assert "Monitoring job is still running" in result.skip_message  # type: ignore
+        # Move the run to a finished state.
+        instance.report_dagster_event(
+            run_id=run.run_id,
+            dagster_event=DagsterEvent(
+                event_type_value="PIPELINE_SUCCESS",
+                job_name=job_name(af_instance.name),
+            ),
+        )
+    # Move time forward and check that we get a new run request.
+    with freeze_time(freeze_datetime + timedelta(seconds=30)):
+        result = defs.sensors[0](context)  # type: ignore
+        assert isinstance(result, RunRequest)
+        assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
+            "config": {
+                "range_start": (freeze_datetime).isoformat(),
+                "range_end": (freeze_datetime + timedelta(seconds=30)).isoformat(),
+            }
+        }

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/Makefile
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/Makefile
@@ -37,9 +37,13 @@ run_observation_defs:
 run_job_based_defs:
 	dagster dev -m kitchen_sink.dagster_defs.job_based_defs -p 3333
 
+run_component_defs:
+	dagster dev -m kitchen_sink.dagster_defs.component_defs -p 3333
+
 # Command to point at a workspace.yaml
 run_dagster_multi_code_locations:
 	dagster dev -w $(MAKEFILE_DIR)/kitchen_sink/dagster_multi_code_locations/workspace.yaml -p 3333
+
 
 wipe: ## Wipe out all the files created by the Makefile
 	rm -rf $(AIRFLOW_HOME) $(DAGSTER_HOME)

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/dataset_dags.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/airflow_dags/dataset_dags.py
@@ -16,7 +16,23 @@ def print_fn() -> None:
     import os
 
     os.environ["NO_PROXY"] = "*"
+    import json
+
     print("Hello")  # noqa: T201
+    data = json.dumps(
+        {
+            "foo": "bar",
+            "my_timestamp": {"raw_value": 111, "type": "timestamp"},
+        }
+    )
+    print(f"DAGSTER_START{data}DAGSTER_END")  # noqa: T201
+    another_data = json.dumps(
+        {
+            "foo": "baz",
+            "my_other_timestamp": {"raw_value": 113, "type": "timestamp"},
+        }
+    )
+    print(f"DAGSTER_START{another_data}DAGSTER_END")  # noqa: T201
 
 
 # Inter-dag structure as follows:

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/component_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/component_defs.py
@@ -1,0 +1,5 @@
+from dagster.components import load_defs
+
+import kitchen_sink.dagster_defs.inner_component_defs as inner_component_defs
+
+defs = load_defs(defs_root=inner_component_defs)

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/inner_component_defs/airlift/component.yaml
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/inner_component_defs/airlift/component.yaml
@@ -1,0 +1,9 @@
+type: dagster_airlift.core.components.airflow_instance.component.AirflowInstanceComponent
+
+attributes:
+  name: kitchen_sink_instance
+  auth:
+    type: basic_auth
+    username: admin
+    password: admin
+    webserver_url: http://localhost:8080

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_api.py
@@ -205,3 +205,15 @@ def test_datasets(airflow_instance: None) -> None:
     )
     assert not asset_spec("example1", defs)
     assert not asset_spec("example2", defs)
+
+
+def test_log_retrieval(airflow_instance: None) -> None:
+    af_instance = local_airflow_instance()
+    run_id = af_instance.trigger_dag("dataset_producer")
+    af_instance.wait_for_run_completion(dag_id="dataset_producer", run_id=run_id)
+    logs = af_instance.get_task_instance_logs(
+        dag_id="dataset_producer", task_id="print_task", run_id=run_id, try_number=1
+    )
+    assert logs
+    assert "DAGSTER_START" in logs
+    assert "DAGSTER_END" in logs

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_components.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_components.py
@@ -1,6 +1,5 @@
-import datetime
+from datetime import datetime, timedelta
 
-from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.metadata.metadata_value import TimestampMetadataValue
 from dagster._core.definitions.run_config import RunConfig
@@ -20,19 +19,20 @@ from kitchen_sink_tests.integration_tests.conftest import (
 )
 
 
-def test_job_based_defs(
+def test_component_based_defs(
     airflow_instance: None,
 ) -> None:
-    """Test that job based defs load properly."""
-    from kitchen_sink.dagster_defs.job_based_defs import defs
+    """Test that component based defs load properly."""
+    from kitchen_sink.dagster_defs.component_defs import defs
 
     assert len(defs.jobs) == 20  # type: ignore
     assert len(defs.assets) == 1  # type: ignore
-    for key in ["print_asset", "another_print_asset", "example1", "example2"]:
+    assert len(defs.sensors) == 1  # type: ignore
+    for key in ["example1", "example2"]:
         assert asset_spec(key, defs)
 
     # First, execute dataset producer dag
-    af_instance = local_airflow_instance()
+    af_instance = local_airflow_instance("kitchen_sink_instance")
     af_run_id = af_instance.trigger_dag("dataset_producer")
     poll_for_airflow_run_existence_and_completion(
         af_instance=af_instance, af_run_id=af_run_id, dag_id="dataset_producer", duration=30
@@ -46,19 +46,16 @@ def test_job_based_defs(
             run_config=RunConfig(
                 ops={
                     monitoring_job_op_name(af_instance): MonitoringConfig(
-                        range_start=(
-                            datetime.datetime.now() - datetime.timedelta(seconds=30)
-                        ).isoformat(),
-                        range_end=datetime.datetime.now().isoformat(),
+                        range_start=(datetime.now() - timedelta(seconds=30)).isoformat(),
+                        range_end=datetime.now().isoformat(),
                     )
                 }
             ),
         )
         assert result.success
-        # There should be a run for the dataset producer dag and a run for the monitoring job
+        # There should be a run for the dataset producer dag
         runs = instance.get_runs()
         assert len(runs) == 2
-
         producer_run = next(run for run in runs if run.job_name == "dataset_producer")
         assert producer_run.status == DagsterRunStatus.SUCCESS
         assert producer_run.tags[DAG_RUN_ID_TAG_KEY] == af_run_id
@@ -102,9 +99,7 @@ def test_job_based_defs(
                 for materialized_records in materialized_records
                 if materialized_records.asset_key == AssetKey(key)
             )
-            asset_metadata = check.not_none(key_record.asset_materialization).metadata
-
-            assert asset_metadata["my_timestamp"] == TimestampMetadataValue(value=111.0)
-            assert asset_metadata["my_other_timestamp"] == TimestampMetadataValue(value=113.0)
-            # It gets overridden by the second print
-            assert asset_metadata["foo"].value == "baz"
+            metadata = key_record.asset_materialization.metadata  # type: ignore
+            assert metadata["my_timestamp"] == TimestampMetadataValue(value=111.0)
+            assert metadata["my_other_timestamp"] == TimestampMetadataValue(value=113.0)
+            assert metadata["foo"].value == "baz"

--- a/python_modules/libraries/dagster-airlift/tox.ini
+++ b/python_modules/libraries/dagster-airlift/tox.ini
@@ -10,7 +10,7 @@ passenv =
     PYTEST_PLUGINS
 install_command = uv pip install {opts} {packages}
 deps =
-  -e ../../../python_modules/dagster[test]
+  -e ../../../python_modules/dagster[test,test-components]
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-shared


### PR DESCRIPTION
## Summary & Motivation
Pipes and airlift have kinda the same mandate here to use a well-structured format for defining metadata in an external process, that may not have access to the dagster package. So we can just move the processing code to a shared place accessible to both, and make the language more generic to instead be "external" metadata.

## How I Tested These Changes
Existing pipes metadata tests
