### PR TITLE
[pipes] Fix issue with pipes and subsettable multi assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -218,7 +218,9 @@ def execute_core_compute(
         # checks are required if we're in requires_typed_event_stream mode
         if step_context.requires_typed_event_stream or output.properties.asset_check_key
     }
-    omitted_outputs = expected_op_output_names.difference(emitted_result_names)
+    omitted_outputs = expected_op_output_names.intersection(
+        step_context.selected_output_names
+    ).difference(emitted_result_names)
     if omitted_outputs:
         message = (
             f"{step_context.op_def.node_type_str} '{step.node_handle}' did not yield or return "

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_require_typed_event_stream.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_require_typed_event_stream.py
@@ -204,3 +204,25 @@ def test_requires_typed_event_stream_multi_asset():
         return Output(None, output_name="foo"), Output(None, output_name="bar")
 
     assert materialize([asset_succeeds_multi_asset_return])
+
+
+def test_requires_typed_event_stream_subsettable_multi_asset():
+    @multi_asset(
+        specs=[AssetSpec("foo", skippable=True), AssetSpec("bar", skippable=True)],
+        can_subset=True,
+    )
+    def asset_subsettable_single(context: OpExecutionContext):
+        context.set_requires_typed_event_stream(error_message=EXTRA_ERROR_MESSAGE)
+        yield Output(None, output_name="foo")
+
+    materialize([asset_subsettable_single], selection=["foo"])
+
+    @multi_asset(
+        specs=[AssetSpec("foo", skippable=True), AssetSpec("bar", skippable=True)],
+        can_subset=True,
+    )
+    def asset_subsettable_none(context: OpExecutionContext):
+        context.set_requires_typed_event_stream(error_message=EXTRA_ERROR_MESSAGE)
+
+    with raises_missing_output_error():
+        materialize([asset_subsettable_none], selection=["bar"])


### PR DESCRIPTION
## Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/26244

The core issue is that the original code was not filtering down the expected output names to the ones that were actually selected for computation.

This system in general is likely long-overdue for a rework, but this is a minimal change that gets to the heart of the issue.

## How I Tested These Changes

unit

## Changelog

Fixed a bug that would multi-assets defined with `can_subset=True` to error when using `dagster-pipes` if not all outputs were emitted.
