### PR TITLE
[manifest] encode git root to defs root path in manifest

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -335,6 +335,7 @@ class BindResourcesToJobs(list):
 class ComponentsDetails:
     root_component: "DefsFolderComponent"
     plugins: Mapping[PluginObjectKey, object]
+    git_root_to_defs_root: Sequence[str]
 
 
 @record_custom

--- a/python_modules/dagster/dagster/_core/remote_representation/components.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/components.py
@@ -1,9 +1,13 @@
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from dagster_shared.record import record
 from dagster_shared.serdes import whitelist_for_serdes
 
 from dagster.components.core.defs_module import DagsterDefsComponent, DefsFolderComponent
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.definitions_class import ComponentsDetails
 
 
 @whitelist_for_serdes
@@ -26,9 +30,10 @@ class ComponentTypeSnap:
 class ComponentManifest:
     types: Sequence[ComponentTypeSnap]
     instances: Sequence[ComponentInstanceSnap]
+    git_root_to_defs_root: Sequence[str]
 
     @staticmethod
-    def from_details(details):
+    def from_details(details: "ComponentsDetails"):
         if details is None:
             return None
 
@@ -36,7 +41,7 @@ class ComponentManifest:
         for key, plugin in details.plugins.items():
             types.append(
                 ComponentTypeSnap(
-                    name=plugin.__name__,
+                    name=plugin.__name__,  # type: ignore
                 )
             )
 
@@ -55,4 +60,5 @@ class ComponentManifest:
         return ComponentManifest(
             types=types,
             instances=instances,
+            git_root_to_defs_root=details.git_root_to_defs_root,
         )

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -104,7 +104,7 @@ def load_defs(
             raise FileNotFoundError(f"Module {defs_root} has no __file__ attribute")
 
         git_path_to_defs_root = Path(defs_root_path).relative_to(
-            git_root or discover_git_root(defs_root_path)
+            git_root or discover_git_root(Path(defs_root_path))
         )
 
         return Definitions.merge(
@@ -114,7 +114,7 @@ def load_defs(
                 components_details=ComponentsDetails(
                     root_component=root_component,
                     plugins=library_objects,
-                    git_root_to_defs_root=list(*git_path_to_defs_root.parts),
+                    git_root_to_defs_root=list(git_path_to_defs_root.parts),
                 ),
             ),
         )

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -99,12 +99,13 @@ def load_defs(
         snaps = [get_package_entry_snap(key, obj) for key, obj in library_objects.items()]
         components_json = json_for_all_components(snaps)
 
-        defs_root_path = getattr(defs_root, "__file__", None)
-        if not defs_root_path:
+        defs_root_file = getattr(defs_root, "__file__", None)
+        if not defs_root_file:
             raise FileNotFoundError(f"Module {defs_root} has no __file__ attribute")
+        defs_root_path = Path(defs_root_file).parent
 
-        git_path_to_defs_root = Path(defs_root_path).relative_to(
-            git_root or discover_git_root(Path(defs_root_path))
+        git_path_to_defs_root = defs_root_path.relative_to(
+            git_root or discover_git_root(defs_root_path)
         )
 
         return Definitions.merge(

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -60,11 +60,21 @@ def get_project_root(defs_root: ModuleType) -> Path:
     raise FileNotFoundError("No project root with pyproject.toml or setup.py found")
 
 
+def discover_git_root(path: Path) -> Path:
+    while path != path.parent:
+        if (path / ".git").exists():
+            return path
+        path = path.parent
+    raise ValueError("Could not find git root")
+
+
 # Public method so optional Nones are fine
 @public
 @preview(emit_runtime_warning=False)
 @suppress_dagster_warnings
-def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Definitions:
+def load_defs(
+    defs_root: ModuleType, project_root: Optional[Path] = None, git_root: Optional[Path] = None
+) -> Definitions:
     """Constructs a Definitions object, loading all Dagster defs in the given module.
 
     Args:
@@ -89,6 +99,14 @@ def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Def
         snaps = [get_package_entry_snap(key, obj) for key, obj in library_objects.items()]
         components_json = json_for_all_components(snaps)
 
+        defs_root_path = getattr(defs_root, "__file__", None)
+        if not defs_root_path:
+            raise FileNotFoundError(f"Module {defs_root} has no __file__ attribute")
+
+        git_path_to_defs_root = Path(defs_root_path).relative_to(
+            git_root or discover_git_root(defs_root_path)
+        )
+
         return Definitions.merge(
             root_component.build_defs(context),
             Definitions(
@@ -96,6 +114,7 @@ def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Def
                 components_details=ComponentsDetails(
                     root_component=root_component,
                     plugins=library_objects,
+                    git_root_to_defs_root=list(*git_path_to_defs_root.parts),
                 ),
             ),
         )


### PR DESCRIPTION
## Summary

Adds a field which stores the detected (or passed) git root to the defs root in the component manifest 


