### PR TITLE
fix branch vs. prod deployment detection when running on an origin branch

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/plus/deploy_session.py
@@ -26,7 +26,7 @@ def _guess_deployment_type(
         click.echo(f"Could not determine a git branch, so deploying to {full_deployment_name}.")
         return DgPlusDeploymentType.FULL_DEPLOYMENT, full_deployment_name
 
-    if branch_name in {"main", "master"}:
+    if branch_name in {"main", "master", "HEAD"}:
         click.echo(f"Current branch is {branch_name}, so deploying to {full_deployment_name}.")
         return DgPlusDeploymentType.FULL_DEPLOYMENT, full_deployment_name
 


### PR DESCRIPTION
Summary:
On e.g. origin/master this returns HEAD. Detect that case and don't try to create a branch for HEAD.

Test Plan:
Run dg deploy with origin/master checked out

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
