### PR TITLE
asset check health uses streamline

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -78,7 +78,7 @@ async def _compute_asset_check_status_counts(
                 num_warning += 1
             else:
                 num_failed += 1
-        if last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+        elif last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
             # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
             # degraded health anyway.
             num_failed += 1
@@ -119,9 +119,9 @@ def _get_asset_check_status_counts_from_asset_health_state(
                 num_warning += 1
             else:
                 num_failed += 1
-        if status == AssetCheckExecutionResolvedStatus.SUCCEEDED:
+        elif status == AssetCheckExecutionResolvedStatus.SUCCEEDED:
             num_passing += 1
-        if status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+        elif status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
             # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
             # degraded health.
             num_failed += 1

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -128,7 +128,7 @@ async def get_asset_check_status_counts(
     for the asset can be computed. If streamline is enabled, use the data from streamline since it is a
     more performant query. Otherwise, compute the status counts from the data available in the db.
     """
-    if graphene_info.context.instance.streamline_read_supported():
+    if graphene_info.context.instance.streamline_read_asset_health_supported():
         asset_check_health_state = (
             graphene_info.context.instance.get_asset_check_health_state_for_asset(asset_key)
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -1,0 +1,165 @@
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.remote_asset_graph import RemoteAssetCheckNode
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
+from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
+from dagster._streamline.asset_check_health import AssetCheckHealthState
+from dagster_shared.record import record
+
+if TYPE_CHECKING:
+    from dagster_graphql.schema.util import ResolveInfo
+
+
+@record
+class AssetChecksStatusCounts:
+    num_passing: int
+    num_warning: int
+    num_failed: int
+    num_unexecuted: int
+    total_num: int
+
+
+async def _compute_asset_check_status_counts(
+    graphene_info: "ResolveInfo", asset_key: AssetKey
+) -> AssetChecksStatusCounts:
+    """Computes the number of asset checks in each terminal state for an asset so that the overall
+    health can be computed in asset_check_health_status_and_metadata_from_counts. Does this by fetching the
+    asset check summary record for each check and checking the status of the latest completed execution.
+    """
+    remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
+
+    total_num_checks = len(remote_check_nodes)
+    num_failed = 0
+    num_warning = 0
+    num_passing = 0
+    num_unexecuted_checks = 0
+    asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
+        graphene_info.context,
+        [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
+    )
+    for summary_record in asset_check_summary_records:
+        if summary_record is None or summary_record.last_check_execution_record is None:
+            # the check has never been executed.
+            num_unexecuted_checks += 1
+            continue
+
+        # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
+        # but we check the last_check_execution_record status first since there is an edge case
+        # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
+        # because the run for the check failed.
+        last_check_execution_status = (
+            await summary_record.last_check_execution_record.resolve_status(graphene_info.context)
+        )
+        last_check_evaluation = summary_record.last_check_execution_record.evaluation
+
+        if last_check_execution_status in [
+            AssetCheckExecutionResolvedStatus.IN_PROGRESS,
+            AssetCheckExecutionResolvedStatus.SKIPPED,
+        ]:
+            # the last check is still in progress or is skipped, so we want to check the status of
+            # the latest completed check instead
+            if summary_record.last_completed_check_execution_record is None:
+                # the check hasn't been executed prior to this in progress check
+                num_unexecuted_checks += 1
+                continue
+            last_check_execution_status = (
+                await summary_record.last_completed_check_execution_record.resolve_status(
+                    graphene_info.context
+                )
+            )
+            last_check_evaluation = summary_record.last_completed_check_execution_record.evaluation
+
+        if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
+            # failed checks should always have an evaluation, but default to ERROR if not
+            if last_check_evaluation.severity == AssetCheckSeverity.WARN:
+                num_warning += 1
+            else:
+                num_failed += 1
+        if last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+            # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
+            # degraded health anyway.
+            num_failed += 1
+        else:
+            # asset check passed
+            num_passing += 1
+
+    return AssetChecksStatusCounts(
+        num_failed=num_failed,
+        num_warning=num_warning,
+        num_unexecuted=num_unexecuted_checks,
+        total_num=total_num_checks,
+        num_passing=num_passing,
+    )
+
+
+def _get_asset_check_status_counts_from_asset_health_state(
+    asset_check_health_state: AssetCheckHealthState,
+    remote_check_nodes: Sequence[RemoteAssetCheckNode],
+) -> AssetChecksStatusCounts:
+    """Converts the asset check health data from streamline into the number of asset checks in each
+    terminal state for an asset.
+    """
+    total_num_checks = len(remote_check_nodes)
+    latest_execution_per_key = {
+        check_key: status_tuples[0]
+        for check_key, status_tuples in asset_check_health_state.latest_evaluations.items()
+    }
+
+    num_failed = 0
+    num_warning = 0
+    num_passing = 0
+    for status, severity, _ in latest_execution_per_key.values():
+        # asset checks only get documented in AssetCheckHealthState if they are in a terminal state, so don't
+        # need to check for IN_PROGRESSS or SKIPPED
+        if status == AssetCheckExecutionResolvedStatus.FAILED:
+            if severity == AssetCheckSeverity.WARN:
+                num_warning += 1
+            else:
+                num_failed += 1
+        if status == AssetCheckExecutionResolvedStatus.SUCCEEDED:
+            num_passing += 1
+        if status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+            # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
+            # degraded health.
+            num_failed += 1
+
+    return AssetChecksStatusCounts(
+        num_failed=num_failed,
+        num_warning=num_warning,
+        num_unexecuted=total_num_checks - len(latest_execution_per_key.keys()),
+        total_num=total_num_checks,
+        num_passing=num_passing,
+    )
+
+
+async def get_asset_check_status_counts(
+    graphene_info: "ResolveInfo",
+    asset_key: AssetKey,
+    remote_check_nodes: Sequence[RemoteAssetCheckNode],
+) -> AssetChecksStatusCounts:
+    """Gets the number of asset checks in each terminal state for an asset so that the overall health
+    for the asset can be computed. If streamline is enabled, use the data from streamline since it is a
+    more performant query. Otherwise, compute the status counts from the data available in the db.
+    """
+    if graphene_info.context.instance.streamline_read_supported():
+        asset_check_health_state = (
+            graphene_info.context.instance.get_asset_check_health_state_for_asset(asset_key)
+        )
+        if asset_check_health_state is None:
+            # asset_check_health_state_for is only None if no checks have been executed
+            return AssetChecksStatusCounts(
+                num_failed=0,
+                num_warning=0,
+                num_unexecuted=len(remote_check_nodes),
+                total_num=len(remote_check_nodes),
+                num_passing=0,
+            )
+
+        return _get_asset_check_status_counts_from_asset_health_state(
+            asset_check_health_state, remote_check_nodes
+        )
+    # otherwise compute the status counts from scratch
+    return await _compute_asset_check_status_counts(graphene_info)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -74,7 +74,7 @@ async def _compute_asset_check_status_counts(
 
         if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
             # failed checks should always have an evaluation, but default to ERROR if not
-            if last_check_evaluation.severity == AssetCheckSeverity.WARN:
+            if last_check_evaluation and last_check_evaluation.severity == AssetCheckSeverity.WARN:
                 num_warning += 1
             else:
                 num_failed += 1
@@ -162,4 +162,4 @@ async def get_asset_check_status_counts(
             asset_check_health_state, remote_check_nodes
         )
     # otherwise compute the status counts from scratch
-    return await _compute_asset_check_status_counts(graphene_info)
+    return await _compute_asset_check_status_counts(graphene_info, asset_key)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -543,9 +543,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def is_executable(self) -> bool:
         return self._asset_node_snap.is_executable
 
-    async def resolve_assetHealth(
-        self, graphene_info: ResolveInfo
-    ) -> Optional[GrapheneAssetHealth]:
+    def resolve_assetHealth(self, graphene_info: ResolveInfo) -> Optional[GrapheneAssetHealth]:
         if not graphene_info.context.instance.dagster_observe_supported():
             return None
         return GrapheneAssetHealth(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -1,18 +1,13 @@
 import asyncio
-from collections.abc import Sequence
 from typing import Optional
 
 import graphene
 from dagster import _check as check
-from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.freshness import FreshnessState
-from dagster._core.definitions.remote_asset_graph import RemoteAssetCheckNode
-from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
 from dagster._core.storage.dagster_run import RunRecord
-from dagster._core.storage.event_log.base import AssetCheckSummaryRecord, AssetRecord
-from dagster._streamline.asset_check_health import AssetCheckHealthState
-from dagster_shared.record import record
+from dagster._core.storage.event_log.base import AssetRecord
 
+from dagster_graphql.implementation.fetch_asset_health import get_asset_check_status_counts
 from dagster_graphql.implementation.fetch_partition_subsets import (
     regenerate_and_check_partition_subsets,
 )
@@ -104,15 +99,6 @@ class GrapheneAssetHealthFreshnessMeta(graphene.ObjectType):
 
     class Meta:
         name = "AssetHealthFreshnessMeta"
-
-
-@record
-class AssetChecksStatusCounts:
-    num_passing: int
-    num_warning: int
-    num_failed: int
-    num_unexecuted: int
-    total_num: int
 
 
 class GrapheneAssetHealth(graphene.ObjectType):
@@ -295,7 +281,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
         _, materialization_status_metadata = await self.materialization_status_task
         return materialization_status_metadata
 
-    async def get_asset_check_health_status_and_metadata(self, graphene_info):
+    async def get_asset_check_health_status_and_metadata(self, graphene_info: ResolveInfo):
         """Computes the health indicator for the asset checks for the assets. Follows these rules:
         HEALTHY - the latest completed execution for every check is a success.
         WARNING - the latest completed execution for any asset check failed with severity WARN
@@ -314,28 +300,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
             # asset doesn't have checks defined
             return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
 
-        # if we can read the asset check statuses from streamline, do that
-        if graphene_info.context.instance.streamline_read_supported():
-            asset_check_health_state = (
-                graphene_info.context.instance.get_asset_check_health_state_for_asset(
-                    self._asset_node_snap.asset_key
-                )
-            )
-            if asset_check_health_state is None:
-                # asset_check_health_state_for is only None if no checks have been executed
-                return (
-                    GrapheneAssetHealthStatus.UNKNOWN,
-                    GrapheneAssetHealthCheckUnknownMeta(
-                        numNotExecutedChecks=len(remote_check_nodes),
-                        totalNumChecks=len(remote_check_nodes),
-                    ),
-                )
-            asset_check_counts = self.get_asset_check_status_counts_from_asset_health_state(
-                asset_check_health_state, remote_check_nodes
-            )
-        else:
-            # otherwise compute the status counts from scratch
-            asset_check_counts = await self.compute_asset_check_status_counts(graphene_info)
+        asset_check_counts = await get_asset_check_status_counts(
+            graphene_info, self._asset_node_snap.asset_key, remote_check_nodes
+        )
 
         if asset_check_counts.num_failed > 0:
             return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthCheckDegradedMeta(
@@ -360,120 +327,6 @@ class GrapheneAssetHealth(graphene.ObjectType):
             )
         # all checks must have executed and passed
         return GrapheneAssetHealthStatus.HEALTHY, None
-
-    async def compute_asset_check_status_counts(
-        self, graphene_info: ResolveInfo
-    ) -> AssetChecksStatusCounts:
-        """Computes the number of asset checks in each terminal state for an asset so that the overall
-        health can be computed in asset_check_health_status_and_metadata_from_counts.
-        """
-        remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(
-            self._asset_node_snap.asset_key
-        )
-
-        total_num_checks = len(remote_check_nodes)
-        num_failed = 0
-        num_warning = 0
-        num_passing = 0
-        num_unexecuted_checks = 0
-        asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
-            graphene_info.context,
-            [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
-        )
-        for summary_record in asset_check_summary_records:
-            if summary_record is None or summary_record.last_check_execution_record is None:
-                # the check has never been executed.
-                num_unexecuted_checks += 1
-                continue
-
-            # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
-            # but we check the last_check_execution_record status first since there is an edge case
-            # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
-            # because the run for the check failed.
-            last_check_execution_status = (
-                await summary_record.last_check_execution_record.resolve_status(
-                    graphene_info.context
-                )
-            )
-            last_check_evaluation = summary_record.last_check_execution_record.evaluation
-
-            if last_check_execution_status in [
-                AssetCheckExecutionResolvedStatus.IN_PROGRESS,
-                AssetCheckExecutionResolvedStatus.SKIPPED,
-            ]:
-                # the last check is still in progress or is skipped, so we want to check the status of
-                # the latest completed check instead
-                if summary_record.last_completed_check_execution_record is None:
-                    # the check hasn't been executed prior to this in progress check
-                    num_unexecuted_checks += 1
-                    continue
-                last_check_execution_status = (
-                    await summary_record.last_completed_check_execution_record.resolve_status(
-                        graphene_info.context
-                    )
-                )
-                last_check_evaluation = (
-                    summary_record.last_completed_check_execution_record.evaluation
-                )
-
-            if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
-                # failed checks should always have an evaluation, but default to ERROR if not
-                if last_check_evaluation.severity == AssetCheckSeverity.WARN:
-                    num_warning += 1
-                else:
-                    num_failed += 1
-            if last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
-                # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
-                # degraded health anyway.
-                num_failed += 1
-            else:
-                # asset check passed
-                num_passing += 1
-
-        return AssetChecksStatusCounts(
-            num_failed=num_failed,
-            num_warning=num_warning,
-            num_unexecuted=num_unexecuted_checks,
-            total_num=total_num_checks,
-            num_passing=num_passing,
-        )
-
-    def get_asset_check_status_counts_from_asset_health_state(
-        self,
-        asset_check_health_state: AssetCheckHealthState,
-        remote_check_nodes: Sequence[RemoteAssetCheckNode],
-    ) -> AssetChecksStatusCounts:
-        total_num_checks = len(remote_check_nodes)
-        latest_execution_per_key = {
-            check_key: status_tuples[0]
-            for check_key, status_tuples in asset_check_health_state.latest_evaluations.items()
-        }
-
-        num_failed = 0
-        num_warning = 0
-        num_passing = 0
-        for status, severity, _ in latest_execution_per_key.values():
-            # asset checks only get documented in AssetCheckHealthState if they are in a terminal state, so don't
-            # need to check for IN_PROGRESSS or SKIPPED
-            if status == AssetCheckExecutionResolvedStatus.FAILED:
-                if severity == AssetCheckSeverity.WARN:
-                    num_warning += 1
-                else:
-                    num_failed += 1
-            if status == AssetCheckExecutionResolvedStatus.SUCCEEDED:
-                num_passing += 1
-            if status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
-                # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
-                # degraded health.
-                num_failed += 1
-
-        return AssetChecksStatusCounts(
-            num_failed=num_failed,
-            num_warning=num_warning,
-            num_unexecuted=total_num_checks - len(latest_execution_per_key.keys()),
-            total_num=total_num_checks,
-            num_passing=num_passing,
-        )
 
     async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo):
         if self.asset_check_status_task is None:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -265,7 +265,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
 
             return fallback_status_and_meta
 
-    async def resolve_materializationStatus(self, graphene_info: ResolveInfo):
+    async def resolve_materializationStatus(self, graphene_info: ResolveInfo) -> str:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
                 self.get_materialization_status_for_asset_health(graphene_info)
@@ -273,7 +273,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
         materialization_status, _ = await self.materialization_status_task
         return materialization_status
 
-    async def resolve_materializationStatusMetadata(self, graphene_info: ResolveInfo):
+    async def resolve_materializationStatusMetadata(
+        self, graphene_info: ResolveInfo
+    ) -> GrapheneAssetHealthMaterializationMeta:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
                 self.get_materialization_status_for_asset_health(graphene_info)
@@ -328,19 +330,21 @@ class GrapheneAssetHealth(graphene.ObjectType):
         # all checks must have executed and passed
         return GrapheneAssetHealthStatus.HEALTHY, None
 
-    async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo):
+    async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo) -> str:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                self.get_asset_check_status_for_asset_health(graphene_info)
+                self.get_asset_check_health_status_and_metadata(graphene_info)
             )
 
         asset_checks_status, _ = await self.asset_check_status_task
         return asset_checks_status
 
-    async def resolve_assetChecksStatusMetadata(self, graphene_info: ResolveInfo):
+    async def resolve_assetChecksStatusMetadata(
+        self, graphene_info: ResolveInfo
+    ) -> GrapheneAssetHealthCheckMeta:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                self.get_asset_check_status_for_asset_health(graphene_info)
+                self.get_asset_check_health_status_and_metadata(graphene_info)
             )
 
         _, asset_checks_status_metadata = await self.asset_check_status_task
@@ -385,7 +389,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
 
         return GrapheneAssetHealthStatus.UNKNOWN, None
 
-    async def resolve_freshnessStatus(self, graphene_info: ResolveInfo):
+    async def resolve_freshnessStatus(self, graphene_info: ResolveInfo) -> str:
         if self.freshness_status_task is None:
             self.freshness_status_task = asyncio.create_task(
                 self.get_freshness_status_for_asset_health(graphene_info)
@@ -394,7 +398,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
         freshness_status, _ = await self.freshness_status_task
         return freshness_status
 
-    async def resolve_freshnessStatusMetadata(self, graphene_info: ResolveInfo):
+    async def resolve_freshnessStatusMetadata(
+        self, graphene_info: ResolveInfo
+    ) -> GrapheneAssetHealthFreshnessMeta:
         if self.freshness_status_task is None:
             self.freshness_status_task = asyncio.create_task(
                 self.get_freshness_status_for_asset_health(graphene_info)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -283,7 +283,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
         _, materialization_status_metadata = await self.materialization_status_task
         return materialization_status_metadata
 
-    async def get_asset_check_health_status_and_metadata(self, graphene_info: ResolveInfo):
+    async def get_asset_check_health_status_and_metadata(
+        self, graphene_info: ResolveInfo
+    ) -> tuple[str, Optional[GrapheneAssetHealthCheckMeta]]:
         """Computes the health indicator for the asset checks for the assets. Follows these rules:
         HEALTHY - the latest completed execution for every check is a success.
         WARNING - the latest completed execution for any asset check failed with severity WARN

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3539,7 +3539,7 @@ class DagsterInstance(DynamicPartitionsStore):
     def internal_asset_freshness_enabled(self) -> bool:
         return False
 
-    def streamline_read_supported(self) -> bool:
+    def streamline_read_asset_health_supported(self) -> bool:
         return False
 
     def get_asset_check_health_state_for_asset(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3536,10 +3536,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def can_read_failure_events_for_asset(self, asset_record: "AssetRecord") -> bool:
         return False
 
-<<<<<<< HEAD
     def internal_asset_freshness_enabled(self) -> bool:
         return False
-=======
+
     def streamline_read_supported(self) -> bool:
         return False
 
@@ -3547,4 +3546,3 @@ class DagsterInstance(DynamicPartitionsStore):
         self, asset_key: AssetKey
     ) -> Optional[AssetCheckHealthState]:
         return None
->>>>>>> 5b793a02ff (asset check health uses streamline)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -84,6 +84,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.types.pagination import PaginatedResults
 from dagster._serdes import ConfigurableClass
+from dagster._streamline.asset_check_health import AssetCheckHealthState
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -3535,5 +3536,15 @@ class DagsterInstance(DynamicPartitionsStore):
     def can_read_failure_events_for_asset(self, asset_record: "AssetRecord") -> bool:
         return False
 
+<<<<<<< HEAD
     def internal_asset_freshness_enabled(self) -> bool:
         return False
+=======
+    def streamline_read_supported(self) -> bool:
+        return False
+
+    def get_asset_check_health_state_for_asset(
+        self, asset_key: AssetKey
+    ) -> Optional[AssetCheckHealthState]:
+        return None
+>>>>>>> 5b793a02ff (asset check health uses streamline)

--- a/python_modules/dagster/dagster/_streamline/asset_check_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_check_health.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING, Optional
+
+from dagster_shared import record
+from dagster_shared.serdes import whitelist_for_serdes
+
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+
+if TYPE_CHECKING:
+    from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
+
+
+@whitelist_for_serdes
+@record.record
+class AssetCheckHealthState:
+    # maps check_key -> list of (status, severity, evaluation | None)
+    # maintains the latest 5 completed evaluations for each check
+    latest_evaluations: dict[
+        str,
+        list[
+            tuple[
+                "AssetCheckExecutionResolvedStatus",
+                AssetCheckSeverity,
+                Optional[AssetCheckEvaluation],
+            ]
+        ],
+    ]

--- a/python_modules/dagster/dagster/_streamline/asset_check_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_check_health.py
@@ -1,27 +1,16 @@
-from typing import TYPE_CHECKING, Optional
-
 from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
-from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
-from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
-
-if TYPE_CHECKING:
-    from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
+from dagster._core.definitions.asset_key import AssetCheckKey
 
 
 @whitelist_for_serdes
 @record.record
 class AssetCheckHealthState:
-    # maps check_key -> list of (status, severity, evaluation | None)
-    # maintains the latest 5 completed evaluations for each check
-    latest_evaluations: dict[
-        str,
-        list[
-            tuple[
-                "AssetCheckExecutionResolvedStatus",
-                AssetCheckSeverity,
-                Optional[AssetCheckEvaluation],
-            ]
-        ],
-    ]
+    """Maintains a list of asset checks for the asset in each terminal state. If a check is in progress,
+    it will not move to a new list until the execution is complete.
+    """
+
+    passing_checks: set[AssetCheckKey]
+    failing_checks: set[AssetCheckKey]
+    warning_checks: set[AssetCheckKey]


### PR DESCRIPTION
## Summary & Motivation
Enables the asset check health resolvers to use data provided by streamline, if available. This should make this query more performant 

- adds a `streamline_read_supported` instance method that is `False` for OSS and has a corresponding internal implementation
- adds a `get_asset_check_health_state_for_asset` that is None for OSS and will fetch the asset check health data from streamline for internal
- refactors the asset check health resolver so that the streamline results and results from manually computing asset check statuses are translated into a common type of the number of each type of check status. Then we can determine the health based on those numbers. 

also adds a gql test util to execute a query within an async test

internal pr https://github.com/dagster-io/internal/pull/15233

TODO:
- need to figure out the rollout plan for the asset health consumer and how to pre-populate the state for all asset checks. Otherwise, every asset will be in an unknown state until new executions occur

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
