### PR TITLE
[dagster-dbt] Add support for `--selector`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -15,6 +15,7 @@ from dagster._utils.warnings import suppress_dagster_warnings
 from dagster_dbt.asset_utils import (
     DAGSTER_DBT_EXCLUDE_METADATA_KEY,
     DAGSTER_DBT_SELECT_METADATA_KEY,
+    DAGSTER_DBT_SELECTOR_METADATA_KEY,
     build_dbt_specs,
 )
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
@@ -28,6 +29,7 @@ def dbt_assets(
     manifest: DbtManifestParam,
     select: str = "fqn:*",
     exclude: Optional[str] = None,
+    selector: Optional[str] = None,
     name: Optional[str] = None,
     io_manager_key: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
@@ -53,6 +55,8 @@ def dbt_assets(
             to include. Defaults to ``fqn:*``.
         exclude (Optional[str]): A dbt selection string for the models in a project that you want
             to exclude. Defaults to "".
+        selector (Optional[str]): A dbt selector for the models in a project that you want to
+            include. Cannot be combined with select or exclude. Defaults to None.
         name (Optional[str]): The name of the op.
         io_manager_key (Optional[str]): The IO manager key that will be set on each of the returned
             assets. When other ops are downstream of the loaded assets, the IOManager specified
@@ -311,6 +315,7 @@ def dbt_assets(
         manifest=manifest,
         select=select,
         exclude=exclude or "",
+        selector=selector,
         io_manager_key=io_manager_key,
         project=project,
     )
@@ -327,9 +332,16 @@ def dbt_assets(
             " with op_tags"
         )
 
+    if op_tags and DAGSTER_DBT_SELECTOR_METADATA_KEY in op_tags:
+        raise DagsterInvalidDefinitionError(
+            f"To specify a dbt selector, use the 'selector' argument, not '{DAGSTER_DBT_SELECTOR_METADATA_KEY}'"
+            " with op_tags"
+        )
+
     resolved_op_tags = {
         **({DAGSTER_DBT_SELECT_METADATA_KEY: select} if select else {}),
         **({DAGSTER_DBT_EXCLUDE_METADATA_KEY: exclude} if exclude else {}),
+        **({DAGSTER_DBT_SELECTOR_METADATA_KEY: selector} if selector else {}),
         **(op_tags if op_tags else {}),
     }
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
@@ -15,6 +15,7 @@ def build_dbt_asset_specs(
     dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
     select: str = "fqn:*",
     exclude: Optional[str] = None,
+    selector: Optional[str] = None,
     project: Optional[DbtProject] = None,
 ) -> Sequence[AssetSpec]:
     """Build a list of asset specs from a set of dbt resources selected from a dbt manifest.
@@ -30,6 +31,8 @@ def build_dbt_asset_specs(
             to include. Defaults to ``fqn:*``.
         exclude (Optional[str]): A dbt selection string for the models in a project that you want
             to exclude. Defaults to "".
+        selector (Optional[str]): A dbt selector for the models in a project that you want
+            to include. Defaults to None.
         project (Optional[DbtProject]): A DbtProject instance which provides a pointer to the dbt
             project location and manifest. Not required, but needed to attach code references from
             model code to Dagster assets.
@@ -45,6 +48,7 @@ def build_dbt_asset_specs(
         translator=dagster_dbt_translator,
         select=select,
         exclude=exclude or "",
+        selector=selector,
         io_manager_key=None,
         project=project,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -349,6 +349,7 @@ class DbtCloudWorkspace(ConfigurableResource):
                 manifest=manifest,
                 select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
                 exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
+                selector=None,
                 dagster_dbt_translator=dagster_dbt_translator,
                 current_dbt_indirect_selection_env=indirect_selection,
             )
@@ -422,6 +423,7 @@ class DbtCloudWorkspaceDefsLoader(StateBackedDefinitionsLoader[DbtCloudWorkspace
             translator=self.translator,
             select=self.select,
             exclude=self.exclude,
+            selector=None,
             io_manager_key=None,
             project=None,
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -131,7 +131,7 @@ class DbtCloudJobRunResults:
         for result in self.run_results["results"]:
             unique_id: str = result["unique_id"]
             dbt_resource_props: Mapping[str, Any] = manifest["nodes"][unique_id]
-            selector: str = ".".join(dbt_resource_props["fqn"])
+            select: str = ".".join(dbt_resource_props["fqn"])
 
             default_metadata = {
                 "unique_id": unique_id,
@@ -152,8 +152,9 @@ class DbtCloudJobRunResults:
             asset_specs, _ = build_dbt_specs(
                 manifest=manifest,
                 translator=dagster_dbt_translator,
-                select=selector,
+                select=select,
                 exclude="",
+                selector=None,
                 io_manager_key=None,
                 project=None,
             )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -32,6 +32,7 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from dagster_dbt.asset_utils import (
     DAGSTER_DBT_EXCLUDE_METADATA_KEY,
     DAGSTER_DBT_SELECT_METADATA_KEY,
+    DAGSTER_DBT_SELECTOR_METADATA_KEY,
     DBT_INDIRECT_SELECTION_ENV,
     get_manifest_and_translator_from_dbt_assets,
     get_subset_selection_for_context,
@@ -640,6 +641,7 @@ class DbtCliResource(ConfigurableResource):
                 manifest=manifest,
                 select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
                 exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
+                selector=context.op.tags.get(DAGSTER_DBT_SELECTOR_METADATA_KEY),
                 dagster_dbt_translator=dagster_dbt_translator,
                 current_dbt_indirect_selection_env=env.get(DBT_INDIRECT_SELECTION_ENV, None),
             )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -43,6 +43,7 @@ class DbtManifestAssetSelection(AssetSelection):
     select: str
     dagster_dbt_translator: DagsterDbtTranslator
     exclude: str
+    selector: Optional[str] = None
 
     def __eq__(self, other):
         if not isinstance(other, DbtManifestAssetSelection):
@@ -61,6 +62,7 @@ class DbtManifestAssetSelection(AssetSelection):
             and self.select == other.select
             and self.dagster_dbt_translator == other.dagster_dbt_translator
             and self.exclude == other.exclude
+            and self.selector == other.selector
         )
 
     @classmethod
@@ -71,6 +73,7 @@ class DbtManifestAssetSelection(AssetSelection):
         *,
         dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
         exclude: Optional[str] = None,
+        selector: Optional[str] = None,
     ):
         return cls(
             manifest=validate_manifest(manifest),
@@ -82,6 +85,7 @@ class DbtManifestAssetSelection(AssetSelection):
                 DagsterDbtTranslator(),
             ),
             exclude=check.opt_str_param(exclude, "exclude", default=""),
+            selector=check.opt_str_param(selector, "selector"),
         )
 
     def resolve_inner(
@@ -91,6 +95,7 @@ class DbtManifestAssetSelection(AssetSelection):
         for unique_id in select_unique_ids_from_manifest(
             select=self.select,
             exclude=self.exclude,
+            selector=self.selector,
             manifest_json=self.manifest,
         ):
             dbt_resource_props = get_node(self.manifest, unique_id)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,7 +1,8 @@
 from argparse import Namespace
 from collections.abc import Mapping
-from typing import AbstractSet, Any  # noqa: UP035
+from typing import AbstractSet, Any, Optional, cast  # noqa: UP035
 
+import dagster_shared.check as check
 from dagster import AssetKey
 from dagster._utils.names import clean_name_lower
 from packaging import version
@@ -22,17 +23,23 @@ def dagster_name_fn(dbt_resource_props: Mapping[str, Any]) -> str:
 
 
 def select_unique_ids_from_manifest(
-    select: str,
-    exclude: str,
-    manifest_json: Mapping[str, Any],
+    select: str, exclude: str, manifest_json: Mapping[str, Any], selector: Optional[str] = None
 ) -> AbstractSet[str]:
     """Method to apply a selection string to an existing manifest.json file."""
     import dbt.graph.cli as graph_cli
     import dbt.graph.selector as graph_selector
     from dbt.contracts.graph.manifest import Manifest
+    from dbt.contracts.selection import SelectorFile
     from dbt.graph.selector_spec import IndirectSelection, SelectionSpec
     from dbt.version import __version__ as dbt_version
     from networkx import DiGraph
+
+    select_specified = select and select != "fqn:*"
+    check.param_invariant(
+        not ((select_specified or exclude) and selector),
+        "selector",
+        "Cannot provide both a selector and a select/exclude param.",
+    )
 
     # NOTE: this was faster than calling `Manifest.from_dict`, so we are keeping this.
     class _DictShim(dict):
@@ -97,8 +104,19 @@ def select_unique_ids_from_manifest(
             if manifest_json.get("saved_queries")
             else {}
         ),
+        **(
+            {
+                "selectors": {
+                    unique_id: _DictShim(info)
+                    for unique_id, info in manifest_json["selectors"].items()
+                }
+            }
+            if manifest_json.get("selectors")
+            else {}
+        ),
         **unit_tests,
     )
+
     child_map = manifest_json["child_map"]
 
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
@@ -110,15 +128,26 @@ def select_unique_ids_from_manifest(
             "WARN_ERROR": True,
         }
     )
-    parsed_spec: SelectionSpec = graph_cli.parse_union([select], True)
+
+    if selector:
+        # must parse all selectors to handle dependencies, then grab the specific selector
+        # that was specified
+        result = graph_cli.parse_from_selectors_definition(
+            source=SelectorFile.from_dict({"selectors": manifest.selectors.values()})
+        )
+        if selector not in result:
+            raise ValueError(f"Selector `{selector}` not found in manifest.")
+        parsed_spec: SelectionSpec = cast("SelectionSpec", result[selector]["definition"])
+    else:
+        parsed_spec: SelectionSpec = graph_cli.parse_union([select], True)
 
     if exclude:
         parsed_exclude_spec = graph_cli.parse_union([exclude], False)
         parsed_spec = graph_cli.SelectionDifference(components=[parsed_spec, parsed_exclude_spec])
 
     # execute this selection against the graph
-    selector = graph_selector.NodeSelector(graph, manifest)
-    selected, _ = selector.select_nodes(parsed_spec)
+    node_selector = graph_selector.NodeSelector(graph, manifest)
+    selected, _ = node_selector.select_nodes(parsed_spec)
     return selected
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -204,6 +204,7 @@ def test_selections(
         translator=DagsterDbtTranslator(),
         select=select,
         exclude=exclude,
+        selector=None,
         io_manager_key=None,
         project=None,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
@@ -1,0 +1,8 @@
+selectors:
+  - name: raw_customer_child_models
+    description: "Equivalent to raw_customers+,resource_type:model"
+    definition:
+      intersection:
+        - method: resource_type
+          value: model
+        - raw_customers+


### PR DESCRIPTION
## Summary & Motivation

We support select and exclude, we should also support selector

## How I Tested These Changes

unit

## Changelog

`@dbt_assets` and `build_dbt_manifest_asset_selection` now support a `selector` argument, allowing you to use yaml-based selectors.
