### PR TITLE
Fix whitespace in github action scaffold

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -540,7 +540,7 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
         build_fragment = _get_build_fragment_for_locations(
             project_contexts, git_root, registry_urls
         )
-        template = template.replace("# TEMPLATE_BUILD_LOCATION_FRAGMENT", build_fragment)
+        template = template.replace("      # TEMPLATE_BUILD_LOCATION_FRAGMENT", build_fragment)
 
         registry_fragment, additional_secrets_hints = _get_registry_fragment(registry_urls)
         template = template.replace(


### PR DESCRIPTION
Summary:
Maybe there's a smarter way to do this - prevents extra whitespace from being added on the left of this sentinel value

dg scaffold github-actions, view whitespace

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
