### PR TITLE
Allow deserialize_value to take generic type

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -5,7 +5,6 @@ import pytest
 from click.testing import CliRunner
 from dagster._core.test_utils import ensure_dagster_tests_import, new_cwd
 from dagster.components.cli import cli
-from dagster_shared import check
 from dagster_shared.serdes.objects import (
     ComponentFeatureData,
     PluginObjectKey,
@@ -40,7 +39,7 @@ def test_list_library_objects_from_module():
     # Now check what we get when we load directly from the test library. This has stable results.
     result = runner.invoke(cli, ["list", "library", "--no-entry-points", "dagster_test.components"])
     assert result.exit_code == 0
-    result = check.is_list(deserialize_value(result.output), PluginObjectSnap)
+    result = deserialize_value(result.output, as_type=list[PluginObjectSnap])
     assert len(result) > 1
 
     assert [obj.key.to_typename() for obj in result] == [

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 import click
-from dagster_shared import check
 from dagster_shared.record import as_dict
 from dagster_shared.serdes import deserialize_value
 from dagster_shared.serdes.objects import PluginObjectSnap
 from dagster_shared.serdes.objects.definition_metadata import (
     DgAssetCheckMetadata,
     DgAssetMetadata,
+    DgDefinitionMetadata,
     DgJobMetadata,
     DgScheduleMetadata,
     DgSensorMetadata,
@@ -292,7 +292,7 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
         last_decode_error = None
         for line in result.splitlines():
             try:
-                defs_list = check.is_list(deserialize_value(line))
+                defs_list = deserialize_value(line, as_type=list[DgDefinitionMetadata])
                 return defs_list
             except json.decoder.JSONDecodeError as e:
                 last_decode_error = e

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -4,7 +4,6 @@ import re
 from collections.abc import Iterable, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import dagster_shared.check as check
 from dagster_shared.serdes import deserialize_value, serialize_value
 from dagster_shared.serdes.objects import PluginObjectKey, PluginObjectSnap
 from dagster_shared.serdes.objects.package_entry import PluginObjectFeature
@@ -160,7 +159,7 @@ def _load_module_library_objects(
 def _parse_raw_registry_data(
     raw_registry_data: str,
 ) -> dict[PluginObjectKey, PluginObjectSnap]:
-    deserialized = check.is_list(deserialize_value(raw_registry_data), of_type=PluginObjectSnap)
+    deserialized = deserialize_value(raw_registry_data, as_type=list[PluginObjectSnap])
     return {obj.key: obj for obj in deserialized}
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -21,6 +21,7 @@ import click
 import tomlkit
 import tomlkit.items
 from click.core import ParameterSource
+from dagster_shared.match import match_type
 from dagster_shared.merger import deep_merge_dicts
 from dagster_shared.plus.config import load_config
 from dagster_shared.utils import remove_none_recursively
@@ -418,7 +419,7 @@ def _validate_cli_config(cli_opts: Mapping[str, object]) -> DgRawCliConfig:
 
 
 def _validate_cli_config_setting(cli_opts: Mapping[str, object], key: str, type_: type) -> None:
-    if key in cli_opts and not _match_type(cli_opts[key], type_):
+    if key in cli_opts and not match_type(cli_opts[key], type_):
         raise DgValidationError(f"`{key}` must be a {type_.__name__}.")
 
 
@@ -713,7 +714,7 @@ class _DgConfigValidator:
         error_type = None
         if is_required and key not in section:
             error_type = "required"
-        if key in section and not _match_type(section[key], class_):
+        if key in section and not match_type(section[key], class_):
             error_type = "mistype"
         if error_type:
             full_key = f"{path_prefix}.{key}" if path_prefix else key
@@ -769,64 +770,3 @@ def _get_origin_name(origin: Any) -> str:
         return "Sequence"  # avoid the collections.abc prefix
     else:
         return origin.__name__
-
-
-def _match_type(obj: object, type_: Any) -> bool:
-    origin = get_origin(type_)
-    # If typ is not a generic alias, do a normal isinstance check
-    if origin is None:
-        # Edge case: Union can appear as typing.Union without origin in older versions,
-        # but with modern Python, get_origin should handle it.
-        # If we get here, it's a concrete type like `int`, `str`, or type(None).
-        return isinstance(obj, type_)
-
-    # Handle Union (e.g. Union[int, str])
-    if origin is Union:
-        subtypes = get_args(type_)  # e.g. (int, str)
-        return any(_match_type(obj, st) for st in subtypes)
-
-    # Handle Literal (e.g. Literal[3, 5, "hello"])
-    if origin is Literal:
-        # get_args(typ) will be the allowed literal values
-        allowed_values = get_args(type_)  # e.g. (3, 5, "hello")
-        return obj in allowed_values
-
-    # Handle list[...] (e.g. list[str])
-    if origin is Sequence:
-        (item_type,) = get_args(type_)  # e.g. (str,) for list[str]
-        if not isinstance(obj, Sequence):
-            return False
-        return all(_match_type(item, item_type) for item in obj)
-
-    # Handle list[...] (e.g. list[str])
-    if origin is list:
-        (item_type,) = get_args(type_)  # e.g. (str,) for list[str]
-        if not isinstance(obj, list):
-            return False
-        return all(_match_type(item, item_type) for item in obj)
-
-    # Handle tuple[...] (e.g. tuple[int, str], tuple[str, ...])
-    if origin is tuple:
-        arg_types = get_args(type_)
-        if not isinstance(obj, tuple):
-            return False
-        # Distinguish fixed-length vs variable-length (ellipsis) tuples
-        if len(arg_types) == 2 and arg_types[1] is Ellipsis:
-            # e.g. tuple[str, ...]
-            elem_type = arg_types[0]
-            return all(_match_type(item, elem_type) for item in obj)
-        else:
-            # e.g. tuple[int, str, float]
-            if len(obj) != len(arg_types):
-                return False
-            return all(_match_type(item, t) for item, t in zip(obj, arg_types))
-
-    # Handle dict[...] (e.g. dict[str, int])
-    if origin is dict:
-        key_type, val_type = get_args(type_)
-        if not isinstance(obj, dict):
-            return False
-        return all(_match_type(k, key_type) and _match_type(v, val_type) for k, v in obj.items())
-
-    # Extend with other generic types (set, frozenset, etc.) if needed
-    raise NotImplementedError(f"No handler for {type_}")

--- a/python_modules/libraries/dagster-shared/dagster_shared/match.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/match.py
@@ -1,0 +1,89 @@
+from collections.abc import Sequence
+from typing import Any, ForwardRef, Literal, NamedTuple, TypeVar, Union, get_args, get_origin
+
+from typing_extensions import TypeGuard
+
+T = TypeVar("T", bound=Any)
+
+
+# Use Any for type_ because there isn't a good static type that can handle all the cases listed
+# here.
+def match_type(obj: object, type_: Union[type[T], tuple[type[T]]]) -> TypeGuard[T]:
+    if isinstance(type_, tuple):
+        return any(match_type(obj, t) for t in type_)
+
+    origin = get_origin(type_)
+    # If typ is not a generic alias, do a normal isinstance check
+    if origin is None:
+        # If we get here, it's a concrete type like `int`, `str`, or type(None).
+        if type_ is Any:
+            return True
+        elif type_ is NamedTuple:
+            return is_named_tuple_instance(obj)
+        elif isinstance(type_, ForwardRef):
+            raise NotImplementedError(
+                f"Got ForwardRef {type_}. ForwardRef is not supported by `match_type`"
+            )
+        else:
+            return isinstance(obj, type_)
+
+    # Handle Union (e.g. Union[int, str])
+    if origin is Union:
+        subtypes = get_args(type_)  # e.g. (int, str)
+        return any(match_type(obj, st) for st in subtypes)
+
+    # Handle Literal (e.g. Literal[3, 5, "hello"])
+    if origin is Literal:
+        # get_args(typ) will be the allowed literal values
+        allowed_values = get_args(type_)  # e.g. (3, 5, "hello")
+        return obj in allowed_values
+
+    # Handle list[...] (e.g. list[str])
+    if origin is Sequence:
+        (item_type,) = get_args(type_)  # e.g. (str,) for list[str]
+        if not isinstance(obj, Sequence):
+            return False
+        return all(match_type(item, item_type) for item in obj)
+
+    # Handle list[...] (e.g. list[str])
+    if origin is list:
+        (item_type,) = get_args(type_)  # e.g. (str,) for list[str]
+        if not isinstance(obj, list):
+            return False
+        return all(match_type(item, item_type) for item in obj)
+
+    # Handle tuple[...] (e.g. tuple[int, str], tuple[str, ...])
+    if origin is tuple:
+        arg_types = get_args(type_)
+        if not isinstance(obj, tuple):
+            return False
+        # Distinguish fixed-length vs variable-length (ellipsis) tuples
+        if len(arg_types) == 2 and arg_types[1] is Ellipsis:
+            # e.g. tuple[str, ...]
+            elem_type = arg_types[0]
+            return all(match_type(item, elem_type) for item in obj)
+        else:
+            # e.g. tuple[int, str, float]
+            if len(obj) != len(arg_types):
+                return False
+            return all(match_type(item, t) for item, t in zip(obj, arg_types))
+
+    # Handle dict[...] (e.g. dict[str, int])
+    if origin is dict:
+        key_type, val_type = get_args(type_)
+        if not isinstance(obj, dict):
+            return False
+        return all(match_type(k, key_type) and match_type(v, val_type) for k, v in obj.items())
+
+    # Extend with other generic types (set, frozenset, etc.) if needed
+    raise NotImplementedError(f"No handler for {type_}")
+
+
+# copied from dagster._utils
+def is_named_tuple_instance(obj: object) -> TypeGuard[NamedTuple]:
+    return isinstance(obj, tuple) and hasattr(obj, "_fields")
+
+
+# copied from dagster._utils
+def is_named_tuple_subclass(klass: type[object]) -> TypeGuard[type[NamedTuple]]:
+    return isinstance(klass, type) and issubclass(klass, tuple) and hasattr(klass, "_fields")

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/definition_metadata.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/definition_metadata.py
@@ -5,14 +5,6 @@ from typing_extensions import TypeAlias
 from dagster_shared.record import record
 from dagster_shared.serdes import whitelist_for_serdes
 
-DgDefinitionMetadata: TypeAlias = Union[
-    "DgAssetMetadata",
-    "DgSensorMetadata",
-    "DgScheduleMetadata",
-    "DgJobMetadata",
-    "DgAssetCheckMetadata",
-]
-
 
 @whitelist_for_serdes
 @record
@@ -52,3 +44,12 @@ class DgAssetCheckMetadata:
     name: str
     additional_deps: list[str]
     description: Optional[str]
+
+
+DgDefinitionMetadata: TypeAlias = Union[
+    DgAssetMetadata,
+    DgSensorMetadata,
+    DgScheduleMetadata,
+    DgJobMetadata,
+    DgAssetCheckMetadata,
+]

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_match.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_match.py
@@ -1,0 +1,63 @@
+from collections.abc import Sequence
+from typing import Any, Literal, NamedTuple, Union
+
+import pytest
+from dagster_shared.match import match_type
+
+
+# Helper to simulate the is_named_tuple_instance logic used in match_type
+class MyTuple(NamedTuple):
+    x: int
+    y: str
+
+
+@pytest.mark.parametrize(
+    "obj,type_,expected",
+    [
+        # Concrete types
+        (5, int, True),
+        ("hello", str, True),
+        (None, type(None), True),
+        (5.5, int, False),
+        (5.5, Any, True),
+        ("abc", Any, True),
+        ([1], Any, True),
+        # Union
+        (5, Union[int, str], True),
+        ("hi", Union[int, str], True),
+        (5.0, Union[int, str], False),
+        # Literal
+        ("hello", Literal["hello", "world"], True),
+        ("nope", Literal["hello", "world"], False),
+        (3, Literal[3, 5], True),
+        (4, Literal[3, 5], False),
+        # list[]
+        ([1, 2, 3], list[int], True),
+        ([1, "x"], list[int], False),
+        ([], list[int], True),
+        # Sequence[] support
+        ([1, 2], Sequence[int], True),
+        ((1, 2), Sequence[int], True),
+        ({1, 2}, Sequence[int], False),
+        # tuple[...] fixed-length
+        ((1, "x"), tuple[int, str], True),
+        ((1, 2), tuple[int, str], False),
+        ((1,), tuple[int, str], False),
+        # tuple[...] variable-length
+        ((1, 2, 3), tuple[int, ...], True),
+        ((1, "x"), tuple[int, ...], False),
+        # dict[]
+        ({"a": 1, "b": 2}, dict[str, int], True),
+        ({"a": 1, 2: "b"}, dict[str, int], False),
+        ({}, dict[str, int], True),
+        # NamedTuple
+        (MyTuple(1, "a"), NamedTuple, True),
+        ((1, "a"), NamedTuple, False),
+        # tuple of types
+        ("abc", (int, str), True),
+        ("abc", (int, Literal["abc", "def"]), True),
+        ("ghi", (int, Literal["abc", "def"]), False),
+    ],
+)
+def test_match_type(obj, type_, expected):
+    assert match_type(obj, type_) == expected


### PR DESCRIPTION
## Summary & Motivation

- Moves `match_type` utility function from `dagster-dg` to `dagster-shared`
- Use this in `deserialize_value`

This permits stuff like:

```
deserialize_value(val, list[SomeSerdesType])
```

Where previously you needed to do `check.is_list(deserialize_value(val), of_type=SomeSerdesType)`. The new form will throw a `DeserializationError` instead of a check error.

This was motivated by the desire to detect deserialization errors in dg when loading the cache so that we can gracefully ignore them and refetch: https://github.com/dagster-io/dagster/pull/29434

## How I Tested These Changes

New unit tests.