### PR TITLE
[docs] filter index pages for doc card lists

### DIFF
--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -4,6 +4,7 @@ import {
   useCurrentSidebarCategory,
   filterDocCardListItems,
 } from '@docusaurus/plugin-content-docs/client';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import DocCard from '@theme/DocCard';
 import type {Props} from '@theme/DocCardList';
 
@@ -19,21 +20,26 @@ export default function DocCardList(props: Props): ReactNode {
   }
   const filteredItems = filterDocCardListItems(items);
 
-  // >>> BEGIN CUSTOMIZATIONS
-
-  // Exclude link item that matches the current href (eg. Examples on the /examples` page)
-  const currentHrefPath = new URL(window.location.href).pathname;
-  const filteredItemsNoIndex = filteredItems.filter((item) => item.href > currentHrefPath);
-
-  // <<< END CUSTOMIZATIONS
+  // The `DocCardList` has been customized to filter cards with `href === window.location.pathname`.
+  //
+  // The `window.location` is only available in the browser, and as Docusaurus is server-side
+  // rendered we have to wrap this component in `BrowserOnly`. For more information see:
+  //
+  // https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/website/docs/advanced/ssg.mdx#browseronly-browseronly
 
   return (
     <section className={clsx('row', className)}>
-      {filteredItemsNoIndex.map((item, index) => (
-        <article key={index} className="col col--6 margin-bottom--lg">
-          <DocCard item={item} />
-        </article>
-      ))}
+      <BrowserOnly>
+        {() => {
+          return filteredItems
+            .filter((item) => item.href > window.location.pathname)
+            .map((item, index) => (
+              <article key={index} className="col col--6 margin-bottom--lg">
+                <DocCard item={item} />
+              </article>
+            ));
+        }}
+      </BrowserOnly>
     </section>
   );
 }

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -1,0 +1,39 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {
+  useCurrentSidebarCategory,
+  filterDocCardListItems,
+} from '@docusaurus/plugin-content-docs/client';
+import DocCard from '@theme/DocCard';
+import type {Props} from '@theme/DocCardList';
+
+function DocCardListForCurrentSidebarCategory({className}: Props) {
+  const category = useCurrentSidebarCategory();
+  return <DocCardList items={category.items} className={className} />;
+}
+
+export default function DocCardList(props: Props): ReactNode {
+  const {items, className} = props;
+  if (!items) {
+    return <DocCardListForCurrentSidebarCategory {...props} />;
+  }
+  const filteredItems = filterDocCardListItems(items);
+
+  // >>> BEGIN CUSTOMIZATIONS
+
+  // Exclude link item that matches the current href (eg. Examples on the /examples` page)
+  const currentHrefPath = new URL(window.location.href).pathname;
+  const filteredItemsNoIndex = filteredItems.filter((item) => item.href > currentHrefPath);
+
+  // <<< END CUSTOMIZATIONS
+
+  return (
+    <section className={clsx('row', className)}>
+      {filteredItemsNoIndex.map((item, index) => (
+        <article key={index} className="col col--6 margin-bottom--lg">
+          <DocCard item={item} />
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -32,7 +32,7 @@ export default function DocCardList(props: Props): ReactNode {
       <BrowserOnly>
         {() => {
           return filteredItems
-            .filter((item) => item.href > window.location.pathname)
+            .filter((item) => item.href !== window.location.pathname)
             .map((item, index) => (
               <article key={index} className="col col--6 margin-bottom--lg">
                 <DocCard item={item} />


### PR DESCRIPTION
## Summary & Motivation

Removes `/index` pages from lists.

**Before**
<img width="997" alt="image" src="https://github.com/user-attachments/assets/0f7a7da0-6ed7-493e-a971-6d490bdff165" />

**Before**
<img width="995" alt="image" src="https://github.com/user-attachments/assets/d5e0ea1c-025d-4150-be9c-8f13d7bd4c5b" />

## How I Tested These Changes

## Changelog

NOCHANGELOG
