### PR TITLE
Add `FreshnessState.NOT_APPLICABLE`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -18,6 +18,7 @@ class FreshnessState(str, Enum):
     WARN = "WARN"
     FAIL = "FAIL"
     UNKNOWN = "UNKNOWN"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
 
 
 @whitelist_for_serdes


### PR DESCRIPTION
## Summary & Motivation
This will be specifically used for cases where an asset does not have a freshness policy, so freshness state cannot be evaluated. Imagine the following scenario:

- asset has freshness policy and has "valid" freshness state (either PASS, FAIL or WARN)
- user removes the freshness policy, code location is reloaded
- we re-evaluate freshness state for the asset - what should this state be?

We could have used UNKNOWN, but that state is also used when an asset does have a freshness policy but has never been materialized. Adding a new NOT_APPLICABLE state lets us be more explicit for cases like this.


## How I Tested These Changes
tests in `internal`: https://github.com/dagster-io/internal/pull/15277

## Changelog

> Insert changelog entry or delete this section.
