### PR TITLE
[dagster-dlt] Include pipeline in DltResourceTranslatorData

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dlt/define_downstream_dependencies.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dlt/define_downstream_dependencies.py
@@ -34,7 +34,7 @@ example_dlt_resource_asset_key = next(
             DagsterDltTranslator().get_asset_spec(
                 data=DltResourceTranslatorData(
                     resource=dlt_source_resource,
-                    destination=example_dlt_pipeline,
+                    pipeline=example_dlt_pipeline,
                 )
             )
             for dlt_source_resource in example_dlt_source().selected_resources.values()

--- a/examples/docs_snippets/docs_snippets/integrations/dlt/define_downstream_dependencies.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dlt/define_downstream_dependencies.py
@@ -34,7 +34,7 @@ example_dlt_resource_asset_key = next(
             DagsterDltTranslator().get_asset_spec(
                 data=DltResourceTranslatorData(
                     resource=dlt_source_resource,
-                    destination=example_dlt_pipeline.destination,
+                    destination=example_dlt_pipeline,
                 )
             )
             for dlt_source_resource in example_dlt_source().selected_resources.values()

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
@@ -38,7 +38,8 @@ def build_dlt_asset_specs(
     return [
         dagster_dlt_translator.get_asset_spec(
             DltResourceTranslatorData(
-                resource=dlt_source_resource, destination=dlt_pipeline.destination
+                resource=dlt_source_resource,
+                pipeline=dlt_pipeline,
             )
         ).merge_attributes(
             metadata={

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -258,9 +258,7 @@ class DagsterDltResource(ConfigurableResource):
         """
         asset_key_dlt_source_resource_mapping = {
             dagster_dlt_translator.get_asset_spec(
-                DltResourceTranslatorData(
-                    resource=dlt_source_resource, destination=dlt_pipeline.destination
-                )
+                DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline)
             ).key: dlt_source_resource
             for dlt_source_resource in dlt_source.selected_resources.values()
         }

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -258,7 +258,7 @@ class DagsterDltResource(ConfigurableResource):
         """
         asset_key_dlt_source_resource_mapping = {
             dagster_dlt_translator.get_asset_spec(
-                DltResourceTranslatorData(resource=dlt_source_resource, destination=dlt_pipeline)
+                DltResourceTranslatorData(resource=dlt_source_resource, pipeline=dlt_pipeline)
             ).key: dlt_source_resource
             for dlt_source_resource in dlt_source.selected_resources.values()
         }

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/translator.py
@@ -8,12 +8,17 @@ from dagster._record import record
 from dagster._utils.warnings import supersession_warning
 from dlt.common.destination import Destination
 from dlt.extract.resource import DltResource
+from dlt.pipeline.pipeline import Pipeline
 
 
 @record
 class DltResourceTranslatorData:
     resource: DltResource
-    destination: Optional[Destination]
+    pipeline: Optional[Pipeline]
+
+    @property
+    def destination(self) -> Optional[Destination]:
+        return self.pipeline.destination if self.pipeline else None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Includes the pipeline object in the `DltResourceTranslatorData` bundle. This allows users to reference e.g. the pipeline's dataset name (schema etc) for purposes of generating their asset key.

## Test Plan

Existing tests, new unit test.
