### PR TITLE
[docs] tiny typo fix

### DIFF
--- a/docs/docs/guides/labs/dg/creating-a-project.md
+++ b/docs/docs/guides/labs/dg/creating-a-project.md
@@ -26,11 +26,13 @@ Before creating a project with `dg`, you must [install `dg`](/guides/labs/dg#ins
 <Tabs>
   <TabItem value="uv" label="uv">
     ```bash
+
     dg init my-project
     ```
   </TabItem>
   <TabItem value="pip" label="pip">
     ```bash
+
     dg init my-project
     ```
   </TabItem>

--- a/docs/docs/guides/labs/dg/creating-a-project.md
+++ b/docs/docs/guides/labs/dg/creating-a-project.md
@@ -25,14 +25,12 @@ Before creating a project with `dg`, you must [install `dg`](/guides/labs/dg#ins
 
 <Tabs>
   <TabItem value="uv" label="uv">
-    ```bash
-
+    ```
     dg init my-project
     ```
   </TabItem>
   <TabItem value="pip" label="pip">
-    ```bash
-
+    ```
     dg init my-project
     ```
   </TabItem>


### PR DESCRIPTION
## Summary

The `bash` string appears in the docs right now for some reason