### PR TITLE
[ui] [asset health] fix helper text for failed partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -3,7 +3,7 @@
   "LogTelemetryMutation": "b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3",
   "AssetGraphLiveQuery": "9f875017c08597b0fa017a17fa40813c255d13e3f92eb98992772f4c8ae42e52",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "79029e5084496e14147e615fa7cf65f4f61d71add7ac519720e1911fbe0bdbc2",
+  "AssetHealthQuery": "b997bd7ba9bb1ff24f2b67c69abca71476043d79466edd614fab6d71767d7fcc",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "724ef0733b9b187ffd012e40c02c3b3a5e32967dbcae46e2024b15dfd5bf0271",
   "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -90,6 +90,7 @@ export const ASSETS_HEALTH_INFO_QUERY = gql`
 
   fragment AssetHealthMaterializationDegradedPartitionedMetaFragment on AssetHealthMaterializationDegradedPartitionedMeta {
     numMissingPartitions
+    numFailedPartitions
     totalNumPartitions
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -23,6 +23,7 @@ export type AssetHealthQuery = {
         | {
             __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
             numMissingPartitions: number;
+            numFailedPartitions: number;
             totalNumPartitions: number;
           }
         | {
@@ -71,6 +72,7 @@ export type AssetHealthFragment = {
       | {
           __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
           numMissingPartitions: number;
+          numFailedPartitions: number;
           totalNumPartitions: number;
         }
       | {
@@ -107,6 +109,7 @@ export type AssetHealthFragment = {
 export type AssetHealthMaterializationDegradedPartitionedMetaFragment = {
   __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
   numMissingPartitions: number;
+  numFailedPartitions: number;
   totalNumPartitions: number;
 };
 
@@ -145,4 +148,4 @@ export type AssetHealthFreshnessMetaFragment = {
   lastMaterializedTimestamp: number | null;
 };
 
-export const AssetHealthQueryVersion = '79029e5084496e14147e615fa7cf65f4f61d71add7ac519720e1911fbe0bdbc2';
+export const AssetHealthQueryVersion = 'b997bd7ba9bb1ff24f2b67c69abca71476043d79466edd614fab6d71767d7fcc';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -212,8 +212,8 @@ const Criteria = React.memo(
           return (
             <Body>
               <Link to={assetDetailsPathForKey(assetKey, {view: 'partitions'})}>
-                Materialization missing in {numberFormatter.format(metadata.numMissingPartitions)}{' '}
-                out of {numberFormatter.format(metadata.totalNumPartitions)} partition
+                Materialization failed in {numberFormatter.format(metadata.numFailedPartitions)} out
+                of {numberFormatter.format(metadata.totalNumPartitions)} partition
                 {ifPlural(metadata.totalNumPartitions, '', 's')}
               </Link>
             </Body>


### PR DESCRIPTION
## Summary & Motivation
didn't notice this in the other PR, but we are using the number of missing partitions when the asset is in the failed state. in this case we want to report on the number of failed partitions

## How I Tested These Changes

