### PR TITLE
Add redirects for /api/python-api path

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -2832,7 +2832,7 @@
     },
     {
       "source": "/master/_apidocs/experimental",
-      "destination": "/api/python-api"
+      "destination": "/api"
     },
     {
       "source": "/tutorial/saving-your-data",
@@ -2945,6 +2945,14 @@
     {
       "source": "/api/python-api/utilities",
       "destination": "/api/dagster/utilities"
+    },
+    {
+      "source": "/api/python-api",
+      "destination": "/api"
+    },
+    {
+      "source": "/api/python-api/",
+      "destination": "/api"
     },
     {
       "source": "/api/api-lifecycle",


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

Tested on staging deployment:

https://nikki-docs-fix-api-redirect.archive.dagster-docs.io/api/python-api/
https://nikki-docs-fix-api-redirect.archive.dagster-docs.io/api/python-api

## Changelog

> Insert changelog entry or delete this section.
