### PR TITLE
[ui] Update the integrations marketplace to show all metadata

### DIFF
--- a/docs/docs/integrations/libraries/snowflake/reference.md
+++ b/docs/docs/integrations/libraries/snowflake/reference.md
@@ -1,6 +1,6 @@
 ---
 title: 'dagster-snowflake integration reference'
-description: Store your Dagster assets in Snowflak
+description: Store your Dagster assets in Snowflake
 sidebar_position: 300
 ---
 

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationPage.tsx
@@ -1,4 +1,4 @@
-import {Body, Box, Colors} from '@dagster-io/ui-components';
+import {Box, Colors} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import {useLayoutEffect, useRef, useState} from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -6,7 +6,7 @@ import {Components} from 'react-markdown/lib/ast-to-react';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 
-import {IntegrationIcon} from './IntegrationIcon';
+import {IntegrationTopcard} from './IntegrationTopcard';
 import {CopyIconButton} from '../ui/CopyButton';
 import styles from './css/IntegrationPage.module.css';
 import {IntegrationConfig} from './types';
@@ -16,21 +16,13 @@ interface Props {
 }
 
 export const IntegrationPage = ({integration}: Props) => {
-  const {
-    frontmatter: {name, title, excerpt, logoFilename},
-    content,
-  } = integration;
+  const {frontmatter, content} = integration;
 
   return (
     <div>
       <Box padding={{vertical: 24}} flex={{direction: 'column', gap: 12}}>
-        <Box flex={{direction: 'row', gap: 12, alignItems: 'flex-start'}}>
-          <IntegrationIcon name={name} logoFilename={logoFilename} />
-          <Box flex={{direction: 'column', gap: 2}} margin={{top: 4}}>
-            <div style={{fontSize: 18, fontWeight: 600}}>{title}</div>
-            <Body color={Colors.textLight()}>{excerpt}</Body>
-          </Box>
-        </Box>
+        <IntegrationTopcard integration={frontmatter} />
+
         <div className={styles.markdownOutput}>
           <ReactMarkdown
             className={styles.integrationPage}

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationTag.tsx
@@ -1,4 +1,4 @@
-import {IconName} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, IconName, Tag} from '@dagster-io/ui-components';
 
 export enum IntegrationTag {
   Alerting = 'alerting',
@@ -16,11 +16,11 @@ export const IntegrationTagKeys: string[] = Object.values(IntegrationTag);
 
 export const IntegrationTagLabel: Record<IntegrationTag, string> = {
   [IntegrationTag.Alerting]: 'Alerting',
-  [IntegrationTag.BiTools]: 'BI tools',
+  [IntegrationTag.BiTools]: 'BI',
   [IntegrationTag.CommunitySupported]: 'Community Supported',
   [IntegrationTag.Compute]: 'Compute',
-  [IntegrationTag.DagsterSupported]: 'Dagster Supported',
-  [IntegrationTag.EtlTools]: 'ETL tools',
+  [IntegrationTag.DagsterSupported]: 'Built by Dagster Labs',
+  [IntegrationTag.EtlTools]: 'ETL',
   [IntegrationTag.Metadata]: 'Metadata',
   [IntegrationTag.Monitoring]: 'Monitoring',
   [IntegrationTag.Storage]: 'Storage',
@@ -37,3 +37,28 @@ export const IntegrationTagIcon: Record<IntegrationTag, IconName> = {
   [IntegrationTag.Monitoring]: 'visibility',
   [IntegrationTag.Storage]: 'download',
 };
+
+export const BuiltByDagsterLabs = () => (
+  <Box
+    flex={{direction: 'row', alignItems: 'center', gap: 4}}
+    style={{fontSize: 12, color: Colors.textLight()}}
+  >
+    <Icon name="shield_check" size={12} color={Colors.textLight()} />
+    Built by Dagster Labs
+  </Box>
+);
+
+export const IntegrationTags = ({tags}: {tags: string[]}) => (
+  <>
+    {tags
+      .filter(
+        (tag): tag is IntegrationTag =>
+          IntegrationTagKeys.includes(tag) && tag !== IntegrationTag.DagsterSupported,
+      )
+      .map((tag) => (
+        <Tag key={tag} icon={IntegrationTagIcon[tag] ?? undefined}>
+          {IntegrationTagLabel[tag]}
+        </Tag>
+      ))}
+  </>
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationTopcard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/IntegrationTopcard.tsx
@@ -1,0 +1,59 @@
+import {Box, Button, Icon} from '@dagster-io/ui-components';
+import {Link} from 'react-router-dom';
+
+import {IntegrationIcon} from './IntegrationIcon';
+import {BuiltByDagsterLabs, IntegrationTag, IntegrationTags} from './IntegrationTag';
+import styles from './css/IntegrationTopcard.module.css';
+import {IntegrationFrontmatter} from './types';
+
+export const IntegrationTopcard = ({integration}: {integration: IntegrationFrontmatter}) => {
+  const {id, name, title, tags, logoFilename, pypi, source} = integration;
+
+  return (
+    <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+      <Link
+        to={`/integrations/${id}`}
+        className={styles.itemLink}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Box flex={{direction: 'row', gap: 16, alignItems: 'flex-start'}}>
+          <IntegrationIcon name={name} logoFilename={logoFilename} />
+          <Box
+            flex={{direction: 'column', gap: 4, justifyContent: 'center'}}
+            style={{minHeight: 48}}
+          >
+            <div style={{fontSize: 16, fontWeight: 600}}>{name || title}</div>
+            {tags.includes(IntegrationTag.DagsterSupported) ? <BuiltByDagsterLabs /> : null}
+          </Box>
+        </Box>
+      </Link>
+      <Box flex={{direction: 'row', gap: 16, alignItems: 'center'}}>
+        <IntegrationTags tags={tags} />
+        <Box flex={{direction: 'row', gap: 8}}>
+          {pypi ? (
+            <a
+              href={pypi}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.externalLink}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button icon={<Icon name="python" size={16} />} />
+            </a>
+          ) : null}
+          {source ? (
+            <a
+              href={source}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.externalLink}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button icon={<Icon name="github" size={16} />} />
+            </a>
+          ) : null}
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/MarketplaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/MarketplaceRoot.tsx
@@ -12,7 +12,11 @@ export const MarketplaceRoot = () => {
   useEffect(() => {
     const fetchIntegrations = async () => {
       const res = await fetch(INTEGRATIONS_URL);
-      const data = await res.json();
+      let data: IntegrationFrontmatter[] = await res.json();
+
+      // Filter out articles and sub-pages that do not have integration names
+      data = data.filter((d) => !!d.name);
+
       setIntegrations(data);
     };
     fetchIntegrations();

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/__stories__/IntegrationPage.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/__stories__/IntegrationPage.stories.tsx
@@ -2,6 +2,7 @@ import {Box, Colors} from '@dagster-io/ui-components';
 import {Meta} from '@storybook/react';
 
 import {IntegrationPage} from '../IntegrationPage';
+import {IntegrationFrontmatter} from '../types';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -10,22 +11,22 @@ export default {
 } as Meta;
 
 export const Default = () => {
+  const frontmatter: IntegrationFrontmatter = {
+    id: 'airbyte-airbyte-cloud',
+    title: 'Using Dagster with Airbyte Cloud',
+    name: 'Airbyte Cloud',
+    description:
+      'Orchestrate Airbyte Cloud connections and schedule syncs alongside upstream or downstream dependencies.',
+    tags: ['dagster-supported', 'etl'],
+    source:
+      'https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-airbyte',
+    pypi: 'https://pypi.org/project/dagster-airbyte/',
+    partnerlink:
+      'https://airbyte.com/tutorials/orchestrate-data-ingestion-and-transformation-pipelines',
+    logoFilename: 'airbyte.svg',
+  };
   const airbyte = {
-    frontmatter: {
-      id: 'airbyte',
-      status: 'published',
-      name: 'airbyte',
-      title: 'Airbyte',
-      excerpt: '',
-      partnerlink: '',
-      categories: [],
-      enabledBy: [],
-      enables: [],
-      tags: [],
-      logoFilename: 'airbyte.svg',
-      pypiUrl: '',
-      repoUrl: '',
-    },
+    frontmatter,
     content: 'placeholder',
   };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/__stories__/MarketplaceHome.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/__stories__/MarketplaceHome.stories.tsx
@@ -2,6 +2,7 @@ import {Box, Colors} from '@dagster-io/ui-components';
 import {Meta} from '@storybook/react';
 
 import {MarketplaceHome} from '../MarketplaceHome';
+import {IntegrationFrontmatter} from '../types';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -10,21 +11,43 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  const integrations = [
+  const integrations: IntegrationFrontmatter[] = [
     {
-      id: 'dbt',
-      status: 'published',
-      name: 'dbt',
-      title: 'Dagster & dbt',
-      excerpt: '',
+      id: 'airlift',
+      title: 'Dagster & Airlift',
+      name: 'Airlift',
+      description: 'Easily integrate Dagster and Airflow.',
+      tags: ['dagster-supported', 'other'],
+      source:
+        'https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-airlift',
+      pypi: 'https://pypi.org/project/dagster-airlift/',
       partnerlink: '',
-      categories: [],
-      enabledBy: [],
-      enables: [],
-      tags: [],
-      logoFilename: 'dbt.svg',
-      pypiUrl: '',
-      repoUrl: '',
+      logoFilename: 'airflow.svg',
+    },
+    {
+      id: 'anthropic',
+      title: 'Dagster & Anthropic',
+      name: 'Anthropic',
+      description:
+        'Integrate Anthropic calls into your Dagster pipelines, without breaking the bank.',
+      tags: ['community-supported'],
+      source:
+        'https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-anthropic',
+      pypi: 'https://pypi.org/project/dagster-anthropic/',
+      partnerlink: '',
+      logoFilename: 'anthropic.svg',
+    },
+    {
+      id: 'azure-adls2',
+      title: 'Dagster &  Azure Data Lake Storage Gen 2',
+      name: 'Azure Data Lake Storage Gen 2',
+      description: 'Get utilities for ADLS2 and Blob Storage.',
+      tags: ['dagster-supported', 'storage'],
+      source:
+        'https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-azure',
+      pypi: 'https://pypi.org/project/dagster-azure/',
+      partnerlink: '',
+      logoFilename: 'azure.svg',
     },
   ];
 

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/css/IntegrationTopcard.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/css/IntegrationTopcard.module.css
@@ -1,0 +1,32 @@
+.itemLink {
+  white-space: normal;
+  color: var(--color-text-default);
+  text-decoration: none;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.itemLink:hover {
+  color: var(--color-text-default);
+  text-decoration: none;
+}
+
+.externalLink {
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: var(--color-link-default);
+}
+
+.externalLink:hover {
+  color: var(--color-link-default);
+  text-decoration: none;
+}
+
+.externalLink:hover div[role='img'] {
+  background-color: var(--color-link-default);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/css/MarketplaceHome.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/css/MarketplaceHome.module.css
@@ -6,53 +6,34 @@
   user-select: none;
 }
 
-.itemLink {
-  white-space: normal;
-  color: var(--color-text-default);
-  text-decoration: none;
-  border-radius: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
 .itemCard:hover {
   background-color: var(--color-background-lighter);
   color: var(--color-text-default);
+  cursor: pointer;
 }
 
-.itemCard:hover .itemLink {
-  color: var(--color-text-default);
-  text-decoration: none;
-}
-
-.itemTags {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-}
-
-.externalLink {
-  font-size: 11px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  text-decoration: none;
-  color: var(--color-link-default);
-}
-
-.externalLink:hover {
-  color: var(--color-link-default);
-  text-decoration: none;
-}
-
-.externalLink:hover div[role='img'] {
-  background-color: var(--color-link-default);
-}
-
-.excerpt {
+.description {
   color: var(--color-text-light);
-  font-size: 12px;
+  font-size: 14px;
   line-height: 20px;
-  margin-top: 8px;
+  margin-top: 12px;
+}
+
+.searchInput {
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+  line-height: 20px;
+}
+
+.searchInput input {
+  height: 48px;
+  padding-left: 40px;
+}
+
+.searchInput div[role='img'] {
+  margin-top: 6px;
+  margin-left: 6px;
+  width: 18px;
+  height: 18px;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/integrations/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/integrations/types.tsx
@@ -5,16 +5,12 @@ export type IntegrationConfig = {
 
 export type IntegrationFrontmatter = {
   id: string;
-  status: string;
   name: string;
   title: string;
-  excerpt: string;
+  description: string;
   logoFilename: string | null;
-  pypiUrl: string | null;
-  repoUrl: string | null;
+  pypi: string | null;
   partnerlink: string;
-  categories: string[];
-  enabledBy: string[];
-  enables: string[];
+  source: string;
   tags: string[];
 };


### PR DESCRIPTION
Resolves https://linear.app/dagster-labs/issue/BUILD-981/dg-in-app-marketplace-incorporate-all-integration-metadata

This PR:

- Updates the design of the integration marketplace to match the latest designs in Figma (https://www.figma.com/design/VVEHsiIWwMuvn5nintNPb2/Dagster-UI-2024-Q4?node-id=4740-46245&p=f&t=XTY75uOvnCv9sYjV-0)

- Shows the github and pypi links as buttons

- Shows the “Built by Dagster Labs” shield icon and hides the “Dagster Supported” tag which duplicates that information

- Persists filtering on the marketplace list view to the URL

- Makes the whole card clickable (since the whole card shows a hover state)

- Allows multi-selection of tag filters

- Updates the storybooks with the latest schemas from integrations/index.json

## How I Tested These Changes

- Storybook and  local dagit hitting https://integration-registry.dagster.io/api/integrations/index.json