### PR TITLE
Support hourly insights granularity

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/DateRangeText.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/DateRangeText.tsx
@@ -18,6 +18,14 @@ export const DateRangeText = (props: {date: Date; granularity: ReportingMetricsG
       return <span>{formatDateTime(date, {month: 'short', day: 'numeric', timeZone: 'UTC'})}</span>;
     }
 
+    case ReportingMetricsGranularity.HOURLY: {
+      return (
+        <span>
+          {formatDateTime(date, {month: 'short', day: 'numeric', hour: 'numeric', timeZone: 'UTC'})}
+        </span>
+      );
+    }
+
     case ReportingMetricsGranularity.WEEKLY: {
       const startDateLabel = formatDateTime(date, {
         month: 'short',

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/types.tsx
@@ -1,4 +1,5 @@
 export enum ReportingMetricsGranularity {
+  HOURLY = 'HOURLY',
   DAILY = 'DAILY',
   MONTHLY = 'MONTHLY',
   WEEKLY = 'WEEKLY',


### PR DESCRIPTION
Corresponding internal diff: https://github.com/dagster-io/internal/pull/15118
