### PR TITLE
[dg] Add loggers to dg

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/34-dg-component-check-defs.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/34-dg-component-check-defs.txt
@@ -1,8 +1,8 @@
 dg check defs
 
 All components validated successfully.
+dagster definitions validate --log-level warning --log-format colored --workspace /tmp/workspace
 
 INFO:dagster.builtin:Running dbt command: `dbt parse --quiet`.
 INFO:dagster.builtin:Finished dbt command: `dbt parse --quiet`.
-dagster definitions validate --log-level warning --log-format colored --workspace /tmp/workspace
 All definitions loaded successfully.

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 from pathlib import Path
 from typing import Final, Literal, Optional
@@ -5,7 +6,7 @@ from typing import Final, Literal, Optional
 from typing_extensions import Self, TypeAlias
 
 from dagster_dg.config import DgConfig
-from dagster_dg.utils import is_macos, is_windows
+from dagster_dg.utils import get_logger, is_macos, is_windows
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
@@ -24,13 +25,13 @@ def get_default_cache_dir() -> Path:
 class DgCache:
     @classmethod
     def from_default(cls) -> Self:
-        return cls.from_parent_path(get_default_cache_dir())
+        return cls.from_parent_path(get_default_cache_dir(), get_logger("dagster_dg.cache", False))
 
     @classmethod
     def from_config(cls, config: DgConfig) -> Self:
         return cls.from_parent_path(
             parent_path=config.cli.cache_dir,
-            logging_enabled=config.cli.verbose,
+            log=get_logger("dagster_dg.cache", config.cli.verbose),
         )
 
     # This is the preferred constructor to use when creating a cache. It ensures that all data is
@@ -38,43 +39,39 @@ class DgCache:
     # When we clear the cache, we only delete this container directory. This is to avoid accidents
     # when the user mistakenly specifies a cache directory that contains other data.
     @classmethod
-    def from_parent_path(cls, parent_path: Path, logging_enabled: bool = False) -> Self:
+    def from_parent_path(cls, parent_path: Path, log: logging.Logger) -> Self:
         root_path = parent_path / _CACHE_CONTAINER_DIR_NAME
-        return cls(root_path, logging_enabled)
+        return cls(root_path, log)
 
-    def __init__(self, root_path: Path, logging_enabled: bool):
+    def __init__(self, root_path: Path, log: logging.Logger) -> None:
         self._root_path = root_path
         self._root_path.mkdir(parents=True, exist_ok=True)
-        self._logging_enabled = logging_enabled
+        self.log = log
 
     def clear_key(self, key: tuple[str, ...]) -> None:
         path = self._get_path(key)
         if path.exists():
             path.unlink()
-            self.log(f"CACHE [clear-key]: {path}")
+            self.log.info(f"CACHE [clear-key]: {path}")
 
     def clear_all(self) -> None:
         shutil.rmtree(self._root_path)
-        self.log(f"CACHE [clear-all]: {self._root_path}")
+        self.log.info(f"CACHE [clear-all]: {self._root_path}")
 
     def get(self, key: tuple[str, ...]) -> Optional[str]:
         path = self._get_path(key)
         if path.exists():
-            self.log(f"CACHE [hit]: {path}")
+            self.log.info(f"CACHE [hit]: {path}")
             return path.read_text()
         else:
-            self.log(f"CACHE [miss]: {path}")
+            self.log.info(f"CACHE [miss]: {path}")
             return None
 
     def set(self, key: tuple[str, ...], value: str) -> None:
         path = self._get_path(key)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(value)
-        self.log(f"CACHE [write]: {path}")
+        self.log.info(f"CACHE [write]: {path}")
 
     def _get_path(self, key: tuple[str, ...]) -> Path:
         return Path(self._root_path, *key)
-
-    def log(self, message: str) -> None:
-        if self._logging_enabled:
-            print(message)  # noqa: T201

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -171,11 +171,11 @@ def check_definitions_command(
                 overall_check_result = overall_check_result and check_result
             if not overall_check_result:
                 click.get_current_context().exit(1)
-        print(f"Using {cmd_location}")  # noqa: T201
+        dg_context.log.warning(f"Using {cmd_location}")
         if workspace_file:  # only non-None deployment context
             cmd.extend(["--workspace", workspace_file])
 
-        print(" ".join(cmd))  # noqa: T201
+        dg_context.log.warning(" ".join(cmd))
 
         result = subprocess.run(cmd, check=False)
         if result.returncode != 0:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import shlex
@@ -40,6 +41,7 @@ from dagster_dg.utils import (
     generate_project_and_activated_venv_mismatch_warning,
     generate_tool_dg_cli_in_project_in_workspace_error_message,
     get_activated_venv,
+    get_logger,
     get_toml_node,
     get_venv_executable,
     has_toml_node,
@@ -498,6 +500,22 @@ class DgContext:
         return {}
 
     # ########################
+    # ##### LOG METHODS
+    # ########################
+
+    @cached_property
+    def log(self) -> logging.Logger:
+        """Return a logger for this context.
+
+        The logger is configured based on the verbose setting in config.
+        Default level is WARNING, and if verbose is set, level is increased to INFO.
+
+        Returns:
+            A configured logger that can be used with methods like info(), debug(), warning(), etc.
+        """
+        return get_logger("dagster_dg.context", self.config.cli.verbose)
+
+    # ########################
     # ##### HELPERS
     # ########################
 
@@ -542,7 +560,7 @@ class DgContext:
 
         with pushd(self.root_path):
             if log:
-                print(f"Using {executable_path}")  # noqa: T201
+                self.log.warning(f"Using {executable_path}")
 
             # We don't capture stderr here-- it will print directly to the console, then we can
             # add a clean error message at the end explaining what happened.

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import logging
 import os
 import posixpath
 import re
@@ -63,6 +64,17 @@ def get_shortest_path_repr(abs_path: Path) -> Path:
         return abs_path.relative_to(Path.cwd())
     except ValueError:  # raised when path is not a descendant of cwd
         return abs_path
+
+
+def get_logger(name: str, verbose: bool) -> logging.Logger:
+    logger = logging.getLogger(name)
+    log_level = logging.INFO if verbose else logging.WARNING
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.handlers = [handler]
+    logger.setLevel(log_level)
+    logger.propagate = False
+    return logger
 
 
 def clear_screen():


### PR DESCRIPTION
## Summary & Motivation

`dagster-dg` currently uses a crude logging system where we conditionally `print()` if `verbose` is set.

This PR transitions the system to use loggers, setting us up for more controlled logging output. There's no behavior change, the loggers are currently configured to just print to stdout and not propagate.

This is laying the groundwork for further changes discussed here: https://www.notion.so/dagster/Logging-in-dg-1d918b92e462800aa05efda464ba2315?pvs=4

## How I Tested These Changes

Existing test suite (which checks for logging output)