### PR TITLE
Add `operator_type` to AutomationConditionNodeSnapshot

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -24,6 +24,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionNodeCursor,
     AutomationConditionNodeSnapshot,
     AutomationConditionSnapshot,
+    OperatorType,
     get_serializable_candidate_subset,
 )
 from dagster._core.definitions.partition import AllPartitionsSubset
@@ -101,6 +102,10 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         """Formal name of this specific condition, generally aligning with its static constructor."""
         return self.__class__.__name__
 
+    @property
+    def operator_type(self) -> OperatorType:
+        return "identity"
+
     def get_label(self) -> Optional[str]:
         return None
 
@@ -112,6 +117,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
             unique_id=unique_id,
             label=self.get_label(),
             name=self.name,
+            operator_type=self.operator_type,
         )
 
     def get_snapshot(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
+from dagster._core.definitions.declarative_automation.serialized_objects import OperatorType
 from dagster._record import copy, record
 
 if TYPE_CHECKING:
@@ -34,6 +35,10 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     @property
     def name(self) -> str:
         return "AND"
+
+    @property
+    def operator_type(self) -> OperatorType:
+        return "and"
 
     @property
     def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
@@ -148,6 +153,10 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return self.operands
 
     @property
+    def operator_type(self) -> OperatorType:
+        return "or"
+
+    @property
     def requires_cursor(self) -> bool:
         return False
 
@@ -245,6 +254,10 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     @property
     def name(self) -> str:
         return "NOT"
+
+    @property
+    def operator_type(self) -> OperatorType:
+        return "not"
 
     @property
     def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
@@ -16,6 +16,7 @@ from dagster._core.definitions.declarative_automation.automation_context import 
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     EntityMatchesCondition,
 )
+from dagster._core.definitions.declarative_automation.serialized_objects import OperatorType
 from dagster._record import copy, record
 from dagster._utils.security import non_secure_md5_hash_str
 
@@ -111,6 +112,10 @@ class AnyChecksCondition(ChecksAutomationCondition):
     def base_name(self) -> str:
         return "ANY_CHECKS_MATCH"
 
+    @property
+    def operator_type(self) -> OperatorType:
+        return "or"
+
     async def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:  # pyright: ignore[reportIncompatibleMethodOverride]
         true_subset = context.get_empty_subset()
 
@@ -142,6 +147,10 @@ class AllChecksCondition(ChecksAutomationCondition):
     @property
     def base_name(self) -> str:
         return "ALL_CHECKS_MATCH"
+
+    @property
+    def operator_type(self) -> OperatorType:
+        return "and"
 
     async def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:  # pyright: ignore[reportIncompatibleMethodOverride]
         check_results = []

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
+from dagster._core.definitions.declarative_automation.serialized_objects import OperatorType
 from dagster._record import copy, record
 from dagster._utils.security import non_secure_md5_hash_str
 
@@ -185,6 +186,10 @@ class AnyDepsCondition(DepsAutomationCondition[T_EntityKey]):
     def base_name(self) -> str:
         return "ANY_DEPS_MATCH"
 
+    @property
+    def operator_type(self) -> OperatorType:
+        return "or"
+
     async def evaluate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, context: AutomationContext[T_EntityKey]
     ) -> AutomationResult[T_EntityKey]:
@@ -212,6 +217,10 @@ class AllDepsCondition(DepsAutomationCondition[T_EntityKey]):
     @property
     def base_name(self) -> str:
         return "ALL_DEPS_MATCH"
+
+    @property
+    def operator_type(self) -> OperatorType:
+        return "and"
 
     async def evaluate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, context: AutomationContext[T_EntityKey]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -4,6 +4,7 @@ from typing import (  # noqa: UP035
     TYPE_CHECKING,
     AbstractSet,
     Generic,
+    Literal,
     NamedTuple,
     Optional,
     TypeVar,
@@ -11,6 +12,7 @@ from typing import (  # noqa: UP035
 )
 
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import TypeAlias
 
 from dagster._core.asset_graph_view.asset_graph_view import TemporalContext
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
@@ -52,6 +54,9 @@ def get_serializable_candidate_subset(
     return candidate_subset
 
 
+OperatorType: TypeAlias = Union[Literal["and"], Literal["or"], Literal["not"], Literal["identity"]]
+
+
 @whitelist_for_serdes(storage_name="AssetConditionSnapshot")
 class AutomationConditionNodeSnapshot(NamedTuple):
     """A serializable snapshot of a node in the AutomationCondition tree."""
@@ -61,6 +66,7 @@ class AutomationConditionNodeSnapshot(NamedTuple):
     unique_id: str
     label: Optional[str] = None
     name: Optional[str] = None
+    operator_type: OperatorType = "identity"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -75,6 +75,9 @@ async def test_eager_unpartitioned() -> None:
     state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
+    evaluation = result.serializable_evaluation
+    assert evaluation.condition_snapshot.operator_type == "and"
+
 
 @pytest.mark.asyncio
 async def test_eager_hourly_partitioned() -> None:


### PR DESCRIPTION
## Summary & Motivation

This will be used to provide the UI with more semantic information about how a given condition works.

To start, we'll use this to help determine the collapsed state of each node in the evaluation tree, but we may also end up using this for other parts of the rendering to make it more obvious how results are being combined together.

## How I Tested These Changes

## Changelog

NOCHANGELOG
