### PR TITLE
[dg] Support `---` in component.yaml to allow for multiple instances

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Optional, TypeVar
 
 from dagster_shared.serdes.objects import PluginObjectKey
-from dagster_shared.yaml_utils import parse_yaml_with_source_position
+from dagster_shared.yaml_utils import parse_yamls_with_source_position
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 import dagster._check as check
@@ -43,6 +43,14 @@ class ComponentFileModel(BaseModel):
     type: str
     attributes: Optional[Mapping[str, Any]] = None
     requirements: Optional[ComponentRequirementsModel] = None
+
+
+class CompositeYamlComponent(Component):
+    def __init__(self, componets: Sequence[Component]):
+        self.components = componets
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions.merge(*(component.build_defs(context) for component in self.components))
 
 
 def get_component(context: ComponentLoadContext) -> Optional[Component]:
@@ -193,40 +201,50 @@ def load_pythonic_component(context: ComponentLoadContext) -> Component:
 def load_yaml_component(context: ComponentLoadContext) -> Component:
     # parse the yaml file
     component_def_path = context.path / "component.yaml"
-    source_tree = parse_yaml_with_source_position(
+    source_trees = parse_yamls_with_source_position(
         component_def_path.read_text(), str(component_def_path)
     )
-    component_file_model = _parse_and_populate_model_with_annotated_errors(
-        cls=ComponentFileModel, obj_parse_root=source_tree, obj_key_path_prefix=[]
-    )
-
-    # find the component type
-    type_str = context.normalize_component_type_str(component_file_model.type)
-    key = PluginObjectKey.from_typename(type_str)
-    obj = load_package_object(key)
-    if not isinstance(obj, type) or not issubclass(obj, Component):
-        raise DagsterInvalidDefinitionError(
-            f"Component type {type_str} is of type {type(obj)}, but must be a subclass of dagster.Component"
+    components = []
+    for source_tree in source_trees:
+        component_file_model = _parse_and_populate_model_with_annotated_errors(
+            cls=ComponentFileModel, obj_parse_root=source_tree, obj_key_path_prefix=[]
         )
 
-    model_cls = obj.get_model_cls()
-    context = context.with_rendering_scope(
-        obj.get_additional_scope(),
-    ).with_source_position_tree(
-        source_tree.source_position_tree,
-    )
+        # find the component type
+        type_str = context.normalize_component_type_str(component_file_model.type)
+        key = PluginObjectKey.from_typename(type_str)
+        obj = load_package_object(key)
+        if not isinstance(obj, type) or not issubclass(obj, Component):
+            raise DagsterInvalidDefinitionError(
+                f"Component type {type_str} is of type {type(obj)}, but must be a subclass of dagster.Component"
+            )
 
-    # grab the attributes from the yaml file
-    with pushd(str(context.path)):
-        if model_cls is None:
-            attributes = None
-        elif source_tree:
-            attributes_position_tree = source_tree.source_position_tree.children["attributes"]
-            with enrich_validation_errors_with_source_position(
-                attributes_position_tree, ["attributes"]
-            ):
+        model_cls = obj.get_model_cls()
+        context = context.with_rendering_scope(
+            obj.get_additional_scope(),
+        ).with_source_position_tree(
+            source_tree.source_position_tree,
+        )
+
+        # grab the attributes from the yaml file
+        with pushd(str(context.path)):
+            if model_cls is None:
+                attributes = None
+            elif source_tree:
+                attributes_position_tree = source_tree.source_position_tree.children["attributes"]
+                with enrich_validation_errors_with_source_position(
+                    attributes_position_tree, ["attributes"]
+                ):
+                    attributes = TypeAdapter(model_cls).validate_python(
+                        component_file_model.attributes
+                    )
+            else:
                 attributes = TypeAdapter(model_cls).validate_python(component_file_model.attributes)
-        else:
-            attributes = TypeAdapter(model_cls).validate_python(component_file_model.attributes)
 
-    return obj.load(attributes, context)
+        components.append(obj.load(attributes, context))
+
+    check.invariant(len(components) > 0, "No components found in YAML file")
+    if len(components) == 1:
+        return components[0]
+    else:
+        return CompositeYamlComponent(components)

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -46,8 +46,8 @@ class ComponentFileModel(BaseModel):
 
 
 class CompositeYamlComponent(Component):
-    def __init__(self, componets: Sequence[Component]):
-        self.components = componets
+    def __init__(self, components: Sequence[Component]):
+        self.components = components
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         return Definitions.merge(*(component.build_defs(context) for component in self.components))

--- a/python_modules/dagster/dagster/components/lib/pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster/components/lib/pipes_subprocess_script_collection.py
@@ -9,11 +9,13 @@ from dagster._annotations import preview, public
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.core_models import ResolvedAssetSpec
+from dagster.components.resolved.model import Model
 
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
@@ -39,32 +41,36 @@ class PipesSubprocessScriptCollectionComponent(Component, Resolvable):
     def specs_by_path(self) -> Mapping[str, Sequence[AssetSpec]]:
         return {script.path: script.assets for script in self.scripts}
 
-    @staticmethod
-    def introspect_from_path(path: Path) -> "PipesSubprocessScriptCollectionComponent":
-        return PipesSubprocessScriptCollectionComponent(
-            [
-                PipesSubprocessScript(path=str(path), assets=[AssetSpec(path.stem)])
-                for path in list(path.rglob("*.py"))
-            ]
-        )
-
     def build_defs(self, context: ComponentLoadContext) -> "Definitions":
         from dagster._core.definitions.definitions_class import Definitions
 
         return Definitions(
             assets=[
-                self._create_asset_def(context.path / path, specs)
+                _create_asset_def(context.path / path, specs)
                 for path, specs in self.specs_by_path.items()
             ],
         )
 
-    def _create_asset_def(self, path: Path, specs: Sequence[AssetSpec]) -> AssetsDefinition:
-        from dagster._core.pipes.subprocess import PipesSubprocessClient
 
-        # TODO: allow name paraeterization
-        @multi_asset(specs=specs, name=f"script_{path.stem}")
-        def _asset(context: AssetExecutionContext):
-            cmd = [shutil.which("python"), path]
-            return PipesSubprocessClient().run(command=cmd, context=context).get_results()
+def _create_asset_def(path: Path, specs: Sequence[AssetSpec]) -> AssetsDefinition:
+    from dagster._core.pipes.subprocess import PipesSubprocessClient
 
-        return _asset
+    # TODO: allow name paraeterization
+    @multi_asset(specs=specs, name=f"script_{path.stem}")
+    def _asset(context: AssetExecutionContext):
+        cmd = [shutil.which("python"), path]
+        return PipesSubprocessClient().run(command=cmd, context=context).get_results()
+
+    return _asset
+
+
+@public
+@preview(emit_runtime_warning=False)
+class PipesSubprocessScriptComponent(Component, Resolvable, Model):
+    path: str
+    assets: Sequence[ResolvedAssetSpec]
+
+    def build_defs(self, context: ComponentLoadContext) -> "Definitions":
+        from dagster._core.definitions.definitions_class import Definitions
+
+        return Definitions(assets=[_create_asset_def(context.path / self.path, self.assets)])

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/component.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/component.yaml
@@ -1,0 +1,24 @@
+type: dagster.components.lib.pipes_subprocess_script_collection.PipesSubprocessScriptComponent
+
+attributes:
+  path: script_one.py
+  assets:
+    - key: a_dash
+      automation_condition: "{{ automation_condition.eager() }}"
+    - key: b_dash
+      automation_condition: "{{ automation_condition.on_cron('@daily') }}"
+      deps: [up1_dash, up2_dash]
+---
+type: dagster.components.lib.pipes_subprocess_script_collection.PipesSubprocessScriptComponent
+
+attributes:
+  path: script_two.py
+  assets:
+    - key: c_dash
+---
+type: dagster.components.lib.pipes_subprocess_script_collection.PipesSubprocessScriptComponent
+
+attributes:
+  path: subdir/script_three.py
+  assets:
+    - key: override_key_dash

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/script_one.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/script_one.py
@@ -1,0 +1,6 @@
+def do_thing() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    do_thing()

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/script_two.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/triple_dash_scripts/script_two.py
@@ -1,0 +1,6 @@
+def do_thing() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    do_thing()

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -21,6 +21,12 @@ def test_load_from_path() -> None:
         AssetKey("up2"),
         AssetKey("override_key"),
         AssetKey("cool_script"),
+        AssetKey("a_dash"),
+        AssetKey("b_dash"),
+        AssetKey("c_dash"),
+        AssetKey("up1_dash"),
+        AssetKey("up2_dash"),
+        AssetKey("override_key_dash"),
     }
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/yaml_utils/__init__.py
@@ -162,7 +162,7 @@ def dump_run_config_yaml(run_config: Mapping[str, Any], sort_keys: bool = True) 
     )
 
 
-def parse_yamls_with_source_positions(
+def parse_yamls_with_source_position(
     src: str,
     filename: str = "<string>",
     implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
@@ -260,7 +260,7 @@ def try_parse_yaml_with_source_position(
     filename: str = "<string>",
     implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
 ) -> Optional[ValueAndSourcePositionTree]:
-    yamls = parse_yamls_with_source_positions(
+    yamls = parse_yamls_with_source_position(
         src,
         filename=filename,
         implicits_to_remove=implicits_to_remove,


### PR DESCRIPTION
## Summary & Motivation

Right now we have "collection" component types which are pretty awkward.

It turns out yaml supports multiple documents in a single file with the `---` delimiter. This ends up being much nicer. Will we be able to compose simpler components in a generic way and it will be expected behavior from users coming from k8s and similar systems.

Thank you @PedramNavid for suggesting! Big advanced.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG