### PR TITLE
`compute_union`, `compute_intersection`, `compute_difference`, `from_coercible_value` methods on SerializableEntitySubset

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -64,12 +64,12 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
             return cls(key=key, value=True)
         if isinstance(value, str):
             partitions_subset = check.not_none(partitions_def).subset_with_partition_keys([value])
-        if isinstance(value, Sequence):
-            check.list_param(value, "value", of_type=str)
-            partitions_subset = check.not_none(partitions_def).subset_with_partition_keys(value)
-        else:
+        elif isinstance(value, PartitionsSubset):
             check.inst_param(value, "value", PartitionsSubset)
             partitions_subset = value
+        else:
+            check.list_param(value, "value", of_type=str)
+            partitions_subset = check.not_none(partitions_def).subset_with_partition_keys(value)
         return cls(key=key, value=partitions_subset)
 
     @property

--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -83,6 +83,7 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
             return partitions_def is None
 
     def _oper(self, other: Self, oper: Callable[..., Any]) -> Self:
+        check.invariant(self.key == other.key, "Keys must match for operation")
         value = oper(self.value, other.value)
         return self.__class__(key=self.key, value=value)
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -115,6 +115,15 @@ def test_from_coercible_value():
 
     assert SerializableEntitySubset.from_coercible_value(
         key=a,
+        value=["1", "2"],
+        partitions_def=partitions_def,
+    ) == SerializableEntitySubset(
+        key=AssetKey("a"),
+        value=partitions_def.subset_with_partition_keys(["1", "2"]),
+    )
+
+    assert SerializableEntitySubset.from_coercible_value(
+        key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=partitions_def,
     ) == SerializableEntitySubset(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -94,28 +94,28 @@ def test_difference():
     )
 
 
-def test_new():
+def test_from_coercible_value():
     a = AssetKey("a")
     partitions_def = StaticPartitionsDefinition(["1", "2", "3", "4"])
 
-    assert SerializableEntitySubset.new(
+    assert SerializableEntitySubset.from_coercible_value(
         key=a,
-        partition_key_or_subset=None,
+        value=None,
         partitions_def=None,
     ) == SerializableEntitySubset(key=AssetKey("a"), value=True)
 
-    assert SerializableEntitySubset.new(
+    assert SerializableEntitySubset.from_coercible_value(
         key=a,
-        partition_key_or_subset="1",
+        value="1",
         partitions_def=partitions_def,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
     )
 
-    assert SerializableEntitySubset.new(
+    assert SerializableEntitySubset.from_coercible_value(
         key=a,
-        partition_key_or_subset=partitions_def.subset_with_partition_keys(["1"]),
+        value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=partitions_def,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
@@ -123,15 +123,15 @@ def test_new():
     )
 
     with pytest.raises(CheckError):
-        SerializableEntitySubset.new(
+        SerializableEntitySubset.from_coercible_value(
             key=a,
-            partition_key_or_subset="1",
+            value="1",
             partitions_def=None,
         )
 
     with pytest.raises(CheckError):
-        SerializableEntitySubset.new(
+        SerializableEntitySubset.from_coercible_value(
             key=a,
-            partition_key_or_subset=None,
+            value=None,
             partitions_def=partitions_def,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -1,0 +1,92 @@
+from dagster import AssetKey, StaticPartitionsDefinition
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+
+
+def test_union():
+    a_true = SerializableEntitySubset(key=AssetKey("a"), value=True)
+    a_false = SerializableEntitySubset(key=AssetKey("a"), value=False)
+
+    assert a_true.compute_union(a_false) == a_true
+    assert a_false.compute_union(a_true) == a_true
+    assert a_true.compute_union(a_true) == a_true
+    assert a_false.compute_union(a_false) == a_false
+
+    partitions_def = StaticPartitionsDefinition(["1", "2", "3", "4"])
+
+    b_12 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1", "2"]),
+    )
+    b_3 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["3"]),
+    )
+
+    assert b_12.compute_union(b_3) == SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1", "2", "3"]),
+    )
+
+
+def test_intersection():
+    a_true = SerializableEntitySubset(key=AssetKey("a"), value=True)
+    a_false = SerializableEntitySubset(key=AssetKey("a"), value=False)
+
+    assert a_true.compute_intersection(a_false) == a_false
+    assert a_false.compute_intersection(a_true) == a_false
+    assert a_true.compute_intersection(a_true) == a_true
+    assert a_false.compute_intersection(a_false) == a_false
+
+    partitions_def = StaticPartitionsDefinition(["1", "2", "3", "4"])
+
+    b_12 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1", "2"]),
+    )
+    b_3 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["3"]),
+    )
+    b_1 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1"]),
+    )
+
+    assert b_12.compute_intersection(b_3) == SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.empty_subset(),
+    )
+
+    assert b_12.compute_intersection(b_1) == b_1
+
+
+def test_difference():
+    a_true = SerializableEntitySubset(key=AssetKey("a"), value=True)
+    a_false = SerializableEntitySubset(key=AssetKey("a"), value=False)
+
+    assert a_true.compute_difference(a_false) == a_true
+    assert a_false.compute_difference(a_true) == a_false
+    assert a_true.compute_difference(a_true) == a_false
+    assert a_false.compute_difference(a_false) == a_false
+
+    partitions_def = StaticPartitionsDefinition(["1", "2", "3", "4"])
+
+    b_12 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1", "2"]),
+    )
+    b_3 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["3"]),
+    )
+    b_1 = SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["1"]),
+    )
+
+    assert b_12.compute_difference(b_3) == b_12
+
+    assert b_12.compute_difference(b_1) == SerializableEntitySubset(
+        key=AssetKey("b"),
+        value=partitions_def.subset_with_partition_keys(["2"]),
+    )


### PR DESCRIPTION
## Summary & Motivation
allows adding and removing partition subsets/bools from `SerializableEntitySubset`  and constructing a `SerializableEntitySubset` from the input types we might expect in code (None, partition key, partitions subset) so that we don't need to branch in the calling code

used in https://github.com/dagster-io/internal/pull/15287

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
