### PR TITLE
[dg scaffold] Add multi_asset shim

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
@@ -34,6 +34,16 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.multi_asset                                         │ Create a         │ [scaffold-targ… │ │
+│               │ │                                                             │ combined         │                 │ │
+│               │ │                                                             │ definition of    │                 │ │
+│               │ │                                                             │ multiple assets  │                 │ │
+│               │ │                                                             │ that are         │                 │ │
+│               │ │                                                             │ computed using   │                 │ │
+│               │ │                                                             │ the same op and  │                 │ │
+│               │ │                                                             │ same             │                 │ │
+│               │ │                                                             │ upstream assets. │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
 │               │ │                                                             │ schedule         │                 │ │
 │               │ │                                                             │ following the    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
@@ -37,6 +37,17 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                  │ │                                                             │ Dagster's      │                │ │
 │                  │ │                                                             │ PipesSubproce… │                │ │
 │                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
+│                  │ │ dagster.multi_asset                                         │ Create a       │ [scaffold-tar… │ │
+│                  │ │                                                             │ combined       │                │ │
+│                  │ │                                                             │ definition of  │                │ │
+│                  │ │                                                             │ multiple       │                │ │
+│                  │ │                                                             │ assets that    │                │ │
+│                  │ │                                                             │ are computed   │                │ │
+│                  │ │                                                             │ using the same │                │ │
+│                  │ │                                                             │ op and same    │                │ │
+│                  │ │                                                             │ upstream       │                │ │
+│                  │ │                                                             │ assets.        │                │ │
+│                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
 │                  │ │ dagster.schedule                                            │ Creates a      │ [scaffold-tar… │ │
 │                  │ │                                                             │ schedule       │                │ │
 │                  │ │                                                             │ following the  │                │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
@@ -33,6 +33,14 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │         │ │                                                             │ Dagster's          │                     │ │
 │         │ │                                                             │ PipesSubprocessCl… │                     │ │
 │         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.multi_asset                                         │ Create a combined  │ [scaffold-target]   │ │
+│         │ │                                                             │ definition of      │                     │ │
+│         │ │                                                             │ multiple assets    │                     │ │
+│         │ │                                                             │ that are computed  │                     │ │
+│         │ │                                                             │ using the same op  │                     │ │
+│         │ │                                                             │ and same           │                     │ │
+│         │ │                                                             │ upstream assets.   │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
 │         │ │ dagster.schedule                                            │ Creates a schedule │ [scaffold-target]   │ │
 │         │ │                                                             │ following the      │                     │ │
 │         │ │                                                             │ provided cron      │                     │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
@@ -34,6 +34,16 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.multi_asset                                         │ Create a         │ [scaffold-targ… │ │
+│               │ │                                                             │ combined         │                 │ │
+│               │ │                                                             │ definition of    │                 │ │
+│               │ │                                                             │ multiple assets  │                 │ │
+│               │ │                                                             │ that are         │                 │ │
+│               │ │                                                             │ computed using   │                 │ │
+│               │ │                                                             │ the same op and  │                 │ │
+│               │ │                                                             │ same             │                 │ │
+│               │ │                                                             │ upstream assets. │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
 │               │ │                                                             │ schedule         │                 │ │
 │               │ │                                                             │ following the    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
@@ -41,6 +41,18 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                      │ │                                                             │ Dagster's    │              │ │
 │                      │ │                                                             │ PipesSubpro… │              │ │
 │                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.multi_asset                                         │ Create a     │ [scaffold-t… │ │
+│                      │ │                                                             │ combined     │              │ │
+│                      │ │                                                             │ definition   │              │ │
+│                      │ │                                                             │ of multiple  │              │ │
+│                      │ │                                                             │ assets that  │              │ │
+│                      │ │                                                             │ are computed │              │ │
+│                      │ │                                                             │ using the    │              │ │
+│                      │ │                                                             │ same op and  │              │ │
+│                      │ │                                                             │ same         │              │ │
+│                      │ │                                                             │ upstream     │              │ │
+│                      │ │                                                             │ assets.      │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
 │                      │ │ dagster.schedule                                            │ Creates a    │ [scaffold-t… │ │
 │                      │ │                                                             │ schedule     │              │ │
 │                      │ │                                                             │ following    │              │ │

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
@@ -12,6 +12,12 @@ dg list plugins
 │                     │ │                                                             │ compute an   │               │ │
 │                     │ │                                                             │ asset.       │               │ │
 │                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
+│                     │ │ dagster.asset_check                                         │ Create a     │ [scaffold-ta… │ │
+│                     │ │                                                             │ definition   │               │ │
+│                     │ │                                                             │ for how to   │               │ │
+│                     │ │                                                             │ execute an   │               │ │
+│                     │ │                                                             │ asset check. │               │ │
+│                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
 │                     │ │ dagster.components.DefinitionsComponent                     │ An arbitrary │ [component,   │ │
 │                     │ │                                                             │ set of       │ scaffold-tar… │ │
 │                     │ │                                                             │ dagster      │               │ │
@@ -33,6 +39,18 @@ dg list plugins
 │                     │ │                                                             │ with         │               │ │
 │                     │ │                                                             │ Dagster's    │               │ │
 │                     │ │                                                             │ PipesSubpro… │               │ │
+│                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
+│                     │ │ dagster.multi_asset                                         │ Create a     │ [scaffold-ta… │ │
+│                     │ │                                                             │ combined     │               │ │
+│                     │ │                                                             │ definition   │               │ │
+│                     │ │                                                             │ of multiple  │               │ │
+│                     │ │                                                             │ assets that  │               │ │
+│                     │ │                                                             │ are computed │               │ │
+│                     │ │                                                             │ using the    │               │ │
+│                     │ │                                                             │ same op and  │               │ │
+│                     │ │                                                             │ same         │               │ │
+│                     │ │                                                             │ upstream     │               │ │
+│                     │ │                                                             │ assets.      │               │ │
 │                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
 │                     │ │ dagster.schedule                                            │ Creates a    │ [scaffold-ta… │ │
 │                     │ │                                                             │ schedule     │               │ │

--- a/python_modules/dagster/dagster/components/components.py
+++ b/python_modules/dagster/dagster/components/components.py
@@ -9,5 +9,6 @@ from dagster.components.lib.pipes_subprocess_script_collection import (
 # These just modify the exsiting Dagster decorators
 from dagster.components.lib.shim_components.asset import asset as asset
 from dagster.components.lib.shim_components.asset_check import asset_check as asset_check
+from dagster.components.lib.shim_components.multi_asset import multi_asset as multi_asset
 from dagster.components.lib.shim_components.schedule import schedule as schedule
 from dagster.components.lib.shim_components.sensor import sensor as sensor

--- a/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
@@ -1,0 +1,57 @@
+import textwrap
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster.components.lib.shim_components.base import ShimScaffolder
+from dagster.components.scaffold.scaffold import scaffold_with
+
+
+class MultiAssetScaffoldParams(BaseModel):
+    asset_key: Optional[list[str]] = Field(
+        default=None, description="Optional list of asset keys to use in specs"
+    )
+
+
+class MultiAssetScaffolder(ShimScaffolder):
+    @classmethod
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+        return MultiAssetScaffoldParams
+
+    def get_text(self, filename: str, params: Any) -> str:
+        asset_keys = (
+            params.asset_key
+            if isinstance(params, MultiAssetScaffoldParams) and params.asset_key
+            # Default to two sample assets based on the filename
+            else [
+                f"{filename}/first_asset",
+                f"{filename}/second_asset",
+            ]
+        )
+
+        specs_str = textwrap.indent(
+            ",\n".join(
+                f"dg.AssetSpec(key=dg.AssetKey({AssetKey.from_user_string(key).path!r}))"
+                for key in asset_keys
+            ),
+            prefix=" " * 20,
+        )
+        return textwrap.dedent(
+            f"""\
+            import dagster as dg
+
+
+            @dg.multi_asset(
+                specs=[
+{specs_str}
+                ]
+            )
+            def {filename}():
+                ...
+            """
+        )
+
+
+scaffold_with(MultiAssetScaffolder)(multi_asset)

--- a/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
@@ -48,7 +48,7 @@ class MultiAssetScaffolder(ShimScaffolder):
 {specs_str}
                 ]
             )
-            def {filename}():
+            def {filename}(context: dg.AssetExecutionContext):
                 ...
             """
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -495,11 +495,36 @@ class DgClickGroup(DgClickHelpMixin, ClickAliasedGroup): ...  # pyright: ignore[
 _JSON_SCHEMA_TYPE_TO_CLICK_TYPE = {"string": str, "integer": int, "number": float, "boolean": bool}
 
 
+def _get_field_type_info_from_field_info(field_info: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Extract the dict holding field type info (in particular, the type and whether it is an array)
+    from a JSON schema field info dict.
+
+    If the field info is not a union type, returns itself.
+    If the field info is a union type, returns the first non-null type.
+    If the field info has no type info, default to type info for type "string".
+    """
+    if field_info.get("type"):
+        return field_info
+    else:
+        return next(
+            (t for t in field_info.get("anyOf", []) if t.get("type") not in (None, "null")),
+            {"type": "string"},
+        )
+
+
 def json_schema_property_to_click_option(
     key: str, field_info: Mapping[str, Any], required: bool
 ) -> click.Option:
-    field_type = field_info.get("type", "string")
+    # Extract the dict holding field type info (in particular, the type and whether it is an array)
+    # This might be nested in an anyOf block
+    field_type_info = _get_field_type_info_from_field_info(field_info)
+    is_array_type = field_type_info.get("type") == "array"
+    field_type = (
+        field_type_info.get("items", {}).get("type") or field_type_info.get("type") or "string"
+    )
+
     option_name = f"--{key.replace('_', '-')}"
+
     # Handle object type fields as JSON strings
     if field_type == "object":
         option_type = str  # JSON string input
@@ -518,6 +543,7 @@ def json_schema_property_to_click_option(
         required=required,
         help=help_text,
         callback=callback,
+        multiple=is_array_type,
     )
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -742,7 +742,7 @@ def test_scaffold_multi_asset_params() -> None:
             "dagster.multi_asset",
             "multi_assets/with_nested_keys.py",
             "--json-params",
-            '{"asset_keys": ["foo/bar", "baz/qux"]}',
+            '{"asset_key": ["foo/bar", "baz/qux"]}',
         )
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/multi_assets/with_nested_keys.py").exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -682,6 +682,81 @@ def test_scaffold_bad_extension() -> None:
         assert_runner_result(result, exit_0=False)
 
 
+def test_scaffold_multi_asset_basic() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke("scaffold", "dagster.multi_asset", "multi_assets/composite.py")
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/multi_assets/composite.py").exists()
+        assert (
+            Path("src/foo_bar/defs/multi_assets/composite.py")
+            .read_text()
+            .startswith("import dagster as dg")
+        )
+        assert "@dg.multi_asset" in Path("src/foo_bar/defs/multi_assets/composite.py").read_text()
+        asset_content = Path("src/foo_bar/defs/multi_assets/composite.py").read_text()
+        assert "dg.AssetSpec(key=dg.AssetKey(['composite', 'first_asset']))" in asset_content
+        assert "dg.AssetSpec(key=dg.AssetKey(['composite', 'second_asset']))" in asset_content
+        assert not Path("src/foo_bar/defs/multi_assets/composite.py").is_dir()
+        assert not Path("src/foo_bar/defs/multi_assets/component.yaml").exists()
+
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
+        output = result.output
+        assert "composite/first_asset" in output
+        assert "composite/second_asset" in output
+
+
+def test_scaffold_multi_asset_params() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        # First, try scaffolding with multiple options using --asset-key
+        result = runner.invoke(
+            "scaffold",
+            "dagster.multi_asset",
+            "multi_assets/custom_keys.py",
+            "--asset-key",
+            "orders",
+            "--asset-key",
+            "customers",
+        )
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/multi_assets/custom_keys.py").exists()
+        asset_content = Path("src/foo_bar/defs/multi_assets/custom_keys.py").read_text()
+        assert "dg.AssetSpec(key=dg.AssetKey(['orders']))" in asset_content
+        assert "dg.AssetSpec(key=dg.AssetKey(['customers']))" in asset_content
+
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
+        output = result.output
+        assert "orders" in output
+        assert "customers" in output
+
+        # Next, try more complex keys with --json-params
+        result = runner.invoke(
+            "scaffold",
+            "dagster.multi_asset",
+            "multi_assets/with_nested_keys.py",
+            "--json-params",
+            '{"asset_keys": ["foo/bar", "baz/qux"]}',
+        )
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/multi_assets/with_nested_keys.py").exists()
+        asset_content = Path("src/foo_bar/defs/multi_assets/with_nested_keys.py").read_text()
+        assert "dg.AssetSpec(key=dg.AssetKey(['foo', 'bar']))" in asset_content
+        assert "dg.AssetSpec(key=dg.AssetKey(['baz', 'qux']))" in asset_content
+
+        result = runner.invoke("list", "defs")
+        assert_runner_result(result)
+        output = result.output
+        assert "foo/bar" in output
+        assert "baz/qux" in output
+
+
 def test_scaffold_sensor() -> None:
     with (
         ProxyRunner.test() as runner,


### PR DESCRIPTION
## Summary

Adds a new shim type for `dagster.multi_asset`. Also does some surgery on the scaffold param generation to turn `list` inputs into `multi=True` click arguments, so the user can pass multiple individual options rather than a single list.

```sh
$ dg scaffold dagster.multi_asset assets/my_multi_asset.py
```

```python
import dagster as dg


@dg.multi_asset(
  specs=[
    dg.AssetSpec(key=dg.AssetKey(["my_multi_asset", "first_asset"]),
    dg.AssetSpec(key=dg.AssetKey(["my_multi_asset", "second_asset"]),
  ]
)
def my_multi_asset(context: dg.AssetExecutionContext): ...
```

```sh
$ dg scaffold dagster.multi_asset assets/my_multi_asset.py --asset-key key_one --asset-key key_two
```

```python
import dagster as dg

@dg.multi_asset(
  specs=[
    dg.AssetSpec(key=dg.AssetKey(["key_one"]),
    dg.AssetSpec(key=dg.AssetKey(["key_two"]),
  ]
)
def my_multi_asset(context: dg.AssetExecutionContext): ...
```

## How I Tested These Changes

New tests.

## Changelog

> [components] Added `dagster.multi_asset` scaffolder
