### PR TITLE
DagsterInstance.report_dagster_event timestamp override

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -645,6 +645,7 @@ class GrapheneRun(graphene.ObjectType):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self.dagster_run.tags.items()
+            if get_tag_type(key) != TagType.HIDDEN
         ]
 
     def resolve_externalJobSource(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -855,7 +855,7 @@ class Definitions(IHaveNew):
         ]
         sensors = []
         for sensor in self.sensors or []:
-            if sensor.has_jobs and any(job.name == job_name for job in sensor.jobs):
+            if has_job_defs_attached(sensor) and any(job.name == job_name for job in sensor.jobs):
                 sensors.append(
                     sensor.with_updated_jobs(
                         [job for job in sensor.jobs if job.name != job_name] + [job_def]
@@ -893,3 +893,7 @@ def get_job_from_defs(
         iter(job for job in (defs.jobs or []) if job.name == name),
         None,
     )
+
+
+def has_job_defs_attached(sensor_def: SensorDefinition) -> bool:
+    return any(target.has_job_def for target in sensor_def.targets)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -7,6 +7,7 @@ import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from enum import Enum
 from tempfile import TemporaryDirectory
 from types import TracebackType
@@ -1925,8 +1926,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.add_snapshot(snapshot)
 
     @traced
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._run_storage.handle_run_event(run_id, event)
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._run_storage.handle_run_event(run_id, event, update_timestamp)
 
     @traced
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2751,6 +2751,7 @@ class DagsterInstance(DynamicPartitionsStore):
         run_id: str,
         log_level: Union[str, int] = logging.INFO,
         batch_metadata: Optional["DagsterEventBatchMetadata"] = None,
+        timestamp: Optional[float] = None,
     ) -> None:
         """Takes a DagsterEvent and stores it in persistent storage for the corresponding DagsterRun."""
         from dagster._core.events.log import EventLogEntry
@@ -2761,7 +2762,7 @@ class DagsterInstance(DynamicPartitionsStore):
             job_name=dagster_event.job_name,
             run_id=run_id,
             error_info=None,
-            timestamp=get_current_timestamp(),
+            timestamp=timestamp or get_current_timestamp(),
             step_key=dagster_event.step_key,
             dagster_event=dagster_event,
         )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -204,8 +204,10 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     ) -> "DagsterRun":
         return self._storage.run_storage.add_historical_run(dagster_run, run_creation_time)
 
-    def handle_run_event(self, run_id: str, event: "DagsterEvent") -> None:
-        return self._storage.run_storage.handle_run_event(run_id, event)
+    def handle_run_event(
+        self, run_id: str, event: "DagsterEvent", update_timestamp: Optional[datetime] = None
+    ) -> None:
+        return self._storage.run_storage.handle_run_event(run_id, event, update_timestamp)
 
     def get_runs(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -62,7 +62,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """Add a historical run to storage."""
 
     @abstractmethod
-    def handle_run_event(self, run_id: str, event: DagsterEvent) -> None:
+    def handle_run_event(
+        self, run_id: str, event: DagsterEvent, update_timestamp: Optional[datetime] = None
+    ) -> None:
         """Update run storage in accordance to a pipeline run related DagsterEvent.
 
         Args:

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -15,7 +15,6 @@ from functools import update_wrapper
 from pathlib import Path
 from signal import Signals
 from threading import Event
-from types import TracebackType
 from typing import (  # noqa: UP035
     AbstractSet,
     Any,
@@ -738,20 +737,18 @@ def get_freezable_log_manager():
             fn: str,
             lno: int,
             msg: object,
-            args: tuple[object, ...] | Mapping[str, object],
-            exc_info: tuple[type[BaseException], BaseException, TracebackType | None]
-            | tuple[None, None, None]
-            | None,
-            func: str | None = None,
-            extra: Mapping[str, object] | None = None,
-            sinfo: str | None = None,
+            args,
+            exc_info,
+            func=None,
+            extra=None,
+            sinfo=None,
         ) -> logging.LogRecord:
             record = super().makeRecord(
                 name, level, fn, lno, msg, args, exc_info, func, extra, sinfo
             )
             record.created = get_current_timestamp()
             record.msecs = (record.created - int(record.created)) * 1000
-            record.relativeCreated = (record.created - logging._startTime) * 1000  # noqa: SLF001
+            record.relativeCreated = record.created  # this is incorrect. You really want to get the start time of the program, but we don't have a great way to do that. Since this is just for testing, we ignore the incosistency.
             return record
 
     return FreezableLogManager

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3099,13 +3099,7 @@ class TestEventLogStorage:
             assert failed_partitions_by_step_key == failed_partitions
 
     def test_timestamp_overrides(self, storage, instance: DagsterInstance) -> None:
-        # instance.report_dagster_event(
-        #     DagsterEvent(
-        #         event_type_value="PIPELINE_START",
-        #         job_name=run.job_name
-        #     ),
-        #     timestamp=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
-        # )
+        frozen_time = get_current_datetime()
         frozen_time = get_current_datetime()
         with freeze_time(frozen_time):
             instance.report_dagster_event(
@@ -3121,7 +3115,7 @@ class TestEventLogStorage:
 
             record = instance.get_asset_records([AssetKey("foo")])[0]
             assert (
-                record.asset_entry.last_materialization_record.timestamp == frozen_time.timestamp()
+                record.asset_entry.last_materialization_record.timestamp == frozen_time.timestamp()  # type: ignore
             )
 
             report_date = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
@@ -3139,7 +3133,7 @@ class TestEventLogStorage:
             )
             record = instance.get_asset_records([AssetKey("foo")])[0]
             assert (
-                record.asset_entry.last_materialization_record.timestamp == report_date.timestamp()
+                record.asset_entry.last_materialization_record.timestamp == report_date.timestamp()  # type: ignore
             )
 
     def test_get_latest_storage_ids_by_partition(self, storage, instance):

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components import Component, ComponentLoadContext, Resolvable
@@ -42,7 +42,7 @@ class AirflowInstanceScaffolder(Scaffolder):
         return AirflowInstanceScaffolderParams
 
     def scaffold(self, request: ScaffoldRequest, params: AirflowInstanceScaffolderParams) -> None:
-        full_params = {
+        full_params: dict[str, Any] = {
             "name": params.name,
         }
         if params.auth_type == "basic_auth":

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -76,7 +76,8 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
         assert keyed_spec is not None
         assert keyed_spec.metadata["foo"] == "bar"
 
-    assert len(defs.jobs) == 3  # monitoring job + 2 dag jobs.
+    assert defs.jobs
+    assert len(defs.jobs) == 3  # type: ignore # monitoring job + 2 dag jobs.
 
 
 def _scaffold_airlift(scaffold_format: str):

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_monitoring_job.py
@@ -51,6 +51,7 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
         defs, af_instance = create_defs_and_instance(
             assets_per_task={
                 "dag": {"task": [("a", [])]},
+                "dag2": {"task": [("b", [])]},
             },
             create_runs=False,
             create_assets_defs=False,
@@ -81,6 +82,14 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     end_date=freeze_datetime,
                     state="failed",
                 ),
+                # Newly finished run that started after the last iteration, and therefore has no corresponding run on the instance.
+                make_dag_run(
+                    dag_id="dag2",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
+                    state="success",
+                ),
             ],
             seeded_task_instances=[
                 # Have a newly completed task instance for the newly started run.
@@ -90,6 +99,14 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     run_id="run-dag",
                     start_date=freeze_datetime - timedelta(seconds=30),
                     end_date=freeze_datetime,
+                ),
+                # Have a newly completed task instance for the late run.
+                make_task_instance(
+                    dag_id="dag2",
+                    task_id="task",
+                    run_id="late-run",
+                    start_date=freeze_datetime - timedelta(seconds=15),
+                    end_date=freeze_datetime - timedelta(seconds=10),
                 ),
             ],
             seeded_logs={
@@ -101,8 +118,8 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
             mapped_defs=defs,
         )
         success_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
                 job_name=job_name("dag"),
                 run_id=success_dagster_run_id,
                 tags={
@@ -110,19 +127,20 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
                     DAG_ID_TAG_KEY: "dag",
                 },
                 status=DagsterRunStatus.STARTED,
-            )
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
         )
         failure_dagster_run_id = make_new_run_id()
-        instance.add_run(
-            DagsterRun(
+        instance.run_storage.add_historical_run(
+            dagster_run=DagsterRun(
                 job_name=job_name("dag"),
                 run_id=failure_dagster_run_id,
                 tags={
                     DAG_RUN_ID_TAG_KEY: "failure-run",
                     DAG_ID_TAG_KEY: "dag",
                 },
-                status=DagsterRunStatus.STARTED,
-            )
+            ),
+            run_creation_time=freeze_datetime - timedelta(seconds=30),
         )
         result = defs.execute_job_in_process(
             job_name=monitoring_job_name(af_instance.name),
@@ -140,29 +158,44 @@ def test_monitoring_job_execution(init_load_context: None, instance: DagsterInst
         assert result.success
 
         # Expect that the success and failure runs are marked as finished.
-        assert (
-            check.not_none(instance.get_run_by_id(success_dagster_run_id)).status
-            == DagsterRunStatus.SUCCESS
-        )
-        assert (
-            check.not_none(instance.get_run_by_id(failure_dagster_run_id)).status
-            == DagsterRunStatus.FAILURE
-        )
+        success_record = check.not_none(instance.get_run_record_by_id(success_dagster_run_id))
+        assert success_record.dagster_run.status == DagsterRunStatus.SUCCESS
+        assert success_record.end_time == (freeze_datetime).timestamp()
+
+        failure_record = check.not_none(instance.get_run_record_by_id(failure_dagster_run_id))
+        assert failure_record.dagster_run.status == DagsterRunStatus.FAILURE
+        assert failure_record.end_time == (freeze_datetime).timestamp()
+
         # Expect that we created a new run for the newly running run.
-        newly_started_run = next(
-            iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
+        newly_started_run_record = next(
+            iter(instance.get_run_records(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
+        )
+        assert newly_started_run_record.dagster_run.status == DagsterRunStatus.STARTED
+        assert (
+            newly_started_run_record.start_time
+            == (freeze_datetime - timedelta(seconds=30)).timestamp()
         )
 
-        assert newly_started_run.status == DagsterRunStatus.STARTED
+        late_run = next(
+            iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "late-run"})))
+        )
+        assert late_run.status == DagsterRunStatus.SUCCESS
+        run_record = check.not_none(instance.get_run_record_by_id(late_run.run_id))
+        assert (
+            run_record.create_timestamp.timestamp()
+            == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        )
+        assert run_record.start_time == (freeze_datetime - timedelta(seconds=15)).timestamp()
+        assert run_record.end_time == (freeze_datetime - timedelta(seconds=10)).timestamp()
 
         # There should be planned materialization data for the task.
         planned_info = instance.get_latest_planned_materialization_info(AssetKey("a"))
         assert planned_info
-        assert planned_info.run_id == newly_started_run.run_id
+        assert planned_info.run_id == newly_started_run_record.dagster_run.run_id
         # Expect that we emitted asset materialization events for the task.
         mapped_asset_mat = instance.get_latest_materialization_event(AssetKey("a"))
         assert mapped_asset_mat is not None
-        assert mapped_asset_mat.run_id == newly_started_run.run_id
+        assert mapped_asset_mat.run_id == newly_started_run_record.dagster_run.run_id
 
 
 def get_invalid_json_log_content() -> str:
@@ -232,9 +265,16 @@ def test_monitoring_job_log_extraction_errors(
             job_name=monitoring_job_name(af_instance.name),
             instance=instance,
             tags={REPOSITORY_LABEL_TAG: "placeholder"},
+            run_config=RunConfig(
+                ops={
+                    monitoring_job_op_name(af_instance): MonitoringConfig(
+                        range_start=(freeze_datetime - timedelta(seconds=30)).isoformat(),
+                        range_end=freeze_datetime.isoformat(),
+                    )
+                }
+            ),
         )
         assert result.success
-
         newly_started_run = next(
             iter(instance.get_runs(filters=RunsFilter(tags={DAG_RUN_ID_TAG_KEY: "run-dag"})))
         )
@@ -350,18 +390,16 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
             instance=instance,
             repository_def=defs.get_repository_def(),
         )
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, RunRequest)
         assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
             "config": {
-                "range_start_iso": (freeze_datetime - timedelta(seconds=30)).isoformat(),
-                "range_end_iso": freeze_datetime.isoformat(),
+                "range_start": (freeze_datetime - timedelta(seconds=30)).isoformat(),
+                "range_end": freeze_datetime.isoformat(),
             }
         }
-        assert (
-            result.tags["range_start_iso"] == (freeze_datetime - timedelta(seconds=30)).isoformat()
-        )
-        assert result.tags["range_end_iso"] == freeze_datetime.isoformat()
+        assert result.tags["range_start"] == (freeze_datetime - timedelta(seconds=30)).isoformat()
+        assert result.tags["range_end"] == freeze_datetime.isoformat()
         # Create an actual run for the monitoring job that is not finished.
         run = instance.create_run_for_job(
             job_def=defs.get_job_def(monitoring_job_name(af_instance.name)),
@@ -370,9 +408,9 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
             status=DagsterRunStatus.STARTED,
             run_config=result.run_config,
         )
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, SkipReason)
-        assert "Monitoring job is still running" in result.skip_message
+        assert "Monitoring job is still running" in result.skip_message  # type: ignore
         # Move the run to a finished state.
         instance.report_dagster_event(
             run_id=run.run_id,
@@ -383,11 +421,11 @@ def test_monitor_sensor_cursor(init_load_context: None, instance: DagsterInstanc
         )
     # Move time forward and check that we get a new run request.
     with freeze_time(freeze_datetime + timedelta(seconds=30)):
-        result = defs.sensors[0](context)
+        result = defs.sensors[0](context)  # type: ignore
         assert isinstance(result, RunRequest)
         assert result.run_config["ops"][monitoring_job_op_name(af_instance)] == {
             "config": {
-                "range_start_iso": (freeze_datetime).isoformat(),
-                "range_end_iso": (freeze_datetime + timedelta(seconds=30)).isoformat(),
+                "range_start": (freeze_datetime).isoformat(),
+                "range_end": (freeze_datetime + timedelta(seconds=30)).isoformat(),
             }
         }


### PR DESCRIPTION
## Summary & Motivation
Allow overriding the timestamp set on the event log entry. This allows for backdating events.

## How I Tested These Changes
Added a new storage test

