### PR TITLE
[dg] Accurately type parse_yaml_with_source_positions

### DIFF
--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -2,7 +2,7 @@ import contextlib
 from collections.abc import Generator, Sequence
 from typing import Optional, TypeVar
 
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from dagster_shared.yaml_utils.source_position import (
     KeyPath,
     SourcePositionTree,
@@ -93,7 +93,7 @@ def parse_yaml_file_to_pydantic(cls: type[T], src: str, filename: str = "<string
             Pydantic2+, errors will include context information about the position in the document
             that the model corresponds to.
     """
-    parsed = parse_yaml_with_source_positions(src, filename)
+    parsed = parse_yaml_with_source_position(src, filename)
     return _parse_and_populate_model_with_annotated_errors(
         cls=cls, obj_parse_root=parsed, obj_key_path_prefix=[]
     )
@@ -160,7 +160,7 @@ def parse_yaml_file_to_pydantic_sequence(
             Pydantic2+, errors will include context information about the position in the document
             that the model corresponds to.
     """
-    parsed = parse_yaml_with_source_positions(src, filename)
+    parsed = parse_yaml_with_source_position(src, filename)
 
     if not isinstance(parsed.value, list):
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Optional, TypeVar
 
 from dagster_shared.serdes.objects import PluginObjectKey
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 import dagster._check as check
@@ -193,7 +193,7 @@ def load_pythonic_component(context: ComponentLoadContext) -> Component:
 def load_yaml_component(context: ComponentLoadContext) -> Component:
     # parse the yaml file
     component_def_path = context.path / "component.yaml"
-    source_tree = parse_yaml_with_source_positions(
+    source_tree = parse_yaml_with_source_position(
         component_def_path.read_text(), str(component_def_path)
     )
     component_file_model = _parse_and_populate_model_with_annotated_errors(

--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Final, Literal, Optional, TypeVar, Union, get
 
 import yaml
 from dagster_shared.record import get_record_annotations, get_record_defaults, is_record, record
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import try_parse_yaml_with_source_position
 from pydantic import BaseModel, PydanticSchemaGenerationError, create_model
 from pydantic.fields import Field, FieldInfo
 from typing_extensions import TypeGuard
@@ -60,7 +60,7 @@ class Resolvable:
 
     @classmethod
     def resolve_from_yaml(cls, yaml: str):
-        parsed_and_src_tree = parse_yaml_with_source_positions(yaml)
+        parsed_and_src_tree = try_parse_yaml_with_source_position(yaml)
         model_cls = cls.model()
         if parsed_and_src_tree:
             model = _parse_and_populate_model_with_annotated_errors(

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -19,7 +19,7 @@ from dagster._utils.pydantic_yaml import enrich_validation_errors_with_source_po
 from dagster.components import Component, ComponentLoadContext
 from dagster.components.utils import ensure_loadable_path
 from dagster_shared import check
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from pydantic import TypeAdapter
 
 T = TypeVar("T")
@@ -35,7 +35,7 @@ def load_context_and_component_for_test(
         component_type.get_model_cls(), "Component must have schema for direct test"
     )
     if isinstance(attrs, str):
-        source_positions = parse_yaml_with_source_positions(attrs)
+        source_positions = parse_yaml_with_source_position(attrs)
         with enrich_validation_errors_with_source_position(
             source_positions.source_position_tree, []
         ):

--- a/python_modules/dagster/dagster_tests/utils_tests/test_source_position.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_source_position.py
@@ -1,4 +1,4 @@
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from dagster_shared.yaml_utils.source_position import (
     HasSourcePositionAndKeyPath,
     KeyPath,
@@ -7,7 +7,7 @@ from dagster_shared.yaml_utils.source_position import (
 )
 
 
-def test_parse_yaml_with_source_positions() -> None:
+def test_parse_yaml_with_source_position() -> None:
     source = """
 foo:
   bar: 1
@@ -20,7 +20,7 @@ foo:
   c: "d"
 """
 
-    value_and_tree = parse_yaml_with_source_positions(source, filename="foo.yaml")
+    value_and_tree = parse_yaml_with_source_position(source, filename="foo.yaml")
 
     assert value_and_tree.value == {
         "foo": {
@@ -72,7 +72,7 @@ def test_populate_source_position_and_key_paths() -> None:
         def __init__(self):
             self.child = Child()
 
-    parsed = parse_yaml_with_source_positions(
+    parsed = parse_yaml_with_source_position(
         """
 child:
   dicts:

--- a/python_modules/libraries/dagster-dg/dagster_dg/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/check.py
@@ -4,7 +4,7 @@ from typing import Any, NamedTuple, Optional
 
 import click
 from dagster_shared.serdes.objects import PluginObjectKey
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from dagster_shared.yaml_utils.source_position import (
     LineCol,
     SourcePosition,
@@ -76,7 +76,7 @@ def check_yaml(
         if component_path.exists():
             text = component_path.read_text()
             try:
-                component_doc_tree = parse_yaml_with_source_positions(
+                component_doc_tree = parse_yaml_with_source_position(
                     text, filename=str(component_path)
                 )
             except ScannerError as se:

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
@@ -162,11 +162,11 @@ def dump_run_config_yaml(run_config: Mapping[str, Any], sort_keys: bool = True) 
     )
 
 
-def parse_yaml_with_source_positions(
+def parse_yamls_with_source_positions(
     src: str,
     filename: str = "<string>",
     implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
-) -> Optional[ValueAndSourcePositionTree]:
+) -> list[ValueAndSourcePositionTree]:
     """Parse YAML source with source position information.
     This function takes a YAML source string and an optional filename, and returns a
     `ValueAndSourcePositionTree` object. The `ValueAndSourcePositionTree` contains the
@@ -244,7 +244,7 @@ def parse_yaml_with_source_positions(
         SourcePositionLoader.remove_implicit_resolver(implicit_to_remove)
 
     try:
-        value_and_tree_node = yaml.load(src, Loader=SourcePositionLoader)
+        value_and_tree_nodes = list(yaml.load_all(src, Loader=SourcePositionLoader))
     except yaml.MarkedYAMLError as e:
         if e.context_mark is not None:
             e.context_mark.name = filename
@@ -252,4 +252,32 @@ def parse_yaml_with_source_positions(
             e.problem_mark.name = filename
         raise e
 
-    return check.opt_inst(value_and_tree_node, ValueAndSourcePositionTree)
+    return check.is_list(value_and_tree_nodes, of_type=ValueAndSourcePositionTree)
+
+
+def try_parse_yaml_with_source_position(
+    src: str,
+    filename: str = "<string>",
+    implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
+) -> Optional[ValueAndSourcePositionTree]:
+    yamls = parse_yamls_with_source_positions(
+        src,
+        filename=filename,
+        implicits_to_remove=implicits_to_remove,
+    )
+    return next(iter(yamls)) if yamls else None
+
+
+def parse_yaml_with_source_position(
+    src: str,
+    filename: str = "<string>",
+    implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
+) -> ValueAndSourcePositionTree:
+    return check.not_none(
+        try_parse_yaml_with_source_position(
+            src,
+            filename=filename,
+            implicits_to_remove=implicits_to_remove,
+        ),
+        f"Not able to parse YAML with source position in filename {filename}",
+    )

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
@@ -1,7 +1,7 @@
 import functools
 import glob
 from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import yaml
 
@@ -166,7 +166,7 @@ def parse_yaml_with_source_positions(
     src: str,
     filename: str = "<string>",
     implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
-) -> ValueAndSourcePositionTree:
+) -> Optional[ValueAndSourcePositionTree]:
     """Parse YAML source with source position information.
     This function takes a YAML source string and an optional filename, and returns a
     `ValueAndSourcePositionTree` object. The `ValueAndSourcePositionTree` contains the
@@ -252,4 +252,4 @@ def parse_yaml_with_source_positions(
             e.problem_mark.name = filename
         raise e
 
-    return value_and_tree_node
+    return check.opt_inst(value_and_tree_node, ValueAndSourcePositionTree)

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/sample_yaml.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/sample_yaml.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 
 import yaml
 
-from dagster_shared.yaml_utils import parse_yaml_with_source_positions
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
 
 REF_BASE = "#/$defs/"
@@ -138,7 +138,7 @@ def generate_sample_yaml(component_type: str, json_schema: Mapping[str, Any]) ->
         Dumper=ComponentDumper,
         sort_keys=False,
     )
-    parsed = parse_yaml_with_source_positions(raw)
+    parsed = parse_yaml_with_source_position(raw)
     comments = dict(_get_source_position_comments([], parsed.source_position_tree, json_schema))
     commented_lines = []
     for line_num, line in enumerate(raw.split("\n")):


### PR DESCRIPTION
## Summary & Motivation

* Change `parse_yaml_with_source_positions` to be accurately typed as returning non-optional type.
* Add `try_parse_yaml_with_source_positions` which allows returning of `None`
* Have the core logic be in terms of N yaml hunks delimited by `---`, which python `yaml` supports.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG