### PR TITLE
[dg] Temporary fix to make list defs more robust

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -287,12 +287,16 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
     # the user prints out a list of json parseable strings on single lines,
     # this will fail.
     def _get_defs() -> list[Any]:
+        last_decode_error = None
         for line in result.splitlines():
             try:
                 defs_list = check.is_list(deserialize_value(line))
                 return defs_list
-            except Exception:
-                pass
+            except json.decoder.JSONDecodeError as e:
+                last_decode_error = e
+
+        if last_decode_error:
+            raise last_decode_error
 
         raise Exception(
             "Did not successfully parse definitions list. Full stdout of subprocess:\n" + result

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -286,6 +286,8 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
     # called tools print out strings to stdout. This is still not robust. If
     # the user prints out a list of json parseable strings on single lines,
     # this will fail.
+    #
+    # See https://linear.app/dagster-labs/issue/BUILD-1027/
     def _get_defs() -> list[Any]:
         last_decode_error = None
         for line in result.splitlines():


### PR DESCRIPTION
## Summary & Motivation

`dg list defs` fails the user (or a tool that the load defs pathway invokes) emits anything to stdout while loading defintiions. See [issue](https://linear.app/dagster-labs/issue/BUILD-1027/dg-list-defs-not-resilient-to-anyone-printing-to-stdour-during-project)

## How I Tested These Changes

Manual on project that prints out string when it loads + BK

## Changelog

NOCHANGELOG