### PR TITLE
DOC-1107 Add redirect for Airflow to Dagster guide

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -568,6 +568,10 @@
       "destination": "/guides/migrate/airflow-to-dagster/"
     },
     {
+      "source": "/integrations/libraries/airlift/airflow-to-dagster",
+      "destination": "/guides/migrate/airflow-to-dagster/"
+    },
+    {
       "source": "/integrations/libraries/airlift/federation-tutorial/",
       "destination": "/guides/migrate/airflow-to-dagster/federation/"
     },


### PR DESCRIPTION
## Summary & Motivation

Fix redirect from `/integrations/libraries/airlift/airflow-to-dagster`

## How I Tested These Changes

Staging build.

## Changelog

> Insert changelog entry or delete this section.
