### PR TITLE
Allow locking down the port range for dagster dev with a "DAGSTER_PORT_RANGE" env var

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -23,6 +23,7 @@ import grpc
 from dagster_shared.error import remove_system_frames_from_error
 from dagster_shared.ipc import open_ipc_subprocess
 from dagster_shared.libraries import DagsterLibraryRegistry
+from dagster_shared.utils import find_free_port
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 import dagster._check as check
@@ -104,7 +105,7 @@ from dagster._grpc.utils import (
     max_send_bytes,
 )
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._utils import find_free_port, get_run_crash_explanation, safe_tempfile_path_unmanaged
+from dagster._utils import get_run_crash_explanation, safe_tempfile_path_unmanaged
 from dagster._utils.container import (
     ContainerUtilizationMetrics,
     retrieve_containerized_utilization_metrics,

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -45,6 +45,7 @@ from dagster_shared.libraries import (
     library_version_from_core_version as library_version_from_core_version,
     parse_package_version as parse_package_version,
 )
+from dagster_shared.utils import find_free_port as find_free_port
 from dagster_shared.utils.hash import (
     hash_collection as hash_collection,
     make_hashable as make_hashable,
@@ -470,13 +471,6 @@ def segfault() -> None:
     import ctypes
 
     ctypes.string_at(0)
-
-
-def find_free_port() -> int:
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
 
 
 def is_port_in_use(host, port) -> bool:

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -147,6 +147,23 @@ load_from:
             pass
 
 
+def test_port_range(instance):
+    with environ({"DAGSTER_PORT_RANGE": "12345-12399"}):
+        with GrpcServerProcess(
+            instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True
+        ) as server_process:
+            assert server_process.port
+            assert server_process.port >= 12345
+            assert server_process.port <= 12399
+
+    with pytest.raises(Exception, match="DAGSTER_PORT_RANGE must be of the form"):
+        with environ({"DAGSTER_PORT_RANGE": "wat"}):
+            with GrpcServerProcess(
+                instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True
+            ) as server_process:
+                pass
+
+
 def test_grpc_server_workspace(instance):
     with GrpcServerProcess(
         instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True


### PR DESCRIPTION
## Summary & Motivation
For environments where you're only allowed to use a certain subset of ports.

## How I Tested These Changes
New test case, run with DAGSTER_PORT_RANGE set locally and force_port = True

## Changelog
Added the ability to restrict the list of ports that `dagster dev` is allowed to use to open subprocesses when running on Windows, by setting the `DAGSTER_PORT_RANGE` env var to a string of the form "<start>=<end>" - for example "20000-30000"
