### PR TITLE
[dg] Move default Unix location for user config to $XDG_CONFIG_HOME (BUILD-1031)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -24,7 +24,7 @@ from click.core import ParameterSource
 from dagster_shared.merger import deep_merge_dicts
 from dagster_shared.plus.config import load_config
 from dagster_shared.utils import remove_none_recursively
-from dagster_shared.utils.config import get_dg_config_path
+from dagster_shared.utils.config import does_dg_config_file_exist, get_dg_config_path
 from typing_extensions import Never, NotRequired, Required, Self, TypeAlias, TypeGuard
 
 from dagster_dg.error import DgError, DgValidationError
@@ -506,6 +506,26 @@ def load_dg_user_file_config(path: Optional[Path] = None) -> DgRawCliConfig:
     contents = load_config(path).get("cli", {})
 
     return DgRawCliConfig(**{k: v for k, v in contents.items() if k != "plus"})
+
+
+_OLD_USER_FILE_CONFIG_LOCATION = Path.home() / ".dg.toml"
+
+
+def has_dg_user_file_config() -> bool:
+    # Remove when we remove other deprecated stuff.
+    if (Path.home() / ".dg.toml").exists():
+        # We can't suppress this warning because we haven't loaded the config with the
+        # suppress_warnings list yet.
+        emit_warning(
+            "deprecated_user_config_location",
+            f"""
+                Found config file ~/.dg.toml. This location for user config is no longer being read.
+                Please move your configuration file to `{get_dg_config_path()}`.
+            """,
+            None,
+            include_suppression_instruction=False,
+        )
+    return does_dg_config_file_exist()
 
 
 def load_dg_root_file_config(

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -12,7 +12,6 @@ from typing import Final, Optional, Union
 import tomlkit
 import tomlkit.items
 import yaml
-from dagster_shared.utils.config import does_dg_config_file_exist
 from typing_extensions import Self
 
 from dagster_dg.cache import CachableDataType, DgCache
@@ -24,6 +23,7 @@ from dagster_dg.config import (
     DgRawCliConfig,
     DgWorkspaceProjectSpec,
     discover_config_file,
+    has_dg_user_file_config,
     load_dg_root_file_config,
     load_dg_user_file_config,
     load_dg_workspace_file_config,
@@ -186,7 +186,7 @@ class DgContext:
             root_file_config = None
             container_workspace_file_config = None
 
-        user_config = load_dg_user_file_config() if does_dg_config_file_exist() else None
+        user_config = load_dg_user_file_config() if has_dg_user_file_config() else None
         config = DgConfig.from_partial_configs(
             root_file_config=root_file_config,
             container_workspace_file_config=container_workspace_file_config,

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
@@ -1,6 +1,6 @@
 import textwrap
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, Optional
 
 import click
 from typing_extensions import TypeAlias
@@ -9,6 +9,7 @@ from dagster_dg.utils import format_multiline_str
 
 DgWarningIdentifier: TypeAlias = Literal[
     "cli_config_in_workspace_project",
+    "deprecated_user_config_location",
     "deprecated_python_environment",
     "deprecated_dagster_dg_library_entry_point",
     "project_and_activated_venv_mismatch",
@@ -16,14 +17,22 @@ DgWarningIdentifier: TypeAlias = Literal[
 
 
 def emit_warning(
-    warning_id: DgWarningIdentifier, msg: str, suppress_warnings: Sequence[DgWarningIdentifier]
+    warning_id: DgWarningIdentifier,
+    msg: str,
+    suppress_warnings: Optional[Sequence[DgWarningIdentifier]],
+    include_suppression_instruction: bool = True,
 ) -> None:
-    if warning_id not in suppress_warnings:
+    if warning_id not in (suppress_warnings or []):
+        formatted_main_msg = textwrap.dedent(msg).strip()
         suppression_instruction = format_multiline_str(f"""
             To suppress this warning, add "{warning_id}" to the `cli.suppress_warnings` list in
             your configuration.
         """)
-        full_msg = f"{textwrap.dedent(msg).strip()}\n\n{suppression_instruction}\n"
+        full_msg = (
+            f"{formatted_main_msg}\n\n{suppression_instruction}\n"
+            if include_suppression_instruction
+            else formatted_main_msg
+        )
         click.secho(
             full_msg,
             fg="yellow",

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/config.py
@@ -11,14 +11,12 @@ def is_windows() -> bool:
     return sys.platform == "win32"
 
 
-def _get_default_dg_cli_file() -> Path:
+def get_default_dg_user_config_path() -> Path:
     if is_windows():
         return Path.home() / "AppData" / "dg" / "dg.toml"
     else:
-        return Path.home() / ".dg.toml"
-
-
-DEFAULT_DG_CLI_FILE = _get_default_dg_cli_file()
+        config_home = Path(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")))
+        return config_home / "dg.toml"
 
 
 def load_config(config_path: Path) -> dict[str, Any]:
@@ -38,7 +36,7 @@ def write_config(config_path: Path, config: dict[str, Any]):
 
 
 def get_dg_config_path() -> Path:
-    return Path(os.getenv("DG_CLI_CONFIG", DEFAULT_DG_CLI_FILE))
+    return Path(os.getenv("DG_CLI_CONFIG", get_default_dg_user_config_path()))
 
 
 def does_dg_config_file_exist() -> bool:


### PR DESCRIPTION
## Summary & Motivation

Move default Unix location for user config from ~/.dg.toml to `$XDG_CONFIG_HOME/dg.toml` (or if not set, `~/.config/dg.toml)`.  Print a warning if we find `~/.dg.toml`.

Also improve tests generally for user config discovery.

## How I Tested These Changes

New unit tests.

## Changelog

The default location for the `dg` user config file on Unix has been moved from `~/.dg.toml` to `~/.config/dg.toml`. `~/.config` can be overridden by setting `$XDG_CONFIG_HOME`.