### PR TITLE
Add memoization to fetch_fivetran_workspace_data

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -914,6 +914,7 @@ class FivetranWorkspace(ConfigurableResource):
             disable_schedule_on_trigger=self.disable_schedule_on_trigger,
         )
 
+    @cached_method
     def fetch_fivetran_workspace_data(
         self,
     ) -> FivetranWorkspaceData:


### PR DESCRIPTION
Summary:
If you have N different build_fivetran_assets_definitions calls, we call this N times on the workspace, even though the underlying data hasn't changed.  Since the underlying data does not change, only call it once.

[dagster-fivetran] Performance improvements for code locations with multiple calls to build_fivetran_assets_definitions.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
