### PR TITLE
Wrap AssetView with key

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {BreadcrumbProps} from '@blueprintjs/core';
 import {Alert, Box, ErrorBoundary, Spinner, Tag} from '@dagster-io/ui-components';
-import {useContext, useEffect, useMemo} from 'react';
+import React, {useContext, useEffect, useMemo} from 'react';
 import {Link, Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
@@ -58,7 +58,11 @@ interface Props {
   currentPath: string[];
 }
 
-export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPath}: Props) => {
+export const AssetView = React.memo((props: Props) => {
+  return <AssetViewImpl {...props} key={tokenForAssetKey(props.assetKey)} />;
+});
+
+const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPath}: Props) => {
   const [params, setParams] = useAssetViewParams();
   const {useTabBuilder, renderFeatureView} = useContext(AssetFeatureContext);
 


### PR DESCRIPTION
## Summary & Motivation

We got a report that the materialize button on the asset page was materializing a previously visited page. This suggests that we're reusing the <LaunchAssetExecutionButton/> in the page header and likely other elements on the page. To prevent this issue lets set a key so that we don't re-use the component instance.