### PR TITLE
[CatalogV2] Include external assets in asset health result to fix infinite loading + skip health query if feature flag disabled

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {ApolloClient, gql, useApolloClient} from '../apollo-client';
 import {AssetBaseData} from './AssetBaseDataProvider';
+import {featureEnabled, setFeatureFlags} from '../app/Flags';
 import {tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {liveDataFactory} from '../live-data-provider/Factory';
@@ -13,7 +13,7 @@ import {
   AssetHealthQuery,
   AssetHealthQueryVariables,
 } from './types/AssetHealthDataProvider.types';
-import {featureEnabled, setFeatureFlags} from '../app/Flags';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 setFeatureFlags({[FeatureFlag.flagUseNewObserveUIs]: true});
 
@@ -69,11 +69,15 @@ export function useAssetHealthData(assetKey: AssetKeyInput, thread: LiveDataThre
   return result;
 }
 
+const memoizedAssetKeys = weakMapMemoize((assetKeys: AssetKeyInput[]) => {
+  return assetKeys.map((key) => tokenForAssetKey(key));
+});
+
 export function useAssetsHealthData(
   assetKeys: AssetKeyInput[],
   thread: LiveDataThreadID = 'AssetHealth', // Use AssetHealth to get 250 batch size
 ) {
-  const keys = React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]);
+  const keys = memoizedAssetKeys(assetKeys);
   const result = AssetHealthData.useLiveData(keys, thread);
   AssetBaseData.useLiveData(keys, thread);
   useBlockTraceUntilTrue(


### PR DESCRIPTION
## Summary & Motivation

External assets when requested do not get included in the response by the assetNodes resolver, so as a workaround lets just include them manually on the frontend but with a null assetHealth object so that they get classified as "Unknown"

## How I Tested These Changes

Saw the external assets in the unknown section
<img width="1726" alt="Screenshot 2025-04-17 at 10 23 29 PM" src="https://github.com/user-attachments/assets/d36ab1b7-abf1-45ca-bef4-1a3a1ecdc9c0" />
