### PR TITLE
[dagster-dlt] Add translation customization to dlt component

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -229,22 +229,6 @@ def test_component_load_multiple_pipelines() -> None:
         }
 
 
-BASIC_GITHUB_COMPONENT_BODY_WITH_TRANSLATOR = {
-    "type": "dagster_dlt.DltLoadCollectionComponent",
-    "attributes": {
-        "loads": [
-            {
-                "pipeline": ".load.duckdb_repo_reactions_issues_only_pipeline",
-                "source": ".load.duckdb_repo_reactions_issues_only_source",
-                "asset_attributes": {
-                    "tags": {"foo": "bar"},
-                },
-            }
-        ]
-    },
-}
-
-
 @pytest.mark.parametrize(
     "attributes, assertion, should_error",
     [
@@ -315,7 +299,7 @@ BASIC_GITHUB_COMPONENT_BODY_WITH_TRANSLATOR = {
         "key_prefix",
     ],
 )
-def test_asset_attributes(
+def test_translation(
     attributes: Mapping[str, Any],
     assertion: Optional[Callable[[AssetSpec], bool]],
     should_error: bool,
@@ -323,7 +307,7 @@ def test_asset_attributes(
     wrapper = pytest.raises(Exception) if should_error else nullcontext()
     with wrapper:
         body = copy.deepcopy(BASIC_GITHUB_COMPONENT_BODY)
-        body["attributes"]["loads"][0]["asset_attributes"] = attributes
+        body["attributes"]["loads"][0]["translation"] = attributes
         with (
             environ({"SOURCES__ACCESS_TOKEN": "fake"}),
             setup_dlt_component(

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -1,16 +1,19 @@
 # ruff: noqa: F841 TID252
 
+import copy
 import importlib
 import inspect
 import subprocess
 import textwrap
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
+import pytest
 import yaml
 from dagster import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path, pushd
@@ -224,6 +227,124 @@ def test_component_load_multiple_pipelines() -> None:
             AssetKey(["dagster_events", "repo_events"]),
             AssetKey(["github_repo_events_repo_events"]),
         }
+
+
+BASIC_GITHUB_COMPONENT_BODY_WITH_TRANSLATOR = {
+    "type": "dagster_dlt.DltLoadCollectionComponent",
+    "attributes": {
+        "loads": [
+            {
+                "pipeline": ".load.duckdb_repo_reactions_issues_only_pipeline",
+                "source": ".load.duckdb_repo_reactions_issues_only_source",
+                "asset_attributes": {
+                    "tags": {"foo": "bar"},
+                },
+            }
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "attributes, assertion, should_error",
+    [
+        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
+        (
+            {"owners": ["team:analytics"]},
+            lambda asset_spec: asset_spec.owners == ["team:analytics"],
+            False,
+        ),
+        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
+        (
+            {"kinds": ["snowflake", "dbt"]},
+            lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
+            False,
+        ),
+        (
+            {"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
+            lambda asset_spec: "snowflake" in asset_spec.kinds
+            and "dbt" in asset_spec.kinds
+            and asset_spec.tags.get("foo") == "bar",
+            False,
+        ),
+        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
+        (
+            {"description": "some description"},
+            lambda asset_spec: asset_spec.description == "some description",
+            False,
+        ),
+        (
+            {"metadata": {"foo": "bar"}},
+            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
+            False,
+        ),
+        (
+            {"deps": ["customers"]},
+            lambda asset_spec: len(asset_spec.deps) == 1
+            and asset_spec.deps[0].asset_key == AssetKey("customers"),
+            False,
+        ),
+        (
+            {"automation_condition": "{{ automation_condition.eager() }}"},
+            lambda asset_spec: asset_spec.automation_condition is not None,
+            False,
+        ),
+        (
+            {"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
+            lambda asset_spec: asset_spec.key == AssetKey(["duckdb_issues", "issues_suffix"]),
+            False,
+        ),
+        (
+            {"key_prefix": "cool_prefix"},
+            lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
+            False,
+        ),
+    ],
+    ids=[
+        "group_name",
+        "owners",
+        "tags",
+        "kinds",
+        "tags-and-kinds",
+        "code-version",
+        "description",
+        "metadata",
+        "deps",
+        "automation_condition",
+        "key",
+        "key_prefix",
+    ],
+)
+def test_asset_attributes(
+    attributes: Mapping[str, Any],
+    assertion: Optional[Callable[[AssetSpec], bool]],
+    should_error: bool,
+) -> None:
+    wrapper = pytest.raises(Exception) if should_error else nullcontext()
+    with wrapper:
+        body = copy.deepcopy(BASIC_GITHUB_COMPONENT_BODY)
+        body["attributes"]["loads"][0]["asset_attributes"] = attributes
+        with (
+            environ({"SOURCES__ACCESS_TOKEN": "fake"}),
+            setup_dlt_component(
+                load_py_contents=github_load,
+                component_body=body,
+                setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
+            ) as (
+                component,
+                defs,
+            ),
+        ):
+            if "key" in attributes:
+                key = AssetKey(["duckdb_issues", "issues_suffix"])
+            elif "key_prefix" in attributes:
+                key = AssetKey(["cool_prefix", "duckdb_issues", "issues"])
+            else:
+                key = AssetKey(["duckdb_issues", "issues"])
+
+            assets_def = defs.get_assets_def(key)
+            if assertion:
+                assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_python_interface(dlt_pipeline: Pipeline):


### PR DESCRIPTION
## Summary

Adds translator/`asset_attributes` support to the dlt component, similar to sling/dbt:

```yaml
type: dagster_dlt.DltLoadCollectionComponent

attributes:
  loads:
    - source: ...
      pipeline: ...
      translation:
        tags:
          foo: bar
```

## Test Plan

unit tests.
