### PR TITLE
[docs] refine styling of examples and integration indexes

### DIFF
--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -70,10 +70,16 @@ function CardLayout({
           />
         </div>
         <div>
-          <Heading as="h2" className={clsx('', styles.cardTitle)} title={title}>
-            {title}
-          </Heading>
-          {community && <p className={clsx(styles.cardSubtitle)}>Community / Partner supported</p>}
+          <div style={{display: 'flex', flexDirection: 'row'}}>
+            <Heading as="h2" className={clsx('', styles.cardTitle)} title={title}>
+              {title}
+            </Heading>
+            {community && (
+              <span style={{marginLeft: 'auto'}}>
+                <div className={clsx(styles.cardTags)}>Community</div>
+              </span>
+            )}
+          </div>
           {description && (
             <p className={clsx(styles.cardDescription)} title={description}>
               {description}

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -10,9 +10,6 @@
   padding: 1rem !important;
 }
 
-.cardContainer h2 {
-  margin-bottom: 0.5rem;
-}
 
 .cardContainer:hover {
   border-color: var(--ifm-color-primary);
@@ -23,23 +20,38 @@
   margin-bottom: 0;
 }
 
-.cardTitle {
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-  font-weight: 400;
+.cardTitleContainer {
+    display: flex;
 }
 
-.cardDescription {
+.cardTitle {
   font-size: 1rem;
-  line-height: 1.5rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  padding-top: 0.2rem;
 }
 
 .cardSubtitle {
   font-size: 1rem;
-  line-height: 1.5rem;
+  font-weight: 500 !important;
+  margin-bottom: 0.5rem !important;
   color: var(--theme-color-text-blue) !important;
+}
+
+.cardTags {
+  padding-left: 8px;
+  padding-right: 8px;
+  background: var(--theme-color-background-blue);
+  border-radius: 16px;
+  font-size: 0.8rem;
+  font-weight: 400;
+}
+
+.cardDescription {
+  font-size: 0.8rem !important;
+  font-weight: 400 !important;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }


### PR DESCRIPTION
## Summary & Motivation

- Refines typography and moves the community label to be inline with the title and as a "tag" or "pill"

**Before**
![image](https://github.com/user-attachments/assets/ca35b86d-80f2-45a8-9481-a7927da0cda8)

**After**
![image](https://github.com/user-attachments/assets/80b7a973-05fe-4220-ab5d-8392ed07f324)


**Before (small)**
![image](https://github.com/user-attachments/assets/9d87fbdf-ebf1-4630-ab63-49320f205964)

**After (small)**
![image](https://github.com/user-attachments/assets/990dafe2-20d4-4bad-8b33-d57a57e217b5)


## How I Tested These Changes

## Changelog

NOCHANGELOG
