### PR TITLE
[dg] ComponentHierarchy

### DIFF
--- a/python_modules/dagster/dagster/components/core/component_hierarchy.py
+++ b/python_modules/dagster/dagster/components/core/component_hierarchy.py
@@ -1,0 +1,172 @@
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Optional
+
+from dagster_shared.record import record
+
+import dagster._check as check
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+
+
+def compute_file_hash(path: Path) -> str:
+    return hashlib.sha1(path.read_text().encode("utf-8")).hexdigest()
+
+
+@record
+class ComponentYamlFile:
+    path: Path
+    sha: str
+
+
+@record
+class ComponentHierarchyNode:
+    path: Path
+
+
+@record
+class YamlComponentHierarchyNode(ComponentHierarchyNode):
+    yaml_file: ComponentYamlFile
+
+
+class PythonicComponentHierarchyNode(ComponentHierarchyNode): ...
+
+
+class DefsComponentHierarchyNode(ComponentHierarchyNode): ...
+
+
+class PythonModuleComponentHierarchyNode(ComponentHierarchyNode): ...
+
+
+@record
+class FolderComponentHierarchyNode(ComponentHierarchyNode):
+    children: Mapping[Path, ComponentHierarchyNode]
+    yaml_file: Optional[ComponentYamlFile] = None
+
+
+@record
+class ComponentHierarchy:
+    root: ComponentHierarchyNode
+
+
+def build_component_hierarchy_node(
+    context: ComponentLoadContext,
+) -> Optional[ComponentHierarchyNode]:
+    component_yaml_path = context.path / "component.yaml"
+    if component_yaml_path.exists():
+        return YamlComponentHierarchyNode(
+            path=context.path,
+            yaml_file=ComponentYamlFile(
+                path=component_yaml_path, sha=compute_file_hash(component_yaml_path)
+            ),
+        )
+    # pythonic component
+    elif (context.path / "component.py").exists():
+        return PythonicComponentHierarchyNode(path=context.path)
+    # defs
+    elif (context.path / "definitions.py").exists():
+        return DefsComponentHierarchyNode(path=context.path)
+    elif context.path.suffix == ".py":
+        return PythonModuleComponentHierarchyNode(path=context.path)
+    # folder
+    elif context.path.is_dir():
+        return build_folder_component_hierarchy_node(context)
+
+    return None
+
+
+def build_component_hierarchy(
+    context: ComponentLoadContext,
+) -> ComponentHierarchy:
+    """Builds a hierarchy of components starting from the given context.
+
+    Args:
+        context (ComponentLoadContext): The context from which to start building the hierarchy.
+
+    Returns:
+        ComponentHierarchy: The root node of the component hierarchy.
+    """
+    root_node = build_component_hierarchy_node(context)
+    if not root_node:
+        raise ValueError("Expected root_node to be defined, but got None")
+    return ComponentHierarchy(root=root_node)
+
+
+def build_root_component(
+    context: ComponentLoadContext, hierarchy: ComponentHierarchy
+) -> Optional[Component]:
+    """Builds the root component from the given context.
+
+    Args:
+        context (ComponentLoadContext): The context from which to start building the component.
+
+    Returns:
+        Optional[Component]: The root component if found, otherwise None.
+    """
+    with use_component_load_context(context):
+        return build_component_from_node(context, hierarchy.root)
+
+
+def build_component_from_node(
+    context: ComponentLoadContext, node: ComponentHierarchyNode
+) -> Component:
+    """Builds a component from the given context and hierarchy node.
+
+    Args:
+        context (ComponentLoadContext): The context from which to start building the component.
+        node (ComponentHierarchyNode): The node representing the component in the hierarchy.
+
+    Returns:
+        Optional[Component]: The component if found, otherwise None.
+    """
+    from dagster.components.core.defs_module import (
+        DagsterDefsComponent,
+        DefsFolderComponent,
+        load_pythonic_component,
+        load_yaml_component,
+    )
+
+    if isinstance(node, YamlComponentHierarchyNode):
+        return load_yaml_component(context)
+    elif isinstance(node, PythonicComponentHierarchyNode):
+        return load_pythonic_component(context)
+    elif isinstance(node, DefsComponentHierarchyNode):
+        return DagsterDefsComponent(path=context.path / "definitions.py")
+    elif isinstance(node, PythonModuleComponentHierarchyNode):
+        return DagsterDefsComponent(path=context.path)
+    elif isinstance(node, FolderComponentHierarchyNode):
+        return DefsFolderComponent(
+            path=context.path,
+
+            children={
+                path: build_component_from_node(context.for_path(path), child_node)
+                for path, child_node in node.children.items()
+            },
+
+            asset_post_processors=None,
+        )
+    else:
+        check.failed(f"Unexpected ComponentHierarchyNode type: {type(node)}")
+
+
+def build_folder_component_hierarchy_node(
+    context: ComponentLoadContext,
+) -> FolderComponentHierarchyNode:
+    found: dict[Path, ComponentHierarchyNode] = {}
+    for subpath in context.path.iterdir():
+        sub_ctx = context.for_path(subpath)
+        with use_component_load_context(sub_ctx):
+            component = build_component_hierarchy_node(sub_ctx)
+            if component:
+                found[subpath] = component
+    component_yaml_path = context.path / "component.yaml"
+    return FolderComponentHierarchyNode(
+        path=context.path,
+        children=found,
+        yaml_file=None
+        if not component_yaml_path.exists()
+        else ComponentYamlFile(
+            path=component_yaml_path, sha=compute_file_hash(component_yaml_path)
+        ),
+    )

--- a/python_modules/dagster/dagster/components/core/component_hierarchy.py
+++ b/python_modules/dagster/dagster/components/core/component_hierarchy.py
@@ -108,6 +108,7 @@ def build_root_component(
         return build_component_from_node(context, hierarchy.root)
 
 
+
 def build_component_from_node(
     context: ComponentLoadContext, node: ComponentHierarchyNode
 ) -> Component:
@@ -118,8 +119,9 @@ def build_component_from_node(
         node (ComponentHierarchyNode): The node representing the component in the hierarchy.
 
     Returns:
-        Optional[Component]: The component if found, otherwise None.
+        Component: The built component.
     """
+
     from dagster.components.core.defs_module import (
         DagsterDefsComponent,
         DefsFolderComponent,

--- a/python_modules/dagster/dagster/components/core/component_hierarchy.py
+++ b/python_modules/dagster/dagster/components/core/component_hierarchy.py
@@ -8,6 +8,12 @@ from dagster_shared.record import record
 
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+from dagster.components.core.defs_module import (
+    DagsterDefsComponent,
+    DefsFolderComponent,
+    load_pythonic_component,
+    load_yaml_component,
+)
 
 
 def compute_file_hash(path: Path) -> str:
@@ -35,29 +41,21 @@ class YamlComponentDeclaration(ComponentDeclaration):
     yaml_file: ComponentYamlFile
 
     def load(self, context: ComponentLoadContext) -> Component:
-        from dagster.components.core.defs_module import load_yaml_component
-
         return load_yaml_component(context)
 
 
 class PythonicComponentDeclaration(ComponentDeclaration):
     def load(self, context: ComponentLoadContext) -> Component:
-        from dagster.components.core.defs_module import load_pythonic_component
-
         return load_pythonic_component(context)
 
 
 class DefsComponentDeclaration(ComponentDeclaration):
     def load(self, context: ComponentLoadContext) -> Component:
-        from dagster.components.core.defs_module import DagsterDefsComponent
-
         return DagsterDefsComponent(path=context.path / "definitions.py")
 
 
 class PythonModuleComponentDeclaration(ComponentDeclaration):
     def load(self, context: ComponentLoadContext) -> Component:
-        from dagster.components.core.defs_module import DagsterDefsComponent
-
         return DagsterDefsComponent(path=context.path)
 
 
@@ -67,8 +65,6 @@ class FolderComponentDeclaration(ComponentDeclaration):
     yaml_file: Optional[ComponentYamlFile] = None
 
     def load(self, context: ComponentLoadContext) -> Component:
-        from dagster.components.core.defs_module import DefsFolderComponent
-
         return DefsFolderComponent(
             path=context.path,
             children={

--- a/python_modules/dagster/dagster/components/core/component_hierarchy.py
+++ b/python_modules/dagster/dagster/components/core/component_hierarchy.py
@@ -24,10 +24,24 @@ class ComponentYamlFile:
 class ComponentDeclaration:
     path: Path
 
+    @classmethod
+    def build(cls, context: ComponentLoadContext) -> "ComponentDeclaration":
+        return cls(path=context.path)
+
 
 @record
 class YamlComponentDeclaration(ComponentDeclaration):
     yaml_file: ComponentYamlFile
+
+    @classmethod
+    def build(cls, context: ComponentLoadContext) -> "YamlComponentDeclaration":
+        component_yaml_path = context.path / "component.yaml"
+        return cls(
+            path=context.path,
+            yaml_file=ComponentYamlFile(
+                path=component_yaml_path, sha=compute_file_hash(component_yaml_path)
+            ),
+        )
 
 
 class PythonicComponentDeclaration(ComponentDeclaration): ...
@@ -44,6 +58,27 @@ class FolderComponentDeclaration(ComponentDeclaration):
     children: Mapping[Path, ComponentDeclaration]
     yaml_file: Optional[ComponentYamlFile] = None
 
+    @classmethod
+    def build(cls, context: ComponentLoadContext) -> "FolderComponentDeclaration":
+        found: dict[Path, ComponentDeclaration] = {}
+        for subpath in context.path.iterdir():
+            sub_ctx = context.for_path(subpath)
+            with use_component_load_context(sub_ctx):
+                component = build_component_declaration(sub_ctx)
+                if component:
+                    found[subpath] = component
+
+        component_yaml_path = context.path / "component.yaml"
+        return cls(
+            path=context.path,
+            children=found,
+            yaml_file=None
+            if not component_yaml_path.exists()
+            else ComponentYamlFile(
+                path=component_yaml_path, sha=compute_file_hash(component_yaml_path)
+            ),
+        )
+
 
 @record
 class ComponentHierarchy:
@@ -53,25 +88,26 @@ class ComponentHierarchy:
 def build_component_declaration(
     context: ComponentLoadContext,
 ) -> Optional[ComponentDeclaration]:
+    # Check for yaml component
     component_yaml_path = context.path / "component.yaml"
     if component_yaml_path.exists():
-        return YamlComponentDeclaration(
-            path=context.path,
-            yaml_file=ComponentYamlFile(
-                path=component_yaml_path, sha=compute_file_hash(component_yaml_path)
-            ),
-        )
-    # pythonic component
-    elif (context.path / "component.py").exists():
-        return PythonicComponentDeclaration(path=context.path)
-    # defs
-    elif (context.path / "definitions.py").exists():
-        return DefsComponentDeclaration(path=context.path)
-    elif context.path.suffix == ".py":
-        return PythonModuleComponentDeclaration(path=context.path)
-    # folder
-    elif context.path.is_dir():
-        return build_folder_component_declaration(context)
+        return YamlComponentDeclaration.build(context)
+
+    # Check for pythonic component
+    if (context.path / "component.py").exists():
+        return PythonicComponentDeclaration.build(context)
+
+    # Check for defs component
+    if (context.path / "definitions.py").exists():
+        return DefsComponentDeclaration.build(context)
+
+    # Check for python module
+    if context.path.suffix == ".py":
+        return PythonModuleComponentDeclaration.build(context)
+
+    # Check for folder component
+    if context.path.is_dir():
+        return FolderComponentDeclaration.build(context)
 
     return None
 

--- a/python_modules/dagster/dagster/components/core/component_hierarchy.py
+++ b/python_modules/dagster/dagster/components/core/component_hierarchy.py
@@ -108,7 +108,6 @@ def build_root_component(
         return build_component_from_node(context, hierarchy.root)
 
 
-
 def build_component_from_node(
     context: ComponentLoadContext, node: ComponentHierarchyNode
 ) -> Component:
@@ -121,7 +120,6 @@ def build_component_from_node(
     Returns:
         Component: The built component.
     """
-
     from dagster.components.core.defs_module import (
         DagsterDefsComponent,
         DefsFolderComponent,
@@ -140,12 +138,10 @@ def build_component_from_node(
     elif isinstance(node, FolderComponentHierarchyNode):
         return DefsFolderComponent(
             path=context.path,
-
             children={
                 path: build_component_from_node(context.for_path(path), child_node)
                 for path, child_node in node.children.items()
             },
-
             asset_post_processors=None,
         )
     else:

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -9,10 +9,7 @@ from dagster._annotations import deprecated, preview, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._utils.warnings import suppress_dagster_warnings
-from dagster.components.core.component_hierarchy import (
-    build_component_hierarchy,
-    build_root_component,
-)
+from dagster.components.core.component_hierarchy import build_component_hierarchy
 from dagster.components.core.context import ComponentLoadContext, use_component_load_context
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
@@ -85,7 +82,7 @@ def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Def
     context = ComponentLoadContext.for_module(defs_root, project_root)
     with use_component_load_context(context):
         hierarchy = build_component_hierarchy(context)
-        root_component = build_root_component(context, hierarchy)
+        root_component = hierarchy.root.load(context)
         if root_component is None:
             raise DagsterInvariantViolationError("Could not resolve root module to a component.")
 


### PR DESCRIPTION
## Summary & Motivation

Adding `ComponentHierarchy` which represents the component hierarchy (`defs` folder) prior to loading all the actual Components.

This will be useful for situations like rendering the component tree in a UI prior to actually loading the components. We can serialize this separately and render it.

Switches `load_defs` to use this.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG