### PR TITLE
[dg] Improve invalid config error messages (BUILD-1002)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/config.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/config.py
@@ -30,6 +30,7 @@ from typing_extensions import Never, NotRequired, Required, Self, TypeAlias, Typ
 
 from dagster_dg.error import DgError, DgValidationError
 from dagster_dg.utils import (
+    exit_with_error,
     get_toml_node,
     has_toml_node,
     is_macos,
@@ -428,11 +429,11 @@ def _validate_cli_config_setting(cli_opts: Mapping[str, object], key: str, type_
 def _validate_cli_config_no_extraneous_keys(cli_opts: Mapping[str, object]) -> None:
     extraneous_keys = [k for k in cli_opts.keys() if k not in DgRawCliConfig.__annotations__]
     if extraneous_keys:
-        raise DgValidationError(f"Unrecognized fields: {extraneous_keys}")
+        raise DgValidationError(f"Unrecognized fields:\n    {extraneous_keys}")
 
 
 def _raise_cli_config_validation_error(message: str) -> None:
-    raise DgError(f"Error in CLI options: {message}")
+    raise DgError(f"Error in CLI options:\n    {message}")
 
 
 # ########################
@@ -661,9 +662,8 @@ class _DgConfigValidator:
             full_key = self._get_full_key("project.python_environment")
             raise DgValidationError(
                 textwrap.dedent(f"""
-                Found conflicting settings in `{full_key}`. Exactly one of
-                {DgRawProjectPythonEnvironment.__annotations__.keys()} must be set if this section
-                is defined.
+                Found conflicting settings in `{full_key}`. If this section is defined, exactly one of the following keys must be set:
+                    {DgRawProjectPythonEnvironment.__annotations__.keys()}
             """).strip()
             )
 
@@ -719,7 +719,7 @@ class _DgConfigValidator:
         extraneous_keys = [k for k in section.keys() if k not in valid_keys]
         if extraneous_keys:
             full_key = self._get_full_key(toml_path)
-            raise DgValidationError(f"Unrecognized fields at `{full_key}`: {extraneous_keys}")
+            raise DgValidationError(f"Unrecognized fields at `{full_key}`:\n    {extraneous_keys}")
 
     # expected_type Any to handle typing constructs (`Literal` etc)
     def _validate_file_config_setting(
@@ -753,17 +753,26 @@ class _DgConfigValidator:
 
     def _raise_missing_required_key_error(self, key: str, type_str: str) -> Never:
         full_key = self._get_full_key(key)
-        raise DgValidationError(f"Missing required value for `{full_key}`. Expected {type_str}.")
+        raise DgValidationError(
+            f"Missing required value for `{full_key}`:\n   Expected {type_str}."
+        )
 
     def _raise_mistyped_key_error(self, key: str, type_str: str, value: object) -> Never:
         full_key = self._get_full_key(key)
         raise DgValidationError(
-            f"`Invalid value for `{full_key}`. Expected {type_str}, got `{value}`."
+            f"Invalid value for `{full_key}`:\n    Expected {type_str}, got `{value}`."
         )
 
 
 def _raise_file_config_validation_error(message: str, file_path: Path) -> Never:
-    raise DgError(f"Error in configuration file {file_path}: {message}")
+    exit_with_error(
+        textwrap.dedent(f"""
+        Error in configuration file:
+            {file_path}
+        """)
+        + message,
+        do_format=False,
+    )
 
 
 # expected_type Any to handle typing constructs (`Literal` etc)


### PR DESCRIPTION
## Summary & Motivation

Improves error messages for invalid config:

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/2b64690a-d50f-4e11-92a2-eb58d5d28f94.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/2c59f2ea-555e-4ec5-971c-9ae3c4f97d23.png)

## How I Tested These Changes

Modified unit tests, also manually.

## Changelog

Error message when an invalid configuration file is detected is now shorter and more clear.