### PR TITLE
add asset execution type to step output properties

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -82,6 +82,7 @@ def create_step_outputs(
                     else None,
                     is_asset_partitioned=bool(asset_node.partitions_def) if asset_node else False,
                     asset_check_key=asset_layer.asset_check_key_for_output(handle, name),
+                    asset_node=asset_node,
                 ),
             )
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -82,7 +82,7 @@ def create_step_outputs(
                     else None,
                     is_asset_partitioned=bool(asset_node.partitions_def) if asset_node else False,
                     asset_check_key=asset_layer.asset_check_key_for_output(handle, name),
-                    asset_node=asset_node,
+                    asset_execution_type=asset_node.execution_type if asset_node else None,
                 ),
             )
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -4,6 +4,7 @@ from typing import NamedTuple, Optional
 import dagster._check as check
 from dagster._core.definitions import AssetMaterialization, NodeHandle
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_graph import AssetNode
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
@@ -27,6 +28,7 @@ class StepOutputProperties(
             ("asset_key", Optional[AssetKey]),
             ("is_asset_partitioned", bool),
             ("asset_check_key", Optional[AssetCheckKey]),
+            ("asset_node", Optional[AssetNode]),
         ],
     )
 ):
@@ -39,6 +41,7 @@ class StepOutputProperties(
         asset_key: Optional[AssetKey] = None,
         is_asset_partitioned: bool = False,
         asset_check_key: Optional[AssetCheckKey] = None,
+        asset_node: Optional[AssetNode] = None,
     ):
         return super().__new__(
             cls,
@@ -49,6 +52,7 @@ class StepOutputProperties(
             check.opt_inst_param(asset_key, "asset_key", AssetKey),
             check.bool_param(is_asset_partitioned, "is_asset_partitioned"),
             check.opt_inst_param(asset_check_key, "asset_check_key", AssetCheckKey),
+            check.opt_inst_param(asset_node, "asset_node", AssetNode),
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -4,7 +4,7 @@ from typing import NamedTuple, Optional
 import dagster._check as check
 from dagster._core.definitions import AssetMaterialization, NodeHandle
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph import AssetNode
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
@@ -28,7 +28,7 @@ class StepOutputProperties(
             ("asset_key", Optional[AssetKey]),
             ("is_asset_partitioned", bool),
             ("asset_check_key", Optional[AssetCheckKey]),
-            ("asset_node", Optional[AssetNode]),
+            ("asset_execution_type", Optional[AssetExecutionType]),
         ],
     )
 ):
@@ -41,7 +41,7 @@ class StepOutputProperties(
         asset_key: Optional[AssetKey] = None,
         is_asset_partitioned: bool = False,
         asset_check_key: Optional[AssetCheckKey] = None,
-        asset_node: Optional[AssetNode] = None,
+        asset_execution_type: Optional[AssetExecutionType] = None,
     ):
         return super().__new__(
             cls,
@@ -52,7 +52,7 @@ class StepOutputProperties(
             check.opt_inst_param(asset_key, "asset_key", AssetKey),
             check.bool_param(is_asset_partitioned, "is_asset_partitioned"),
             check.opt_inst_param(asset_check_key, "asset_check_key", AssetCheckKey),
-            check.opt_inst_param(asset_node, "asset_node", AssetNode),
+            check.opt_inst_param(asset_execution_type, "asset_node", AssetExecutionType),
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -52,7 +52,7 @@ class StepOutputProperties(
             check.opt_inst_param(asset_key, "asset_key", AssetKey),
             check.bool_param(is_asset_partitioned, "is_asset_partitioned"),
             check.opt_inst_param(asset_check_key, "asset_check_key", AssetCheckKey),
-            check.opt_inst_param(asset_execution_type, "asset_node", AssetExecutionType),
+            check.opt_inst_param(asset_execution_type, "asset_execution_type", AssetExecutionType),
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_execution_plan.ambr
@@ -38,6 +38,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -110,6 +111,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -178,6 +180,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -257,6 +260,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -391,6 +395,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -463,6 +468,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -513,6 +519,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -593,6 +600,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,
@@ -643,6 +651,7 @@
             "properties": {
               "__class__": "StepOutputProperties",
               "asset_check_key": null,
+              "asset_execution_type": null,
               "asset_key": null,
               "is_asset": false,
               "is_asset_partitioned": false,


### PR DESCRIPTION
## Summary & Motivation
Adds the execution type for each asset in a run to the step output properties so that we can use it in https://github.com/dagster-io/internal/pull/15127

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
