### PR TITLE
[gql] asset check health simplification of streamline and non-streamline paths

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -60,7 +60,7 @@ async def get_asset_check_status_and_metadata(
         return (
             GrapheneAssetHealthStatus.UNKNOWN,
             GrapheneAssetHealthCheckUnknownMeta(
-                numUnexecutedChecks=len(asset_check_health_state.all_checks)
+                numNotExecutedChecks=len(asset_check_health_state.all_checks)
                 - len(asset_check_health_state.passing_checks)
                 - len(asset_check_health_state.failing_checks)
                 - len(asset_check_health_state.warning_checks),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -1,86 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
-from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
-from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 from dagster._streamline.asset_check_health import AssetCheckHealthState
 from dagster._streamline.asset_health import AssetHealthStatus
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.asset_health import GrapheneAssetHealthCheckMeta
     from dagster_graphql.schema.util import ResolveInfo
-
-
-async def _compute_asset_check_health_state(
-    graphene_info: "ResolveInfo", asset_key: AssetKey
-) -> AssetCheckHealthState:
-    """Computes the number of asset checks in each terminal state for an asset so that the overall
-    health can be computed in get_asset_check_status_and_metadata. Does this by fetching the
-    asset check summary record for each check and checking the status of the latest completed execution.
-    """
-    remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
-    if not remote_check_nodes or len(remote_check_nodes) == 0:
-        # asset doesn't have checks defined
-        return AssetCheckHealthState.default()
-
-    failed_checks = set()
-    warning_checks = set()
-    passing_checks = set()
-    asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
-        graphene_info.context,
-        [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
-    )
-    for summary_record in asset_check_summary_records:
-        if summary_record is None or summary_record.last_check_execution_record is None:
-            # the check has never been executed.
-            continue
-
-        # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
-        # but we check the last_check_execution_record status first since there is an edge case
-        # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
-        # because the run for the check failed.
-        last_check_execution_status = (
-            await summary_record.last_check_execution_record.resolve_status(graphene_info.context)
-        )
-        last_check_evaluation = summary_record.last_check_execution_record.evaluation
-
-        if last_check_execution_status in [
-            AssetCheckExecutionResolvedStatus.IN_PROGRESS,
-            AssetCheckExecutionResolvedStatus.SKIPPED,
-        ]:
-            # the last check is still in progress or is skipped, so we want to check the status of
-            # the latest completed check instead
-            if summary_record.last_completed_check_execution_record is None:
-                # the check hasn't been executed prior to this in progress check
-                continue
-            last_check_execution_status = (
-                await summary_record.last_completed_check_execution_record.resolve_status(
-                    graphene_info.context
-                )
-            )
-            last_check_evaluation = summary_record.last_completed_check_execution_record.evaluation
-
-        if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
-            # failed checks should always have an evaluation, but default to ERROR if not
-            if last_check_evaluation and last_check_evaluation.severity == AssetCheckSeverity.WARN:
-                warning_checks.add(summary_record.asset_check_key)
-            else:
-                failed_checks.add(summary_record.asset_check_key)
-        elif last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
-            # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
-            # degraded health anyway.
-            failed_checks.add(summary_record.asset_check_key)
-        else:
-            # asset check passed
-            passing_checks.add(summary_record.asset_check_key)
-
-    return AssetCheckHealthState(
-        passing_checks=passing_checks,
-        failing_checks=failed_checks,
-        warning_checks=warning_checks,
-        all_checks={node.asset_check.key for node in remote_check_nodes},
-    )
 
 
 async def get_asset_check_status_and_metadata(
@@ -105,7 +31,11 @@ async def get_asset_check_status_and_metadata(
             # asset_check_health_state_for is only None if no are defined on the asset
             return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
     else:
-        asset_check_health_state = await _compute_asset_check_health_state(graphene_info, asset_key)
+        remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
+        asset_check_health_state = await AssetCheckHealthState.compute_for_asset_checks(
+            {remote_check_node.asset_check.key for remote_check_node in remote_check_nodes},
+            graphene_info.context,
+        )
 
     if asset_check_health_state.health_status == AssetHealthStatus.HEALTHY:
         return GrapheneAssetHealthStatus.HEALTHY, None

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -4,6 +4,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
 from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
+from dagster._streamline.asset_check_health import AssetCheckHealthState
 from dagster._streamline.asset_health import AssetHealthStatus
 
 if TYPE_CHECKING:
@@ -11,30 +12,21 @@ if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
 
-async def _compute_asset_check_status_and_metadata(
+async def _compute_asset_check_health_state(
     graphene_info: "ResolveInfo", asset_key: AssetKey
-) -> tuple[str, Optional["GrapheneAssetHealthCheckMeta"]]:
+) -> AssetCheckHealthState:
     """Computes the number of asset checks in each terminal state for an asset so that the overall
-    health can be computed in asset_check_health_status_and_metadata_from_counts. Does this by fetching the
+    health can be computed in get_asset_check_status_and_metadata. Does this by fetching the
     asset check summary record for each check and checking the status of the latest completed execution.
     """
-    from dagster_graphql.schema.asset_health import (
-        GrapheneAssetHealthCheckDegradedMeta,
-        GrapheneAssetHealthCheckUnknownMeta,
-        GrapheneAssetHealthCheckWarningMeta,
-        GrapheneAssetHealthStatus,
-    )
-
     remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
     if not remote_check_nodes or len(remote_check_nodes) == 0:
         # asset doesn't have checks defined
-        return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+        return AssetCheckHealthState.default()
 
-    total_num_checks = len(remote_check_nodes)
-    num_failed = 0
-    num_warning = 0
-    num_passing = 0
-    num_unexecuted_checks = 0
+    failed_checks = set()
+    warning_checks = set()
+    passing_checks = set()
     asset_check_summary_records = await AssetCheckSummaryRecord.gen_many(
         graphene_info.context,
         [remote_check_node.asset_check.key for remote_check_node in remote_check_nodes],
@@ -42,7 +34,6 @@ async def _compute_asset_check_status_and_metadata(
     for summary_record in asset_check_summary_records:
         if summary_record is None or summary_record.last_check_execution_record is None:
             # the check has never been executed.
-            num_unexecuted_checks += 1
             continue
 
         # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
@@ -62,7 +53,6 @@ async def _compute_asset_check_status_and_metadata(
             # the latest completed check instead
             if summary_record.last_completed_check_execution_record is None:
                 # the check hasn't been executed prior to this in progress check
-                num_unexecuted_checks += 1
                 continue
             last_check_execution_status = (
                 await summary_record.last_completed_check_execution_record.resolve_status(
@@ -74,46 +64,32 @@ async def _compute_asset_check_status_and_metadata(
         if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
             # failed checks should always have an evaluation, but default to ERROR if not
             if last_check_evaluation and last_check_evaluation.severity == AssetCheckSeverity.WARN:
-                num_warning += 1
+                warning_checks.add(summary_record.asset_check_key)
             else:
-                num_failed += 1
+                failed_checks.add(summary_record.asset_check_key)
         elif last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
             # EXECUTION_FAILED checks may not have an evaluation, and we want to show these as
             # degraded health anyway.
-            num_failed += 1
+            failed_checks.add(summary_record.asset_check_key)
         else:
             # asset check passed
-            num_passing += 1
+            passing_checks.add(summary_record.asset_check_key)
 
-    if num_failed > 0:
-        return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthCheckDegradedMeta(
-            numFailedChecks=num_failed,
-            numWarningChecks=num_warning,
-            totalNumChecks=total_num_checks,
-        )
-    if num_warning > 0:
-        return GrapheneAssetHealthStatus.WARNING, GrapheneAssetHealthCheckWarningMeta(
-            numWarningChecks=num_warning,
-            totalNumChecks=total_num_checks,
-        )
-    if num_unexecuted_checks > 0:
-        # if any check has never been executed, we report this as unknown, even if other checks
-        # have passed
-        return (
-            GrapheneAssetHealthStatus.UNKNOWN,
-            GrapheneAssetHealthCheckUnknownMeta(
-                numNotExecutedChecks=num_unexecuted_checks,
-                totalNumChecks=total_num_checks,
-            ),
-        )
-    # all checks must have executed and passed
-    return GrapheneAssetHealthStatus.HEALTHY, None
+    return AssetCheckHealthState(
+        passing_checks=passing_checks,
+        failing_checks=failed_checks,
+        warning_checks=warning_checks,
+        all_checks={node.asset_check.key for node in remote_check_nodes},
+    )
 
 
-def _get_streamline_asset_check_health_and_metadata(
+async def get_asset_check_status_and_metadata(
     graphene_info: "ResolveInfo",
     asset_key: AssetKey,
 ) -> tuple[str, Optional["GrapheneAssetHealthCheckMeta"]]:
+    """Converts an AssetCheckHealthState object to a GrapheneAssetHealthStatus and the metdata
+    needed to power the UIs.
+    """
     from dagster_graphql.schema.asset_health import (
         GrapheneAssetHealthCheckDegradedMeta,
         GrapheneAssetHealthCheckUnknownMeta,
@@ -121,12 +97,15 @@ def _get_streamline_asset_check_health_and_metadata(
         GrapheneAssetHealthStatus,
     )
 
-    asset_check_health_state = (
-        graphene_info.context.instance.get_asset_check_health_state_for_asset(asset_key)
-    )
-    if asset_check_health_state is None:
-        # asset_check_health_state_for is only None if no are defined on the asset
-        return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+    if graphene_info.context.instance.streamline_read_asset_health_supported():
+        asset_check_health_state = (
+            graphene_info.context.instance.get_asset_check_health_state_for_asset(asset_key)
+        )
+        if asset_check_health_state is None:
+            # asset_check_health_state_for is only None if no are defined on the asset
+            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
+    else:
+        asset_check_health_state = await _compute_asset_check_health_state(graphene_info, asset_key)
 
     if asset_check_health_state.health_status == AssetHealthStatus.HEALTHY:
         return GrapheneAssetHealthStatus.HEALTHY, None
@@ -160,12 +139,3 @@ def _get_streamline_asset_check_health_and_metadata(
         )
     else:  # asset_check_health_state.health_status == AssetHealthStatus.NOT_APPLICABLE
         return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
-
-
-async def get_asset_check_status_and_metadata(
-    graphene_info: "ResolveInfo",
-    asset_key: AssetKey,
-) -> tuple[str, Optional["GrapheneAssetHealthCheckMeta"]]:
-    if graphene_info.context.instance.streamline_read_asset_health_supported():
-        return _get_streamline_asset_check_health_and_metadata(graphene_info, asset_key)
-    return await _compute_asset_check_status_and_metadata(graphene_info, asset_key)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.storage.dagster_run import RunRecord
 from dagster._core.storage.event_log.base import AssetRecord
 
-from dagster_graphql.implementation.fetch_asset_health import get_asset_check_status_counts
+from dagster_graphql.implementation.fetch_asset_health import get_asset_check_status_and_metadata
 from dagster_graphql.implementation.fetch_partition_subsets import (
     regenerate_and_check_partition_subsets,
 )
@@ -283,59 +283,10 @@ class GrapheneAssetHealth(graphene.ObjectType):
         _, materialization_status_metadata = await self.materialization_status_task
         return materialization_status_metadata
 
-    async def get_asset_check_health_status_and_metadata(
-        self, graphene_info: ResolveInfo
-    ) -> tuple[str, Optional[GrapheneAssetHealthCheckMeta]]:
-        """Computes the health indicator for the asset checks for the assets. Follows these rules:
-        HEALTHY - the latest completed execution for every check is a success.
-        WARNING - the latest completed execution for any asset check failed with severity WARN
-            (and no checks failed with severity ERROR).
-        DEGRADED - the latest completed execution for any asset check failed with severity ERROR.
-        UNKNOWN - any asset checks has never been executed.
-        NOT_APPLICABLE - the asset has no asset checks defined.
-
-        Note: the latest completed execution for each check may not have executed based on the
-        most recent materialization of the asset.
-        """
-        remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(
-            self._asset_node_snap.asset_key
-        )
-        if not remote_check_nodes or len(remote_check_nodes) == 0:
-            # asset doesn't have checks defined
-            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
-
-        asset_check_counts = await get_asset_check_status_counts(
-            graphene_info, self._asset_node_snap.asset_key, remote_check_nodes
-        )
-
-        if asset_check_counts.num_failed > 0:
-            return GrapheneAssetHealthStatus.DEGRADED, GrapheneAssetHealthCheckDegradedMeta(
-                numFailedChecks=asset_check_counts.num_failed,
-                numWarningChecks=asset_check_counts.num_warning,
-                totalNumChecks=asset_check_counts.total_num,
-            )
-        if asset_check_counts.num_warning > 0:
-            return GrapheneAssetHealthStatus.WARNING, GrapheneAssetHealthCheckWarningMeta(
-                numWarningChecks=asset_check_counts.num_warning,
-                totalNumChecks=asset_check_counts.total_num,
-            )
-        if asset_check_counts.num_unexecuted > 0:
-            # if any check has never been executed, we report this as unknown, even if other checks
-            # have passed
-            return (
-                GrapheneAssetHealthStatus.UNKNOWN,
-                GrapheneAssetHealthCheckUnknownMeta(
-                    numNotExecutedChecks=asset_check_counts.num_unexecuted,
-                    totalNumChecks=asset_check_counts.total_num,
-                ),
-            )
-        # all checks must have executed and passed
-        return GrapheneAssetHealthStatus.HEALTHY, None
-
     async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo) -> str:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                self.get_asset_check_health_status_and_metadata(graphene_info)
+                get_asset_check_status_and_metadata(graphene_info, self._asset_node_snap.asset_key)
             )
 
         asset_checks_status, _ = await self.asset_check_status_task
@@ -346,7 +297,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     ) -> GrapheneAssetHealthCheckMeta:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                self.get_asset_check_health_status_and_metadata(graphene_info)
+                get_asset_check_status_and_metadata(graphene_info, self._asset_node_snap.asset_key)
             )
 
         _, asset_checks_status_metadata = await self.asset_check_status_task

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -372,7 +372,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
         materialization_status, _ = await self.materialization_status_task
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                self.get_asset_check_status_for_asset_health(graphene_info)
+                get_asset_check_status_and_metadata(graphene_info, self._asset_node_snap.asset_key)
             )
         asset_checks_status, _ = await self.asset_check_status_task
         if self.freshness_status_task is None:

--- a/python_modules/dagster/dagster/_streamline/asset_check_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_check_health.py
@@ -2,6 +2,7 @@ from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
 from dagster._core.definitions.asset_key import AssetCheckKey
+from dagster._streamline.asset_health import AssetHealthStatus
 
 
 @whitelist_for_serdes
@@ -24,3 +25,24 @@ class AssetCheckHealthState:
             warning_checks=set(),
             all_checks=set(),
         )
+
+    @property
+    def health_status(self) -> AssetHealthStatus:
+        """Returns the health status of the asset based on the checks."""
+        if len(self.all_checks) == 0:
+            return AssetHealthStatus.NOT_APPLICABLE
+        if len(self.failing_checks) > 0:
+            return AssetHealthStatus.DEGRADED
+        if len(self.warning_checks) > 0:
+            return AssetHealthStatus.WARNING
+
+        num_unexecuted = (
+            len(self.all_checks)
+            - len(self.passing_checks)
+            - len(self.failing_checks)
+            - len(self.warning_checks)
+        )
+        if num_unexecuted > 0:
+            return AssetHealthStatus.UNKNOWN
+        # all checks are passing
+        return AssetHealthStatus.HEALTHY

--- a/python_modules/dagster/dagster/_streamline/asset_check_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_check_health.py
@@ -1,7 +1,11 @@
 from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
+from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_key import AssetCheckKey
+from dagster._core.loader import LoadingContext
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
+from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 from dagster._streamline.asset_health import AssetHealthStatus
 
 
@@ -46,3 +50,83 @@ class AssetCheckHealthState:
             return AssetHealthStatus.UNKNOWN
         # all checks are passing
         return AssetHealthStatus.HEALTHY
+
+    @classmethod
+    async def compute_for_asset_checks(
+        cls, check_keys: set[AssetCheckKey], loading_context: LoadingContext
+    ) -> "AssetCheckHealthState":
+        """Using the latest terminal state for each check as stored in the DB, returns a set of
+        asset checks in each terminal state. If a check is in progress, it remains in the terminal
+        state it was in prior to the in progress execution.
+        """
+        if len(check_keys) == 0:
+            # no checks defined
+            return AssetCheckHealthState.default()
+
+        passing_checks = set()
+        warning_checks = set()
+        failing_checks = set()
+
+        check_records = await AssetCheckSummaryRecord.gen_many(
+            loading_context,
+            check_keys,
+        )
+
+        for check_record in check_records:
+            if check_record is None or check_record.last_check_execution_record is None:
+                # check has never been executed
+                continue
+
+            check_key = check_record.asset_check_key
+
+            # if the last_check_execution_record is completed, it will be the same as last_completed_check_execution_record,
+            # but we check the last_check_execution_record status first since there is an edge case
+            # where the record will have status PLANNED, but the resolve_status will be EXECUTION_FAILED
+            # because the run for the check failed.
+            last_check_execution_status = (
+                await check_record.last_check_execution_record.resolve_status(loading_context)
+            )
+            last_check_evaluation = check_record.last_check_execution_record.evaluation
+
+            if last_check_execution_status in [
+                AssetCheckExecutionResolvedStatus.IN_PROGRESS,
+                AssetCheckExecutionResolvedStatus.SKIPPED,
+            ]:
+                # the last check is still in progress or is skipped, so we want to check the status of
+                # the latest completed check instead
+                if check_record.last_completed_check_execution_record is None:
+                    # the check hasn't been executed prior to this in progress check
+                    continue
+                # should never need to fetch a run since the non-resolved status is success or failed.
+                # this method converts directly to the resolved status
+                last_check_execution_status = (
+                    await check_record.last_completed_check_execution_record.resolve_status(
+                        loading_context
+                    )
+                )
+                last_check_evaluation = (
+                    check_record.last_completed_check_execution_record.evaluation
+                )
+
+            if last_check_execution_status == AssetCheckExecutionResolvedStatus.FAILED:
+                # failed checks should always have an evaluation, but default to ERROR if not
+                if (
+                    last_check_evaluation
+                    and last_check_evaluation.severity == AssetCheckSeverity.WARN
+                ):
+                    warning_checks.add(check_key)
+                else:
+                    failing_checks.add(check_key)
+            elif last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
+                # EXECUTION_FAILED checks don't have an evaluation and we want to report them as failures
+                failing_checks.add(check_key)
+            else:
+                # asset check passed
+                passing_checks.add(check_key)
+
+        return AssetCheckHealthState(
+            passing_checks=passing_checks,
+            failing_checks=failing_checks,
+            warning_checks=warning_checks,
+            all_checks=check_keys,
+        )

--- a/python_modules/dagster/dagster/_streamline/asset_check_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_check_health.py
@@ -4,8 +4,6 @@ from dagster_shared.serdes import whitelist_for_serdes
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._core.loader import LoadingContext
-from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus
-from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 from dagster._streamline.asset_health import AssetHealthStatus
 
 
@@ -59,6 +57,11 @@ class AssetCheckHealthState:
         asset checks in each terminal state. If a check is in progress, it remains in the terminal
         state it was in prior to the in progress execution.
         """
+        from dagster._core.storage.asset_check_execution_record import (
+            AssetCheckExecutionResolvedStatus,
+        )
+        from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
+
         if len(check_keys) == 0:
             # no checks defined
             return AssetCheckHealthState.default()

--- a/python_modules/dagster/dagster/_streamline/asset_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_health.py
@@ -1,0 +1,14 @@
+import enum
+
+from dagster_shared.serdes import whitelist_for_serdes
+
+
+@whitelist_for_serdes
+class AssetHealthStatus(enum.Enum):
+    """Enum for the health status of an asset."""
+
+    HEALTHY = "HEALTHY"
+    WARNING = "WARNING"
+    DEGRADED = "DEGRADED"
+    UNKNOWN = "UNKNOWN"
+    NOT_APPLICABLE = "NOT_APPLICABLE"


### PR DESCRIPTION
## Summary & Motivation
this is a mainly refactoring PR, no business logic is changing

Simplifies the shared code between the streamline and non-streamline implementations so that an `AssetCheckHealthState` object is created/fetched for both and then converted to the graphene health statuses and metadata

The one new thing this PR introduces is an `AssetHealthStatus` enum so that we can call `asset_check_health_state.asset_health` and get the enum value back, rather than having to compute from the number of checks in each state every time we want to know the state

Internal PR https://github.com/dagster-io/internal/pull/15396

## How I Tested These Changes
existing tests

