### PR TITLE
perf: Avoid run storage ID query when telemetry disabled

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -221,12 +221,13 @@ def _get_instance_telemetry_info(
     check.inst_param(instance, "instance", DagsterInstance)
     dagster_telemetry_enabled = _get_instance_telemetry_enabled(instance)
     instance_id = None
+    instance_id = None
+    run_storage_id = None
     if dagster_telemetry_enabled:
         instance_id = get_or_set_instance_id()
+        if isinstance(instance.run_storage, SqlRunStorage):
+            run_storage_id = instance.run_storage.get_run_storage_id()
 
-    run_storage_id = None
-    if isinstance(instance.run_storage, SqlRunStorage):
-        run_storage_id = instance.run_storage.get_run_storage_id()
     return TelemetrySettings(
         dagster_telemetry_enabled=dagster_telemetry_enabled,
         instance_id=instance_id,


### PR DESCRIPTION
## Summary & Motivation

The `_get_instance_telemetry_info` function previously fetched the `run_storage_id` from the instance's run storage regardless of whether telemetry was enabled or disabled in the `dagster.yaml` configuration.

For instances using `SqlRunStorage`, fetching this ID involves a database query. This query is unnecessary work if the telemetry data (which includes this ID) is not going to be logged or sent anywhere.

As pointed out in issue #11891, performing this query even when telemetry is disabled is inefficient and potentially exposes users with telemetry disabled to errors originating from this query (like the SQLAlchemy incompatibility that originally caused that issue, although that specific crash is now fixed).

This change moves the call to `instance.run_storage.get_run_storage_id()` inside the `if dagster_telemetry_enabled:` block, ensuring the database is only queried for this ID when telemetry is actually active. This provides a minor performance improvement during instance loading and command execution for users with telemetry disabled.

## How I Tested These Changes

Wrote and run tests with tox.