### PR TITLE
[dg] Basic support for scaffolding multi-document YAML components

### DIFF
--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -32,12 +32,29 @@ def scaffold_component(
     yaml_attributes: Optional[Mapping[str, Any]] = None,
 ) -> None:
     if request.scaffold_format == "yaml":
-        with open(request.target_path / "component.yaml", "w") as f:
-            component_data = {"type": request.type_name, "attributes": yaml_attributes or {}}
-            yaml.dump(
-                component_data, f, Dumper=ComponentDumper, sort_keys=False, default_flow_style=False
-            )
-            f.writelines([""])
+        component_data = {"type": request.type_name, "attributes": yaml_attributes or {}}
+
+        target_file = request.target_path / "component.yaml"
+        if target_file.exists() and target_file.stat().st_size > 0:
+            # Append a new YAML document to the existing file
+            with open(target_file, "a") as f:
+                f.write("\n---\n\n")
+                yaml.dump(
+                    component_data,
+                    f,
+                    Dumper=ComponentDumper,
+                    sort_keys=False,
+                    default_flow_style=False,
+                )
+        else:
+            with open(target_file, "w") as f:
+                yaml.dump(
+                    component_data,
+                    f,
+                    Dumper=ComponentDumper,
+                    sort_keys=False,
+                    default_flow_style=False,
+                )
     elif request.scaffold_format == "python":
         with open(request.target_path / "component.py", "w") as f:
             fqtn = request.type_name

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -785,13 +785,30 @@ def _core_scaffold(
     key_value_params,
     json_params,
     scaffold_format: ScaffoldFormatOptions,
+    skip_confirmation_prompt: bool,
 ) -> None:
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
     if not registry.has(object_key):
         exit_with_error(f"Scaffoldable object type `{object_key.to_typename()}` not found.")
     elif dg_context.has_component_instance(instance_name):
-        exit_with_error(f"A component instance named `{instance_name}` already exists.")
+        if (
+            scaffold_format == "yaml"
+            and (Path(dg_context.defs_path) / instance_name / "component.yaml").exists()
+        ):
+            if not skip_confirmation_prompt:
+                click.confirm(
+                    f"A component already exists at `{Path(dg_context.defs_path) / instance_name / 'component.yaml'!s}`."
+                    "\nAdd a new instance to component.yaml?",
+                    abort=True,
+                )
+            else:
+                click.echo(
+                    f"A component already exists at `{Path(dg_context.defs_path) / instance_name / 'component.yaml'!s}`."
+                    "\nAdding a new instance to component.yaml."
+                )
+        else:
+            exit_with_error(f"A component instance named `{instance_name}` already exists.")
 
     # Specified key-value params will be passed to this function with their default value of
     # `None` even if the user did not set them. Filter down to just the ones that were set by
@@ -844,6 +861,13 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
         default="yaml",
         help="Format of the component configuration (yaml or python)",
     )
+    @click.option(
+        "-y",
+        "--yes",
+        "skip_confirmation_prompt",
+        is_flag=True,
+        help="Do not confirm merging of multiple documents in yaml format.",
+    )
     @click.pass_context
     @cli_telemetry_wrapper
     def scaffold_command(
@@ -851,6 +875,7 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
         instance_name: str,
         json_params: Mapping[str, Any],
         format: str,  # noqa: A002 "format" name required for click magic
+        skip_confirmation_prompt: bool,
         **key_value_params: Any,
     ) -> None:
         f"""Scaffold a {key.name} object.
@@ -883,6 +908,7 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
             key_value_params,
             json_params,
             cast("ScaffoldFormatOptions", format),
+            skip_confirmation_prompt,
         )
 
     # If there are defined scaffold params, add them to the command

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -409,6 +409,39 @@ def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
+def test_scaffold_yaml_multiple_documents_success(in_workspace: bool) -> None:
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace),
+    ):
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+        )
+        assert_runner_result(result)
+        assert Path("src/foo_bar/defs/qux").exists()
+        component_yaml_path = Path("src/foo_bar/defs/qux/component.yaml")
+        assert component_yaml_path.exists()
+        assert component_yaml_path.read_text().count("---") == 0
+
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux", input="n\n"
+        )
+        assert_runner_result(result, exit_0=False)
+
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux", input="y\n"
+        )
+        assert_runner_result(result)
+        assert component_yaml_path.read_text().count("---") == 1
+
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux", "--yes"
+        )
+        assert_runner_result(result)
+        assert component_yaml_path.read_text().count("---") == 2
+
+
+@pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,


### PR DESCRIPTION
## Summary

Based on https://github.com/dagster-io/dagster/pull/29696, updates `dg scaffold` to allow scaffolding multiple instances of a component into a `component.yaml` file, if the user confirms a dialog.

The `scaffold_component` util now merges YAML into a YAML file rather than replacing it. User-defined scaffolders will need to gracefully handle scaffolding multiple copies of other files (e.g. replication.yaml) - we may want to make this explicitly opt-in functionality from a component type author.

```sh
dg scaffold dagster_sling.SlingReplicationCollectionComponent sync_to_snowflake
A component already exists at `/Users/ben/repos/components_demo/multiyaml/src/multiyaml/defs/sync_to_snowflake/component.yaml`.
Add a new instance to component.yaml? [y/N]: y
```



## Test Plan

New unit tests.
