### PR TITLE
dagster-k8s: handle jobs with backoff retries

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -477,25 +477,6 @@ class DagsterKubernetesClient:
 
         return k8s_api_retry(_get_job_status, max_retries=3, timeout=wait_time_between_attempts)
 
-    def get_job(
-        self,
-        job_name: str,
-        namespace: str,
-        wait_time_between_attempts=DEFAULT_WAIT_BETWEEN_ATTEMPTS,
-    ) -> Optional[V1Job]:
-        def _get_job():
-            try:
-                job = self.batch_api.read_namespaced_job(job_name, namespace=namespace)
-            except kubernetes.client.rest.ApiException as e:
-                if e.status == 404:
-                    return None
-                else:
-                    raise
-
-            return job
-
-        return k8s_api_retry(_get_job, max_retries=3, timeout=wait_time_between_attempts)
-
     def delete_job(
         self,
         job_name,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -477,6 +477,25 @@ class DagsterKubernetesClient:
 
         return k8s_api_retry(_get_job_status, max_retries=3, timeout=wait_time_between_attempts)
 
+    def get_job(
+        self,
+        job_name: str,
+        namespace: str,
+        wait_time_between_attempts=DEFAULT_WAIT_BETWEEN_ATTEMPTS,
+    ) -> Optional[V1Job]:
+        def _get_job():
+            try:
+                job = self.batch_api.read_namespaced_job(job_name, namespace=namespace)
+            except kubernetes.client.rest.ApiException as e:
+                if e.status == 404:
+                    return None
+                else:
+                    raise
+
+            return job
+
+        return k8s_api_retry(_get_job, max_retries=3, timeout=wait_time_between_attempts)
+
     def delete_job(
         self,
         job_name,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -419,7 +419,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             run.run_id, resume_attempt_number=self._get_resume_attempt_number(run)
         )
         try:
-            status = self._api_client.get_job_status(
+            job = self._api_client.get_job(
                 namespace=container_context.namespace,  # pyright: ignore[reportArgumentType]
                 job_name=job_name,
             )
@@ -428,8 +428,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                 WorkerStatus.UNKNOWN, str(serializable_error_info_from_exc_info(sys.exc_info()))
             )
 
-        if not status:
+        if not job:
             return CheckRunHealthResult(WorkerStatus.UNKNOWN, f"Job {job_name} could not be found")
+
+        status = job.status
 
         inactive_job_with_finished_pods = bool(
             (not status.active) and (status.failed or status.succeeded)
@@ -445,7 +447,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                 WorkerStatus.FAILED, "Run has not completed but K8s job has no active pods"
             )
 
-        if status.failed:
+        if status.failed == job.spec.backoff_limit:
             return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
         if status.succeeded:
             return CheckRunHealthResult(WorkerStatus.SUCCESS)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -447,8 +447,6 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
         if status.succeeded:
             return CheckRunHealthResult(WorkerStatus.SUCCESS)
-        else:
-            if status.failed > 0 and not status.active:
-                return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
-
+        if status.failed and not status.active:
+            return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
         return CheckRunHealthResult(WorkerStatus.RUNNING)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -21,9 +21,7 @@ from dagster_k8s import K8sRunLauncher
 from dagster_k8s.job import DAGSTER_PG_PASSWORD_ENV_VAR, get_job_name_from_run_id
 from kubernetes import __version__ as kubernetes_version
 from kubernetes.client.models.v1_job import V1Job
-from kubernetes.client.models.v1_job_spec import V1JobSpec
 from kubernetes.client.models.v1_job_status import V1JobStatus
-from kubernetes.client.models.v1_job_template_spec import V1JobTemplateSpec
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 
 if kubernetes_version >= "13":
@@ -619,7 +617,7 @@ def test_check_run_health(kubeconfig_file):
     labels = {"foo_label_key": "bar_label_value"}
 
     # Construct a K8s run launcher in a fake k8s environment.
-    mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job"])
+    mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job_status"])
 
     k8s_run_launcher = K8sRunLauncher(
         service_account_name="webserver-admin",
@@ -671,9 +669,8 @@ def test_check_run_health(kubeconfig_file):
             )
             k8s_run_launcher.register_instance(instance)
 
-            mock_k8s_client_batch_api.read_namespaced_job.return_value = V1Job(
-                status=V1JobStatus(failed=0, succeeded=0, active=0),
-                spec=V1JobSpec(backoff_limit=1, template=V1JobTemplateSpec()),
+            mock_k8s_client_batch_api.read_namespaced_job_status.return_value = V1Job(
+                status=V1JobStatus(failed=0, succeeded=0, active=0)
             )
 
             health = k8s_run_launcher.check_run_worker_health(started_run)
@@ -682,9 +679,8 @@ def test_check_run_health(kubeconfig_file):
             health = k8s_run_launcher.check_run_worker_health(finished_run)
             assert health.status == WorkerStatus.RUNNING, health.msg
 
-            mock_k8s_client_batch_api.read_namespaced_job.return_value = V1Job(
-                status=V1JobStatus(failed=0, succeeded=1, active=0),
-                spec=V1JobSpec(backoff_limit=1, template=V1JobTemplateSpec()),
+            mock_k8s_client_batch_api.read_namespaced_job_status.return_value = V1Job(
+                status=V1JobStatus(failed=0, succeeded=1, active=0)
             )
 
             health = k8s_run_launcher.check_run_worker_health(started_run)
@@ -693,9 +689,8 @@ def test_check_run_health(kubeconfig_file):
             health = k8s_run_launcher.check_run_worker_health(finished_run)
             assert health.status == WorkerStatus.SUCCESS, health.msg
 
-            mock_k8s_client_batch_api.read_namespaced_job.return_value = V1Job(
-                status=V1JobStatus(failed=1, succeeded=0, active=0),
-                spec=V1JobSpec(backoff_limit=1, template=V1JobTemplateSpec()),
+            mock_k8s_client_batch_api.read_namespaced_job_status.return_value = V1Job(
+                status=V1JobStatus(failed=1, succeeded=0, active=0)
             )
 
             health = k8s_run_launcher.check_run_worker_health(started_run)
@@ -704,9 +699,8 @@ def test_check_run_health(kubeconfig_file):
             health = k8s_run_launcher.check_run_worker_health(finished_run)
             assert health.status == WorkerStatus.FAILED, health.msg
 
-            mock_k8s_client_batch_api.read_namespaced_job.return_value = V1Job(
-                status=V1JobStatus(failed=1, succeeded=0, active=1),
-                spec=V1JobSpec(backoff_limit=2, template=V1JobTemplateSpec()),
+            mock_k8s_client_batch_api.read_namespaced_job_status.return_value = V1Job(
+                status=V1JobStatus(failed=1, succeeded=0, active=1)
             )
 
             health = k8s_run_launcher.check_run_worker_health(started_run)
@@ -715,9 +709,8 @@ def test_check_run_health(kubeconfig_file):
             health = k8s_run_launcher.check_run_worker_health(finished_run)
             assert health.status == WorkerStatus.RUNNING, health.msg
 
-            mock_k8s_client_batch_api.read_namespaced_job.return_value = V1Job(
-                status=V1JobStatus(failed=1, succeeded=1, active=0),
-                spec=V1JobSpec(backoff_limit=2, template=V1JobTemplateSpec()),
+            mock_k8s_client_batch_api.read_namespaced_job_status.return_value = V1Job(
+                status=V1JobStatus(failed=1, succeeded=1, active=0)
             )
 
             health = k8s_run_launcher.check_run_worker_health(started_run)
@@ -726,7 +719,7 @@ def test_check_run_health(kubeconfig_file):
             health = k8s_run_launcher.check_run_worker_health(finished_run)
             assert health.status == WorkerStatus.SUCCESS, health.msg
 
-            mock_k8s_client_batch_api.read_namespaced_job.side_effect = (
+            mock_k8s_client_batch_api.read_namespaced_job_status.side_effect = (
                 kubernetes.client.rest.ApiException(status=404, reason="Not Found")
             )
 
@@ -743,7 +736,9 @@ def test_check_run_health(kubeconfig_file):
 def test_get_run_worker_debug_info(kubeconfig_file):
     labels = {"foo_label_key": "bar_label_value"}
 
-    mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job", "list_namespaced_job"])
+    mock_k8s_client_batch_api = mock.Mock(
+        spec_set=["read_namespaced_job_status", "list_namespaced_job"]
+    )
     mock_k8s_client_core_api = mock.Mock(spec_set=["list_namespaced_pod", "list_namespaced_event"])
 
     k8s_run_launcher = K8sRunLauncher(


### PR DESCRIPTION
## Summary & Motivation
We use karpenter as our k8s autoscaler. Karpenter's handling of daemonsets sometimes leads to pod preemption in k8s (see their [FAQ](https://karpenter.sh/docs/faq/#when-deploying-an-additional-daemonset-to-my-cluster-why-does-karpenter-not-scale-up-my-nodes-to-support-the-extra-daemonset) for reference). As such, we increased the backoff_limit on our dagster jobs using the K8sRunLauncher.

Unfortunately, this is leading to false failure detection in k8s run monitoring. Here's an example of a dagster job that was declared failed.
```
spec:
  backoffLimit: 2
  completionMode: NonIndexed
  completions: 1
  manualSelector: false
  parallelism: 1
  podReplacementPolicy: TerminatingOrFailed
...
status:
  active: 1
  failed: 1
  ready: 1
  startTime: "2025-04-17T19:52:23Z"
  terminating: 0
  uncountedTerminatedPods: {}
```

k8s event logs show that the original pod was preempted, so it was rescheduled.
```
4m10s       Normal    SuccessfulCreate       job/dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91         Created pod: dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91-d8qg8
4m20s       Normal    Scheduled              pod/dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91-ttjmx   Successfully assigned dagster/dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91-ttjmx to ip-172-24-8-32.ec2.internal
4m19s       Normal    Preempted              pod/dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91-ttjmx   Preempted by pod 9cda2b57-b855-4e1d-a66a-d4e506b96416 on node ip-172-24-8-32.ec2.internal

4m10s       Normal    SuccessfulCreate       job/dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91         Created pod: dagster-run-269c122e-9f18-42bc-b9de-7a8047578b91-d8qg8
```

In other words, the original pod was preempted before the job even started, and then a new pod was launched. In dagster UI, we get the following:
![image](https://github.com/user-attachments/assets/79c17d6e-970e-4f69-9eca-e323ed282ab7)
The job starts running at this point, but later a "failure" is recorded since run monitoring doesn't handle the backoff.
![image](https://github.com/user-attachments/assets/d88d27f4-0814-4711-9838-cf712320dd99)

I'm very open to other solutions here, but thought it'd be more effective to start a discussion with a proposed solution.

This builds on work from #16303 and may resolve (at least part of) #6236.

## How I Tested These Changes
Added to unit tests

## Changelog

dagster-k8s: improved run monitoring when running with increased backoff limits