### PR TITLE
[dg] Add setup.cfg support for reading entry points (BUILD-1034)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -179,6 +179,27 @@ def test_warning_suppression():
             DgContext.for_project_environment(Path("projects/foo-bar"), {})
 
 
+def test_setup_cfg_entry_point():
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        # Delete the entry point section from pyproject.toml
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+            delete_toml_node(toml, ("project", "entry-points", "dagster_dg.plugin"))
+        # Create a setup.cfg file with the entry point
+        with open("setup.cfg", "w") as f:
+            f.write(
+                """
+                [options.entry_points]
+                dagster_dg.plugin =
+                    foo_bar = foo_bar.lib
+                """
+            )
+        context = DgContext.for_project_environment(Path.cwd(), {})
+        assert context.is_plugin
+
+
 def test_deprecated_entry_point_group_warning():
     with (
         ProxyRunner.test() as runner,

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -45,6 +45,7 @@ setup(
         # Unfortunately mcp package is not available for python 3.9
         "mcp; python_version >= '3.10'",
         "yaspin",
+        "setuptools",  # Needed to parse setup.cfg
         "python-dotenv",
         # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
         # frequently updated since is designed to be used from an isolated environment.


### PR DESCRIPTION
## Summary & Motivation

This enables reading entry points in `dagster-dg` from `setup.cfg` (as opposed to `pyproject.toml`). This is necessary for projects that use `setup.py` rather than `pyproject.toml`. We read from `setup.cfg` instead of `setup.py` because there is no reliable way to read `setup.py` (since it's arbitrary Python code).

## How I Tested These Changes

New unit test.