### PR TITLE
[dg] Warn when package defines entry point but its missing from manifest (BUILD-1030)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/warnings.py
@@ -12,6 +12,7 @@ DgWarningIdentifier: TypeAlias = Literal[
     "deprecated_user_config_location",
     "deprecated_python_environment",
     "deprecated_dagster_dg_library_entry_point",
+    "missing_dg_plugin_module_in_manifest",
     "project_and_activated_venv_mismatch",
 ]
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -177,7 +177,7 @@ def test_sub_command_with_option_help_message():
 def test_dynamic_subcommand_help_message():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
-        isolated_example_project_foo_bar(runner),
+        isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
         with fixed_panel_width(width=120):
             result = runner.invoke(


### PR DESCRIPTION
## Summary & Motivation

Emit a warning when a project defines a `dagster_dg.plugin` entry point, but the targeted module is not present in the `PluginManifest` retrieved via `dagster-components list plugins`. This can help users avoid the frustrating situation where they've defined an entry point but their custom components aren't showing up. The warning is:

```
Your package defines a `dagster_dg.plugin` entry point, but this module was not
found in the plugin manifest for the current environment. This means either that
your project is not installed in the current environment, or that the entry point
metadata was added after your module was installed. Python entry points are
registered at package install time. Please reinstall your package into the current
environment to ensure the entry point is registered.

Entry point module: `foo_bar.lib`
```

## How I Tested These Changes

New unit tests

## Changelog

`dg` will now emit a warning prompting the user to reinstall the package if it detects an entry point in project metadata that does not show up when running in `dg list plugins`.