### PR TITLE
Fix kitchen sink tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -704,6 +704,8 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             # airflow
             AvailablePythonVersion.V3_12,
         ],
+        timeout_in_minutes=40,
+        queue=BuildkiteQueue.DOCKER,
     ),
     # Runs against live dbt cloud instance, we only want to run on commits and on the
     # nightly build


### PR DESCRIPTION
## Summary & Motivation
Kitchen sink tests are failing on master due to timeout issues. This bumps timeout and uses the beefier box, I've put it on the docket to figure out how to make the tests faster in general.