### PR TITLE
[docs] Update hello world `dg`

### DIFF
--- a/examples/docs_snippets/docs_snippets/getting-started/hello-world.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/hello-world.py
@@ -11,8 +11,6 @@ def world(context: dg.AssetExecutionContext):
     context.log.info("World!")
 
 
-defs = dg.Definitions(assets=[hello, world])
-
 if __name__ == "__main__":
     dg.materialize(hello)
     dg.materialize(world)


### PR DESCRIPTION
## Summary & Motivation
Updating hello world example on the main page by removing the explicit `Definitions` object. This example would still load probably with `dagster dev -f hello-world.py` and would not need the assets set in the Definitions if scaffolded with `dg`.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
