### PR TITLE
[dagster-datadog] exposes flush and wait_for_pending dogstatsd methods

### DIFF
--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -31,6 +31,8 @@ class DatadogClient:
             "service_check",
             "timed",
             "timing",
+            "flush",
+            "wait_for_pending",
         ]:
             setattr(self, method, getattr(statsd, method))
 

--- a/python_modules/libraries/dagster-datadog/dagster_datadog_tests/test_resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog_tests/test_resources.py
@@ -17,6 +17,8 @@ def assert_datadog_client_class(
     service_check,
     timed,
     timing,
+    flush,
+    wait_for_pending,
     Event,
     Metric,
     ServiceCheck,
@@ -51,6 +53,12 @@ def assert_datadog_client_class(
 
     datadog_client.timing("query.response.time", 1234)
     timing.assert_called_with("query.response.time", 1234)
+
+    datadog_client.flush()
+    flush.assert_called()
+
+    datadog_client.wait_for_pending()
+    wait_for_pending.assert_called()
 
     datadog_client.api.Event.create(
         title="Something happened!", text="Event text", tags=["version:1", "application:web"]
@@ -91,6 +99,8 @@ def assert_datadog_client_class(
 @mock.patch("datadog.api.ServiceCheck")
 @mock.patch("datadog.api.Metric")
 @mock.patch("datadog.api.Event")
+@mock.patch("datadog.statsd.wait_for_pending")
+@mock.patch("datadog.statsd.flush")
 @mock.patch("datadog.statsd.timing")
 @mock.patch("datadog.statsd.timed")
 @mock.patch("datadog.statsd.service_check")
@@ -112,6 +122,8 @@ def test_datadog_resource(
     service_check,
     timed,
     timing,
+    flush,
+    wait_for_pending,
     Event,
     Metric,
     ServiceCheck,
@@ -134,6 +146,8 @@ def test_datadog_resource(
             service_check,
             timed,
             timing,
+            flush,
+            wait_for_pending,
             Event,
             Metric,
             ServiceCheck,
@@ -155,6 +169,8 @@ def test_datadog_resource(
 @mock.patch("datadog.api.ServiceCheck")
 @mock.patch("datadog.api.Metric")
 @mock.patch("datadog.api.Event")
+@mock.patch("datadog.statsd.wait_for_pending")
+@mock.patch("datadog.statsd.flush")
 @mock.patch("datadog.statsd.timing")
 @mock.patch("datadog.statsd.timed")
 @mock.patch("datadog.statsd.service_check")
@@ -176,6 +192,8 @@ def test_datadog_pythonic_resource_standalone_op(
     service_check,
     timed,
     timing,
+    flush,
+    wait_for_pending,
     Event,
     Metric,
     ServiceCheck,
@@ -199,6 +217,8 @@ def test_datadog_pythonic_resource_standalone_op(
             service_check,
             timed,
             timing,
+            flush,
+            wait_for_pending,
             Event,
             Metric,
             ServiceCheck,
@@ -217,6 +237,8 @@ def test_datadog_pythonic_resource_standalone_op(
 @mock.patch("datadog.api.ServiceCheck")
 @mock.patch("datadog.api.Metric")
 @mock.patch("datadog.api.Event")
+@mock.patch("datadog.statsd.wait_for_pending")
+@mock.patch("datadog.statsd.flush")
 @mock.patch("datadog.statsd.timing")
 @mock.patch("datadog.statsd.timed")
 @mock.patch("datadog.statsd.service_check")
@@ -238,6 +260,8 @@ def test_datadog_pythonic_resource_factory_op_in_job(
     service_check,
     timed,
     timing,
+    flush,
+    wait_for_pending,
     Event,
     Metric,
     ServiceCheck,
@@ -263,6 +287,8 @@ def test_datadog_pythonic_resource_factory_op_in_job(
             service_check,
             timed,
             timing,
+            flush,
+            wait_for_pending,
             Event,
             Metric,
             ServiceCheck,


### PR DESCRIPTION
## Summary & Motivation

When sending metric data points at the end of a pipeline, sometimes the buffer won't have the time to flush before termination.

## How I Tested These Changes

- added methods to test suite

## Changelog

- [dagster-datadog] exposes flush and wait_for_pending dogstatsd methods