### PR TITLE
improve entry point errors (BUILD-985)

### DIFF
--- a/python_modules/dagster/dagster/components/core/package_entry.py
+++ b/python_modules/dagster/dagster/components/core/package_entry.py
@@ -18,7 +18,9 @@ OLD_DG_PLUGIN_ENTRY_POINT_GROUP = "dagster_dg.library"
 
 
 class ComponentsEntryPointLoadError(DagsterError):
-    pass
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
 
 
 def get_entry_points_from_python_environment(group: str) -> Sequence[importlib.metadata.EntryPoint]:
@@ -47,7 +49,7 @@ def discover_entry_point_package_objects() -> dict[PluginObjectKey, object]:
         except Exception as e:
             raise ComponentsEntryPointLoadError(
                 format_error_message(f"""
-                    Error loading entry point `{entry_point.name}` in group `{DG_PLUGIN_ENTRY_POINT_GROUP}`.
+                    Error loading entry point `{entry_point.value}` in group `{entry_point.group}`.
                     Please fix the error or uninstall the package that defines this entry point.
                 """)
             ) from e

--- a/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
+++ b/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
@@ -15,6 +15,7 @@ from dagster.components import Component
 from dagster.components.core.package_entry import discover_entry_point_package_objects
 from dagster.components.core.snapshot import get_package_entry_snap
 from dagster_dg.utils import get_venv_executable
+from dagster_shared.error import SerializableErrorInfo
 from dagster_shared.serdes.objects import PluginObjectKey
 from dagster_shared.serdes.objects.package_entry import PluginManifest
 from dagster_shared.serdes.serdes import deserialize_value
@@ -235,7 +236,9 @@ def test_bad_entry_point_error_message(entry_point_group: str):
         entry_point_group, pre_install_hook=pre_install_hook
     ) as venv_root:
         result = _get_component_print_script_result(venv_root)
+        error = deserialize_value(result.stdout, SerializableErrorInfo)
         assert (
-            "Error loading entry point `dagster_foo` in group `dagster_dg.plugin`" in result.stderr
+            f"Error loading entry point `fake.module` in group `{entry_point_group}`"
+            in error.message
         )
-        assert result.returncode != 0
+        assert result.returncode == 0

--- a/python_modules/libraries/dagster-shared/dagster_shared/error.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/error.py
@@ -87,6 +87,7 @@ DAGSTER_FRAMEWORK_SUBSTRINGS = [
 
 IMPORT_MACHINERY_SUBSTRINGS = [
     "importlib/__init__.py",
+    "importlib/metadata/__init__.py",
     "importlib._bootstrap",
 ]
 
@@ -106,6 +107,19 @@ def remove_system_frames_from_error(
         DAGSTER_FRAMEWORK_SUBSTRINGS + IMPORT_MACHINERY_SUBSTRINGS,
         build_system_frame_removed_hint,
     )
+
+
+def make_simple_frames_removed_hint(
+    additional_first_hint_warning: Optional[str] = None,
+) -> Callable[[bool, int], Optional[str]]:
+    def frames_removed_hint(is_first_hidden_frame: bool, num_hidden_frames: int) -> Optional[str]:
+        base_hint = f"{num_hidden_frames} dagster system frames hidden"
+        if is_first_hidden_frame and additional_first_hint_warning:
+            return f"  [{base_hint}, {additional_first_hint_warning}]\n"
+        else:
+            return f"  [{base_hint}]\n"
+
+    return frames_removed_hint
 
 
 def remove_matching_lines_from_error_info(


### PR DESCRIPTION
## Summary & Motivation

Improve the error message when an entry point blows up.

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/c768ea8d-c592-4cbc-a52c-6ea135d17035.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/4ee567a2-5e94-4a32-93b0-52fa394c9d2b.png)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
