### PR TITLE
Add BUILDKITE_BUILD_URL environment variable to buildkite step builder

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -90,6 +90,7 @@ class CommandStepBuilder:
         buildkite_envvars.append("BUILDKITE_TEST_SUITE_SLUG")
         buildkite_envvars.append("BUILDKITE_BRANCH")
         buildkite_envvars.append("BUILDKITE_COMMIT")
+        buildkite_envvars.append("BUILDKITE_BUILD_URL")
 
         # Set PYTEST_DEBUG_TEMPROOT to our mounted /tmp volume. Any time the
         # pytest `tmp_path` or `tmpdir` fixtures are used used, the temporary


### PR DESCRIPTION
We are not including the BUILDKITE_BUILD_URL in the code to create a buildkite step. So instead of seeing:
![Screenshot 2025-04-22 at 2 07 33 PM](https://github.com/user-attachments/assets/da355112-1cf4-41e3-9f97-8db508fa16ce)
we see 
[
![Screenshot 2025-04-22 at 2 06 49 PM](https://github.com/user-attachments/assets/2f3bad46-cb3f-408f-9600-4ab0129097bc)
](url)

in the BuildKite test page.

By making this change, we now explicitly add the environment variable to the list of variables included in the command.

Locally tested by running and confirming the output included the environment variable in the yaml file

`BUILDKITE_DOCKER_QUEUE=test BUILDKITE_BRANCH=test BUILDKITE_MEDIUM_QUEUE=test BUILDKITE_COMMIT=test BUILDKITE_MESSAGE=test  dagster-buildkite`

I will also check the BuildKite run for this PR to see if the url is now included