### PR TITLE
Add a toy asset with internal freshness policy that fails quickly

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/freshness.py
+++ b/python_modules/dagster-test/dagster_test/toys/freshness.py
@@ -27,9 +27,19 @@ def asset_with_time_window_freshness_and_warning():
     return 1
 
 
+@dg.asset(
+    internal_freshness_policy=InternalFreshnessPolicy.time_window(
+        fail_window=timedelta(seconds=60), warn_window=timedelta(seconds=30)
+    )
+)
+def asset_with_time_window_freshness_fast_fail():
+    return 1
+
+
 def get_freshness_assets():
     return [
         asset_with_time_window_freshness_60m,
         asset_with_time_window_freshness_30m,
         asset_with_time_window_freshness_and_warning,
+        asset_with_time_window_freshness_fast_fail,
     ]


### PR DESCRIPTION
## Summary & Motivation
Short fail window (60s) and warn window (30s) for quicker testing

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
