### PR TITLE
[dagster-dg] Add test for initializing project and listing definitions

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_list_defs_workflow.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_list_defs_workflow.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+from dagster_dg_tests.utils import ProxyRunner, assert_runner_result, install_to_venv
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
+
+def test_init_project_and_list_defs():
+    """Test that we can initialize a project with `dg init` and then run `dg list defs` without errors."""
+    with ProxyRunner.test() as runner, runner.isolated_filesystem():
+        result = runner.invoke(
+            "init",
+            "--project-name",
+            "test-project",
+        )
+        assert_runner_result(result)
+
+        assert Path("test-project").exists()
+
+        os.chdir("test-project")
+
+        result = runner.invoke("list", "defs")
+
+        assert_runner_result(result)
+
+        assert "Section" in result.output
+        assert "Definitions" in result.output


### PR DESCRIPTION
## Summary & Motivation

Added a test to verify that `dg init` and `dg list defs` commands work together correctly. This is a very simple test just to make sure basic functionality works. I imagine this can be extended to an approved workflow that we run. 

## How I Tested These Changes

Test fails on master (expected) and passes prior to the commit that broke this test (ran on HEAD~10)

## Changelog

Add test for `dg init` followed by `dg list defs`.