### PR TITLE
remove @cached_property from several fields of BaseAssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -279,23 +279,23 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
     def get_all_asset_keys(self) -> AbstractSet[AssetKey]:
         return set(self._asset_nodes_by_key)
 
-    @cached_property
+    @property
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for key, node in self._asset_nodes_by_key.items() if node.is_materializable}
 
-    @cached_property
+    @property
     def observable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for key, node in self._asset_nodes_by_key.items() if node.is_observable}
 
-    @cached_property
+    @property
     def external_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for key, node in self._asset_nodes_by_key.items() if node.is_external}
 
-    @cached_property
+    @property
     def executable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for key, node in self._asset_nodes_by_key.items() if node.is_executable}
 
-    @cached_property
+    @property
     def unexecutable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for key, node in self._asset_nodes_by_key.items() if not node.is_executable}
 


### PR DESCRIPTION
## Summary & Motivation

@cached_property can induce lock contention even across instances as in python<3.12 it is backed by a global lock. For these fields that are easy to compute, we can avoid this by just re-computing when they are accessed

## How I Tested These Changes

Nothing should be affected other than performance in the edge case
