### PR TITLE
[dg] Properly cache dg scaffold subcommands, making --help faster

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -99,6 +99,8 @@ class ScaffoldGroup(DgClickGroup):
             command = _create_scaffold_subcommand(key, component_type)
             self.add_command(command)
 
+        self._commands_defined = True
+
 
 class ScaffoldSubCommand(DgClickCommand):
     # We have to override this because the implementation of `format_help` used elsewhere will only

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/conftest.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_defined_commands():
+    """Reset the _commands_defined flag on scaffold_group between tests,
+    to ensure the cache of scaffold subcommands is cleared. This isn't an issue outside
+    of tests because we're not reusing a Python process between different dg venvs.
+    """
+    from dagster_dg.cli.scaffold import scaffold_group
+
+    scaffold_group._commands_defined = False  # noqa: SLF001

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -605,7 +605,7 @@ class ProxyRunner:
 
 def assert_runner_result(result: Result, exit_0: bool = True) -> None:
     try:
-        assert result.exit_code == 0 if exit_0 else result.exit_code != 0
+        assert result.exit_code == 0 if exit_0 else result.exit_code != 0, result.output
     except AssertionError:
         if result.output:
             print(result.output)  # noqa: T201


### PR DESCRIPTION
## Summary

`dg scaffold --help` has been quite slow, we end up defining the subcommands repeatedly, which calls out to the `dagster-components` CLI. Turns out we have a cache here and just never set it as complete.

Before:
```sh
dg scaffold --help
                                                                                                                                                                                                                                                                                                                                                                                                                                         
 Usage: dg scaffold [OPTIONS] COMMAND [ARGS]...                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                         
 Commands for scaffolding Dagster code.                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                         
╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help  -h        Show this message and exit.                                                                                                                                                                                                                                                                                                                                                                                         │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Global options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --verbose                    Enable verbose output for debugging.                                                                                                                                                                                                                                                                                                                                                                     │
│ --disable-cache              Disable the cache..                                                                                                                                                                                                                                                                                                                                                                                      │
│ --cache-dir            TEXT  Specify a directory to use for the cache.                                                                                                                                                                                                                                                                                                                                                                │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
╭─ Commands ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ component-type                                                Scaffold of a custom Dagster component type.                                                                                                                                                                                                                                                                                                                            │
│ dagster.asset                                                                                                                                                                                                                                                                                                                                                                                                                         │
│ dagster.components.DefinitionsComponent                                                                                                                                                                                                                                                                                                                                                                                               │
│ dagster.components.DefsFolderComponent                                                                                                                                                                                                                                                                                                                                                                                                │
│ dagster.components.PipesSubprocessScriptCollectionComponent                                                                                                                                                                                                                                                                                                                                                                           │
│ dagster.schedule                                                                                                                                                                                                                                                                                                                                                                                                                      │
│ dagster.sensor                                                                                                                                                                                                                                                                                                                                                                                                                        │
│ dagster_dbt.DbtProjectComponent                                                                                                                                                                                                                                                                                                                                                                                                       │
│ dagster_sling.SlingReplicationCollectionComponent                                                                                                                                                                                                                                                                                                                                                                                     │
│ github-actions                                                Scaffold a GitHub Actions workflow for a Dagster project.                                                                                                                                                                                                                                                                                                               │
│ project                                                       Scaffold a Dagster project file structure and a uv-managed virtual environment scoped to                                                                                                                                                                                                                                                                                │
│                                                               the project.                                                                                                                                                                                                                                                                                                                                                            │
│ workspace                                                     Initialize a new Dagster workspace.                                                                                                                                                                                                                                                                                                                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

After:
```sh
dg scaffold --help
                                                                                                                                                                                                                                                                                                                                                                                                                                         
 Usage: dg scaffold [OPTIONS] COMMAND [ARGS]...                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                         
 Commands for scaffolding Dagster code.                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                         
╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help  -h        Show this message and exit.                                                                                                                                                                                                                                                                                                                                                                                         │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Global options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --verbose                    Enable verbose output for debugging.                                                                                                                                                                                                                                                                                                                                                                     │
│ --disable-cache              Disable the cache..                                                                                                                                                                                                                                                                                                                                                                                      │
│ --cache-dir            TEXT  Specify a directory to use for the cache.                                                                                                                                                                                                                                                                                                                                                                │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Using /Users/ben/.pyenv/versions/dagster/bin/dagster-components
╭─ Commands ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ component-type                                                Scaffold of a custom Dagster component type.                                                                                                                                                                                                                                                                                                                            │
│ dagster.asset                                                                                                                                                                                                                                                                                                                                                                                                                         │
│ dagster.components.DefinitionsComponent                                                                                                                                                                                                                                                                                                                                                                                               │
│ dagster.components.DefsFolderComponent                                                                                                                                                                                                                                                                                                                                                                                                │
│ dagster.components.PipesSubprocessScriptCollectionComponent                                                                                                                                                                                                                                                                                                                                                                           │
│ dagster.schedule                                                                                                                                                                                                                                                                                                                                                                                                                      │
│ dagster.sensor                                                                                                                                                                                                                                                                                                                                                                                                                        │
│ dagster_dbt.DbtProjectComponent                                                                                                                                                                                                                                                                                                                                                                                                       │
│ dagster_sling.SlingReplicationCollectionComponent                                                                                                                                                                                                                                                                                                                                                                                     │
│ github-actions                                                Scaffold a GitHub Actions workflow for a Dagster project.                                                                                                                                                                                                                                                                                                               │
│ project                                                       Scaffold a Dagster project file structure and a uv-managed virtual environment scoped to                                                                                                                                                                                                                                                                                │
│                                                               the project.                                                                                                                                                                                                                                                                                                                                                            │
│ workspace                                                     Initialize a new Dagster workspace.                                                                                                                                                                                                                                                                                                                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## How I Tested These Changes

Tested locally, way faster now.
