### PR TITLE
[dagster-dbt] Clean name for dbt Cloud polling sensor

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -31,6 +31,7 @@ from dagster_dbt.cloud_v2.run_handler import (
 )
 from dagster_dbt.cloud_v2.types import DbtCloudRun
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+from dagster_dbt.utils import clean_name
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_DBT_CLOUD_SENSOR_INTERVAL_SECONDS = 30
@@ -166,7 +167,9 @@ def build_dbt_cloud_polling_sensor(
     dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
     @sensor(
-        name=f"{workspace.account_name}_{workspace.project_name}_{workspace.environment_name}__run_status_sensor",
+        name=clean_name(
+            f"{workspace.account_name}_{workspace.project_name}_{workspace.environment_name}__run_status_sensor"
+        ),
         minimum_interval_seconds=minimum_interval_seconds,
         default_status=default_sensor_status or DefaultSensorStatus.RUNNING,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,3 +1,4 @@
+import re
 from argparse import Namespace
 from collections.abc import Mapping
 from typing import AbstractSet, Any  # noqa: UP035
@@ -7,6 +8,11 @@ from packaging import version
 
 # dbt resource types that may be considered assets
 ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
+
+
+def clean_name(name: str) -> str:
+    """Cleans an input to be a valid Dagster asset name."""
+    return re.sub(r"[^a-z0-9]+", "_", name.lower())
 
 
 def default_node_info_to_asset_key(node_info: Mapping[str, Any]) -> AssetKey:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -36,14 +36,14 @@ run_results_path = tests_path.joinpath("run_results.json")
 
 
 TEST_ACCOUNT_ID = 1111
-TEST_ACCOUNT_NAME = "test_account_name"
+TEST_ACCOUNT_NAME = "Test Account Name"
 TEST_ACCESS_URL = "https://cloud.getdbt.com"
 TEST_TOKEN = "test_token"
 
 TEST_PROJECT_ID = 2222
 TEST_ENVIRONMENT_ID = 3333
-TEST_PROJECT_NAME = "test_project_name"
-TEST_ENVIRONMENT_NAME = "test_environment_name"
+TEST_PROJECT_NAME = "Test Project Name"
+TEST_ENVIRONMENT_NAME = "Test Environment Name"
 
 TEST_JOB_ID = 4444
 TEST_RUN_ID = 5555
@@ -840,22 +840,10 @@ def workspace_fixture(credentials: DbtCloudCredentials) -> DbtCloudWorkspace:
 
 
 @pytest.fixture(
-    name="job_api_mocks",
+    name="project_environment_api_mocks",
 )
-def job_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
+def project_environment_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
     with responses.RequestsMock() as response:
-        response.add(
-            method=responses.GET,
-            url=f"{TEST_REST_API_BASE_URL}/jobs",
-            json=SAMPLE_LIST_JOBS_RESPONSE,
-            status=200,
-        )
-        response.add(
-            method=responses.POST,
-            url=f"{TEST_REST_API_BASE_URL}/jobs",
-            json=SAMPLE_DEFAULT_CREATE_JOB_RESPONSE,
-            status=201,
-        )
         response.add(
             method=responses.GET,
             url=f"{TEST_REST_API_BASE_URL}/projects/{TEST_PROJECT_ID}",
@@ -869,6 +857,27 @@ def job_api_mocks_fixture() -> Iterator[responses.RequestsMock]:
             status=200,
         )
         yield response
+
+
+@pytest.fixture(
+    name="job_api_mocks",
+)
+def job_api_mocks_fixture(
+    project_environment_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    project_environment_api_mocks.add(
+        method=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}/jobs",
+        json=SAMPLE_LIST_JOBS_RESPONSE,
+        status=200,
+    )
+    project_environment_api_mocks.add(
+        method=responses.POST,
+        url=f"{TEST_REST_API_BASE_URL}/jobs",
+        json=SAMPLE_DEFAULT_CREATE_JOB_RESPONSE,
+        status=201,
+    )
+    yield project_environment_api_mocks
 
 
 @pytest.fixture(
@@ -896,6 +905,21 @@ def fetch_workspace_data_api_mocks_fixture(
         status=200,
     )
     yield job_api_mocks
+
+
+@pytest.fixture(
+    name="sensor_builder_api_mocks",
+)
+def sensor_builder_api_mocks_fixture(
+    project_environment_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    project_environment_api_mocks.add(
+        method=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}",
+        json=SAMPLE_ACCOUNT_RESPONSE,
+        status=200,
+    )
+    yield project_environment_api_mocks
 
 
 @pytest.fixture(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
@@ -28,7 +28,6 @@ def test_sensor_name(
     workspace: DbtCloudWorkspace,
     sensor_builder_api_mocks: responses.RequestsMock,
 ) -> None:
-    """Test the case with no runs."""
     sensor = build_dbt_cloud_polling_sensor(workspace=workspace)
     assert sensor.name == clean_name(
         f"{TEST_ACCOUNT_NAME}_{TEST_PROJECT_NAME}_{TEST_ENVIRONMENT_NAME}_run_status_sensor"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
@@ -5,15 +5,34 @@ import responses
 from dagster import DagsterInstance, SensorResult, build_sensor_context
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value
-from dagster_dbt.cloud_v2.sensor_builder import DbtCloudPollingSensorCursor
+from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
+from dagster_dbt.cloud_v2.sensor_builder import (
+    DbtCloudPollingSensorCursor,
+    build_dbt_cloud_polling_sensor,
+)
+from dagster_dbt.utils import clean_name
 
 from dagster_dbt_tests.cloud_v2.conftest import (
     SAMPLE_EMPTY_BATCH_LIST_RUNS_RESPONSE,
+    TEST_ACCOUNT_NAME,
+    TEST_ENVIRONMENT_NAME,
+    TEST_PROJECT_NAME,
     TEST_REST_API_BASE_URL,
     TEST_RUN_URL,
     build_and_invoke_sensor,
     fully_loaded_repo_from_dbt_cloud_workspace,
 )
+
+
+def test_sensor_name(
+    workspace: DbtCloudWorkspace,
+    sensor_builder_api_mocks: responses.RequestsMock,
+) -> None:
+    """Test the case with no runs."""
+    sensor = build_dbt_cloud_polling_sensor(workspace=workspace)
+    assert sensor.name == clean_name(
+        f"{TEST_ACCOUNT_NAME}_{TEST_PROJECT_NAME}_{TEST_ENVIRONMENT_NAME}_run_status_sensor"
+    )
 
 
 def test_asset_materializations(


### PR DESCRIPTION
## Summary & Motivation

Fix name format for the dbt Cloud polling sensor

Before:

```bash
2025-04-16 17:10:04 -0400 - dagster.code_server - ERROR - dagster._core.errors.DagsterInvalidDefinitionError: "Dagster Labs_Analytics_test__run_status_sensor" is not a valid name in Dagster. Names must be in regex ^[A-Za-z0-9_]+$.

Stack Trace:
  [8 dagster system frames hidden, run with --verbose to see the full stack trace]
  File "/Users/maximearmstrong/Documents/Repositories/dagster-io/dagster/examples/test/definitions.py", line 31, in <module>
    sensors=[build_dbt_cloud_polling_sensor(workspace=workspace)],
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [7 dagster system frames hidden]
```

## How I Tested These Changes

BK

