### PR TITLE
[dagster-dlt] Introduce component YAML scaffolder

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -7,15 +7,17 @@ from typing import Annotated, Callable, Optional, Union
 import dagster as dg
 from dagster import AssetKey, AssetSpec
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components import Component, ComponentLoadContext, Resolvable
+from dagster.components import Component, ComponentLoadContext, Resolvable, Resolver
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.core_models import AssetAttributesModel, Resolver
+from dagster.components.resolved.core_models import AssetAttributesModel
+from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils import TranslatorResolvingInfo
 from dlt import Pipeline
 from dlt.extract.source import DltSource
 from typing_extensions import TypeAlias
 
 from dagster_dlt.asset_decorator import dlt_assets
+from dagster_dlt.components.dlt_load_collection.scaffolder import DltComponentScaffolder
 from dagster_dlt.translator import DagsterDltTranslator, DltResourceTranslatorData
 
 TranslationFn: TypeAlias = Callable[[AssetSpec, DltResourceTranslatorData], AssetSpec]
@@ -106,6 +108,7 @@ class DltLoadSpecModel(Resolvable):
         return ComponentDagsterDltTranslator()
 
 
+@scaffold_with(DltComponentScaffolder)
 @dataclass
 class DltLoadCollectionComponent(Component, Resolvable):
     """Expose one or more dlt loads to Dagster as assets.

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/scaffolder.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/scaffolder.py
@@ -1,0 +1,179 @@
+import ast
+import shutil
+import subprocess
+import textwrap
+from collections.abc import Mapping
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+from dagster._utils import pushd
+from dagster.components import Scaffolder, ScaffoldRequest, scaffold_component
+from dagster.components.utils import check
+from pydantic import BaseModel
+
+
+class PipelineAndSource(NamedTuple):
+    pipeline_src: str
+    source_src: str
+
+
+class ParsedPipelineAndSource(NamedTuple):
+    imports: list[str]
+    pipelines_and_sources: Mapping[str, PipelineAndSource]
+
+
+def _extract_pipeline_and_source_from_init_file(
+    node: ast.FunctionDef,
+) -> PipelineAndSource:
+    """Given a function body AST node, extracts the source code for the
+    local Pipeline and DltSource objects.
+    """
+    pipeline_src = None
+    source_src = None
+
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign):
+            target = stmt.targets[0]
+            if isinstance(target, ast.Name):
+                var_name = target.id
+                if var_name == "pipeline":
+                    pipeline_src = ast.unparse(stmt)
+                elif var_name == "data":
+                    source_src = ast.unparse(stmt)
+
+    return PipelineAndSource(check.not_none(pipeline_src), check.not_none(source_src))
+
+
+def _extract_pipelines_and_sources_from_pipeline_file(
+    file_path: Path,
+) -> ParsedPipelineAndSource:
+    """Process a Python file and generate a new file with pipeline and data definitions."""
+    imports = []
+    pipelines_and_sources = {}
+    source = file_path.read_text()
+    tree = ast.parse(source)
+
+    # Create new file content
+    new_content = []
+    new_content.append('"""Generated pipeline and data definitions."""\n')
+
+    # Add imports from original file
+    for node in tree.body:
+        if isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom):
+            imports.append(ast.unparse(node).replace("from ", "from ."))
+
+    # Process each function
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            pipelines_and_sources[node.name.removeprefix("load_")] = (
+                _extract_pipeline_and_source_from_init_file(node)
+            )
+
+    return ParsedPipelineAndSource(imports, pipelines_and_sources)
+
+
+def _construct_pipeline_source_file(
+    file_path: Path,
+    parsed_pipeline_and_source: ParsedPipelineAndSource,
+) -> None:
+    """Construct a new pipeline source file from a set of pipeline and source definitions."""
+    new_content = []
+    for import_line in parsed_pipeline_and_source.imports:
+        new_content.append(import_line)
+
+    new_content.append("\n")
+
+    for load_name, (
+        pipeline_src,
+        source_src,
+    ) in parsed_pipeline_and_source.pipelines_and_sources.items():
+        new_content.append(source_src.replace("data =", f"{load_name}_source ="))
+        new_content.append(pipeline_src.replace("pipeline =", f"{load_name}_pipeline ="))
+        new_content.append("")
+
+    file_path.write_text("\n".join(new_content))
+
+
+class DltScaffolderParams(BaseModel):
+    source: Optional[str] = None
+    destination: Optional[str] = None
+
+
+DLT_INIT_FILES_TO_CLEAN_UP = [".gitignore", "requirements.txt", ".dlt"]
+
+
+class DltComponentScaffolder(Scaffolder):
+    @classmethod
+    def get_scaffold_params(cls) -> Optional[type[BaseModel]]:
+        return DltScaffolderParams
+
+    def scaffold(self, request: ScaffoldRequest, params: DltScaffolderParams) -> None:
+        params = params or DltScaffolderParams(source=None, destination=None)
+        with pushd(str(request.target_path)):
+            Path.cwd().mkdir(parents=True, exist_ok=True)
+            # Given source and destination, we can use dlt init to scaffold the source
+            # code and some sample pipelines and sources.
+            if params.source and params.destination:
+                yes = subprocess.Popen(["yes", "y"], stdout=subprocess.PIPE)
+                try:
+                    subprocess.call(
+                        ["dlt", "init", params.source, params.destination], stdin=yes.stdout
+                    )
+                finally:
+                    yes.kill()
+                # dlt init scaffolds a Python file with some example pipelines, nested in functions
+                # we extract them into top-level objects which we stash in loads.py as a sample
+                examples_python_file = next(Path(".").glob("*.py"))
+                pipelines_and_sources = _extract_pipelines_and_sources_from_pipeline_file(
+                    examples_python_file
+                )
+                examples_python_file.unlink()
+                for file in DLT_INIT_FILES_TO_CLEAN_UP:
+                    if Path(file).is_dir():
+                        shutil.rmtree(file)
+                    else:
+                        Path(file).unlink()
+                _construct_pipeline_source_file(Path("loads.py"), pipelines_and_sources)
+            elif params.source or params.destination:
+                raise ValueError("Must provide neither or both of source and destination")
+            else:
+                Path("loads.py").write_text(
+                    textwrap.dedent(
+                        """
+                        import dlt
+
+                        @dlt.source
+                        def my_source():
+                            @dlt.resource
+                            def hello_world():
+                                return "hello, world!"
+
+                            return hello_world
+
+                        my_load_source = my_source()
+                        my_load_pipeline = dlt.pipeline()
+                        """
+                    )
+                )
+                pipelines_and_sources = ParsedPipelineAndSource(
+                    imports=[],
+                    pipelines_and_sources={
+                        "my_load": PipelineAndSource(
+                            pipeline_src="pipeline = dlt.pipeline()",
+                            source_src="data = my_source()",
+                        )
+                    },
+                )
+
+        scaffold_component(
+            request=request,
+            yaml_attributes={
+                "loads": [
+                    {
+                        "source": f".loads.{load_name}_source",
+                        "pipeline": f".loads.{load_name}_pipeline",
+                    }
+                    for load_name in pipelines_and_sources.pipelines_and_sources.keys()
+                ]
+            },
+        )

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -378,7 +378,7 @@ def test_scaffold_bare_component():
 
         assert len(component.loads) == 1
         assert defs.get_asset_graph().get_all_asset_keys() == {
-            AssetKey(["dlt_my_source_hello_world"]),
+            AssetKey(["example", "hello_world"]),
             AssetKey(["my_source_hello_world"]),
         }
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional
 
 import pytest
 import yaml
+from click.testing import CliRunner
 from dagster import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
@@ -19,6 +20,7 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path, pushd
 from dagster._utils.env import environ
 from dagster.components import ComponentLoadContext
+from dagster.components.cli import cli
 from dagster.components.core.context import use_component_load_context
 from dagster.components.core.defs_module import get_component
 from dagster_dg.utils import ensure_dagster_dg_tests_import
@@ -38,18 +40,20 @@ from dagster_dg_tests.utils import (
 )
 
 
-@contextmanager
-def _modify_yaml(path: Path) -> Iterator[dict[str, Any]]:
-    with open(path) as f:
-        data = yaml.safe_load(f)
-    yield data  # modify data here
-    with open(path, "w") as f:
-        yaml.dump(data, f)
-
-
 def dlt_init(source: str, dest: str) -> None:
     yes = subprocess.Popen(["yes", "y"], stdout=subprocess.PIPE)
     subprocess.check_call(["dlt", "init", source, dest], stdin=yes.stdout)
+
+
+@contextmanager
+def setup_dlt_ready_project() -> Iterator[None]:
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+        alter_sys_path(to_add=[str(Path.cwd() / "src")], to_remove=[]),
+    ):
+        install_editable_dagster_packages_to_venv(Path(".venv"), ["libraries/dagster-dlt"])
+        yield
 
 
 @contextmanager
@@ -57,13 +61,7 @@ def setup_dlt_component(
     load_py_contents: Callable, component_body: dict[str, Any], setup_dlt_sources: Callable
 ) -> Iterator[tuple[DltLoadCollectionComponent, Definitions]]:
     """Sets up a components project with a dlt component based on provided params."""
-    with (
-        ProxyRunner.test(use_fixed_test_components=True) as runner,
-        isolated_example_project_foo_bar(runner, in_workspace=False),
-        alter_sys_path(to_add=[str(Path.cwd() / "src")], to_remove=[]),
-    ):
-        install_editable_dagster_packages_to_venv(Path(".venv"), ["libraries/dagster-dlt"])
-
+    with setup_dlt_ready_project():
         defs_path = Path.cwd() / "src" / "foo_bar" / "defs"
         component_path = defs_path / "ingest"
         component_path.mkdir(parents=True, exist_ok=True)
@@ -348,3 +346,72 @@ def test_python_interface(dlt_pipeline: Pipeline):
         AssetKey(["example", "repo_issues"]),
         AssetKey(["pipeline_repos"]),
     }
+
+
+def test_scaffold_bare_component():
+    runner = CliRunner()
+
+    with setup_dlt_ready_project() as project_path:
+        result = runner.invoke(
+            cli,
+            [
+                "scaffold",
+                "object",
+                "dagster_dlt.DltLoadCollectionComponent",
+                "src/foo_bar/defs/my_barebones_dlt_component",
+                "--scaffold-format",
+                "yaml",
+            ],
+        )
+        assert result.exit_code == 0
+        assert Path("src/foo_bar/defs/my_barebones_dlt_component/loads.py").exists()
+        assert Path("src/foo_bar/defs/my_barebones_dlt_component/component.yaml").exists()
+
+        defs_root = importlib.import_module("foo_bar.defs.my_barebones_dlt_component")
+        project_root = Path.cwd()
+
+        context = ComponentLoadContext.for_module(defs_root, project_root)
+        with use_component_load_context(context):
+            component = get_component(context)
+            assert isinstance(component, DltLoadCollectionComponent)
+            defs = component.build_defs(context)
+
+        assert len(component.loads) == 1
+        assert defs.get_asset_graph().get_all_asset_keys() == {
+            AssetKey(["dlt_my_source_hello_world"]),
+            AssetKey(["my_source_hello_world"]),
+        }
+
+
+def test_scaffold_component_with_source_and_destination():
+    runner = CliRunner()
+
+    with setup_dlt_ready_project() as project_path, environ({"SOURCES__ACCESS_TOKEN": "fake"}):
+        result = runner.invoke(
+            cli,
+            [
+                "scaffold",
+                "object",
+                "dagster_dlt.DltLoadCollectionComponent",
+                "src/foo_bar/defs/my_barebones_dlt_component",
+                "--scaffold-format",
+                "yaml",
+                "--json-params",
+                '{"source": "github", "destination": "snowflake"}',
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("src/foo_bar/defs/my_barebones_dlt_component/loads.py").exists()
+        assert Path("src/foo_bar/defs/my_barebones_dlt_component/component.yaml").exists()
+
+        defs_root = importlib.import_module("foo_bar.defs.my_barebones_dlt_component")
+        project_root = Path.cwd()
+
+        context = ComponentLoadContext.for_module(defs_root, project_root)
+        with use_component_load_context(context):
+            component = get_component(context)
+            assert isinstance(component, DltLoadCollectionComponent)
+            defs = component.build_defs(context)
+
+        # should be many loads, not hardcoding in case dlt changes
+        assert len(component.loads) > 1


### PR DESCRIPTION
## Summary

Introduces a dlt component scaffolder. By default (no args), generates a sample `loads.py` file with a barebones dlt source and pipeline:
```yaml
type: dagster_dlt.DltLoadCollectionComponent

attributes:
  loads:
    - source: .loads.my_load_source
      pipeline: .loads.my_load_pipeline
```

```python
import dlt

@dlt.source
def my_source():
    @dlt.resource
    def hello_world():
        return "hello, world!"

    return hello_world

my_load_source = my_source()
my_load_pipeline = dlt.pipeline()
```

If the user instead provides a `--source` and `--destination`, under the hood calls `dlt init [source] [destination]` and adapts the results to be ready-to-use for components. This is some `ast` magic and might be a little more complex than we want out of a scaffolder, but I do think the results are pretty convincing:

```yaml
type: dagster_dlt.DltLoadCollectionComponent

attributes:
  loads:
    - source: .loads.duckdb_repo_reactions_issues_only_source
      pipeline: .loads.duckdb_repo_reactions_issues_only_pipeline
    - source: .loads.airflow_events_source
      pipeline: .loads.airflow_events_pipeline
    - source: .loads.dlthub_dlt_all_data_source
      pipeline: .loads.dlthub_dlt_all_data_pipeline
    - source: .loads.dlthub_dlt_stargazers_source
      pipeline: .loads.dlthub_dlt_stargazers_pipeline
```

```python
import dlt
from .github import github_reactions, github_repo_events, github_stargazers


duckdb_repo_reactions_issues_only_source = github_reactions('duckdb', 'duckdb', items_per_page=100, max_items=100).with_resources('issues')
duckdb_repo_reactions_issues_only_pipeline = dlt.pipeline('github_reactions', destination='snowflake', dataset_name='duckdb_issues', dev_mode=True)

airflow_events_source = github_repo_events('apache', 'airflow', access_token='')
airflow_events_pipeline = dlt.pipeline('github_events', destination='snowflake', dataset_name='airflow_events')

dlthub_dlt_all_data_source = github_reactions('dlt-hub', 'dlt')
dlthub_dlt_all_data_pipeline = dlt.pipeline('github_reactions', destination='snowflake', dataset_name='dlthub_reactions', dev_mode=True)

dlthub_dlt_stargazers_source = github_stargazers('dlt-hub', 'dlt')
dlthub_dlt_stargazers_pipeline = dlt.pipeline('github_stargazers', destination='snowflake', dataset_name='dlthub_stargazers', dev_mode=True)

```
## Test Plan

Scaffolding unit tests.