### PR TITLE
[da] Allow AutomationResult to take a `metadata` parameter

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -105,6 +105,7 @@ class AutomationConditionEvaluation(Generic[T_EntityKey]):
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     child_evaluations: Sequence["AutomationConditionEvaluation"]
+    metadata: Optional[MetadataMapping] = None
 
     @property
     def key(self) -> T_EntityKey:
@@ -158,6 +159,7 @@ class AutomationConditionNodeCursor(Generic[T_EntityKey]):
     ]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
     extra_state: Optional[StructuredCursor]
+    metadata: Optional[MetadataMapping] = None
 
     def get_structured_cursor(
         self, as_type: type[T_StructuredCursor]


### PR DESCRIPTION
## Summary & Motivation

This is used upstack to add additional metadata to the evaluation of a SinceCondition.

This likely has other applications as well (e.g. the EntityMatches condition could store AssetKeyMetadataValues to be a bit more explicit about what asset is getting evaluated).

While it's a bit funky to use SubsetsWithMetadata for this sort of thing, I deemed this safer than adding a whole extra parallel storage field. It's sorta nice to just reuse what we have here.

## How I Tested These Changes

## Changelog

NOCHANGELOG
