### PR TITLE
Dev multi asset ops handler error

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -335,6 +335,7 @@ def asset(
         ),
         backfill_policy=backfill_policy,
         retry_policy=retry_policy,
+        skip_failed_execution=None,
         code_version=code_version,
         check_specs=check_specs,
         key=key,
@@ -408,6 +409,7 @@ class AssetDecoratorArgs(NamedTuple):
     automation_condition: Optional[AutomationCondition]
     backfill_policy: Optional[BackfillPolicy]
     retry_policy: Optional[RetryPolicy]
+    skip_failed_execution: Optional[bool]
     code_version: Optional[str]
     key: Optional[CoercibleToAssetKey]
     check_specs: Optional[Sequence[AssetCheckSpec]]
@@ -501,6 +503,7 @@ def create_assets_def_from_fn_and_decorator_args(
             group_name=args.group_name,
             partitions_def=args.partitions_def,
             retry_policy=args.retry_policy,
+            skip_failed_execution=args.skip_failed_execution,
             code_version=args.code_version,
             op_tags=args.op_tags,
             config_schema=args.config_schema,
@@ -581,6 +584,7 @@ def multi_asset(
     resource_defs: Optional[Mapping[str, object]] = None,
     group_name: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
+    skip_failed_execution: Optional[bool] = None,
     code_version: Optional[str] = None,
     specs: Optional[Sequence[AssetSpec]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
@@ -633,6 +637,7 @@ def multi_asset(
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
+        skip_failed_execution (Optional[bool]): Whether Op should continue/skip failed output or not.
         code_version (Optional[str]): Version of the code encapsulated by the multi-asset. If set,
             this is used as a default code version for all defined assets.
         specs (Optional[Sequence[AssetSpec]]): The specifications for the assets materialized
@@ -696,6 +701,7 @@ def multi_asset(
         group_name=group_name,
         partitions_def=partitions_def,
         retry_policy=retry_policy,
+        skip_failed_execution=skip_failed_execution,
         code_version=code_version,
         op_tags=op_tags,
         config_schema=check.opt_mapping_param(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -240,7 +240,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     partitions_def: Optional[PartitionsDefinition]
     required_resource_keys: AbstractSet[str]
     retry_policy: Optional[RetryPolicy]
-    retry_policy: Optional[RetryPolicy]
+    skip_failed_execution: Optional[bool]
     specs: Sequence[AssetSpec]
     upstream_asset_deps: Optional[Iterable[AssetDep]]
     execution_type: Optional[AssetExecutionType]
@@ -565,6 +565,7 @@ class DecoratorAssetsDefinitionBuilder:
             },
             config_schema=self.args.config_schema,
             retry_policy=self.args.retry_policy,
+            skip_failed_execution=self.args.skip_failed_execution,
             code_version=self.args.code_version,
             pool=self.args.pool,
         )(self.fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -48,6 +48,7 @@ class _Op:
         code_version: Optional[str] = None,
         decorator_takes_context: Optional[bool] = True,
         retry_policy: Optional[RetryPolicy] = None,
+        skip_failed_execution: Optional[bool] = None,
         ins: Optional[Mapping[str, In]] = None,
         out: Optional[Union[Out, Mapping[str, Out]]] = None,
         pool: Optional[str] = None,
@@ -64,6 +65,7 @@ class _Op:
         self.tags = tags
         self.code_version = code_version
         self.retry_policy = retry_policy
+        self.skip_failed_execution = skip_failed_execution
         self.pool = pool
 
         # config will be checked within OpDefinition
@@ -131,6 +133,7 @@ class _Op:
             tags=self.tags,
             code_version=self.code_version,
             retry_policy=self.retry_policy,
+            skip_failed_execution=self.skip_failed_execution,
             version=None,  # code_version has replaced version
             pool=self.pool,
         )
@@ -154,6 +157,7 @@ def op(
     tags: Optional[Mapping[str, Any]] = ...,
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
+    skip_failed_execution: Optional[bool] = ...,
     code_version: Optional[str] = ...,
     pool: Optional[str] = None,
 ) -> _Op: ...
@@ -174,6 +178,7 @@ def op(
     tags: Optional[Mapping[str, Any]] = None,
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
+    skip_failed_execution: Optional[bool] = None,
     code_version: Optional[str] = None,
     pool: Optional[str] = None,
 ) -> Union["OpDefinition", _Op]:
@@ -218,6 +223,7 @@ def op(
         code_version (Optional[str]): Version of the logic encapsulated by the op. If set,
             this is used as a default version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
+        skip_failed_execution (Optional[bool]): Whether ops should continue after error.
 
     Examples:
         .. code-block:: python
@@ -267,6 +273,7 @@ def op(
         tags=tags,
         code_version=code_version,
         retry_policy=retry_policy,
+        skip_failed_execution=skip_failed_execution,
         ins=ins,
         out=out,
         pool=pool,

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -83,6 +83,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         code_version (Optional[str]): Version of the code encapsulated by the op. If set,
             this is used as a default code version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
+        skip_failed_execution (Optional[bool]): Whether Ops should continue after error.
         pool (Optional[str]): A string that identifies the pool that governs this op's execution.
 
 
@@ -105,6 +106,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     _required_resource_keys: AbstractSet[str]
     _version: Optional[str]
     _retry_policy: Optional[RetryPolicy]
+    _skip_failed_execution: Optional[bool]
     _pool: Optional[str]
 
     def __init__(
@@ -119,6 +121,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         tags: Optional[Mapping[str, Any]] = None,
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
+        skip_failed_execution: Optional[bool] = None,
         code_version: Optional[str] = None,
         pool: Optional[str] = None,
     ):
@@ -165,6 +168,9 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
         )
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
+        self._skip_failed_execution = check.opt_inst_param(
+            skip_failed_execution, "skip_failed_execution", bool
+        )
         self._pool = pool
         pool = _validate_pool(pool, tags)
 
@@ -195,6 +201,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         tags: Optional[Mapping[str, Any]],
         version: Optional[str],
         retry_policy: Optional[RetryPolicy],
+        skip_failed_execution: Optional[bool],
         code_version: Optional[str],
         pool: Optional[str],
     ) -> "OpDefinition":
@@ -209,6 +216,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             tags=tags,
             version=version,
             retry_policy=retry_policy,
+            skip_failed_execution=skip_failed_execution,
             code_version=code_version,
             pool=pool,
         )
@@ -269,6 +277,12 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def retry_policy(self) -> Optional[RetryPolicy]:
         """Optional[RetryPolicy]: The RetryPolicy for this op."""
         return self._retry_policy
+
+    @public
+    @property
+    def skip_failed_execution(self) -> Optional[bool]:
+        """Optional[bool]: Whether the ops should continue after failed execution."""
+        return self._skip_failed_execution
 
     @public
     @property
@@ -391,6 +405,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             required_resource_keys=self.required_resource_keys,
             code_version=self._version,
             retry_policy=self.retry_policy,
+            skip_failed_execution=self.skip_failed_execution,
             version=None,  # code_version replaces version
             pool=self.pool,
         )


### PR DESCRIPTION
## Summary & Motivation
When a single output of a multi asset fails during HANDLE_OUTPUT, the whole multi asset is aborted.
This PR try to solve that problem.
See #27943 for more details and example.

## How I Tested These Changes
I create new unit test in test_materilize.py to simulate the situation where old method failed. Then new algorithm is implemented which can then be enabled with additional flag ```skip_failed_execution```.
Example situation from #27943 is also recreated to test new feature in situation. 

## Changelog
- Add unitest for case with failed output_handler during op execution
- Add optional argument for skip_failed_execution for op.
- Add property handler and setter for skip_failed_execution in OpDefinition.
- Add skip_failed_execution argument for multiasset to set Op argument.
- Add additional algorithm to handle exception during the for-loop to not interrupt the execution process.
- Use op skip_failed_execution flag to determine whether loop should be interrupted or not.
- Log all error catch during the loop to log and raise final error message to be catch.
