### PR TITLE
[dg] Collapse load errors when invoking dg list defs

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -96,18 +96,10 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
     "--output-file",
     help="Write to file instead of stdout. If not specified, will write to stdout.",
 )
-@click.option(
-    "--verbose",
-    "-v",
-    flag_value=True,
-    default=False,
-    help="Show verbose stack traces, including system frames in stack traces.",
-)
 @click.pass_context
 def list_definitions_command(
     ctx: click.Context,
     location: Optional[str],
-    verbose: bool,
     output_file: Optional[str],
     **other_opts: object,
 ) -> None:
@@ -134,13 +126,10 @@ def list_definitions_command(
             recon_repo = recon_repository_from_origin(repository_origin)
             repo_def = recon_repo.get_definition()
         except Exception:
-            if verbose:
-                underlying_error = serializable_error_info_from_exc_info(sys.exc_info())
-            else:
-                underlying_error = remove_system_frames_from_error(
-                    serializable_error_info_from_exc_info(sys.exc_info()),
-                    build_system_frame_removed_hint=removed_system_frame_hint,
-                )
+            underlying_error = remove_system_frames_from_error(
+                serializable_error_info_from_exc_info(sys.exc_info()),
+                build_system_frame_removed_hint=removed_system_frame_hint,
+            )
 
             logger.error(f"Loading location {location} failed:\n\n{underlying_error.to_string()}")
             sys.exit(1)


### PR DESCRIPTION
## Summary

Collapse error messages when loading a repo for the purposes of `dg list defs`, in a similar vein to what we do for `dg dev` and `dg check defs`:

```sh
$ dg list defs
Using /Users/ben/repos/components_demo/missing-resource-demo/.venv/bin/dagster-components
Loading location missing-resource-demo failed:

dagster._core.errors.DagsterInvalidDefinitionError: resource with key 'my_resource' required by op 'my_asset' was not provided. Please provide a ResourceDefinition to key 'my_resource', or change the required key to one of the following keys which points to an ResourceDefinition: ['io_manager']

Stack Trace:
  [15 dagster system frames hidden, run dg check defs --verbose to see the full stack trace]

An error occurred while executing a `dagster-components` command in the Python environment at /Users/ben/repos/components_demo/missing-resource-demo/.venv.

`uv run dagster-components list definitions --location missing-resource-demo --module-name missing_resource_demo.definitions --output-file /var/folders/bc/4npnrqyd46l4vbbkdsdsw3_h0000gn/T/tmpspyxetpf` exited with code 1. Aborting.
```

Users are instructed to call `dg check defs --verbose` to get the full stacktrace.

## How I Tested These Changes

New unit test, tested locally.

## Changelog

> [dg] `dg list defs` now collapses long system stacktraces
