### PR TITLE
[ui] Support new freshness row on faceted asset nodes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, Tag, Tooltip} from '@dagster-io/ui-components';
+import {Box, Colors, Tag, Tooltip} from '@dagster-io/ui-components';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -15,6 +15,7 @@ import {
   AssetNodeRowBox,
 } from './AssetNode';
 import {AssetNodeFacet, labelForFacet} from './AssetNodeFacets';
+import {AssetNodeFreshnessRow, AssetNodeFreshnessRowOld} from './AssetNodeFreshnessRow';
 import {AssetNodeHealthRow} from './AssetNodeHealthRow';
 import {assetNodeLatestEventContent, buildAssetNodeStatusContent} from './AssetNodeStatusContent';
 import {LiveDataForNode, LiveDataForNodeWithStaleData} from './Utils';
@@ -22,13 +23,12 @@ import {ASSET_NODE_TAGS_HEIGHT} from './layout';
 import {featureEnabled} from '../app/Flags';
 import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {ChangedReasonsTag} from '../assets/ChangedReasons';
-import {isAssetOverdue} from '../assets/OverdueTag';
 import {StaleReasonsTag} from '../assets/Stale';
-import {AssetNodeFragment} from './types/AssetNode.types';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKind} from '../graph/KindTags';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
+import {AssetNodeFragment} from './types/AssetNode.types';
 
 interface Props2025 {
   definition: AssetNodeFragment;
@@ -111,21 +111,12 @@ export const AssetNodeWithLiveData = ({
               ) : null}
             </AssetNodeRow>
           )}
-          {facets.has(AssetNodeFacet.Freshness) && (
-            <AssetNodeRow label={labelForFacet(AssetNodeFacet.Freshness)}>
-              {!liveData?.freshnessInfo ? null : isAssetOverdue(liveData) ? (
-                <Box flex={{gap: 4, alignItems: 'center'}}>
-                  <Icon name="close" color={Colors.accentRed()} />
-                  Violated
-                </Box>
-              ) : (
-                <Box flex={{gap: 4, alignItems: 'center'}}>
-                  <Icon name="done" color={Colors.accentGreen()} />
-                  Passing
-                </Box>
-              )}
-            </AssetNodeRow>
-          )}
+          {facets.has(AssetNodeFacet.Freshness) &&
+            (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
+              <AssetNodeFreshnessRow definition={definition} liveData={liveData} />
+            ) : (
+              <AssetNodeFreshnessRowOld liveData={liveData} />
+            ))}
           {facets.has(AssetNodeFacet.Status) &&
             (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
               <AssetNodeHealthRow definition={definition} liveData={liveData} />
@@ -153,7 +144,7 @@ export const AssetNodeWithLiveData = ({
   );
 };
 
-const AssetNodeRow = ({
+export const AssetNodeRow = ({
   label,
   children,
 }: {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFreshnessRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFreshnessRow.tsx
@@ -1,0 +1,54 @@
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
+
+import {AssetNodeRow} from './AssetNode2025';
+import {AssetNodeFacet, labelForFacet} from './AssetNodeFacets';
+import {LiveDataForNode} from './Utils';
+import {useAssetHealthData} from '../asset-data/AssetHealthDataProvider';
+import {statusToIconAndColor} from '../assets/AssetHealthSummary';
+import {AssetNodeFragment} from './types/AssetNode.types';
+import {humanizedMinutesLateString, isAssetOverdue} from '../assets/OverdueTag';
+
+export const AssetNodeFreshnessRow = ({
+  definition,
+  liveData,
+}: {
+  definition: AssetNodeFragment;
+  liveData: LiveDataForNode | undefined;
+}) => {
+  const {liveData: healthData} = useAssetHealthData(definition.assetKey);
+  const health = healthData?.assetHealth;
+
+  if (!health?.freshnessStatus) {
+    return <AssetNodeFreshnessRowOld liveData={liveData} />;
+  }
+
+  const {iconColor, subStatusIconName, text2} =
+    statusToIconAndColor[health?.freshnessStatus ?? 'undefined'];
+
+  return (
+    <AssetNodeRow label={labelForFacet(AssetNodeFacet.Freshness)}>
+      <Box flex={{gap: 4, alignItems: 'center'}}>
+        <Icon name={subStatusIconName} color={iconColor} />
+        {text2}
+      </Box>
+    </AssetNodeRow>
+  );
+};
+
+export const AssetNodeFreshnessRowOld = ({liveData}: {liveData: LiveDataForNode | undefined}) => {
+  return (
+    <AssetNodeRow label={labelForFacet(AssetNodeFacet.Freshness)}>
+      {!liveData?.freshnessInfo ? null : isAssetOverdue(liveData) ? (
+        <Box flex={{gap: 4, alignItems: 'center'}}>
+          <Icon name="close" color={Colors.accentRed()} />
+          {humanizedMinutesLateString(liveData.freshnessInfo.currentMinutesLate ?? 0)}
+        </Box>
+      ) : (
+        <Box flex={{gap: 4, alignItems: 'center'}}>
+          <Icon name="done" color={Colors.accentGreen()} />
+          Passing
+        </Box>
+      )}
+    </AssetNodeRow>
+  );
+};


### PR DESCRIPTION
This is a small update that improves support for "Freshness Policy" on the new faceted asset nodes.

This row supports the old freshness policy concept all the time, and the new one if the `Observe UI` feature flag is enabled and a new freshness policy is present. (It's valid to have Observe UI turned on and an old style freshness policy)



Example of an asset with an old freshness policy:

![image](https://github.com/user-attachments/assets/8a8d58c9-1edc-42d9-8edc-c2a265c18aa1)
![image](https://github.com/user-attachments/assets/7e45930d-0ecc-48e3-b078-bc83c0088152)

Example of an asset with a new freshness policy and the Observe UI feature enabled:

![image](https://github.com/user-attachments/assets/294ca3bf-019c-45b8-9a7e-1eb10e840bd1)
![image](https://github.com/user-attachments/assets/d2c3376f-267b-422d-9a32-32f5319bd107)
![image](https://github.com/user-attachments/assets/828bdb44-c353-4447-9809-ce34bda92f0b)

## Testing:

I verified these on live assets and also in the storybook 

![image](https://github.com/user-attachments/assets/2060819e-c9fd-4d17-86fd-fae6a719aa77)


