### PR TITLE
POC - read privacy visibility layer, enforced via middleware

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import dagster._check as check
+import graphene
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -50,6 +51,11 @@ def assert_permission_for_location(
     context = cast("BaseWorkspaceRequestContext", graphene_info.context)
     if not context.has_permission_for_location(permission, location_name):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
+
+
+def mark_visibility_checked(graphene_object: graphene.ObjectType):
+    graphene_object.__visibility__checked = True  # noqa
+    return graphene_object
 
 
 def require_permission_check(

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -57,6 +57,7 @@ from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._core.workspace.permissions import (
     PermissionResult,
+    Permissions,
     get_location_scoped_user_permissions,
     get_user_permissions,
 )
@@ -147,6 +148,9 @@ class BaseWorkspaceRequestContext(LoadingContext):
     @abstractmethod
     def permissions_for_location(self, *, location_name: str) -> Mapping[str, PermissionResult]:
         pass
+
+    def can_view_location(self, location_name: str) -> bool:
+        return self.has_permission_for_location(Permissions.VIEW_CODE_LOCATION, location_name)
 
     def has_permission_for_location(self, permission: str, location_name: str) -> bool:
         if self.has_code_location_name(location_name):

--- a/python_modules/dagster/dagster/_core/workspace/permissions.py
+++ b/python_modules/dagster/dagster/_core/workspace/permissions.py
@@ -22,6 +22,7 @@ class Permissions(str, Enum):
     EDIT_DYNAMIC_PARTITIONS = "edit_dynamic_partitions"
     TOGGLE_AUTO_MATERIALIZE = "toggle_auto_materialize"
     EDIT_CONCURRENCY_LIMIT = "edit_concurrency_limit"
+    VIEW_CODE_LOCATION = "view_code_location"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -45,6 +46,7 @@ VIEWER_PERMISSIONS: dict[str, bool] = {
     Permissions.EDIT_DYNAMIC_PARTITIONS: False,
     Permissions.TOGGLE_AUTO_MATERIALIZE: False,
     Permissions.EDIT_CONCURRENCY_LIMIT: False,
+    Permissions.VIEW_CODE_LOCATION: True,
 }
 
 EDITOR_PERMISSIONS: dict[str, bool] = {
@@ -65,6 +67,7 @@ EDITOR_PERMISSIONS: dict[str, bool] = {
     Permissions.EDIT_DYNAMIC_PARTITIONS: True,
     Permissions.TOGGLE_AUTO_MATERIALIZE: True,
     Permissions.EDIT_CONCURRENCY_LIMIT: True,
+    Permissions.VIEW_CODE_LOCATION: True,
 }
 
 LOCATION_SCOPED_PERMISSIONS = {
@@ -81,6 +84,7 @@ LOCATION_SCOPED_PERMISSIONS = {
     Permissions.CANCEL_PARTITION_BACKFILL,
     Permissions.EDIT_DYNAMIC_PARTITIONS,
     Permissions.REPORT_RUNLESS_ASSET_EVENTS,
+    Permissions.VIEW_CODE_LOCATION,
 }
 
 


### PR DESCRIPTION
Summary:
- graphql middleware that logs (and presumably raises once we're sure we have full coverage) if an object comes through that hasn't been validated for read privacy
- example of how you would add read validation checks for a particular graphene field. Would be a whole journey to do the rest.

Curious for initial thoughts on the high level approach.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
