### PR TITLE
Feat/asset selection submit job

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -179,11 +179,11 @@ class DagsterGraphQLClient:
                     f" name {pipeline_name}.\n\tchoose one of: {job_info_lst}"
                 )
 
-        asset_key_input = (
-            [AssetKey.from_coercible(key).to_graphql_input() for key in asset_selection]
-            if asset_selection is not None
-            else None
-        )
+        asset_key_input = None
+        if asset_selection is not None:
+            asset_key_input = [
+                AssetKey.from_coercible(key).to_graphql_input() for key in asset_selection
+            ]
 
         variables: dict[str, Any] = {
             "executionParams": {

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -180,7 +180,7 @@ class DagsterGraphQLClient:
                 )
 
         asset_key_input = (
-            [{"path": AssetKey.from_coercible(key).path} for key in asset_selection]
+            [AssetKey.from_coercible(key).to_graphql_input() for key in asset_selection]
             if asset_selection is not None
             else None
         )

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -182,7 +182,8 @@ class DagsterGraphQLClient:
         asset_key_input = None
         if asset_selection is not None:
             asset_key_input = [
-                AssetKey.from_coercible(key).to_graphql_input() for key in asset_selection
+                AssetKey.from_coercible(coercible).to_graphql_input()
+                for coercible in asset_selection
             ]
 
         variables: dict[str, Any] = {

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -262,7 +262,7 @@ class DagsterGraphQLClient:
                 JobConfigValidationInvalid. Defaults to None.
             tags (Optional[Dict[str, Any]]): A set of tags to add to the job execution.
             op_selection (Optional[Sequence[str]]): A list of ops to execute.
-            asset_selection (Optional[AssetSelection]): An asset selection to execute.
+            asset_selection (Optional[Sequence[CoercibleToAssetKey]]): A list of asset keys to execute.
 
         Raises:
             DagsterGraphQLClientError("InvalidStepError", invalid_step_key): the job has an invalid step

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -80,14 +80,14 @@ def test_job_asset_subset_success(mock_client: MockClient):
         "bar",
         repository_location_name="baz",
         repository_name="quuz",
-        asset_selection=["foo"],
+        asset_selection=[["foo", "bar"], "quux"],
     )
     assert actual_run_id == EXPECTED_RUN_ID
     # Check if the asset_selection argument is properly passed to the GraphQL query
     execute_call_args = mock_client.mock_gql_client.execute.call_args
     selector = execute_call_args[1]["variable_values"]["executionParams"]["selector"]
     assert "assetSelection" in selector
-    assert selector["assetSelection"] == [{"path": ["foo"]}]
+    assert selector["assetSelection"] == [{"path": ["foo", "bar"]}, {"path": ["quux"]}]
 
 
 @python_client_test_suite

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -1,5 +1,6 @@
 import pytest
 from dagster import Config, DagsterInvalidDefinitionError, RunConfig
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.utils import make_new_run_id
 from dagster_graphql import DagsterGraphQLClientError, InvalidOutputErrorInfo
 
@@ -87,7 +88,10 @@ def test_job_asset_subset_success(mock_client: MockClient):
     execute_call_args = mock_client.mock_gql_client.execute.call_args
     selector = execute_call_args[1]["variable_values"]["executionParams"]["selector"]
     assert "assetSelection" in selector
-    assert selector["assetSelection"] == [{"path": ["foo", "bar"]}, {"path": ["quux"]}]
+    assert selector["assetSelection"] == [
+        AssetKey(["foo", "bar"]).to_graphql_input(),
+        AssetKey(["quux"]).to_graphql_input(),
+    ]
 
 
 @python_client_test_suite

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -63,9 +63,31 @@ def test_job_subset_success(mock_client: MockClient):
         "bar",
         repository_location_name="baz",
         repository_name="quuz",
-        op_selection=[""],
+        op_selection=["foobar"],
     )
     assert actual_run_id == EXPECTED_RUN_ID
+    # Check if the op_selection argument is properly passed to the GraphQL query
+    execute_call_args = mock_client.mock_gql_client.execute.call_args
+    assert execute_call_args is not None
+    selector = execute_call_args[1]["variable_values"]["executionParams"]["selector"]
+    assert selector["solidSelection"] == ["foobar"]
+
+
+@python_client_test_suite
+def test_job_asset_subset_success(mock_client: MockClient):
+    mock_client.mock_gql_client.execute.return_value = launch_job_success_response
+    actual_run_id = mock_client.python_client.submit_job_execution(
+        "bar",
+        repository_location_name="baz",
+        repository_name="quuz",
+        asset_selection=["foo"],
+    )
+    assert actual_run_id == EXPECTED_RUN_ID
+    # Check if the asset_selection argument is properly passed to the GraphQL query
+    execute_call_args = mock_client.mock_gql_client.execute.call_args
+    selector = execute_call_args[1]["variable_values"]["executionParams"]["selector"]
+    assert "assetSelection" in selector
+    assert selector["assetSelection"] == [{"path": ["foo"]}]
 
 
 @python_client_test_suite

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -69,7 +69,6 @@ def test_job_subset_success(mock_client: MockClient):
     assert actual_run_id == EXPECTED_RUN_ID
     # Check if the op_selection argument is properly passed to the GraphQL query
     execute_call_args = mock_client.mock_gql_client.execute.call_args
-    assert execute_call_args is not None
     selector = execute_call_args[1]["variable_values"]["executionParams"]["selector"]
     assert selector["solidSelection"] == ["foobar"]
 


### PR DESCRIPTION
## Summary & Motivation

This PR is to address this [issue](https://github.com/dagster-io/dagster/issues/27653).

The idea is to increment the `submit_job_execution` and make it accept a list of AssetKeys as input.

## How I Tested These Changes

First, I ran an example Dagster instance on my machine:
```sh
PYTHONPATH=$(pwd)/examples/docs_snippets dagster dev -f examples/docs_snippets/docs_snippets/concepts/assets/build_job.py -p 3333
```

Then I created a Python script to check the changes:
```py
from dagster_graphql import DagsterGraphQLClient

client = DagsterGraphQLClient("localhost", 3333)

client.submit_job_execution(
    "all_assets_job", asset_selection=["sugary_cereals"]
)

client.submit_job_execution(
    "all_assets_job", asset_selection=["shopping_list"]
)

client.submit_job_execution(
    "all_assets_job"
)
```

And checked that each run selected the correct assets. The last one selected all assets by default and is just a sanity check.

## Changelog

> Expose asset_selection parameter for `submit_job_execution` function in DagsterGraphQLClient.
