### PR TITLE
[ui] Fix dg-docs error on some schemas, visual nits

### DIFF
--- a/js_modules/dagster-ui/packages/dg-docs-components/package.json
+++ b/js_modules/dagster-ui/packages/dg-docs-components/package.json
@@ -15,7 +15,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "strip-markdown": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentHeader.tsx
@@ -1,8 +1,9 @@
-import {HTMLProps} from 'react';
+import {HTMLProps, useMemo} from 'react';
 import Markdown, {Components} from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-
+import {remark} from 'remark';
 import styles from './css/ComponentHeader.module.css';
+import strip from 'strip-markdown';
 
 import ComponentTags from './ComponentTags';
 import {ComponentType} from './types';
@@ -15,11 +16,16 @@ interface Props {
 export default function ComponentHeader({config, descriptionStyle}: Props) {
   const {description, name} = config;
 
-  // For truncated display, use only the first line in the description.
-  const displayedDescription =
-    descriptionStyle === 'truncated'
-      ? ((description || '').split('\n').find((str) => str.trim().length > 0) ?? '')
-      : description;
+  // For truncated display, use only the first text block in the description.
+  const displayedDescription = useMemo(
+    () =>
+      descriptionStyle === 'truncated'
+        ? (markdownToPlaintext(description || '')
+            .split('\n\n')
+            .find((str) => str.trim().length > 0) ?? '')
+        : description,
+    [descriptionStyle, description],
+  );
 
   return (
     <div className={styles.container}>
@@ -58,4 +64,10 @@ export default function ComponentHeader({config, descriptionStyle}: Props) {
 
 const componentsMinusLinks: Components = {
   a: ({children}: HTMLProps<HTMLAnchorElement>) => <span>{children}</span>,
+};
+
+const Remark = remark().use(strip);
+
+export const markdownToPlaintext = (md: string) => {
+  return Remark.processSync(md).toString().replace(/\\/g, '').trim();
 };

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentSchema.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentSchema.tsx
@@ -67,11 +67,14 @@ function Property({
     return null;
   }
 
-  const {anyOf, type, description, default: defaultValue, $ref, required, examples} = property;
+  const {anyOf, type, description, $ref, required, examples} = property;
 
   const expandable = isExpandableProperty(property);
 
   const firstExample = examples ? (Array.isArray(examples) ? examples[0] : examples) : null;
+
+  const defaultValue =
+    property.default && property.default !== '__DAGSTER_UNSET_DEFAULT__' ? property.default : null;
 
   return (
     <div className={styles.propertyContainer}>
@@ -83,7 +86,7 @@ function Property({
         <div className={styles.property}>
           <div className={styles.propertyNameAndTypes}>
             <div className={styles.propertyName}>{name}</div>
-            {$ref ? <PropertyRef ref={$ref} defs={defs} /> : null}
+            {$ref ? <PropertyRef $ref={$ref} defs={defs} /> : null}
             {type ? <PropertyType property={property} defs={defs} /> : null}
             {anyOf ? <PropertyAnyOf anyOf={anyOf} defs={defs} /> : null}
             {required ? <div className={styles.required}>required</div> : null}
@@ -246,13 +249,13 @@ function propertyTypeToString(typeName: JSONSchema7TypeName) {
 }
 
 function PropertyRef({
-  ref,
+  $ref,
   defs,
 }: {
-  ref: string;
+  $ref: string;
   defs: Record<string, JSONSchema7Definition> | undefined;
 }) {
-  const refName = ref.split('/').pop();
+  const refName = $ref.split('/').pop();
   if (refName) {
     const definition = defs?.[refName];
     if (definition) {

--- a/js_modules/dagster-ui/packages/dg-docs-components/src/css/PackagePageDetails.module.css
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/css/PackagePageDetails.module.css
@@ -1,7 +1,7 @@
 .container {
   overflow-y: auto;
   flex: 1;
-  padding: 24px 32px;
+  padding: 16px 24px;
 }
 
 .container a {

--- a/js_modules/dagster-ui/packages/dg-docs-site/package.json
+++ b/js_modules/dagster-ui/packages/dg-docs-site/package.json
@@ -18,7 +18,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "strip-markdown": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -3624,6 +3624,7 @@ __metadata:
     react-dom: ^18.3.1
     react-markdown: ^10.1.0
     remark-gfm: ^4.0.1
+    strip-markdown: ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3649,6 +3650,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-markdown: "npm:^10.1.0"
     remark-gfm: "npm:^4.0.1"
+    strip-markdown: "npm:^6.0.0"
     typescript: "npm:^5"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR makes a couple drive-by changes:

- The positioning of the content anchoring icon no longer changes as you switch between the list and detail pages of docs. I used a bit of a non-standard padding value but it's a lot less jarring I think?

- The descriptions use the first text block of the parsed markdown, not the first line of the unparsed markdown, which fixes 

<img width="623" alt="image" src="https://github.com/user-attachments/assets/dd6bcfda-7e2a-4df0-a228-a33a7aae7bcf" />


- There was a remaining reference to a prop called ref, and it needed to be $ref to avoid a React deprecation crash. 
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/d79dfd08-656b-4862-aeee-4098bb4290c2" />
