### PR TITLE
Allow sourcing root path from cli input instead of assuming Path.cwd()

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
@@ -5,14 +5,16 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
  CLI for managing Dagster projects.                                                                                     
                                                                                                                         
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --clear-cache                           Clear the cache.                                                             │
-│ --rebuild-component-registry            Recompute and cache the set of available component types for the current     │
-│                                         environment. Note that this also happens automatically whenever the cache is │
-│                                         detected to be stale.                                                        │
-│ --install-completion                    Automatically detect your shell and install a completion script for the `dg` │
-│                                         command. This will append to your shell startup file.                        │
-│ --version                     -v        Show the version and exit.                                                   │
-│ --help                        -h        Show this message and exit.                                                  │
+│ --path                                PATH  Specify a directory to use to load the context for this command. This    │
+│                                             will typically be a folder with a dg.toml or pyproject.toml file in it.  │
+│ --clear-cache                               Clear the cache.                                                         │
+│ --rebuild-component-registry                Recompute and cache the set of available component types for the current │
+│                                             environment. Note that this also happens automatically whenever the      │
+│                                             cache is detected to be stale.                                           │
+│ --install-completion                        Automatically detect your shell and install a completion script for the  │
+│                                             `dg` command. This will append to your shell startup file.               │
+│ --version                     -v            Show the version and exit.                                               │
+│ --help                        -h            Show this message and exit.                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --verbose                    Enable verbose output for debugging.                                                    │

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -12,7 +12,7 @@ from dagster_dg.cli.launch import launch_command
 from dagster_dg.cli.list import list_group
 from dagster_dg.cli.plus import plus_group
 from dagster_dg.cli.scaffold import scaffold_group
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.cli.utils import utils_group
 from dagster_dg.component import RemotePluginRegistry
 from dagster_dg.config import normalize_cli_config
@@ -44,6 +44,7 @@ def create_dg_cli():
         invoke_without_command=True,
         cls=DgClickGroup,
     )
+    @dg_path_options
     @dg_global_options
     @click.option(
         "--clear-cache",
@@ -71,6 +72,7 @@ def create_dg_cli():
         install_completion: bool,
         clear_cache: bool,
         rebuild_component_registry: bool,
+        path: Path,
         **global_options: object,
     ):
         """CLI for managing Dagster projects."""
@@ -86,9 +88,7 @@ def create_dg_cli():
             exit_with_error("Cannot specify both --clear-cache and --rebuild-component-registry.")
         elif clear_cache:
             cli_config = normalize_cli_config(global_options, context)
-            dg_context = DgContext.from_file_discovery_and_command_line_config(
-                Path.cwd(), cli_config
-            )
+            dg_context = DgContext.from_file_discovery_and_command_line_config(path, cli_config)
             # Normally we would access the cache through the DgContext, but cache is currently
             # disabled outside of a project context. When that restriction is lifted, we will change
             # this to access the cache through the DgContext.
@@ -98,7 +98,7 @@ def create_dg_cli():
                 context.exit(0)
         elif rebuild_component_registry:
             cli_config = normalize_cli_config(global_options, context)
-            dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
+            dg_context = DgContext.for_defined_registry_environment(path, cli_config)
             if context.invoked_subcommand is not None:
                 exit_with_error("Cannot specify --rebuild-component-registry with a subcommand.")
             _rebuild_component_registry(dg_context)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -8,7 +8,7 @@ import click
 
 from dagster_dg.check import check_yaml as check_yaml_fn
 from dagster_dg.cli.dev import format_forwarded_option
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.cli.utils import create_dagster_cli_cmd
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -41,16 +41,18 @@ def check_group():
     help="Validate environment variables in requirements for all components in the given module.",
 )
 @dg_global_options
+@dg_path_options
 @cli_telemetry_wrapper
 def check_yaml_command(
     paths: Sequence[str],
     watch: bool,
     validate_requirements: bool,
+    path: Path,
     **global_options: object,
 ) -> None:
     """Check component.yaml files against their schemas, showing validation errors."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_project_environment(path, cli_config)
     resolved_paths = [Path(path).absolute() for path in paths]
 
     def run_check(_: Any = None) -> bool:
@@ -97,6 +99,7 @@ def check_yaml_command(
     default=True,
     help="Whether to schema-check component.yaml files for the project before loading and checking all definitions.",
 )
+@dg_path_options
 @dg_global_options
 @click.pass_context
 @cli_telemetry_wrapper
@@ -105,6 +108,7 @@ def check_definitions_command(
     log_level: str,
     log_format: str,
     verbose: bool,
+    path: Path,
     **global_options: Mapping[str, object],
 ) -> None:
     """Loads and validates your Dagster definitions using a Dagster instance.
@@ -120,7 +124,7 @@ def check_definitions_command(
 
     """
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(path, cli_config)
 
     forward_options = [
         *format_forwarded_option("--log-level", log_level),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -11,7 +11,7 @@ from typing import Optional, TypeVar
 import click
 
 from dagster_dg.check import check_yaml as check_yaml_fn
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.cli.utils import create_dagster_cli_cmd
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -78,6 +78,7 @@ _SUBPROCESS_WAIT_TIMEOUT = 60
     default=True,
     help="Whether to schema-check component.yaml files for the project before starting the dev server.",
 )
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def dev_command(
@@ -88,6 +89,7 @@ def dev_command(
     host: Optional[str],
     live_data_poll_rate: int,
     check_yaml: bool,
+    path: Path,
     **global_options: Mapping[str, object],
 ) -> None:
     """Start a local instance of Dagster.
@@ -96,7 +98,7 @@ def dev_command(
     workspace. If launched inside a project directory, it will launch only that project.
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(path, cli_config)
 
     forward_options = [
         *format_forwarded_option("--code-server-log-level", code_server_log_level),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/docs.py
@@ -11,7 +11,7 @@ import click
 from dagster_shared.serdes.objects.package_entry import json_for_all_components
 from yaspin import yaspin
 
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.component import PluginObjectKey, RemotePluginRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -47,16 +47,18 @@ LOCALHOST_URL_REGEX = re.compile(b".*(http://localhost.*)\n")
 @docs_group.command(name="serve", cls=DgClickCommand)
 @click.argument("component_type", type=str, default="")
 @click.option("--port", type=int, default=3004)
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def serve_docs_command(
     component_type: Optional[str],
     port: int,
+    path: Path,
     **global_options: object,
 ) -> None:
     """Serve the Dagster components docs, to be viewed in a browser."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     component_key = None
@@ -113,15 +115,17 @@ def serve_docs_command(
 
 @docs_group.command(name="build", cls=DgClickCommand)
 @click.argument("output_dir", type=click.Path(exists=False))
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def build_docs_command(
     output_dir: str,
+    path: Path,
     **global_options: object,
 ) -> None:
     """Build a static version of the Dagster components docs, to be served by a static file server."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     with pushd(ACTIVE_DOCS_DIR):

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from dagster_dg.cli.dev import format_forwarded_option
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.utils import DgClickCommand
@@ -24,6 +24,7 @@ from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 @click.option(
     "--config-json", type=click.STRING, help="JSON string of config to use for the launched run."
 )
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def launch_command(
@@ -31,6 +32,7 @@ def launch_command(
     partition: Optional[str],
     partition_range: Optional[str],
     config_json: Optional[str],
+    path: Path,
     **global_options: Mapping[str, object],
 ):
     """Launch a Dagster run."""
@@ -50,7 +52,7 @@ def launch_command(
     # dev/OSS, and executes the selected assets in process using the "dagster asset materialize"
     # command.
 
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_project_environment(path, cli_config)
 
     cmd_location = dg_context.get_executable("dagster")
     click.echo(f"Using {cmd_location}")

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.text import Text
 
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.component import PluginObjectFeature, RemotePluginRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -60,11 +60,12 @@ def DagsterOuterTable(columns: Sequence[str]) -> Table:
 
 @list_group.command(name="project", cls=DgClickCommand)
 @dg_global_options
+@dg_path_options
 @cli_telemetry_wrapper
-def list_project_command(**global_options: object) -> None:
+def list_project_command(path: Path, **global_options: object) -> None:
     """List projects in the current workspace."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_workspace_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_environment(path, cli_config)
 
     for project in dg_context.project_specs:
         click.echo(project.path)
@@ -76,12 +77,13 @@ def list_project_command(**global_options: object) -> None:
 
 
 @list_group.command(name="component", cls=DgClickCommand)
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
-def list_component_command(**global_options: object) -> None:
+def list_component_command(path: Path, **global_options: object) -> None:
     """List Dagster component instances defined in the current project."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_project_environment(path, cli_config)
 
     for component_instance_name in dg_context.get_component_instance_names():
         click.echo(component_instance_name)
@@ -153,6 +155,7 @@ def _all_plugins_object_table(
     default=False,
     help="Output as JSON instead of a table.",
 )
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def list_plugins_command(
@@ -160,11 +163,12 @@ def list_plugins_command(
     plugin: Optional[str],
     feature: Optional[PluginObjectFeature],
     output_json: bool,
+    path: Path,
     **global_options: object,
 ) -> None:
     """List dg plugins and their corresponding objects in the current Python environment."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_defined_registry_environment(path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     if output_json:
@@ -255,12 +259,13 @@ def _get_sensors_table(sensors: Sequence[DgSensorMetadata]) -> Table:
     default=False,
     help="Output as JSON instead of a table.",
 )
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
-def list_defs_command(output_json: bool, **global_options: object) -> None:
+def list_defs_command(output_json: bool, path: Path, **global_options: object) -> None:
     """List registered Dagster definitions in the current project environment."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_project_environment(path, cli_config)
 
     result = dg_context.external_components_command(
         [
@@ -318,12 +323,13 @@ def list_defs_command(output_json: bool, **global_options: object) -> None:
 
 
 @list_group.command(name="env", cls=DgClickCommand)
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
-def list_env_command(**global_options: object) -> None:
+def list_env_command(path: Path, **global_options: object) -> None:
     """List environment variables from the .env file of the current project."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_project_environment(path, cli_config)
 
     env = ProjectEnvVars.from_ctx(dg_context)
     if not env.values:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/__init__.py
@@ -11,7 +11,7 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.plus.login_server import start_login_server
 
 from dagster_dg.cli.plus.deploy import deploy_group
-from dagster_dg.cli.shared_options import dg_global_options
+from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
 from dagster_dg.env import ProjectEnvVars
@@ -112,12 +112,13 @@ def _get_local_secrets_for_locations(
 
 @plus_pull_group.command(name="env", cls=DgClickCommand)
 @dg_global_options
+@dg_path_options
 @cli_telemetry_wrapper
-def pull_env_command(**global_options: object) -> None:
+def pull_env_command(path: Path, **global_options: object) -> None:
     """Pull environment variables from Dagster Plus and save to a .env file for local use."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(path, cli_config)
     config = _get_config_or_error()
 
     project_ctxs = []
@@ -214,6 +215,7 @@ def plus_create_group():
     is_flag=True,
     help="Do not confirm the creation of the environment variable, if it already exists.",
 )
+@dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
 def create_env_command(
@@ -223,6 +225,7 @@ def create_env_command(
     global_: bool,
     from_local_env: bool,
     skip_confirmation_prompt: bool,
+    path: Path,
     **global_options: object,
 ) -> None:
     """Create or update an environment variable in Dagster Plus."""
@@ -237,7 +240,7 @@ def create_env_command(
 
     cli_config = normalize_cli_config(global_options, click.get_current_context())
 
-    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(path, cli_config)
     if dg_context.is_workspace:
         global_ = True
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -17,6 +17,7 @@ from dagster_dg.cli.shared_options import (
     GLOBAL_OPTIONS,
     dg_editable_dagster_options,
     dg_global_options,
+    dg_path_options,
 )
 from dagster_dg.component import RemotePluginRegistry
 from dagster_dg.config import (
@@ -528,11 +529,12 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
     help="Whether to automatically make the generated class inherit from dagster.components.Model.",
 )
 @click.argument("name", type=str)
+@dg_path_options
 @dg_global_options
 @click.pass_context
 @cli_telemetry_wrapper
 def scaffold_component_type_command(
-    context: click.Context, name: str, model: bool, **global_options: object
+    context: click.Context, name: str, model: bool, path: Path, **global_options: object
 ) -> None:
     """Scaffold of a custom Dagster component type.
 
@@ -540,7 +542,7 @@ def scaffold_component_type_command(
     will be placed in submodule `<project_name>.lib.<name>`.
     """
     cli_config = normalize_cli_config(global_options, context)
-    dg_context = DgContext.for_component_library_environment(Path.cwd(), cli_config)
+    dg_context = DgContext.for_component_library_environment(path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/shared_options.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/shared_options.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar, Union
 
 import click
@@ -127,3 +128,20 @@ EDITABLE_DAGSTER_OPTIONS = {
 }
 
 dg_editable_dagster_options = make_option_group(EDITABLE_DAGSTER_OPTIONS)
+
+PATH_OPTIONS = {
+    not_none(option.name): option
+    for option in [
+        click.Option(
+            ["--path"],
+            type=click.Path(
+                resolve_path=True,
+                path_type=Path,
+            ),
+            help="Specify a directory to use to load the context for this command. This will typically be a folder with a dg.toml or pyproject.toml file in it.",
+            default=lambda: Path.cwd(),  # defer for tests
+        ),
+    ]
+}
+
+dg_path_options = make_option_group(PATH_OPTIONS)


### PR DESCRIPTION
Summary:
This is for the github action, which may want to, say, run dg deploy commands in a different folder than the current cwd without needing to pushd or gross workarounds like that.

Test Plan: BK gives us coverage that the right path is being passed in
