### PR TITLE
Add dg scaffold build-artifacts

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -15,7 +15,7 @@ from dagster_dg.cli.utils import create_temp_dagster_cloud_yaml_file
 from dagster_dg.config import DgRawBuildConfig, merge_build_configs
 from dagster_dg.context import DgContext
 from dagster_dg.utils.git import get_local_branch_name
-from dagster_dg.utils.plus.build import create_deploy_dockerfile
+from dagster_dg.utils.plus.build import create_deploy_dockerfile, get_dockerfile_path
 
 
 def _guess_deployment_type(
@@ -222,7 +222,7 @@ def _build_artifact_for_project(
         build_directory = Path(check.not_none(merged_build_config["directory"]))
         assert build_directory.is_absolute(), "Build directory must be an absolute path"
 
-    dockerfile_path = build_directory / "Dockerfile"
+    dockerfile_path = get_dockerfile_path(dg_context)
     if not os.path.exists(dockerfile_path):
         click.echo(f"No Dockerfile found - scaffolding a default one at {dockerfile_path}.")
         create_deploy_dockerfile(dockerfile_path, python_version, use_editable_dagster)
@@ -243,7 +243,7 @@ def _build_artifact_for_project(
     else:
         build_impl(
             statedir=str(statedir),
-            dockerfile_path=str(dg_context.root_path / "Dockerfile"),
+            dockerfile_path=str(dockerfile_path),
             use_editable_dagster=use_editable_dagster,
             location_name=[dg_context.code_location_name],
             build_directory=str(build_directory),

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -222,7 +222,7 @@ def _build_artifact_for_project(
         build_directory = Path(check.not_none(merged_build_config["directory"]))
         assert build_directory.is_absolute(), "Build directory must be an absolute path"
 
-    dockerfile_path = get_dockerfile_path(dg_context)
+    dockerfile_path = get_dockerfile_path(dg_context, workspace_context)
     if not os.path.exists(dockerfile_path):
         click.echo(f"No Dockerfile found - scaffolding a default one at {dockerfile_path}.")
         create_deploy_dockerfile(dockerfile_path, python_version, use_editable_dagster)

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -220,11 +220,21 @@ def scaffold_workspace_command(
         "Python version used to deploy the project. If not set, defaults to the calling process's Python minor version."
     ),
 )
+@click.option(
+    "-y",
+    "--yes",
+    "skip_confirmation_prompt",
+    is_flag=True,
+    help="Skip confirmation prompts.",
+)
 @dg_editable_dagster_options
 @dg_global_options
 @cli_telemetry_wrapper
 def scaffold_build_artifacts_command(
-    python_version: str, use_editable_dagster: Optional[str], **global_options: object
+    python_version: str,
+    use_editable_dagster: Optional[str],
+    skip_confirmation_prompt: bool,
+    **global_options: object,
 ) -> None:
     """Scaffolds a Dockerfile to build the given Dagster project or workspace."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
@@ -236,7 +246,7 @@ def scaffold_build_artifacts_command(
 
         create = True
         if project_context.build_config_path.exists():
-            create = click.confirm(
+            create = skip_confirmation_prompt or click.confirm(
                 f"Build config already exists at {project_context.build_config_path}. Overwrite it?",
             )
         if create:
@@ -248,7 +258,7 @@ def scaffold_build_artifacts_command(
         dockerfile_path = get_dockerfile_path(project_context, workspace_context=dg_context)
         create = True
         if dockerfile_path.exists():
-            create = click.confirm(
+            create = skip_confirmation_prompt or click.confirm(
                 f"A Dockerfile already exists at {dockerfile_path}. Overwrite it?",
             )
         if create:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -500,7 +500,7 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
         registry_urls = cast("list[str]", registry_urls)
 
         for location_ctx in project_contexts:
-            dockerfile_path = _get_dockerfile_path(location_ctx)
+            dockerfile_path = get_dockerfile_path(location_ctx)
             if not dockerfile_path.exists():
                 raise click.ClickException(
                     f"Dockerfile not found at {dockerfile_path}. Please run `dg scaffold dockerfile` in {location_ctx.root_path} to create one."

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -52,7 +52,11 @@ from dagster_dg.utils import (
     parse_json_option,
     snakecase,
 )
-from dagster_dg.utils.plus.build import create_deploy_dockerfile, get_agent_type
+from dagster_dg.utils.plus.build import (
+    create_deploy_dockerfile,
+    get_agent_type,
+    get_dockerfile_path,
+)
 from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 
 DEFAULT_WORKSPACE_NAME = "dagster-workspace"
@@ -203,13 +207,6 @@ def scaffold_workspace_command(
 # ########################
 
 
-def _get_dockerfile_path(dg_context: DgContext) -> Path:
-    if dg_context.build_config and dg_context.build_config.get("directory"):
-        return Path(check.not_none(dg_context.build_config["directory"])) / "Dockerfile"
-    else:
-        return Path.cwd() / "Dockerfile"
-
-
 @scaffold_group.command(
     name="Dockerfile",
     cls=ScaffoldSubCommand,
@@ -233,7 +230,7 @@ def scaffold_dockerfile_command(
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
-    dockerfile_path = _get_dockerfile_path(dg_context)
+    dockerfile_path = get_dockerfile_path(dg_context)
     if dockerfile_path.exists():
         click.confirm(
             f"A Dockerfile already exists at {dockerfile_path}. Overwrite it?",

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -512,7 +512,7 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
             dockerfile_path = get_dockerfile_path(location_ctx, dg_context)
             if not dockerfile_path.exists():
                 raise click.ClickException(
-                    f"Dockerfile not found at {dockerfile_path}. Please run `dg scaffold dockerfile` in {location_ctx.root_path} to create one."
+                    f"Dockerfile not found at {dockerfile_path}. Please run `dg scaffold build-artifacts` in {location_ctx.root_path} to create one."
                 )
 
         build_fragment = _get_build_fragment_for_locations(

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -278,7 +278,6 @@ def merge_build_configs(
 ) -> DgRawBuildConfig:
     project_dict = remove_none_recursively(project_build_config or {})
     workspace_dict = remove_none_recursively(workspace_build_config or {})
-
     return cast(
         "DgRawBuildConfig",
         deep_merge_dicts(workspace_dict, project_dict),

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -9,7 +9,6 @@ from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
 from dagster_dg.context import DgContext
-from dagster_dg.utils.plus.build import create_deploy_dockerfile, get_agent_type
 from dagster_dg.utils.plus.gql import DEPLOYMENT_INFO_QUERY
 from dagster_dg.utils.plus.gql_client import DagsterPlusGraphQLClient
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -20,17 +20,17 @@ class AgentType(str, Enum):
 
 
 def get_dockerfile_path(
-    dg_context: DgContext, workspace_context: Optional[DgContext] = None
+    project_context: DgContext, workspace_context: Optional[DgContext] = None
 ) -> Path:
     merged_build_config: DgRawBuildConfig = merge_build_configs(
         workspace_context.build_config if workspace_context else None,
-        dg_context.build_config,
+        project_context.build_config,
     )
 
     if merged_build_config and merged_build_config.get("directory"):
         return Path(check.not_none(merged_build_config["directory"])) / "Dockerfile"
     else:
-        return Path.cwd() / "Dockerfile"
+        return project_context.root_path / "Dockerfile"
 
 
 def get_agent_type(cli_config: Optional[DagsterPlusCliConfig] = None) -> AgentType:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -8,6 +8,7 @@ import jinja2
 from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
+from dagster_dg.config import DgRawBuildConfig, merge_build_configs
 from dagster_dg.context import DgContext
 from dagster_dg.utils.plus.gql import DEPLOYMENT_INFO_QUERY
 from dagster_dg.utils.plus.gql_client import DagsterPlusGraphQLClient
@@ -18,9 +19,16 @@ class AgentType(str, Enum):
     HYBRID = "HYBRID"
 
 
-def get_dockerfile_path(dg_context: DgContext) -> Path:
-    if dg_context.build_config and dg_context.build_config.get("directory"):
-        return Path(check.not_none(dg_context.build_config["directory"])) / "Dockerfile"
+def get_dockerfile_path(
+    dg_context: DgContext, workspace_context: Optional[DgContext] = None
+) -> Path:
+    merged_build_config: DgRawBuildConfig = merge_build_configs(
+        workspace_context.build_config if workspace_context else None,
+        dg_context.build_config,
+    )
+
+    if merged_build_config and merged_build_config.get("directory"):
+        return Path(check.not_none(merged_build_config["directory"])) / "Dockerfile"
     else:
         return Path.cwd() / "Dockerfile"
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -49,7 +49,7 @@ def get_agent_type(cli_config: Optional[DagsterPlusCliConfig] = None) -> AgentTy
         )
 
 
-def create_deploy_dockerfile(dst_path, python_version, use_editable_dagster: bool):
+def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_dagster: bool):
     dockerfile_template_path = (
         Path(__file__).parent.parent.parent
         / "templates"

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -5,8 +5,11 @@ from typing import Optional
 
 import click
 import jinja2
+from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
+from dagster_dg.context import DgContext
+from dagster_dg.utils.plus.build import create_deploy_dockerfile, get_agent_type
 from dagster_dg.utils.plus.gql import DEPLOYMENT_INFO_QUERY
 from dagster_dg.utils.plus.gql_client import DagsterPlusGraphQLClient
 
@@ -14,6 +17,13 @@ from dagster_dg.utils.plus.gql_client import DagsterPlusGraphQLClient
 class AgentType(str, Enum):
     SERVERLESS = "SERVERLESS"
     HYBRID = "HYBRID"
+
+
+def get_dockerfile_path(dg_context: DgContext) -> Path:
+    if dg_context.build_config and dg_context.build_config.get("directory"):
+        return Path(check.not_none(dg_context.build_config["directory"])) / "Dockerfile"
+    else:
+        return Path.cwd() / "Dockerfile"
 
 
 def get_agent_type(cli_config: Optional[DagsterPlusCliConfig] = None) -> AgentType:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
@@ -97,6 +97,10 @@ def test_scaffold_build_artifacts_command_workspace(
     assert (Path("foo") / "build.yaml").read_text() != modified_build_yaml
     assert (Path("foo") / "Dockerfile").read_text() != "junk"
 
+    # Test --yes flag skips confirmation prompts
+    result = runner.invoke("scaffold", "build-artifacts", "--yes")
+    assert result.exit_code == 0, result.output + " " + str(result.exception)
+
 
 def test_scaffold_build_artifacts_command_project(
     dg_plus_cli_config, setup_populated_git_workspace: ProxyRunner
@@ -328,7 +332,9 @@ def test_scaffold_github_actions_command_success_hybrid(
     runner = setup_populated_git_workspace
     result = runner.invoke("scaffold", "build-artifacts")
     assert result.exit_code == 0, result.output + " " + str(result.exception)
-    Path("build.yaml").write_text(yaml.dump({"registry": registry_url}))
+    (Path("foo") / "build.yaml").write_text(yaml.dump({"registry": registry_url, "build": "."}))
+    (Path("bar") / "build.yaml").write_text(yaml.dump({"registry": registry_url, "build": "."}))
+    (Path("baz") / "build.yaml").write_text(yaml.dump({"registry": registry_url, "build": "."}))
 
     result = runner.invoke("scaffold", "github-actions")
     assert result.exit_code == 0, result.output + " " + str(result.exception)
@@ -378,7 +384,8 @@ def test_scaffold_github_actions_command_success_project_hybrid(
         result = runner.invoke("scaffold", "github-actions")
         assert result.exit_code == 1, result.output + " " + str(result.exception)
         assert "No registry URL found" in result.output
-        Path("build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL}))
+        Path("build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL, "build": "."}))
+
         result = runner.invoke("scaffold", "github-actions")
         assert result.exit_code == 1, result.output + " " + str(result.exception)
         assert "Dockerfile not found" in result.output
@@ -424,7 +431,9 @@ def test_scaffold_github_actions_command_no_plus_config_hybrid(
 
         result = runner.invoke("scaffold", "build-artifacts")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
-        Path("build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL}))
+        (Path("foo") / "build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL, "build": "."}))
+        (Path("bar") / "build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL, "build": "."}))
+        (Path("baz") / "build.yaml").write_text(yaml.dump({"registry": FAKE_ECR_URL, "build": "."}))
 
         result = runner.invoke(
             "scaffold",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
@@ -326,21 +326,14 @@ def test_scaffold_github_actions_command_success_project_hybrid(
 
         subprocess.run(["git", "init"], check=False)
 
-        result = runner.invoke(
-            "scaffold",
-            "github-actions",
-            input=FAKE_ECR_URL if registry_source == "prompt" else None,
-        )
+        result = runner.invoke("scaffold", "github-actions")
         assert result.exit_code == 1, result.output + " " + str(result.exception)
         assert "Dockerfile not found" in result.output
 
         result = runner.invoke("scaffold", "Dockerfile")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
-        result = runner.invoke(
-            "scaffold",
-            "github-actions",
-        )
+        result = runner.invoke("scaffold", "github-actions")
         assert result.exit_code == 0, result.output + " " + str(result.exception)
 
         assert Path(".github/workflows/dagster-plus-deploy.yml").exists()


### PR DESCRIPTION
## Summary

Adds a dg command to scaffold a Dockerfile for building a dg project.

`dg scaffold github-actions` now relies on having a Dockerfile in the serverless context.

## Test Plan

New unit test, update hybrid actions tests.