### PR TITLE
[dg] Add job scaffolder

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
@@ -34,6 +34,15 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.job                                                 │ Creates a job    │ [scaffold-targ… │ │
+│               │ │                                                             │ with the         │                 │ │
+│               │ │                                                             │ specified        │                 │ │
+│               │ │                                                             │ parameters from  │                 │ │
+│               │ │                                                             │ the decorated    │                 │ │
+│               │ │                                                             │ graph/op         │                 │ │
+│               │ │                                                             │ invocation       │                 │ │
+│               │ │                                                             │ function.        │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.multi_asset                                         │ Create a         │ [scaffold-targ… │ │
 │               │ │                                                             │ combined         │                 │ │
 │               │ │                                                             │ definition of    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
@@ -37,6 +37,16 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                  │ │                                                             │ Dagster's      │                │ │
 │                  │ │                                                             │ PipesSubproce… │                │ │
 │                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
+│                  │ │ dagster.job                                                 │ Creates a job  │ [scaffold-tar… │ │
+│                  │ │                                                             │ with the       │                │ │
+│                  │ │                                                             │ specified      │                │ │
+│                  │ │                                                             │ parameters     │                │ │
+│                  │ │                                                             │ from the       │                │ │
+│                  │ │                                                             │ decorated      │                │ │
+│                  │ │                                                             │ graph/op       │                │ │
+│                  │ │                                                             │ invocation     │                │ │
+│                  │ │                                                             │ function.      │                │ │
+│                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
 │                  │ │ dagster.multi_asset                                         │ Create a       │ [scaffold-tar… │ │
 │                  │ │                                                             │ combined       │                │ │
 │                  │ │                                                             │ definition of  │                │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
@@ -33,6 +33,14 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │         │ │                                                             │ Dagster's          │                     │ │
 │         │ │                                                             │ PipesSubprocessCl… │                     │ │
 │         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.job                                                 │ Creates a job with │ [scaffold-target]   │ │
+│         │ │                                                             │ the specified      │                     │ │
+│         │ │                                                             │ parameters from    │                     │ │
+│         │ │                                                             │ the decorated      │                     │ │
+│         │ │                                                             │ graph/op           │                     │ │
+│         │ │                                                             │ invocation         │                     │ │
+│         │ │                                                             │ function.          │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
 │         │ │ dagster.multi_asset                                         │ Create a combined  │ [scaffold-target]   │ │
 │         │ │                                                             │ definition of      │                     │ │
 │         │ │                                                             │ multiple assets    │                     │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
@@ -34,6 +34,15 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ Dagster's        │                 │ │
 │               │ │                                                             │ PipesSubprocess… │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.job                                                 │ Creates a job    │ [scaffold-targ… │ │
+│               │ │                                                             │ with the         │                 │ │
+│               │ │                                                             │ specified        │                 │ │
+│               │ │                                                             │ parameters from  │                 │ │
+│               │ │                                                             │ the decorated    │                 │ │
+│               │ │                                                             │ graph/op         │                 │ │
+│               │ │                                                             │ invocation       │                 │ │
+│               │ │                                                             │ function.        │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.multi_asset                                         │ Create a         │ [scaffold-targ… │ │
 │               │ │                                                             │ combined         │                 │ │
 │               │ │                                                             │ definition of    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
@@ -41,6 +41,16 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                      │ │                                                             │ Dagster's    │              │ │
 │                      │ │                                                             │ PipesSubpro… │              │ │
 │                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.job                                                 │ Creates a    │ [scaffold-t… │ │
+│                      │ │                                                             │ job with the │              │ │
+│                      │ │                                                             │ specified    │              │ │
+│                      │ │                                                             │ parameters   │              │ │
+│                      │ │                                                             │ from the     │              │ │
+│                      │ │                                                             │ decorated    │              │ │
+│                      │ │                                                             │ graph/op     │              │ │
+│                      │ │                                                             │ invocation   │              │ │
+│                      │ │                                                             │ function.    │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
 │                      │ │ dagster.multi_asset                                         │ Create a     │ [scaffold-t… │ │
 │                      │ │                                                             │ combined     │              │ │
 │                      │ │                                                             │ definition   │              │ │

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
@@ -40,6 +40,16 @@ dg list plugins
 │                     │ │                                                             │ Dagster's    │               │ │
 │                     │ │                                                             │ PipesSubpro… │               │ │
 │                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
+│                     │ │ dagster.job                                                 │ Creates a    │ [scaffold-ta… │ │
+│                     │ │                                                             │ job with the │               │ │
+│                     │ │                                                             │ specified    │               │ │
+│                     │ │                                                             │ parameters   │               │ │
+│                     │ │                                                             │ from the     │               │ │
+│                     │ │                                                             │ decorated    │               │ │
+│                     │ │                                                             │ graph/op     │               │ │
+│                     │ │                                                             │ invocation   │               │ │
+│                     │ │                                                             │ function.    │               │ │
+│                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
 │                     │ │ dagster.multi_asset                                         │ Create a     │ [scaffold-ta… │ │
 │                     │ │                                                             │ combined     │               │ │
 │                     │ │                                                             │ definition   │               │ │

--- a/python_modules/dagster/dagster/components/components.py
+++ b/python_modules/dagster/dagster/components/components.py
@@ -9,6 +9,7 @@ from dagster.components.lib.pipes_subprocess_script_collection import (
 # These just modify the exsiting Dagster decorators
 from dagster.components.lib.shim_components.asset import asset as asset
 from dagster.components.lib.shim_components.asset_check import asset_check as asset_check
+from dagster.components.lib.shim_components.job import job as job
 from dagster.components.lib.shim_components.multi_asset import multi_asset as multi_asset
 from dagster.components.lib.shim_components.schedule import schedule as schedule
 from dagster.components.lib.shim_components.sensor import sensor as sensor

--- a/python_modules/dagster/dagster/components/lib/shim_components/job.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/job.py
@@ -1,0 +1,29 @@
+import textwrap
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from dagster._core.definitions.decorators.job_decorator import job
+from dagster.components.lib.shim_components.base import ShimScaffolder
+from dagster.components.scaffold.scaffold import scaffold_with
+
+
+class JobScaffolder(ShimScaffolder):
+    @classmethod
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+        return None
+
+    def get_text(self, filename: str, params: Any) -> str:
+        return textwrap.dedent(
+            f"""\
+            import dagster as dg
+
+
+            @dg.job
+            def {filename}():
+                pass
+            """
+        )
+
+
+scaffold_with(JobScaffolder)(job)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -761,6 +761,32 @@ def test_scaffold_multi_asset_params() -> None:
         assert "baz/qux" in output
 
 
+def test_scaffold_job() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke("scaffold", "dagster.job", "jobs/my_pipeline.py")
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/jobs/my_pipeline.py").exists()
+        assert (
+            Path("src/foo_bar/defs/jobs/my_pipeline.py")
+            .read_text()
+            .startswith("import dagster as dg")
+        )
+        assert "@dg.job" in Path("src/foo_bar/defs/jobs/my_pipeline.py").read_text()
+        job_content = Path("src/foo_bar/defs/jobs/my_pipeline.py").read_text()
+        # Check for simple job scaffolding
+        assert "pass" in job_content
+        assert not Path("src/foo_bar/defs/jobs/my_pipeline.py").is_dir()
+        assert not Path("src/foo_bar/defs/jobs/component.yaml").exists()
+
+        # Create another job file to verify it works consistently
+        result = runner.invoke("scaffold", "dagster.job", "jobs/another_job.py")
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/jobs/another_job.py").exists()
+
+
 def test_scaffold_sensor() -> None:
     with (
         ProxyRunner.test() as runner,


### PR DESCRIPTION
## Summary

Super basic job scaffolder which just scaffolds an op-job `@job` decorator without any ops.

Some question if this is particularly useful, or whether we ought to make an asset-job version (which could also probably live in YAML).

## How I Tested These Changes

New test.

## Changelog

> [components] Added `dagster.job` scaffolder.
