### PR TITLE
[Catalogv2] Add favorites support

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -2,7 +2,7 @@ import uniq from 'lodash/uniq';
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import {AssetBaseData, __resetForJest as __resetBaseData} from './AssetBaseDataProvider';
-import {AssetHealthData} from './AssetHealthDataProvider';
+import {AssetHealthData, __resetForJest as __resetHealthData} from './AssetHealthDataProvider';
 import {
   AssetStaleStatusData,
   __resetForJest as __resetStaleData,
@@ -184,4 +184,5 @@ export function AssetLiveDataRefreshButton() {
 export function __resetForJest() {
   __resetBaseData();
   __resetStaleData();
+  __resetHealthData();
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -1,37 +1,20 @@
-import {
-  Box,
-  Colors,
-  Container,
-  Icon,
-  IconWrapper,
-  Inner,
-  Row,
-  Skeleton,
-  Subtitle1,
-  SubtitleSmall,
-  Tab,
-  Tabs,
-  ifPlural,
-} from '@dagster-io/ui-components';
-import {useVirtualizer} from '@tanstack/react-virtual';
+import {Box, Skeleton, Subtitle1, Tab, Tabs, ifPlural} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import updateLocale from 'dayjs/plugin/updateLocale';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Link, useRouteMatch} from 'react-router-dom';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
 import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
-import styled from 'styled-components';
 
 import {AssetCatalogAssetGraph} from './AssetCatalogAssetGraph';
-import {AssetHealthStatusString, STATUS_INFO, statusToIconAndColor} from './AssetHealthSummary';
-import {AssetRecentUpdatesTrend} from './AssetRecentUpdatesTrend';
+import {AssetCatalogV2VirtualizedTable} from './AssetCatalogV2VirtualizedTable';
+import {AssetHealthStatusString, statusToIconAndColor} from './AssetHealthSummary';
 import {useAllAssets} from './AssetsCatalogTable';
 import {AssetsEmptyState} from './AssetsEmptyState';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {asAssetKeyInput} from './asInput';
-import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {currentPageAtom} from '../app/analytics';
@@ -44,11 +27,10 @@ import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {SyntaxError} from '../selection/CustomErrorListener';
 import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
 import {numberFormatter} from '../ui/formatters';
-
 dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);
 
-export const AssetsCatalogTableV2Impl = React.memo(
+export const AssetsCatalogTableV2 = React.memo(
   ({isFullScreen, toggleFullScreen}: {isFullScreen: boolean; toggleFullScreen: () => void}) => {
     const {assets, loading: assetsLoading, error} = useAllAssets();
     useBlockTraceUntilTrue('useAllAssets', !!assets?.length && !assetsLoading);
@@ -206,6 +188,8 @@ const Table = React.memo(
       [assets],
     );
 
+    // console.log({groupedByStatus, loading});
+
     return (
       <div style={{display: 'grid', gridTemplateRows: 'minmax(0, 1fr)', height: '100%'}}>
         <div
@@ -239,7 +223,7 @@ const Table = React.memo(
                 <LaunchAssetExecutionButton primary={false} scope={scope} />
               )}
             </Box>
-            <VirtualizedTable groupedByStatus={groupedByStatus} loading={loading} />
+            <AssetCatalogV2VirtualizedTable groupedByStatus={groupedByStatus} loading={loading} />
           </div>
           {/* <Box border="left" padding={{vertical: 24, horizontal: 12}}>
             Sidebar
@@ -250,184 +234,6 @@ const Table = React.memo(
   },
 );
 
-const shimmer = {shimmer: true};
-const shimmerRows = [shimmer, shimmer, shimmer, shimmer, shimmer];
-
-const VirtualizedTable = React.memo(
-  ({
-    groupedByStatus,
-    loading,
-  }: {
-    groupedByStatus: Record<AssetHealthStatusString, AssetHealthFragment[]>;
-    loading: boolean;
-  }) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-
-    const [openStatuses, setOpenStatuses] = useState<Set<AssetHealthStatusString>>(
-      new Set(['Unknown', 'Healthy', 'Warning', 'Degraded']),
-    );
-
-    const unGroupedRowItems = useMemo(() => {
-      return Object.keys(groupedByStatus).flatMap((status_: string) => {
-        const status = status_ as AssetHealthStatusString;
-        if (!groupedByStatus[status].length) {
-          return [];
-        }
-        if (openStatuses.has(status)) {
-          return [{header: true, status}, ...groupedByStatus[status]];
-        }
-        return [{header: true, status}];
-      });
-    }, [groupedByStatus, openStatuses]);
-
-    const rowItems = loading ? shimmerRows : unGroupedRowItems;
-
-    const rowVirtualizer = useVirtualizer({
-      count: rowItems.length,
-      getScrollElement: () => containerRef.current,
-      estimateSize: () => 32,
-      overscan: 5,
-    });
-
-    const totalHeight = rowVirtualizer.getTotalSize();
-    const items = rowVirtualizer.getVirtualItems();
-
-    return (
-      <Container ref={containerRef} style={{overflow: 'scroll'}}>
-        <Inner $totalHeight={totalHeight}>
-          {items.map(({index, key, size, start}) => {
-            const item = rowItems[index]!;
-
-            const wrapper = (content: React.ReactNode) => (
-              <Row key={key} $height={size} $start={start}>
-                <div data-index={index} ref={rowVirtualizer.measureElement}>
-                  <Box border="bottom" padding={{horizontal: 24, vertical: 12}}>
-                    {content}
-                  </Box>
-                </div>
-              </Row>
-            );
-
-            if ('shimmer' in item) {
-              return wrapper(<Skeleton key={key} $height={21} $width="45%" />);
-            }
-            if ('header' in item) {
-              return (
-                <Row key={key} $height={size} $start={start}>
-                  <div data-index={index} ref={rowVirtualizer.measureElement}>
-                    <StatusHeader
-                      status={item.status}
-                      open={openStatuses.has(item.status)}
-                      count={groupedByStatus[item.status].length}
-                      onToggle={() =>
-                        setOpenStatuses((prev) => {
-                          const newSet = new Set(prev);
-                          if (newSet.has(item.status)) {
-                            newSet.delete(item.status);
-                          } else {
-                            newSet.add(item.status);
-                          }
-                          return newSet;
-                        })
-                      }
-                    />
-                  </div>
-                </Row>
-              );
-            }
-            return wrapper(<AssetRow asset={item} />);
-          })}
-        </Inner>
-      </Container>
-    );
-  },
-);
-
-const StatusHeader = React.memo(
-  ({
-    status,
-    open,
-    count,
-    onToggle,
-  }: {
-    status: AssetHealthStatusString;
-    open: boolean;
-    count: number;
-    onToggle: () => void;
-  }) => {
-    const {iconName, iconColor, text} = STATUS_INFO[status];
-    return (
-      <StatusHeaderContainer
-        flex={{direction: 'row', alignItems: 'center', gap: 4}}
-        onClick={onToggle}
-      >
-        <Icon name={iconName} color={iconColor} />
-        <SubtitleSmall>
-          {text} ({numberFormatter.format(count)})
-        </SubtitleSmall>
-        <Icon
-          name="arrow_drop_down"
-          style={{transform: open ? 'rotate(0deg)' : 'rotate(-90deg)'}}
-          color={Colors.textLight()}
-        />
-      </StatusHeaderContainer>
-    );
-  },
-);
-
-const StatusHeaderContainer = styled(Box)`
-  background-color: ${Colors.backgroundLight()};
-  &:hover {
-    background-color: ${Colors.backgroundLightHover()};
-  }
-  border-radius: 4px;
-  padding: 6px 24px;
-`;
-
-const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
-  const linkUrl = assetDetailsPathForKey({path: asset.assetKey.path});
-
-  return (
-    <RowWrapper to={linkUrl}>
-      <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
-        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-          <AssetIconWrapper>
-            <Icon name="asset" />
-          </AssetIconWrapper>
-          {asset.assetKey.path.join(' / ')}
-        </Box>
-        {/* Prevent clicks on the trend from propoagating to the row and triggering the link */}
-        <div
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-          className="test"
-        >
-          <AssetRecentUpdatesTrend asset={asset} />
-        </div>
-      </Box>
-    </RowWrapper>
-  );
-});
-
 type AssetWithDefinition = AssetTableFragment & {
   definition: NonNullable<AssetTableFragment['definition']>;
 };
-const AssetIconWrapper = styled.div``;
-
-const RowWrapper = styled(Link)`
-  color: ${Colors.textLight()};
-  cursor: pointer;
-  :hover {
-    &,
-    ${AssetIconWrapper} ${IconWrapper} {
-      color: ${Colors.textDefault()};
-      text-decoration: none;
-    }
-    ${AssetIconWrapper} ${IconWrapper} {
-      background: ${Colors.textDefault()};
-      text-decoration: none;
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogV2VirtualizedTable.tsx
@@ -1,0 +1,200 @@
+import {
+  Box,
+  Colors,
+  Container,
+  Icon,
+  IconWrapper,
+  Inner,
+  Row,
+  Skeleton,
+  SubtitleSmall,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import React, {useMemo, useRef, useState} from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {AssetHealthStatusString, STATUS_INFO} from './AssetHealthSummary';
+import {AssetRecentUpdatesTrend} from './AssetRecentUpdatesTrend';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {AssetHealthFragment} from '../asset-data/types/AssetHealthDataProvider.types';
+import {numberFormatter} from '../ui/formatters';
+
+const shimmer = {shimmer: true};
+const shimmerRows = [shimmer, shimmer, shimmer, shimmer, shimmer];
+
+export const AssetCatalogV2VirtualizedTable = React.memo(
+  ({
+    groupedByStatus,
+    loading,
+  }: {
+    groupedByStatus: Record<AssetHealthStatusString, AssetHealthFragment[]>;
+    loading: boolean;
+  }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const [openStatuses, setOpenStatuses] = useState<Set<AssetHealthStatusString>>(
+      new Set(['Unknown', 'Healthy', 'Warning', 'Degraded']),
+    );
+
+    const unGroupedRowItems = useMemo(() => {
+      return Object.keys(groupedByStatus).flatMap((status_: string) => {
+        const status = status_ as AssetHealthStatusString;
+        if (!groupedByStatus[status].length) {
+          return [];
+        }
+        if (openStatuses.has(status)) {
+          return [{header: true, status}, ...groupedByStatus[status]];
+        }
+        return [{header: true, status}];
+      });
+    }, [groupedByStatus, openStatuses]);
+
+    const rowItems = loading ? shimmerRows : unGroupedRowItems;
+
+    const rowVirtualizer = useVirtualizer({
+      count: rowItems.length,
+      getScrollElement: () => containerRef.current,
+      estimateSize: () => 32,
+      overscan: 5,
+    });
+
+    const totalHeight = rowVirtualizer.getTotalSize();
+    const items = rowVirtualizer.getVirtualItems();
+
+    return (
+      <Container ref={containerRef} style={{overflow: 'scroll'}}>
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const item = rowItems[index]!;
+
+            const wrapper = (content: React.ReactNode) => (
+              <Row key={key} $height={size} $start={start}>
+                <div data-index={index} ref={rowVirtualizer.measureElement}>
+                  <Box border="bottom" padding={{horizontal: 24, vertical: 12}}>
+                    {content}
+                  </Box>
+                </div>
+              </Row>
+            );
+
+            if ('shimmer' in item) {
+              return wrapper(<Skeleton key={key} $height={21} $width="45%" />);
+            }
+            if ('header' in item) {
+              return (
+                <Row key={key} $height={size} $start={start}>
+                  <div data-index={index} ref={rowVirtualizer.measureElement}>
+                    <StatusHeader
+                      status={item.status}
+                      open={openStatuses.has(item.status)}
+                      count={groupedByStatus[item.status].length}
+                      onToggle={() =>
+                        setOpenStatuses((prev) => {
+                          const newSet = new Set(prev);
+                          if (newSet.has(item.status)) {
+                            newSet.delete(item.status);
+                          } else {
+                            newSet.add(item.status);
+                          }
+                          return newSet;
+                        })
+                      }
+                    />
+                  </div>
+                </Row>
+              );
+            }
+            return wrapper(<AssetRow asset={item} />);
+          })}
+        </Inner>
+      </Container>
+    );
+  },
+);
+
+const StatusHeader = React.memo(
+  ({
+    status,
+    open,
+    count,
+    onToggle,
+  }: {
+    status: AssetHealthStatusString;
+    open: boolean;
+    count: number;
+    onToggle: () => void;
+  }) => {
+    const {iconName, iconColor, text} = STATUS_INFO[status];
+    return (
+      <StatusHeaderContainer
+        flex={{direction: 'row', alignItems: 'center', gap: 4}}
+        onClick={onToggle}
+      >
+        <Icon name={iconName} color={iconColor} />
+        <SubtitleSmall>
+          {text} ({numberFormatter.format(count)})
+        </SubtitleSmall>
+        <Icon
+          name="arrow_drop_down"
+          style={{transform: open ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+          color={Colors.textLight()}
+        />
+      </StatusHeaderContainer>
+    );
+  },
+);
+
+const StatusHeaderContainer = styled(Box)`
+  background-color: ${Colors.backgroundLight()};
+  &:hover {
+    background-color: ${Colors.backgroundLightHover()};
+  }
+  border-radius: 4px;
+  padding: 6px 24px;
+`;
+
+const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
+  const linkUrl = assetDetailsPathForKey({path: asset.assetKey.path});
+
+  return (
+    <RowWrapper to={linkUrl}>
+      <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <AssetIconWrapper>
+            <Icon name="asset" />
+          </AssetIconWrapper>
+          {asset.assetKey.path.join(' / ')}
+        </Box>
+        {/* Prevent clicks on the trend from propoagating to the row and triggering the link */}
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          className="test"
+        >
+          <AssetRecentUpdatesTrend asset={asset} />
+        </div>
+      </Box>
+    </RowWrapper>
+  );
+});
+
+const AssetIconWrapper = styled.div``;
+
+const RowWrapper = styled(Link)`
+  color: ${Colors.textLight()};
+  cursor: pointer;
+  :hover {
+    &,
+    ${AssetIconWrapper} ${IconWrapper} {
+      color: ${Colors.textDefault()};
+      text-decoration: none;
+    }
+    ${AssetIconWrapper} ${IconWrapper} {
+      background: ${Colors.textDefault()};
+      text-decoration: none;
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalog.tsx
@@ -4,7 +4,7 @@ import {useRouteMatch} from 'react-router-dom';
 import {useRecoilState, useSetRecoilState} from 'recoil';
 import {ViewBreadcrumb} from 'shared/assets/ViewBreadcrumb.oss';
 
-import {AssetsCatalogTableV2Impl} from './AssetCatalogTableV2';
+import {AssetsCatalogTableV2} from './AssetCatalogTableV2';
 import {isFullScreenAtom} from '../app/AppTopNav/AppTopNavContext';
 import {currentPageAtom} from '../app/analytics';
 
@@ -33,7 +33,7 @@ export const AssetsCatalog = React.memo(() => {
       >
         <ViewBreadcrumb full />
       </Box>
-      <AssetsCatalogTableV2Impl
+      <AssetsCatalogTableV2
         isFullScreen={isFullScreen}
         toggleFullScreen={() => setIsFullScreen(!isFullScreen)}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -1,0 +1,230 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import {MemoryRouter} from 'react-router';
+import {RecoilRoot} from 'recoil';
+
+import {ASSETS_HEALTH_INFO_QUERY} from '../../asset-data/AssetHealthDataProvider';
+import {AssetLiveDataProvider, __resetForJest} from '../../asset-data/AssetLiveDataProvider';
+import {buildMockedAssetGraphLiveQuery} from '../../asset-data/__tests__/util';
+import {
+  AssetHealthQuery,
+  AssetHealthQueryVariables,
+} from '../../asset-data/types/AssetHealthDataProvider.types';
+import {useAssetSelectionInput} from '../../asset-selection/input/useAssetSelectionInput';
+import {
+  Asset,
+  AssetHealthStatus,
+  AssetKey,
+  buildAsset,
+  buildAssetConnection,
+  buildAssetHealth,
+  buildAssetKey,
+  buildAssetNode,
+} from '../../graphql/types';
+import {buildQueryMock, getMockResultFn} from '../../testing/mocking';
+import {AssetsCatalogTableV2} from '../AssetCatalogTableV2';
+import {AssetCatalogV2VirtualizedTable} from '../AssetCatalogV2VirtualizedTable';
+import {ASSET_CATALOG_TABLE_QUERY} from '../AssetsCatalogTable';
+import {
+  AssetCatalogTableQuery,
+  AssetCatalogTableQueryVariables,
+} from '../types/AssetsCatalogTable.types';
+
+jest.mock('../../util/idb-lru-cache', () => {
+  const mockedCache = {
+    has: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    constructorArgs: {},
+  };
+
+  return {
+    cache: (...args: any[]) => {
+      mockedCache.constructorArgs = args;
+      return mockedCache;
+    },
+  };
+});
+
+jest.mock('../AssetCatalogV2VirtualizedTable', () => ({
+  AssetCatalogV2VirtualizedTable: jest.fn(() => null),
+}));
+
+const createMock = ({nodes, returnedCursor}: {returnedCursor: string | null; nodes: Asset[]}) =>
+  buildQueryMock<AssetCatalogTableQuery, AssetCatalogTableQueryVariables>({
+    query: ASSET_CATALOG_TABLE_QUERY,
+    variableMatcher: () => true,
+    data: {
+      assetsOrError: buildAssetConnection({
+        nodes,
+        cursor: returnedCursor,
+      }),
+    },
+    delay: 100,
+    maxUsageCount: 100,
+  });
+
+const assetsMock = createMock({
+  nodes: [
+    buildAsset({key: buildAssetKey({path: ['asset1']})}),
+    buildAsset({key: buildAssetKey({path: ['asset2']})}),
+    buildAsset({key: buildAssetKey({path: ['asset3']})}),
+    buildAsset({key: buildAssetKey({path: ['asset4']})}),
+    buildAsset({key: buildAssetKey({path: ['asset5']})}),
+  ],
+  returnedCursor: '-1',
+});
+
+let mockFavorites: undefined | Set<string> = undefined;
+jest.mock('shared/assets/useFavoriteAssets.oss', () => ({
+  useFavoriteAssets: jest.fn(() => ({
+    favorites: mockFavorites,
+    loading: false,
+  })),
+}));
+
+jest.mock('shared/asset-selection/input/useAssetSelectionInput', () => {
+  const mock: typeof useAssetSelectionInput = ({
+    assets,
+    assetsLoading,
+  }: {
+    assets: any;
+    assetsLoading?: boolean;
+  }) => {
+    return {
+      filterInput: <div />,
+      fetchResult: {loading: false},
+      loading: !!assetsLoading,
+      filtered: assets,
+      assetSelection: '',
+      setAssetSelection: () => {},
+    };
+  };
+  return {
+    useAssetSelectionInput: mock,
+  };
+});
+
+afterEach(() => {
+  __resetForJest();
+  mockFavorites = undefined;
+  jest.clearAllMocks();
+});
+
+const statuses = [
+  AssetHealthStatus.HEALTHY,
+  AssetHealthStatus.DEGRADED,
+  AssetHealthStatus.WARNING,
+  AssetHealthStatus.UNKNOWN,
+];
+const getHealthQueryMock = (assetKeys: AssetKey[]) =>
+  buildQueryMock<AssetHealthQuery, AssetHealthQueryVariables>({
+    query: ASSETS_HEALTH_INFO_QUERY,
+    variableMatcher: () => true,
+    data: {
+      assetNodes: assetKeys.map((assetKey, idx) =>
+        buildAssetNode({
+          assetKey,
+          assetHealth: buildAssetHealth({
+            assetHealth: statuses[idx % statuses.length],
+          }),
+        }),
+      ),
+    },
+  });
+
+describe('AssetCatalogTableV2', () => {
+  it('renders', async () => {
+    const assetKeys = [
+      buildAssetKey({path: ['asset1']}),
+      buildAssetKey({path: ['asset2']}),
+      buildAssetKey({path: ['asset3']}),
+      buildAssetKey({path: ['asset4']}),
+      buildAssetKey({path: ['asset5']}),
+    ];
+    const healthQueryMock = getHealthQueryMock(assetKeys);
+    const resultFn = getMockResultFn(healthQueryMock);
+    expect(() =>
+      render(
+        <RecoilRoot>
+          <MemoryRouter>
+            <MockedProvider
+              mocks={[
+                assetsMock,
+                healthQueryMock,
+                ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
+              ]}
+            >
+              <AssetLiveDataProvider>
+                <AssetsCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+              </AssetLiveDataProvider>
+            </MockedProvider>
+          </MemoryRouter>
+        </RecoilRoot>,
+      ),
+    ).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByText('5 assets')).toBeInTheDocument();
+      expect(resultFn).toHaveBeenCalled();
+    });
+    expect(AssetCatalogV2VirtualizedTable).toHaveBeenCalledWith(
+      {
+        groupedByStatus: {
+          Healthy: [
+            expect.objectContaining({assetKey: buildAssetKey({path: ['asset1']})}),
+            expect.objectContaining({assetKey: buildAssetKey({path: ['asset5']})}),
+          ],
+          Degraded: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset2']})})],
+          Warning: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset3']})})],
+          Unknown: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset4']})})],
+        },
+        loading: false,
+      },
+      {},
+    );
+  });
+
+  it('renders with favorites', async () => {
+    mockFavorites = new Set(['asset1', 'asset2']);
+    const assetKeys = [buildAssetKey({path: ['asset1']}), buildAssetKey({path: ['asset2']})];
+    const healthQueryMock = getHealthQueryMock(assetKeys);
+    const resultFn = getMockResultFn(healthQueryMock);
+    expect(() =>
+      render(
+        <RecoilRoot>
+          <MemoryRouter>
+            <MockedProvider
+              mocks={[
+                assetsMock,
+                healthQueryMock,
+                ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
+              ]}
+            >
+              <AssetLiveDataProvider>
+                <AssetsCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+              </AssetLiveDataProvider>
+            </MockedProvider>
+          </MemoryRouter>
+        </RecoilRoot>,
+      ),
+    ).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByText('2 assets')).toBeInTheDocument();
+      expect(resultFn).toHaveBeenCalled();
+    });
+    expect(AssetCatalogV2VirtualizedTable).toHaveBeenCalledWith(
+      {
+        groupedByStatus: {
+          Healthy: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset1']})})],
+          Degraded: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset2']})})],
+          Warning: [],
+          Unknown: [],
+        },
+        loading: false,
+      },
+      {},
+    );
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -185,7 +185,7 @@ describe('AssetCatalogTableV2', () => {
     );
   });
 
-  it('renders with favorites', async () => {
+  it('renders with favorites and ignores results from useAllAssets', async () => {
     mockFavorites = new Set(['asset1', 'asset2']);
     const assetKeys = [buildAssetKey({path: ['asset1']}), buildAssetKey({path: ['asset2']})];
     const healthQueryMock = getHealthQueryMock(assetKeys);


### PR DESCRIPTION
## Summary & Motivation

Similar to what we do  [here](https://github.com/dagster-io/dagster/blob/08aa439c5a52d3c24ff6e3e1856e2172f26bca8d/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx#L220) and [here](https://github.com/dagster-io/dagster/blob/08aa439c5a52d3c24ff6e3e1856e2172f26bca8d/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGlobalGraphRoot.tsx#L65). Basically since this is in OSS we use that hook to signal whether or not we're currently in the favorites view and so should use the favorited assets.

## How I Tested These Changes

jest