### PR TITLE
[dg] [docs] Switch order of incremental adoption project and definitions guides

### DIFF
--- a/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
+++ b/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
@@ -1,6 +1,6 @@
 ---
 title: 'Converting an existing project to use dg'
-sidebar_position: 200
+sidebar_position: 100
 ---
 
 import DgComponentsPreview from '@site/docs/partials/\_DgComponentsPreview.md';


### PR DESCRIPTION
## Summary & Motivation

Converting an existing project should definitely come before converting definitions in an already converted project.

@PedramNavid was confused by the current ordering:

>I see the guide for converting my definitions but it doesn’t cover that I need to change my pyproject.toml too. So then I have to go to Converting an existing project to use dg | Dagster Docs which feels like it should come before trying to convert my definitions.

## How I Tested These Changes

Exiting test suite.