### PR TITLE
[dg] Make dg list defs use a tempfile channel (BUILD-1027)

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Literal, Optional, Union
 
 import click
@@ -85,9 +86,13 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
 @click.option(
     "--location", "-l", help="Name of the code location, can be used to scope environment variables"
 )
+@click.option(
+    "--output-file",
+    help="Write to file instead of stdout. If not specified, will write to stdout.",
+)
 @click.pass_context
 def list_definitions_command(
-    ctx: click.Context, location: Optional[str], **other_opts: object
+    ctx: click.Context, location: Optional[str], output_file: Optional[str], **other_opts: object
 ) -> None:
     """List Dagster definitions."""
     python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
@@ -150,7 +155,12 @@ def list_definitions_command(
         for sensor in repo_def.sensor_defs:
             all_defs.append(DgSensorMetadata(name=sensor.name))
 
-        click.echo(serialize_value(all_defs))
+        output = serialize_value(all_defs)
+        if output_file:
+            click.echo("[dagster-components] Writing to file " + output_file)
+            Path(output_file).write_text(output)
+        else:
+            click.echo(output)
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from typing import Any, Optional
 
 import click
+from dagster_shared.ipc import ipc_tempfile
 from dagster_shared.record import as_dict
 from dagster_shared.serdes import deserialize_value
+from dagster_shared.serdes.errors import DeserializationError
 from dagster_shared.serdes.objects import PluginObjectSnap
 from dagster_shared.serdes.objects.definition_metadata import (
     DgAssetCheckMetadata,
@@ -15,6 +17,7 @@ from dagster_shared.serdes.objects.definition_metadata import (
     DgScheduleMetadata,
     DgSensorMetadata,
 )
+from packaging.version import Version
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
@@ -251,6 +254,30 @@ def _get_sensors_table(sensors: Sequence[DgSensorMetadata]) -> Table:
     return table
 
 
+# On older versions of `dagster`, `dagster-components list defs` output was written directly to
+# stdout, where it was possibly polluted by other output from user code. This scans raw stdout for
+# the line containing the output.
+def _extract_list_defs_output_from_raw_output(raw_output: str) -> list[Any]:
+    last_decode_error = None
+    for line in raw_output.splitlines():
+        try:
+            defs_list = deserialize_value(line, as_type=list[DgDefinitionMetadata])
+            return defs_list
+        except (json.JSONDecodeError, DeserializationError) as e:
+            last_decode_error = e
+
+    if last_decode_error:
+        raise last_decode_error
+
+    raise Exception(
+        "Did not successfully parse definitions list. Full stdout of subprocess:\n" + raw_output
+    )
+
+
+MIN_DAGSTER_COMPONENTS_LIST_DEFINITIONS_LOCATION_OPTION_VERSION = Version("1.10.8")
+MIN_DAGSTER_COMPONENTS_LIST_DEFINITIONS_OUTPUT_FILE_OPTION_VERSION = Version("1.10.12")
+
+
 @list_group.command(name="defs", aliases=["def"], cls=DgClickCommand)
 @click.option(
     "--json",
@@ -267,44 +294,47 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(path, cli_config)
 
-    result = dg_context.external_components_command(
-        [
-            "list",
-            "definitions",
-            "-m",
-            dg_context.code_location_target_module_name,
-        ],
-        # Sets the "--location" option for "dagster-components definitions list"
-        # using the click auto-envvar prefix for backwards compatibility on older versions
-        # before that option was added
-        additional_env={"DG_CLI_LIST_DEFINITIONS_LOCATION": dg_context.code_location_name},
-    )
+    # On newer versions, we use a dedicated channel in the form of a tempfile that will _only_ have
+    # the expected output written to it.
+    if (
+        dg_context.dagster_version
+        >= MIN_DAGSTER_COMPONENTS_LIST_DEFINITIONS_OUTPUT_FILE_OPTION_VERSION
+    ):
+        with ipc_tempfile() as temp_file:
+            dg_context.external_components_command(
+                [
+                    "list",
+                    "definitions",
+                    "--location",
+                    dg_context.code_location_name,
+                    "--module-name",
+                    dg_context.code_location_target_module_name,
+                    "--output-file",
+                    temp_file,
+                ],
+            )
+            definitions = deserialize_value(
+                Path(temp_file).read_text(), as_type=list[DgDefinitionMetadata]
+            )
 
-    # Temporary hack -- schrockn 2025-04-19
-    # We should have more reliable side channel (like writing to a file) to make
-    # this more robuss. However this will at least prevent errors when users or
-    # called tools print out strings to stdout. This is still not robust. If
-    # the user prints out a list of json parseable strings on single lines,
-    # this will fail.
-    #
-    # See https://linear.app/dagster-labs/issue/BUILD-1027/
-    def _get_defs() -> list[Any]:
-        last_decode_error = None
-        for line in result.splitlines():
-            try:
-                defs_list = deserialize_value(line, as_type=list[DgDefinitionMetadata])
-                return defs_list
-            except json.decoder.JSONDecodeError as e:
-                last_decode_error = e
-
-        if last_decode_error:
-            raise last_decode_error
-
-        raise Exception(
-            "Did not successfully parse definitions list. Full stdout of subprocess:\n" + result
+    # On older versions, we extract the output from the raw stdout of the command.
+    else:
+        location_opts = (
+            ["--location", dg_context.code_location_name]
+            if dg_context.dagster_version
+            >= MIN_DAGSTER_COMPONENTS_LIST_DEFINITIONS_LOCATION_OPTION_VERSION
+            else []
         )
-
-    definitions = _get_defs()
+        output = dg_context.external_components_command(
+            [
+                "list",
+                "definitions",
+                "--module-name",
+                dg_context.code_location_target_module_name,
+                *location_opts,
+            ],
+        )
+        definitions = _extract_list_defs_output_from_raw_output(output)
 
     # JSON
     if output_json:  # pass it straight through

--- a/python_modules/libraries/dagster-shared/dagster_shared/libraries/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/libraries/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 from collections.abc import Mapping
 
-import packaging.version
+from packaging.version import Version
 
 from dagster_shared import check
 from dagster_shared.version import __version__
@@ -22,10 +22,18 @@ class DagsterLibraryRegistry:
         return cls._libraries.copy()
 
 
-def parse_package_version(version_str: str) -> packaging.version.Version:
-    parsed_version = packaging.version.parse(version_str)
-    assert isinstance(parsed_version, packaging.version.Version)
+def parse_package_version(version_str: str) -> Version:
+    parsed_version = Version(version_str)
+    assert isinstance(parsed_version, Version)
     return parsed_version
+
+
+def increment_micro_version(v: Version, interval: int) -> Version:
+    major, minor, micro = v.major, v.minor, v.micro
+    new_micro = micro + interval
+    if new_micro < 0:
+        raise ValueError(f"Micro version cannot be negative: {new_micro}")
+    return Version(f"{major}.{minor}.{new_micro}")
 
 
 def check_dagster_package_version(library_name: str, library_version: str) -> None:


### PR DESCRIPTION
## Summary & Motivation

This makes `dg list defs` use a tempfile for its channel instead of stdout. This makes it robust to other output being printed to stdout during code location definitions loading, which could otherwise pollute the JSON stream read by `dg`.

## How I Tested These Changes

New unit tests (that also pass on windows, where non-stdio IPC is always a concern)

## Changelog

Fixed a bug where `dg list defs` would crash if anything was written to stdout while loading a project's definitions.