### PR TITLE
[docs] update integration packages to use PackageInstallInstructions component

### DIFF
--- a/docs/docs/integrations/libraries/airbyte/airbyte-cloud.md
+++ b/docs/docs/integrations/libraries/airbyte/airbyte-cloud.md
@@ -39,9 +39,7 @@ This guide provides instructions for using Dagster with Airbyte Cloud using the 
 
 To get started, you'll need to install the `dagster` and `dagster-airbyte` Python packages:
 
-```bash
-pip install dagster dagster-airbyte
-```
+<PackageInstallInstructions packageName="dagster-airbyte" />
 
 ## Represent Airbyte Cloud assets in the asset graph
 

--- a/docs/docs/integrations/libraries/airbyte/airbyte-oss.md
+++ b/docs/docs/integrations/libraries/airbyte/airbyte-oss.md
@@ -14,9 +14,7 @@ Using this integration, you can trigger Airbyte syncs and orchestrate your Airby
 
 ### Installation
 
-```bash
-pip install dagster-airbyte
-```
+<PackageInstallInstructions packageName="dagster-airbyte" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/anthropic.md
+++ b/docs/docs/integrations/libraries/anthropic.md
@@ -15,9 +15,7 @@ When paired with Dagster assets, the resource automatically logs Anthropic usage
 
 ### Installation
 
-```bash
-pip install dagster dagster-anthropic
-```
+<PackageInstallInstructions packageName="dagster-anthropic" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/aws/athena.md
+++ b/docs/docs/integrations/libraries/aws/athena.md
@@ -14,9 +14,7 @@ This integration allows you to connect to AWS Athena, a serverless interactive q
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/cloudwatch.md
+++ b/docs/docs/integrations/libraries/aws/cloudwatch.md
@@ -20,9 +20,7 @@ Using this integration, you can configure your Dagster jobs to log directly to A
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/ecr.md
+++ b/docs/docs/integrations/libraries/aws/ecr.md
@@ -20,9 +20,7 @@ Using this integration, you can seamlessly integrate AWS ECR into your Dagster p
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/emr.md
+++ b/docs/docs/integrations/libraries/aws/emr.md
@@ -21,9 +21,7 @@ Using this integration, you can:
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/glue.md
+++ b/docs/docs/integrations/libraries/aws/glue.md
@@ -14,9 +14,7 @@ The `dagster-aws` integration library provides the `PipesGlueClient` resource, e
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/lambda.md
+++ b/docs/docs/integrations/libraries/aws/lambda.md
@@ -14,9 +14,7 @@ Using this integration, you can leverage AWS Lambda to execute external code as 
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/redshift.md
+++ b/docs/docs/integrations/libraries/aws/redshift.md
@@ -14,9 +14,7 @@ Using this integration, you can connect to an AWS Redshift cluster and issue que
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/s3.md
+++ b/docs/docs/integrations/libraries/aws/s3.md
@@ -14,9 +14,7 @@ The AWS S3 integration allows data engineers to easily read, and write objects t
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/secretsmanager.md
+++ b/docs/docs/integrations/libraries/aws/secretsmanager.md
@@ -18,9 +18,7 @@ This integration allows you to manage, retrieve, and rotate credentials, API key
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/aws/ssm.md
+++ b/docs/docs/integrations/libraries/aws/ssm.md
@@ -18,9 +18,7 @@ The Dagster AWS Systems Manager (SSM) Parameter Store integration allows you to 
 
 ### Installation
 
-```bash
-pip install dagster-aws
-```
+<PackageInstallInstructions packageName="dagster-aws" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/azure-adls2.md
+++ b/docs/docs/integrations/libraries/azure-adls2.md
@@ -13,9 +13,7 @@ Dagster helps you use Azure Storage Accounts as part of your data pipeline. Azur
 
 ### Installation
 
-```bash
-pip install dagster-azure
-```
+<PackageInstallInstructions packageName="dagster-azure" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/census.md
+++ b/docs/docs/integrations/libraries/census.md
@@ -15,9 +15,7 @@ With the `dagster-census` integration you can execute a Census sync and poll unt
 
 ### Installation
 
-```bash
-pip install dagster-census
-```
+<PackageInstallInstructions packageName="dagster-census" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/chroma.md
+++ b/docs/docs/integrations/libraries/chroma.md
@@ -14,9 +14,7 @@ The `dagster-chroma` library allows you to easily interact with Chroma's vector 
 
 ### Installation
 
-```bash
-pip install dagster dagster-chroma
-```
+<PackageInstallInstructions packageName="dagster-chroma" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/cube.md
+++ b/docs/docs/integrations/libraries/cube.md
@@ -15,9 +15,7 @@ With the `dagster_cube` integration you can setup Cube and Dagster to work toget
 
 ### Installation
 
-```bash
-pip install dagster_cube
-```
+<PackageInstallInstructions packageName="dagster-cube" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/databricks.md
+++ b/docs/docs/integrations/libraries/databricks.md
@@ -14,9 +14,7 @@ The `dagster-databricks` integration library provides the `PipesDatabricksClient
 
 ### Installation
 
-```bash
-pip install dagster-databricks
-```
+<PackageInstallInstructions packageName="dagster-databricks" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/datadog.md
+++ b/docs/docs/integrations/libraries/datadog.md
@@ -18,9 +18,7 @@ While Dagster provides comprehensive monitoring and observability of the pipelin
 
 ### Installation
 
-```bash
-pip install dagster-datadog
-```
+<PackageInstallInstructions packageName="dagster-datadog" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/dbt/dbt-cloud.md
+++ b/docs/docs/integrations/libraries/dbt/dbt-cloud.md
@@ -18,9 +18,7 @@ Dagster allows you to run dbt Cloud jobs alongside other technologies. You can s
 
 ### Installation
 
-```bash
-pip install dagster-dbt
-```
+<PackageInstallInstructions packageName="dagster-dbt" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/dbt/dbt-core.md
+++ b/docs/docs/integrations/libraries/dbt/dbt-core.md
@@ -20,9 +20,7 @@ Dagster assets understand dbt at the level of individual dbt models. This means 
 
 ### Installation
 
-```bash
-pip install dagster-dbt
-```
+<PackageInstallInstructions packageName="dagster-dbt" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/dbt/transform-dbt.md
+++ b/docs/docs/integrations/libraries/dbt/transform-dbt.md
@@ -14,9 +14,7 @@ To follow the steps in this guide, you'll need:
 - To install the [dbt](https://docs.getdbt.com/docs/core/installation-overview) and [DuckDB CLIs](https://duckdb.org/docs/api/cli/overview.html)
 - To install the following packages:
 
-```shell
-pip install dagster duckdb plotly pandas dagster-dbt dbt-duckdb
-```
+<PackageInstallInstructions packageName="dagster duckdb plotly pandas dagster-dbt dbt-duckdb" />
 
 </details>
 

--- a/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/downstream-assets.md
+++ b/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/downstream-assets.md
@@ -14,9 +14,7 @@ In this step, you'll:
 
 ## Step 1: Install the plotly library
 
-```shell
-pip install plotly
-```
+<PackageInstallInstructions packageName="plotly" />
 
 ## Step 2: Define the order_count_chart asset
 

--- a/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/index.md
+++ b/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/index.md
@@ -30,9 +30,7 @@ To complete this tutorial, you'll need:
 
 - **To install dbt, Dagster, and the Dagster webserver/UI**. Run the following to install everything using pip:
 
-  ```shell
-  pip install dagster-dbt dagster-webserver dbt-duckdb
-  ```
+  <PackageInstallInstructions packageName="dagster-dbt dbt-duckdb" />
 
   The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies. `dbt-duckdb` is installed as you'll be using [DuckDB](https://duckdb.org/) as a database during this tutorial. Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/installation) installation docs for more info.
 

--- a/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/upstream-assets.md
+++ b/docs/docs/integrations/libraries/dbt/using-dbt-with-dagster/upstream-assets.md
@@ -23,9 +23,7 @@ You'll:
 
 The Dagster asset that you write will fetch data using [Pandas](https://pandas.pydata.org/) and write it out to your DuckDB warehouse using [DuckDB's Python API](https://duckdb.org/docs/api/python/overview.html). To use these, you'll need to install them:
 
-```shell
-pip install pandas duckdb pyarrow
-```
+<PackageInstallInstructions packageName="pandas duckdb pyarrow" />
 
 ## Step 2: Define an upstream Dagster asset
 

--- a/docs/docs/integrations/libraries/deltalake/index.md
+++ b/docs/docs/integrations/libraries/deltalake/index.md
@@ -24,11 +24,7 @@ Here are some of the benefits that Delta Lake provides Dagster users:
 
 ### Installation
 
-```bash
-pip install dagster-deltalake
-pip install dagster-deltalake-pandas
-pip install dagster-deltalake-polars
-```
+<PackageInstallInstructions packageName="dagster-deltalake dagster-deltalake-pandas dagster-deltalake-polars" />
 
 ### About Delta Lake
 

--- a/docs/docs/integrations/libraries/deltalake/using-deltalake-with-dagster.md
+++ b/docs/docs/integrations/libraries/deltalake/using-deltalake-with-dagster.md
@@ -19,9 +19,7 @@ While this guide focuses on storing and loading Pandas DataFrames in Delta Lakes
 
 To complete this tutorial, you'll need to install the `dagster-deltalake` and `dagster-deltalake-pandas` libraries:
 
-```shell
-pip install dagster-deltalake dagster-deltalake-pandas
-```
+<PackageInstallInstructions packageName="dagster-deltalake dagster-deltalake-pandas" />
 
 ## Step 1: Configure the Delta Lake I/O manager
 

--- a/docs/docs/integrations/libraries/dingtalk.md
+++ b/docs/docs/integrations/libraries/dingtalk.md
@@ -13,3 +13,7 @@ sidebar_custom_props:
 The community-supported `dagster-dingtalk` package provides an integration with DingTalk.
 
 For more information, see the [dagster-dingtalk GitHub repository](https://github.com/sqkkyzx/dagster-dingtalk).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-dingtalk" />

--- a/docs/docs/integrations/libraries/dlt.md
+++ b/docs/docs/integrations/libraries/dlt.md
@@ -65,9 +65,7 @@ To follow the steps in this guide, you'll need:
 - **To read the [dlt introduction](https://dlthub.com/docs/intro)**, if you've never worked with dlt before.
 - **[To install](/getting-started/installation) the following libraries**:
 
-  ```bash
-  pip install dagster dagster-dlt
-  ```
+  <PackageInstallInstructions packageName="dagster-dlt" />
 
   Installing `dagster-dlt` will also install the `dlt` package.
 

--- a/docs/docs/integrations/libraries/docker.md
+++ b/docs/docs/integrations/libraries/docker.md
@@ -14,9 +14,7 @@ The `dagster-docker` integration library provides the `PipesDockerClient` resour
 
 ### Installation
 
-```bash
-pip install dagster-docker
-```
+<PackageInstallInstructions packageName="dagster-docker" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/duckdb/index.md
+++ b/docs/docs/integrations/libraries/duckdb/index.md
@@ -14,9 +14,7 @@ This library provides an integration with the DuckDB database, and allows for an
 
 ### Installation
 
-```bash
-pip install dagster-duckdb
-```
+<PackageInstallInstructions packageName="dagster-duckdb" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/duckdb/reference.md
+++ b/docs/docs/integrations/libraries/duckdb/reference.md
@@ -208,9 +208,7 @@ The DuckDB I/O manager also supports storing and loading PySpark and Polars Data
 
 To use the <PyObject section="libraries" module="dagster_duckdb_pyspark" object="DuckDBPySparkIOManager" />, first install the package:
 
-```shell
-pip install dagster-duckdb-pyspark
-```
+<PackageInstallInstructions packageName="dagster-duckdb-pyspark" />
 
 Then you can use the `DuckDBPySparkIOManager` in your <PyObject section="definitions" module="dagster" object="Definitions" /> as in [Step 1: Configure the DuckDB I/O manager](/integrations/libraries/duckdb/using-duckdb-with-dagster#step-1-configure-the-duckdb-io-manager) of the [Using Dagster with DuckDB tutorial](/integrations/libraries/duckdb/using-duckdb-with-dagster).
 
@@ -244,9 +242,7 @@ The `DuckDBPySparkIOManager` requires an active `SparkSession`. You can either c
 
 To use the <PyObject section="libraries" module="dagster_duckdb_polars" object="DuckDBPolarsIOManager" />, first install the package:
 
-```shell
-pip install dagster-duckdb-polars
-```
+<PackageInstallInstructions packageName="dagster-duckdb-polars" />
 
 Then you can use the `DuckDBPolarsIOManager` in your <PyObject section="definitions" module="dagster" object="Definitions" /> as in [Step 1: Configure the DuckDB I/O manager](/integrations/libraries/duckdb/using-duckdb-with-dagster#step-1-configure-the-duckdb-io-manager) of the [Using Dagster with DuckDB tutorial](/integrations/libraries/duckdb/using-duckdb-with-dagster).
 

--- a/docs/docs/integrations/libraries/duckdb/using-duckdb-with-dagster.md
+++ b/docs/docs/integrations/libraries/duckdb/using-duckdb-with-dagster.md
@@ -39,9 +39,7 @@ To complete this tutorial, you'll need:
 
 - **To install the `dagster-duckdb` and `dagster-duckdb-pandas` libraries**:
 
-  ```shell
-  pip install dagster-duckdb dagster-duckdb-pandas
-  ```
+  <PackageInstallInstructions packageName="dagster-duckdb dagster-duckdb-pandas" />
 
 ## Option 1: Using the DuckDB resource
 

--- a/docs/docs/integrations/libraries/embedded-elt.md
+++ b/docs/docs/integrations/libraries/embedded-elt.md
@@ -19,9 +19,7 @@ This package includes two integrations:
 
 ## Installation
 
-```bash
-pip install dagster-embedded-elt
-```
+<PackageInstallInstructions packageName="dagster-embedded-elt" />
 
 ## Sling
 

--- a/docs/docs/integrations/libraries/evidence.md
+++ b/docs/docs/integrations/libraries/evidence.md
@@ -14,9 +14,7 @@ The `dagster-evidence` library offers a component to easily generate dashboards 
 
 ## Installation
 
-```bash
-pip install dagster-evidence
-```
+<PackageInstallInstructions packageName="dagster-evidence" />
 
 ## Example
 

--- a/docs/docs/integrations/libraries/fivetran.md
+++ b/docs/docs/integrations/libraries/fivetran.md
@@ -45,9 +45,7 @@ Your Fivetran connectors must have been synced at least once to be represented i
 
 To get started, you'll need to install the `dagster` and `dagster-fivetran` Python packages:
 
-```bash
-pip install dagster dagster-fivetran
-```
+<PackageInstallInstructions packageName="dagster-fivetran" />
 
 ## Represent Fivetran assets in the asset graph
 

--- a/docs/docs/integrations/libraries/gcp/bigquery/index.md
+++ b/docs/docs/integrations/libraries/gcp/bigquery/index.md
@@ -18,9 +18,7 @@ The Google Cloud Platform BigQuery integration allows data engineers to easily q
 
 ### Installation
 
-```bash
-pip install dagster-gcp
-```
+<PackageInstallInstructions packageName="dagster-gcp" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/gcp/bigquery/reference.md
+++ b/docs/docs/integrations/libraries/gcp/bigquery/reference.md
@@ -197,9 +197,7 @@ In this example, the `iris_data` asset uses the I/O manager bound to the key `wa
 
 The BigQuery I/O manager also supports storing and loading PySpark DataFrames. To use the <PyObject section="libraries" module="dagster_gcp_pyspark" object="BigQueryPySparkIOManager" />, first install the package:
 
-```shell
-pip install dagster-gcp-pyspark
-```
+<PackageInstallInstructions packageName="dagster-gcp-pyspark" />
 
 Then you can use the `gcp_pyspark_io_manager` in your `Definitions` as in [Step 1: Configure the BigQuery I/O manager](/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster#step-1-configure-the-bigquery-io-manager) of the [Using Dagster with BigQuery tutorial](/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster).
 

--- a/docs/docs/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster.md
+++ b/docs/docs/integrations/libraries/gcp/bigquery/using-bigquery-with-dagster.md
@@ -41,9 +41,7 @@ To complete this tutorial, you'll need:
 
 - **To install the `dagster-gcp` and `dagster-gcp-pandas` libraries**:
 
-  ```shell
-  pip install dagster-gcp dagster-gcp-pandas
-  ```
+  <PackageInstallInstructions packageName="dagster-gcp dagster-gcp-pandas" />
 
 - **To gather the following information**:
 

--- a/docs/docs/integrations/libraries/gcp/dataproc.md
+++ b/docs/docs/integrations/libraries/gcp/dataproc.md
@@ -18,9 +18,7 @@ Using this integration, you can manage and interact with Google Cloud Platform's
 
 ### Installation
 
-```bash
-pip install dagster-gcp
-```
+<PackageInstallInstructions packageName="dagster-gcp" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/gcp/gcs.md
+++ b/docs/docs/integrations/libraries/gcp/gcs.md
@@ -14,9 +14,7 @@ This integration allows you to interact with Google Cloud Storage (GCS) using Da
 
 ### Installation
 
-```bash
-pip install dagster-gcp
-```
+<PackageInstallInstructions packageName="dagster-gcp" />
 
 ### Examples
 

--- a/docs/docs/integrations/libraries/gemini.md
+++ b/docs/docs/integrations/libraries/gemini.md
@@ -16,9 +16,7 @@ When paired with Dagster assets, the resource automatically logs Gemini usage me
 
 ### Installation
 
-```bash
-pip install dagster dagster-gemini
-```
+<PackageInstallInstructions packageName="dagster-gemini" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/github.md
+++ b/docs/docs/integrations/libraries/github.md
@@ -18,9 +18,7 @@ This library provides an integration with _[GitHub Apps](https://docs.github.com
 
 ### Installation
 
-```bash
-pip install dagster-github
-```
+<PackageInstallInstructions packageName="dagster-github" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/hashicorp-nomad.md
+++ b/docs/docs/integrations/libraries/hashicorp-nomad.md
@@ -14,3 +14,7 @@ partnerlink: https://developer.hashicorp.com/nomad
 The community-supported `dagster-nomad` package provides an integration with HashiCorp Nomad.
 
 For more information, see the [dagster-nomad GitHub repository](https://github.com/PayLead/dagster-nomad).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-nomad" />

--- a/docs/docs/integrations/libraries/hashicorp.md
+++ b/docs/docs/integrations/libraries/hashicorp.md
@@ -15,9 +15,7 @@ Package for integrating HashiCorp Vault into Dagster so that you can securely ma
 
 ### Installation
 
-```bash
-pip install dagster-hashicorp
-```
+<PackageInstallInstructions packageName="dagster-hashicorp" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/hex.md
+++ b/docs/docs/integrations/libraries/hex.md
@@ -14,3 +14,7 @@ partnerlink: https://hex.tech/
 The community-supported `dagster-hex` package provides an integration with HashiCorp Nomad.
 
 For more information, see the [Dagster Community Integrations GitHub repository](https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-hex).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-hex" />

--- a/docs/docs/integrations/libraries/hightouch.md
+++ b/docs/docs/integrations/libraries/hightouch.md
@@ -17,9 +17,7 @@ This native integration helps your team more effectively orchestrate the last mi
 
 ### Installation
 
-```bash
-pip install dagster-hightouch
-```
+<PackageInstallInstructions packageName="dagster-hightouch" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
+++ b/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
@@ -32,9 +32,7 @@ To complete this tutorial, you'll need:
 
 - **To install Dagster and Jupyter**. Run the following to install using pip:
 
-  ```shell
-  pip install dagster notebook
-  ```
+  <PackageInstallInstructions packageName="dagster notebook" />
 
   Refer to the [Dagster](/getting-started/installation) installation docs for more info.
 

--- a/docs/docs/integrations/libraries/kubernetes.md
+++ b/docs/docs/integrations/libraries/kubernetes.md
@@ -14,9 +14,7 @@ The `dagster-k8s` integration library provides the `PipesK8sClient` resource, en
 
 ### Installation
 
-```bash
-pip install dagster-k8s
-```
+<PackageInstallInstructions packageName="dagster-k8s" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/lakefs.md
+++ b/docs/docs/integrations/libraries/lakefs.md
@@ -19,9 +19,7 @@ Furthermore, with lakeFS branching capabilities, Dagster jobs can run on separat
 
 ### Installation
 
-```bash
-pip install lakefs-client
-```
+<PackageInstallInstructions packageName="lakefs-client" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/looker.md
+++ b/docs/docs/integrations/libraries/looker.md
@@ -38,9 +38,7 @@ This guide provides instructions for using Dagster with Looker using the `dagste
 
 To get started, you'll need to install the `dagster` and `dagster-looker` Python packages:
 
-```bash
-pip install dagster dagster-looker
-```
+<PackageInstallInstructions packageName="dagster-looker" />
 
 ## Represent Looker assets in the asset graph
 

--- a/docs/docs/integrations/libraries/meltano.md
+++ b/docs/docs/integrations/libraries/meltano.md
@@ -17,9 +17,7 @@ The `dagster-meltano` library allows you to run Meltano using Dagster. Design an
 
 ### Installation
 
-```bash
-pip install dagster-meltano
-```
+<PackageInstallInstructions packageName="dagster-meltano" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/microsoft-teams.md
+++ b/docs/docs/integrations/libraries/microsoft-teams.md
@@ -14,9 +14,7 @@ By configuring this resource, you can post messages to MS Teams from any Dagster
 
 ### Installation
 
-```bash
-pip install dagster-msteams
-```
+<PackageInstallInstructions packageName="dagster-msteams" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/modal.md
+++ b/docs/docs/integrations/libraries/modal.md
@@ -14,3 +14,7 @@ partnerlink:
 The community-supported `dagster-modal` package provides an integration with Modal.
 
 For more information, see the [Dagster Community Integrations GitHub repository](https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-modal).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-modal" />

--- a/docs/docs/integrations/libraries/mssql-bulk-copy-tool.md
+++ b/docs/docs/integrations/libraries/mssql-bulk-copy-tool.md
@@ -13,3 +13,7 @@ partnerlink:
 The community-supported `dagster-mssql-bcp` package is a custom Dagster I/O manager for loading data into SQL Server using the bcp utility.
 
 For more information, see the [dagster-mssql-bcp GitHub repository](https://github.com/cody-scott/dagster-mssql-bcp).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-mssql-bcp" />

--- a/docs/docs/integrations/libraries/notdiamond.md
+++ b/docs/docs/integrations/libraries/notdiamond.md
@@ -15,9 +15,7 @@ Leverage the Not Diamond resource to easily determine which LLM provider is most
 
 ### Installation
 
-```bash
-pip install dagster-notdiamond
-```
+<PackageInstallInstructions packageName="dagster-notdiamond" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/openai.md
+++ b/docs/docs/integrations/libraries/openai.md
@@ -24,9 +24,7 @@ Before you get started with the `dagster-openai` library, we recommend familiari
 
 To get started, install the `dagster` and `dagster-openai` Python packages:
 
-```bash
-pip install dagster dagster-openai
-```
+<PackageInstallInstructions packageName="dagster-openai" />
 
 Note that you will need an OpenAI [API key](https://platform.openai.com/api-keys) to use the resource, which can be generated in your OpenAI account.
 

--- a/docs/docs/integrations/libraries/pagerduty.md
+++ b/docs/docs/integrations/libraries/pagerduty.md
@@ -14,9 +14,7 @@ This library provides an integration between Dagster and PagerDuty to support cr
 
 ### Installation
 
-```bash
-pip install dagster-pagerduty
-```
+<PackageInstallInstructions packageName="dagster-pagerduty" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/pandera.md
+++ b/docs/docs/integrations/libraries/pandera.md
@@ -31,9 +31,7 @@ To get started, you'll need:
 
 - [To install](/getting-started/installation) the `dagster` and `dagster-pandera` Python packages:
 
-  ```bash
-  pip install dagster dagster-pandera
-  ```
+  <PackageInstallInstructions packageName="dagster-pandera" />
 
 - Familiarity with [Dagster Types](/api/dagster/types
 

--- a/docs/docs/integrations/libraries/patito.md
+++ b/docs/docs/integrations/libraries/patito.md
@@ -25,7 +25,7 @@ For more information on how to use Dagster with Polars, see [dagster-polars docu
 
 ## Installation
 
-`pip install 'dagster-polars[patito]'`
+<PackageInstallInstructions packageName="dagster-polars[patito]" />
 
 ## Usage
 

--- a/docs/docs/integrations/libraries/perian.md
+++ b/docs/docs/integrations/libraries/perian.md
@@ -14,3 +14,7 @@ partnerlink:
 The `dagster-perian` integration allows you to easily dockerize your codebase and execute it on the PERIAN platform, PERIAN's serverless GPU environment.
 
 For more information, please visit the [dagster-perian GitHub repository](https://github.com/Perian-io/dagster-perian) and the [PERIAN documentation](https://perian.io/docs).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-perian" />

--- a/docs/docs/integrations/libraries/polars.md
+++ b/docs/docs/integrations/libraries/polars.md
@@ -26,9 +26,8 @@ The `dagster-polars` integration allows using Polars eager or lazy DataFrames as
 `dagster-polars` integrates with [Patito](https://github.com/JakobGM/patito) for data validation. Learn more on the [Patito integration page](/integrations/libraries/patito).
 
 ## Installation
-```shell
-pip install dagster-polars
-```
+
+<PackageInstallInstructions packageName="dagster-polars" />
 
 ## Example
 ```python

--- a/docs/docs/integrations/libraries/powerbi.md
+++ b/docs/docs/integrations/libraries/powerbi.md
@@ -39,9 +39,7 @@ This guide provides instructions for using Dagster with Power BI using the [`dag
 
 To get started, you'll need to install the `dagster` and `dagster-powerbi` Python packages:
 
-```bash
-pip install dagster dagster-powerbi
-```
+<PackageInstallInstructions packageName="dagster-powerbi" />
 
 ## Represent Power BI assets in the asset graph
 

--- a/docs/docs/integrations/libraries/prometheus.md
+++ b/docs/docs/integrations/libraries/prometheus.md
@@ -18,9 +18,7 @@ This integration allows you to push metrics to the Prometheus gateway from withi
 
 ### Installation
 
-```bash
-pip install dagster-prometheus
-```
+<PackageInstallInstructions packageName="dagster-prometheus" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/qdrant.md
+++ b/docs/docs/integrations/libraries/qdrant.md
@@ -14,9 +14,7 @@ The `dagster-qdrant` library lets you integrate Qdrant's vector database with Da
 
 ### Installation
 
-```bash
-pip install dagster dagster-qdrant
-```
+<PackageInstallInstructions packageName="dagster-qdrant" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/ray.md
+++ b/docs/docs/integrations/libraries/ray.md
@@ -14,3 +14,7 @@ partnerlink:
 The community-supported `dagster-ray` package allows orchestrating distributed Ray compute from Dagster pipelines.
 
 For more information, see the [dagster-ray GitHub repository](https://github.com/danielgafni/dagster-ray).
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-ray" />

--- a/docs/docs/integrations/libraries/sigma.md
+++ b/docs/docs/integrations/libraries/sigma.md
@@ -37,9 +37,7 @@ This guide provides instructions for using Dagster with Sigma using the [`dagste
 
 To get started, you'll need to install the `dagster` and `dagster-sigma` Python packages:
 
-```bash
-pip install dagster dagster-sigma
-```
+<PackageInstallInstructions packageName="dagster-sigma" />
 
 ## Represent Sigma assets in the asset graph
 

--- a/docs/docs/integrations/libraries/slack.md
+++ b/docs/docs/integrations/libraries/slack.md
@@ -14,9 +14,7 @@ This library provides an integration with Slack to support posting messages in y
 
 ### Installation
 
-```bash
-pip install dagster-slack
-```
+<PackageInstallInstructions packageName="dagster-slack" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/sling.md
+++ b/docs/docs/integrations/libraries/sling.md
@@ -31,9 +31,7 @@ To follow the steps in this guide:
 - **Familiarize yourself with [Sling's replication configuration](https://docs.slingdata.io/sling-cli/run/configuration/replication)**, if you've never worked with Sling before. The replication configuration is a YAML file that specifies the source and target connections, as well as which streams to sync from. The `dagster-sling` integration uses this configuration to build assets for both sources and destinations.
 - **To install the following libraries**:
 
-  ```bash
-  pip install dagster dagster-sling
-  ```
+  <PackageInstallInstructions packageName="dagster-sling" />
 
   Refer to the [Dagster installation](/getting-started/installation) guide for more info.
 

--- a/docs/docs/integrations/libraries/snowflake/index.md
+++ b/docs/docs/integrations/libraries/snowflake/index.md
@@ -14,9 +14,7 @@ This library provides an integration with the Snowflake data warehouse. Connect 
 
 ### Installation
 
-```bash
-pip install dagster-snowflake
-```
+<PackageInstallInstructions packageName="dagster-snowflake" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/snowflake/reference.md
+++ b/docs/docs/integrations/libraries/snowflake/reference.md
@@ -235,9 +235,7 @@ In this example, the `iris_dataset` asset uses the I/O manager bound to the key 
 
 The Snowflake I/O manager also supports storing and loading PySpark DataFrames. To use the <PyObject section="libraries" module="dagster_snowflake_pyspark" object="SnowflakePySparkIOManager" />, first install the package:
 
-```shell
-pip install dagster-snowflake-pyspark
-```
+<PackageInstallInstructions packageName="dagster-snowflake-pyspark" />
 
 Then you can use the `SnowflakePySparkIOManager` in your `Definitions` as in [Step 1](/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers#step-1-configure-the-snowflake-io-manager) of the [Snowflake I/O manager tutorial](/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers).
 

--- a/docs/docs/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers.md
+++ b/docs/docs/integrations/libraries/snowflake/using-snowflake-with-dagster-io-managers.md
@@ -23,9 +23,7 @@ To complete this tutorial, you'll need:
 
 - **To install the `dagster-snowflake` and `dagster-snowflake-pandas` libraries**:
 
-  ```shell
-  pip install dagster-snowflake dagster-snowflake-pandas
-  ```
+  <PackageInstallInstructions packageName="dagster-snowflake dagster-snowflake-pandas" />
 
 - **To gather the following information**, which is required to use the Snowflake I/O manager:
 

--- a/docs/docs/integrations/libraries/snowflake/using-snowflake-with-dagster.md
+++ b/docs/docs/integrations/libraries/snowflake/using-snowflake-with-dagster.md
@@ -21,9 +21,7 @@ To complete this tutorial, you'll need:
 
 - **To install the following libraries**:
 
-  ```shell
-  pip install dagster dagster-snowflake pandas
-  ```
+  <PackageInstallInstructions packageName="dagster-snowflake pandas" />
 
 - **To gather the following information**, which is required to use the Snowflake resource:
 

--- a/docs/docs/integrations/libraries/ssh-sftp.md
+++ b/docs/docs/integrations/libraries/ssh-sftp.md
@@ -18,9 +18,7 @@ This integration provides a resource for SSH remote execution using [Paramiko](h
 
 ### Installation
 
-```bash
-pip install dagster-ssh
-```
+<PackageInstallInstructions packageName="dagster-ssh" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/tableau.md
+++ b/docs/docs/integrations/libraries/tableau.md
@@ -42,9 +42,7 @@ This guide provides instructions for using Dagster with Tableau using the `dagst
 
 To get started, you'll need to install the `dagster` and `dagster-tableau` Python packages:
 
-```bash
-pip install dagster dagster-tableau
-```
+<PackageInstallInstructions packageName="dagster-tableau" />
 
 ## Represent Tableau assets in the asset graph
 

--- a/docs/docs/integrations/libraries/teradata.md
+++ b/docs/docs/integrations/libraries/teradata.md
@@ -35,23 +35,17 @@ With your virtual environment active, the next step is to install dagster and th
 
 1. Install the Required Packages:
 
-   ```bash
-   pip install dagster dagster-webserver dagster-teradata
-   ```
+   <PackageInstallInstructions packageName="dagster-teradata" />
 
 2. Note about Optional Dependencies:
 
    a) `dagster-teradata` relies on dagster-aws for ingesting data from an S3 bucket into Teradata Vantage. Since `dagster-aws` is an optional dependency, users can install it by running:
 
-   ```bash
-   pip install dagster-teradata[aws]
-   ```
+   <PackageInstallInstructions packageName="dagster-teradata[aws]" />
 
    b) `dagster-teradata` also relies on `dagster-azure` for ingesting data from an Azure Blob Storage container into Teradata Vantage. To install this dependency, run:
 
-   ```bash
-   pip install dagster-teradata[azure]
-   ```
+   <PackageInstallInstructions packageName="dagster-teradata[azure]" />
 
 3. Verify the Installation:
 

--- a/docs/docs/integrations/libraries/twilio.md
+++ b/docs/docs/integrations/libraries/twilio.md
@@ -14,9 +14,7 @@ Use your Twilio `Account SID` and `Auth Token` to build Twilio tasks right into 
 
 ### Installation
 
-```bash
-pip install dagster-twilio
-```
+<PackageInstallInstructions packageName="dagster-twilio" />
 
 ### Example
 

--- a/docs/docs/integrations/libraries/weaviate.md
+++ b/docs/docs/integrations/libraries/weaviate.md
@@ -14,9 +14,7 @@ The `dagster-weaviate` library allows you to easily interact with Weaviate's vec
 
 ### Installation
 
-```bash
-pip install dagster dagster-weaviate
-```
+<PackageInstallInstructions packageName="dagster-weaviate" />
 
 ### Examples
 


### PR DESCRIPTION
## Summary & Motivation

Updates integrations to use the new component that provides a tabbed installation instructions for `uv` and `pip`.

## How I Tested These Changes

## Changelog

NOCHANGELOG
