### PR TITLE
[dagster-dbt] Consolidate cli invocation params logic in dbt core and cloud

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -415,8 +415,6 @@ def get_updated_cli_invocation_params_for_context(
             current_dbt_indirect_selection_env=indirect_selection,
         )
 
-        # set dbt indirect selection if needed to execute specific dbt tests due to asset check
-        # selection
         indirect_selection = (
             indirect_selection_override if indirect_selection_override else indirect_selection
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -4,7 +4,7 @@ import textwrap
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, AbstractSet, Any, Final, Optional, Union  # noqa: UP035
+from typing import TYPE_CHECKING, AbstractSet, Annotated, Any, Final, Optional, Union  # noqa: UP035
 
 from dagster import (
     AssetCheckKey,
@@ -31,7 +31,7 @@ from dagster import (
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._core.types.dagster_type import Nothing
-from dagster._record import record
+from dagster._record import ImportFrom, record
 
 from dagster_dbt.dbt_project import DbtProject
 from dagster_dbt.metadata_set import DbtMetadataSet
@@ -392,7 +392,9 @@ def get_asset_keys_to_resource_props(
 @record
 class DbtCliInvocationPartialParams:
     manifest: Mapping[str, Any]
-    dagster_dbt_translator: "DagsterDbtTranslator"
+    dagster_dbt_translator: Annotated[
+        "DagsterDbtTranslator", ImportFrom("dagster_dbt.dagster_dbt_translator")
+    ]
     selection_args: Sequence[str]
     indirect_selection: Optional[str]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -1,14 +1,11 @@
 import logging
-import os
 from collections.abc import Sequence
-from contextlib import suppress
 from functools import cached_property, lru_cache
 from typing import NamedTuple, Optional, Union
 
 from dagster import (
     AssetCheckSpec,
     AssetExecutionContext,
-    AssetsDefinition,
     AssetSpec,
     ConfigurableResource,
     Definitions,
@@ -19,20 +16,11 @@ from dagster import (
 from dagster._annotations import preview
 from dagster._config.pythonic_config.resource import ResourceDependency
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
-from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._record import record
 from dagster._utils.cached_method import cached_method
 from pydantic import Field
 
-from dagster_dbt.asset_utils import (
-    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
-    DAGSTER_DBT_SELECT_METADATA_KEY,
-    DAGSTER_DBT_SELECTOR_METADATA_KEY,
-    DBT_INDIRECT_SELECTION_ENV,
-    build_dbt_specs,
-    get_manifest_and_translator_from_dbt_assets,
-    get_subset_selection_for_context,
-)
+from dagster_dbt.asset_utils import build_dbt_specs, get_updated_cli_invocation_params_for_context
 from dagster_dbt.cloud_v2.cli_invocation import DbtCloudCliInvocation
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunHandler
@@ -342,37 +330,15 @@ class DbtCloudWorkspace(ConfigurableResource):
         job_id = workspace_data.adhoc_job_id
         manifest = workspace_data.manifest
 
-        assets_def: Optional[AssetsDefinition] = None
-        with suppress(DagsterInvalidPropertyError):
-            assets_def = context.assets_def if context else assets_def
-
-        selection_args: list[str] = []
-        indirect_selection_args: list[str] = []
-        if context and assets_def is not None:
-            manifest, dagster_dbt_translator = get_manifest_and_translator_from_dbt_assets(
-                [assets_def]
+        manifest, dagster_dbt_translator, selection_args, indirect_selection = (
+            get_updated_cli_invocation_params_for_context(
+                context=context, manifest=manifest, dagster_dbt_translator=dagster_dbt_translator
             )
+        )
 
-            indirect_selection = os.getenv(DBT_INDIRECT_SELECTION_ENV, None)
-
-            selection_args, indirect_selection_override = get_subset_selection_for_context(
-                context=context,
-                manifest=manifest,
-                select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
-                exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
-                selector=context.op.tags.get(DAGSTER_DBT_SELECTOR_METADATA_KEY),
-                dagster_dbt_translator=dagster_dbt_translator,
-                current_dbt_indirect_selection_env=indirect_selection,
-            )
-
-            # set dbt indirect selection if needed to execute specific dbt tests due to asset check
-            # selection
-            indirect_selection = (
-                indirect_selection_override if indirect_selection_override else indirect_selection
-            )
-            indirect_selection_args = (
-                [f"--indirect-selection {indirect_selection}"] if indirect_selection else []
-            )
+        indirect_selection_args = (
+            [f"--indirect-selection {indirect_selection}"] if indirect_selection else []
+        )
 
         full_dbt_args = [*args, *selection_args, *indirect_selection_args]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -336,6 +336,8 @@ class DbtCloudWorkspace(ConfigurableResource):
             )
         )
 
+        # set dbt indirect selection if needed to execute specific dbt tests due to asset check
+        # selection
         indirect_selection_args = (
             [f"--indirect-selection {indirect_selection}"] if indirect_selection else []
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -330,11 +330,13 @@ class DbtCloudWorkspace(ConfigurableResource):
         job_id = workspace_data.adhoc_job_id
         manifest = workspace_data.manifest
 
-        manifest, dagster_dbt_translator, selection_args, indirect_selection = (
-            get_updated_cli_invocation_params_for_context(
-                context=context, manifest=manifest, dagster_dbt_translator=dagster_dbt_translator
-            )
+        updated_params = get_updated_cli_invocation_params_for_context(
+            context=context, manifest=manifest, dagster_dbt_translator=dagster_dbt_translator
         )
+        manifest = updated_params.manifest
+        dagster_dbt_translator = updated_params.dagster_dbt_translator
+        selection_args = updated_params.selection_args
+        indirect_selection = updated_params.indirect_selection
 
         # set dbt indirect selection if needed to execute specific dbt tests due to asset check
         # selection

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -3,20 +3,17 @@ import shutil
 import uuid
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
-from contextlib import suppress
 from pathlib import Path
 from typing import Any, Optional, Union, cast
 
 import yaml
 from dagster import (
     AssetExecutionContext,
-    AssetsDefinition,
     ConfigurableResource,
     OpExecutionContext,
     get_dagster_logger,
 )
 from dagster._annotations import public
-from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._utils import pushd
 from dbt.adapters.base.impl import BaseAdapter
@@ -30,16 +27,12 @@ from packaging import version
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 
 from dagster_dbt.asset_utils import (
-    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
-    DAGSTER_DBT_SELECT_METADATA_KEY,
-    DAGSTER_DBT_SELECTOR_METADATA_KEY,
     DBT_INDIRECT_SELECTION_ENV,
-    get_manifest_and_translator_from_dbt_assets,
-    get_subset_selection_for_context,
+    get_updated_cli_invocation_params_for_context,
 )
 from dagster_dbt.core.dbt_cli_invocation import DbtCliInvocation, _get_dbt_target_path
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_opt_translator
-from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
+from dagster_dbt.dbt_manifest import DbtManifestParam
 from dagster_dbt.dbt_project import DbtProject
 
 IS_DBT_CORE_VERSION_LESS_THAN_1_8_0 = version.parse(dbt_version) < version.parse("1.8.0")
@@ -590,10 +583,13 @@ class DbtCliResource(ConfigurableResource):
                     yield from dbt.cli(["run-operation", "my-macro", json.dumps(dbt_macro_args)]).stream()
         """
         dagster_dbt_translator = validate_opt_translator(dagster_dbt_translator)
+        dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
 
-        assets_def: Optional[AssetsDefinition] = None
-        with suppress(DagsterInvalidPropertyError):
-            assets_def = context.assets_def if context else None
+        manifest, dagster_dbt_translator, selection_args, indirect_selection = (
+            get_updated_cli_invocation_params_for_context(
+                context=context, manifest=manifest, dagster_dbt_translator=dagster_dbt_translator
+            )
+        )
 
         target_path = target_path or self._get_unique_target_path(context=context)
         env = {
@@ -629,29 +625,10 @@ class DbtCliResource(ConfigurableResource):
             **({"DBT_PROJECT_DIR": self.project_dir} if self.project_dir else {}),
         }
 
-        selection_args: list[str] = []
-        dagster_dbt_translator = dagster_dbt_translator or DagsterDbtTranslator()
-        if context and assets_def is not None:
-            manifest, dagster_dbt_translator = get_manifest_and_translator_from_dbt_assets(
-                [assets_def]
-            )
-
-            selection_args, indirect_selection = get_subset_selection_for_context(
-                context=context,
-                manifest=manifest,
-                select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
-                exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
-                selector=context.op.tags.get(DAGSTER_DBT_SELECTOR_METADATA_KEY),
-                dagster_dbt_translator=dagster_dbt_translator,
-                current_dbt_indirect_selection_env=env.get(DBT_INDIRECT_SELECTION_ENV, None),
-            )
-
-            # set dbt indirect selection if needed to execute specific dbt tests due to asset check
-            # selection
-            if indirect_selection:
-                env[DBT_INDIRECT_SELECTION_ENV] = indirect_selection
-        else:
-            manifest = validate_manifest(manifest) if manifest else {}
+        # set dbt indirect selection if needed to execute specific dbt tests due to asset check
+        # selection
+        if indirect_selection:
+            env[DBT_INDIRECT_SELECTION_ENV] = indirect_selection
 
         # TODO: verify that args does not have any selection flags if the context and manifest
         # are passed to this function.


### PR DESCRIPTION
## Summary & Motivation

Following the thread [here](https://github.com/dagster-io/dagster/pull/28902#discussion_r2021967005), consolidate the logic to get the manifest, translator and selection args for a given context in a single function. The function is the same for dbt core and dbt Cloud.

## How I Tested These Changes

Existing tests with BK

