### PR TITLE
[partitions] Fix issue with the `has_partition_key` method on MultiPartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -896,3 +896,22 @@ def test_large_cross_product_memory_usage():
         assert paginated_results.has_more
         mock_product.assert_not_called()
         mock_get_partition_keys.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("a|2", True),
+        ("c|1", True),
+        ("2|a", False),
+        ("a|b", False),
+        ("abc", False),
+        ("super1@#^k-INVALID", False),
+    ],
+)
+def test_has_partition_key(key: str, expected: bool) -> None:
+    dim1 = StaticPartitionsDefinition(["a", "b", "c"])
+    dim2 = StaticPartitionsDefinition(["1", "2", "3"])
+
+    multi_partitions = MultiPartitionsDefinition({"dim1": dim1, "dim2": dim2})
+    assert multi_partitions.has_partition_key(key) == expected


### PR DESCRIPTION
## Summary & Motivation

If the partition key that's passed into a MultiPartitionsDefinition's has_partition_key is not a multi partition key, it spits out an error. This is bad, and we should instead return false.

## How I Tested These Changes

## Changelog

Fixed a bug which could cause an error when calling `MultiPartitionsDefinition.has_partition_key()` on invalid keys.
