### PR TITLE
[dg] Add `dg list dags` for a CLI-output of the project dag

### DIFF
--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -45,6 +45,7 @@ setup(
         "mcp",
         "yaspin",
         "python-dotenv",
+        "networkx",
         # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
         # frequently updated since is designed to be used from an isolated environment.
         "typer==0.15.1",


### PR DESCRIPTION
## Summary & Motivation

For a demo I'm creating, I thought it'd be neat to be able to see the DAG via the CLI. Here's a basic implementation using networkx. 

```
❯ dg list dag

Asset Dependency Graph
╟── checklist_2020
╎   └─╼ birds ╾ checklist_2023
╎       └─╼ all_birds ╾ sites, species
╎           └─╼  ...
╟── checklist_2023
╎   └─╼  ...
╟── public/events
╎   └─╼ target/public/events
╎       ├─╼ events ╾ target/public/tickets
╎       └─╼ tickets ╾ target/public/tickets
╎           └─╼  ...
╟── public/tickets
╎   └─╼ target/public/tickets
╎       └─╼  ...
╟── site_description_data
╎   └─╼ sites
╎       └─╼  ...
╙── species_translation_data
    └─╼ species
        └─╼  ...
```

And from the UI:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/80phFRWNTJBzbgP9Xj13/d1d4f650-7b8e-4754-a346-686b851b5f05.png)

I don't know if this is worth pursuing, but if it is, can happily add some tests. 

## How I Tested These Changes

## Changelog

[dg] add list dag command