### PR TITLE
[dg] Rename --rebuild-component-registry to --rebuild-plugin-cache (BUILD-1023)

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
@@ -5,16 +5,16 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
  CLI for managing Dagster projects.                                                                                     
                                                                                                                         
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --path                                PATH  Specify a directory to use to load the context for this command. This    │
-│                                             will typically be a folder with a dg.toml or pyproject.toml file in it.  │
-│ --clear-cache                               Clear the cache.                                                         │
-│ --rebuild-component-registry                Recompute and cache the set of available component types for the current │
-│                                             environment. Note that this also happens automatically whenever the      │
-│                                             cache is detected to be stale.                                           │
-│ --install-completion                        Automatically detect your shell and install a completion script for the  │
-│                                             `dg` command. This will append to your shell startup file.               │
-│ --version                     -v            Show the version and exit.                                               │
-│ --help                        -h            Show this message and exit.                                              │
+│ --path                          PATH  Specify a directory to use to load the context for this command. This will     │
+│                                       typically be a folder with a dg.toml or pyproject.toml file in it.             │
+│ --clear-cache                         Clear the cache.                                                               │
+│ --rebuild-plugin-cache                Refetch and cache the set of available dg plugins and associated plugin        │
+│                                       objects for the current environment. Note that this also happens automatically │
+│                                       whenever the plugin cache is detected to be stale.                             │
+│ --install-completion                  Automatically detect your shell and install a completion script for the `dg`   │
+│                                       command. This will append to your shell startup file.                          │
+│ --version               -v            Show the version and exit.                                                     │
+│ --help                  -h            Show this message and exit.                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --verbose                    Enable verbose output for debugging.                                                    │

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -9,7 +9,7 @@ from dagster_dg.utils import is_macos, is_windows
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
-CachableDataType: TypeAlias = Literal["component_registry_data", "all_components_schema"]
+CachableDataType: TypeAlias = Literal["plugin_registry_data", "all_components_schema"]
 
 
 def get_default_cache_dir() -> Path:

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -55,11 +55,11 @@ def create_dg_cli():
         default=False,
     )
     @click.option(
-        "--rebuild-component-registry",
+        "--rebuild-plugin-cache",
         is_flag=True,
         help=(
-            "Recompute and cache the set of available component types for the current environment."
-            " Note that this also happens automatically whenever the cache is detected to be stale."
+            "Refetch and cache the set of available dg plugins and associated plugin objects for the current environment."
+            " Note that this also happens automatically whenever the plugin cache is detected to be stale."
         ),
         default=False,
     )
@@ -73,7 +73,7 @@ def create_dg_cli():
     def group(
         install_completion: bool,
         clear_cache: bool,
-        rebuild_component_registry: bool,
+        rebuild_plugin_cache: bool,
         path: Path,
         **global_options: object,
     ):
@@ -86,8 +86,8 @@ def create_dg_cli():
 
             dagster_dg.completion.install_completion(context)
             context.exit(0)
-        elif clear_cache and rebuild_component_registry:
-            exit_with_error("Cannot specify both --clear-cache and --rebuild-component-registry.")
+        elif clear_cache and rebuild_plugin_cache:
+            exit_with_error("Cannot specify both --clear-cache and --rebuild-plugin-cache.")
         elif clear_cache:
             cli_config = normalize_cli_config(global_options, context)
             dg_context = DgContext.from_file_discovery_and_command_line_config(path, cli_config)
@@ -98,12 +98,12 @@ def create_dg_cli():
             cache.clear_all()
             if context.invoked_subcommand is None:
                 context.exit(0)
-        elif rebuild_component_registry:
+        elif rebuild_plugin_cache:
             cli_config = normalize_cli_config(global_options, context)
             dg_context = DgContext.for_defined_registry_environment(path, cli_config)
             if context.invoked_subcommand is not None:
-                exit_with_error("Cannot specify --rebuild-component-registry with a subcommand.")
-            _rebuild_component_registry(dg_context)
+                exit_with_error("Cannot specify --rebuild-plugin-cache with a subcommand.")
+            _rebuild_plugin_cache(dg_context)
         elif context.invoked_subcommand is None:
             click.echo(context.get_help())
             context.exit(0)
@@ -111,17 +111,13 @@ def create_dg_cli():
     return group
 
 
-def _rebuild_component_registry(dg_context: DgContext):
+def _rebuild_plugin_cache(dg_context: DgContext):
     if not dg_context.has_cache:
         exit_with_error("Cache is disabled. This command cannot be run without a cache.")
-    elif not dg_context.use_dg_managed_environment:
-        exit_with_error(
-            "Cannot rebuild the component registry with environment management disabled."
-        )
     dg_context.ensure_uv_lock()
-    key = dg_context.get_cache_key("component_registry_data")
+    key = dg_context.get_cache_key("plugin_registry_data")
     dg_context.cache.clear_key(key)
-    # This will trigger a rebuild of the component registry
+    # This will trigger a rebuild of the plugin cache
     RemotePluginRegistry.from_dg_context(dg_context)
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -101,7 +101,7 @@ def _load_entry_point_components(
     dg_context: "DgContext",
 ) -> dict[PluginObjectKey, PluginObjectSnap]:
     if dg_context.has_cache:
-        cache_key = dg_context.get_cache_key("component_registry_data")
+        cache_key = dg_context.get_cache_key("plugin_registry_data")
         raw_registry_data = dg_context.cache.get(cache_key)
     else:
         cache_key = None

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -53,7 +53,7 @@ COMPONENT_LIBRARY_CONTEXT_COMMANDS = [
 ]
 
 REGISTRY_CONTEXT_COMMANDS = [
-    CommandSpec(tuple(), "--rebuild-component-registry"),
+    CommandSpec(tuple(), "--rebuild-plugin-cache"),
     CommandSpec(("docs", "serve")),
     CommandSpec(("list", "plugins")),
     CommandSpec(("utils", "inspect-component-type"), DEFAULT_COMPONENT_TYPE),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -90,13 +90,13 @@ def test_clear_cache(clear_outside_project: bool):
         assert "CACHE [miss]" in result.output
 
 
-def test_rebuild_component_registry_success():
+def test_rebuild_plugin_cache_success():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("--rebuild-component-registry")
+        result = runner.invoke("--rebuild-plugin-cache")
         assert_runner_result(result)
 
         # Run it again and ensure it clears the previous entry
-        result = runner.invoke("--rebuild-component-registry")
+        result = runner.invoke("--rebuild-plugin-cache")
         assert_runner_result(result)
         assert "CACHE [clear-key]" in result.output
 
@@ -105,26 +105,26 @@ def test_rebuild_component_registry_success():
         assert "CACHE [hit]" in result.output
 
 
-def test_rebuild_component_registry_fails_with_subcommand():
+def test_rebuild_plugin_cache_fails_with_subcommand():
     with (
         ProxyRunner.test(**cache_runner_args) as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("--rebuild-component-registry", "list", "plugins")
+        result = runner.invoke("--rebuild-plugin-cache", "list", "plugins")
         assert_runner_result(result, exit_0=False)
-        assert "Cannot specify --rebuild-component-registry with a subcommand." in result.output
+        assert "Cannot specify --rebuild-plugin-cache with a subcommand." in result.output
 
 
-def test_rebuild_component_registry_fails_with_clear_cache():
+def test_rebuild_plugin_cache_fails_with_clear_cache():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("--rebuild-component-registry", "--clear-cache")
+        result = runner.invoke("--rebuild-plugin-cache", "--clear-cache")
         assert_runner_result(result, exit_0=False)
-        assert "Cannot specify both --clear-cache and --rebuild-component-registry" in result.output
+        assert "Cannot specify both --clear-cache and --rebuild-plugin-cache" in result.output
 
 
-def test_rebuild_component_registry_fails_with_disabled_cache():
+def test_rebuild_plugin_cache_fails_with_disabled_cache():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
-        result = runner.invoke("--rebuild-component-registry", "--disable-cache")
+        result = runner.invoke("--rebuild-plugin-cache", "--disable-cache")
         assert_runner_result(result, exit_0=False)
         assert "Cache is disabled" in result.output
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -53,7 +53,7 @@ def crawl_cli_commands() -> dict[tuple[str, ...], click.Command]:
     """Note that this does not pick up:
     - all `scaffold` subcommands, because these are dynamically generated and vary across
       environment.
-    - special --ACTION options with callbacks (e.g. `--rebuild-component-registry`).
+    - special --ACTION options with callbacks (e.g. `--rebuild-plugin-cache`).
     """
     commands: dict[tuple[str, ...], click.Command] = {}
 


### PR DESCRIPTION
## Summary & Motivation

"Component registry" is an old name. This is a one-off "action option" (`dg --rebuild-component-registry`)-- it is highly unlikely anyone was programming against this API, so I did not implement backcompat for this.

## How I Tested These Changes

Modified unit tests.

## Changelog

`dg --rebuild-component-registry` has been renamed to `dg --rebuild-plugin-cache`.