### PR TITLE
Remove asset check run observations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -1,3 +1,4 @@
+import uniq from 'lodash/uniq';
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import {AssetBaseData, __resetForJest as __resetBaseData} from './AssetBaseDataProvider';
@@ -140,17 +141,9 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
 
     const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));
 
-    const runInProgressId: string[] = [];
-    // const runInProgressId = uniq(
-    //   dataForObservedKeys.flatMap((p) => [
-    //     ...p.unstartedRunIds,
-    //     ...p.inProgressRunIds,
-    //     ...p.assetChecks
-    //       .map((c) => c.executionForLatestMaterialization)
-    //       .filter(Boolean)
-    //       .map((e) => e!.runId),
-    //   ]),
-    // ).sort();
+    const runInProgressId = uniq(
+      dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
+    ).sort();
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
       if (


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/pull/16290 added logic to observe the latest run for asset checks but causes an issue where we observe  runs regardless of whether they're inprogress. To do that we open a websocket connection for every unique run id of every asset check of every visible asset. I believe the intention was to only observe runs that are in progress but currently we have no way of knowing that for asset checks and end up observing the latest run regardless of its state.

## Test plan

There are no existing jest tests for this... I can look into that if we want to re-enable this behavior.