### PR TITLE
Gate internal freshness policy gql

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -852,8 +852,11 @@ class GrapheneAssetNode(graphene.ObjectType):
         return None
 
     def resolve_internalFreshnessPolicy(
-        self, _graphene_info: ResolveInfo
+        self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneInternalFreshnessPolicy]:
+        if not graphene_info.context.instance.internal_asset_freshness_enabled():
+            return None
+
         if self._asset_node_snap.internal_freshness_policy:
             return GrapheneInternalFreshnessPolicy.from_policy(
                 self._asset_node_snap.internal_freshness_policy

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
@@ -48,31 +48,14 @@ def get_repo() -> RepositoryDefinition:
     ).get_repository_def()
 
 
-def test_internal_freshness_policy_time_window():
+# There is a separate implementation for plus graphql tests.
+def test_internal_freshness_policy():
     with instance_for_test() as instance:
+        assert not instance.internal_asset_freshness_enabled()
         with define_out_of_process_context(__file__, "get_repo", instance) as graphql_context:
             result = execute_dagster_graphql(
                 graphql_context,
                 GET_INTERNAL_FRESHNESS_POLICY,
                 variables={"assetKey": asset_with_internal_freshness_policy.key.to_graphql_input()},
             )
-            assert result.data["assetNodes"][0]["internalFreshnessPolicy"] == {
-                "failWindowSeconds": 600,
-                "warnWindowSeconds": None,
-            }
-
-
-def test_internal_freshness_policy_time_window_with_warn_window():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(__file__, "get_repo", instance) as graphql_context:
-            result = execute_dagster_graphql(
-                graphql_context,
-                GET_INTERNAL_FRESHNESS_POLICY,
-                variables={
-                    "assetKey": asset_with_internal_freshness_policy_with_warn_window.key.to_graphql_input()
-                },
-            )
-            assert result.data["assetNodes"][0]["internalFreshnessPolicy"] == {
-                "failWindowSeconds": 600,
-                "warnWindowSeconds": 300,
-            }
+            assert result.data["assetNodes"][0]["internalFreshnessPolicy"] is None

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3534,3 +3534,6 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def can_read_failure_events_for_asset(self, asset_record: "AssetRecord") -> bool:
         return False
+
+    def internal_asset_freshness_enabled(self) -> bool:
+        return False


### PR DESCRIPTION
## Summary & Motivation
Adds a new dagster instance property `internal_asset_freshness_enabled` to allow gating freshness policy gql apis.

Relies on https://github.com/dagster-io/internal/pull/15253

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
