### PR TITLE
Replace calls to PersistedTimeWindow.start.timestamp() and PersistedTimeWindow.end.timestamp() with start_timestamp and end_timestamp properties

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -932,7 +932,7 @@ def _compute_subset_value_str(subset: SerializableEntitySubset) -> str:
     elif isinstance(subset.value, TimeWindowPartitionsSubset):
         return str(
             [
-                (tw.start.timestamp(), tw.end.timestamp())
+                (tw.start_timestamp, tw.end_timestamp)
                 for tw in sorted(subset.value.included_time_windows)
             ]
         )


### PR DESCRIPTION
## Summary & Motivation
PersistedTimeWindow starts with a UTC timestamp, so transforming this into a datetime just to transform it back into a UTC timestamp is inefficient. Furthermore we have some evidence of lock contention in cached_property calls in python versions < 3.12, so we can avoid using a cached_property in a hot path that we don't need.

The main unfortunate thing here is that there are callsites that mix the user-facing TimeWindow class (which does not have a start_timestamp or end_timestamp property) with this PersistedTimeWindow class that does. Typechecking should help us avoid errors here but we could consider adding the properties to TimeWindow as well as a backstop.

## How I Tested These Changes
BK

