### PR TITLE
refactor asset health computations

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,0 +1,34 @@
+from dagster import _check as check
+
+from dagster_graphql.implementation.fetch_assets import get_partition_subsets
+
+
+def regenerate_and_check_partition_subsets(context, asset_node_snap, dynamic_partitions_loader):
+    # TODO - move to implementation dir, type hints
+    if not dynamic_partitions_loader:
+        check.failed("dynamic_partitions_loader must be provided to get partition keys")
+
+    (
+        materialized_partition_subset,
+        failed_partition_subset,
+        in_progress_subset,
+    ) = get_partition_subsets(
+        context.instance,
+        context,
+        asset_node_snap.asset_key,
+        dynamic_partitions_loader,
+        (
+            asset_node_snap.partitions.get_partitions_definition()
+            if asset_node_snap.partitions
+            else None
+        ),
+    )
+
+    if (
+        materialized_partition_subset is None
+        or failed_partition_subset is None
+        or in_progress_subset is None
+    ):
+        check.failed("Expected partitions subset for a partitioned asset")
+
+    return materialized_partition_subset, failed_partition_subset, in_progress_subset

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,10 +1,18 @@
+from typing import Optional
+
 from dagster import _check as check
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsSubset
+from dagster._core.remote_representation.external_data import AssetNodeSnap
+from dagster._core.workspace.context import WorkspaceRequestContext
 
 from dagster_graphql.implementation.fetch_assets import get_partition_subsets
 
 
-def regenerate_and_check_partition_subsets(context, asset_node_snap, dynamic_partitions_loader):
-    # TODO - move to implementation dir, type hints
+def regenerate_and_check_partition_subsets(
+    context: WorkspaceRequestContext,
+    asset_node_snap: AssetNodeSnap,
+    dynamic_partitions_loader: Optional[CachingDynamicPartitionsLoader],
+) -> tuple[PartitionsSubset[str], PartitionsSubset[str], PartitionsSubset[str]]:
     if not dynamic_partitions_loader:
         check.failed("dynamic_partitions_loader must be provided to get partition keys")
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -55,6 +55,9 @@ from dagster_graphql.implementation.fetch_assets import (
     get_freshness_info,
     get_partition_subsets,
 )
+from dagster_graphql.implementation.fetch_partition_subsets import (
+    regenerate_and_check_partition_subsets,
+)
 from dagster_graphql.implementation.loader import StaleStatusLoader
 from dagster_graphql.schema import external
 from dagster_graphql.schema.asset_checks import (
@@ -127,37 +130,6 @@ GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
 )
 
 GrapheneAssetChangedReason = graphene.Enum.from_enum(AssetDefinitionChangeType, name="ChangeReason")
-
-
-def regenerate_and_check_partition_subsets(context, asset_node_snap, dynamic_partitions_loader):
-    # TODO - move to implementation dir, type hints
-    if not dynamic_partitions_loader:
-        check.failed("dynamic_partitions_loader must be provided to get partition keys")
-
-    (
-        materialized_partition_subset,
-        failed_partition_subset,
-        in_progress_subset,
-    ) = get_partition_subsets(
-        context.instance,
-        context,
-        asset_node_snap.asset_key,
-        dynamic_partitions_loader,
-        (
-            asset_node_snap.partitions.get_partitions_definition()
-            if asset_node_snap.partitions
-            else None
-        ),
-    )
-
-    if (
-        materialized_partition_subset is None
-        or failed_partition_subset is None
-        or in_progress_subset is None
-    ):
-        check.failed("Expected partitions subset for a partitioned asset")
-
-    return materialized_partition_subset, failed_partition_subset, in_progress_subset
 
 
 class GrapheneUserAssetOwner(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -6,7 +6,6 @@ from dagster import (
     AssetKey,
     _check as check,
 )
-from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_graph_differ import AssetDefinitionChangeType, AssetGraphDiffer
 from dagster._core.definitions.data_version import (
     NULL_DATA_VERSION,
@@ -16,7 +15,6 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionSnapshot,
 )
-from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
     PartitionLoadingContext,
@@ -40,12 +38,8 @@ from dagster._core.remote_representation.external_data import (
     TimeWindowPartitionsSnap,
 )
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
-from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionResolvedStatus,
-    AssetCheckInstanceSupport,
-)
-from dagster._core.storage.dagster_run import RunRecord
-from dagster._core.storage.event_log.base import AssetCheckSummaryRecord, AssetRecord
+from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
+from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.utils import is_valid_email
 from dagster._core.workspace.permissions import Permissions
@@ -72,19 +66,7 @@ from dagster_graphql.schema.asset_checks import (
     GrapheneAssetChecks,
     GrapheneAssetChecksOrError,
 )
-from dagster_graphql.schema.asset_health import (
-    GrapheneAssetHealth,
-    GrapheneAssetHealthCheckDegradedMeta,
-    GrapheneAssetHealthCheckMeta,
-    GrapheneAssetHealthCheckUnknownMeta,
-    GrapheneAssetHealthCheckWarningMeta,
-    GrapheneAssetHealthFreshnessMeta,
-    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta,
-    GrapheneAssetHealthMaterializationDegradedPartitionedMeta,
-    GrapheneAssetHealthMaterializationMeta,
-    GrapheneAssetHealthMaterializationWarningPartitionedMeta,
-    GrapheneAssetHealthStatus,
-)
+from dagster_graphql.schema.asset_health import GrapheneAssetHealth
 from dagster_graphql.schema.auto_materialize_policy import GrapheneAutoMaterializePolicy
 from dagster_graphql.schema.automation_condition import GrapheneAutomationCondition
 from dagster_graphql.schema.backfill import GrapheneBackfillPolicy
@@ -145,6 +127,37 @@ GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
 )
 
 GrapheneAssetChangedReason = graphene.Enum.from_enum(AssetDefinitionChangeType, name="ChangeReason")
+
+
+def regenerate_and_check_partition_subsets(context, asset_node_snap, dynamic_partitions_loader):
+    # TODO - move to implementation dir, type hints
+    if not dynamic_partitions_loader:
+        check.failed("dynamic_partitions_loader must be provided to get partition keys")
+
+    (
+        materialized_partition_subset,
+        failed_partition_subset,
+        in_progress_subset,
+    ) = get_partition_subsets(
+        context.instance,
+        context,
+        asset_node_snap.asset_key,
+        dynamic_partitions_loader,
+        (
+            asset_node_snap.partitions.get_partitions_definition()
+            if asset_node_snap.partitions
+            else None
+        ),
+    )
+
+    if (
+        materialized_partition_subset is None
+        or failed_partition_subset is None
+        or in_progress_subset is None
+    ):
+        check.failed("Expected partitions subset for a partitioned asset")
+
+    return materialized_partition_subset, failed_partition_subset, in_progress_subset
 
 
 class GrapheneUserAssetOwner(graphene.ObjectType):
@@ -556,336 +569,14 @@ class GrapheneAssetNode(graphene.ObjectType):
     def is_executable(self) -> bool:
         return self._asset_node_snap.is_executable
 
-    async def get_materialization_status_for_asset_health(
-        self, graphene_info: ResolveInfo
-    ) -> tuple[str, Optional[GrapheneAssetHealthMaterializationMeta]]:
-        """Computes the health indicator for the asset materialization status. Follows these rules:
-        If the asset is partitioned:
-            - HEALTHY - all partitions successfully materialized.
-            - WARNING - some partitions are successful but any number of partitions are missing (but no failed partitions).
-            - DEGRADED - any number of partitions are failed.
-            - UNKNOWN - all partitions are missing.
-        If the asset is not partitioned:
-            - HEALTHY - the latest materialization of an asset was successfully materialized.
-            - WARNING - no conditions lead to a warning status.
-            - DEGRADED - latest materialization of an asset failed.
-            - UNKNOWN - asset has never had a materialization attempt.
-        """
-        partitions_snap = self._asset_node_snap.partitions
-        asset_key = self._asset_node_snap.asset_key
-        if partitions_snap is not None:  # isPartitioned
-            (
-                materialized_partition_subset,
-                failed_partition_subset,
-                _,
-            ) = self.regenerate_and_check_partition_subsets(graphene_info.context, asset_key)
-            total_num_partitions = partitions_snap.get_partitions_definition().get_num_partitions(
-                dynamic_partitions_store=self._dynamic_partitions_loader
-            )
-            currently_materialized_subset = materialized_partition_subset - failed_partition_subset
-            num_materialized = len(currently_materialized_subset)
-            num_failed = len(failed_partition_subset)
-            if num_materialized == 0 and num_failed == 0:
-                # asset has never been materialized
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-            num_missing = total_num_partitions - num_materialized - num_failed
-            if num_failed > 0:
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedPartitionedMeta(
-                        numFailedPartitions=num_failed,
-                        numMissingPartitions=num_missing,
-                        totalNumPartitions=total_num_partitions,
-                    ),
-                )
-            if num_missing > 0:
-                # some partitions have never been materialized
-                return (
-                    GrapheneAssetHealthStatus.WARNING,
-                    GrapheneAssetHealthMaterializationWarningPartitionedMeta(
-                        numMissingPartitions=num_missing,
-                        totalNumPartitions=total_num_partitions,
-                    ),
-                )
-            # if no partitions are failed or missing, they must all be successfully materialized
-            return GrapheneAssetHealthStatus.HEALTHY, None
-
-        asset_record = await AssetRecord.gen(graphene_info.context, asset_key)
-        if asset_record is None:
-            return GrapheneAssetHealthStatus.UNKNOWN, None
-        asset_entry = asset_record.asset_entry
-
-        if self.asset_node_snap.is_observable and not self.asset_node_snap.is_materializable:
-            # for observable assets, if there is an observation event then the asset is healthy
-            if asset_entry.last_observation is not None:
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            else:
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-
-        if graphene_info.context.instance.can_read_failure_events_for_asset(asset_record):
-            # compute the status based on the asset key table
-            if (
-                asset_entry.last_materialization_storage_id is None
-                and asset_entry.last_failed_to_materialize_storage_id is None
-            ):
-                # never materialized
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-            if asset_entry.last_failed_to_materialize_storage_id is None:
-                # last_materialization_record must be non-null, therefore the asset successfully materialized
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            elif asset_entry.last_materialization_storage_id is None:
-                # last_failed_to_materialize_record must be non-null, therefore the asset failed to materialize
-                last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                        failedRunId=last_failed_record.run_id,
-                    ),
-                )
-
-            if (
-                asset_entry.last_materialization_storage_id
-                > asset_entry.last_failed_to_materialize_storage_id
-            ):
-                # latest materialization succeeded
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            # latest materialization failed
-            last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
-            return (
-                GrapheneAssetHealthStatus.DEGRADED,
-                GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                    failedRunId=last_failed_record.run_id,
-                ),
-            )
-        # we are not storing failure events for this asset, so must compute status based on the information we have available
-        # in some cases this results in reporting as asset as HEALTHY or UNKNOWN during an in progress run
-        # even if the asset was previously failed
-        else:
-            # if the asset has been successfully materialized in the past, we fallback to that status
-            # when we don't have the information available to compute status based on the latest run
-            fallback_status_and_meta = (
-                (GrapheneAssetHealthStatus.UNKNOWN, None)
-                if asset_entry.last_materialization is None
-                else (GrapheneAssetHealthStatus.HEALTHY, None)
-            )
-            if asset_entry.last_run_id is None:
-                return fallback_status_and_meta
-
-            assert asset_entry.last_run_id is not None
-            if (
-                asset_entry.last_materialization is not None
-                and asset_entry.last_run_id == asset_entry.last_materialization.run_id
-            ):
-                # latest materialization succeeded in the latest run
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            run_record = await RunRecord.gen(graphene_info.context, asset_entry.last_run_id)
-            if run_record is None or not run_record.dagster_run.is_finished:
-                return fallback_status_and_meta
-            run_end_time = check.not_none(run_record.end_time)
-            if (
-                asset_entry.last_materialization
-                and asset_entry.last_materialization.timestamp > run_end_time
-            ):
-                # latest materialization was reported manually
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            if run_record.dagster_run.is_failure:
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                        failedRunId=run_record.dagster_run.run_id,
-                    ),
-                )
-
-            return fallback_status_and_meta
-
-    async def get_asset_check_status_for_asset_health(
-        self, graphene_info: ResolveInfo
-    ) -> tuple[str, Optional[GrapheneAssetHealthCheckMeta]]:
-        """Computes the health indicator for the asset checks for the assets. Follows these rules:
-        HEALTHY - the latest completed execution for every check is a success.
-        WARNING - the latest completed execution for any asset check failed with severity WARN
-            (and no checks failed with severity ERROR).
-        DEGRADED - the latest completed execution for any asset check failed with severity ERROR.
-        UNKNOWN - any asset checks has never been executed.
-        NOT_APPLICABLE - the asset has no asset checks defined.
-
-        Note: the latest completed execution for each check may not have executed based on the
-        most recent materialization of the asset.
-        """
-        remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(
-            self._asset_node_snap.asset_key
-        )
-        if not remote_check_nodes or len(remote_check_nodes) == 0:
-            # asset doesn't have checks defined
-            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
-        else:
-            total_num_checks = len(remote_check_nodes)
-            check_statuses = []
-            check_failure_severities = []
-            asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
-                graphene_info.context,
-                [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
-            )
-            for summary_record in asset_check_summary_records:
-                if summary_record is None or summary_record.last_check_execution_record is None:
-                    # the check has never been executed.
-                    continue
-
-                # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
-                # but we check the last_check_execution_record status first since there is an edge case
-                # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
-                # because the run for the check failed.
-                last_check_execution_status = (
-                    await summary_record.last_check_execution_record.resolve_status(
-                        graphene_info.context
-                    )
-                )
-                last_check_evaluation = summary_record.last_check_execution_record.evaluation
-
-                if last_check_execution_status in [
-                    AssetCheckExecutionResolvedStatus.IN_PROGRESS,
-                    AssetCheckExecutionResolvedStatus.SKIPPED,
-                ]:
-                    # the last check is still in progress or is skipped, so we want to check the status of
-                    # the latest completed check instead
-                    if summary_record.last_completed_check_execution_record is None:
-                        # the check hasn't been executed prior to this in progress check
-                        continue
-                    last_check_execution_status = (
-                        await summary_record.last_completed_check_execution_record.resolve_status(
-                            graphene_info.context
-                        )
-                    )
-                    last_check_evaluation = (
-                        summary_record.last_completed_check_execution_record.evaluation
-                    )
-
-                check_statuses.append(last_check_execution_status)
-                if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
-                    # failed checks should always have an evaluation, but default to ERROR if not
-                    check_failure_severities.append(
-                        last_check_evaluation.severity
-                        if last_check_evaluation
-                        else AssetCheckSeverity.ERROR
-                    )
-                if (
-                    last_check_execution_status
-                    == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
-                ):
-                    # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
-                    # degraded health anyway.
-                    check_failure_severities.append(AssetCheckSeverity.ERROR)
-
-            num_unexecuted_checks = total_num_checks - len(check_statuses)
-
-            if len(check_statuses) == 0:
-                # checks have never been executed
-                return GrapheneAssetHealthStatus.UNKNOWN, GrapheneAssetHealthCheckUnknownMeta(
-                    numNotExecutedChecks=num_unexecuted_checks,
-                    totalNumChecks=total_num_checks,
-                )
-
-            if any(
-                status == AssetCheckExecutionResolvedStatus.FAILED
-                or status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
-                for status in check_statuses
-            ):
-                if all(
-                    severity == AssetCheckSeverity.WARN for severity in check_failure_severities
-                ):
-                    # all failed checks are with warning severity
-                    return (
-                        GrapheneAssetHealthStatus.WARNING,
-                        GrapheneAssetHealthCheckWarningMeta(
-                            numWarningChecks=len(check_failure_severities),
-                            totalNumChecks=total_num_checks,
-                        ),
-                    )
-                # at least one failing check had error severity
-                num_failed = len(
-                    [sev for sev in check_failure_severities if sev == AssetCheckSeverity.ERROR]
-                )
-                num_warn = len(check_failure_severities) - num_failed
-                return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthCheckDegradedMeta(
-                    numFailedChecks=num_failed,
-                    numWarningChecks=num_warn,
-                    totalNumChecks=total_num_checks,
-                )
-
-            # since we are only looking at the latest completed execution for each check, if there
-            # are no failed checks, then all checks must have succeeded
-            if num_unexecuted_checks > 0:
-                # if any check has never been executed, we report this as unknown, even if other checks
-                # have passed
-                return (
-                    GrapheneAssetHealthStatus.UNKNOWN,
-                    GrapheneAssetHealthCheckUnknownMeta(
-                        numNotExecutedChecks=num_unexecuted_checks,
-                        totalNumChecks=total_num_checks,
-                    ),
-                )
-            # all checks must have executed and passed
-            return GrapheneAssetHealthStatus.HEALTHY, None
-
-    async def get_freshness_status_for_asset_health(
-        self, graphene_info: ResolveInfo
-    ) -> tuple[str, Optional[GrapheneAssetHealthFreshnessMeta]]:
-        """Computes the health indicator for the freshness for an asset. Follows these rules:
-        HEALTHY - the freshness policy is in a PASS-ing state
-        WARNING - the freshness policy is in a WARN-ing state
-        DEGRADED - the freshness policy is in a FAIL-ing state
-        UNKNOWN - the freshness policy has never been evaluated or is in an UNKNOWN state
-        NOT_APPLICABLE - the asset does not have a freshness policy defined.
-        """
-        if self._asset_node_snap.internal_freshness_policy is None:
-            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
-
-        freshness_state_record = graphene_info.context.instance.get_entity_freshness_state(
-            self._asset_node_snap.asset_key
-        )
-        if freshness_state_record is None:
-            return GrapheneAssetHealthStatus.UNKNOWN, None
-        state = freshness_state_record.freshness_state
-        if state == FreshnessState.PASS:
-            return GrapheneAssetHealthStatus.HEALTHY, None
-
-        asset_record = await AssetRecord.gen(graphene_info.context, self._asset_node_snap.asset_key)
-        last_materialization = (
-            asset_record.asset_entry.last_materialization.timestamp
-            if asset_record and asset_record.asset_entry.last_materialization
-            else None
-        )
-        if state == FreshnessState.WARN:
-            return GrapheneAssetHealthStatus.WARNING, GrapheneAssetHealthFreshnessMeta(
-                lastMaterializedTimestamp=last_materialization,
-            )
-        if state == FreshnessState.FAIL:
-            return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthFreshnessMeta(
-                lastMaterializedTimestamp=last_materialization,
-            )
-
-        return GrapheneAssetHealthStatus.UNKNOWN, None
-
     async def resolve_assetHealth(
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetHealth]:
         if not graphene_info.context.instance.dagster_observe_supported():
             return None
-        check_status, check_meta = await self.get_asset_check_status_for_asset_health(graphene_info)
-        (
-            materialization_status,
-            materialization_meta,
-        ) = await self.get_materialization_status_for_asset_health(graphene_info)
-        freshness_status, freshness_meta = await self.get_freshness_status_for_asset_health(
-            graphene_info
-        )
         return GrapheneAssetHealth(
-            assetChecksStatus=check_status,
-            assetChecksStatusMetadata=check_meta,
-            materializationStatus=materialization_status,
-            materializationStatusMetadata=materialization_meta,
-            freshnessStatus=freshness_status,
-            freshnessStatusMetadata=freshness_meta,
+            asset_node_snap=self._asset_node_snap,
+            dynamic_partitions_loader=self._dynamic_partitions_loader,
         )
 
     def resolve_hasMaterializePermission(
@@ -1423,47 +1114,18 @@ class GrapheneAssetNode(graphene.ObjectType):
             partitions_def,
         )
 
-    def regenerate_and_check_partition_subsets(self, context, asset_key: AssetKey):
-        if not self._dynamic_partitions_loader:
-            check.failed("dynamic_partitions_loader must be provided to get partition keys")
-
-        (
-            materialized_partition_subset,
-            failed_partition_subset,
-            in_progress_subset,
-        ) = get_partition_subsets(
-            context.instance,
-            context,
-            asset_key,
-            self._dynamic_partitions_loader,
-            (
-                self._asset_node_snap.partitions.get_partitions_definition()
-                if self._asset_node_snap.partitions
-                else None
-            ),
-        )
-
-        if (
-            materialized_partition_subset is None
-            or failed_partition_subset is None
-            or in_progress_subset is None
-        ):
-            check.failed("Expected partitions subset for a partitioned asset")
-
-        return materialized_partition_subset, failed_partition_subset, in_progress_subset
-
     def resolve_partitionStats(
         self, graphene_info: ResolveInfo
     ) -> Optional[GraphenePartitionStats]:
         partitions_snap = self._asset_node_snap.partitions
         if partitions_snap:
-            asset_key = self._asset_node_snap.asset_key
-
             (
                 materialized_partition_subset,
                 failed_partition_subset,
                 in_progress_subset,
-            ) = self.regenerate_and_check_partition_subsets(graphene_info.context, asset_key)
+            ) = regenerate_and_check_partition_subsets(
+                graphene_info.context, self._asset_node_snap, self._dynamic_partitions_loader
+            )
 
             failed_or_in_progress_subset = failed_partition_subset | in_progress_subset
             failed_and_not_in_progress_subset = failed_partition_subset - in_progress_subset

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -8,7 +8,9 @@ from dagster._core.storage.asset_check_execution_record import AssetCheckExecuti
 from dagster._core.storage.dagster_run import RunRecord
 from dagster._core.storage.event_log.base import AssetCheckSummaryRecord, AssetRecord
 
-from dagster_graphql.schema.asset_graph import regenerate_and_check_partition_subsets
+from dagster_graphql.implementation.fetch_partition_subsets import (
+    regenerate_and_check_partition_subsets,
+)
 from dagster_graphql.schema.util import ResolveInfo
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -1,5 +1,14 @@
-import graphene
+from typing import Optional
 
+import graphene
+from dagster import _check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+from dagster._core.definitions.freshness import FreshnessState
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
+from dagster._core.storage.dagster_run import RunRecord
+from dagster._core.storage.event_log.base import AssetCheckSummaryRecord, AssetRecord
+
+from dagster_graphql.schema.asset_graph import regenerate_and_check_partition_subsets
 from dagster_graphql.schema.util import ResolveInfo
 
 
@@ -102,13 +111,385 @@ class GrapheneAssetHealth(graphene.ObjectType):
     class Meta:
         name = "AssetHealth"
 
+    def __init__(self, asset_node_snap, dynamic_partitions_loader):
+        super().__init__()
+        self._asset_node_snap = asset_node_snap
+        self._dynamic_partitions_loader = dynamic_partitions_loader
+        self.materialization_status = None
+        self.materialization_status_metadata = None
+        self.asset_checks_status = None
+        self.asset_checks_status_metadata = None
+        self.freshness_status = None
+        self.freshness_status_metadata = None
+
+    async def get_materialization_status_for_asset_health(
+        self, graphene_info: ResolveInfo
+    ) -> tuple[str, Optional[GrapheneAssetHealthMaterializationMeta]]:
+        """Computes the health indicator for the asset materialization status. Follows these rules:
+        If the asset is partitioned:
+            - HEALTHY - all partitions successfully materialized.
+            - WARNING - some partitions are successful but any number of partitions are missing (but no failed partitions).
+            - DEGRADED - any number of partitions are failed.
+            - UNKNOWN - all partitions are missing.
+        If the asset is not partitioned:
+            - HEALTHY - the latest materialization of an asset was successfully materialized.
+            - WARNING - no conditions lead to a warning status.
+            - DEGRADED - latest materialization of an asset failed.
+            - UNKNOWN - asset has never had a materialization attempt.
+        """
+        partitions_snap = self._asset_node_snap.partitions
+        asset_key = self._asset_node_snap.asset_key
+        if partitions_snap is not None:  # isPartitioned
+            (
+                materialized_partition_subset,
+                failed_partition_subset,
+                _,
+            ) = regenerate_and_check_partition_subsets(
+                graphene_info.context, self._asset_node_snap, self._dynamic_partitions_loader
+            )
+            total_num_partitions = partitions_snap.get_partitions_definition().get_num_partitions(
+                dynamic_partitions_store=self._dynamic_partitions_loader
+            )
+            currently_materialized_subset = materialized_partition_subset - failed_partition_subset
+            num_materialized = len(currently_materialized_subset)
+            num_failed = len(failed_partition_subset)
+            if num_materialized == 0 and num_failed == 0:
+                # asset has never been materialized
+                return GrapheneAssetHealthStatus.UNKNOWN, None
+            num_missing = total_num_partitions - num_materialized - num_failed
+            if num_failed > 0:
+                return (
+                    GrapheneAssetHealthStatus.DEGRADED,
+                    GrapheneAssetHealthMaterializationDegradedPartitionedMeta(
+                        numFailedPartitions=num_failed,
+                        numMissingPartitions=num_missing,
+                        totalNumPartitions=total_num_partitions,
+                    ),
+                )
+            if num_missing > 0:
+                # some partitions have never been materialized
+                return (
+                    GrapheneAssetHealthStatus.WARNING,
+                    GrapheneAssetHealthMaterializationWarningPartitionedMeta(
+                        numMissingPartitions=num_missing,
+                        totalNumPartitions=total_num_partitions,
+                    ),
+                )
+            # if no partitions are failed or missing, they must all be successfully materialized
+            return GrapheneAssetHealthStatus.HEALTHY, None
+
+        asset_record = await AssetRecord.gen(graphene_info.context, asset_key)
+        if asset_record is None:
+            return GrapheneAssetHealthStatus.UNKNOWN, None
+        asset_entry = asset_record.asset_entry
+
+        if self.asset_node_snap.is_observable and not self.asset_node_snap.is_materializable:
+            # for observable assets, if there is an observation event then the asset is healthy
+            if asset_entry.last_observation is not None:
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            else:
+                return GrapheneAssetHealthStatus.UNKNOWN, None
+
+        if graphene_info.context.instance.can_read_failure_events_for_asset(asset_record):
+            # compute the status based on the asset key table
+            if (
+                asset_entry.last_materialization_storage_id is None
+                and asset_entry.last_failed_to_materialize_storage_id is None
+            ):
+                # never materialized
+                return GrapheneAssetHealthStatus.UNKNOWN, None
+            if asset_entry.last_failed_to_materialize_storage_id is None:
+                # last_materialization_record must be non-null, therefore the asset successfully materialized
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            elif asset_entry.last_materialization_storage_id is None:
+                # last_failed_to_materialize_record must be non-null, therefore the asset failed to materialize
+                last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
+                return (
+                    GrapheneAssetHealthStatus.DEGRADED,
+                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
+                        failedRunId=last_failed_record.run_id,
+                    ),
+                )
+
+            if (
+                asset_entry.last_materialization_storage_id
+                > asset_entry.last_failed_to_materialize_storage_id
+            ):
+                # latest materialization succeeded
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            # latest materialization failed
+            last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
+            return (
+                GrapheneAssetHealthStatus.DEGRADED,
+                GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
+                    failedRunId=last_failed_record.run_id,
+                ),
+            )
+        # we are not storing failure events for this asset, so must compute status based on the information we have available
+        # in some cases this results in reporting as asset as HEALTHY or UNKNOWN during an in progress run
+        # even if the asset was previously failed
+        else:
+            # if the asset has been successfully materialized in the past, we fallback to that status
+            # when we don't have the information available to compute status based on the latest run
+            fallback_status_and_meta = (
+                (GrapheneAssetHealthStatus.UNKNOWN, None)
+                if asset_entry.last_materialization is None
+                else (GrapheneAssetHealthStatus.HEALTHY, None)
+            )
+            if asset_entry.last_run_id is None:
+                return fallback_status_and_meta
+
+            assert asset_entry.last_run_id is not None
+            if (
+                asset_entry.last_materialization is not None
+                and asset_entry.last_run_id == asset_entry.last_materialization.run_id
+            ):
+                # latest materialization succeeded in the latest run
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            run_record = await RunRecord.gen(graphene_info.context, asset_entry.last_run_id)
+            if run_record is None or not run_record.dagster_run.is_finished:
+                return fallback_status_and_meta
+            run_end_time = check.not_none(run_record.end_time)
+            if (
+                asset_entry.last_materialization
+                and asset_entry.last_materialization.timestamp > run_end_time
+            ):
+                # latest materialization was reported manually
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            if run_record.dagster_run.is_failure:
+                return (
+                    GrapheneAssetHealthStatus.DEGRADED,
+                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
+                        failedRunId=run_record.dagster_run.run_id,
+                    ),
+                )
+
+            return fallback_status_and_meta
+
+    async def resolve_materializationStatus(self, graphene_info: ResolveInfo):
+        if self.materialization_status is None:
+            (
+                self.materialization_status,
+                self.materialization_status_metadata,
+            ) = await self.get_materialization_status_for_asset_health(graphene_info)
+        return self.materialization_status
+
+    async def resolve_materializationStatusMetadata(self, graphene_info: ResolveInfo):
+        if self.materialization_status_metadata is None:
+            (
+                self.materialization_status,
+                self.materialization_status_metadata,
+            ) = await self.get_materialization_status_for_asset_health(graphene_info)
+        return self.materialization_status_metadata
+
+    async def get_asset_check_status_for_asset_health(
+        self, graphene_info: ResolveInfo
+    ) -> tuple[str, Optional[GrapheneAssetHealthCheckMeta]]:
+        """Computes the health indicator for the asset checks for the assets. Follows these rules:
+        HEALTHY - the latest completed execution for every check is a success.
+        WARNING - the latest completed execution for any asset check failed with severity WARN
+            (and no checks failed with severity ERROR).
+        DEGRADED - the latest completed execution for any asset check failed with severity ERROR.
+        UNKNOWN - any asset checks has never been executed.
+        NOT_APPLICABLE - the asset has no asset checks defined.
+
+        Note: the latest completed execution for each check may not have executed based on the
+        most recent materialization of the asset.
+        """
+        remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(
+            self._asset_node_snap.asset_key
+        )
+        if not remote_check_nodes or len(remote_check_nodes) == 0:
+            # asset doesn't have checks defined
+            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+        else:
+            total_num_checks = len(remote_check_nodes)
+            check_statuses = []
+            check_failure_severities = []
+            asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
+                graphene_info.context,
+                [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
+            )
+            for summary_record in asset_check_summary_records:
+                if summary_record is None or summary_record.last_check_execution_record is None:
+                    # the check has never been executed.
+                    continue
+
+                # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
+                # but we check the last_check_execution_record status first since there is an edge case
+                # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
+                # because the run for the check failed.
+                last_check_execution_status = (
+                    await summary_record.last_check_execution_record.resolve_status(
+                        graphene_info.context
+                    )
+                )
+                last_check_evaluation = summary_record.last_check_execution_record.evaluation
+
+                if last_check_execution_status in [
+                    AssetCheckExecutionResolvedStatus.IN_PROGRESS,
+                    AssetCheckExecutionResolvedStatus.SKIPPED,
+                ]:
+                    # the last check is still in progress or is skipped, so we want to check the status of
+                    # the latest completed check instead
+                    if summary_record.last_completed_check_execution_record is None:
+                        # the check hasn't been executed prior to this in progress check
+                        continue
+                    last_check_execution_status = (
+                        await summary_record.last_completed_check_execution_record.resolve_status(
+                            graphene_info.context
+                        )
+                    )
+                    last_check_evaluation = (
+                        summary_record.last_completed_check_execution_record.evaluation
+                    )
+
+                check_statuses.append(last_check_execution_status)
+                if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
+                    # failed checks should always have an evaluation, but default to ERROR if not
+                    check_failure_severities.append(
+                        last_check_evaluation.severity
+                        if last_check_evaluation
+                        else AssetCheckSeverity.ERROR
+                    )
+                if (
+                    last_check_execution_status
+                    == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
+                ):
+                    # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
+                    # degraded health anyway.
+                    check_failure_severities.append(AssetCheckSeverity.ERROR)
+
+            num_unexecuted_checks = total_num_checks - len(check_statuses)
+
+            if len(check_statuses) == 0:
+                # checks have never been executed
+                return GrapheneAssetHealthStatus.UNKNOWN, GrapheneAssetHealthCheckUnknownMeta(
+                    numNotExecutedChecks=num_unexecuted_checks,
+                    totalNumChecks=total_num_checks,
+                )
+
+            if any(
+                status == AssetCheckExecutionResolvedStatus.FAILED
+                or status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
+                for status in check_statuses
+            ):
+                if all(
+                    severity == AssetCheckSeverity.WARN for severity in check_failure_severities
+                ):
+                    # all failed checks are with warning severity
+                    return (
+                        GrapheneAssetHealthStatus.WARNING,
+                        GrapheneAssetHealthCheckWarningMeta(
+                            numWarningChecks=len(check_failure_severities),
+                            totalNumChecks=total_num_checks,
+                        ),
+                    )
+                # at least one failing check had error severity
+                num_failed = len(
+                    [sev for sev in check_failure_severities if sev == AssetCheckSeverity.ERROR]
+                )
+                num_warn = len(check_failure_severities) - num_failed
+                return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthCheckDegradedMeta(
+                    numFailedChecks=num_failed,
+                    numWarningChecks=num_warn,
+                    totalNumChecks=total_num_checks,
+                )
+
+            # since we are only looking at the latest completed execution for each check, if there
+            # are no failed checks, then all checks must have succeeded
+            if num_unexecuted_checks > 0:
+                # if any check has never been executed, we report this as unknown, even if other checks
+                # have passed
+                return (
+                    GrapheneAssetHealthStatus.UNKNOWN,
+                    GrapheneAssetHealthCheckUnknownMeta(
+                        numNotExecutedChecks=num_unexecuted_checks,
+                        totalNumChecks=total_num_checks,
+                    ),
+                )
+            # all checks must have executed and passed
+            return GrapheneAssetHealthStatus.HEALTHY, None
+
+    async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo):
+        if self.asset_checks_status is None:
+            (
+                self.asset_checks_status,
+                self.asset_checks_status_metadata,
+            ) = await self.get_asset_check_status_for_asset_health(graphene_info)
+        return self.asset_checks_status
+
+    async def resolve_assetChecksStatusMetadata(self, graphene_info: ResolveInfo):
+        if self.asset_checks_status_metadata is None:
+            (
+                self.asset_checks_status,
+                self.asset_checks_status_metadata,
+            ) = await self.get_asset_check_status_for_asset_health(graphene_info)
+        return self.asset_checks_status_metadata
+
+    async def get_freshness_status_for_asset_health(
+        self, graphene_info: ResolveInfo
+    ) -> tuple[str, Optional[GrapheneAssetHealthFreshnessMeta]]:
+        """Computes the health indicator for the freshness for an asset. Follows these rules:
+        HEALTHY - the freshness policy is in a PASS-ing state
+        WARNING - the freshness policy is in a WARN-ing state
+        DEGRADED - the freshness policy is in a FAIL-ing state
+        UNKNOWN - the freshness policy has never been evaluated or is in an UNKNOWN state
+        NOT_APPLICABLE - the asset does not have a freshness policy defined.
+        """
+        if self._asset_node_snap.internal_freshness_policy is None:
+            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+
+        freshness_state_record = graphene_info.context.instance.get_entity_freshness_state(
+            self._asset_node_snap.asset_key
+        )
+        if freshness_state_record is None:
+            return GrapheneAssetHealthStatus.UNKNOWN, None
+        state = freshness_state_record.freshness_state
+        if state == FreshnessState.PASS:
+            return GrapheneAssetHealthStatus.HEALTHY, None
+
+        asset_record = await AssetRecord.gen(graphene_info.context, self._asset_node_snap.asset_key)
+        last_materialization = (
+            asset_record.asset_entry.last_materialization.timestamp
+            if asset_record and asset_record.asset_entry.last_materialization
+            else None
+        )
+        if state == FreshnessState.WARN:
+            return GrapheneAssetHealthStatus.WARNING, GrapheneAssetHealthFreshnessMeta(
+                lastMaterializedTimestamp=last_materialization,
+            )
+        if state == FreshnessState.FAIL:
+            return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthFreshnessMeta(
+                lastMaterializedTimestamp=last_materialization,
+            )
+
+        return GrapheneAssetHealthStatus.UNKNOWN, None
+
+    async def resolve_freshnessStatus(self, graphene_info: ResolveInfo):
+        if self.freshness_status is None:
+            (
+                self.freshness_status,
+                self.freshness_status_metadata,
+            ) = await self.get_freshness_status_for_asset_health(graphene_info)
+        return self.freshness_status
+
+    async def resolve_freshnessStatusMetadata(self, graphene_info: ResolveInfo):
+        if self.freshness_status_metadata is None:
+            (
+                self.freshness_status,
+                self.freshness_status_metadata,
+            ) = await self.get_freshness_status_for_asset_health(graphene_info)
+        return self.freshness_status_metadata
+
     def resolve_assetHealth(self, graphene_info: ResolveInfo):
         if not graphene_info.context.instance.dagster_observe_supported():
             return GrapheneAssetHealthStatus.UNKNOWN
+        # TODO - don't call the resolvers
         statuses = [
-            self.materializationStatus,
-            self.assetChecksStatus,
-            self.freshnessStatus,
+            self.resolve_materializationStatus(graphene_info),
+            self.resolve_assetChecksStatus(graphene_info),
+            self.resolve_freshnessStatus(graphene_info),
         ]
         if GrapheneAssetHealthStatus.DEGRADED in statuses:
             return GrapheneAssetHealthStatus.DEGRADED


### PR DESCRIPTION
## Summary & Motivation
Moves the asset health computations to `asset_health.py` instead of in `asset_graph.py` with the other assetNode resolvers. This makes it more organized (all asset health related GQL stuff is in one file) and makes it so that you can query for just the freshness status and not have to recompute all other statuses.

no logic changes, just moving code

## How I Tested These Changes
existing tests
