### PR TITLE
[dg] Print a message when rebuilding the plugin object cache (BUILD-1005)

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -13,6 +13,7 @@ from docs_snippets_tests.snippet_checks.guides.components.utils import (
     EDITABLE_DIR,
     MASK_EDITABLE_DAGSTER,
     MASK_JAFFLE_PLATFORM,
+    MASK_PLUGIN_CACHE_REBUILD,
     MASK_TMP_WORKSPACE,
     DgTestPackageManager,
     format_multiline,
@@ -199,6 +200,7 @@ def test_components_docs_index(
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 MASK_JAFFLE_PLATFORM,
+                MASK_PLUGIN_CACHE_REBUILD,
                 _MASK_EMPTY_WARNINGS,
             ],
         )
@@ -219,6 +221,7 @@ def test_components_docs_index(
             update_snippets=update_snippets,
             snippet_replace_regex=[
                 MASK_JAFFLE_PLATFORM,
+                MASK_PLUGIN_CACHE_REBUILD,
                 _MASK_EMPTY_WARNINGS,
             ],
         )
@@ -360,6 +363,7 @@ def test_components_docs_index(
                 update_snippets=update_snippets,
                 snippet_replace_regex=[
                     MASK_JAFFLE_PLATFORM,
+                    MASK_PLUGIN_CACHE_REBUILD,
                     _MASK_EMPTY_WARNINGS,
                 ],
             )
@@ -463,6 +467,7 @@ def test_components_docs_index(
                 update_snippets=update_snippets,
                 snippet_replace_regex=[
                     MASK_JAFFLE_PLATFORM,
+                    MASK_PLUGIN_CACHE_REBUILD,
                     _MASK_EMPTY_WARNINGS,
                 ],
             )

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from dagster._utils.env import environ
 from docs_snippets_tests.snippet_checks.guides.components.utils import (
     DAGSTER_ROOT,
+    MASK_PLUGIN_CACHE_REBUILD,
     isolated_snippet_generation_environment,
 )
 from docs_snippets_tests.snippet_checks.utils import (
@@ -30,13 +31,13 @@ COMPONENTS_SNIPPETS_DIR = (
 )
 
 
-def test_components_docs_index(
+def test_creating_a_component(
     update_snippets: bool, update_screenshots: bool, get_selenium_driver
 ) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         # Scaffold code location
         _run_command(
-            cmd="dg scaffold project my-component-library --python-environment uv_managed --use-editable-dagster && cd my-component-library",
+            cmd="dg init my-component-library --python-environment uv_managed --use-editable-dagster && cd my-component-library",
         )
 
         #########################################################
@@ -49,7 +50,10 @@ def test_components_docs_index(
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-dg-scaffold-shell-command.txt",
             update_snippets=update_snippets,
-            snippet_replace_regex=[MASK_MY_COMPONENT_LIBRARY],
+            snippet_replace_regex=[
+                MASK_MY_COMPONENT_LIBRARY,
+                MASK_PLUGIN_CACHE_REBUILD,
+            ],
         )
 
         # Validate scaffolded files
@@ -83,7 +87,10 @@ def test_components_docs_index(
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-dg-list-plugins.txt",
             update_snippets=update_snippets,
-            snippet_replace_regex=[MASK_MY_COMPONENT_LIBRARY],
+            snippet_replace_regex=[
+                MASK_MY_COMPONENT_LIBRARY,
+                MASK_PLUGIN_CACHE_REBUILD,
+            ],
         )
 
         # Disabled for now, since the new dg docs command does not support output to console
@@ -136,7 +143,10 @@ def test_components_docs_index(
             snippet_path=COMPONENTS_SNIPPETS_DIR
             / f"{get_next_snip_number()}-scaffold-instance-of-component.txt",
             update_snippets=update_snippets,
-            snippet_replace_regex=[MASK_MY_COMPONENT_LIBRARY],
+            snippet_replace_regex=[
+                MASK_MY_COMPONENT_LIBRARY,
+                MASK_PLUGIN_CACHE_REBUILD,
+            ],
         )
 
         check_file(

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
@@ -23,6 +23,7 @@ MASK_TMP_WORKSPACE = (
     r"--workspace (/var/folders/.+|/tmp/tmp\w+)",
     "--workspace /tmp/workspace",
 )
+MASK_PLUGIN_CACHE_REBUILD = (r"Plugin object cache is invalidated or empty.*\n", "")
 # Kind of a hack, "Running `uv sync` ..." appears after you enter "y" at the prompt, but when we
 # simulate the input we don't get the "y" or newline we get in terminal so we slide it in here.
 FIX_UV_SYNC_PROMPT = (r"Running `uv sync`\.\.\.", "y\nRunning `uv sync`...")

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
@@ -4,6 +4,7 @@ from dagster._utils.env import environ
 from docs_snippets_tests.snippet_checks.guides.components.utils import (
     DAGSTER_ROOT,
     EDITABLE_DIR,
+    MASK_PLUGIN_CACHE_REBUILD,
     format_multiline,
     isolated_snippet_generation_environment,
 )
@@ -30,22 +31,20 @@ SNIPPETS_DIR = (
 )
 
 
-def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
+def test_dagster_definitions(update_snippets: bool) -> None:
     with isolated_snippet_generation_environment() as get_next_snip_number:
         _run_command(
-            cmd="dg scaffold project my-project --python-environment uv_managed --use-editable-dagster && cd my-project",
-        )
-        _run_command(cmd="uv venv")
-        _run_command(cmd="uv sync")
-        _run_command(
-            f"uv add --editable '{DAGSTER_ROOT / 'python_modules' / 'dagster'!s}' '{DAGSTER_ROOT / 'python_modules' / 'dagster-webserver'!s}'"
+            cmd="dg init my-project --python-environment uv_managed --use-editable-dagster && cd my-project",
         )
 
         run_command_and_snippet_output(
             cmd="dg scaffold dagster.asset assets/my_asset.py",
             snippet_path=SNIPPETS_DIR / f"{get_next_snip_number()}-scaffold.txt",
             update_snippets=update_snippets,
-            snippet_replace_regex=[MASK_MY_PROJECT],
+            snippet_replace_regex=[
+                MASK_MY_PROJECT,
+                MASK_PLUGIN_CACHE_REBUILD,
+            ],
         )
 
         _run_command(r"find . -type d -name __pycache__ -exec rm -r {} \+")

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
@@ -72,7 +72,7 @@ def test_migrating_project(
         )
         if package_manager == "uv":
             run_command_and_snippet_output(
-                cmd=get_editable_install_cmd_for_project(Path("."), package_manager),
+                cmd=f"uv venv && {get_editable_install_cmd_for_project(Path('.'), package_manager)}",
                 snippet_path=get_venv_snip_path(),
                 update_snippets=update_snippets,
                 print_cmd="uv sync",

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -86,6 +86,8 @@ def all_components_schema_from_dg_context(dg_context: "DgContext") -> Mapping[st
     if dg_context.has_cache:
         cache_key = dg_context.get_cache_key("all_components_schema")
         schema_raw = dg_context.cache.get(cache_key)
+        if schema_raw is None:
+            print("Component schema cache is invalidated or empty. Building cache...")  # noqa: T201
 
     if not schema_raw:
         schema_raw = dg_context.external_components_command(["list", "all-components-schema"])
@@ -103,6 +105,8 @@ def _load_entry_point_components(
     if dg_context.has_cache:
         cache_key = dg_context.get_cache_key("plugin_registry_data")
         raw_registry_data = dg_context.cache.get(cache_key)
+        if raw_registry_data is None:
+            print("Plugin object cache is invalidated or empty. Building cache...")  # noqa: T201
     else:
         cache_key = None
         raw_registry_data = None
@@ -127,6 +131,10 @@ def _load_module_library_objects(
             if raw_data:
                 data.update(_parse_raw_registry_data(raw_data))
                 modules_to_fetch.remove(module)
+        if modules_to_fetch:
+            print(  # noqa: T201
+                f"Plugin object cache is invalidated or empty for modules: [{modules_to_fetch}]. Building cache..."
+            )
 
     if modules_to_fetch:
         raw_local_object_data = dg_context.external_components_command(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -184,8 +184,8 @@ def test_dynamic_subcommand_help_message():
                 "scaffold", "dagster_test.components.SimplePipesScriptComponent", "--help"
             )
             assert_runner_result(result)
-            # Strip interpreter logging line
-            output = "\n".join(result.output.split("\n")[1:])
+            # Strip logging lines
+            output = "\n".join(result.output.split("\n")[2:])
         assert match_terminal_box_output(
             output.strip(),
             textwrap.dedent("""


### PR DESCRIPTION
## Summary & Motivation

This adds a message whenever the cache is being rebuilt. It is more user-friendly than our existing cache log messages, which only show up in `--verbose` mode anyway.

## How I Tested These Changes

Modified unit tests.