### PR TITLE
[dg] Remove code_location_name from DgWorkspaceProjectSpec (BUILD-969)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -348,21 +348,16 @@ class DgRawWorkspaceConfig(TypedDict, total=False):
 @dataclass
 class DgWorkspaceProjectSpec:
     path: Path
-    code_location_name: Optional[str] = None
 
     @classmethod
     def from_raw(cls, raw: "DgRawWorkspaceProjectSpec") -> Self:
         return cls(
             path=Path(raw["path"]),
-            code_location_name=raw.get(
-                "code_location_name", DgWorkspaceProjectSpec.code_location_name
-            ),
         )
 
 
 class DgRawWorkspaceProjectSpec(TypedDict, total=False):
     path: Required[str]
-    code_location_name: str
 
 
 @dataclass


### PR DESCRIPTION
## Summary & Motivation

Removed the `code_location_name` field from `DgWorkspaceProjectSpec`. This was a dead param not being used anywhere (code location name is sourced from the project config itself when creating a workspace.yaml)

## How I Tested These Changes

Existing test suite.