### PR TITLE
[Catalogv2] Update asset health summary cards + fix flickering + skeleton perf + css

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.module.css
@@ -1,0 +1,37 @@
+.skeleton {
+    display: block;
+    min-height: 1.5em;
+    border-radius: 6px;
+    position: relative;
+    overflow: hidden;
+    contain: paint layout style size;
+    isolation: isolate;
+    background: var(--skeleton-bg);
+  }
+  
+  .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      var(--skeleton-bg) 0%,
+      var(--skeleton-bg-hover) 50%,
+      var(--skeleton-bg) 100%
+    );
+    animation: shimmer 1.4s ease infinite;
+    will-change: transform;
+    contain: paint layout style size;
+    isolation: isolate;
+    pointer-events: none;
+  }
+  
+  @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+  

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
@@ -6,15 +6,17 @@ import styles from './Skeleton.module.css';
 type Props = {
   $height?: string | number;
   $width?: string | number;
+  style?: React.CSSProperties;
 };
 
-export const Skeleton = ({$height, $width}: Props) => {
-  const style = {
+export const Skeleton = ({$height, $width, style}: Props) => {
+  const allStyles = {
     height: Number($height) ? `${$height}px` : ($height ?? '100%'),
     width: Number($width) ? `${$width}px` : ($width ?? '100%'),
     '--skeleton-bg': Colors.backgroundLight(),
     '--skeleton-bg-hover': Colors.backgroundLightHover(),
+    ...style,
   } as React.CSSProperties;
 
-  return <div className={styles.skeleton} style={style} />;
+  return <div className={styles.skeleton} style={allStyles} />;
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.tsx
@@ -1,41 +1,20 @@
-import styled from 'styled-components';
+import React from 'react';
 
 import {Colors} from './Color';
+import styles from './Skeleton.module.css';
 
-export const Skeleton = styled.div<{$height?: string | number; $width?: string | number}>`
-  width: ${(p) => (Number(p.$width) ? `${p.$width}px` : p.$width ? p.$width : `100%`)};
-  height: ${(p) => (Number(p.$height) ? `${p.$height}px` : p.$height ? p.$height : `100%`)};
-  display: block;
-  min-height: 1.5em;
-  border-radius: 6px;
-  background: ${Colors.backgroundLight()};
-  position: relative;
-  overflow: hidden;
-  contain: layout style size;
-  isolation: isolate;
+type Props = {
+  $height?: string | number;
+  $width?: string | number;
+};
 
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: linear-gradient(
-      90deg,
-      ${Colors.backgroundLight()} 0%,
-      ${Colors.backgroundLightHover()} 50%,
-      ${Colors.backgroundLight()} 100%
-    );
-    animation: skeleton-loading 1.4s ease infinite;
-  }
+export const Skeleton = ({$height, $width}: Props) => {
+  const style = {
+    height: Number($height) ? `${$height}px` : ($height ?? '100%'),
+    width: Number($width) ? `${$width}px` : ($width ?? '100%'),
+    '--skeleton-bg': Colors.backgroundLight(),
+    '--skeleton-bg-hover': Colors.backgroundLightHover(),
+  } as React.CSSProperties;
 
-  @keyframes skeleton-loading {
-    0% {
-      transform: translateX(-100%);
-    }
-    100% {
-      transform: translateX(100%);
-    }
-  }
-`;
+  return <div className={styles.skeleton} style={style} />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -716,6 +716,7 @@ const AssetGraphExplorerWithData = ({
 
             <TopbarWrapper $isFullScreen={isFullScreen}>
               <Box flex={{direction: 'column'}} style={{width: '100%'}}>
+                {isFullScreen ? <IndeterminateLoadingBar $loading={nextLayoutLoading} /> : null}
                 <Box
                   flex={{gap: 12, alignItems: 'flex-start'}}
                   padding={{left: showSidebar ? 12 : 24, vertical: 12, right: 12}}
@@ -775,15 +776,17 @@ const AssetGraphExplorerWithData = ({
                     />
                   )}
                 </Box>
-                <IndeterminateLoadingBar
-                  $loading={nextLayoutLoading}
-                  style={{
-                    position: 'absolute',
-                    left: 0,
-                    right: 0,
-                    bottom: -2,
-                  }}
-                />
+                {isFullScreen ? null : (
+                  <IndeterminateLoadingBar
+                    $loading={nextLayoutLoading}
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      right: 0,
+                      bottom: -2,
+                    }}
+                  />
+                )}
               </Box>
             </TopbarWrapper>
           </ErrorBoundary>
@@ -888,11 +891,11 @@ const TopbarWrapper = styled.div<{$isFullScreen?: boolean}>`
       ? ''
       : `
         background: ${Colors.backgroundDefault()};
+        border-bottom: 1px solid ${Colors.keylineDefault()};
       `;
   }}
   gap: 12px;
   align-items: center;
-  border-bottom: 1px solid ${Colors.keylineDefault()};
 `;
 
 const GraphQueryInputFlexWrap = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -46,7 +46,9 @@ export const AssetNode = React.memo(({definition, selected, onChangeAssetSelecti
           flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
           style={{minHeight: ASSET_NODE_TAGS_HEIGHT, marginTop: marginTopForCenteringNode}}
         >
-          <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+          <div>
+            <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+          </div>
           <ChangedReasonsTag
             changedReasons={definition.changedReasons}
             assetKey={definition.assetKey}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -55,7 +55,9 @@ export const AssetNodeWithLiveData = ({
             flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
             style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
           >
-            <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+            <div>
+              <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+            </div>
             <ChangedReasonsTag
               changedReasons={definition.changedReasons}
               assetKey={definition.assetKey}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -1,4 +1,13 @@
-import {Button, Icon, Menu, MenuItem, Popover, Spinner, Tooltip} from '@dagster-io/ui-components';
+import {
+  Button,
+  Icon,
+  Menu,
+  MenuItem,
+  Popover,
+  Spinner,
+  Tooltip,
+  UnstyledButton,
+} from '@dagster-io/ui-components';
 import {memo, useContext, useMemo} from 'react';
 import {AddToFavoritesMenuItem} from 'shared/assets/AddToFavoritesMenuItem.oss';
 
@@ -20,10 +29,11 @@ interface Props {
   definition: AssetTableDefinitionFragment | null;
   repoAddress: RepoAddress | null;
   onRefresh?: () => void;
+  unstyledButton?: boolean;
 }
 
 export const AssetActionMenu = memo((props: Props) => {
-  const {repoAddress, path, definition, onRefresh} = props;
+  const {repoAddress, path, definition, onRefresh, unstyledButton} = props;
   const {
     featureContext: {canSeeMaterializeAction},
   } = useContext(CloudOSSContext);
@@ -68,6 +78,13 @@ export const AssetActionMenu = memo((props: Props) => {
       {deletePartitions.element}
       <Popover
         position="bottom-right"
+        targetTagName="div"
+        targetProps={{
+          style: {
+            display: 'flex',
+            alignItems: 'center',
+          },
+        }}
         content={
           <Menu>
             {executeItem}
@@ -122,7 +139,13 @@ export const AssetActionMenu = memo((props: Props) => {
           </Menu>
         }
       >
-        <Button icon={<Icon name="expand_more" />} />
+        {unstyledButton ? (
+          <UnstyledButton style={{display: 'flex', alignItems: 'center', padding: 8}}>
+            <Icon name="expand_more" />
+          </UnstyledButton>
+        ) : (
+          <Button icon={<Icon name="expand_more" />} />
+        )}
       </Popover>
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -49,19 +49,27 @@ export const AssetCatalogTableV2 = React.memo(
     }, [favorites, assets]);
 
     const [errorState, setErrorState] = useState<SyntaxError[]>([]);
-    const {filterInput, filtered, loading, setAssetSelection, assetSelection} =
-      useAssetSelectionInput<AssetTableFragment>({
-        assets: penultimateAssets,
-        assetsLoading: !assets && (assetsLoading || favoritesLoading),
-        onErrorStateChange: useCallback(
-          (errors: SyntaxError[]) => {
-            if (errors !== errorState) {
-              setErrorState(errors);
-            }
-          },
-          [errorState],
-        ),
-      });
+
+    const {
+      filterInput,
+      filtered,
+      loading: selectionLoading,
+      setAssetSelection,
+      assetSelection,
+    } = useAssetSelectionInput<AssetTableFragment>({
+      assets: penultimateAssets,
+      assetsLoading: !assets && (assetsLoading || favoritesLoading),
+      onErrorStateChange: useCallback(
+        (errors: SyntaxError[]) => {
+          if (errors !== errorState) {
+            setErrorState(errors);
+          }
+        },
+        [errorState],
+      ),
+    });
+
+    const loading = selectionLoading && !filtered.length;
 
     const {liveDataByNode} = useAssetsHealthData(
       useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -252,7 +252,7 @@ const Table = React.memo(
               {loading ? (
                 <Skeleton $width={300} $height={21} />
               ) : (
-                <LaunchAssetExecutionButton primary={false} scope={scope} />
+                <LaunchAssetExecutionButton scope={scope} />
               )}
             </Box>
             <AssetCatalogV2VirtualizedTable groupedByStatus={groupedByStatus} loading={loading} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -216,7 +216,7 @@ const Table = React.memo(
         style={{
           display: 'grid',
           gridTemplateRows: 'minmax(0, 1fr)',
-          height: '100%',
+          height: 'calc(100% - 108px)', // TODO: temporary hack to account for top section. Will redo this rendering logic
         }}
       >
         <div

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -94,12 +94,12 @@ export const AssetCatalogTableV2 = React.memo(
       return byStatus;
     }, [liveDataByNode]);
 
-    const [selectedTab, setSelectedTab] = useQueryPersistedState<string | undefined>({
+    const [selectedTab, setSelectedTab] = useQueryPersistedState<string>({
       queryKey: 'selectedTab',
       defaults: {selectedTab: 'catalog'},
       decode: (qs) =>
-        qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : undefined,
-      encode: (b) => ({selectedTab: b || undefined}),
+        qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : 'catalog',
+      encode: (b) => ({selectedTab: b || 'catalog'}),
     });
 
     const setCurrentPage = useSetRecoilState(currentPageAtom);
@@ -164,12 +164,13 @@ export const AssetCatalogTableV2 = React.memo(
         <Box
           flex={{direction: 'row', alignItems: 'center', gap: 8}}
           padding={{vertical: 12, horizontal: 24}}
-          border="bottom"
+          border={['insights', 'lineage'].includes(selectedTab) ? 'bottom' : undefined}
         >
           <Box flex={{grow: 1, shrink: 1}}>{filterInput}</Box>
           <CreateCatalogViewButton />
         </Box>
-        {['insights', 'lineage'].includes(selectedTab ?? '') ? null : (
+        {/* Lineage and Insights render their own loading bars */}
+        {['insights', 'lineage'].includes(selectedTab) ? null : (
           <IndeterminateLoadingBar $loading={loading || healthDataLoading} />
         )}
         <Box border="bottom">

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogV2VirtualizedTable.tsx
@@ -14,11 +14,14 @@ import React, {useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
+import {AssetActionMenu} from './AssetActionMenu';
 import {AssetHealthStatusString, STATUS_INFO} from './AssetHealthSummary';
 import {AssetRecentUpdatesTrend} from './AssetRecentUpdatesTrend';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {useAssetDefinition} from './useAssetDefinition';
 import {AssetHealthFragment} from '../asset-data/types/AssetHealthDataProvider.types';
 import {numberFormatter} from '../ui/formatters';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 const shimmer = {shimmer: true};
 const shimmerRows = [shimmer, shimmer, shimmer, shimmer, shimmer];
@@ -55,7 +58,7 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
     const rowVirtualizer = useVirtualizer({
       count: rowItems.length,
       getScrollElement: () => containerRef.current,
-      estimateSize: () => 32,
+      estimateSize: () => 44,
       overscan: 5,
     });
 
@@ -69,13 +72,15 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
             const item = rowItems[index]!;
 
             const wrapper = (content: React.ReactNode) => (
-              <Row key={key} $height={size} $start={start}>
-                <div data-index={index} ref={rowVirtualizer.measureElement}>
-                  <Box border="bottom" padding={{horizontal: 24, vertical: 12}}>
-                    {content}
-                  </Box>
-                </div>
-              </Row>
+              <RowWrapper key={key}>
+                <Row $height={size} $start={start}>
+                  <div data-index={index} ref={rowVirtualizer.measureElement}>
+                    <Box border="bottom" padding={{horizontal: 24, vertical: 12}}>
+                      {content}
+                    </Box>
+                  </div>
+                </Row>
+              </RowWrapper>
             );
 
             if ('shimmer' in item) {
@@ -157,8 +162,15 @@ const StatusHeaderContainer = styled(Box)`
 const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
   const linkUrl = assetDetailsPathForKey({path: asset.assetKey.path});
 
+  const {definition: _definition, refresh, cachedDefinition} = useAssetDefinition(asset.assetKey);
+  const definition = cachedDefinition || _definition;
+
+  const repoAddress = definition?.repository
+    ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
+    : null;
+
   return (
-    <RowWrapper to={linkUrl}>
+    <Link to={linkUrl}>
       <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           <AssetIconWrapper>
@@ -167,27 +179,40 @@ const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
           {asset.assetKey.path.join(' / ')}
         </Box>
         {/* Prevent clicks on the trend from propoagating to the row and triggering the link */}
-        <div
+        <Box
+          flex={{direction: 'row', alignItems: 'center', gap: 4}}
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
           }}
-          className="test"
+          style={{marginTop: -6, marginBottom: -6}}
         >
           <AssetRecentUpdatesTrend asset={asset} />
-        </div>
+          <AssetActionMenu
+            unstyledButton
+            path={asset.assetKey.path}
+            definition={definition}
+            repoAddress={repoAddress}
+            onRefresh={refresh}
+          />
+        </Box>
       </Box>
-    </RowWrapper>
+    </Link>
   );
 });
 
 const AssetIconWrapper = styled.div``;
 
-const RowWrapper = styled(Link)`
-  color: ${Colors.textLight()};
-  cursor: pointer;
-  :hover {
-    &,
+const RowWrapper = styled.div`
+  a {
+    color: ${Colors.textLight()};
+    cursor: pointer;
+    transition: color 0.3s ease-in-out;
+  }
+  background: ${Colors.backgroundDefault()};
+  &:hover {
+    background: ${Colors.backgroundDefaultHover()};
+    a,
     ${AssetIconWrapper} ${IconWrapper} {
       color: ${Colors.textDefault()};
       text-decoration: none;
@@ -197,4 +222,5 @@ const RowWrapper = styled(Link)`
       text-decoration: none;
     }
   }
+  transition: background 0.3s ease-in-out;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -10,14 +10,17 @@ import {
   Skeleton,
   SubtitleLarge,
   Tag,
+  UnstyledButton,
   ifPlural,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {asAssetKeyInput} from './asInput';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {featureEnabled} from '../app/Flags';
 import {assertUnreachable} from '../app/Util';
 import {useAssetHealthData} from '../asset-data/AssetHealthDataProvider';
 import {
@@ -34,6 +37,16 @@ import {numberFormatter} from '../ui/formatters';
 
 export const AssetHealthSummary = React.memo(
   ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {
+    if (!featureEnabled(FeatureFlag.flagUseNewObserveUIs)) {
+      return null;
+    }
+
+    return <AssetHealthSummaryImpl assetKey={assetKey} iconOnly={iconOnly} />;
+  },
+);
+
+const AssetHealthSummaryImpl = React.memo(
+  ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {
     const key = useMemo(() => asAssetKeyInput(assetKey), [assetKey]);
 
     const {liveData} = useAssetHealthData(key);
@@ -47,7 +60,11 @@ export const AssetHealthSummary = React.memo(
 
     function content() {
       if (iconOnly) {
-        return icon;
+        return (
+          <UnstyledButton style={{display: 'flex', alignItems: 'center', padding: 8}}>
+            {icon}
+          </UnstyledButton>
+        );
       }
       return (
         <Tag intent={intent} icon={iconName}>
@@ -93,7 +110,7 @@ export const AssetHealthSummary = React.memo(
           </div>
         }
       >
-        {content()}
+        <div>{content()}</div>
       </Popover>
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -293,16 +293,21 @@ const Criteria = React.memo(
     }, [type, status, metadata]);
 
     return (
-      <Box
-        padding={{horizontal: 12, vertical: 4}}
-        flex={{direction: 'row', alignItems: 'flex-start', gap: 6}}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '20px 1fr',
+          columnGap: 6,
+          rowGap: 2,
+          padding: '4px 12px',
+          alignItems: 'center',
+        }}
       >
         <Icon name={subStatusIconName} color={iconColor} style={{paddingTop: 2}} />
-        <Box flex={{direction: 'column', gap: 2}}>
-          <Body color={textColor}>{text}</Body>
-          <Body color={Colors.textLight()}>{derivedExplanation}</Body>
-        </Box>
-      </Box>
+        <Body color={textColor}>{text}</Body>
+        <div />
+        <Body color={Colors.textLight()}>{derivedExplanation}</Body>
+      </div>
     );
   },
 );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -74,38 +74,21 @@ export const AssetHealthSummary = React.memo(
             </Box>
             <Criteria
               assetKey={key}
-              text="Successfully materialized in last run"
               status={health?.materializationStatus}
               metadata={health?.materializationStatusMetadata}
-              explanation={
-                !health || health?.materializationStatus === AssetHealthStatus.UNKNOWN
-                  ? 'No materializations'
-                  : undefined
-              }
+              type="materialization"
             />
             <Criteria
               assetKey={key}
-              text="Has no freshness violations"
               status={health?.freshnessStatus}
               metadata={health?.freshnessStatusMetadata}
-              explanation={
-                !health || health?.freshnessStatus === AssetHealthStatus.NOT_APPLICABLE
-                  ? 'No freshness policy defined'
-                  : undefined
-              }
+              type="freshness"
             />
             <Criteria
               assetKey={key}
-              text="Has no check errors"
               status={health?.assetChecksStatus}
               metadata={health?.assetChecksStatusMetadata}
-              explanation={
-                !health || health?.assetChecksStatus === AssetHealthStatus.UNKNOWN
-                  ? 'No checks executed'
-                  : health?.assetChecksStatus === AssetHealthStatus.NOT_APPLICABLE
-                    ? 'No checks defined'
-                    : undefined
-              }
+              type="checks"
             />
           </div>
         }
@@ -119,14 +102,12 @@ export const AssetHealthSummary = React.memo(
 const Criteria = React.memo(
   ({
     status,
-    text,
     metadata,
-    explanation,
+    type,
     assetKey,
   }: {
     assetKey: {path: string[]};
     status: AssetHealthStatus | undefined;
-    text: string;
     metadata?:
       | AssetHealthCheckDegradedMetaFragment
       | AssetHealthCheckWarningMetaFragment
@@ -137,7 +118,7 @@ const Criteria = React.memo(
       | AssetHealthFreshnessMetaFragment
       | undefined
       | null;
-    explanation?: string;
+    type: 'materialization' | 'freshness' | 'checks';
   }) => {
     const {subStatusIconName, iconColor, textColor} = statusToIconAndColor[status ?? 'undefined'];
 
@@ -147,13 +128,11 @@ const Criteria = React.memo(
           if (metadata.numNotExecutedChecks > 0) {
             return (
               <Body>
-                {numberFormatter.format(metadata.numNotExecutedChecks)} /{' '}
-                {numberFormatter.format(metadata.totalNumChecks)}{' '}
                 <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                  check
-                  {ifPlural(metadata.totalNumChecks, '', 's')}
-                </Link>{' '}
-                not executed
+                  {numberFormatter.format(metadata.numNotExecutedChecks)} /{' '}
+                  {numberFormatter.format(metadata.totalNumChecks)} check{' '}
+                  {ifPlural(metadata.totalNumChecks, '', 's')} not executed
+                </Link>
               </Body>
             );
           }
@@ -162,74 +141,62 @@ const Criteria = React.memo(
           if (metadata.numWarningChecks > 0 && metadata.numFailedChecks > 0) {
             return (
               <Body>
-                {numberFormatter.format(metadata.numWarningChecks)}/
-                {numberFormatter.format(metadata.totalNumChecks)}{' '}
                 <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                  check
+                  {numberFormatter.format(metadata.numWarningChecks)}/
+                  {numberFormatter.format(metadata.totalNumChecks)} check
+                  {ifPlural(metadata.totalNumChecks, '', 's')} warning,{' '}
+                  {numberFormatter.format(metadata.numFailedChecks)}/
+                  {numberFormatter.format(metadata.totalNumChecks)} check
                   {ifPlural(metadata.totalNumChecks, '', 's')}
-                </Link>{' '}
-                warning, {numberFormatter.format(metadata.numFailedChecks)}/
-                {numberFormatter.format(metadata.totalNumChecks)}{' '}
-                <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                  check
-                  {ifPlural(metadata.totalNumChecks, '', 's')}
-                </Link>{' '}
-                failed
+                  failed
+                </Link>
               </Body>
             );
           }
           if (metadata.numWarningChecks > 0) {
             return (
               <Body>
-                {numberFormatter.format(metadata.numWarningChecks)}/
-                {numberFormatter.format(metadata.totalNumChecks)}{' '}
                 <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                  check
-                  {ifPlural(metadata.totalNumChecks, '', 's')}
-                </Link>{' '}
-                warning
+                  {numberFormatter.format(metadata.numWarningChecks)}/
+                  {numberFormatter.format(metadata.totalNumChecks)} check
+                  {ifPlural(metadata.totalNumChecks, '', 's')} warning
+                </Link>
               </Body>
             );
           }
           return (
             <Body>
-              {numberFormatter.format(metadata.numFailedChecks)}/
-              {numberFormatter.format(metadata.totalNumChecks)}{' '}
               <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                check
-                {ifPlural(metadata.totalNumChecks, '', 's')}
-              </Link>{' '}
-              failed
+                {numberFormatter.format(metadata.numFailedChecks)}/
+                {numberFormatter.format(metadata.totalNumChecks)} check
+                {ifPlural(metadata.totalNumChecks, '', 's')} failed
+              </Link>
             </Body>
           );
         case 'AssetHealthCheckWarningMeta':
           return (
             <Body>
-              {numberFormatter.format(metadata.numWarningChecks)}/
-              {numberFormatter.format(metadata.totalNumChecks)}{' '}
               <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
-                check
-                {ifPlural(metadata.totalNumChecks, '', 's')}
-              </Link>{' '}
-              warning
+                {numberFormatter.format(metadata.numWarningChecks)}/
+                {numberFormatter.format(metadata.totalNumChecks)} check
+                {ifPlural(metadata.totalNumChecks, '', 's')} warning
+              </Link>
             </Body>
           );
         case 'AssetHealthMaterializationDegradedNotPartitionedMeta':
           return (
             <Body>
-              Materialization failed in run{' '}
               <Link to={`/runs/${metadata.failedRunId}`}>
-                {metadata.failedRunId.split('-').shift()}
+                Materialization failed in run {metadata.failedRunId.split('-').shift()}
               </Link>
             </Body>
           );
         case 'AssetHealthMaterializationDegradedPartitionedMeta':
           return (
             <Body>
-              Materialization missing in {numberFormatter.format(metadata.numMissingPartitions)} out
-              of {numberFormatter.format(metadata.totalNumPartitions)}{' '}
               <Link to={assetDetailsPathForKey(assetKey, {view: 'partitions'})}>
-                partition
+                Materialization missing in {numberFormatter.format(metadata.numMissingPartitions)}{' '}
+                out of {numberFormatter.format(metadata.totalNumPartitions)} partition
                 {ifPlural(metadata.totalNumPartitions, '', 's')}
               </Link>
             </Body>
@@ -237,10 +204,9 @@ const Criteria = React.memo(
         case 'AssetHealthMaterializationWarningPartitionedMeta':
           return (
             <Body>
-              Materialization missing in {numberFormatter.format(metadata.numMissingPartitions)} out
-              of {numberFormatter.format(metadata.totalNumPartitions)}{' '}
               <Link to={assetDetailsPathForKey(assetKey, {view: 'partitions'})}>
-                partition
+                Materialization missing in {numberFormatter.format(metadata.numMissingPartitions)}{' '}
+                out of {numberFormatter.format(metadata.totalNumPartitions)} partition
                 {ifPlural(metadata.totalNumPartitions, '', 's')}
               </Link>
             </Body>
@@ -263,6 +229,69 @@ const Criteria = React.memo(
       }
     }, [metadata, assetKey]);
 
+    const text = useMemo(() => {
+      switch (type) {
+        case 'materialization':
+          switch (status) {
+            case AssetHealthStatus.DEGRADED:
+              return 'Failed to materialize';
+            case AssetHealthStatus.HEALTHY:
+              return 'Successfully materialized';
+            // Warning case should not be possible for materializations
+            case AssetHealthStatus.WARNING:
+            case AssetHealthStatus.NOT_APPLICABLE:
+            case AssetHealthStatus.UNKNOWN:
+            case undefined:
+              return 'No materializations';
+            default:
+              assertUnreachable(status);
+          }
+        case 'freshness':
+          switch (status) {
+            case AssetHealthStatus.HEALTHY:
+              return 'Freshness policy passing';
+            case AssetHealthStatus.DEGRADED:
+              return 'Freshness policy failed';
+            case AssetHealthStatus.WARNING:
+              return 'Freshness policy warning';
+            case undefined:
+            case AssetHealthStatus.NOT_APPLICABLE:
+              return 'No freshness policy defined';
+            case AssetHealthStatus.UNKNOWN:
+              return 'Freshness policy not evaluated';
+            default:
+              assertUnreachable(status);
+          }
+        case 'checks':
+          switch (status) {
+            case AssetHealthStatus.HEALTHY:
+              return 'All checks passed';
+            case AssetHealthStatus.DEGRADED:
+              if (metadata && 'numFailedChecks' in metadata && 'totalNumChecks' in metadata) {
+                if (metadata.numFailedChecks === metadata.totalNumChecks) {
+                  return 'All checks failed';
+                }
+                return 'Some checks failed';
+              }
+              return 'Checks failed';
+            case AssetHealthStatus.WARNING:
+              if (metadata && 'numWarningChecks' in metadata && 'totalNumChecks' in metadata) {
+                if (metadata.numWarningChecks === metadata.totalNumChecks) {
+                  return 'All checks failed';
+                }
+              }
+              return 'Some checks failed';
+            case AssetHealthStatus.NOT_APPLICABLE:
+              return 'No checks defined';
+            case AssetHealthStatus.UNKNOWN:
+            case undefined:
+              return 'No checks evaluated';
+            default:
+              assertUnreachable(status);
+          }
+      }
+    }, [type, status, metadata]);
+
     return (
       <Box
         padding={{horizontal: 12, vertical: 4}}
@@ -271,7 +300,7 @@ const Criteria = React.memo(
         <Icon name={subStatusIconName} color={iconColor} style={{paddingTop: 2}} />
         <Box flex={{direction: 'column', gap: 2}}>
           <Body color={textColor}>{text}</Body>
-          <Body color={Colors.textLight()}>{explanation ?? derivedExplanation}</Body>
+          <Body color={Colors.textLight()}>{derivedExplanation}</Body>
         </Box>
       </Box>
     );
@@ -315,7 +344,7 @@ export const STATUS_INFO: Record<
   },
   Warning: {
     iconName: 'warning_trend',
-    subStatusIconName: 'close',
+    subStatusIconName: 'warning',
     iconColor: Colors.accentYellow(),
     text: 'Warning',
     textColor: Colors.textYellow(),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -67,7 +67,7 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
   }, [lastEvent]);
 
   return (
-    <Box flex={{direction: 'row', gap: 6, alignItems: 'center'}}>
+    <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
       {loading && !lastEvent ? (
         <Skeleton $width={100} $height={21} />
       ) : (
@@ -86,8 +86,8 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
 
 const Pill = styled.div<{$index: number; $color: string}>`
   border-radius: 2px;
-  height: 12px;
-  width: 4px;
+  height: 16px;
+  width: 6px;
   background: ${({$color}) => $color};
   opacity: ${({$index}) => OPACITIES[$index] ?? 1};
   &:hover {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -570,7 +570,6 @@ const AssetViewPageHeaderTags = ({
             liveData={liveData}
             assetKey={definition.assetKey}
             onClick={onShowUpstream}
-            nullable
           />
           <ChangedReasonsTag
             changedReasons={definition.changedReasons}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -570,6 +570,7 @@ const AssetViewPageHeaderTags = ({
             liveData={liveData}
             assetKey={definition.assetKey}
             onClick={onShowUpstream}
+            nullable
           />
           <ChangedReasonsTag
             changedReasons={definition.changedReasons}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -171,7 +171,9 @@ export function useAllAssets({
       groupQuery();
     } else {
       fetchAllAssets()
-        .then((allAssets) => setErrorAndAssets({error: undefined, assets: allAssets}))
+        .then((allAssets) => {
+          setErrorAndAssets({error: undefined, assets: allAssets});
+        })
         .catch((e: any) => {
           if (e.__typename === 'PythonError') {
             setErrorAndAssets((prev) => ({error: e, assets: prev.assets}));

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -119,14 +119,19 @@ export const StaleReasonsTag = ({
   assetKey,
   liveData,
   onClick,
+  nullable,
 }: {
   assetKey: AssetKeyInput;
   liveData?: StaleDataForNode;
   onClick?: () => void;
+  nullable?: boolean;
 }) => {
   const grouped = groupedCauses(assetKey, liveData);
   const totalCauses = Object.values(grouped).reduce((s, g) => s + g.length, 0);
   if (!totalCauses) {
+    if (nullable) {
+      return null;
+    }
     return <div />;
   }
   const label = <Caption>Unsynced ({numberFormatter.format(totalCauses)})</Caption>;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -119,20 +119,15 @@ export const StaleReasonsTag = ({
   assetKey,
   liveData,
   onClick,
-  nullable,
 }: {
   assetKey: AssetKeyInput;
   liveData?: StaleDataForNode;
   onClick?: () => void;
-  nullable?: boolean;
 }) => {
   const grouped = groupedCauses(assetKey, liveData);
   const totalCauses = Object.values(grouped).reduce((s, g) => s + g.length, 0);
   if (!totalCauses) {
-    if (nullable) {
-      return null;
-    }
-    return <div />;
+    return null;
   }
   const label = <Caption>Unsynced ({numberFormatter.format(totalCauses)})</Caption>;
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinition.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinition.ts
@@ -1,4 +1,4 @@
-import {useContext, useMemo} from 'react';
+import {useCallback, useContext, useMemo} from 'react';
 
 import {ASSET_VIEW_DEFINITION_QUERY} from './AssetView';
 import {useAllAssets} from './AssetsCatalogTable';
@@ -13,7 +13,7 @@ import {
 import {useIndexedDBCachedQuery} from '../search/useIndexedDBCachedQuery';
 
 export const useAssetDefinition = (assetKey: AssetKey) => {
-  const {assets} = useAllAssets();
+  const {assets, query} = useAllAssets();
   const cachedDefinition = useMemo(
     () =>
       assets?.find((asset) => tokenForAssetKey(asset.key) === tokenForAssetKey(assetKey))
@@ -31,6 +31,13 @@ export const useAssetDefinition = (assetKey: AssetKey) => {
     version: AssetViewDefinitionQueryVersion,
   });
 
+  const refetchResult = result.fetch;
+
+  const refresh = useCallback(() => {
+    query();
+    refetchResult();
+  }, [query, refetchResult]);
+
   const {assetOrError} = result.data || result.previousData || {};
   const asset = assetOrError && assetOrError.__typename === 'Asset' ? assetOrError : null;
   if (!asset) {
@@ -47,5 +54,6 @@ export const useAssetDefinition = (assetKey: AssetKey) => {
     definition: asset.definition,
     lastMaterialization: asset.assetMaterializations ? asset.assetMaterializations[0] : null,
     cachedDefinition,
+    refresh,
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
@@ -15,7 +15,9 @@ interface InsightsIconProps {
 export const InsightsIcon = (props: InsightsIconProps) => {
   const {name, color = Colors.accentPrimary(), size = 16} = props;
   if (IconNames.includes(name as IconName)) {
-    return <Icon name={name as IconName} style={{marginLeft: 0}} color={color} />;
+    return (
+      <Icon name={name as IconName} style={{marginLeft: 0}} color={color} size={size as any} />
+    );
   } else {
     const known = KNOWN_TAGS[props.name as IntegrationIconName];
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.module.css
@@ -1,0 +1,43 @@
+.loadingBar {
+  height: 0px;
+  width: 100%;
+  flex-shrink: 0;
+  border-radius: 0 0 8px 8px;
+  position: relative;
+  &::before {
+    position: absolute;
+    top: -2px;
+    content: '';
+    display: block;
+    height: 2px;
+    width: 100%;
+    background: var(--color-background-gray);
+  }
+}
+
+.loading {
+  &::after {
+    content: '';
+    display: block;
+    height: 2px;
+    width: 100%;
+    background: var(--color-accent-blue);
+    transform-origin: left center;
+    will-change: transform;
+    animation: load 2s infinite;
+    contain: layout style size;
+    isolation: isolate;
+  }
+}
+
+@keyframes load {
+  0% {
+    transform: scaleX(0);
+  }
+  50% {
+    transform: scaleX(0.5);
+  }
+  100% {
+    transform: scaleX(1);
+  }
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
@@ -6,7 +6,7 @@ export const IndeterminateLoadingBar = ({
   $loading,
   style,
 }: {
-  $loading: boolean;
+  $loading: boolean | undefined;
   style?: React.CSSProperties;
 }) => {
   return <div className={clsx(styles.loadingBar, $loading && styles.loading)} style={style} />;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
@@ -1,41 +1,13 @@
-import {Colors} from '@dagster-io/ui-components';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
-export const IndeterminateLoadingBar = styled.div<{$loading?: boolean}>`
-  height: 2px;
-  width: 100%;
-  flex-shrink: 0;
-  background: ${Colors.backgroundGray()};
-  border-radius: 0 0 8px 8px;
-  overflow: hidden;
+import styles from './IndeterminateLoadingBar.module.css';
 
-  ${({$loading}) =>
-    $loading
-      ? `
-  &::after {
-    content: '';
-    display: block;
-    height: 100%;
-    width: 100%;
-    background: ${Colors.accentBlue()};
-    transform-origin: left center;
-    will-change: transform;
-    animation: load 2s infinite;
-    contain: layout style size;
-    isolation: isolate;
-
-    @keyframes load {
-      0% {
-        transform: scaleX(0);
-      }
-      50% {
-        transform: scaleX(0.5);
-      }
-      100% {
-        transform: scaleX(1);
-      }
-    }
-  }
-    `
-      : ''}
-`;
+export const IndeterminateLoadingBar = ({
+  $loading,
+  style,
+}: {
+  $loading: boolean;
+  style?: React.CSSProperties;
+}) => {
+  return <div className={clsx(styles.loadingBar, $loading && styles.loading)} style={style} />;
+};


### PR DESCRIPTION
## Summary & Motivation

1. Update asset health cards with new copy from https://www.figma.com/design/wXU4we6PavPVZt5dHZNQkY/Dagster-Observe---2025?node-id=1483-16917&m=dev
2. Fix flickering due to re-entering loading state temporarily
3. Use a css module + define keyframes once for skeleton component
4. Bunch of design nits.

## How I Tested These Changes
<img width="284" alt="Screenshot 2025-04-17 at 1 24 59 AM" src="https://github.com/user-attachments/assets/60fc1be1-4002-4c75-82ba-2851c512230b" />
<img width="310" alt="Screenshot 2025-04-17 at 1 24 13 AM" src="https://github.com/user-attachments/assets/9f5df6eb-b80a-42fe-a814-dff1e0d2550a" />
<img width="297" alt="Screenshot 2025-04-17 at 1 23 54 AM" src="https://github.com/user-attachments/assets/8c06ab8e-6e9e-4cf6-a30c-3eb61cc92487" />
<img width="369" alt="Screenshot 2025-04-17 at 1 23 07 AM" src="https://github.com/user-attachments/assets/10d6afbb-c74e-4eb8-a9f6-9aa698cc1ca3" />
<img width="350" alt="Screenshot 2025-04-17 at 1 23 04 AM" src="https://github.com/user-attachments/assets/cd877bb3-daae-4a9e-bbbe-3f442f28b69b" />

