### PR TITLE
Add missing args to dg plus deploy and dg plus deploy start for parity with dagster-cloud ci init

### DIFF
--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -31,6 +31,7 @@ deps =
   -e ../../python_modules/libraries/dagster-azure
   -e ../../python_modules/libraries/dagster-celery
   -e ../../python_modules/libraries/dagster-census
+  -e ../../python_modules/libraries/dagster-cloud-cli
   -e ../../python_modules/libraries/dagster-dask
   -e ../../python_modules/libraries/dagster-databricks
   -e ../../python_modules/libraries/dagster-datadog
@@ -87,7 +88,6 @@ allowlist_externals =
   sh
 commands =
   # install cloud packages out of band due to version conflicts between pypi and source
-  all: uv pip install dagster-cloud-cli --no-deps
   all: uv pip install dagster-cloud --no-deps
   all: uv pip install path
   all: /bin/bash -c '! pip list --exclude-editable | grep -e dagster | grep -v dagster-cloud'

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from dagster_cloud_cli.types import SnapshotBaseDeploymentCondition
 from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.seven.temp_dir import get_system_temp_directory
 
@@ -110,6 +111,17 @@ org_and_deploy_option_group = make_option_group(
     required=False,
     multiple=True,
 )
+@click.option("--status-url", "status_url")
+@click.option(
+    "--snapshot-base-condition",
+    "snapshot_base_condition_str",
+    type=click.Choice(
+        [
+            snapshot_base_condition.value
+            for snapshot_base_condition in SnapshotBaseDeploymentCondition
+        ]
+    ),
+)
 @dg_editable_dagster_options
 @dg_path_options
 @dg_global_options
@@ -126,6 +138,8 @@ def deploy_group(
     skip_confirmation_prompt: bool,
     location_names: tuple[str],
     path: Path,
+    status_url: Optional[str],
+    snapshot_base_condition_str: Optional[str],
     **global_options: object,
 ) -> None:
     """Deploy a project or workspace to Dagster Plus. Handles all state management for the deploy
@@ -145,6 +159,12 @@ def deploy_group(
         raise click.UsageError(
             "Agent type not specified. To specify an agent type, use the --agent-type option."
         )
+
+    snapshot_base_condition = (
+        SnapshotBaseDeploymentCondition(snapshot_base_condition_str)
+        if snapshot_base_condition_str
+        else None
+    )
 
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     plus_config = DagsterPlusCliConfig.get()
@@ -171,6 +191,8 @@ def deploy_group(
         git_url,
         commit_hash,
         location_names,
+        status_url,
+        snapshot_base_condition,
     )
 
     build_artifact(
@@ -230,6 +252,17 @@ def _validate_location_names(
     multiple=True,
 )
 @dg_path_options
+@click.option("--status-url", "status_url")
+@click.option(
+    "--snapshot-base-condition",
+    "snapshot_base_condition_str",
+    type=click.Choice(
+        [
+            snapshot_base_condition.value
+            for snapshot_base_condition in SnapshotBaseDeploymentCondition
+        ]
+    ),
+)
 @dg_global_options
 @cli_telemetry_wrapper
 def start_deploy_session_command(
@@ -241,6 +274,8 @@ def start_deploy_session_command(
     commit_hash: Optional[str],
     location_names: tuple[str],
     path: Path,
+    status_url: Optional[str],
+    snapshot_base_condition_str: Optional[str],
     **global_options: object,
 ) -> None:
     """Start a new deploy session. Determines which code locations will be deployed and what
@@ -256,6 +291,12 @@ def start_deploy_session_command(
     _validate_location_names(dg_context, location_names, cli_config)
     statedir = _get_statedir()
 
+    snapshot_base_condition = (
+        SnapshotBaseDeploymentCondition(snapshot_base_condition_str)
+        if snapshot_base_condition_str
+        else None
+    )
+
     init_deploy_session(
         organization,
         deployment,
@@ -266,6 +307,8 @@ def start_deploy_session_command(
         git_url,
         commit_hash,
         location_names,
+        status_url,
+        snapshot_base_condition,
     )
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import click
 import dagster_shared.check as check
+from dagster_cloud_cli.types import SnapshotBaseDeploymentCondition
 
 from dagster_dg.cli.plus.constants import DgPlusAgentType, DgPlusDeploymentType
 from dagster_dg.cli.utils import create_temp_dagster_cloud_yaml_file
@@ -118,6 +119,8 @@ def init_deploy_session(
     git_url: Optional[str],
     commit_hash: Optional[str],
     location_names: tuple[str],
+    status_url: Optional[str],
+    snapshot_base_condition: Optional[SnapshotBaseDeploymentCondition],
 ):
     from dagster_cloud_cli.commands.ci import init_impl
 
@@ -147,8 +150,8 @@ def init_deploy_session(
         git_url=git_url,
         commit_hash=commit_hash,
         dagster_env=None,
-        status_url=None,
-        snapshot_base_condition=None,
+        status_url=status_url,
+        snapshot_base_condition=snapshot_base_condition,
         clean_statedir=False,
         location_name=list(location_names),
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -114,6 +114,7 @@ def isolated_dg_venv(runner: Union[CliRunner, "ProxyRunner"]) -> Iterator[Path]:
             [
                 "libraries/dagster-dg",
                 "libraries/dagster-shared",
+                "libraries/dagster-cloud-cli",
             ],
         )
 


### PR DESCRIPTION
Summary:
These args in the github action and just needed to be passed through.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
