### PR TITLE
[dg] Don't show empty table when no definitions for list defs (BUILD-1016)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -296,6 +296,7 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
 
         if len(definitions) == 0:
             click.echo("No definitions are defined for this project.")
+            return
 
         console = Console()
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -334,6 +334,11 @@ def test_list_defs_complex_assets_succeeds():
         result = runner.invoke("scaffold", "dagster.components.DefsFolderComponent", "mydefs")
         assert_runner_result(result)
 
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
+        assert "No definitions are defined" in result.output
+        assert "Definitions" not in result.output  # no table header means no table
+
         with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:
             defs_source = textwrap.dedent(
                 inspect.getsource(_sample_complex_asset_defs).split("\n", 1)[1]


### PR DESCRIPTION
## Summary & Motivation

Currently you get a kind of odd empty table if there are no defs:

```
No definitions are defined for this project.
┏━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Section ┃ Definitions ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━┩
└─────────┴─────────────┘
```

This PR drops the table:

```
No definitions are defined for this project.
```

## How I Tested These Changes

Changed existing test