### PR TITLE
[dg] Update dg list plugin IPC

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/1-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/1-tree.txt
@@ -1,6 +1,7 @@
 tree
 
 .
+├── README.md
 ├── my_existing_project
 │   ├── __init__.py
 │   ├── analytics
@@ -14,7 +15,6 @@ tree
 │       ├── __init__.py
 │       ├── assets.py
 │       └── jobs.py
-├── pyproject.toml
-└── README.md
+└── pyproject.toml
 
 5 directories, 11 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/5-tree-after.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/5-tree-after.txt
@@ -1,6 +1,7 @@
 tree
 
 .
+├── README.md
 ├── my_existing_project
 │   ├── __init__.py
 │   ├── analytics
@@ -15,7 +16,6 @@ tree
 │           ├── assets.py
 │           └── jobs.py
 ├── pyproject.toml
-├── README.md
 └── uv.lock
 
 5 directories, 12 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/6-tree-after-all.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-definitions/6-tree-after-all.txt
@@ -1,6 +1,7 @@
 tree
 
 .
+├── README.md
 ├── my_existing_project
 │   ├── __init__.py
 │   ├── definitions.py
@@ -15,7 +16,6 @@ tree
 │           ├── assets.py
 │           └── jobs.py
 ├── pyproject.toml
-├── README.md
 └── uv.lock
 
 5 directories, 12 files

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_definitions/test_migrating_definitions.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_definitions/test_migrating_definitions.py
@@ -57,7 +57,6 @@ def test_components_docs_migrating_definitions(update_snippets: bool) -> None:
         )
 
         _run_command(cmd="uv venv")
-        _run_command(cmd="uv sync")
         _run_command(
             f"uv add --editable '{DAGSTER_ROOT / 'python_modules' / 'dagster'!s}' "
             f"'{DAGSTER_ROOT / 'python_modules' / 'libraries' / 'dagster-shared'!s}' "

--- a/python_modules/dagster/dagster/components/core/package_entry.py
+++ b/python_modules/dagster/dagster/components/core/package_entry.py
@@ -28,17 +28,20 @@ def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.m
         return importlib.metadata.entry_points().get(group, [])
 
 
+def get_plugin_entry_points() -> Sequence[importlib.metadata.EntryPoint]:
+    return [
+        *get_entry_points_from_python_environment(DG_PLUGIN_ENTRY_POINT_GROUP),
+        *get_entry_points_from_python_environment(OLD_DG_PLUGIN_ENTRY_POINT_GROUP),
+    ]
+
+
 def discover_entry_point_package_objects() -> dict[PluginObjectKey, object]:
     """Discover package entries registered in the Python environment via the
     `dagster_dg.plugin` entry point group.
     """
     objects: dict[PluginObjectKey, object] = {}
-    entry_points = [
-        *get_entry_points_from_python_environment(DG_PLUGIN_ENTRY_POINT_GROUP),
-        *get_entry_points_from_python_environment(OLD_DG_PLUGIN_ENTRY_POINT_GROUP),
-    ]
 
-    for entry_point in entry_points:
+    for entry_point in get_plugin_entry_points():
         try:
             root_module = entry_point.load()
         except Exception as e:

--- a/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
+++ b/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
@@ -16,6 +16,7 @@ from dagster.components.core.package_entry import discover_entry_point_package_o
 from dagster.components.core.snapshot import get_package_entry_snap
 from dagster_dg.utils import get_venv_executable
 from dagster_shared.serdes.objects import PluginObjectKey
+from dagster_shared.serdes.objects.package_entry import PluginManifest
 from dagster_shared.serdes.serdes import deserialize_value
 
 ensure_dagster_tests_import()
@@ -47,7 +48,7 @@ def _get_component_print_script_result(venv_root: Path) -> subprocess.CompletedP
     dagster_components_path = get_venv_executable(venv_root, "dagster-components")
     assert dagster_components_path.exists()
     result = subprocess.run(
-        [str(dagster_components_path), "list", "library"],
+        [str(dagster_components_path), "list", "plugins"],
         capture_output=True,
         text=True,
         check=False,
@@ -57,7 +58,9 @@ def _get_component_print_script_result(venv_root: Path) -> subprocess.CompletedP
 
 def _get_component_types_in_python_environment(venv_root: Path) -> Sequence[str]:
     result = _get_component_print_script_result(venv_root)
-    return [obj.key.to_typename() for obj in deserialize_value(result.stdout, list)]
+    return [
+        obj.key.to_typename() for obj in deserialize_value(result.stdout, PluginManifest).objects
+    ]
 
 
 def _find_repo_root():

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -126,8 +126,9 @@ def _all_plugins_object_table(
     for package in sorted(registry.packages):
         if not name_only:
             objs = registry.get_objects(package, feature)
-            inner_table = _plugin_object_table(objs)
-            table.add_row(package, inner_table)
+            if objs:  # only add the row if there are objects
+                inner_table = _plugin_object_table(objs)
+                table.add_row(package, inner_table)
         else:
             table.add_row(package)
     return table
@@ -173,6 +174,7 @@ def list_plugins_command(
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_defined_registry_environment(path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
+    # pp(registry.get_objects())
 
     if output_json:
         output: list[dict[str, object]] = []

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -352,7 +352,7 @@ def test_scaffold_project_already_exists_fails() -> None:
 
 def test_scaffold_project_non_editable_dagster_dagster_components_executable_exists() -> None:
     with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke("scaffold", "project", "bar")
+        result = runner.invoke("scaffold", "project", "bar", "--python-environment", "uv_managed")
         assert_runner_result(result)
         with pushd("bar"):
             result = runner.invoke("list", "plugins", "--verbose")
@@ -491,7 +491,7 @@ def test_scaffold_component_command_with_non_matching_module_name():
             "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
-        assert "Cannot find module `foo_bar.lib`" in str(result.exception)
+        assert "Cannot find module `foo_bar.lib`" in result.output
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
@@ -544,7 +544,7 @@ def test_scaffold_component_fails_defs_module_does_not_exist() -> None:
             "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
-        assert "Cannot find module `foo_bar._defs`" in str(result.exception)
+        assert "Cannot find module `foo_bar._defs`" in result.output
 
 
 def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
@@ -867,6 +867,4 @@ def test_scaffold_component_type_fails_components_lib_package_does_not_exist(cap
         # code, because the entry points are loaded first.
         result = runner.invoke("scaffold", "component-type", "Baz")
         assert_runner_result(result, exit_0=False)
-
-        captured = capfd.readouterr()
-        assert "Error loading entry point `foo_bar` in group `dagster_dg.plugin`." in captured.err
+        assert "Cannot find module `foo_bar.fake`" in result.output

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
@@ -78,8 +78,10 @@ class ScaffoldTargetTypeData(PluginObjectFeatureData):
 
 
 ###############
-# PACKAGE ENTRY
+# PLUGIN MANIFEST
 ###############
+
+
 @whitelist_for_serdes
 @record
 class PluginObjectSnap:
@@ -117,6 +119,29 @@ class PluginObjectSnap:
     def component_schema(self) -> Optional[dict[str, Any]]:
         component_data = self.get_feature_data("component")
         return component_data.schema if component_data else None
+
+
+@whitelist_for_serdes
+@record
+class PluginManifest:
+    """A manifest of all components in a package.
+
+    This is used to generate the component registry and to validate that the package entry point
+    is valid.
+    """
+
+    modules: Sequence[str]  # List of modules scanned
+    objects: Sequence[PluginObjectSnap]
+
+    def merge(self, other: "PluginManifest") -> "PluginManifest":
+        """Merge another manifest with this one and return a new instance."""
+        shared_modules = set(self.modules).intersection(other.modules)
+        if shared_modules:
+            raise ValueError(f"Cannot merge manifests with overlapping modules: {shared_modules}.")
+        return PluginManifest(
+            modules=[*self.modules, *other.modules],
+            objects=[*self.objects, *other.objects],
+        )
 
 
 ###################################


### PR DESCRIPTION
## Summary & Motivation

- Change `dagster-components list library` -> `list plugins`. This should have been done when the `dg` command was converted.
- The output format has been changed. `list libraries` outputs a `list[PluginObjectSnap]`. `list plugins` outputs a `PluginManifest`. The `PluginManifest` contains a `list[PluginObjectSnap]` but also a list of all modules scanned. This means it contains information about which plugins were scanned but contained no objects. This is useful to detect the situation where a project declares an entry point but it isn't registered (see [upstack](https://github.com/dagster-io/dagster/pull/29514)).
- `dg` will detect when it's dealing with a version with `list plugins` or `list libraries` and call the appropriate command. It also normalizes the differing output formats to the same `PluginManifest` format on the `dg` end.

## How I Tested These Changes

New unit tests, including backcompat tests.