### PR TITLE
[docs] Adds PackageInstallInstructions component

### DIFF
--- a/docs/src/components/PackageInstall.tsx
+++ b/docs/src/components/PackageInstall.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+export const PackageInstallInstructions: React.FunctionComponent<{packageName: string}> = ({packageName}) => {
+  const uvCommand = `uv add ${packageName}`;
+  const pipCommand = `pip install ${packageName}`;
+
+  return (
+    <Tabs>
+      <TabItem value="uv" label="uv">
+        <CodeBlock language="shell">{uvCommand || 'Loading...'}</CodeBlock>
+      </TabItem>
+      <TabItem value="pip" label="pip">
+        <CodeBlock language="shell">{pipCommand || 'Loading...'}</CodeBlock>
+      </TabItem>
+    </Tabs>
+  );
+};

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -1,14 +1,15 @@
 // Import the original mapper
-import MDXComponents from '@theme-original/MDXComponents';
-import {PyObject} from '../components/PyObject';
-import CodeExample from '../components/CodeExample';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
-import Link from '@docusaurus/Link';
 import CliInvocationExample from '../components/CliInvocationExample';
-import {CodeReferenceLink} from '../components/CodeReferenceLink';
+import CodeExample from '../components/CodeExample';
+import Link from '@docusaurus/Link';
+import MDXComponents from '@theme-original/MDXComponents';
+import TOCInline from '@theme/TOCInline';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
 import WideContent from '../components/WideContent';
+import {CodeReferenceLink} from '../components/CodeReferenceLink';
+import {PackageInstallInstructions} from '../components/PackageInstall';
+import {PyObject} from '../components/PyObject';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
@@ -16,9 +17,10 @@ export default {
   CodeExample,
   CodeReferenceLink,
   Link,
+  PackageInstallInstructions,
   PyObject,
   TOCInline,
   TabItem,
-  WideContent,
   Tabs,
+  WideContent,
 };


### PR DESCRIPTION
## Summary & Motivation

Adds reusable component for package install instructions.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8uYb05u2cFYvF82VTjME/c92fc8c2-8154-4f9c-ac19-80cf446c18aa.png)

## How I Tested These Changes

## Changelog

NOCHANGELOG
