### PR TITLE
[ui] Fix “View lineage” links for saved views, change “Catalog” tab to “Assets”

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetCatalogTableV2.tsx
@@ -96,10 +96,10 @@ export const AssetCatalogTableV2 = React.memo(
 
     const [selectedTab, setSelectedTab] = useQueryPersistedState<string>({
       queryKey: 'selectedTab',
-      defaults: {selectedTab: 'catalog'},
+      defaults: {selectedTab: 'assets'},
       decode: (qs) =>
-        qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : 'catalog',
-      encode: (b) => ({selectedTab: b || 'catalog'}),
+        qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : 'assets',
+      encode: (b) => ({selectedTab: b || 'assets'}),
     });
 
     const setCurrentPage = useSetRecoilState(currentPageAtom);
@@ -180,7 +180,7 @@ export const AssetCatalogTableV2 = React.memo(
               selectedTabId={selectedTab}
               style={{marginLeft: 24, marginRight: 24}}
             >
-              <Tab id="catalog" title="Catalog" />
+              <Tab id="assets" title="Assets" />
               <Tab id="lineage" title="Lineage" />
               <Tab id="insights" title="Insights" />
             </Tabs>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -4,9 +4,11 @@ import {Box, Colors, Heading, Icon, MiddleTruncate, PageHeader} from '@dagster-i
 import * as React from 'react';
 import {useContext} from 'react';
 import {Link, useHistory, useLocation} from 'react-router-dom';
+import {useAssetSelectionState} from 'shared/asset-selection/useAssetSelectionState.oss';
 import {getAssetFilterStateQueryString} from 'shared/assets/useAssetDefinitionFilterState.oss';
 import styled from 'styled-components';
 
+import {globalAssetGraphPathToString} from './globalAssetGraphPathToString';
 import {AppContext} from '../app/AppContext';
 import {AnchorButton} from '../ui/AnchorButton';
 import {CopyIconButton} from '../ui/CopyButton';
@@ -115,14 +117,17 @@ const TruncatedHeading = styled(Heading)`
   overflow: hidden;
 `;
 
-export const AssetGlobalLineageLink = () => (
-  <Link to="/asset-groups">
-    <Box flex={{gap: 4}}>
-      <Icon color={Colors.linkDefault()} name="lineage" />
-      View lineage
-    </Box>
-  </Link>
-);
+export const AssetGlobalLineageLink = () => {
+  const [assetSelection] = useAssetSelectionState();
+  return (
+    <Link to={globalAssetGraphPathToString({opsQuery: assetSelection, opNames: []})}>
+      <Box flex={{gap: 4}}>
+        <Icon color={Colors.linkDefault()} name="lineage" />
+        View lineage
+      </Box>
+    </Link>
+  );
+};
 
 export const AssetGlobalLineageButton = () => (
   <AnchorButton intent="primary" icon={<Icon name="lineage" />} to="/asset-groups">


### PR DESCRIPTION
With the Observe UI feature flag off, the view lineage link was always going to the global asset graph, even if you are viewing a view.

With the Observe UI feature flag on, we want the leftmost tab of a view to be “Assets” instead of “Catalog”
