### PR TITLE
[WorkspaceContext] Add back refetch but smarter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/TimingControls.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/TimingControls.ts
@@ -1,10 +1,10 @@
 export const TimingControls = {
   // This is kinda goofy but to allow the jest tests to test the loading from cache we use this abstraction to allow jest
   // to stop us from loading from the server immediately so that it can confirm the cached data was loaded and returned first.
-  loadFromServer: (fn: () => void) => {
-    fn();
+  loadFromServer: async (fn: () => Promise<void>) => {
+    await fn();
   },
-  handleStatusUpdate: (fn: () => void) => {
-    fn();
+  handleStatusUpdate: async (fn: () => Promise<void>) => {
+    await fn();
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
@@ -57,10 +57,14 @@ export class WorkspaceManager {
       this.setData(this.data);
     });
 
-    this.statusPoller.subscribe(({locationStatuses}) => {
+    this.statusPoller.subscribe(async ({locationStatuses}) => {
       this.data.locationStatuses = locationStatuses;
       this.setData(this.data);
     });
+  }
+
+  public async refetchAll() {
+    await this.statusPoller.refetch();
   }
 
   public destroy() {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
@@ -28,7 +28,7 @@ export class WorkspaceStatusPoller {
       updated: string[];
       removed: string[];
       locationStatuses: Record<string, LocationStatusEntryFragment>;
-    }) => void
+    }) => Promise<void>
   >;
   private interval: NodeJS.Timeout | undefined;
   private setCodeLocationStatusAtom: (status: CodeLocationStatusQuery) => void;
@@ -80,14 +80,14 @@ export class WorkspaceStatusPoller {
       bypassCache: true,
     });
     if (error) {
-      console.error(error);
+      console.error('Error loading code location statuses from server', error);
     } else if (data) {
       this.setCodeLocationStatusAtom(data);
       if (data.locationStatusesOrError.__typename === 'WorkspaceLocationStatusEntries') {
         const nextStatuses = Object.fromEntries(
           data.locationStatusesOrError.entries.map((entry) => [entry.name, entry]),
         );
-        this.checkForChanges(this.statuses, nextStatuses);
+        await this.checkForChanges(this.statuses, nextStatuses);
       } else {
         console.error('Error loading location statuses from server', data.locationStatusesOrError);
       }
@@ -96,7 +96,7 @@ export class WorkspaceStatusPoller {
     }
   }
 
-  private checkForChanges(
+  private async checkForChanges(
     prevStatuses: Record<string, LocationStatusEntryFragment>,
     nextStatuses: Record<string, LocationStatusEntryFragment>,
   ) {
@@ -115,8 +115,8 @@ export class WorkspaceStatusPoller {
     this.statuses = nextStatuses;
     this.lastChanged = {added, updated, removed};
     if (added.length > 0 || updated.length > 0 || removed.length > 0 || !this.hasNotifiedOnce) {
-      this.notifySubscribers();
       this.hasNotifiedOnce = true;
+      await this.notifySubscribers();
     }
   }
 
@@ -126,7 +126,7 @@ export class WorkspaceStatusPoller {
       updated: string[];
       removed: string[];
       locationStatuses: Record<string, LocationStatusEntryFragment>;
-    }) => void,
+    }) => Promise<void>,
   ) {
     this.subscribers.add(subscriber);
     if (this.lastChanged !== EMPTY_CHANGES) {
@@ -138,13 +138,19 @@ export class WorkspaceStatusPoller {
     return () => this.subscribers.delete(subscriber);
   }
 
-  private notifySubscribers() {
-    this.subscribers.forEach((subscriber) => {
-      subscriber({...this.lastChanged, locationStatuses: this.statuses});
-    });
+  private async notifySubscribers() {
+    await Promise.all(
+      Array.from(this.subscribers).map((subscriber) => {
+        return subscriber({...this.lastChanged, locationStatuses: this.statuses});
+      }),
+    );
   }
 
   public destroy() {
     clearInterval(this.interval);
+  }
+
+  public async refetch() {
+    await this.loadFromServer();
   }
 }


### PR DESCRIPTION
## Summary & Motivation

Adds back a refetch function that causes an immediate fetch of the CodeLocationStatusQuery triggering only changed code locations to refetch (or to be deleted if they no longer exist). 

## How I Tested These Changes

Jest tests + manual testing