### PR TITLE
[resolved] split asset defs update and asset spec update handling

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -220,6 +220,11 @@ def test_sling_subclass() -> None:
             lambda asset_spec: asset_spec.key == AssetKey("overridden_key"),
             False,
         ),
+        (
+            {"key_prefix": "overridden_prefix"},
+            lambda asset_spec: asset_spec.key.has_prefix(["overridden_prefix"]),
+            False,
+        ),
     ],
     ids=[
         "group_name",
@@ -233,6 +238,7 @@ def test_sling_subclass() -> None:
         "deps",
         "automation_condition",
         "key",
+        "key_prefix",
     ],
 )
 def test_asset_attributes(
@@ -247,10 +253,13 @@ def test_asset_attributes(
             [{"path": "./replication.yaml", "asset_attributes": attributes}]
         ) as (component, defs),
     ):
-        key = attributes.get("key", "input_duckdb")
+        key = AssetKey(attributes.get("key", "input_duckdb"))
+        if attributes.get("key_prefix"):
+            key = key.with_prefix(attributes["key_prefix"])
+
         assets_def: AssetsDefinition = defs.get_assets_def(key)
     if assertion:
-        assert assertion(assets_def.get_asset_spec(AssetKey(key)))
+        assert assertion(assets_def.get_asset_spec(key))
 
 
 IGNORED_KEYS = {"skippable"}


### PR DESCRIPTION
Currently we just have `AssetAttributes` which we use to power both `Definitions` post processing as well as pre-definitions `AssetSpec` customization. 

Unfortunately, these two context have different constraints. We do not support changing the key of an asset spec inside of an already formed `AssetsDefinition` as its difficult to ensure it could safely handle that transformation in all cases. 

This change separates the two cases, and adds `key_prefix` for the spec only update condition. 

## How I Tested These Changes

added tests