### PR TITLE
Add io_manager_key to metadata for single assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -310,6 +310,15 @@ def asset(
 
     only_allow_hidden_params_in_kwargs(asset, kwargs)
 
+    if io_manager_key:
+        if metadata:
+            metadata = dict(metadata)
+        else:
+            metadata = dict()
+
+        if "io_manager_key" not in metadata:
+            metadata["io_manager_key"] = io_manager_key
+
     args = AssetDecoratorArgs(
         name=name,
         key_prefix=key_prefix,


### PR DESCRIPTION
## Summary & Motivation
This change adds `io_manager_key` to a single asset's metadata, which is a feature already available for multi-assets (i.e. feature parity for single assets).

This is a bugfix for issue #27607.

## How I Tested These Changes
1. We replicated the test case locally in the Dagster repository using the [Dagster contributing guide](https://docs.dagster.io/about/contributing) as a starting point and the [examples shown in the issue page](https://github.com/dagster-io/dagster/issues/27607).
2. We made our change and ran the project, manually viewing the metadata for both single and multi assets to confirm that the `io_manager_key` was included in a single asset's metadata. Multi-asset metadata was not changed post-fix.

https://github.com/user-attachments/assets/051562e0-ca4a-4438-9a0a-01f3b3e50dd5

As we're students, we were not able to run BuildKite tests locally (as it requires a key), but plan on using the Dagster PR CI/CD pipeline to run the tests to make sure we didn't break anything else.
