### PR TITLE
[dg] Prompt to create venv when running dg init

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
@@ -1,5 +1,6 @@
-dg init --project-name my-project
+dg init --project-name my-project --uv-sync
 
 Creating a Dagster project at /.../my-project.
 Scaffolded files for Dagster project at /.../my-project.
-You can create additional projects later by running 'dg scaffold project'.
+Running `uv sync`...
+...

--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
@@ -11,7 +11,8 @@ tree
     │       │   └── __init__.py
     │       └── lib
     │           └── __init__.py
-    └── tests
-        └── __init__.py
+    ├── tests
+    │   └── __init__.py
+    └── uv.lock
 
-7 directories, 6 files
+7 directories, 7 files

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_scaffolding_project.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_scaffolding_project.py
@@ -32,7 +32,7 @@ SNIPPETS_DIR = (
 def test_dg_docs_scaffolding_project(update_snippets: bool) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         run_command_and_snippet_output(
-            cmd="dg init --project-name my-project --use-editable-dagster",
+            cmd="dg init --project-name my-project --uv-sync --use-editable-dagster",
             snippet_path=SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffolding-project.txt",
             update_snippets=update_snippets,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from typing import Final, Optional, get_args
 
@@ -13,7 +14,15 @@ from dagster_dg.config import (
 )
 from dagster_dg.context import DgContext
 from dagster_dg.scaffold import scaffold_project, scaffold_workspace
-from dagster_dg.utils import DgClickCommand, exit_with_error
+from dagster_dg.utils import (
+    DgClickCommand,
+    exit_with_error,
+    format_multiline_str,
+    get_shortest_path_repr,
+    get_venv_activation_cmd,
+    is_uv_installed,
+    pushd,
+)
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 # Workspace
@@ -40,6 +49,14 @@ _DEFAULT_INIT_PROJECTS_DIR: Final = "projects"
     type=click.Choice(get_args(DgProjectPythonEnvironmentFlag)),
     help="Type of Python environment in which to launch subprocesses for the project.",
 )
+@click.option(
+    "--uv-sync/--no-uv-sync",
+    is_flag=True,
+    default=None,
+    help="""
+        Preemptively answer the "Run uv sync?" prompt presented after project initialization.
+    """.strip(),
+)
 @click.argument(
     "dirname",
     required=False,
@@ -51,6 +68,7 @@ def init_command(
     workspace: bool,
     project_name: Optional[str],
     python_environment: DgProjectPythonEnvironmentFlag,
+    uv_sync: Optional[bool],
     **global_options: object,
 ):
     """Initialize a new Dagster project, optionally inside a workspace.
@@ -103,6 +121,21 @@ def init_command(
 
     workspace_dirname = None
 
+    if uv_sync is True and not is_uv_installed():
+        exit_with_error("""
+            uv is not installed. Please install uv to use the `--uv-sync` option.
+            See https://docs.astral.sh/uv/getting-started/installation/.
+        """)
+    elif uv_sync is False and python_environment == "uv_managed":
+        exit_with_error(
+            "The `--uv-sync` option cannot be set to False when using the `--python-environment uv_managed` option."
+        )
+    elif python_environment == "uv_managed" and not is_uv_installed():
+        exit_with_error("""
+            uv is not installed. Please install uv to use the `--python-environment uv_managed` option.
+            See https://docs.astral.sh/uv/getting-started/installation/.
+        """)
+
     if workspace:
         workspace_config = DgRawWorkspaceConfig(
             scaffold_project_options=DgWorkspaceScaffoldProjectOptions.get_raw_from_cli(
@@ -149,4 +182,47 @@ def init_command(
         python_environment=DgProjectPythonEnvironment.from_flag(python_environment),
     )
 
-    click.echo("You can create additional projects later by running 'dg scaffold project'.")
+    if workspace:
+        click.echo("You can create additional projects later by running 'dg scaffold project'.")
+
+    venv_path = project_path / ".venv"
+    if _should_run_uv_sync(python_environment, venv_path, uv_sync):
+        click.echo("Running `uv sync`...")
+        with pushd(project_path):
+            subprocess.run(["uv", "sync"], check=True)
+
+        click.echo("\nuv.lock and virtual environment created.")
+        display_venv_path = get_shortest_path_repr(venv_path)
+        click.echo(
+            f"""
+            Run `{get_venv_activation_cmd(display_venv_path)}` to activate your project's virtual environment.
+            """.strip()
+        )
+
+
+def _should_run_uv_sync(
+    python_environment: DgProjectPythonEnvironmentFlag,
+    venv_path: Path,
+    uv_sync_flag: Optional[bool],
+) -> bool:
+    # This already will have occurred during the scaffolding step
+    if python_environment == "uv_managed" or uv_sync_flag is False:
+        return False
+    # This can force running `uv sync` even if a venv already exists
+    elif uv_sync_flag is True:
+        return True
+    elif venv_path.exists():
+        return False
+    elif is_uv_installed():  # uv_sync_flag is unset (None)
+        response = click.prompt(
+            format_multiline_str("""
+            Run uv sync? This will create the virtual environment you need to activate in
+            order to work on this project. (y/n)
+        """),
+            default="y",
+        ).lower()
+        if response not in ("y", "n"):
+            exit_with_error(f"Invalid response '{response}'. Please enter 'y' or 'n'.")
+        return response == "y"
+    else:
+        return False

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -1,7 +1,9 @@
 import os
+import subprocess
 from pathlib import Path
 from typing import Optional, get_args
 
+import dagster_shared.check as check
 import pytest
 import tomlkit
 from dagster_dg.utils import discover_git_root, ensure_dagster_dg_tests_import, get_toml_node
@@ -18,24 +20,51 @@ from dagster_dg_tests.utils import ProxyRunner, assert_runner_result
 
 
 @pytest.mark.parametrize(
-    "cli_args,input_str",
+    "cli_args,input_str,opts",
     [
-        (("--", "."), None),
-        (("--", "helloworld"), None),
-        (("--project-name", "helloworld"), None),
-        (tuple(), "helloworld\n"),
+        (("--", "."), "y\n", {}),
+        # Test preexisting venv in the project directory
+        (("--", "."), None, {"use_preexisting_venv": True}),
+        # Skip the uv sync prompt and automatically uv sync
+        (("--uv-sync", "--", "."), None, {}),
+        # Skip the uv sync prompt and don't uv sync
+        (("--no-uv-sync", "--", "."), None, {}),
+        # Test uv not available. When uv is not available there will be no prompt-- so this test
+        # will hang if it's not working because we don't provide an input string.
+        (("--", "."), None, {"no_uv": True}),
+        (("--", "helloworld"), "y\n", {}),
+        (("--project-name", "helloworld"), "y\n", {}),
+        (tuple(), "helloworld\ny\n", {}),
+        # Test declining to create a venv
+        (("--", "helloworld"), "n\n", {}),
     ],
-    ids=["dirname_cwd", "dirname_arg", "project_name_opt", "project_name_prompt"],
+    ids=[
+        "dirname_cwd",
+        "dirname_cwd_preexisting_venv",
+        "dirname_cwd_explicit_uv_sync",
+        "dirname_cwd_explicit_no_uv_sync",
+        "dirname_cwd_no_uv",
+        "dirname_arg",
+        "project_name_opt",
+        "project_name_prompt",
+        "dirname_arg_no_venv",
+    ],
 )
-def test_init_success_no_workspace(
-    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str]
+def test_init_success_project(
+    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str], opts: dict[str, object]
 ) -> None:
+    use_preexisting_venv = check.opt_bool_elem(opts, "use_preexisting_venv") or False
+    no_uv = check.opt_bool_elem(opts, "no_uv") or False
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
+    if no_uv:
+        monkeypatch.setattr("dagster_dg.cli.init.is_uv_installed", lambda: False)
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         if "." in cli_args:  # creating in CWD
             os.mkdir("helloworld")
             os.chdir("helloworld")
+            if use_preexisting_venv:
+                subprocess.run(["uv", "venv"], check=True)
 
         result = runner.invoke(
             "init",
@@ -54,27 +83,56 @@ def test_init_success_no_workspace(
         assert Path("helloworld/pyproject.toml").exists()
         assert Path("helloworld/tests").exists()
 
+        # this indicates user opts to create venv and uv.lock
+        if not use_preexisting_venv and (
+            (input_str and input_str.endswith("y\n")) or "--uv-sync" in cli_args
+        ):
+            assert Path("helloworld/.venv").exists()
+            assert Path("helloworld/uv.lock").exists()
+        elif use_preexisting_venv:
+            assert Path("helloworld/.venv").exists()
+            assert not Path("helloworld/uv.lock").exists()
+        else:
+            assert not Path("helloworld/.venv").exists()
+            assert not Path("helloworld/uv.lock").exists()
+
 
 @pytest.mark.parametrize(
-    "cli_args,input_str",
+    "cli_args,input_str,opts",
     [
-        (("--project-name", "helloworld", "."), None),
-        (("--project-name", "helloworld", "dagster-workspace"), None),
-        (("--", "dagster-workspace"), "helloworld\n"),
-        (tuple(), "dagster-workspace\nhelloworld\n"),
+        (("--project-name", "helloworld", "."), "y\n", {}),
+        # Test declining to create a venv
+        (("--project-name", "helloworld", "."), "n\n", {}),
+        # Skip the uv sync prompt and automatically uv sync
+        (("--uv-sync", "--project-name", "helloworld", "."), None, {}),
+        # Skip the uv sync prompt and don't uv sync
+        (("--no-uv-sync", "--project-name", "helloworld", "."), None, {}),
+        # Test uv not available. When uv is not available there will be no prompt-- so this test
+        # will hang if it's not working because we don't provide an input string.
+        (("--project-name", "helloworld", "."), None, {"no_uv": True}),
+        (("--project-name", "helloworld", "dagster-workspace"), "y\n", {}),
+        (("--", "dagster-workspace"), "helloworld\ny\n", {}),
+        (tuple(), "dagster-workspace\nhelloworld\ny\n", {}),
     ],
     ids=[
         "dirname_cwd_and_project_name",
+        "dirname_cwd_and_project_name_decline_venv",
+        "dirname_cwd_and_project_name_explicit_uv_sync",
+        "dirname_cwd_and_project_name_explicit_no_uv_sync",
+        "dirname_cwd_and_project_name_no_uv",
         "dirname_arg_and_project_name",
         "dirname_arg_no_project_name",
         "no_dirname_arg_no_project_name",
     ],
 )
 def test_init_success_workspace(
-    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str]
+    monkeypatch, cli_args: tuple[str, ...], input_str: Optional[str], opts: dict[str, object]
 ) -> None:
+    no_uv = check.opt_bool_elem(opts, "no_uv") or False
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
+    if no_uv:
+        monkeypatch.setattr("dagster_dg.cli.init.is_uv_installed", lambda: False)
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
         if "." in cli_args:  # creating in CWD
             os.mkdir("dagster-workspace")
@@ -100,6 +158,14 @@ def test_init_success_workspace(
         assert Path("dagster-workspace/projects/helloworld/src/helloworld").exists()
         assert Path("dagster-workspace/projects/helloworld/pyproject.toml").exists()
         assert Path("dagster-workspace/projects/helloworld/tests").exists()
+
+        # this indicates user opts to create venv and uv.lock
+        if not no_uv and ((input_str and input_str.endswith("y\n")) or "--uv-sync" in cli_args):
+            assert Path("dagster-workspace/projects/helloworld/.venv").exists()
+            assert Path("dagster-workspace/projects/helloworld/uv.lock").exists()
+        else:
+            assert not Path("dagster-workspace/projects/helloworld/.venv").exists()
+            assert not Path("dagster-workspace/projects/helloworld/uv.lock").exists()
 
         # Check workspace TOML content
         toml = tomlkit.parse(Path("dagster-workspace/dg.toml").read_text())
@@ -152,7 +218,7 @@ def test_init_use_editable_dagster(option: EditableOption, value_source: str, mo
             "--workspace",
             *editable_args,
             "dagster-workspace",
-            input="helloworld\n",
+            input="helloworld\ny\n",
         )
         assert_runner_result(result)
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/check/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/check/__init__.py
@@ -43,6 +43,7 @@ from dagster_shared.check.functions import (
     not_none as not_none,
     not_none_param as not_none_param,
     numeric_param as numeric_param,
+    opt_bool_elem as opt_bool_elem,
     opt_bool_param as opt_bool_param,
     opt_callable_param as opt_callable_param,
     opt_class_param as opt_class_param,

--- a/python_modules/libraries/dagster-shared/dagster_shared/check/functions.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/check/functions.py
@@ -97,6 +97,20 @@ def bool_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None
     return value
 
 
+def opt_bool_elem(
+    ddict: Mapping, key: str, additional_message: Optional[str] = None
+) -> Optional[bool]:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise _element_check_error(key, value, ddict, bool, additional_message)
+    return value
+
+
 # ########################
 # ##### CALLABLE
 # ########################

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_check.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_check.py
@@ -104,6 +104,18 @@ def test_bool_elem():
         check.bool_elem(ddict, "a_str")
 
 
+def test_opt_bool_elem():
+    ddict = {"a_bool": True, "a_float": 1.0, "a_int": 1, "a_none": None, "a_str": "a"}
+
+    assert check.opt_bool_elem(ddict, "a_bool") is True
+    assert check.opt_bool_elem(ddict, "a_none") is None
+    assert check.opt_bool_elem(ddict, "nonexistentkey") is None
+
+    for key in ["a_float", "a_int", "a_str"]:
+        with pytest.raises(ElementCheckError):
+            assert check.opt_bool_elem(ddict, key) is False
+
+
 # ########################
 # ##### CALLABLE
 # ########################


### PR DESCRIPTION
## Summary & Motivation

Make `dg init` prompt to create a venv in the created project after it runs:

```
$ dg init my-project --use-editable-dagster
Creating a Dagster project at /Users/smackesey/stm/code/elementl/tmp/my-project.
Scaffolded files for Dagster project at /Users/smackesey/stm/code/elementl/tmp/my-project.
Run `uv sync` to bootstrap a uv.lock and virtual environment (y/n)? [y]: 
... venv creation

uv.lock and virtual environment created.
Your project is configured with `project.python_environment = "active"`, so you will need to activate the created virtual environment to use it with your `dg` project. To activate the virtual environment, run:

    source my-project/.venv/bin/activate
```

This prompt only appears if:

- the `--python-environment` option is set to `active` (the default) (in `uv_managed` mode we always created the venv)
- a `uv` installation is detected
- there is not already a `.venv` in the project directory

## How I Tested These Changes

New unit tests.