### PR TITLE
[dg] Fail on dagster-dg version less than dagster version (BUILD-1041)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import textwrap
 from collections.abc import Iterable, Mapping
 from functools import cached_property
 from pathlib import Path
@@ -909,12 +910,15 @@ def _validate_dagster_dg_and_dagster_version_compatibility(context: DgContext) -
     minimum_dagster_dg_version = Version(library_version_from_core_version(str(dagster_version)))
     if dagster_dg_version < minimum_dagster_dg_version:
         exit_with_error(
-            f"""
-            dagster-dg version is incompatible with the installed version of dagster.
+            textwrap.dedent(f"""
+            Current `dg` version ({dagster_dg_version}) is incompatible with `dagster` version ({dagster_version}) in the resolved environment.
+            Please upgrade your `dg` version to at least {minimum_dagster_dg_version} in order to use `dg` with this environment.
 
-                dagster-dg: {dagster_dg_version}
-                dagster: {dagster_version}
+                dg version: {dagster_dg_version}
+                dg executable: {shutil.which("dg")}
 
-            For dagster=={dagster_version} The minimum compatible version of dagster-dg is {minimum_dagster_dg_version}.
-            """
+                dagster version: {dagster_version}
+                dagster executable: {context.get_executable("dagster")}
+            """).strip(),
+            do_format=False,
         )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -36,7 +36,9 @@ from dagster_dg_tests.utils import (
     ConfigFileType,
     ProxyRunner,
     assert_runner_result,
+    dg_does_not_exit,
     dg_does_not_warn,
+    dg_exits,
     dg_warns,
     install_editable_dagster_packages_to_venv,
     isolated_components_venv,
@@ -324,6 +326,27 @@ def test_dg_up_to_date_warning(monkeypatch):
             DgContext.from_file_discovery_and_command_line_config(Path.cwd(), cli_config)
             out_str = out.getvalue()
             assert warning_str not in out_str
+
+
+def test_fail_on_dagster_dg_less_than_dagster(monkeypatch):
+    match_str = "dagster-dg version is incompatible with the installed version of dagster"
+
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
+        context = DgContext.for_project_environment(Path.cwd(), {})
+
+        # Versions are the same, (0+dev) for the dev versions of packages, so no problem
+        with dg_does_not_exit(match_str):
+            context.external_components_command(["--help"])
+
+        # Now dagster-dg is greater than dagster, this is still OK
+        monkeypatch.setattr(dagster_dg.context, "__version__", "2!0+dev")
+        with dg_does_not_exit(match_str):
+            context.external_components_command(["--help"])
+
+        # Now dagster-dg is less than dagster, this should fail
+        monkeypatch.setattr(dagster_dg.context, "__version__", "0!0+dev")
+        with dg_exits("dagster-dg version is incompatible with the installed version of dagster"):
+            context.external_components_command(["--help"])
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_context.py
@@ -329,23 +329,23 @@ def test_dg_up_to_date_warning(monkeypatch):
 
 
 def test_fail_on_dagster_dg_less_than_dagster(monkeypatch):
-    match_str = "dagster-dg version is incompatible with the installed version of dagster"
+    match_strs = ["Current `dg` version", "incompatible with `dagster` version"]
 
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
         context = DgContext.for_project_environment(Path.cwd(), {})
 
         # Versions are the same, (0+dev) for the dev versions of packages, so no problem
-        with dg_does_not_exit(match_str):
+        with dg_does_not_exit(*match_strs):
             context.external_components_command(["--help"])
 
         # Now dagster-dg is greater than dagster, this is still OK
         monkeypatch.setattr(dagster_dg.context, "__version__", "2!0+dev")
-        with dg_does_not_exit(match_str):
+        with dg_does_not_exit(*match_strs):
             context.external_components_command(["--help"])
 
         # Now dagster-dg is less than dagster, this should fail
         monkeypatch.setattr(dagster_dg.context, "__version__", "0!0+dev")
-        with dg_exits("dagster-dg version is incompatible with the installed version of dagster"):
+        with dg_exits(*match_strs):
             context.external_components_command(["--help"])
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -404,7 +404,7 @@ def convert_dg_toml_to_pyproject_toml(dg_toml_path: Path, pyproject_toml_path: P
 
 
 @contextmanager
-def dg_exits(matches: str) -> Iterator[None]:
+def dg_exits(*matches: str) -> Iterator[None]:
     """Context manager that checks for an error message and SysExit exception. Designed to be a
     replacement for `pytest.raises`, since the error messages we print aren't part of the exception
     message.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -20,6 +20,7 @@ from typing import Any, Literal, Optional, TextIO, Union
 
 import click
 import psutil
+import pytest
 import requests
 import tomlkit
 import tomlkit.items
@@ -403,6 +404,47 @@ def convert_dg_toml_to_pyproject_toml(dg_toml_path: Path, pyproject_toml_path: P
 
 
 @contextmanager
+def dg_exits(matches: str) -> Iterator[None]:
+    """Context manager that checks for an error message and SysExit exception. Designed to be a
+    replacement for `pytest.raises`, since the error messages we print aren't part of the exception
+    message.
+
+    Args:
+        match: The string to match against the warning message.
+    """
+    with redirect_dg_output() as out:
+        with pytest.raises(SystemExit):
+            yield
+        output = out.getvalue()
+        for m in matches:
+            assert re.search(m, output), textwrap.dedent(f"""
+            Output did not match.
+            Target:
+                {m}
+            Output:
+            """) + textwrap.indent(output, "    ")
+
+
+@contextmanager
+def dg_does_not_exit(*matches: str) -> Iterator[None]:
+    """Context manager that checks that dg does not emit the given output or throw an exception.
+
+    Args:
+        match: The string to match against the warning message.
+    """
+    with redirect_dg_output() as out:
+        yield
+        output = out.getvalue()
+        for m in matches:
+            assert not re.search(m, output), textwrap.dedent(f"""
+            Output matched when it should not.
+            Target:
+                {m}
+            Output:
+            """) + textwrap.indent(output, "    ")
+
+
+@contextmanager
 def dg_warns(*matches: str) -> Iterator[None]:
     """Context manager that checks for dg warnings. Designed to be a replacement for `pytest.warns`,
     since dg warnings don't emit actual python warnings.
@@ -422,23 +464,8 @@ def dg_warns(*matches: str) -> Iterator[None]:
             """) + textwrap.indent(output, "    ")
 
 
-@contextmanager
-def dg_does_not_warn(*matches: str) -> Iterator[None]:
-    """Context manager that checks that dg does not emit a given warning.
-
-    Args:
-        match: The string to match against the warning message.
-    """
-    with redirect_dg_output() as out:
-        yield
-        output = out.getvalue()
-        for m in matches:
-            assert not re.search(m, output), textwrap.dedent(f"""
-            Output matched when it should not.
-            Target:
-                {m}
-            Output:
-            """) + textwrap.indent(output, "    ")
+# They have the same inner behavior but nice to have two names
+dg_does_not_warn = dg_does_not_exit
 
 
 @contextmanager


### PR DESCRIPTION
## Summary & Motivation

Exit with an error when the `dg` version is less than the dagster in the in-scope environment. We have to transform the "core version" of `dagster` to a "library version" in order to perform the comparison.

The check is run whenever we spawn a `dagster-components` subprocess.
## How I Tested These Changes

New unit tests.

## Changelog

`dg` will now fail with an error message if it's version is below the minimum supported version for the version of `dagster` in your environment.
