### PR TITLE
[streamline] State for the latest materialization timestamp for an asset

### DIFF
--- a/python_modules/dagster/dagster/_streamline/lastest_materialization_state.py
+++ b/python_modules/dagster/dagster/_streamline/lastest_materialization_state.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from dagster_shared import record
+from dagster_shared.serdes import whitelist_for_serdes
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.loader import LoadingContext
+from dagster._core.storage.event_log.base import AssetRecord
+
+
+@whitelist_for_serdes
+@record.record
+class AssetLatestMaterializationState:
+    """Maintains info about the latest materialization of an asset."""
+
+    timestamp: float
+    run_id: str
+
+    @classmethod
+    async def compute_for_asset(
+        cls, asset_key: AssetKey, loading_context: LoadingContext
+    ) -> Optional["AssetLatestMaterializationState"]:
+        """Compute the latest materialization state for an asset based on data stored in the DB."""
+        asset_record = await AssetRecord.gen(loading_context, asset_key)
+        if asset_record is None or asset_record.asset_entry.last_materialization is None:
+            # asset has never been materialized
+            return None
+        return cls(
+            timestamp=asset_record.asset_entry.last_materialization.timestamp,
+            run_id=asset_record.asset_entry.last_materialization.run_id,
+        )


### PR DESCRIPTION
## Summary & Motivation
For asset health, we want to report on the latest materialization of an asset when a freshness policy has been violated. We could store the latest materialization timestamp on the freshness state object, but the implementation became quite tricky, since we'd need to keep tracking the latest materialization timestamp for every asset even if it had no freshness policy so that if a freshness policy were added in the future, we'd have the metadata without having to query the event log.

Being able to access the latest materialization time and run id (and maybe some other metadata in the future) for an asset seems generally useful, so i figured i'd break it out into it's own state and streamline consumer. this made the freshness implementation wayyyyyy simpler too. 

Having this as a streamline consumer isn't strictly required since we can get this info w one DB row read from the AssetKeys table, but i figured i'd throw this out there as an option

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
