### PR TITLE
[2/n][dagster-tableau] Update spec parser to include extracts as materializable assets

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -6,7 +6,7 @@ from dagster import (
     _check as check,
 )
 
-from dagster_tableau.translator import TableauTagSet
+from dagster_tableau.translator import TableauMetadataSet, TableauTagSet
 
 
 class ParsedTableauAssetSpecs(
@@ -30,22 +30,47 @@ class ParsedTableauAssetSpecs(
 
 def parse_tableau_external_and_materializable_asset_specs(
     specs: Sequence[AssetSpec],
+    include_data_sources_with_extracts: bool = False,
 ) -> ParsedTableauAssetSpecs:
     """Parses a list of Tableau AssetSpecs provided as input and return two lists of AssetSpecs,
     one for the Tableau external assets and another one for the Tableau materializable assets.
 
     In Tableau, data sources are considered external assets,
     while sheets and dashboards are considered materializable assets.
+
+    Args:
+        specs (Sequence[AssetSpec]): The asset specs of the assets in the Tableau workspace.
+        include_data_sources_with_extracts (bool):
+            Whether to include data sources with extracts in materializable assets.
+
+    Returns:
+        ParsedTableauAssetSpecs: A named tuple representing the parsed Tableau asset specs
+            as `external_asset_specs` and `materializable_asset_specs`.
     """
-    external_asset_specs = [
+    data_source_asset_specs = [
         spec for spec in specs if TableauTagSet.extract(spec.tags).asset_type == "data_source"
     ]
 
-    materializable_asset_specs = [
+    extract_asset_specs, not_extract_asset_specs = [], []
+    for spec in data_source_asset_specs:
+        (not_extract_asset_specs, extract_asset_specs)[
+            TableauMetadataSet.extract(spec.metadata).has_extracts
+        ].append(spec)
+
+    view_asset_specs = [
         spec
         for spec in specs
         if TableauTagSet.extract(spec.tags).asset_type in ["dashboard", "sheet"]
     ]
+
+    external_asset_specs = (
+        not_extract_asset_specs if include_data_sources_with_extracts else data_source_asset_specs
+    )
+    materializable_asset_specs = (
+        view_asset_specs + extract_asset_specs
+        if include_data_sources_with_extracts
+        else view_asset_specs
+    )
 
     return ParsedTableauAssetSpecs(
         external_asset_specs=external_asset_specs,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -51,11 +51,12 @@ def parse_tableau_external_and_materializable_asset_specs(
         spec for spec in specs if TableauTagSet.extract(spec.tags).asset_type == "data_source"
     ]
 
-    extract_asset_specs, not_extract_asset_specs = [], []
+    extract_asset_specs, non_extract_asset_specs = [], []
     for spec in data_source_asset_specs:
-        (not_extract_asset_specs, extract_asset_specs)[
-            TableauMetadataSet.extract(spec.metadata).has_extracts
-        ].append(spec)
+        if TableauMetadataSet.extract(spec.metadata).has_extracts:
+            extract_asset_specs.append(spec)
+        else:
+            non_extract_asset_specs.append(spec)
 
     view_asset_specs = [
         spec
@@ -64,7 +65,7 @@ def parse_tableau_external_and_materializable_asset_specs(
     ]
 
     external_asset_specs = (
-        not_extract_asset_specs if include_data_sources_with_extracts else data_source_asset_specs
+        non_extract_asset_specs if include_data_sources_with_extracts else data_source_asset_specs
     )
     materializable_asset_specs = (
         view_asset_specs + extract_asset_specs

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -6,7 +6,7 @@ from dagster import (
     _check as check,
 )
 
-from dagster_tableau.translator import TableauMetadataSet, TableauTagSet
+from dagster_tableau.translator import TableauDataSourceMetadataSet, TableauTagSet
 
 
 class ParsedTableauAssetSpecs(
@@ -53,7 +53,7 @@ def parse_tableau_external_and_materializable_asset_specs(
 
     extract_asset_specs, non_extract_asset_specs = [], []
     for spec in data_source_asset_specs:
-        if TableauMetadataSet.extract(spec.metadata).has_extracts:
+        if TableauDataSourceMetadataSet.extract(spec.metadata).has_extracts:
             extract_asset_specs.append(spec)
         else:
             non_extract_asset_specs.append(spec)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -9,6 +9,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.test_utils import environ
 from dagster_shared.check import CheckError
 from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace, load_tableau_asset_specs
+from dagster_tableau.asset_utils import parse_tableau_external_and_materializable_asset_specs
 from dagster_tableau.translator import DagsterTableauTranslator, TableauTranslatorData
 
 
@@ -277,3 +278,67 @@ def test_translator_custom_metadata_legacy(
         assert asset_spec.metadata["custom"] == "metadata"
         assert asset_spec.key.path == ["prefix", "superstore_datasource"]
         assert asset_spec.tags["dagster/storage_kind"] == "tableau"
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "clazz,host_key,host_value",
+    [
+        (
+            TableauServerWorkspace,
+            "server_name",
+            "fake_server_name",
+        ),
+        (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
+    ],
+)
+@pytest.mark.usefixtures("site_name")
+@pytest.mark.usefixtures("sign_in")
+@pytest.mark.usefixtures("get_workbooks")
+@pytest.mark.usefixtures("get_workbook")
+def test_parse_asset_specs(
+    clazz: Union[type[TableauCloudWorkspace], type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    sign_in: MagicMock,
+    get_workbooks: MagicMock,
+    get_workbook: MagicMock,
+) -> None:
+    connected_app_client_id = uuid.uuid4().hex
+    connected_app_secret_id = uuid.uuid4().hex
+    connected_app_secret_value = uuid.uuid4().hex
+    username = "fake_username"
+
+    with environ({"TABLEAU_CLIENT_ID": connected_app_client_id}):
+        resource_args = {
+            "connected_app_client_id": EnvVar("TABLEAU_CLIENT_ID"),
+            "connected_app_secret_id": connected_app_secret_id,
+            "connected_app_secret_value": connected_app_secret_value,
+            "username": username,
+            "site_name": site_name,
+            host_key: host_value,
+        }
+
+        resource = clazz(**resource_args)
+        resource.build_client()
+
+        all_assets = load_tableau_asset_specs(resource)
+
+        # Data source with extracts are considered as external assets
+        external_asset_specs, materializable_asset_specs = (
+            parse_tableau_external_and_materializable_asset_specs(
+                specs=all_assets, include_data_sources_with_extracts=False
+            )
+        )
+        assert len(external_asset_specs) == 2
+        assert len(materializable_asset_specs) == 3
+
+        # Data source with extracts are considered as materializable assets
+        external_asset_specs, materializable_asset_specs = (
+            parse_tableau_external_and_materializable_asset_specs(
+                specs=all_assets, include_data_sources_with_extracts=True
+            )
+        )
+        assert len(external_asset_specs) == 1
+        assert len(materializable_asset_specs) == 4


### PR DESCRIPTION
## Summary & Motivation

This PR updates the `parse_tableau_external_and_materializable_asset_specs` fn to let users select data sources with extracts as materializable Tableau assets.

## How I Tested These Changes

New test with BK

