### PR TITLE
[NO_SKIP=true] Run kitchen-sink on Docker queue

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -704,6 +704,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             # airflow
             AvailablePythonVersion.V3_12,
         ],
+        queue=BuildkiteQueue.DOCKER,
     ),
     # Runs against live dbt cloud instance, we only want to run on commits and on the
     # nightly build


### PR DESCRIPTION
This started failing recently in ways that look like resource contention on the instance. The agent itself is getting killed about 2/3 of the way through.

This runs it with more resources. Something we previously did for a similar variant of kitchen-sink tests:

https://github.com/dagster-io/dagster/pull/25487

If this build doesn't pass, I'll instead skip the test suite entirely. Either way, we should carve out time to improve this suite's performance and reliability.
