### PR TITLE
[dg] Add warning suppression API

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -1,6 +1,5 @@
 import functools
 import textwrap
-import warnings
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -37,6 +36,7 @@ from dagster_dg.utils import (
     load_toml_as_dict,
     modify_toml,
 )
+from dagster_dg.utils.warnings import DgWarningIdentifier, emit_warning
 
 T = TypeVar("T")
 
@@ -190,6 +190,7 @@ class DgCliConfig:
     cache_dir: Path = DEFAULT_CACHE_DIR
     verbose: bool = False
     use_component_modules: list[str] = field(default_factory=list)
+    suppress_warnings: list["DgWarningIdentifier"] = field(default_factory=list)
     telemetry_enabled: bool = True
 
     @classmethod
@@ -207,6 +208,10 @@ class DgCliConfig:
                 "use_component_modules",
                 cls.__dataclass_fields__["use_component_modules"].default_factory(),
             ),
+            suppress_warnings=merged.get(
+                "suppress_warnings",
+                cls.__dataclass_fields__["suppress_warnings"].default_factory(),
+            ),
             telemetry_enabled=merged.get("telemetry", {}).get(
                 "enabled", DgCliConfig.telemetry_enabled
             ),
@@ -223,6 +228,7 @@ class DgRawCliConfig(TypedDict, total=False):
     cache_dir: str
     verbose: bool
     use_component_modules: Sequence[str]
+    suppress_warnings: Sequence[DgWarningIdentifier]
     telemetry: RawDgTelemetryConfig
 
 
@@ -544,28 +550,36 @@ class _DgConfigValidator:
 
     def normalize_deprecated_settings(self, raw_dict: dict[str, Any]) -> None:
         """Normalize deprecated settings to the new format."""
+        # We have to separately extract the warning suppression list since we haven't validated the
+        # config yet.
+        cli_section = raw_dict.get("cli", {})
+        self._validate_file_config_setting(
+            cli_section, "suppress_warnings", list[DgWarningIdentifier], "cli"
+        )
+        suppress_warnings = cast(
+            "list[DgWarningIdentifier]", cli_section.get("suppress_warnings", [])
+        )
+
         if has_toml_node(raw_dict, ("project", "python_environment")):
             full_key = self._get_full_key("project.python_environment")
             python_environment = get_toml_node(raw_dict, ("project", "python_environment"), object)
             if python_environment == "active":
-                warnings.warn(
-                    textwrap.dedent(f"""
+                msg = textwrap.dedent(f"""
                     Setting `{full_key} = "active"` is deprecated. Please update to:
 
                         [{full_key}]
                         active = true
-                    """).strip()
-                )
+                """).strip()
+                emit_warning("deprecated_python_environment", msg, suppress_warnings)
                 raw_dict["project"]["python_environment"] = {"active": True}
             elif python_environment == "persistent_uv":
-                warnings.warn(
-                    textwrap.dedent(f"""
+                msg = textwrap.dedent(f"""
                     Setting `{full_key} = "persistent_uv"` is deprecated. Please update to:
 
                         [{full_key}]
                         uv_managed = true
-                    """).strip()
-                )
+                """).strip()
+                emit_warning("deprecated_python_environment", msg, suppress_warnings)
                 raw_dict["project"]["python_environment"] = {"uv_managed": True}
 
     def validate(self, raw_dict: dict[str, Any]) -> DgFileConfig:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -426,14 +426,12 @@ def generate_tool_dg_cli_in_project_in_workspace_error_message(
     project_path: Path, workspace_path: Path
 ) -> str:
     return textwrap.dedent(f"""
-        `tool.dg.cli` section detected in project `pyproject.toml` file at:
-            {project_path}
-        This project is inside of a workspace at:
-            {workspace_path}
-        """).lstrip() + format_multiline_str("""
         The `tool.dg.cli` section is ignored for project `pyproject.toml` files inside of a
         workspace. Any `tool.dg.cli` settings should be placed in the workspace config file.
-        """)
+
+        `cli` section detected in workspace project `pyproject.toml` file at:
+            {project_path}
+        """).strip()
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
@@ -1,0 +1,28 @@
+from collections.abc import Sequence
+from typing import Literal
+
+import click
+from typing_extensions import TypeAlias
+
+from dagster_dg.utils import format_multiline_str
+
+DgWarningIdentifier: TypeAlias = Literal[
+    "cli_config_in_workspace_project",
+    "deprecated_python_environment",
+]
+
+
+def emit_warning(
+    warning_id: DgWarningIdentifier, msg: str, suppress_warnings: Sequence[DgWarningIdentifier]
+) -> None:
+    if warning_id not in suppress_warnings:
+        suppression_instruction = format_multiline_str(f"""
+            To suppress this warning, add "{warning_id}" to the `cli.suppress_warnings` list in
+            your configuration.
+        """)
+        full_msg = f"{msg}\n\n{suppression_instruction}\n"
+        click.secho(
+            full_msg,
+            fg="yellow",
+            err=True,
+        )


### PR DESCRIPTION
## Summary & Motivation

Add an API for suppressing warnings. Each warning we emit gets a string id. There is a new setting `cli.suppress_warnings` that takes a list of these ids, and will suppress these warnings.

Warnings are echoed directly to stderr by `click`, styled in yellow, and do not go through Python's `warnings.warn`. All warnings messages have a trailer that explains how to suppress them. Example:

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/5cd915a7-d239-41ac-86b5-bf2ec6573c9e" />

## How I Tested These Changes

New unit tests

## Changelog

A new `dg` setting `cli.suppress_warnings` available. This takes a list of warning types to suppress.
