### PR TITLE
[docs] fix scroll into view for anchored tags

### DIFF
--- a/docs/src/plugins/sidebar-scroll-into-view/index.js
+++ b/docs/src/plugins/sidebar-scroll-into-view/index.js
@@ -14,15 +14,17 @@
 const INNER_HTML = `
   function handleScrollIntoView() {
     const observer = new MutationObserver(() => {
-    const element = document.querySelector('aside .menu__link--active');
-      if (element) {
+    const sidebarElement = document.querySelector('aside .menu__link--active');
+      if (sidebarElement) {
         observer.disconnect();
-        element.scrollIntoView(); // scroll sidebar
-        document.querySelector('body').scrollIntoView(); // scroll main body back to top
+        sidebarElement.scrollIntoView({
+          block: 'center',
+          inline: 'nearest',
+          scrollMode: 'if-needed',
+          behavior: 'smooth'
+        });
       }
     });
-
-
     observer.observe(document.body, { childList: true, subtree: true });
   }
 


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-1069.

Do not scroll `body` into view, but only the side bar element. This is to ensure anchor tags are appropriately loaded.

## How I Tested These Changes

Locally navigating to anchored pages.

## Changelog

NOCHANGELOG
