### PR TITLE
[marketplace] fix generate; add pypi and source

### DIFF
--- a/marketplace/scripts/generate.ts
+++ b/marketplace/scripts/generate.ts
@@ -49,11 +49,6 @@ async function main() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const matterResult = file.data.matter as any;
 
-    // Skip any md files that are not for integrations (e.g. index files for categories).
-    if (matterResult.layout !== 'Integration') {
-      continue;
-    }
-
     let kebabCaseFileName = fileName;
 
     if (fileName.includes('/')) {
@@ -65,20 +60,24 @@ async function main() {
 
     kebabCaseFileName = kebabCaseFileName.replace('.md', '');
 
+    // Prevent inclusion of `index.md` pages
+    if (kebabCaseFileName === 'index' || kebabCaseFileName.endsWith('-index')) {
+      continue;
+    }
+
     fullList.push(kebabCaseFileName);
 
     const frontmatter: IntegrationFrontmatter = {
       id: kebabCaseFileName,
-      status: matterResult.status ?? '',
-      name: matterResult.name ?? '',
       title: matterResult.title ?? '',
-      excerpt: matterResult.excerpt ?? '',
-      logoFilename: null,
-      partnerlink: matterResult.partnerlink ?? '',
-      categories: matterResult.categories ?? [],
-      enabledBy: matterResult.enabledBy ?? [],
-      enables: matterResult.enables ?? [],
+      name: matterResult.sidebar_label ?? '',
+      description: matterResult.description ?? '',
       tags: matterResult.tags ?? [],
+      source: matterResult.source ?? '',
+      pypi: matterResult.pypi ?? '',
+      partnerlink: matterResult.partnerlink ?? '',
+      logoFilename: null,
+      logoPath: null,
     };
 
     let logoFileExists = false;

--- a/marketplace/scripts/types.ts
+++ b/marketplace/scripts/types.ts
@@ -5,14 +5,12 @@ export type IntegrationConfig = {
 
 export type IntegrationFrontmatter = {
   id: string;
-  status: string;
-  name: string;
   title: string;
-  excerpt: string;
+  name: string;
+  description: string;
   partnerlink: string;
   logoFilename: string | null;
-  categories: string[];
-  enabledBy: string[];
-  enables: string[];
   tags: string[];
+  pypi: string;
+  source: string;
 };


### PR DESCRIPTION
## Summary & Motivation

- `layout` has been removed, so we now filter integrations on if they are not `index.md` files
- Adds the `pypi` and `source` meta fields
- Updates `excerpt` to be `description`
- Built-by has been removed and replaced by `tags: ['dagster-supported']` or `tags: ['community-supported']`

## How I Tested These Changes

`yarn generate && yarn start`

## Changelog

NOCHANGELOG
