### PR TITLE
Update link to components API docs

### DIFF
--- a/docs/docs/guides/labs/components/index.md
+++ b/docs/docs/guides/labs/components/index.md
@@ -16,7 +16,7 @@ Dagster Components is a new way to structure your Dagster projects. It provides:
 
 For more advanced use cases, it provides:
 
-- A class-based interface (<PyObject section="components" module="dagster" object="components.Component" />) for dynamically constructing Dagster definitions from arbitrary data (such as third-party integration configuration files).
+- A class-based interface ([Component](/api/dagster/components)) for dynamically constructing Dagster definitions from arbitrary data (such as third-party integration configuration files).
 - A toolkit for building YAML domain-specific languages (DSLs) for `Components`, allowing instances of components to be defined with little to no Python code.
 
 ## Installation


### PR DESCRIPTION
## Summary & Motivation

Updates the link to the Components API docs on the Components index page; after this is merged, I'll cherry-pick to the 1.10.12 branch. Doing all this because Vercel is reporting this link as broken when building docs from the 1.10.12 branch, even though those docs build fine locally.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
