### PR TITLE
[resolved] Propagate default value to inner ResolvableModel schema when possible

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
@@ -45,7 +45,7 @@ def test_override_dataclass() -> None:
 
     annotations = _get_annotations(Derived)
     assert "value" in annotations
-    resolver = _get_resolver(annotations["value"][0], "value")
+    resolver = _get_resolver(annotations["value"].type, "value")
     assert isinstance(resolver, CustomResolver)
     Derived(value="hi")
 
@@ -61,5 +61,5 @@ def test_override_pydantic() -> None:
 
     annotations = _get_annotations(Derived)
     assert "value" in annotations
-    resolver = _get_resolver(annotations["value"][0], "value")
+    resolver = _get_resolver(annotations["value"].type, "value")
     assert isinstance(resolver, CustomResolver)


### PR DESCRIPTION
## Summary & Motivation

This prevents the `__DAGSTER_UNSET_DEFAULT__` thing from showing up all over the docs, I believe. Also good for tooling in general, as it makes the default values get represented in the json schema where possible.

Sometimes, the default value will not be serializble (e.g. it's a default factory or a complex object type), and then we fall back to the unsightly string

## How I Tested These Changes

## Changelog

NOCHANGELOG
