### PR TITLE
[ui] asset health copy updates

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -164,8 +164,7 @@ const Criteria = React.memo(
                   {ifPlural(metadata.totalNumChecks, '', 's')} warning,{' '}
                   {numberFormatter.format(metadata.numFailedChecks)}/
                   {numberFormatter.format(metadata.totalNumChecks)} check
-                  {ifPlural(metadata.totalNumChecks, '', 's')}
-                  failed
+                  {ifPlural(metadata.totalNumChecks, '', 's')} failed
                 </Link>
               </Body>
             );
@@ -253,8 +252,9 @@ const Criteria = React.memo(
               return 'Failed to materialize';
             case AssetHealthStatus.HEALTHY:
               return 'Successfully materialized';
-            // Warning case should not be possible for materializations
+            // Warning case is only possible for partitioned assets
             case AssetHealthStatus.WARNING:
+              return 'Missing partitions';
             case AssetHealthStatus.NOT_APPLICABLE:
             case AssetHealthStatus.UNKNOWN:
             case undefined:
@@ -384,7 +384,7 @@ export const STATUS_INFO: Record<
   Warning: {
     iconName: 'warning_trend',
     iconName2: 'warning_outline',
-    subStatusIconName: 'warning',
+    subStatusIconName: 'warning_outline',
     iconColor: Colors.accentYellow(),
     text: 'Warning',
     text2: 'Warning',


### PR DESCRIPTION
## Summary & Motivation
Fixes two things found while dogfooding

Now there is a space between `checks` and `failed`
<img width="412" alt="Screenshot 2025-04-17 at 4 36 51 PM" src="https://github.com/user-attachments/assets/ad8540de-2d31-415c-bf3c-3e1db27900e0" />

when partitions are missing from an asset, the label text is "Missing partitions" rather than "No materializations" and updates the triangle warning icon to be the line version, not the filled version

<img width="412" alt="Screenshot 2025-04-17 at 5 20 14 PM" src="https://github.com/user-attachments/assets/06c2e408-32cb-45f0-b336-11436c11a8af" />

## How I Tested These Changes
👀 
