### PR TITLE
[dg] Fix workspace guide

### DIFF
--- a/docs/docs/guides/labs/dg/multiple-projects.md
+++ b/docs/docs/guides/labs/dg/multiple-projects.md
@@ -25,9 +25,15 @@ A workspace does not define a Python environment by default. Instead, Python env
 
 ## Scaffold a new workspace and first project
 
-To scaffold a new workspace with an initial project called `project-1`, run `dg init` with the `--workspace` option. You will be prompted for the name of the project:
+To scaffold a new workspace with an initial project called `project-1`, run `dg init` with the `--workspace` option and `--python-environment uv_managed` option. You will be prompted for the name of the project:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/1-dg-init.txt" />
+
+:::note
+
+Currently `dg` workspaces only support projects using `uv` with `project.python_environment.uv_managed = true`. This means that the Python environment for the workspace is managed by `uv`, and subprocesses are launched by `uv run`, ignoring the activated virtual environment. If all projects in a workspace do not conform to this, you will likely encounter errors.
+
+:::
 
 This will create a new directory called `dagster-workspace` with a `projects` subdirectory that contains `project-1`. It will also set up a new `uv`-managed Python environment for this project.
 
@@ -37,7 +43,7 @@ The new workspace has the following structure:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/2-tree.txt" />
 
-The `pyproject.toml` file for the `workspace` folder contains a `directory_type = "workspace"` setting that marks this directory as a workspace:
+The `dg.toml` file for the `dagster-workspace` folder contains a `directory_type = "workspace"` setting that marks this directory as a workspace:
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/dg/workspace/3-dg.toml"

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-init.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-init.txt
@@ -1,4 +1,4 @@
-dg init --workspace dagster-workspace
+dg init --workspace dagster-workspace --python-environment uv_managed
 
 Scaffolded files for Dagster workspace at /.../dagster-workspace.
 Enter the name of your Dagster project: project-1

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dg_docs_workspace.py
@@ -46,7 +46,7 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
                     "of your Dagster project: project-1\n",
                 ),
             ],
-            print_cmd="dg init --workspace dagster-workspace",
+            print_cmd="dg init --workspace dagster-workspace --python-environment uv_managed",
         )
 
         # Remove files we don't want to show up in the tree
@@ -96,6 +96,7 @@ def test_dg_docs_workspace(update_snippets: bool) -> None:
                 MASK_MY_WORKSPACE,
                 (r"\nUsing[\s\S]*", "\n..."),
             ],
+            print_cmd="dg scaffold project projects/project-2 --python-environment uv_managed",
         )
 
         # List projects


### PR DESCRIPTION
## Summary & Motivation

Fix `dg` workspace guide to specify that only `uv_managed` projects are currently supported.

## How I Tested These Changes

Existing test suite.