### PR TITLE
Stop fetching asset graph live query from asset health hook

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -1,7 +1,6 @@
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {ApolloClient, gql, useApolloClient} from '../apollo-client';
-import {AssetBaseData} from './AssetBaseDataProvider';
 import {featureEnabled} from '../app/Flags';
 import {tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
@@ -77,7 +76,6 @@ export function useAssetsHealthData(
 ) {
   const keys = memoizedAssetKeys(assetKeys);
   const result = AssetHealthData.useLiveData(keys, thread);
-  AssetBaseData.useLiveData(keys, thread);
   useBlockTraceUntilTrue(
     'useAssetsHealthData',
     !!(Object.keys(result.liveDataByNode).length === assetKeys.length),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -1,4 +1,3 @@
-import uniq from 'lodash/uniq';
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import {AssetBaseData, __resetForJest as __resetBaseData} from './AssetBaseDataProvider';
@@ -141,9 +140,10 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
 
     const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));
 
-    const runInProgressId = uniq(
-      dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
-    ).sort();
+    const runInProgressId: string[] = [];
+    // const runInProgressId = uniq(
+    //   dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
+    // ).sort();
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
       if (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -1,3 +1,4 @@
+import uniq from 'lodash/uniq';
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import {AssetBaseData, __resetForJest as __resetBaseData} from './AssetBaseDataProvider';
@@ -140,10 +141,11 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
 
     const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));
 
-    const runInProgressId: string[] = [];
-    // const runInProgressId = uniq(
-    //   dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
-    // ).sort();
+    const runInProgressId = uniq(
+      dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
+    )
+      .sort()
+      .slice(0, 5);
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
       if (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -143,8 +143,7 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
 
     const runInProgressId = uniq(
       dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
-    )
-      .sort();
+    ).sort();
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
       if (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -144,8 +144,7 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
     const runInProgressId = uniq(
       dataForObservedKeys.flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
     )
-      .sort()
-      .slice(0, 5);
+      .sort();
 
     const unobserve = observeAssetEventsInRuns(runInProgressId, (events) => {
       if (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -6,6 +6,7 @@ import {getSupplementaryDataKey} from '../asset-selection/util';
 import {AssetKey} from '../assets/types';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {SupplementaryInformation} from '../asset-selection/types';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 const emptyObject = {} as SupplementaryInformation;
 export const useAssetGraphSupplementaryData = (
@@ -41,6 +42,8 @@ export const useAssetGraphSupplementaryData = (
 
   return {
     loading: needsAssetHealthData && loading,
-    data: loading ? emptyObject : assetsByStatus,
+    data: loading ? emptyObject : memoizedData(JSON.stringify(assetsByStatus)),
   };
 };
+
+const memoizedData = weakMapMemoize((data: string) => JSON.parse(data));

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -42,7 +42,10 @@ export const useAssetGraphSupplementaryData = (
 
   return {
     loading: needsAssetHealthData && loading,
-    data: loading ? emptyObject : memoizedData(JSON.stringify(assetsByStatus)),
+    data: useMemo(
+      () => (loading ? emptyObject : memoizedData(JSON.stringify(assetsByStatus))),
+      [loading, assetsByStatus],
+    ),
   };
 };
 


### PR DESCRIPTION
## Summary & Motivation

Also add some memoization because in `useAssetGraphSupplementaryData` because the reference seems to be changing more often than necessary... stopgap for now.

## How I Tested These Changes

app proxy load the app and see that the catalog home page no longer makes AssetGraphLiveQuery calls.
