### PR TITLE
Clarify `SerializableTimeDelta` is for internal use only in docstring

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/utils.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/utils.py
@@ -33,6 +33,9 @@ class SerializableTimeDelta(NamedTuple):
     """A Dagster-serializable version of a datetime.timedelta. The datetime.timedelta class
     internally stores values as an integer number of days, seconds, and microseconds. This class
     handles converting between the in-memory and serializable formats.
+
+    Do not use the `days`, `seconds` or `microseconds` attributes to get the duration of the timedelta.
+    Instead, use `total_seconds()` or convert to a `datetime.timedelta` using `to_timedelta()`.
     """
 
     days: int
@@ -49,3 +52,10 @@ class SerializableTimeDelta(NamedTuple):
         return datetime.timedelta(
             days=self.days, seconds=self.seconds, microseconds=self.microseconds
         )
+
+    def total_seconds(self) -> float:
+        """Returns the total number of seconds in the timedelta.
+        Use this to get the total duration of the timedelta, instead of `SerializableTimeDelta.seconds`.
+        `SerializableTimeDelta.seconds` is set to 0 for any timedelta greater than or equal to 24 hours.
+        """
+        return self.to_timedelta().total_seconds()

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/utils.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/utils.py
@@ -34,8 +34,10 @@ class SerializableTimeDelta(NamedTuple):
     internally stores values as an integer number of days, seconds, and microseconds. This class
     handles converting between the in-memory and serializable formats.
 
-    Do not use the `days`, `seconds` or `microseconds` attributes to get the duration of the timedelta.
-    Instead, use `total_seconds()` or convert to a `datetime.timedelta` using `to_timedelta()`.
+    This class should not be used directly in application code. Any place it pops up should be converted to `datetime.timedelta`
+    using `to_timedelta()`.
+
+    Consequently, also do not rely on `days`, `seconds`, or `microseconds` attributes for any datetime arithmetic.
     """
 
     days: int
@@ -52,10 +54,3 @@ class SerializableTimeDelta(NamedTuple):
         return datetime.timedelta(
             days=self.days, seconds=self.seconds, microseconds=self.microseconds
         )
-
-    def total_seconds(self) -> float:
-        """Returns the total number of seconds in the timedelta.
-        Use this to get the total duration of the timedelta, instead of `SerializableTimeDelta.seconds`.
-        `SerializableTimeDelta.seconds` is set to 0 for any timedelta greater than or equal to 24 hours.
-        """
-        return self.to_timedelta().total_seconds()


### PR DESCRIPTION
## Summary & Motivation
[EDIT 04/23] - based on PR feedback, limiting this PR to docstring only, will remove direct usages of `SerializableTimeDelta` in cloud code.

--- 

I ran into a pretty subtle "bug" with `SerializableTimeDelta` - or an accessibility issue, really -  when trying to use it for some datetime arithmetic. This PR adds some docstrings and a `total_seconds()` method as guardrails to hopefully make it less likely to bite someone else in future. 

Let's say you create a `SerializableTimeDelta` from a `datetime.timedelta` that is 24 hours long:
```
td = datetime.timedelta(hours=24)
serializable_td = SerializableTimeDelta.from_timedelta(td)
```

If you now want to get the duration of `serializable_td` in seconds, you may naturally reach for the `seconds` attribute. You would expect this to equal 86,400 seconds. However, this is not the case - it would actually be 0!
```
# This resolves to 0
seconds = serializable_td.seconds 

# This resolves to 86400
seconds = serializable_td.to_timestamp().total_seconds()
```

~So I added a `total_seconds()` method that is pass through to `datetime.timedelta.total_seconds` and some docstrings warning not to use the `days`, `seconds` or `microseconds` properties for any datetime arithmetic.~


## How I Tested These Changes
bk

## Changelog

> Insert changelog entry or delete this section.
