### PR TITLE
Fix asset selection by code location

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -1012,13 +1012,15 @@ class CodeLocationAssetSelection(AssetSelection):
             "code_location: cannot be used to select assets in user code.",
         )
 
+        asset_graph = cast("RemoteAssetGraph", asset_graph)
+
         # If the code location is in the form of "repo_name@location_name", we need to
         # split the string and filter the asset keys based on the repository and location name.
         if "@" in self.selected_code_location:
             asset_keys = set()
             location = self.selected_code_location.split("@")[1]
             name = self.selected_code_location.split("@")[0]
-            for asset_key in cast("RemoteAssetGraph", asset_graph).remote_asset_nodes_by_key:
+            for asset_key in asset_graph.remote_asset_nodes_by_key:
                 repo_handle = (
                     asset_graph.get(asset_key)
                     .resolve_to_singular_repo_scoped_node()
@@ -1031,7 +1033,7 @@ class CodeLocationAssetSelection(AssetSelection):
         # Otherwise, filter only by location name
         return {
             key
-            for key in cast("RemoteAssetGraph", asset_graph).remote_asset_nodes_by_key
+            for key in asset_graph.remote_asset_nodes_by_key
             if (
                 asset_graph.get(key)
                 .resolve_to_singular_repo_scoped_node()

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -1012,6 +1012,23 @@ class CodeLocationAssetSelection(AssetSelection):
             "code_location: cannot be used to select assets in user code.",
         )
 
+        # If the code location is in the form of "repo_name@location_name", we need to
+        # split the string and filter the asset keys based on the repository and location name.
+        if "@" in self.selected_code_location:
+            asset_keys = set()
+            location = self.selected_code_location.split("@")[1]
+            name = self.selected_code_location.split("@")[0]
+            for asset_key in cast("RemoteAssetGraph", asset_graph).remote_asset_nodes_by_key:
+                repo_handle = (
+                    asset_graph.get(asset_key)
+                    .resolve_to_singular_repo_scoped_node()
+                    .repository_handle
+                )
+                if repo_handle.location_name == location and repo_handle.repository_name == name:
+                    asset_keys.add(asset_key)
+            return asset_keys
+
+        # Otherwise, filter only by location name
         return {
             key
             for key in cast("RemoteAssetGraph", asset_graph).remote_asset_nodes_by_key

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -963,6 +963,12 @@ def test_code_location() -> None:
         == set()
     )
 
+    selection = CodeLocationAssetSelection(selected_code_location="bar_repo@code_location1")
+    assert selection.resolve_inner(
+        remote_repo.asset_graph,
+        allow_missing=False,
+    ) == {AssetKey("my_asset")}
+
 
 def test_column() -> None:
     @asset


### PR DESCRIPTION
Selection syntax in the UI passes strings of format `repo@code_location`. Let's make the python implementation handle that. This fixes asset selection issues in the new insights view.

## How I Tested These Changes
BK

## Changelog
NOCHANGELOG
