### PR TITLE
[ui] Update asset nodes to reflect the observe UI feature flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeHealthRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeHealthRow.tsx
@@ -1,0 +1,68 @@
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {AssetNodeRowBox} from './AssetNode';
+import {AssetLatestRunSpinner, AssetRunLink} from './AssetRunLinking';
+import {LiveDataForNode} from './Utils';
+import {useAssetHealthData} from '../asset-data/AssetHealthDataProvider';
+import {AssetHealthSummaryPopover, statusToIconAndColor} from '../assets/AssetHealthSummary';
+import {titleForRun} from '../runs/RunUtils';
+import {AssetNodeFragment} from './types/AssetNode.types';
+
+export const AssetNodeHealthRow = ({
+  definition,
+  liveData,
+}: {
+  definition: AssetNodeFragment;
+  liveData: LiveDataForNode | undefined;
+}) => {
+  const {liveData: healthData} = useAssetHealthData(definition.assetKey);
+  const health = healthData?.assetHealth;
+
+  const {inProgressRunIds, unstartedRunIds, partitionStats} = liveData || {};
+  const materializingRunId = inProgressRunIds?.[0] || unstartedRunIds?.[0];
+  const numMaterializing = partitionStats?.numMaterializing;
+
+  const {iconName, iconColor, backgroundColor, textColor, text} = React.useMemo(() => {
+    return statusToIconAndColor[health?.assetHealth ?? 'undefined'];
+  }, [health]);
+
+  if (materializingRunId) {
+    return (
+      <AssetNodeRowBox
+        padding={{horizontal: 8}}
+        background={Colors.backgroundBlue()}
+        flex={{justifyContent: 'space-between', alignItems: 'center', gap: 6}}
+      >
+        <Box flex={{gap: 6, alignItems: 'center'}}>
+          <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
+          <span style={{color: Colors.textBlue()}}>
+            {numMaterializing === 1
+              ? `Materializing 1 partition...`
+              : numMaterializing
+                ? `Materializing ${numMaterializing} partitions...`
+                : `Materializing...`}
+          </span>
+        </Box>
+        {!numMaterializing || numMaterializing === 1 ? (
+          <AssetRunLink assetKey={definition.assetKey} runId={materializingRunId}>
+            <span>Run {titleForRun({id: materializingRunId})}</span>
+          </AssetRunLink>
+        ) : undefined}
+      </AssetNodeRowBox>
+    );
+  }
+
+  return (
+    <AssetNodeRowBox
+      padding={{horizontal: 8}}
+      background={materializingRunId ? Colors.backgroundBlue() : backgroundColor}
+      flex={{justifyContent: 'flex-start', alignItems: 'center', gap: 6}}
+    >
+      <AssetHealthSummaryPopover health={health} assetKey={definition.assetKey}>
+        <Icon name={iconName} color={iconColor} />
+      </AssetHealthSummaryPopover>
+      <span style={{color: textColor}}>{text}</span>
+    </AssetNodeRowBox>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -1,7 +1,9 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
+import * as Flags from '../../app/Flags';
 import {withMiddleTruncation} from '../../app/Util';
 import {AssetBaseData} from '../../asset-data/AssetBaseDataProvider';
 import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
@@ -25,6 +27,10 @@ const Scenarios = [
 describe('AssetNode', () => {
   Scenarios.forEach((scenario) =>
     it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {
+      jest.spyOn(Flags, 'featureEnabled').mockImplementation((flag) => {
+        return flag === FeatureFlag.flagUseNewObserveUIs ? false : true;
+      });
+
       const definitionCopy = {
         ...scenario.definition,
         assetKey: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -18,8 +18,6 @@ import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
-import {asAssetKeyInput} from './asInput';
-import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {featureEnabled} from '../app/Flags';
 import {assertUnreachable} from '../app/Util';
 import {useAssetHealthData} from '../asset-data/AssetHealthDataProvider';
@@ -27,13 +25,15 @@ import {
   AssetHealthCheckDegradedMetaFragment,
   AssetHealthCheckUnknownMetaFragment,
   AssetHealthCheckWarningMetaFragment,
+  AssetHealthFragment,
   AssetHealthFreshnessMetaFragment,
   AssetHealthMaterializationDegradedNotPartitionedMetaFragment,
   AssetHealthMaterializationDegradedPartitionedMetaFragment,
   AssetHealthMaterializationWarningPartitionedMetaFragment,
 } from '../asset-data/types/AssetHealthDataProvider.types';
-import {AssetHealthStatus} from '../graphql/types';
+import {AssetHealthStatus, AssetKeyInput} from '../graphql/types';
 import {numberFormatter} from '../ui/formatters';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
 export const AssetHealthSummary = React.memo(
   ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {
@@ -47,22 +47,18 @@ export const AssetHealthSummary = React.memo(
 
 const AssetHealthSummaryImpl = React.memo(
   ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {
-    const key = useMemo(() => asAssetKeyInput(assetKey), [assetKey]);
-
-    const {liveData} = useAssetHealthData(key);
-
+    const {liveData} = useAssetHealthData(assetKey);
     const health = liveData?.assetHealth;
+
     const {iconName, iconColor, intent, text} = useMemo(() => {
       return statusToIconAndColor[health?.assetHealth ?? 'undefined'];
     }, [health]);
-
-    const icon = <Icon name={iconName} color={iconColor} />;
 
     function content() {
       if (iconOnly) {
         return (
           <UnstyledButton style={{display: 'flex', alignItems: 'center', padding: 8}}>
-            {icon}
+            <Icon name={iconName} color={iconColor} />
           </UnstyledButton>
         );
       }
@@ -78,43 +74,60 @@ const AssetHealthSummaryImpl = React.memo(
     }
 
     return (
-      <Popover
-        interactionKind="hover"
-        content={
-          <div onClick={(e) => e.stopPropagation()}>
-            <Box
-              padding={12}
-              flex={{direction: 'row', alignItems: 'center', gap: 6}}
-              border="bottom"
-            >
-              {icon} <SubtitleLarge>{text}</SubtitleLarge>
-            </Box>
-            <Criteria
-              assetKey={key}
-              status={health?.materializationStatus}
-              metadata={health?.materializationStatusMetadata}
-              type="materialization"
-            />
-            <Criteria
-              assetKey={key}
-              status={health?.freshnessStatus}
-              metadata={health?.freshnessStatusMetadata}
-              type="freshness"
-            />
-            <Criteria
-              assetKey={key}
-              status={health?.assetChecksStatus}
-              metadata={health?.assetChecksStatusMetadata}
-              type="checks"
-            />
-          </div>
-        }
-      >
-        <div>{content()}</div>
-      </Popover>
+      <AssetHealthSummaryPopover assetKey={assetKey} health={health}>
+        {content()}
+      </AssetHealthSummaryPopover>
     );
   },
 );
+
+export const AssetHealthSummaryPopover = ({
+  health,
+  assetKey,
+  children,
+}: {
+  health: AssetHealthFragment['assetHealth'] | undefined;
+  assetKey: AssetKeyInput;
+  children: React.ReactNode;
+}) => {
+  const {iconName, iconColor, text} = useMemo(() => {
+    return statusToIconAndColor[health?.assetHealth ?? 'undefined'];
+  }, [health]);
+
+  return (
+    <Popover
+      interactionKind="hover"
+      content={
+        <div onClick={(e) => e.stopPropagation()}>
+          <Box padding={12} flex={{direction: 'row', alignItems: 'center', gap: 6}} border="bottom">
+            <Icon name={iconName} color={iconColor} />
+            <SubtitleLarge>{text}</SubtitleLarge>
+          </Box>
+          <Criteria
+            assetKey={assetKey}
+            status={health?.materializationStatus}
+            metadata={health?.materializationStatusMetadata}
+            type="materialization"
+          />
+          <Criteria
+            assetKey={assetKey}
+            status={health?.freshnessStatus}
+            metadata={health?.freshnessStatusMetadata}
+            type="freshness"
+          />
+          <Criteria
+            assetKey={assetKey}
+            status={health?.assetChecksStatus}
+            metadata={health?.assetChecksStatusMetadata}
+            type="checks"
+          />
+        </div>
+      }
+    >
+      <div>{children}</div>
+    </Popover>
+  );
+};
 
 const Criteria = React.memo(
   ({
@@ -338,6 +351,7 @@ export const STATUS_INFO: Record<
     subStatusIconName: IconName;
     iconColor: string;
     textColor: string;
+    borderColor: string;
     text: AssetHealthStatusString;
     intent: Intent;
     backgroundColor: string;
@@ -354,6 +368,7 @@ export const STATUS_INFO: Record<
     text2: 'None set',
     intent: 'none',
     subStatusIconName: 'missing',
+    borderColor: Colors.accentGray(),
     backgroundColor: Colors.backgroundGray(),
     hoverBackgroundColor: Colors.backgroundGrayHover(),
   },
@@ -366,6 +381,7 @@ export const STATUS_INFO: Record<
     text2: 'Not evaluated',
     intent: 'none',
     subStatusIconName: 'missing',
+    borderColor: Colors.accentGray(),
     backgroundColor: Colors.backgroundGray(),
     hoverBackgroundColor: Colors.backgroundGrayHover(),
   },
@@ -376,8 +392,9 @@ export const STATUS_INFO: Record<
     iconColor: Colors.accentRed(),
     textColor: Colors.textRed(),
     text: 'Degraded',
-    intent: 'danger',
     text2: 'Failed',
+    intent: 'danger',
+    borderColor: Colors.accentRed(),
     backgroundColor: Colors.backgroundRed(),
     hoverBackgroundColor: Colors.backgroundRedHover(),
   },
@@ -389,6 +406,7 @@ export const STATUS_INFO: Record<
     text: 'Warning',
     text2: 'Warning',
     textColor: Colors.textYellow(),
+    borderColor: Colors.accentYellow(),
     backgroundColor: Colors.backgroundYellow(),
     hoverBackgroundColor: Colors.backgroundYellowHover(),
     intent: 'warning',
@@ -402,6 +420,7 @@ export const STATUS_INFO: Record<
     text: 'Healthy',
     text2: 'Passing',
     intent: 'success',
+    borderColor: Colors.accentGreen(),
     backgroundColor: Colors.backgroundGreen(),
     hoverBackgroundColor: Colors.backgroundGreenHover(),
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -18,6 +18,7 @@ import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {featureEnabled} from '../app/Flags';
 import {assertUnreachable} from '../app/Util';
 import {useAssetHealthData} from '../asset-data/AssetHealthDataProvider';
@@ -33,7 +34,6 @@ import {
 } from '../asset-data/types/AssetHealthDataProvider.types';
 import {AssetHealthStatus, AssetKeyInput} from '../graphql/types';
 import {numberFormatter} from '../ui/formatters';
-import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
 export const AssetHealthSummary = React.memo(
   ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecksStatusSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecksStatusSummary.tsx
@@ -145,12 +145,13 @@ export const AssetChecksStatusSummary = ({
       return <Icon name="done" color={Colors.accentGreen()} />;
     };
 
+    const succeeded = byIconType[AssetCheckExecutionResolvedStatus.SUCCEEDED] ?? 0;
+    const total = liveData.assetChecks.length;
     return (
       <Box flex={{gap: 4, alignItems: 'center'}}>
         {icon()}
         <span>
-          {byIconType[AssetCheckExecutionResolvedStatus.SUCCEEDED]} / {liveData.assetChecks.length}{' '}
-          Passed
+          {succeeded} / {total} Passed
         </span>
       </Box>
     );


### PR DESCRIPTION
## Summary & Motivation

This PR updates the "status bar" at the bottom of asset nodes, and the coloring that is displayed on them when you zoom out, to reflect the new Observe UI "health" concept.

This feature flag may be used in tandem with the new faceted asset node designs, but both feature flags can also be used independently. Having four different possible cases makes the code a bit dense, but we'll clean it up when the feature flags go GA! 

Because the asset nodes include other elements from live data (the last event, asset check statuses, stale and change reason tags, etc), the nodes use BOTH `useAssetLiveData` and `useAssetHealthData` when the observe UI is enabled. I think this is nice but the data does load at separate times. So far it doesn't seem like an issue.

<img width="462" alt="image" src="https://github.com/user-attachments/assets/62ff267a-1da5-4bf8-9ce9-fbf8752de9f1" />

<img width="503" alt="image" src="https://github.com/user-attachments/assets/402d165d-3634-4d29-a9f4-c2333a259c64" />

## How I Tested These Changes

I tested this against dogfood in all four feature flag states.

## Changelog

[ui] The asset graph now displays asset health information when the new Observe UI feature flag is enabled.