### PR TITLE
Store dynamic partitions loader on the request context instead of passing it around

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -13,11 +13,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.partition import (
-    CachingDynamicPartitionsLoader,
-    PartitionsDefinition,
-    PartitionsSubset,
-)
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.remote_asset_graph import RemoteAssetNode
 from dagster._core.definitions.time_window_partitions import (
     PartitionRangeStatus,
@@ -196,14 +192,12 @@ def _graphene_asset_node(
     graphene_info: "ResolveInfo",
     remote_node: RemoteAssetNode,
     stale_status_loader: Optional[StaleStatusLoader],
-    dynamic_partitions_loader: CachingDynamicPartitionsLoader,
 ):
     from dagster_graphql.schema.asset_graph import GrapheneAssetNode
 
     return GrapheneAssetNode(
         remote_node=remote_node,
         stale_status_loader=stale_status_loader,
-        dynamic_partitions_loader=dynamic_partitions_loader,
     )
 
 
@@ -219,14 +213,11 @@ def get_asset_nodes_by_asset_key(
         loading_context=graphene_info.context,
     )
 
-    dynamic_partitions_loader = CachingDynamicPartitionsLoader(graphene_info.context.instance)
-
     return {
         remote_node.key: _graphene_asset_node(
             graphene_info,
             remote_node,
             stale_status_loader=stale_status_loader,
-            dynamic_partitions_loader=dynamic_partitions_loader,
         )
         for remote_node in graphene_info.context.asset_graph.asset_nodes
     }
@@ -251,9 +242,6 @@ def get_asset_node(
             asset_graph=lambda: graphene_info.context.asset_graph,
             loading_context=graphene_info.context,
         ),
-        dynamic_partitions_loader=CachingDynamicPartitionsLoader(
-            graphene_info.context.instance,
-        ),
     )
 
 
@@ -275,9 +263,6 @@ def get_asset(
             graphene_info,
             graphene_info.context.asset_graph.get(asset_key),
             stale_status_loader=None,
-            dynamic_partitions_loader=CachingDynamicPartitionsLoader(
-                graphene_info.context.instance,
-            ),
         )
     else:
         def_node = None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -17,7 +17,6 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionSnapshot,
 )
 from dagster._core.definitions.partition import (
-    CachingDynamicPartitionsLoader,
     PartitionLoadingContext,
     PartitionsDefinition,
     TemporalContext,
@@ -345,7 +344,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         *,
         remote_node: RemoteAssetNode,
         stale_status_loader: Optional[StaleStatusLoader] = None,
-        dynamic_partitions_loader: Optional[CachingDynamicPartitionsLoader] = None,
     ):
         from dagster_graphql.implementation.fetch_assets import get_unique_asset_id
 
@@ -361,9 +359,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             "stale_status_loader",
             StaleStatusLoader,
         )
-        self._dynamic_partitions_loader = check.opt_inst_param(
-            dynamic_partitions_loader, "dynamic_partitions_loader", CachingDynamicPartitionsLoader
-        )
+
         self._remote_job = None  # lazily loaded
         self._node_definition_snap = None  # lazily loaded
         self._asset_graph_differ = None  # lazily loaded
@@ -458,8 +454,9 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         return self._node_definition_snap
 
-    def get_partition_keys(
+    def _get_partition_keys(
         self,
+        graphene_info: ResolveInfo,
         partitions_snap: Optional[PartitionsSnap] = None,
         start_idx: Optional[int] = None,
         end_idx: Optional[int] = None,
@@ -471,8 +468,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         check.opt_int_param(start_idx, "start_idx")
         check.opt_int_param(end_idx, "end_idx")
 
-        if not self._dynamic_partitions_loader:
-            check.failed("dynamic_partitions_loader must be provided to get partition keys")
+        dynamic_partitions_loader = graphene_info.context.dynamic_partitions_loader
 
         partitions_snap = (
             self._asset_node_snap.partitions if not partitions_snap else partitions_snap
@@ -492,10 +488,10 @@ class GrapheneAssetNode(graphene.ObjectType):
                     )
                 else:
                     return partitions_snap.get_partitions_definition().get_partition_keys(
-                        dynamic_partitions_store=self._dynamic_partitions_loader
+                        dynamic_partitions_store=dynamic_partitions_loader
                     )
             elif isinstance(partitions_snap, DynamicPartitionsSnap):
-                return self._dynamic_partitions_loader.get_dynamic_partitions(
+                return dynamic_partitions_loader.get_dynamic_partitions(
                     partitions_def_name=partitions_snap.name
                 )
             else:
@@ -548,7 +544,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return None
         return GrapheneAssetHealth(
             asset_node_snap=self._asset_node_snap,
-            dynamic_partitions_loader=self._dynamic_partitions_loader,
+            dynamic_partitions_loader=graphene_info.context.dynamic_partitions_loader,
         )
 
     def resolve_hasMaterializePermission(
@@ -1028,7 +1024,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         # return materializations in the same order as the provided partitions, None if
         # materialization does not exist
-        partitions = self.get_partition_keys() if partitions is None else partitions
+        partitions = self._get_partition_keys(graphene_info) if partitions is None else partitions
         ordered_materializations = [
             latest_materialization_by_partition.get(partition) for partition in partitions
         ]
@@ -1060,9 +1056,6 @@ class GrapheneAssetNode(graphene.ObjectType):
     ]:
         asset_key = self._asset_node_snap.asset_key
 
-        if not self._dynamic_partitions_loader:
-            check.failed("dynamic_partitions_loader must be provided to get partition keys")
-
         partitions_def = (
             self._asset_node_snap.partitions.get_partitions_definition()
             if self._asset_node_snap.partitions
@@ -1077,12 +1070,12 @@ class GrapheneAssetNode(graphene.ObjectType):
             graphene_info.context.instance,
             graphene_info.context,
             asset_key,
-            self._dynamic_partitions_loader,
+            graphene_info.context.dynamic_partitions_loader,
             partitions_def,
         )
 
         return build_partition_statuses(
-            self._dynamic_partitions_loader,
+            graphene_info.context.dynamic_partitions_loader,
             materialized_partition_subset,
             failed_partition_subset,
             in_progress_subset,
@@ -1099,7 +1092,9 @@ class GrapheneAssetNode(graphene.ObjectType):
                 failed_partition_subset,
                 in_progress_subset,
             ) = regenerate_and_check_partition_subsets(
-                graphene_info.context, self._asset_node_snap, self._dynamic_partitions_loader
+                graphene_info.context,
+                self._asset_node_snap,
+                graphene_info.context.dynamic_partitions_loader,
             )
 
             failed_or_in_progress_subset = failed_partition_subset | in_progress_subset
@@ -1112,7 +1107,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return GraphenePartitionStats(
                 numMaterialized=len(materialized_and_not_failed_or_in_progress_subset),
                 numPartitions=partitions_snap.get_partitions_definition().get_num_partitions(
-                    dynamic_partitions_store=self._dynamic_partitions_loader
+                    dynamic_partitions_store=graphene_info.context.dynamic_partitions_loader
                 ),
                 numFailed=len(failed_and_not_in_progress_subset),
                 numMaterializing=len(in_progress_subset),
@@ -1173,7 +1168,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_partitionKeysByDimension(
         self,
-        _graphene_info: ResolveInfo,
+        graphene_info: ResolveInfo,
         startIdx: Optional[int] = None,
         endIdx: Optional[int] = None,
     ) -> Sequence[GrapheneDimensionPartitionKeys]:
@@ -1188,7 +1183,8 @@ class GrapheneAssetNode(graphene.ObjectType):
             return [
                 GrapheneDimensionPartitionKeys(
                     name=dimension.name,
-                    partition_keys=self.get_partition_keys(
+                    partition_keys=self._get_partition_keys(
+                        graphene_info,
                         dimension.partitions,
                         startIdx,
                         endIdx,
@@ -1209,12 +1205,14 @@ class GrapheneAssetNode(graphene.ObjectType):
                 type=GraphenePartitionDefinitionType.from_partition_def_data(
                     self._asset_node_snap.partitions
                 ),
-                partition_keys=self.get_partition_keys(start_idx=startIdx, end_idx=endIdx),
+                partition_keys=self._get_partition_keys(
+                    graphene_info=graphene_info, start_idx=startIdx, end_idx=endIdx
+                ),
             )
         ]
 
-    def resolve_partitionKeys(self, _graphene_info: ResolveInfo) -> Sequence[str]:
-        return self.get_partition_keys()
+    def resolve_partitionKeys(self, graphene_info: ResolveInfo) -> Sequence[str]:
+        return self._get_partition_keys(graphene_info)
 
     def resolve_partitionKeyConnection(
         self,
@@ -1223,9 +1221,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         ascending: bool,
         cursor: Optional[str] = None,
     ) -> Optional[GraphenePartitionKeyConnection]:
-        if not self._dynamic_partitions_loader:
-            check.failed("dynamic_partitions_loader must be provided to get partition keys")
-
         if not self._remote_node.is_partitioned:
             return None
 
@@ -1235,7 +1230,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 effective_dt=get_current_datetime(),
                 last_event_id=graphene_info.context.instance.event_log_storage.get_maximum_record_id(),
             ),
-            dynamic_partitions_store=self._dynamic_partitions_loader,
+            dynamic_partitions_store=graphene_info.context.dynamic_partitions_loader,
         )
         results = partitions_def.get_paginated_partition_keys(
             context=context,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Optional, cast
 
 import graphene
 from dagster import _check as check
-from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation import (
     CodeLocation,
@@ -386,9 +385,6 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_assetNodes(self, graphene_info: ResolveInfo):
         remote_nodes = self.get_repository(graphene_info).asset_graph.asset_nodes
 
-        dynamic_partitions_loader = CachingDynamicPartitionsLoader(
-            graphene_info.context.instance,
-        )
         stale_status_loader = StaleStatusLoader(
             instance=graphene_info.context.instance,
             asset_graph=lambda: self.get_repository(graphene_info).asset_graph,
@@ -399,7 +395,6 @@ class GrapheneRepository(graphene.ObjectType):
             GrapheneAssetNode(
                 remote_node=remote_node,
                 stale_status_loader=stale_status_loader,
-                dynamic_partitions_loader=dynamic_partitions_loader,
             )
             for remote_node in remote_nodes
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -5,7 +5,6 @@ import dagster._check as check
 import graphene
 from dagster import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import (
     InstigatorSelector,
@@ -1051,7 +1050,6 @@ class GrapheneQuery(graphene.ObjectType):
 
         repo = None
 
-        dynamic_partitions_loader = CachingDynamicPartitionsLoader(graphene_info.context.instance)
         if group is not None:
             group_name = group.groupName
             repo_sel = RepositorySelector.from_graphql_input(group)
@@ -1110,7 +1108,6 @@ class GrapheneQuery(graphene.ObjectType):
             GrapheneAssetNode(
                 remote_node=remote_node,
                 stale_status_loader=stale_status_loader,
-                dynamic_partitions_loader=dynamic_partitions_loader,
             )
             for remote_node in results
         ]

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -15,6 +15,7 @@ import dagster._check as check
 from dagster._config.snap import ConfigTypeSnap
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.remote_asset_graph import RemoteRepositoryAssetNode
 from dagster._core.definitions.selector import (
     JobSelector,
@@ -127,6 +128,10 @@ class BaseWorkspaceRequestContext(LoadingContext):
             asset_graph=self.asset_graph,
             loading_context=self,
         )
+
+    @cached_property
+    def dynamic_partitions_loader(self) -> CachingDynamicPartitionsLoader:
+        return CachingDynamicPartitionsLoader(self.instance)
 
     @cached_property
     def data_time_resolver(self) -> CachingDataTimeResolver:


### PR DESCRIPTION
## Summary & Motivation
Right now we pass around this object to the GrapheneAssetNode construction, but not every callsite is covered. Instead, put one on the request context so that it is always available.

## How I Tested These Changes
Existing coverage


