### PR TITLE
Automatically marks inactive PRs / issues as stale and close

### DIFF
--- a/.github/workflows/automate-stale-issues.yml
+++ b/.github/workflows/automate-stale-issues.yml
@@ -36,18 +36,20 @@ jobs:
         id: stale
         with:
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had any
-            activity for 90 days. It will be closed if no further activity occurs. Thank
-            you for your contributions.
+            This issue has been automatically marked as stale because it has not had any activity
+            for 365 days. It will be closed if no further activity occurs. Please indicate if this
+            issue should be re-opened. Thank you!
           days-before-issue-stale: 365
           days-before-issue-close: 7
           # exempt-issue-labels: "type: idea"
           stale-issue-label: stale
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had any
-            recent activity from the author for 30 days. It will be closed if no further
+            recent activity from the author for 365 days. It will be closed if no further
             activity occurs. If the PR was closed and you want it re-opened, please let
             us know and we'll re-open the PR.
+
+            Thank you for your contributions.
           days-before-pr-stale: 365
           days-before-pr-close: 7
           # exempt-pr-labels: tech-debt

--- a/.github/workflows/automate-stale-issues.yml
+++ b/.github/workflows/automate-stale-issues.yml
@@ -8,7 +8,7 @@
 # The following automations will occur:
 #
 #  - Stale label is added to issues and pull requests after 365 days of inactivity
-#  - Close stale issues and pull requests after 7 days of inactivity (365 + 7 days total inactivity)
+#  - Close stale issues and pull requests after 30 days of inactivity (365 + 30 days total inactivity)
 #  - Remove stale label and restart timer if an update/comment occurs
 
 name: Automate stale issues
@@ -40,7 +40,7 @@ jobs:
             for 365 days. It will be closed if no further activity occurs. Please indicate if this
             issue should be re-opened. Thank you!
           days-before-issue-stale: 365
-          days-before-issue-close: 7
+          days-before-issue-close: 30
           # exempt-issue-labels: "type: idea"
           stale-issue-label: stale
           stale-pr-message: >
@@ -51,7 +51,7 @@ jobs:
 
             Thank you for your contributions.
           days-before-pr-stale: 365
-          days-before-pr-close: 7
+          days-before-pr-close: 30
           # exempt-pr-labels: tech-debt
           stale-pr-label: stale
           operations-per-run: 100

--- a/.github/workflows/automate-stale-issues.yml
+++ b/.github/workflows/automate-stale-issues.yml
@@ -1,0 +1,55 @@
+# Automation to mark issues and pull requests stale
+#
+# REFERENCES
+#
+#     https://github.com/step-security/harden-runner
+#     https://github.com/actions/stale
+#
+# The following automations will occur:
+#
+#  - Stale label is added to issues and pull requests after 365 days of inactivity
+#  - Close stale issues and pull requests after 7 days of inactivity (365 + 7 days total inactivity)
+#  - Remove stale label and restart timer if an update/comment occurs
+
+name: Automate stale issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/30 * * * *' # run every 30 minutes as it handles label removal
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        id: stale
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had any
+            activity for 90 days. It will be closed if no further activity occurs. Thank
+            you for your contributions.
+          days-before-issue-stale: 365
+          days-before-issue-close: 7
+          # exempt-issue-labels: "type: idea"
+          stale-issue-label: stale
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had any
+            recent activity from the author for 30 days. It will be closed if no further
+            activity occurs. If the PR was closed and you want it re-opened, please let
+            us know and we'll re-open the PR.
+          days-before-pr-stale: 365
+          days-before-pr-close: 7
+          # exempt-pr-labels: tech-debt
+          stale-pr-label: stale
+          operations-per-run: 100


### PR DESCRIPTION
## Summary & Motivation

Recreation of https://github.com/dagster-io/dagster/pull/20588

Closes DR-1008.

The Dagster repository has accumulated many issues and pull requests that are likely no longer relevant or actively being worked on. This Github action automates the process of marking issues and pull requests as "stale", and closing them after a certain period of time after that staleness marker has been applied. Overall, the following automations will occur:

- `stale` label is added to issues and pull requests after 365 days of inactivity
- `stale` issue or PR is closed after 30 days of inactivity after being marked (365 + 30 days total inactivity)
- Remove stale label and restart timer if an update/comment occurs

## How I Tested These Changes

## Changelog

NOCHANGELOG
