### PR TITLE
`AssetFreshnessHealthState` for streamline

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -18,7 +18,6 @@ class FreshnessState(str, Enum):
     WARN = "WARN"
     FAIL = "FAIL"
     UNKNOWN = "UNKNOWN"
-    NOT_APPLICABLE = "NOT_APPLICABLE"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -18,6 +18,7 @@ class FreshnessState(str, Enum):
     WARN = "WARN"
     FAIL = "FAIL"
     UNKNOWN = "UNKNOWN"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -35,6 +35,7 @@ from dagster._core.definitions.base_asset_graph import (
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -324,6 +325,10 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
     @property
     def backfill_policy(self) -> Optional[BackfillPolicy]:
         return self._materializable_node_snap.backfill_policy if self.is_materializable else None
+
+    @property
+    def internal_freshness_policy(self) -> Optional[InternalFreshnessPolicy]:
+        return InternalFreshnessPolicy.from_asset_spec_metadata(self.metadata)
 
     ##### REMOTE-SPECIFIC INTERFACE
     @cached_method

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -748,8 +748,8 @@ class DagsterEvent(
             return self.asset_materialization_planned_data.asset_key
         elif self.event_type == DagsterEventType.ASSET_FAILED_TO_MATERIALIZE:
             return self.asset_failed_to_materialize_data.asset_key
-        elif self.event_type == DagsterEventType.FRESHNESS_STATE_EVALUATION:
-            return self.asset_freshness_state_evaluation_data.key
+        elif self.event_type == DagsterEventType.FRESHNESS_STATE_CHANGE:
+            return self.asset_freshness_state_change_data.key
         else:
             return None
 
@@ -849,15 +849,15 @@ class DagsterEvent(
         return cast("AssetFailedToMaterializeData", self.event_specific_data)
 
     @property
-    def asset_freshness_state_evaluation_data(
+    def asset_freshness_state_change_data(
         self,
-    ) -> "FreshnessStateEvaluation":
+    ) -> "FreshnessStateChange":
         _assert_type(
-            "asset_freshness_state_evaluation_data",
-            DagsterEventType.FRESHNESS_STATE_EVALUATION,
+            "asset_freshness_state_change_data",
+            DagsterEventType.FRESHNESS_STATE_CHANGE,
             self.event_type,
         )
-        return cast("FreshnessStateEvaluation", self.event_specific_data)
+        return cast("FreshnessStateChange", self.event_specific_data)
 
     @property
     def step_expectation_result_data(self) -> "StepExpectationResultData":

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -748,6 +748,8 @@ class DagsterEvent(
             return self.asset_materialization_planned_data.asset_key
         elif self.event_type == DagsterEventType.ASSET_FAILED_TO_MATERIALIZE:
             return self.asset_failed_to_materialize_data.asset_key
+        elif self.event_type == DagsterEventType.FRESHNESS_STATE_EVALUATION:
+            return self.asset_freshness_state_evaluation_data.key
         else:
             return None
 
@@ -845,6 +847,17 @@ class DagsterEvent(
             self.event_type,
         )
         return cast("AssetFailedToMaterializeData", self.event_specific_data)
+
+    @property
+    def asset_freshness_state_evaluation_data(
+        self,
+    ) -> "FreshnessStateEvaluation":
+        _assert_type(
+            "asset_freshness_state_evaluation_data",
+            DagsterEventType.FRESHNESS_STATE_EVALUATION,
+            self.event_type,
+        )
+        return cast("FreshnessStateEvaluation", self.event_specific_data)
 
     @property
     def step_expectation_result_data(self) -> "StepExpectationResultData":

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -22,6 +22,8 @@ class AssetFreshnessHealthState:
             return AssetHealthStatus.WARNING
         elif self.freshness_state == FreshnessState.FAIL:
             return AssetHealthStatus.DEGRADED
+        elif self.freshness_state == FreshnessState.NOT_APPLICABLE:
+            return AssetHealthStatus.NOT_APPLICABLE
         else:
             return AssetHealthStatus.UNKNOWN
 

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -1,12 +1,9 @@
-from typing import Optional
-
 from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.loader import LoadingContext
-from dagster._core.storage.event_log.base import AssetRecord
 from dagster._streamline.asset_health import AssetHealthStatus
 
 
@@ -16,7 +13,6 @@ class AssetFreshnessHealthState:
     """Maintains the latest freshness state for the asset."""
 
     freshness_state: FreshnessState
-    last_materialization_timestamp: Optional[float] = None
 
     @property
     def health_status(self) -> AssetHealthStatus:
@@ -32,27 +28,17 @@ class AssetFreshnessHealthState:
             return AssetHealthStatus.UNKNOWN
 
     @classmethod
-    async def compute_for_asset(
+    def compute_for_asset(
         cls, asset_key: AssetKey, loading_context: LoadingContext
     ) -> "AssetFreshnessHealthState":
-        """Using the latest terminal state for each check as stored in the DB, returns a set of
-        asset checks in each terminal state. If a check is in progress, it remains in the terminal
-        state it was in prior to the in progress execution.
-        """
+        """Gets the freshness state for the asset from the DB."""
         freshness_state_record = loading_context.instance.get_entity_freshness_state(asset_key)
-        asset_record = await AssetRecord.gen(loading_context, asset_key)
-        last_materialization_ts = (
-            asset_record.asset_entry.last_materialization.timestamp
-            if asset_record and asset_record.asset_entry.last_materialization
-            else None
-        )
+
         if freshness_state_record is None:
-            # asset has a freshness policy, but it has not been evaluated yet
+            # freshness policy has no evaluations yet
             return cls(
                 freshness_state=FreshnessState.UNKNOWN,
-                last_materialization_timestamp=last_materialization_ts,
             )
         return cls(
             freshness_state=freshness_state_record.freshness_state,
-            last_materialization_timestamp=last_materialization_ts,
         )

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -1,7 +1,12 @@
+from typing import Optional
+
 from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.freshness import FreshnessState
+from dagster._core.loader import LoadingContext
+from dagster._core.storage.event_log.base import AssetRecord
 from dagster._streamline.asset_health import AssetHealthStatus
 
 
@@ -11,6 +16,7 @@ class AssetFreshnessHealthState:
     """Maintains the latest freshness state for the asset."""
 
     freshness_state: FreshnessState
+    last_materialization_timestamp: Optional[float] = None
 
     @property
     def health_status(self) -> AssetHealthStatus:
@@ -26,13 +32,27 @@ class AssetFreshnessHealthState:
             return AssetHealthStatus.UNKNOWN
 
     @classmethod
-    def compute_for_asset(cls, asset_key, loading_context):
+    async def compute_for_asset(
+        cls, asset_key: AssetKey, loading_context: LoadingContext
+    ) -> "AssetFreshnessHealthState":
         """Using the latest terminal state for each check as stored in the DB, returns a set of
         asset checks in each terminal state. If a check is in progress, it remains in the terminal
         state it was in prior to the in progress execution.
         """
         freshness_state_record = loading_context.instance.get_entity_freshness_state(asset_key)
+        asset_record = await AssetRecord.gen(loading_context, asset_key)
+        last_materialization_ts = (
+            asset_record.asset_entry.last_materialization.timestamp
+            if asset_record and asset_record.asset_entry.last_materialization
+            else None
+        )
         if freshness_state_record is None:
             # asset has a freshness policy, but it has not been evaluated yet
-            return cls(freshness_state=FreshnessState.UNKNOWN)
-        return cls(freshness_state=freshness_state_record.freshness_state)
+            return cls(
+                freshness_state=FreshnessState.UNKNOWN,
+                last_materialization_timestamp=last_materialization_ts,
+            )
+        return cls(
+            freshness_state=freshness_state_record.freshness_state,
+            last_materialization_timestamp=last_materialization_ts,
+        )

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -1,0 +1,18 @@
+from dagster_shared import record
+from dagster_shared.serdes import whitelist_for_serdes
+
+from dagster._core.definitions.freshness import FreshnessState
+
+
+@whitelist_for_serdes
+@record.record
+class AssetFreshnessHealthState:
+    """Maintains the latest freshness state for the asset."""
+
+    freshness_state: FreshnessState
+
+    @classmethod
+    def default(cls) -> "AssetFreshnessHealthState":
+        return cls(
+            freshness_state=FreshnessState.UNKNOWN,
+        )

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -22,8 +22,6 @@ class AssetFreshnessHealthState:
             return AssetHealthStatus.WARNING
         elif self.freshness_state == FreshnessState.FAIL:
             return AssetHealthStatus.DEGRADED
-        elif self.freshness_state == FreshnessState.NOT_APPLICABLE:
-            return AssetHealthStatus.NOT_APPLICABLE
         else:
             return AssetHealthStatus.UNKNOWN
 

--- a/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_freshness_health.py
@@ -2,6 +2,7 @@ from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
 from dagster._core.definitions.freshness import FreshnessState
+from dagster._streamline.asset_health import AssetHealthStatus
 
 
 @whitelist_for_serdes
@@ -11,8 +12,27 @@ class AssetFreshnessHealthState:
 
     freshness_state: FreshnessState
 
+    @property
+    def health_status(self) -> AssetHealthStatus:
+        if self.freshness_state == FreshnessState.PASS:
+            return AssetHealthStatus.HEALTHY
+        elif self.freshness_state == FreshnessState.WARN:
+            return AssetHealthStatus.WARNING
+        elif self.freshness_state == FreshnessState.FAIL:
+            return AssetHealthStatus.DEGRADED
+        elif self.freshness_state == FreshnessState.NOT_APPLICABLE:
+            return AssetHealthStatus.NOT_APPLICABLE
+        else:
+            return AssetHealthStatus.UNKNOWN
+
     @classmethod
-    def default(cls) -> "AssetFreshnessHealthState":
-        return cls(
-            freshness_state=FreshnessState.UNKNOWN,
-        )
+    def compute_for_asset(cls, asset_key, loading_context):
+        """Using the latest terminal state for each check as stored in the DB, returns a set of
+        asset checks in each terminal state. If a check is in progress, it remains in the terminal
+        state it was in prior to the in progress execution.
+        """
+        freshness_state_record = loading_context.instance.get_entity_freshness_state(asset_key)
+        if freshness_state_record is None:
+            # asset has a freshness policy, but it has not been evaluated yet
+            return cls(freshness_state=FreshnessState.UNKNOWN)
+        return cls(freshness_state=freshness_state_record.freshness_state)


### PR DESCRIPTION
## Summary & Motivation
Adds a `AssetFreshnessHealthState` state for streamline to update. 

Also adds some helper methods to get info about a freshness event from the event log entry and the freshness policy from an assetnode

corresponding internal pr https://github.com/dagster-io/internal/pull/15433

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
