### PR TITLE
[dg] Update install_editable_uv_tools with dagster-cloud-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ install_editable_uv_tools:
 	# Install dg cli editably
 	uv tool install -e python_modules/libraries/dagster-dg \
 	  --with-editable python_modules/libraries/dagster-shared \
+	  --with-editable python_modules/libraries/dagster-cloud-cli \
 	  --reinstall
 
 	# Install dagster cli editably as a tool with dagster-webserver


### PR DESCRIPTION
## Summary & Motivation

We added dagster-cloud-cli as a dependency but did not update this makefile command

## How I Tested These Changes

Scaffolded new project. Was able to run `dg`

## Changelog

NOCHANGELOG

