### PR TITLE
[dbt] fix test_project_prepare_cli take 2

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -17,6 +17,7 @@ from dagster.components.core.load_defs import build_component_defs
 from dagster.components.resolved.core_models import AssetAttributesModel
 from dagster_dbt import DbtProject, DbtProjectComponent
 from dagster_dbt.cli.app import project_app_typer_click_object
+from dagster_dbt.components.dbt_project.component import get_projects_from_dbt_component
 
 ensure_dagster_tests_import()
 from dagster_tests.components_tests.integration_tests.component_loader import (
@@ -120,8 +121,11 @@ def test_project_prepare_cli(dbt_path: Path) -> None:
                 str(p),
             ],
         )
+        assert result.exit_code == 0
 
-    assert "Project preparation complete" in result.stdout, result.stdout
+        projects = get_projects_from_dbt_component(p)
+        for p in projects:
+            assert p.manifest_path.exists()
 
 
 def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:


### PR DESCRIPTION
well, the test all python versions flag didn't work in #29544 so that didn't fix it

stop validating via `stdout` (which I belive is having issues on `3.9` & `3.10` due to dbt cli using `rich.Console` and some complexity there)
and just make sure the `manifest.json` got made

## How I Tested These Changes

bk and more carefully validate all py versions were run 