### PR TITLE
[ui] Don't persist asset view params across tabs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -59,40 +59,40 @@ export type AssetTabConfig = {
 export const buildAssetViewParams = (params: AssetViewParams) => `?${qs.stringify(params)}`;
 
 export const buildAssetTabMap = (input: AssetTabConfigInput) => {
-  const {definition, params} = input;
+  const {definition} = input;
 
   return {
     overview: {
       id: 'overview',
       title: 'Overview',
-      to: buildAssetViewParams({...params, view: 'overview'}),
+      to: buildAssetViewParams({view: 'overview'}),
     } as AssetTabConfig,
     partitions: {
       id: 'partitions',
       title: 'Partitions',
-      to: buildAssetViewParams({...params, view: 'partitions'}),
+      to: buildAssetViewParams({view: 'partitions'}),
       hidden: !definition?.partitionDefinition || !definition?.isMaterializable,
     } as AssetTabConfig,
     checks: {
       id: 'checks',
       title: 'Checks',
-      to: buildAssetViewParams({...params, view: 'checks'}),
+      to: buildAssetViewParams({view: 'checks'}),
     } as AssetTabConfig,
     events: {
       id: 'events',
       title: 'Events',
-      to: buildAssetViewParams({...params, view: 'events', partition: undefined}),
+      to: buildAssetViewParams({view: 'events', partition: undefined}),
     } as AssetTabConfig,
     lineage: {
       id: 'lineage',
       title: 'Lineage',
-      to: buildAssetViewParams({...params, view: 'lineage'}),
+      to: buildAssetViewParams({view: 'lineage'}),
       disabled: !definition,
     } as AssetTabConfig,
     automation: {
       id: 'automation',
       title: 'Automation',
-      to: buildAssetViewParams({...params, view: 'automation'}),
+      to: buildAssetViewParams({view: 'automation'}),
       disabled: !definition,
       hidden: !definition?.automationCondition,
     } as AssetTabConfig,


### PR DESCRIPTION
## Summary & Motivation

Don't persist query params across asset tabs. Some tabs use the same parameter names (e.g. `status`) but encode them differently, leading to JS errors or unexpected behavior when those values are preserved across tab navigation.

## How I Tested These Changes

Load app, view an asset, navigate to "Events" and change the filters so that I get a `status` query param. Click "Partitions", verify that the query params are removed from the new URL and that no JS errors occur.

## Changelog

[ui] Fix navigation between asset tabs by no longer preserving query parameters from one tab to the next.
