### PR TITLE
[dg] Add YamlComponentStorage

### DIFF
--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -1,19 +1,15 @@
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components import Component, ComponentLoadContext, ComponentTypeSpec, Model, Resolvable
+from dagster.components.resolved.core_models import ResolvedAssetKey
 
 
 class SimpleAssetComponent(Component, Resolvable, Model):
     """A simple asset that returns a constant string value."""
 
-    asset_key: str
+    asset_key: ResolvedAssetKey
     value: str
-
-    def __init__(self, asset_key: AssetKey, value: str):
-        self._asset_key = asset_key
-        self._value = value
 
     @classmethod
     def get_spec(cls):
@@ -23,8 +19,8 @@ class SimpleAssetComponent(Component, Resolvable, Model):
         )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        @asset(key=self._asset_key)
+        @asset(key=self.asset_key)
         def dummy(context: AssetExecutionContext):
-            return self._value
+            return self.value
 
         return Definitions(assets=[dummy])

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -26,8 +26,9 @@ class YamlComponentStorage(ABC):
     @abstractmethod
     def read_declaration(self, context: "ComponentLoadContext") -> str: ...
 
-    @abstractmethod
-    def subcontexts(self, context: "ComponentLoadContext") -> Iterable["ComponentLoadContext"]: ...
+    def subcontexts(self, context: "ComponentLoadContext") -> Iterable["ComponentLoadContext"]:
+        for subpath in context.path.iterdir():
+            yield context.for_path(subpath)
 
 
 class LocalYamlComponentStorage(YamlComponentStorage):
@@ -36,10 +37,6 @@ class LocalYamlComponentStorage(YamlComponentStorage):
 
     def read_declaration(self, context: "ComponentLoadContext") -> str:
         return (context.path / "component.yaml").read_text()
-
-    def subcontexts(self, context: "ComponentLoadContext") -> Iterable["ComponentLoadContext"]:
-        for subpath in context.path.iterdir():
-            yield context.for_path(subpath)
 
 
 @public

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -161,7 +161,6 @@ class DefsFolderComponent(Component):
 def _crawl(context: ComponentLoadContext) -> Mapping[Path, Component]:
     found = {}
     for sub_ctx in context.yaml_component_storage.subcontexts(context):
-        # print(f"Crawling subcontext: {sub_ctx.path}")
         with use_component_load_context(sub_ctx):
             component = get_component(sub_ctx)
             if component:
@@ -209,9 +208,7 @@ def load_yaml_component(context: ComponentLoadContext) -> Component:
     # parse the yaml file
     source_trees = parse_yamls_with_source_position(
         context.yaml_component_storage.read_declaration(context),
-        str(
-            context.path / "component.yaml"
-        ),  # TODO: What to put here in the remote case? Is this fine
+        str(context.path / "component.yaml"),
     )
     components = []
     for source_tree in source_trees:

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -60,7 +60,11 @@ def test_list_plugins_from_module():
                 schema={
                     "additionalProperties": False,
                     "properties": {
-                        "asset_key": {"title": "Asset Key", "type": "string"},
+                        "asset_key": {
+                            "description": "A unique identifier for the asset.",
+                            "title": "Asset Key",
+                            "type": "string",
+                        },
                         "value": {"title": "Value", "type": "string"},
                     },
                     "required": ["asset_key", "value"],

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_loading_components_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_loading_components_in_memory.py
@@ -41,6 +41,8 @@ attributes:
     )
 
     foo_path = str(path / "foo")
+    assert Path(foo_path).exists()
+
     context = ComponentLoadContext.for_test(
         path=path, yaml_component_storage=InMemoryYamlComponentStorage({foo_path: yaml})
     )

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_loading_components_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_loading_components_in_memory.py
@@ -1,0 +1,53 @@
+# # from dagster_test.components.simple_asset import SimpleAssetComponent
+
+
+# # SimpleAssetComponent()
+# from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+# from dagster.components.core.defs_module import get_component
+
+from pathlib import Path
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components.core.context import ComponentLoadContext, YamlComponentStorage
+from dagster.components.core.defs_module import get_component
+
+
+class InMemoryYamlComponentStorage(YamlComponentStorage):
+    def __init__(self, yamls: dict) -> None:
+        self.yamls = yamls
+
+    def is_in_storage(self, context: "ComponentLoadContext") -> bool:
+        return str(context.path) in self.yamls
+
+    def read_declaration(self, context: "ComponentLoadContext") -> str:
+        # This method should return the YAML declaration of the component.
+        # For testing purposes, we can return a hardcoded YAML string.
+        return self.yamls[str(context.path)]
+
+
+def test_simple_asset_component_in_memory() -> None:
+    yaml = """type: dagster_test.components.simple_asset.SimpleAssetComponent
+
+attributes:
+    asset_key: "simple_asset"
+    value: "Hello, Dagster!"
+    """
+
+    path = (
+        Path(__file__).parent
+        / "component_loading_test_cases"
+        / "test_simple_asset_component_in_memory"
+        / "defs"
+    )
+
+    foo_path = str(path / "foo")
+    context = ComponentLoadContext.for_test(
+        path=path, yaml_component_storage=InMemoryYamlComponentStorage({foo_path: yaml})
+    )
+
+    root_component = get_component(context)
+
+    assert root_component is not None
+    defs = root_component.build_defs(context)
+    assert isinstance(defs, Definitions)
+    assert defs.get_assets_def("simple_asset")


### PR DESCRIPTION
## Summary & Motivation


Adds `YamlComponentStorage` Makes so that the component loading path can load yaml declarations from arbitrary storage instead of just the file system. We test this with a test case that contains the yaml as an in-memory string.

Note that that folder must exist on disk (for example, so that relative paths in the yaml still works). 

## How I Tested These Changes

BK

## Changelog

