### PR TITLE
[dg] Catch missing modules before running dg dev, dg check defs, dg list defs

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check.py
@@ -149,7 +149,9 @@ def check_definitions_command(
 
     with (
         pushd(dg_context.root_path),
-        create_dagster_cli_cmd(dg_context, forward_options, run_cmds) as (
+        create_dagster_cli_cmd(
+            dg_context, forward_options, run_cmds, validate_modules_accessible=True
+        ) as (
             cmd_location,
             cmd,
             workspace_file,

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/dev.py
@@ -151,7 +151,9 @@ def dev_command(
 
     with (
         pushd(dg_context.root_path),
-        create_dagster_cli_cmd(dg_context, forward_options, run_cmds=run_cmds) as cmd_object,
+        create_dagster_cli_cmd(
+            dg_context, forward_options, run_cmds=run_cmds, validate_modules_accessible=True
+        ) as cmd_object,
     ):
         if check_yaml:
             overall_check_result = True

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -23,6 +23,7 @@ from rich.table import Table
 from rich.text import Text
 
 from dagster_dg.cli.shared_options import dg_global_options, dg_path_options
+from dagster_dg.cli.utils import validate_modules_accessible_or_err
 from dagster_dg.component import PluginObjectFeature, RemotePluginRegistry
 from dagster_dg.config import normalize_cli_config
 from dagster_dg.context import DgContext
@@ -293,6 +294,7 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
     """List registered Dagster definitions in the current project environment."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(path, cli_config)
+    validate_modules_accessible_or_err(dg_context)
 
     # On newer versions, we use a dedicated channel in the form of a tempfile that will _only_ have
     # the expected output written to it.

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -13,6 +13,8 @@ from packaging.version import Version
 
 ensure_dagster_dg_tests_import()
 
+import os
+
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
 from dagster_dg_tests.utils import (
@@ -20,10 +22,12 @@ from dagster_dg_tests.utils import (
     assert_runner_result,
     fixed_panel_width,
     isolated_components_venv,
+    isolated_dg_venv,
     isolated_example_component_library_foo_bar,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
     match_terminal_box_output,
+    pushd,
 )
 
 # ########################
@@ -484,6 +488,22 @@ def _sample_env_var_assets():
 def test_list_defs_aliases(alias: str):
     with ProxyRunner.test() as runner:
         assert_runner_result(runner.invoke("list", alias, "--help"))
+
+
+def test_list_defs_has_comprehensible_error_when_modules_not_available():
+    with ProxyRunner.test() as runner, isolated_dg_venv(runner):
+        result = runner.invoke("scaffold", "project", "my-new-project")
+        assert_runner_result(result)
+
+        with pushd("my-new-project"):
+            result = runner.invoke("list", "defs")
+            assert result.exit_code != 0, str(result.stdout) + "\n" + str(result.exception)
+            assert "Could not locate module `my_new_project.definitions`" in str(
+                result.stdout
+            ) + "\n" + str(result.exception)
+            assert f"You may need to run `pip install -e {os.getcwd()}`" in str(
+                result.stdout
+            ) + "\n" + str(result.exception)
 
 
 # ########################


### PR DESCRIPTION
## Summary

Runs a pre-flight check before invoking an underlying `dagster` or `dagster-components` command which requires loading a Python entrypoint module for a project. If that module is not accessible, raises a clearly actionable error:

```sh
dg list defs
Could not locate module `my_project_no_sync.definitions` using Python executable /Users/ben/.pyenv/versions/dagster/bin/python.

You may need to run `pip install -e /Users/ben/repos/components_demo/my_project_no_sync`.
```

## How I Tested These Changes

New unit tests.

## Changelog

> [dg] dg CLI tools now more clearly error when the target project is not installed to the Python venv.
