### PR TITLE
[docs] adds plugin to generate /llms.txt and /llms-full.txt

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,7 +1,7 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
-import type * as Preset from '@docusaurus/preset-classic';
 import DagsterVersions from './dagsterVersions.json';
+import type * as Preset from '@docusaurus/preset-classic';
+import type {Config} from '@docusaurus/types';
+import {themes as prismThemes} from 'prism-react-renderer';
 
 const DagsterVersionsDropdownItems = Object.entries(DagsterVersions).splice(0, 5);
 
@@ -27,6 +27,7 @@ const config: Config = {
     require.resolve('./src/plugins/scoutos'),
     require.resolve('./src/plugins/segment'),
     require.resolve('./src/plugins/sidebar-scroll-into-view'),
+    require.resolve('./src/plugins/llms-txt'),
     // Enable local search when not in a Vercel production instance
     process.env.VERCEL_ENV !== 'production' && [
       require.resolve('docusaurus-lunr-search'),

--- a/docs/src/plugins/llms-txt/index.ts
+++ b/docs/src/plugins/llms-txt/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Plugin to generate /llms.txt and /llms-full.txt
+ *
+ * Heavily inspired by the Prisma documentation (thank you!):
+ *
+ * - https://github.com/prisma/docs/blob/22208d52e4168028dbbe8b020b10682e6b526e50/docusaurus.config.ts
+ *
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+
+module.exports = function (context, options) {
+  return {
+    name: 'llms-txt-plugin',
+    loadContent: async () => {
+      const {siteDir} = context;
+      const contentDir = path.join(siteDir, 'docs');
+      const allMdx: string[] = [];
+
+      // recursive function to get all mdx files
+      const getMdxFiles = async (dir: string) => {
+        const entries = await fs.promises.readdir(dir, {withFileTypes: true});
+
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            await getMdxFiles(fullPath);
+          } else if (entry.name.endsWith('.mdx')) {
+            const content = await fs.promises.readFile(fullPath, 'utf8');
+            allMdx.push(content);
+          }
+        }
+      };
+
+      await getMdxFiles(contentDir);
+      return {allMdx};
+    },
+    postBuild: async ({content, routes, outDir}) => {
+      const {allMdx} = content as {allMdx: string[]};
+
+      // Write concatenated MDX content
+      const concatenatedPath = path.join(outDir, 'llms-full.txt');
+      await fs.promises.writeFile(concatenatedPath, allMdx.join('\n\n---\n\n'));
+
+      // we need to dig down several layers:
+      // find PluginRouteConfig marked by plugin.name === "docusaurus-plugin-content-docs"
+      const docsPluginRouteConfig = routes.filter(
+        (route) => route.plugin.name === 'docusaurus-plugin-content-docs',
+      )[0];
+
+      // docsPluginRouteConfig has a routes property has a record with the path "/" that contains all docs routes.
+      const allDocsRouteConfig = docsPluginRouteConfig.routes?.filter((route) => route.path === '/')[0];
+
+      // A little type checking first
+      if (!allDocsRouteConfig?.props?.version) {
+        return;
+      }
+
+      // this route config has a `props` property that contains the current documentation.
+      const currentVersionDocsRoutes = (allDocsRouteConfig.props.version as Record<string, unknown>).docs as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      // for every single docs route we now parse a path (which is the key) and a title
+      const docsRecords = Object.entries(currentVersionDocsRoutes).map(([path, record]) => {
+        return `- [${record.title}](${path}): ${record.description}`;
+      });
+
+      // Build up llms.txt file
+      const llmsTxt = `# ${context.siteConfig.title}\n\n## Docs\n\n${docsRecords.join('\n')}`;
+
+      // Write llms.txt file
+      const llmsTxtPath = path.join(outDir, 'llms.txt');
+      try {
+        fs.writeFileSync(llmsTxtPath, llmsTxt);
+      } catch (err) {
+        throw err;
+      }
+    },
+  };
+};
+


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-921.

<img width="1712" alt="image" src="https://github.com/user-attachments/assets/7e232d52-6200-49d9-9960-44aaaad90e2c" />

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/a6ce43a1-d4ce-4640-a07f-c6f2670b3668" />

## How I Tested These Changes

`yarn build && yarn serve`

## Changelog

- [docs] Added `/llms.txt` and `/llms-full.txt`
