### PR TITLE
[dg] Improve missing object error message for `dg scaffold` (BUILD-988)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -46,7 +46,7 @@ from dagster_dg.utils import (
     DgClickCommand,
     DgClickGroup,
     exit_with_error,
-    generate_missing_component_type_error_message,
+    generate_missing_plugin_object_error_message,
     json_schema_property_to_click_option,
     not_none,
     parse_json_option,
@@ -79,7 +79,7 @@ class ScaffoldGroup(DgClickGroup):
             self._define_commands(ctx)
         cmd = super().get_command(ctx, cmd_name)
         if cmd is None:
-            exit_with_error(generate_missing_component_type_error_message(cmd_name))
+            exit_with_error(generate_missing_plugin_object_error_message(cmd_name))
         return cmd
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/utils.py
@@ -19,7 +19,7 @@ from dagster_dg.utils import (
     DgClickCommand,
     DgClickGroup,
     exit_with_error,
-    generate_missing_component_type_error_message,
+    generate_missing_plugin_object_error_message,
 )
 from dagster_dg.utils.editor import (
     install_or_update_yaml_schema_extension,
@@ -89,7 +89,7 @@ def inspect_component_type_command(
     registry = RemotePluginRegistry.from_dg_context(dg_context)
     component_key = PluginObjectKey.from_typename(component_type)
     if not registry.has(component_key):
-        exit_with_error(generate_missing_component_type_error_message(component_type))
+        exit_with_error(generate_missing_plugin_object_error_message(component_type))
     elif sum([description, scaffold_params_schema, component_schema]) > 1:
         exit_with_error(
             "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -371,11 +371,11 @@ def format_multiline_str(message: str) -> str:
     return "\n\n".join(paragraphs)
 
 
-def generate_missing_component_type_error_message(component_key_str: str) -> str:
+def generate_missing_plugin_object_error_message(plugin_object_key: str) -> str:
     return f"""
-        No component type `{component_key_str}` is registered. Use `dg list plugins --feature component`
-        to see the registered component types in your environment. You may need to install a package
-        that provides `{component_key_str}` into your environment.
+        No plugin object `{plugin_object_key}` is registered. Use `dg list plugins`
+        to see the registered plugin objects in your environment. You may need to install a package
+        that provides `{plugin_object_key}` into your environment.
     """
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -474,7 +474,7 @@ def test_scaffold_component_undefined_component_type_fails() -> None:
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         result = runner.invoke("scaffold", "fake.Fake", "qux")
         assert_runner_result(result, exit_0=False)
-        assert "No component type `fake.Fake` is registered" in result.output
+        assert "No plugin object `fake.Fake` is registered" in result.output
 
 
 def test_scaffold_component_command_with_non_matching_module_name():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_utils_inspect_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_utils_inspect_command.py
@@ -208,4 +208,4 @@ def test_utils_inspect_component_type_undefined_component_type_fails() -> None:
             "fake.Fake",
         )
         assert_runner_result(result, exit_0=False)
-        assert "No component type `fake.Fake` is registered" in result.output
+        assert "No plugin object `fake.Fake` is registered" in result.output


### PR DESCRIPTION
## Summary & Motivation

Changes the error message when you run `dg scaffold nonexistent.object` to refer to "plugin object" instead of "component", this is more accurate.

## How I Tested These Changes

Changed existing unit tests.