### PR TITLE
Only show last N lines in pipes pod failure logs

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -526,7 +526,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
                     pod_name=pod_name,
                     enable_multi_container_logs=enable_multi_container_logs,
                 ):
-                    # We need to wait for the pod to start up so that the log streaming is successful afterwards.
+                    # wait until the pod is fully terminated (or raise an exception if it failed)
                     client.wait_for_pod(
                         pod_name,
                         namespace,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -677,8 +677,8 @@ def test_wait_for_ready_but_terminated_unsuccessfully():
 
     assert (
         str(exc_info.value)
-        == f'Pod {pod_name} terminated but some containers exited with errors:\nContainer "{container_name}" failed with message: "error_message" '
-        'and pod logs: "raw_logs_ret_val"'
+        == f'Pod {pod_name} terminated but some containers exited with errors:\nContainer "{container_name}" failed with message: "error_message".'
+        ' Last 100 log lines: "raw_logs_ret_val"'
     )
 
 


### PR DESCRIPTION
## Summary:
Right now if there's a failure after a long pod run it writes out the full output. Return the last N lines instead.

Also remove a confusing comment that I suspect was copy-pasted incorrectly from elsewhere.

## How I Tested These Changes
Existing pipes integration tests include an error case (verify, inspect output)

## Changelog
[dagster-k8s] K8sPipeClient failures will now include the last 100 lines of the logs of the pod that failed, instead of the full log output.