### PR TITLE
[docs] construct absolute anchors for changelog headers

### DIFF
--- a/docs/docs/about/changelog.md
+++ b/docs/docs/about/changelog.md
@@ -5,8 +5,8 @@ title: Changelog
 toc_max_heading_level: 2
 ---
 
-import Changes, {toc as ChangesTOC} from '@site/../CHANGES.md';
+import { ChangelogTOC } from '@site/src/components/Changelog';
 
-<Changes />
+<Changelog />
 
-export const toc = ChangesTOC;
+export const toc = ChangelogTOC;

--- a/docs/src/components/Changelog.tsx
+++ b/docs/src/components/Changelog.tsx
@@ -1,0 +1,38 @@
+/**
+ * Custom parsing of CHANGES.md MDX to construct anchor IDs via component injection.
+ *
+ * https://mdxjs.com/guides/injecting-components/#injecting-components
+ *
+ */
+
+import Changes, {toc as ChangelogTOC} from '@site/../CHANGES.md';
+import React, {useRef} from 'react';
+import Heading from '@theme/Heading';
+import Link from '@docusaurus/Link';
+
+const Changelog = () => {
+  const lastParentId = useRef(null); // track parent ID for anchor construction
+
+  return (
+    <Changes
+      components={{
+        h2(properties) {
+          lastParentId.current = properties.id; // update the ref when an h2 is rendered
+          return <Heading as="h2" {...properties} />;
+        },
+        h3(properties) {
+          const h3Id = properties.id;
+          const combinedId = lastParentId.current ? `${lastParentId.current}-${h3Id}` : h3Id;
+
+          return (
+            <Heading as="h3" {...properties} id={combinedId}>
+              {properties.children}
+            </Heading>
+          );
+        },
+      }}
+    />
+  );
+};
+
+export {Changelog, ChangelogTOC};

--- a/docs/src/components/Changelog.tsx
+++ b/docs/src/components/Changelog.tsx
@@ -1,6 +1,10 @@
 /**
  * Custom parsing of CHANGES.md MDX to construct anchor IDs via component injection.
  *
+ * This was created to resolve an issue with anchor tags in the `/about/changelog` page where
+ * subheaders like `## New` or `## Bugfixes` would create incremtan tags like `new-1` and `new-2`.
+ * This was a problem because on each release the `new-1` would change, and break existing anchors.
+ *
  * https://mdxjs.com/guides/injecting-components/#injecting-components
  *
  */

--- a/docs/src/components/Changelog.tsx
+++ b/docs/src/components/Changelog.tsx
@@ -14,13 +14,19 @@ import React, {useRef, useMemo} from 'react';
 import Heading from '@theme/Heading';
 import Link from '@docusaurus/Link';
 
+/**
+ * Normalizes ID for use in anchor tag; removes appended index as this makes IDs subject to side-effects.
+ */
+function normalizeId(id: string) {
+  return id.replace(/-\d+$/, '');
+}
+
 // Create transformed TOC that matches our custom anchor structure
 const transformedTOC = (() => {
   // Deep clone the original TOC to avoid mutations
   const newTOC = JSON.parse(JSON.stringify(originalTOC));
 
   let currentH2Id = null;
-
   return newTOC.map((item) => {
     if (item.level === 2) {
       currentH2Id = item.id;
@@ -28,9 +34,10 @@ const transformedTOC = (() => {
     }
 
     if (item.level === 3 && currentH2Id) {
+      const id = normalizeId(item.id);
       return {
         ...item,
-        id: `${currentH2Id}-${item.id}`,
+        id: `${currentH2Id}-${id}`,
       };
     }
 
@@ -50,7 +57,7 @@ const Changelog = () => {
             return <Heading as="h2" {...properties} />;
           },
           h3(properties) {
-            const h3Id = properties.id;
+            const h3Id = normalizeId(properties.id);
             const combinedId = lastParentId.current ? `${lastParentId.current}-${h3Id}` : h3Id;
             return (
               <Heading as="h3" {...properties} id={combinedId}>

--- a/docs/src/components/Changelog.tsx
+++ b/docs/src/components/Changelog.tsx
@@ -2,7 +2,7 @@
  * Custom parsing of CHANGES.md MDX to construct anchor IDs via component injection.
  *
  * This was created to resolve an issue with anchor tags in the `/about/changelog` page where
- * subheaders like `## New` or `## Bugfixes` would create incremtan tags like `new-1` and `new-2`.
++ * subheaders like `## New` or `## Bugfixes` would create incremental tags like `new-1` and `new-2`.
  * This was a problem because on each release the `new-1` would change, and break existing anchors.
  *
  * https://mdxjs.com/guides/injecting-components/#injecting-components

--- a/docs/src/components/Changelog.tsx
+++ b/docs/src/components/Changelog.tsx
@@ -5,34 +5,60 @@
  *
  */
 
-import Changes, {toc as ChangelogTOC} from '@site/../CHANGES.md';
-import React, {useRef} from 'react';
+import Changes, {toc as originalTOC} from '@site/../CHANGES.md';
+import React, {useRef, useMemo} from 'react';
 import Heading from '@theme/Heading';
 import Link from '@docusaurus/Link';
+
+// Create transformed TOC that matches our custom anchor structure
+const transformedTOC = (() => {
+  // Deep clone the original TOC to avoid mutations
+  const newTOC = JSON.parse(JSON.stringify(originalTOC));
+
+  let currentH2Id = null;
+
+  return newTOC.map((item) => {
+    if (item.level === 2) {
+      currentH2Id = item.id;
+      return item;
+    }
+
+    if (item.level === 3 && currentH2Id) {
+      return {
+        ...item,
+        id: `${currentH2Id}-${item.id}`,
+      };
+    }
+
+    return item;
+  });
+})();
 
 const Changelog = () => {
   const lastParentId = useRef(null); // track parent ID for anchor construction
 
   return (
-    <Changes
-      components={{
-        h2(properties) {
-          lastParentId.current = properties.id; // update the ref when an h2 is rendered
-          return <Heading as="h2" {...properties} />;
-        },
-        h3(properties) {
-          const h3Id = properties.id;
-          const combinedId = lastParentId.current ? `${lastParentId.current}-${h3Id}` : h3Id;
-
-          return (
-            <Heading as="h3" {...properties} id={combinedId}>
-              {properties.children}
-            </Heading>
-          );
-        },
-      }}
-    />
+    <>
+      <Changes
+        components={{
+          h2(properties) {
+            lastParentId.current = properties.id; // update the ref when an h2 is rendered
+            return <Heading as="h2" {...properties} />;
+          },
+          h3(properties) {
+            const h3Id = properties.id;
+            const combinedId = lastParentId.current ? `${lastParentId.current}-${h3Id}` : h3Id;
+            return (
+              <Heading as="h3" {...properties} id={combinedId}>
+                {properties.children}
+              </Heading>
+            );
+          },
+        }}
+      />
+    </>
   );
 };
 
-export {Changelog, ChangelogTOC};
+// Export the transformed TOC instead of the original
+export {Changelog, transformedTOC as ChangelogTOC};

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -1,5 +1,6 @@
 // Import the original mapper
 import CliInvocationExample from '../components/CliInvocationExample';
+import {Changelog} from '../components/Changelog';
 import CodeExample from '../components/CodeExample';
 import Link from '@docusaurus/Link';
 import MDXComponents from '@theme-original/MDXComponents';
@@ -14,6 +15,7 @@ export default {
   // Re-use the default mapping
   ...MDXComponents,
   CliInvocationExample,
+  Changelog,
   CodeExample,
   CodeReferenceLink,
   Link,


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-823.

Explanation for this work can be found in the header comment of the custom `Changelog` component:

```
/**
 * Custom parsing of CHANGES.md MDX to construct anchor IDs via component injection.
 *
 * This was created to resolve an issue with anchor tags in the `/about/changelog` page where
 * subheaders like `## New` or `## Bugfixes` would create incremental tags like `new-1` and `new-2`.
 * This was a problem because on each release the `new-1` would change, and break existing anchors.
 *
 * https://mdxjs.com/guides/injecting-components/#injecting-components
 *
 */
 ```

## How I Tested These Changes

`yarn start`

## Changelog

- [docs] Fix broken anchors for subheading on the `/about/changelog` page
