### PR TITLE
[historical-runs 1/n][dagster-airlift] make monitor job range configurable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
@@ -15,7 +15,7 @@ export type AssetGraphSidebarQuery = {
         id: string;
         pipelineSnapshotId: string;
         parentSnapshotId: string | null;
-        externalJobSource: Types.ExternalJobSource | null;
+        externalJobSource: string | null;
         name: string;
         description: string | null;
         metadataEntries: Array<

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1220,7 +1220,7 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   parentSnapshotId: String
   graphName: String!
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!
@@ -1232,10 +1232,6 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
     selectedAssetKeys: [AssetKeyInput!]
   ): PartitionKeys!
   partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
-}
-
-enum ExternalJobSource {
-  AIRFLOW
 }
 
 type PartitionKeys {
@@ -1528,7 +1524,7 @@ type PipelineSnapshot implements SolidContainer & IPipelineSnapshot & PipelineRe
   graphName: String!
   solidSelection: [String!]
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
 }
 
 union PipelineSnapshotOrError =
@@ -1594,7 +1590,7 @@ type Run implements PipelineRun & RunsFeedEntry {
   allPools: [String!]
   hasUnconstrainedRootNodes: Boolean!
   hasRunMetricsEnabled: Boolean!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
 }
 
 interface RunsFeedEntry {
@@ -2328,7 +2324,7 @@ type Job implements SolidContainer & IPipelineSnapshot {
   parentSnapshotId: String
   graphName: String!
   runTags: [PipelineTag!]!
-  externalJobSource: ExternalJobSource
+  externalJobSource: String
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1735,10 +1735,6 @@ export type ExpectationResult = DisplayableEvent & {
   success: Scalars['Boolean']['output'];
 };
 
-export enum ExternalJobSource {
-  AIRFLOW = 'AIRFLOW',
-}
-
 export type FailedToMaterializeEvent = DisplayableEvent &
   MessageEvent &
   StepEvent & {
@@ -2257,7 +2253,7 @@ export type Job = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     isAssetJob: Scalars['Boolean']['output'];
@@ -3627,7 +3623,7 @@ export type Pipeline = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     isAssetJob: Scalars['Boolean']['output'];
@@ -3869,7 +3865,7 @@ export type PipelineSnapshot = IPipelineSnapshot &
     dagsterTypeOrError: DagsterTypeOrError;
     dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']['output']>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     graphName: Scalars['String']['output'];
     id: Scalars['ID']['output'];
     metadataEntries: Array<
@@ -4752,7 +4748,7 @@ export type Run = PipelineRun &
     endTime: Maybe<Scalars['Float']['output']>;
     eventConnection: EventConnection;
     executionPlan: Maybe<ExecutionPlan>;
-    externalJobSource: Maybe<ExternalJobSource>;
+    externalJobSource: Maybe<Scalars['String']['output']>;
     hasConcurrencyKeySlots: Scalars['Boolean']['output'];
     hasDeletePermission: Scalars['Boolean']['output'];
     hasReExecutePermission: Scalars['Boolean']['output'];
@@ -9881,7 +9877,7 @@ export const buildJob = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'suscipit',
     graphName:
       overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'eveniet',
     id:
@@ -12196,7 +12192,7 @@ export const buildPipeline = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'quis',
     graphName: overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'eius',
     id:
       overrides && overrides.hasOwnProperty('id')
@@ -12629,7 +12625,7 @@ export const buildPipelineSnapshot = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'ut',
     graphName:
       overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'dolorum',
     id:
@@ -13866,7 +13862,7 @@ export const buildRun = (
     externalJobSource:
       overrides && overrides.hasOwnProperty('externalJobSource')
         ? overrides.externalJobSource!
-        : ExternalJobSource.AIRFLOW,
+        : 'similique',
     hasConcurrencyKeySlots:
       overrides && overrides.hasOwnProperty('hasConcurrencyKeySlots')
         ? overrides.hasConcurrencyKeySlots!

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/getLeftNavItemsForOption.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import {LeftNavItemType} from './LeftNavItemType';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {ExternalJobSource} from '../graphql/types';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -85,7 +84,7 @@ export const getJobItemsForOption = (option: DagsterRepoOption) => {
     const sensorsForJob = sensors.filter((sensor) =>
       sensor.targets?.map((target) => target.pipelineName).includes(name),
     );
-    const isAirflowJob = externalJobSource === ExternalJobSource.AIRFLOW;
+    const isAirflowJob = externalJobSource === 'airflow';
 
     items.push({
       name,

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
@@ -4533,7 +4533,7 @@ export type GraphExplorerFragment_PipelineSnapshot = {
   description: string | null;
   pipelineSnapshotId: string;
   parentSnapshotId: string | null;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   metadataEntries: Array<
     | {
         __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
@@ -20,7 +20,7 @@ export type PipelineExplorerRootQuery = {
         description: string | null;
         pipelineSnapshotId: string;
         parentSnapshotId: string | null;
-        externalJobSource: Types.ExternalJobSource | null;
+        externalJobSource: string | null;
         metadataEntries: Array<
           | {
               __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
@@ -4530,7 +4530,7 @@ export type SidebarRootContainerFragment_PipelineSnapshot = {
   __typename: 'PipelineSnapshot';
   pipelineSnapshotId: string;
   parentSnapshotId: string | null;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   id: string;
   name: string;
   description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
@@ -1,4 +1,4 @@
-import {ExternalJobSource, RunStatus} from '../graphql/types';
+import {RunStatus} from '../graphql/types';
 import {RepoAddress} from '../workspace/types';
 
 export type RunAutomation =
@@ -11,7 +11,7 @@ export type TimelineRun = {
   startTime: number;
   endTime: number;
   automation: null | RunAutomation;
-  externalJobSource: null | ExternalJobSource;
+  externalJobSource: null | string;
 };
 
 export type RowObjectType = 'job' | 'asset' | 'schedule' | 'sensor' | 'legacy-amp' | 'manual';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -6,7 +6,7 @@ export type RunTimelineFragment = {
   __typename: 'Run';
   id: string;
   pipelineName: string;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   status: Types.RunStatus;
   creationTime: number;
   startTime: number | null;
@@ -38,7 +38,7 @@ export type OngoingRunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          externalJobSource: Types.ExternalJobSource | null;
+          externalJobSource: string | null;
           status: Types.RunStatus;
           creationTime: number;
           startTime: number | null;
@@ -72,7 +72,7 @@ export type CompletedRunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          externalJobSource: Types.ExternalJobSource | null;
+          externalJobSource: string | null;
           status: Types.RunStatus;
           creationTime: number;
           startTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
@@ -60,7 +60,7 @@ export type LocationWorkspaceQuery = {
                   name: string;
                   isJob: boolean;
                   isAssetJob: boolean;
-                  externalJobSource: Types.ExternalJobSource | null;
+                  externalJobSource: string | null;
                   pipelineSnapshotId: string;
                 }>;
                 schedules: Array<{
@@ -224,7 +224,7 @@ export type WorkspaceLocationNodeFragment = {
             name: string;
             isJob: boolean;
             isAssetJob: boolean;
-            externalJobSource: Types.ExternalJobSource | null;
+            externalJobSource: string | null;
             pipelineSnapshotId: string;
           }>;
           schedules: Array<{
@@ -368,7 +368,7 @@ export type WorkspaceLocationFragment = {
       name: string;
       isJob: boolean;
       isAssetJob: boolean;
-      externalJobSource: Types.ExternalJobSource | null;
+      externalJobSource: string | null;
       pipelineSnapshotId: string;
     }>;
     schedules: Array<{
@@ -492,7 +492,7 @@ export type WorkspaceRepositoryFragment = {
     name: string;
     isJob: boolean;
     isAssetJob: boolean;
-    externalJobSource: Types.ExternalJobSource | null;
+    externalJobSource: string | null;
     pipelineSnapshotId: string;
   }>;
   schedules: Array<{
@@ -611,7 +611,7 @@ export type WorkspacePipelineFragment = {
   name: string;
   isJob: boolean;
   isAssetJob: boolean;
-  externalJobSource: Types.ExternalJobSource | null;
+  externalJobSource: string | null;
   pipelineSnapshotId: string;
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,4 +1,3 @@
-import enum
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, AbstractSet, Optional  # noqa: UP035
 
@@ -420,13 +419,6 @@ class GrapheneEventConnectionOrError(graphene.Union):
         name = "EventConnectionOrError"
 
 
-class ExternalJobSource(enum.Enum):
-    AIRFLOW = "AIRFLOW"
-
-
-GrapheneExternalJobSource = graphene.Enum.from_enum(ExternalJobSource)
-
-
 class GraphenePipelineRun(graphene.Interface):
     id = graphene.NonNull(graphene.ID)
     runId = graphene.NonNull(graphene.String)
@@ -517,7 +509,7 @@ class GrapheneRun(graphene.ObjectType):
     allPools = graphene.List(graphene.NonNull(graphene.String))
     hasUnconstrainedRootNodes = graphene.NonNull(graphene.Boolean)
     hasRunMetricsEnabled = graphene.NonNull(graphene.Boolean)
-    externalJobSource = GrapheneExternalJobSource()
+    externalJobSource = graphene.String()
 
     class Meta:
         interfaces = (GraphenePipelineRun, GrapheneRunsFeedEntry)
@@ -653,12 +645,13 @@ class GrapheneRun(graphene.ObjectType):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self.dagster_run.tags.items()
+            if get_tag_type(key) != TagType.HIDDEN
         ]
 
     def resolve_externalJobSource(self, _graphene_info: ResolveInfo):
         source_str = self.dagster_run.tags.get(EXTERNAL_JOB_SOURCE_TAG_KEY)
         if source_str:
-            return ExternalJobSource(source_str.upper())
+            return source_str.lower()
         return None
 
     def resolve_rootRunId(self, _graphene_info: ResolveInfo):
@@ -819,7 +812,7 @@ class GrapheneIPipelineSnapshotMixin:
     sensors = non_null_list(GrapheneSensor)
     parent_snapshot_id = graphene.String()
     graph_name = graphene.NonNull(graphene.String)
-    externalJobSource = GrapheneExternalJobSource()
+    externalJobSource = graphene.String()
 
     class Meta:
         name = "IPipelineSnapshotMixin"
@@ -925,7 +918,7 @@ class GrapheneIPipelineSnapshotMixin:
         represented_pipeline = self.get_represented_job()
         source_str = represented_pipeline.job_snapshot.tags.get(EXTERNAL_JOB_SOURCE_TAG_KEY)
         if source_str:
-            return ExternalJobSource(source_str.upper())
+            return source_str.lower()
         return None
 
     def resolve_run_tags(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -855,7 +855,7 @@ class Definitions(IHaveNew):
         ]
         sensors = []
         for sensor in self.sensors or []:
-            if sensor.has_jobs and any(job.name == job_name for job in sensor.jobs):
+            if has_job_defs_attached(sensor) and any(job.name == job_name for job in sensor.jobs):
                 sensors.append(
                     sensor.with_updated_jobs(
                         [job for job in sensor.jobs if job.name != job_name] + [job_def]
@@ -893,3 +893,7 @@ def get_job_from_defs(
         iter(job for job in (defs.jobs or []) if job.name == name),
         None,
     )
+
+
+def has_job_defs_attached(sensor_def: SensorDefinition) -> bool:
+    return any(target.has_job_def for target in sensor_def.targets)

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -44,7 +44,6 @@ from dagster._core.execution.resources_init import (
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._loggers import default_loggers, default_system_loggers
@@ -55,10 +54,16 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.outputs import StepOutputHandle
     from dagster._core.executor.base import Executor
 
+    # Import within functions so that we can mock the class in tests using freeze_time.
+    # Essentially, we want to be able to control the timestamp of the log records.
+    from dagster._core.log_manager import DagsterLogManager
+
 
 def initialize_console_manager(
     dagster_run: Optional[DagsterRun], instance: Optional[DagsterInstance] = None
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
+    from dagster._core.log_manager import DagsterLogManager
+
     # initialize default colored console logger
     loggers = []
     for logger_def, logger_config in default_system_loggers(instance):
@@ -458,7 +463,9 @@ def scoped_job_context(
 
 def create_log_manager(
     context_creation_data: ContextCreationData,
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(context_creation_data, "context_creation_data", ContextCreationData)
 
     job_def, resolved_run_config, dagster_run = (
@@ -506,7 +513,7 @@ def create_log_manager(
 
 def create_context_free_log_manager(
     instance: DagsterInstance, dagster_run: DagsterRun
-) -> DagsterLogManager:
+) -> "DagsterLogManager":
     """In the event of pipeline initialization failure, we want to be able to log the failure
     without a dependency on the PlanExecutionContext to initialize DagsterLogManager.
 
@@ -514,6 +521,8 @@ def create_context_free_log_manager(
         dagster_run (PipelineRun)
         pipeline_def (JobDefinition)
     """
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(dagster_run, "dagster_run", DagsterRun)
 

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -26,7 +26,6 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.executor.base import Executor
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._loggers import default_system_loggers
 from dagster._utils import ensure_single_item
@@ -80,6 +79,8 @@ def host_mode_execution_context_event_generator(
     output_capture: None,
     resume_from_failure: bool = False,
 ) -> Iterator[Union[PlanOrchestrationContext, DagsterEvent]]:
+    from dagster._core.log_manager import DagsterLogManager
+
     check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
     check.inst_param(pipeline, "pipeline", ReconstructableJob)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -7,6 +7,7 @@ import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from enum import Enum
 from tempfile import TemporaryDirectory
 from types import TracebackType
@@ -85,7 +86,7 @@ from dagster._core.storage.tags import (
 from dagster._core.types.pagination import PaginatedResults
 from dagster._serdes import ConfigurableClass
 from dagster._streamline.asset_check_health import AssetCheckHealthState
-from dagster._time import get_current_datetime, get_current_timestamp
+from dagster._time import datetime_from_timestamp, get_current_datetime, get_current_timestamp
 from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
@@ -1925,8 +1926,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.add_snapshot(snapshot)
 
     @traced
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._run_storage.handle_run_event(run_id, event)
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._run_storage.handle_run_event(run_id, event, update_timestamp)
 
     @traced
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
@@ -2668,7 +2671,9 @@ class DagsterInstance(DynamicPartitionsStore):
                 and event.is_dagster_event
                 and event.get_dagster_event().is_job_event
             ):
-                self._run_storage.handle_run_event(run_id, event.get_dagster_event())
+                self._run_storage.handle_run_event(
+                    run_id, event.get_dagster_event(), datetime_from_timestamp(event.timestamp)
+                )
                 run = self.get_run_by_id(run_id)
                 if run and event.get_dagster_event().is_run_failure and self.run_retries_enabled:
                     # Note that this tag is only applied to runs that fail. Successful runs will not
@@ -2749,6 +2754,7 @@ class DagsterInstance(DynamicPartitionsStore):
         run_id: str,
         log_level: Union[str, int] = logging.INFO,
         batch_metadata: Optional["DagsterEventBatchMetadata"] = None,
+        timestamp: Optional[float] = None,
     ) -> None:
         """Takes a DagsterEvent and stores it in persistent storage for the corresponding DagsterRun."""
         from dagster._core.events.log import EventLogEntry
@@ -2759,7 +2765,7 @@ class DagsterInstance(DynamicPartitionsStore):
             job_name=dagster_event.job_name,
             run_id=run_id,
             error_info=None,
-            timestamp=get_current_timestamp(),
+            timestamp=timestamp or get_current_timestamp(),
             step_key=dagster_event.step_key,
             dagster_event=dagster_event,
         )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Union  # noqa: UP035
 
 from dagster import _check as check
@@ -198,8 +199,15 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def add_run(self, dagster_run: "DagsterRun") -> "DagsterRun":
         return self._storage.run_storage.add_run(dagster_run)
 
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._storage.run_storage.handle_run_event(run_id, event)
+    def add_historical_run(
+        self, dagster_run: "DagsterRun", run_creation_time: datetime
+    ) -> "DagsterRun":
+        return self._storage.run_storage.add_historical_run(dagster_run, run_creation_time)
+
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._storage.run_storage.handle_run_event(run_id, event, update_timestamp)
 
     def get_runs(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Union
 
 from typing_extensions import TypedDict
@@ -55,7 +56,15 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def handle_run_event(self, run_id: str, event: DagsterEvent) -> None:
+    def add_historical_run(
+        self, dagster_run: DagsterRun, run_creation_time: datetime
+    ) -> DagsterRun:
+        """Add a historical run to storage."""
+
+    @abstractmethod
+    def handle_run_event(
+        self, run_id: str, event: DagsterEvent, update_timestamp: Optional[datetime] = None
+    ) -> None:
         """Update run storage in accordance to a pipeline run related DagsterEvent.
 
         Args:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -55,6 +55,9 @@ class TestSqliteRunStorage(TestRunStorage):
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
@@ -83,6 +86,9 @@ class TestInMemoryRunStorage(TestRunStorage):
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         with DagsterInstance.ephemeral() as the_instance:
@@ -109,6 +115,9 @@ class TestLegacyRunStorage(TestRunStorage):
         return True
 
     def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+        return True
+
+    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return True
 
     @pytest.fixture(name="instance", scope="function")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -121,7 +121,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
     MULTIDIMENSIONAL_PARTITION_PREFIX,
 )
-from dagster._core.test_utils import create_run_for_test, instance_for_test
+from dagster._core.test_utils import create_run_for_test, freeze_time, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._loggers import colored_console_logger
@@ -3097,6 +3097,44 @@ class TestEventLogStorage:
                 )
 
             assert failed_partitions_by_step_key == failed_partitions
+
+    def test_timestamp_overrides(self, storage, instance: DagsterInstance) -> None:
+        frozen_time = get_current_datetime()
+        frozen_time = get_current_datetime()
+        with freeze_time(frozen_time):
+            instance.report_dagster_event(
+                run_id="",
+                dagster_event=DagsterEvent(
+                    event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,
+                    job_name="",
+                    event_specific_data=StepMaterializationData(
+                        AssetMaterialization(asset_key="foo")
+                    ),
+                ),
+            )
+
+            record = instance.get_asset_records([AssetKey("foo")])[0]
+            assert (
+                record.asset_entry.last_materialization_record.timestamp == frozen_time.timestamp()  # type: ignore
+            )
+
+            report_date = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+
+            instance.report_dagster_event(
+                run_id="",
+                dagster_event=DagsterEvent(
+                    event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,
+                    job_name="",
+                    event_specific_data=StepMaterializationData(
+                        AssetMaterialization(asset_key="foo")
+                    ),
+                ),
+                timestamp=report_date.timestamp(),
+            )
+            record = instance.get_asset_records([AssetKey("foo")])[0]
+            assert (
+                record.asset_entry.last_materialization_record.timestamp == report_date.timestamp()  # type: ignore
+            )
 
     def test_get_latest_storage_ids_by_partition(self, storage, instance):
         a = AssetKey(["a"])

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components import Component, ComponentLoadContext, Resolvable
@@ -42,7 +42,7 @@ class AirflowInstanceScaffolder(Scaffolder):
         return AirflowInstanceScaffolderParams
 
     def scaffold(self, request: ScaffoldRequest, params: AirflowInstanceScaffolderParams) -> None:
-        full_params = {
+        full_params: dict[str, Any] = {
             "name": params.name,
         }
         if params.auth_type == "basic_auth":

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
@@ -1,34 +1,59 @@
-from typing import Union
+import datetime
+from typing import Optional, Union
 
-from dagster import RunRequest
+from dagster import RunRequest, sensor
 from dagster._annotations import beta
+from dagster._config.pythonic_config.config import Config
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.op_decorator import op
-from dagster._core.definitions.decorators.schedule_decorator import schedule
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.run_request import SkipReason
-from dagster._core.definitions.schedule_definition import (
-    DefaultScheduleStatus,
-    ScheduleEvaluationContext,
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    SensorDefinition,
+    SensorEvaluationContext,
 )
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
-from dagster._core.storage.dagster_run import RunsFilter
+from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster._grpc.client import DEFAULT_SENSOR_GRPC_TIMEOUT
-from dagster._time import datetime_from_timestamp, get_current_datetime
+from dagster._record import record
+from dagster._serdes import deserialize_value, serialize_value
+from dagster._time import get_current_datetime
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.monitoring_job.event_stream import persist_events
-from dagster_airlift.core.monitoring_job.utils import (
-    augment_monitor_run_with_range_tags,
-    get_range_from_run_history,
-    structured_log,
-)
+from dagster_airlift.core.monitoring_job.utils import structured_log
 from dagster_airlift.core.utils import monitoring_job_name
+from dagster_shared.serdes import whitelist_for_serdes
+from pydantic import Field
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 30
 START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
+
+
+@whitelist_for_serdes
+@record
+class AirflowMonitoringJobSensorCursor:
+    range_start: str
+    range_end: str
+
+    def to_config(self) -> "MonitoringConfig":
+        return MonitoringConfig(range_start=self.range_start, range_end=self.range_end)
+
+    def to_tags(self) -> dict[str, str]:
+        return {
+            "range_start": self.range_start,
+            "range_end": self.range_end,
+        }
+
+    def advance(self, effective_timestamp: datetime.datetime) -> "AirflowMonitoringJobSensorCursor":
+        return AirflowMonitoringJobSensorCursor(
+            range_start=self.range_end, range_end=effective_timestamp.isoformat()
+        )
 
 
 # IMPROVEME BCOR-102: We should be able to replace the sensor from the original Airlift functionality with this job.
@@ -38,39 +63,84 @@ def build_airflow_monitoring_defs(
     airflow_instance: AirflowInstance,
 ) -> Definitions:
     """The constructed job polls the Airflow instance for activity, and inserts asset events into Dagster's event log."""
-
-    @job(name=monitoring_job_name(airflow_instance.name))
-    def airflow_monitoring_job():
-        _build_monitoring_op(airflow_instance)()
-
-    @schedule(
-        job=airflow_monitoring_job,
-        cron_schedule="* * * * *",
-        name=f"{airflow_instance.name}__airflow_monitoring_job_schedule",
-        default_status=DefaultScheduleStatus.RUNNING,
-    )
-    def airflow_monitoring_job_schedule(
-        context: ScheduleEvaluationContext,
-    ) -> Union[RunRequest, SkipReason]:
-        """The schedule that runs the sensor job."""
-        # Get the last run for this job
-        last_run = next(
-            iter(
-                context.instance.get_runs(
-                    filters=RunsFilter(job_name=airflow_monitoring_job.name),
-                    limit=1,
-                )
-            ),
-            None,
-        )
-        if not last_run or last_run.is_finished:
-            return RunRequest()
-        else:
-            return SkipReason("Monitoring job is already running.")
-
     return Definitions(
-        jobs=[airflow_monitoring_job],
-        schedules=[airflow_monitoring_job_schedule],
+        jobs=[build_monitoring_job(airflow_instance=airflow_instance)],
+        sensors=[build_monitoring_sensor(airflow_instance=airflow_instance)],
+    )
+
+
+class MonitoringConfig(Config):
+    range_start: str = Field(
+        description="The start of the range to process. Should be an ISO 8601 formatted string."
+    )
+    range_end: str = Field(
+        description="The end of the range to process. Should be an ISO 8601 formatted string."
+    )
+
+    @property
+    def range_start_datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.range_start)
+
+    @property
+    def range_end_datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.range_end)
+
+
+def build_monitoring_sensor(
+    *,
+    airflow_instance: AirflowInstance,
+) -> SensorDefinition:
+    @sensor(
+        job_name=monitoring_job_name(airflow_instance.name),
+        name=f"{airflow_instance.name}__airflow_monitoring_job_sensor",
+        default_status=DefaultSensorStatus.RUNNING,
+    )
+    def airflow_monitoring_job_sensor(
+        context: SensorEvaluationContext,
+    ) -> Union[RunRequest, SkipReason]:
+        effective_timestamp = get_current_datetime()
+        if context.cursor is None:
+            cursor = AirflowMonitoringJobSensorCursor(
+                range_start=(get_current_datetime() - datetime.timedelta(seconds=30)).isoformat(),
+                range_end=effective_timestamp.isoformat(),
+            )
+        else:
+            cursor = deserialize_value(context.cursor, AirflowMonitoringJobSensorCursor)
+
+        run = _get_run_for_cursor(context, airflow_instance, cursor)
+        if run and not run.is_finished:
+            return SkipReason(
+                f"Monitoring job is still running for range {cursor.range_start} to {cursor.range_end}. Waiting to advance."
+            )
+        # We only advance the cursor if the run has finished.
+        cursor = cursor if not run else cursor.advance(effective_timestamp)
+        context.update_cursor(serialize_value(cursor))
+
+        return RunRequest(
+            run_config=RunConfig(
+                ops={monitoring_job_op_name(airflow_instance): cursor.to_config()},
+            ),
+            tags=cursor.to_tags(),
+        )
+
+    return airflow_monitoring_job_sensor
+
+
+def _get_run_for_cursor(
+    context: SensorEvaluationContext,
+    airflow_instance: AirflowInstance,
+    cursor: AirflowMonitoringJobSensorCursor,
+) -> Optional[DagsterRun]:
+    return next(
+        iter(
+            context.instance.get_runs(
+                filters=RunsFilter(
+                    job_name=monitoring_job_name(airflow_instance.name), tags=cursor.to_tags()
+                ),
+                limit=1,
+            )
+        ),
+        None,
     )
 
 
@@ -80,7 +150,7 @@ def _build_monitoring_op(
     @op(
         name=monitoring_job_op_name(airflow_instance),
     )
-    def monitor_dags(context: OpExecutionContext) -> None:
+    def monitor_dags(context: OpExecutionContext, config: MonitoringConfig) -> None:
         """The main function that runs the sensor. It polls the Airflow instance for activity and emits asset events."""
         # This is a hack to get the repository tag for the current run. It's bad because it assumes that the job we're
         # creating a run for is within the same repository; but I think that we'll have to do a second pass to get "outside of code
@@ -88,19 +158,32 @@ def _build_monitoring_op(
         airflow_data = AirflowDefinitionsData(
             airflow_instance=airflow_instance, resolved_repository=context.repository_def
         )
-        # get previously processed time range from run tags
-        current_date = get_current_datetime()
-        range_start, range_end = get_range_from_run_history(context, current_date.timestamp())
-        augment_monitor_run_with_range_tags(context, range_start, range_end)
 
         structured_log(
             context,
-            f"Processing from {datetime_from_timestamp(range_start)} to {datetime_from_timestamp(range_end)}",
+            f"Processing from {config.range_start} to {config.range_end}",
         )
-        persist_events(context, airflow_data, airflow_instance, range_start, range_end)
+        persist_events(
+            context,
+            airflow_data,
+            airflow_instance,
+            config.range_start_datetime.timestamp(),
+            config.range_end_datetime.timestamp(),
+        )
 
     return monitor_dags
 
 
 def monitoring_job_op_name(airflow_instance: AirflowInstance) -> str:
     return f"core_monitor__{airflow_instance.name}"
+
+
+def build_monitoring_job(
+    *,
+    airflow_instance: AirflowInstance,
+) -> JobDefinition:
+    @job(name=monitoring_job_name(airflow_instance.name))
+    def airflow_monitoring_job():
+        _build_monitoring_op(airflow_instance)()
+
+    return airflow_monitoring_job

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
@@ -12,44 +12,9 @@ from dagster._core.definitions.metadata.external_metadata import (
 )
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
+from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY
 from dagster_airlift.core.runtime_representations import DagRun, TaskInstance
-
-START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
-
-
-def get_range_from_run_history(
-    context: OpExecutionContext, effective_ts: float
-) -> tuple[float, float]:
-    prev_run = next(
-        iter(
-            context.instance.get_runs(
-                filters=RunsFilter(job_name=context.job_name, statuses=[DagsterRunStatus.SUCCESS]),
-                limit=1,
-            )
-        ),
-        None,
-    )
-    if prev_run:
-        # Start from the end of the last run
-        range_start = float(prev_run.tags_for_storage()["dagster-airlift/monitoring_job_range_end"])
-    else:
-        range_start = effective_ts - START_LOOKBACK_SECONDS
-    range_end = effective_ts
-    return range_start, range_end
-
-
-def augment_monitor_run_with_range_tags(
-    context: OpExecutionContext, range_start: float, range_end: float
-) -> None:
-    context.instance.add_run_tags(
-        run_id=context.run_id,
-        new_tags={
-            "dagster-airlift/monitoring_job_range_start": str(range_start),
-            "dagster-airlift/monitoring_job_range_end": str(range_end),
-        },
-    )
 
 
 def structured_log(context: OpExecutionContext, message: str) -> None:

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -281,6 +281,7 @@ def make_task_instance(
     start_date: datetime,
     end_date: datetime,
     logical_date: Optional[datetime] = None,
+    try_number: int = 1,
 ) -> TaskInstance:
     return TaskInstance(
         webserver_url="http://dummy.domain",
@@ -292,7 +293,7 @@ def make_task_instance(
             "start_date": start_date.isoformat(),
             "end_date": end_date.isoformat(),
             "logical_date": logical_date.isoformat() if logical_date else start_date.isoformat(),
-            "try_number": 1,
+            "try_number": try_number,
         },
     )
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -76,7 +76,8 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
         assert keyed_spec is not None
         assert keyed_spec.metadata["foo"] == "bar"
 
-    assert len(defs.jobs) == 3  # monitoring job + 2 dag jobs.
+    assert defs.jobs
+    assert len(defs.jobs) == 3  # type: ignore # monitoring job + 2 dag jobs.
 
 
 def _scaffold_airlift(scaffold_format: str):

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
@@ -51,6 +51,7 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
         defs, af_instance = create_defs_and_instance(
             assets_per_task={
                 "dag": {"task": [("a", [])]},
+                "dag2": {"task": [("b", [])]},
             },
             create_runs=False,
             create_assets_defs=False,
@@ -81,6 +82,14 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     end_date=freeze_datetime,
                     state="failed",
                 ),
+                # Newly finished run that started after the last iteration, and therefore has no corresponding run on the instance.
+                make_dag_run(
+                    dag_id="dag2",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
+                    state="success",
+                ),
             ],
             seeded_task_instances=[
                 # Have a newly completed task instance for the newly started run.
@@ -90,6 +99,14 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     run_id="run-dag",
                     start_date=freeze_datetime - timedelta(seconds=30),
                     end_date=freeze_datetime,
+                ),
+                # Have a newly completed task instance for the late run.
+                make_task_instance(
+                    dag_id="dag2",
+                    task_id="task",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
                 ),
             ],
             seeded_logs={
@@ -101,8 +118,8 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
             mapped_defs=defs,
         )
         success_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
                 job_name=job_name("dag"),
                 run_id=success_dagster_run_id,
                 tags={
@@ -110,19 +127,20 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     DAG_ID_TAG_KEY: "dag",
                 },
                 status=DagsterRunStatus.STARTED,
-            )
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
         )
         failure_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
                 job_name=job_name("dag"),
                 run_id=failure_dagster_run_id,
                 tags={
                     DAG_RUN_ID_TAG_KEY: "failure-run",
                     DAG_ID_TAG_KEY: "dag",
                 },
-                status=DagsterRunStatus.STARTED,
-            )
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
         )
         result = defs.execute_job_in_process(
             job_name=monitoring_job_name(af_instance.name),
@@ -140,29 +158,44 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
         assert result.success
 
         # Expect that the success and failure runs are marked as finished.
-        assert (
-            check.not_none(instance.get_run_by_id(success_dagster_run_id)).status
-            == DagsterRunStatus.SUCCESS
-        )
-        assert (
-            check.not_none(instance.get_run_by_id(failure_dagster_run_id)).status
-            == DagsterRunStatus.FAILURE
-        )
+        success_record = check.not_none(instance.get_run_record_by_id(success_dagster_run_id))
+        assert success_record.dagster_run.status == DagsterRunStatus.SUCCESS
+        assert success_record.end_time == (freeze_datetime).timestamp()
+
+        failure_record = check.not_none(instance.get_run_record_by_id(failure_dagster_run_id))
+        assert failure_record.dagster_run.status == DagsterRunStatus.FAILURE
+        assert failure_record.end_time == (freeze_datetime).timestamp()
+
         # Expect that we created a new run for the newly running run.
-        newly_started_run = next(
-            iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
+        newly_started_run_record = next(
+            iter(instance.get_run_records(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
+        )
+        assert newly_started_run_record.dagster_run.status == DagsterRunStatus.STARTED
+        assert (
+            newly_started_run_record.start_time
+            == (freeze_datetime - timedelta(seconds=30)).timestamp()
         )
 
-        assert newly_started_run.status == DagsterRunStatus.STARTED
+        late_run = next(
+            iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "late-run"})))
+        )
+        assert late_run.status == DagsterRunStatus.SUCCESS
+        run_record = check.not_none(instance.get_run_record_by_id(late_run.run_id))
+        assert (
+            run_record.create_timestamp.timestamp()
+            == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        )
+        assert run_record.start_time == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        assert run_record.end_time == (freeze_datetime - timedelta(seconds=10)).timestamp()
 
         # There should be planned materialization data for the task.
         planned_info = instance.get_latest_planned_materialization_info(AssetKey("a"))
         assert planned_info
-        assert planned_info.run_id == newly_started_run.run_id
+        assert planned_info.run_id == newly_started_run_record.dagster_run.run_id
         # Expect that we emitted asset materialization events for the task.
         mapped_asset_mat = instance.get_latest_materialization_event(AssetKey("a"))
         assert mapped_asset_mat is not None
-        assert mapped_asset_mat.run_id == newly_started_run.run_id
+        assert mapped_asset_mat.run_id == newly_started_run_record.dagster_run.run_id
 
 
 def get_invalid_json_log_content() -> str:
@@ -232,9 +265,16 @@ def test_monitoring_job_log_extraction_errors(
             job_name=monitoring_job_name(af_instance.name),
             instance=instance,
             tags={REPOSITORY_LABEL_TAG: "placeholder"},
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(freeze_datetime - timedelta(seconds=30)).isoformat(),
+                        range_end=freeze_datetime.isoformat(),
+                    )
+                }
+            ),
         )
         assert result.success
-
         newly_started_run = next(
             iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
         )
@@ -350,18 +390,16 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
             instance=instance,
             repository_def=defs.get_repository_def(),
         )
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, RunRequest)
         assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
             "config": {
-                "range_start_iso": (freeze_datetime - timedelta(seconds=30)).isoformat(),
-                "range_end_iso": freeze_datetime.isoformat(),
+                "range_start": (freeze_datetime - timedelta(seconds=30)).isoformat(),
+                "range_end": freeze_datetime.isoformat(),
             }
         }
-        assert (
-            result.tags["range_start_iso"] == (freeze_datetime - timedelta(seconds=30)).isoformat()
-        )
-        assert result.tags["range_end_iso"] == freeze_datetime.isoformat()
+        assert result.tags["range_start"] == (freeze_datetime - timedelta(seconds=30)).isoformat()
+        assert result.tags["range_end"] == freeze_datetime.isoformat()
         # Create an actual run for the monitoring job that is not finished.
         run = instance.create_run_for_job(
             job_def=defs.get_job_def(monitoring_job_name(af_instance.name)),
@@ -370,9 +408,9 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
             status=DagsterRunStatus.STARTED,
             run_config=result.run_config,
         )
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, SkipReason)
-        assert "Monitoring job is still running" in result.skip_message
+        assert "Monitoring job is still running" in result.skip_message  # type: ignore
         # Move the run to a finished state.
         instance.report_dagster_event(
             run_id=run.run_id,
@@ -383,11 +421,11 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
         )
     # Move time forward and check that we get a new run request.
     with freeze_time(freeze_datetime + timedelta(seconds=30)):
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, RunRequest)
         assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
             "config": {
-                "range_start_iso": (freeze_datetime).isoformat(),
-                "range_end_iso": (freeze_datetime + timedelta(seconds=30)).isoformat(),
+                "range_start": (freeze_datetime).isoformat(),
+                "range_end": (freeze_datetime + timedelta(seconds=30)).isoformat(),
             }
         }

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_jobs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_jobs.py
@@ -1,12 +1,16 @@
+import datetime
+
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.metadata.metadata_value import TimestampMetadataValue
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY
+from dagster_airlift.core.monitoring_job.builder import MonitoringConfig, monitoring_job_op_name
 from dagster_airlift.core.utils import monitoring_job_name
 from dagster_airlift.test.test_utils import asset_spec
 from kitchen_sink.airflow_instance import local_airflow_instance
@@ -37,7 +41,18 @@ def test_job_based_defs(
     # Then, execute monitoring job
     with instance_for_test() as instance:
         result = defs.execute_job_in_process(
-            monitoring_job_name(af_instance.name), instance=instance
+            monitoring_job_name(af_instance.name),
+            instance=instance,
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(
+                            datetime.datetime.now() - datetime.timedelta(seconds=30)
+                        ).isoformat(),
+                        range_end=datetime.datetime.now().isoformat(),
+                    )
+                }
+            ),
         )
         assert result.success
         # There should be a run for the dataset producer dag and a run for the monitoring job


### PR DESCRIPTION
## Summary & Motivation
Switches the monitor job to operate over a range specified via config. This opens the door to make it usable for history import.

The upshot is that we switch to a sensor instead of a schedule for kicking off compute so that we can manage the range interval we're operating over in a cursor. I think this is actually nicer / more observable overall.

## How I Tested These Changes
New tests for sensor behavior, updated existing monitor job tests.
