### PR TITLE
[dg] Add warning if using pip or not using uv sync

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/init.py
@@ -212,6 +212,7 @@ def _should_run_uv_sync(
     elif uv_sync_flag is True:
         return True
     elif venv_path.exists():
+        _print_package_install_warning_message()
         return False
     elif is_uv_installed():  # uv_sync_flag is unset (None)
         response = click.prompt(
@@ -223,6 +224,23 @@ def _should_run_uv_sync(
         ).lower()
         if response not in ("y", "n"):
             exit_with_error(f"Invalid response '{response}'. Please enter 'y' or 'n'.")
+        if response == "n":
+            _print_package_install_warning_message()
         return response == "y"
     else:
         return False
+
+
+def _print_package_install_warning_message() -> None:
+    pip_install_cmd = "pip install --editable ."
+    uv_install_cmd = "uv sync"
+    click.secho(
+        format_multiline_str(
+            f"""
+            The environment used for your project must include an installation of your project
+            package. Please run `{uv_install_cmd}` (for uv) or `{pip_install_cmd}` (for pip) before
+            running `dg` commands against your project.
+        """,
+        ),
+        fg="yellow",
+    )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_init_command.py
@@ -96,6 +96,9 @@ def test_init_success_project(
             assert not Path("helloworld/.venv").exists()
             assert not Path("helloworld/uv.lock").exists()
 
+        if use_preexisting_venv in cli_args:
+            assert "environment used for your project must include" in result.output
+
 
 @pytest.mark.parametrize(
     "cli_args,input_str,opts",


### PR DESCRIPTION
## Summary & Motivation

Added a warning message when users choose not to run `uv sync` (or when there is a pre-existing venv) during project initialization. This message informs users that they need to manually install their project package using either `uv sync` or `pip install --editable .` before running `dg` commands against their project.

## How I Tested These Changes

Updated the existing test case to verify that the warning message appears when the `--use-preexisting-venv` flag is used.

## Changelog

Added a warning message to inform users they need to install their project package when skipping automatic environment setup.