### PR TITLE
Add an entrypoint.py to dagster_dg.cli

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/entrypoint.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/entrypoint.py
@@ -1,0 +1,4 @@
+from dagster_dg.cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
This allows pex files to run e.g.

dagster-cloud.pex -m dagster_dg.cli.entrypoint

To invoke the CLI. Mimics similar functionality in dagster-cloud-cli

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
