### PR TITLE
[dg] User hints for project/workspace validation

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -42,6 +42,7 @@ from dagster_dg.utils import (
     get_toml_node,
     get_venv_executable,
     has_toml_node,
+    msg_with_potential_paths,
     pushd,
     resolve_local_venv,
     strip_activated_venv_from_env_vars,
@@ -89,6 +90,13 @@ class DgContext:
 
         # Commands that operate on a workspace need to be run inside a workspace context.
         if not context.is_workspace:
+            potential_paths = cls._locate_potential_projects_or_workspaces(
+                path, command_line_config, allow_projects=False, allow_workspaces=True
+            )
+            if potential_paths:
+                exit_with_error(
+                    msg_with_potential_paths(NOT_WORKSPACE_ERROR_MESSAGE, potential_paths)
+                )
             exit_with_error(NOT_WORKSPACE_ERROR_MESSAGE)
         return context
 
@@ -97,9 +105,41 @@ class DgContext:
         context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
         if not context.is_project:
+            potential_paths = cls._locate_potential_projects_or_workspaces(
+                path, command_line_config, allow_projects=True, allow_workspaces=False
+            )
+            if potential_paths:
+                exit_with_error(
+                    msg_with_potential_paths(NOT_PROJECT_ERROR_MESSAGE, potential_paths)
+                )
             exit_with_error(NOT_PROJECT_ERROR_MESSAGE)
         _validate_project_venv_activated(context)
         return context
+
+    @classmethod
+    def _locate_potential_projects_or_workspaces(
+        cls,
+        path: Path,
+        command_line_config: DgRawCliConfig,
+        allow_projects: bool,
+        allow_workspaces: bool,
+    ) -> list[Path]:
+        """Locates potential project or workspace directories by iterating over parent directories
+        or immediate children, to present to the user if they run a command in a directory that
+        is not a project or workspace.
+        """
+        potential_paths = [
+            *path.parents,
+            *path.iterdir(),
+        ]
+        matching_paths = []
+        for path in potential_paths:
+            context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
+            if context.is_workspace and allow_workspaces:
+                matching_paths.append(path)
+            elif context.is_project and allow_projects:
+                matching_paths.append(path)
+        return matching_paths
 
     @classmethod
     def for_workspace_or_project_environment(
@@ -110,6 +150,15 @@ class DgContext:
         # Commands that operate on a workspace need to be run inside a workspace or project
         # context.
         if not (context.is_workspace or context.is_project):
+            potential_paths = cls._locate_potential_projects_or_workspaces(
+                path, commmand_line_config, allow_projects=True, allow_workspaces=True
+            )
+            if potential_paths:
+                exit_with_error(
+                    msg_with_potential_paths(
+                        NOT_WORKSPACE_OR_PROJECT_ERROR_MESSAGE, potential_paths
+                    )
+                )
             exit_with_error(NOT_WORKSPACE_OR_PROJECT_ERROR_MESSAGE)
         if context.is_project:
             _validate_project_venv_activated(context)

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -434,7 +434,7 @@ nearest pyproject.toml has `tool.dg.directory_type = "project"` or `tool.dg.dire
 def msg_with_potential_paths(message: str, potential_paths: list[Path]) -> str:
     paths_str = "\n".join([f"- {p}" for p in potential_paths])
     return f"""{message}
-You may have wanted to run this command in the following project or workspace:
+You may have wanted to run this command in the following directory:
 
 {paths_str}
 """

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -430,6 +430,16 @@ nearest pyproject.toml has `tool.dg.directory_type = "project"` or `tool.dg.dire
 "workspace"` set.
 """
 
+
+def msg_with_potential_paths(message: str, potential_paths: list[Path]) -> str:
+    paths_str = "\n".join([f"- {p}" for p in potential_paths])
+    return f"""{message}
+You may have wanted to run this command in the following project or workspace:
+
+{paths_str}
+"""
+
+
 NOT_COMPONENT_LIBRARY_ERROR_MESSAGE = """
 This command must be run inside a Dagster component library directory. Ensure that the nearest
 pyproject.toml has an entry point defined under the `dagster_dg.plugin` group.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -164,6 +164,13 @@ def test_no_project_failure(spec: CommandSpec) -> None:
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster project directory" in result.output
 
+        runner.invoke("scaffold", "project", "foo")
+        result = runner.invoke(*spec.to_cli_args())
+        assert_runner_result(result, exit_0=False)
+        assert "must be run inside a Dagster project directory" in result.output
+        assert "You may have wanted to" in result.output
+        assert "/foo" in result.output
+
 
 @pytest.mark.parametrize(
     "spec", COMPONENT_LIBRARY_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command)
@@ -189,6 +196,14 @@ def test_no_workspace_failure(spec: CommandSpec) -> None:
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster workspace directory" in result.output
+        assert "You may have wanted to" not in result.output
+
+        runner.invoke("scaffold", "workspace", "foo")
+        result = runner.invoke(*spec.to_cli_args())
+        assert_runner_result(result, exit_0=False)
+        assert "must be run inside a Dagster workspace directory" in result.output
+        assert "You may have wanted to" in result.output
+        assert "/foo" in result.output
 
 
 @pytest.mark.parametrize(
@@ -202,6 +217,14 @@ def test_no_workspace_or_project_failure(spec: CommandSpec) -> None:
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster workspace or project directory" in result.output
+        assert "You may have wanted to" not in result.output
+
+        runner.invoke("scaffold", "project", "foo")
+        result = runner.invoke(*spec.to_cli_args())
+        assert_runner_result(result, exit_0=False)
+        assert "must be run inside a Dagster workspace or project directory" in result.output
+        assert "You may have wanted to" in result.output
+        assert "/foo" in result.output
 
 
 # ########################


### PR DESCRIPTION
## Summary

Adds a user-facing hint when a dg command is run in a directory not matching the current required type (project/workspace), if a parent or immediate child dir does match the required type:

```sh
$ dg scaffold github-actions
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
This command must be run inside a Dagster workspace or project directory. Ensure that the nearest pyproject.toml has `tool.dg.directory_type = "project"` or `tool.dg.directory_type = "workspace"` set.

You may have wanted to run this command in the following directory:

- /Users/ben/repos/april-seventeenth-test/april-seventeenth
```

## How I Tested These Changes

Test cases.
