### PR TITLE
Fix `get_objects` return value in case of no new files since `since_last_modified`

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -65,6 +65,8 @@ def get_objects(
         for idx, obj in enumerate(sorted_objects):
             if obj.get("LastModified") > since_last_modified:
                 return sorted_objects[idx:]
+        # If no new files are found, return an empty list.
+        return []
 
     return sorted_objects
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
@@ -279,3 +279,10 @@ def test_get_objects_with_modified():
         assert len(objects) == 2
         assert objects[0].get("Key").endswith("C")
         assert objects[1].get("Key").endswith("B")
+
+        # Get objects later than the latest. This must return an empty list.
+        objects = get_objects(
+            bucket=BUCKET_NAME, prefix=PREFIX, since_last_modified=objects[-1].get("LastModified")
+        )
+
+        assert not objects


### PR DESCRIPTION
## Summary & Motivation

`get_objects` must return an empty list if no files can be found later than a given `last_modified_date`.
Closes #25890. There's an inactive open PR for this as well: #25891.

## How I Tested These Changes

- Added a unittest.

## Changelog

> S3 sensor's `get_objects` now returns an empty list if no new files can be found since `since_last_modified` parameter.
