### PR TITLE
[dg] Warn on outdated dagster-dg (BUILD-998)

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
@@ -1,5 +1,4 @@
 dg scaffold component-type ShellCommand
 
-Using /.../my-component-library/.venv/bin/dagster-components
 Creating a Dagster component type at /.../my-component-library/src/my_component_library/lib/shell_command.py.
 Scaffolded files for Dagster component type at /.../my-component-library/src/my_component_library/lib/shell_command.py.

--- a/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/1-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/1-scaffold.txt
@@ -1,4 +1,3 @@
 dg scaffold dagster.asset assets/my_asset.py
 
 Using /.../my-project/.venv/bin/dagster-components
-Using /.../my-project/.venv/bin/dagster-components

--- a/examples/docs_snippets/docs_snippets_tests/conftest.py
+++ b/examples/docs_snippets/docs_snippets_tests/conftest.py
@@ -1,5 +1,8 @@
+import os
+
 import boto3
 import pytest
+from dagster_dg.context import DG_UPDATE_CHECK_ENABLED_ENV_VAR
 from moto import mock_s3
 
 from dagster import file_relative_path
@@ -24,6 +27,13 @@ def mock_s3_bucket(mock_s3_resource):
 # ########################
 # ##### SNIPPET CHECKS
 # ########################
+
+
+# Runs once before every test
+def pytest_configure():
+    # Disable the dg update check for all tests because we don't want to bomb the PyPI API.
+    # Tests that specifically want to test the update check should set this env var to "1".
+    os.environ[DG_UPDATE_CHECK_ENABLED_ENV_VAR] = "0"
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -35,6 +35,7 @@ deps =
   -e ../../python_modules/libraries/dagster-dask
   -e ../../python_modules/libraries/dagster-databricks
   -e ../../python_modules/libraries/dagster-datadog
+  -e ../../python_modules/libraries/dagster-dg
   -e ../../python_modules/libraries/dagster-dbt
   -e ../../python_modules/libraries/dagster-deltalake
   -e ../../python_modules/libraries/dagster-deltalake-pandas
@@ -75,12 +76,8 @@ deps =
   -e ../../python_modules/libraries/dagstermill[test]
   docs_snapshot_test: dbt-duckdb
   docs_snapshot_test: selenium
-  docs_snapshot_test: -e ../../python_modules/libraries/dagster-dg
-  docs_snapshot_test: -e ../../python_modules/libraries/dagster-sling
   docs_snapshot_update: dbt-duckdb
   docs_snapshot_update: selenium
-  docs_snapshot_update: -e ../../python_modules/libraries/dagster-dg
-  docs_snapshot_update: -e ../../python_modules/libraries/dagster-sling
   -e .[full]
 allowlist_externals =
   /bin/bash

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -147,7 +147,7 @@ jupyter-events==0.12.0
 jupyter-lsp==2.2.5
 jupyter-server==2.15.0
 jupyter-server-terminals==0.5.3
-jupyterlab==4.4.0
+jupyterlab==4.4.1
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
 keyring==25.6.0

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -185,7 +185,7 @@ dagster-qdrant==0.0.2
 dagster-weaviate==0.0.2
 -e python_modules/dagster-webserver
 -e python_modules/libraries/dagstermill
-dask==2025.3.0
+dask==2025.4.0
 dask-jobqueue==0.9.0
 dask-kubernetes==2022.9.0
 dask-yarn==0.9
@@ -213,7 +213,7 @@ deprecated==1.2.18
 dict2css==0.3.0.post1
 dill==0.4.0
 distlib==0.3.9
-distributed==2025.3.0
+distributed==2025.4.0
 distro==1.9.0
 -e examples/experimental/dagster-dlift/kitchen-sink
 dlt==1.10.0
@@ -348,7 +348,7 @@ jupyter-events==0.12.0
 jupyter-lsp==2.2.5
 jupyter-server==2.15.0
 jupyter-server-terminals==0.5.3
-jupyterlab==4.4.0
+jupyterlab==4.4.1
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
 jupyterlab-widgets==3.0.14

--- a/python_modules/libraries/dagster-dg/dagster_dg/cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cache.py
@@ -12,7 +12,9 @@ from dagster_dg.utils import get_logger, is_macos, is_windows
 
 _CACHE_CONTAINER_DIR_NAME: Final = "dg-cache"
 
-CachableDataType: TypeAlias = Literal["plugin_registry_data", "all_components_schema"]
+CachableDataType: TypeAlias = Literal[
+    "plugin_registry_data", "all_components_schema", "dg_update_check_timestamp"
+]
 
 T_PackableValue = TypeVar("T_PackableValue", bound=PackableValue, default=PackableValue)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/__init__.py
@@ -112,8 +112,8 @@ def create_dg_cli():
 
 
 def _rebuild_plugin_cache(dg_context: DgContext):
-    if not dg_context.has_cache:
-        exit_with_error("Cache is disabled. This command cannot be run without a cache.")
+    if not dg_context.is_plugin_cache_enabled:
+        exit_with_error("Plugin cache is disabled. This command cannot be run without a cache.")
     dg_context.ensure_uv_lock()
     key = dg_context.get_cache_key("plugin_registry_data")
     dg_context.cache.clear_key(key)

--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -107,6 +107,8 @@ def get_config_from_cli_context(cli_context: click.Context) -> "DgRawCliConfig":
 # ##### MAIN
 # ########################
 
+_ConfigCacheKey: TypeAlias = tuple[Any, ...]
+
 
 @dataclass
 class DgConfig:

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -13,6 +14,9 @@ from typing import Final, Optional, Union
 import tomlkit
 import tomlkit.items
 import yaml
+from dagster_shared.libraries import DagsterPyPiAccessError, get_published_pypi_versions
+from dagster_shared.record import record
+from dagster_shared.serdes.serdes import serialize_value, whitelist_for_serdes
 from packaging.version import Version
 from typing_extensions import Self
 
@@ -54,6 +58,7 @@ from dagster_dg.utils import (
 from dagster_dg.utils.filesystem import hash_paths
 from dagster_dg.utils.version import get_uv_tool_core_pin_string
 from dagster_dg.utils.warnings import emit_warning
+from dagster_dg.version import __version__
 
 # Project
 _DEFAULT_PROJECT_DEFS_SUBMODULE: Final = "defs"
@@ -82,10 +87,7 @@ class DgContext:
         self.root_path = root_path
         self._workspace_root_path = workspace_root_path
         self.cli_opts = cli_opts
-        if config.cli.disable_cache or not self.has_uv_lock:
-            self._cache = None
-        else:
-            self._cache = DgCache.from_config(config)
+        self._cache = None if config.cli.disable_cache else DgCache.from_config(config)
         self.component_registry = RemotePluginRegistry.empty()
 
         # Always run this check, its a no-op if there is no pyproject.toml.
@@ -250,12 +252,15 @@ class DgContext:
                 "cli_config_in_workspace_project", cli_config_warning, config.cli.suppress_warnings
             )
 
-        return cls(
+        context = cls(
             config=config,
             root_path=root_path,
             workspace_root_path=workspace_root_path,
             cli_opts=command_line_config,
         )
+        _validate_dg_up_to_date(context)
+
+        return context
 
     @classmethod
     def default(cls) -> Self:
@@ -283,6 +288,10 @@ class DgContext:
     def has_cache(self) -> bool:
         return self._cache is not None
 
+    @property
+    def is_plugin_cache_enabled(self) -> bool:
+        return self.has_cache and self.has_uv_lock
+
     def component_registry_paths(self) -> list[Path]:
         """Paths that should be watched for changes to the component registry."""
         return [
@@ -308,6 +317,9 @@ class DgContext:
             return ("_".join(path_parts), env_hash, "local_component_registry")
         else:
             return self.get_cache_key(module_name)
+
+    def get_cache_key_for_update_check_timestamp(self) -> tuple[str]:
+        return ("dg_update_check_timestamp",)
 
     # ########################
     # ##### WORKSPACE METHODS
@@ -800,3 +812,89 @@ def _validate_plugin_entry_point(context: DgContext) -> None:
             """,
             context.config.cli.suppress_warnings,
         )
+
+
+DG_UPDATE_CHECK_INTERVAL = datetime.timedelta(hours=1)
+DG_UPDATE_CHECK_ENABLED_ENV_VAR = "DAGSTER_DG_UPDATE_CHECK_ENABLED"
+
+
+@whitelist_for_serdes
+@record
+class DgPyPiVersionInfo:
+    timestamp: float
+    raw_versions: list[str]
+
+    @property
+    def datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(self.timestamp)
+
+    @cached_property
+    def versions(self) -> list[Version]:
+        return sorted(Version(v) for v in self.raw_versions)
+
+
+def _validate_dg_up_to_date(context: DgContext) -> None:
+    # Don't check if we've disabled the check
+    if not (
+        bool(int(os.getenv(DG_UPDATE_CHECK_ENABLED_ENV_VAR, "1")))
+        and "dg_outdated" not in context.config.cli.suppress_warnings
+    ):
+        return
+
+    version_info = _get_dg_pypi_version_info(context)
+    if version_info is None:  # Nothing cached and network error occurred
+        return None
+
+    installed_version = Version(__version__)
+    latest_version = version_info.versions[-1]
+    if installed_version < latest_version:
+        emit_warning(
+            "dg_outdated",
+            f"""
+            There is a new version of `dagster-dg` available:
+
+                Latest version: {latest_version}
+                Installed version: {installed_version}
+
+            Update your dagster-dg installation to keep up to date:
+
+                [uv tool]  $ uv tool upgrade dagster-dg
+                [uv local] $ uv sync --upgrade dagster-dg
+                [pip]      $ pip install --upgrade dagster-dg
+            """,
+            context.config.cli.suppress_warnings,
+        )
+
+
+def _get_dg_pypi_version_info(context: DgContext) -> Optional[DgPyPiVersionInfo]:
+    key = context.get_cache_key_for_update_check_timestamp()
+    if context.has_cache:
+        version_info = context.cache.get(key, DgPyPiVersionInfo)
+    else:
+        version_info = None
+
+    now = datetime.datetime.now()
+    if version_info and now - version_info.datetime < DG_UPDATE_CHECK_INTERVAL:
+        return version_info
+    else:
+        try:
+            if context.config.cli.verbose:
+                context.log.info("Checking for the latest version of `dagster-dg` on PyPI.")
+            published_versions = get_published_pypi_versions("dagster-dg")
+            version_info = DgPyPiVersionInfo(
+                raw_versions=[str(v) for v in published_versions], timestamp=now.timestamp()
+            )
+            if context.has_cache:
+                context.cache.set(key, serialize_value(version_info))
+        except DagsterPyPiAccessError as e:
+            emit_warning(
+                "dg_outdated",
+                f"""
+                There was an error checking for the latest version of `dagster-dg` on PyPI. Please check your
+                internet connection and try again.
+
+                Error: {e}
+                """,
+                context.config.cli.suppress_warnings,
+            )
+    return version_info

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
@@ -10,6 +10,7 @@ from dagster_dg.utils import format_multiline_str
 DgWarningIdentifier: TypeAlias = Literal[
     "cli_config_in_workspace_project",
     "deprecated_user_config_location",
+    "dg_outdated",
     "deprecated_python_environment",
     "deprecated_dagster_dg_library_entry_point",
     "missing_dg_plugin_module_in_manifest",

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -164,8 +164,8 @@ def test_list_plugins_success():
         with fixed_panel_width(width=120):
             result = runner.invoke("list", "plugins")
             assert_runner_result(result)
-            # strip the first line of logging output
-            output = "\n".join(result.output.split("\n")[1:])
+            # strip the first two lines of logging output
+            output = "\n".join(result.output.split("\n")[2:])
             match_terminal_box_output(output.strip(), _EXPECTED_COMPONENT_TYPES)
 
 
@@ -177,7 +177,7 @@ def test_list_plugins_json_success():
         result = runner.invoke("list", "plugins", "--json")
         assert_runner_result(result)
         # strip the first line of logging output
-        output = "\n".join(result.output.split("\n")[1:])
+        output = "\n".join(result.output.split("\n")[2:])
         assert output.strip() == _EXPECTED_COMPONENT_TYPES_JSON
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/conftest.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+from dagster_dg.context import DG_UPDATE_CHECK_ENABLED_ENV_VAR
+
+
+# Runs once before every test
+def pytest_configure():
+    # Disable the update check for all tests because we don't want to bomb the PyPI API.
+    # Tests that specifically want to test the update check should set this env var to "1".
+    os.environ[DG_UPDATE_CHECK_ENABLED_ENV_VAR] = "0"

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -126,7 +126,7 @@ def test_rebuild_plugin_cache_fails_with_disabled_cache():
     with ProxyRunner.test(**cache_runner_args) as runner, example_project(runner):
         result = runner.invoke("--rebuild-plugin-cache", "--disable-cache")
         assert_runner_result(result, exit_0=False)
-        assert "Cache is disabled" in result.output
+        assert "Plugin cache is disabled" in result.output
 
 
 def test_cache_disabled():

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -47,6 +47,7 @@ setup(
         "mcp; python_version >= '3.10'",
         "yaspin",
         "setuptools",  # Needed to parse setup.cfg
+        "packaging",
         "python-dotenv",
         # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
         # frequently updated since is designed to be used from an isolated environment.
@@ -65,6 +66,7 @@ setup(
         "test": [
             "click",
             "dagster",
+            "freezegun",
             "psutil",
             "pydantic",
             "pytest",


### PR DESCRIPTION
## Summary & Motivation

Warns when a newer version of `dagster-dg` is available.

- If the cache is enabled, then PyPI will only be hit once per hour.
- The check can be prevented from ever running by suppressing the `dg_outdated` warning.
- A special private env var `DAGSTER_DG_UPDATE_CHECK_ENABLED` is also checked. We set this to 0 in tests to prevent bombing the PyPI API in CI.

The warning looks like this:

```
There is a new version of `dagster-dg` available:

    Latest version: 0.26.11
    Installed version: 0.26.11rc1

Update your dagster-dg installation to keep up to date:

    [uv tool]  $ uv tool upgrade dagster-dg
    [uv local] $ uv sync --upgrade dagster-dg
    [pip]      $ pip install --upgrade dagster-dg

To suppress this warning, add "dg_outdated" to the `cli.suppress_warnings` list in your configuration.
```

## How I Tested These Changes

New unit tests.

## Changelog

`dg` now checks for new versions and prompts the user to update. The check runs automatically at `dg` startup once per day.