### PR TITLE
Defer find_free_port parameterization

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
@@ -34,8 +34,9 @@ from dagster_dg_tests.utils import (
 # ########################
 
 
-@pytest.mark.parametrize("port", [None, find_free_port()])
+@pytest.mark.parametrize("port", [None, find_free_port])
 def test_docs_component_type_success(port: Optional[int]):
+    port = find_free_port()
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional
+from typing import Callable, Optional
 
 import pytest
 from dagster_dg.utils import ensure_dagster_dg_tests_import, get_venv_executable, install_to_venv
@@ -34,9 +34,9 @@ from dagster_dg_tests.utils import (
 # ########################
 
 
-@pytest.mark.parametrize("port", [None, find_free_port])
-def test_docs_component_type_success(port: Optional[int]):
-    port = find_free_port()
+@pytest.mark.parametrize("get_port", [None, find_free_port])
+def test_docs_component_type_success(get_port: Optional[Callable]):
+    port = get_port() if get_port else None
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),


### PR DESCRIPTION
This defers the actual execution of `find_free_port()` until the test has started which produces a subtle difference to the pytest test output:

Before:

```
python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py::test_docs_component_type_success[None] PASSED [ 50%]
python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py::test_docs_component_type_success[52039] PASSED           [100%]
```

After:

```
python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py::test_docs_component_type_success[None] PASSED [ 50%]
python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_docs_commands.py::test_docs_component_type_success[find_free_port] PASSED  [100%]
```

This is useful because it lets us instrument all of these test invocations as one test instead of one test per port. Which will both let us measure the over time health of the test and allow us to selectively mute it if it ever degrades.