### PR TITLE
[components] Require opt-in to multi-document YAML scaffolding, provide context to scaffolder

### DIFF
--- a/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/all_metadata_empty_asset.py
@@ -2,8 +2,16 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components import Component, ComponentLoadContext
+from dagster.components.scaffold.scaffold import Scaffolder, scaffold_with
 
 
+class AllMetadataEmptyComponentScaffolder(Scaffolder):
+    @classmethod
+    def supports_multi_document_yaml(cls) -> bool:
+        return True
+
+
+@scaffold_with(AllMetadataEmptyComponentScaffolder)
 class AllMetadataEmptyComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         @asset

--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -105,12 +105,20 @@ def scaffold_object(
         f"scaffold must be either 'yaml' or 'python'. Got {scaffold_format}.",
     )
 
+    if scaffold_format == "yaml" and (path / "component.yaml").exists():
+        is_subsequent_instance = True
+        yaml_instance_index = (path / "component.yaml").read_text().count("---") + 2
+    else:
+        is_subsequent_instance = False
+        yaml_instance_index = None
     scaffolder.scaffold(
         ScaffoldRequest(
             type_name=typename,
             target_path=path,
             scaffold_format=cast("ScaffoldFormatOptions", scaffold_format),
             project_root=project_root,
+            is_subsequent_instance=is_subsequent_instance,
+            yaml_instance_index=yaml_instance_index,
         ),
         scaffold_params,
     )

--- a/python_modules/dagster/dagster/components/core/snapshot.py
+++ b/python_modules/dagster/dagster/components/core/snapshot.py
@@ -39,7 +39,8 @@ def _get_component_type_data(obj: type[Component]) -> ComponentFeatureData:
 def _get_scaffold_target_type_data(scaffolder: Scaffolder) -> ScaffoldTargetTypeData:
     scaffolder_schema = scaffolder.get_scaffold_params()
     return ScaffoldTargetTypeData(
-        schema=scaffolder_schema.model_json_schema() if scaffolder_schema else None
+        schema=scaffolder_schema.model_json_schema() if scaffolder_schema else None,
+        supports_multi_document_yaml=scaffolder.supports_multi_document_yaml(),
     )
 
 

--- a/python_modules/dagster/dagster/components/scaffold/scaffold.py
+++ b/python_modules/dagster/dagster/components/scaffold/scaffold.py
@@ -92,6 +92,10 @@ class ScaffoldRequest:
     scaffold_format: ScaffoldFormatOptions
     # the root of the dg project
     project_root: Optional[Path]
+    # whether this request is for a second, third, etc instance of a multi-document yaml file
+    is_subsequent_instance: bool
+    # the index of the yaml instance if this is a subsequent instance
+    yaml_instance_index: Optional[int]
 
 
 @public
@@ -105,3 +109,7 @@ class Scaffolder:
 
     @abstractmethod
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None: ...
+
+    @classmethod
+    def supports_multi_document_yaml(cls) -> bool:
+        return False

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -68,7 +68,7 @@ def test_list_plugins_from_module():
                     "type": "object",
                 }
             ),
-            ScaffoldTargetTypeData(schema=None),
+            ScaffoldTargetTypeData(schema=None, supports_multi_document_yaml=False),
         ],
     )
 
@@ -101,7 +101,10 @@ def test_list_plugins_from_module():
         tags=[],
         feature_data=[
             ComponentFeatureData(schema=pipes_script_component_model_schema),
-            ScaffoldTargetTypeData(schema=pipes_script_component_scaffold_params_schema),
+            ScaffoldTargetTypeData(
+                schema=pipes_script_component_scaffold_params_schema,
+                supports_multi_document_yaml=False,
+            ),
         ],
     )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -786,6 +786,7 @@ def _core_scaffold(
     json_params,
     scaffold_format: ScaffoldFormatOptions,
     skip_confirmation_prompt: bool,
+    supports_multi_document_yaml: bool,
 ) -> None:
     dg_context = DgContext.for_project_environment(Path.cwd(), cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
@@ -795,6 +796,7 @@ def _core_scaffold(
         if (
             scaffold_format == "yaml"
             and (Path(dg_context.defs_path) / instance_name / "component.yaml").exists()
+            and supports_multi_document_yaml
         ):
             if not skip_confirmation_prompt:
                 click.confirm(
@@ -909,6 +911,7 @@ def _create_scaffold_subcommand(key: PluginObjectKey, obj: PluginObjectSnap) -> 
             json_params,
             cast("ScaffoldFormatOptions", format),
             skip_confirmation_prompt,
+            obj.supports_multi_document_yaml,
         )
 
     # If there are defined scaffold params, add them to the command

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
@@ -71,6 +71,7 @@ class ComponentFeatureData(PluginObjectFeatureData):
 @record
 class ScaffoldTargetTypeData(PluginObjectFeatureData):
     schema: Optional[dict[str, Any]]
+    supports_multi_document_yaml: bool
 
     @property
     def feature(self) -> PluginObjectFeature:
@@ -114,6 +115,11 @@ class PluginObjectSnap:
     def scaffolder_schema(self) -> Optional[dict[str, Any]]:
         scaffolder_data = self.get_feature_data("scaffold-target")
         return scaffolder_data.schema if scaffolder_data else None
+
+    @property
+    def supports_multi_document_yaml(self) -> bool:
+        scaffolder_data = self.get_feature_data("scaffold-target")
+        return scaffolder_data.supports_multi_document_yaml if scaffolder_data else False
 
     @property
     def component_schema(self) -> Optional[dict[str, Any]]:

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/scaffolder.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/scaffolder.py
@@ -7,7 +7,16 @@ from dagster.components.component_scaffolding import scaffold_component
 
 class SlingReplicationComponentScaffolder(Scaffolder):
     def scaffold(self, request: ScaffoldRequest, params: Any) -> None:
-        scaffold_component(request, {"replications": [{"path": "replication.yaml"}]})
-        replication_path = request.target_path / "replication.yaml"
+        replication_file_name = (
+            "replication.yaml"
+            if not request.is_subsequent_instance
+            else f"replication_{request.yaml_instance_index}.yaml"
+        )
+        scaffold_component(request, {"replications": [{"path": replication_file_name}]})
+        replication_path = request.target_path / replication_file_name
         with open(replication_path, "w") as f:
             yaml.dump({"source": {}, "target": {}, "streams": {}}, f)
+
+    @classmethod
+    def supports_multi_document_yaml(cls) -> bool:
+        return True


### PR DESCRIPTION
## Summary

Potentially overkill mitigation to #29720 which requires that scaffolders explicitly opt in to allowing for multi-document YAML components. The scaffold function is provided with a boolean value and integer index for the newly scaffolded component in a multi-document file:

```sh
$ dg scaffold dagster_sling.SlingReplicationCollectionComponent sync_to_snowflake
Using /Users/ben/repos/components_demo/multiyaml/.venv/bin/dagster-components


$ tree src/multiyaml/defs/sync_to_snowflake/
src/multiyaml/defs/sync_to_snowflake/
├── component.yaml
└── replication.yaml

1 directory, 2 files


$ dg scaffold dagster_sling.SlingReplicationCollectionComponent sync_to_snowflake
A component already exists at `/Users/ben/repos/components_demo/multiyaml/src/multiyaml/defs/sync_to_snowflake/component.yaml`.
Add a new instance to component.yaml? [y/N]: y
Using /Users/ben/repos/components_demo/multiyaml/.venv/bin/dagster-components


$ tree src/multiyaml/defs/sync_to_snowflake/
src/multiyaml/defs/sync_to_snowflake/
├── component.yaml
├── replication_2.yaml
└── replication.yaml

1 directory, 3 files


$ cat src/multiyaml/defs/sync_to_snowflake/component.yaml 
type: dagster_sling.SlingReplicationCollectionComponent

attributes:
  replications:
    - path: replication.yaml

---

type: dagster_sling.SlingReplicationCollectionComponent

attributes:
  replications:
    - path: replication_2.yaml
```


## Test Plan

Existing tests.
