### PR TITLE
Drop max step timeout to 30m

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -6,7 +6,7 @@ from dagster_buildkite.images.versions import BUILDKITE_TEST_IMAGE_VERSION
 from dagster_buildkite.python_version import AvailablePythonVersion
 from dagster_buildkite.utils import CommandStep, safe_getenv
 
-DEFAULT_TIMEOUT_IN_MIN = 45
+DEFAULT_TIMEOUT_IN_MIN = 35
 
 DOCKER_PLUGIN = "docker#v5.10.0"
 ECR_PLUGIN = "ecr#v2.7.0"


### PR DESCRIPTION
Looking at our build data, it was a good decision to raise this limit because we do see a handful of different steps with a max successful runtime of more than 25 minutes:

https://github.com/dagster-io/dagster/pull/28945

But we picked 45 pretty blindly. Since then, we've better instrumented our tests and can now measure our longest successful steps. I'd like to start ratcheting this down because when tests do hang, it really baloons the length of the total build. For example:

https://buildkite.com/dagster/dagster-dagster/builds/121207#019688a0-ab20-403b-946a-29acc089444c

It looks like the only test suites that have exceeded 35 minutes in the last 6 weeks and still passed are dagster-dg - but we've since split that into multiple test suites:

https://github.com/dagster-io/dagster/pull/29353

Data analysis:

https://app.hex.tech/455a1b0e-b799-4046-a886-2f1798e9dbc0/hex/0196897d-6e7b-700a-a274-91c3798a6eb8/draft/logic

And we can keep ratcheting this number down over time.