### PR TITLE
[dg] Add consuming components to `dg list env`

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/env.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/env.py
@@ -23,7 +23,7 @@ def get_project_specified_env_vars(dg_context: DgContext) -> Mapping[str, Sequen
     requiring them.
     """
     env_vars = defaultdict(list)
-    for component_dir in dg_context.defs_path.iterdir():
+    for component_dir in dg_context.defs_path.rglob("*"):
         component_path = component_dir / "component.yaml"
 
         if component_path.exists():

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -582,10 +582,10 @@ def test_list_env_succeeds():
         )
 
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "mydefs"
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "subfolder/mydefs"
         )
         assert_runner_result(result)
-        Path("src/foo_bar/defs/mydefs/component.yaml").write_text(
+        Path("src/foo_bar/defs/subfolder/mydefs/component.yaml").write_text(
             textwrap.dedent("""
                 type: dagster_test.components.AllMetadataEmptyComponent
 
@@ -600,11 +600,11 @@ def test_list_env_succeeds():
         assert (
             result.output.strip()
             == textwrap.dedent("""
-               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
-               ┃ Env Var ┃ Value ┃ Components ┃
-               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
-               │ FOO     │ bar   │ mydefs     │
-               └─────────┴───────┴────────────┘
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components       ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+               │ FOO     │ bar   │ subfolder/mydefs │
+               └─────────┴───────┴──────────────────┘
         """).strip()
         )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -573,11 +573,38 @@ def test_list_env_succeeds():
         assert (
             result.output.strip()
             == textwrap.dedent("""
-               ┏━━━━━━━━━┳━━━━━━━┓
-               ┃ Env Var ┃ Value ┃
-               ┡━━━━━━━━━╇━━━━━━━┩
-               │ FOO     │ bar   │
-               └─────────┴───────┘
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
+               │ FOO     │ bar   │            │
+               └─────────┴───────┴────────────┘
+        """).strip()
+        )
+
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "mydefs"
+        )
+        assert_runner_result(result)
+        Path("src/foo_bar/defs/mydefs/component.yaml").write_text(
+            textwrap.dedent("""
+                type: dagster_test.components.AllMetadataEmptyComponent
+
+                requirements:
+                    env:
+                        - FOO
+            """)
+        )
+
+        result = runner.invoke("list", "env")
+        assert_runner_result(result)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
+               │ FOO     │ bar   │ mydefs     │
+               └─────────┴───────┴────────────┘
         """).strip()
         )
 


### PR DESCRIPTION
## Summary

This was somewhere in the env demo stack and never got split into its own PR.

Adds a column to the `dg list env` output showing which components consume an env var:
```sh
$ dg list env

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
┃ Env Var                                        ┃ Value ┃ Components ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
│ DESTINATION__SNOWFLAKE__CREDENTIALS__DATABASE  │       │ envvar2    │
│ DESTINATION__SNOWFLAKE__CREDENTIALS__HOST      │       │ envvar2    │
│ DESTINATION__SNOWFLAKE__CREDENTIALS__PASSWORD  │       │ envvar2    │
│ DESTINATION__SNOWFLAKE__CREDENTIALS__ROLE      │       │ envvar2    │
│ DESTINATION__SNOWFLAKE__CREDENTIALS__USERNAME  │       │ envvar2    │
│ DESTINATION__SNOWFLAKE__CREDENTIALS__WAREHOUSE │       │ envvar2    │
│ SOURCES__GITHUB__ACCESS_TOKEN                  │       │ envvar2    │
└────────────────────────────────────────────────┴───────┴────────────┘
```

## TEst Plan

Unit test.
