### PR TITLE
Catalog insights polish

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -27,7 +27,7 @@ import {MaterializationHistoryEventTypeSelector} from '../graphql/types';
 
 export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthFragment}) => {
   // Wait 100ms to avoid querying during fast scrolling of the table
-  const shouldQuery = useDelayedState(100);
+  const shouldQuery = useDelayedState(500);
   const {
     materializations: _materializations,
     observations: _observations,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Mono,
   Popover,
+  Spinner,
   Subheading,
 } from '@dagster-io/ui-components';
 import React from 'react';
@@ -27,12 +28,16 @@ export type ActivityChartData = {
 };
 
 export const ActivityChart = React.memo(
-  ({metrics, unit}: {metrics: ActivityChartData; unit: string}) => {
+  ({metrics, unit, loading}: {metrics: ActivityChartData; unit: string; loading: boolean}) => {
     const {header, color, dataByDay, max} = metrics;
     return (
       <div className={styles.ActivityChartContainer}>
-        <Box flex={{direction: 'row', alignItems: 'center'}} padding={{bottom: 12}}>
+        <Box
+          flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+          padding={{bottom: 12}}
+        >
           <BodyLarge>{header}</BodyLarge>
+          {loading ? <Spinner purpose="body-text" /> : null}
         </Box>
         <div className={styles.ActivityChart}>
           {dataByDay.map((dayData) => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -1,11 +1,21 @@
-import {BodyLarge, BodySmall, Box, Popover} from '@dagster-io/ui-components';
+import {
+  Body,
+  BodyLarge,
+  BodySmall,
+  Box,
+  Mono,
+  Popover,
+  Subheading,
+} from '@dagster-io/ui-components';
 import React from 'react';
 
 import styles from './AssetCatalogInsights.module.css';
+import {TooltipCard} from '../../insights/InsightsChartShared';
 import {numberFormatter} from '../../ui/formatters';
+import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
 export type ActivityChartDayData = {
-  date: string;
+  date: number;
   hourlyValues: Array<number | null>;
 };
 
@@ -16,37 +26,40 @@ export type ActivityChartData = {
   color: string;
 };
 
-export const ActivityChart = React.memo(({metrics}: {metrics: ActivityChartData}) => {
-  const {header, color, dataByDay, max} = metrics;
-  return (
-    <div className={styles.ActivityChartContainer}>
-      <Box flex={{direction: 'row', alignItems: 'center'}} padding={{bottom: 12}}>
-        <BodyLarge>{header}</BodyLarge>
-      </Box>
-      <div className={styles.ActivityChart}>
-        {dataByDay.map((dayData) => (
-          <ActivityChartRow
-            key={dayData.date}
-            date={dayData.date}
-            hourlyValues={dayData.hourlyValues}
-            max={max}
-            color={color}
-          />
-        ))}
-        <div className={styles.ActivityChartRow}>
-          <div />
-          <div className={styles.ActivityChartBottomLegend}>
-            <BodySmall>12AM</BodySmall>
-            <BodySmall>6AM</BodySmall>
-            <BodySmall>12PM</BodySmall>
-            <BodySmall>6PM</BodySmall>
-            <BodySmall>12AM</BodySmall>
+export const ActivityChart = React.memo(
+  ({metrics, unit}: {metrics: ActivityChartData; unit: string}) => {
+    const {header, color, dataByDay, max} = metrics;
+    return (
+      <div className={styles.ActivityChartContainer}>
+        <Box flex={{direction: 'row', alignItems: 'center'}} padding={{bottom: 12}}>
+          <BodyLarge>{header}</BodyLarge>
+        </Box>
+        <div className={styles.ActivityChart}>
+          {dataByDay.map((dayData) => (
+            <ActivityChartRow
+              key={dayData.date}
+              date={dayData.date}
+              hourlyValues={dayData.hourlyValues}
+              max={max}
+              color={color}
+              unit={unit}
+            />
+          ))}
+          <div className={styles.ActivityChartRow}>
+            <div />
+            <div className={styles.ActivityChartBottomLegend}>
+              <BodySmall>12AM</BodySmall>
+              <BodySmall>6AM</BodySmall>
+              <BodySmall>12PM</BodySmall>
+              <BodySmall>6PM</BodySmall>
+              <BodySmall>12AM</BodySmall>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 const ActivityChartRow = React.memo(
   ({
@@ -54,15 +67,18 @@ const ActivityChartRow = React.memo(
     hourlyValues,
     max,
     color,
+    unit,
   }: {
-    date: string;
+    date: number;
     hourlyValues: Array<number | null>;
     max: number | null;
     color: string;
+    unit: string;
   }) => {
+    const formatDate = useFormatDateTime();
     return (
       <div className={styles.ActivityChartRow}>
-        <BodySmall>{date}</BodySmall>
+        <BodySmall>{formatDate(new Date(date), {month: 'short', day: 'numeric'})}</BodySmall>
         <div
           style={{
             display: 'grid',
@@ -75,22 +91,33 @@ const ActivityChartRow = React.memo(
             if (value === null) {
               return <div key={index} />;
             }
-            if (value === 0) {
-              return (
-                <div key={index} className={styles.TileContainer}>
-                  <div className={styles.Tile} />
-                </div>
-              );
-            }
             return (
               <Popover
                 key={index}
                 targetTagName="div"
                 interactionKind="hover"
                 content={
-                  <div className={styles.Tooltip}>
-                    <BodySmall>{numberFormatter.format(value)}</BodySmall>
-                  </div>
+                  <TooltipCard>
+                    <Box
+                      flex={{direction: 'column', gap: 4}}
+                      padding={{vertical: 8, horizontal: 12}}
+                    >
+                      <Box border="bottom" padding={{bottom: 4}} margin={{bottom: 4}}>
+                        <Subheading>
+                          {formatDate(new Date(date + index * 60 * 60 * 1000), {
+                            month: 'short',
+                            day: 'numeric',
+                            hour: 'numeric',
+                            minute: 'numeric',
+                          })}
+                        </Subheading>
+                      </Box>
+                      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                        <Mono>{numberFormatter.format(value)}</Mono>
+                        <Body>{unit}</Body>
+                      </Box>
+                    </Box>
+                  </TooltipCard>
                 }
               >
                 <div className={styles.TileContainer}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -1,24 +1,28 @@
-import {Box} from '@dagster-io/ui-components';
+import {Box, Colors, Mono, Subheading} from '@dagster-io/ui-components';
 import {
   CategoryScale,
+  ChartData,
   Chart as ChartJS,
+  ChartOptions,
   LineElement,
   LinearScale,
   PointElement,
   Tooltip,
 } from 'chart.js';
-import React from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Line} from 'react-chartjs-2';
 
 import styles from './AssetCatalogLineChart.module.css';
+import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
+import {TooltipCard} from '../../insights/InsightsChartShared';
+import {
+  RenderTooltipFn,
+  renderInsightsChartTooltip,
+} from '../../insights/renderInsightsChartTooltip';
+import {numberFormatter} from '../../ui/formatters';
+import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
 ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip);
-
-const L_FORMAT = new Intl.DateTimeFormat(navigator.language, {
-  month: 'short',
-  day: 'numeric',
-  timeZone: 'UTC',
-});
 
 export type LineChartMetrics = {
   title: string;
@@ -38,12 +42,21 @@ export type LineChartMetrics = {
   };
 };
 
-const getDataset = (metrics: LineChartMetrics) => {
+const getDataset = (
+  metrics: LineChartMetrics,
+  formatDatetime: (date: Date, options: Intl.DateTimeFormatOptions) => string,
+): ChartData<'line', (number | null)[], string> => {
   const start = metrics.timestamps.length
-    ? L_FORMAT.format(new Date(metrics.timestamps[0]! * 1000))
+    ? formatDatetime(new Date(metrics.timestamps[0]! * 1000), {
+        month: 'short',
+        day: 'numeric',
+      })
     : '';
   const end = metrics.timestamps.length
-    ? L_FORMAT.format(new Date(metrics.timestamps[metrics.timestamps.length - 1]! * 1000))
+    ? formatDatetime(new Date(metrics.timestamps[metrics.timestamps.length - 1]! * 1000), {
+        month: 'short',
+        day: 'numeric',
+      })
     : '';
 
   const labels = metrics.timestamps.length
@@ -73,33 +86,120 @@ const getDataset = (metrics: LineChartMetrics) => {
   };
 };
 
-const options = {
-  plugins: {legend: {display: false}, tooltip: {enabled: false}},
-  scales: {
-    x: {
-      grid: {display: false},
-      ticks: {color: '#9ca3af'},
-    },
-    y: {
-      display: false,
-    },
-  },
-  responsive: true,
-  maintainAspectRatio: false,
-};
-
 export const AssetCatalogInsightsLineChart = React.memo(
   ({metrics}: {metrics: LineChartMetrics}) => {
+    const formatDatetime = useFormatDateTime();
+    const rgbColors = useRGBColorsForTheme();
+
+    const renderTooltipFn = useCallback(
+      ({dataPoints}: Parameters<RenderTooltipFn>[0], metrics: LineChartMetrics) => {
+        const currentPeriodDataPoint = dataPoints[0]!;
+        const prevPeriodDataPoint = dataPoints[1]!;
+        const date = formatDatetime(
+          new Date(metrics.timestamps[currentPeriodDataPoint.dataIndex]! * 1000),
+          {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+          },
+        );
+        return (
+          <TooltipCard>
+            <Box flex={{direction: 'column', gap: 4}} padding={{vertical: 8, horizontal: 12}}>
+              <Box border="bottom" padding={{bottom: 4}} margin={{bottom: 4}}>
+                <Subheading>{date}</Subheading>
+              </Box>
+              <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                  <div
+                    style={{
+                      width: 12,
+                      height: 12,
+                      backgroundColor: metrics.currentPeriod.color,
+                      border: `1px solid ${rgbColors[Colors.textDefault()]}`,
+                    }}
+                  />
+                  <div>Current Period:</div>
+                </Box>
+                <Mono>{currentPeriodDataPoint?.formattedValue ?? 0}</Mono>
+              </Box>
+              <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                  <div
+                    style={{
+                      width: 12,
+                      height: 12,
+                      backgroundColor: metrics.prevPeriod.color,
+                      border: `1px solid ${rgbColors[Colors.textDefault()]}`,
+                    }}
+                  />
+                  <div>Previous Period:</div>
+                </Box>
+                <Mono>{prevPeriodDataPoint?.formattedValue ?? 0}</Mono>
+              </Box>
+            </Box>
+          </TooltipCard>
+        );
+      },
+      [formatDatetime, rgbColors],
+    );
+
+    const options: ChartOptions<'line'> = useMemo(
+      () => ({
+        plugins: {
+          legend: {display: false},
+          tooltip: {
+            enabled: false,
+            position: 'nearest',
+            external: (context) =>
+              renderInsightsChartTooltip({
+                ...context,
+                renderFn: (config) => renderTooltipFn(config, metrics),
+              }),
+          },
+        },
+        interaction: {
+          mode: 'nearest',
+          axis: 'x',
+          intersect: false,
+        },
+        scales: {
+          x: {
+            grid: {display: false},
+            ticks: {
+              color: rgbColors[Colors.textLight()],
+              maxRotation: 0,
+              minRotation: 0,
+              autoSkip: false,
+              includeBounds: true,
+            },
+          },
+          y: {
+            beginAtZero: true,
+          },
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+      }),
+      [metrics, renderTooltipFn, rgbColors],
+    );
     return (
       <div className={styles.chartContainer}>
         <div className={styles.chartHeader}>{metrics.title}</div>
         <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-          <div className={styles.chartCount}>{metrics.currentPeriod.aggregateValue}</div>
-          {metrics.pctChange && <div className={styles.chartChange}>{metrics.pctChange}</div>}
+          <div className={styles.chartCount}>
+            {metrics.currentPeriod.aggregateValue
+              ? numberFormatter.format(Math.round(metrics.currentPeriod.aggregateValue))
+              : 0}
+          </div>
+          <div className={styles.chartChange}>
+            {numberFormatter.format(Math.round((metrics.pctChange ?? 0) * 100))}%
+          </div>
         </Box>
         <div className={styles.chartWrapper}>
           <div className={styles.chartGraph}>
-            <Line data={getDataset(metrics)} options={options} />
+            <Line data={getDataset(metrics, formatDatetime)} options={options} />
           </div>
         </div>
       </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Mono, Subheading} from '@dagster-io/ui-components';
+import {Box, Colors, Mono, Spinner, Subheading} from '@dagster-io/ui-components';
 import {
   CategoryScale,
   ChartData,
@@ -87,7 +87,7 @@ const getDataset = (
 };
 
 export const AssetCatalogInsightsLineChart = React.memo(
-  ({metrics}: {metrics: LineChartMetrics}) => {
+  ({metrics, loading}: {metrics: LineChartMetrics; loading: boolean}) => {
     const formatDatetime = useFormatDateTime();
     const rgbColors = useRGBColorsForTheme();
 
@@ -186,7 +186,12 @@ export const AssetCatalogInsightsLineChart = React.memo(
     );
     return (
       <div className={styles.chartContainer}>
-        <div className={styles.chartHeader}>{metrics.title}</div>
+        <div className={styles.chartHeader}>
+          <Box flex={{direction: 'row', gap: 4, justifyContent: 'space-between'}}>
+            <Subheading>{metrics.title}</Subheading>
+            {loading ? <Spinner purpose="body-text" /> : null}
+          </Box>
+        </div>
         <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
           <div className={styles.chartCount}>
             {metrics.currentPeriod.aggregateValue

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.module.css
@@ -1,0 +1,46 @@
+.rateCardContainer {
+  background-color: var(--color-background-default);
+  border-radius: 12px;
+  border: 1px solid var(--color-keyline-default);
+  padding: 16px;
+  width: 100%;
+  min-width: 260px;
+  height: 120px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+}
+
+.rateCardRow {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.rateCardValue {
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 24px;
+  display: flex;
+  flex-direction: row;
+}
+
+.rateCardPrev, .rateCardDeltaRow {
+  font-size: 12px;
+  color: var(--color-text-light);
+}
+
+.rateCardDeltaRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+}
+
+.rateCardDelta {
+  font-size: 14px;
+  color: var(--color-text-light);
+} 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -1,0 +1,65 @@
+import {BodyLarge, Box, Colors, Icon, Spinner} from '@dagster-io/ui-components';
+import React from 'react';
+
+import styles from './AssetCatalogRateCard.module.css';
+import {numberFormatter} from '../../ui/formatters';
+
+export interface AssetCatalogRateCardProps {
+  title: string;
+  value: number | null; // e.g., 0.981 for 98.1%
+  prevValue: number | null; // e.g., 1 for 100%
+}
+
+export function AssetCatalogRateCard({title, value, prevValue}: AssetCatalogRateCardProps) {
+  const pct = value ? Math.round(value * 1000) / 10 : 0;
+  const prevPct = prevValue ? Math.round(prevValue * 1000) / 10 : 0;
+  const delta = pct - prevPct;
+  const isDown = delta < 0;
+  const absDelta = Math.abs(delta);
+
+  const loadingCurrentPeriod = !value;
+  const loadingPrevPeriod = !prevValue;
+
+  return (
+    <div className={styles.rateCardContainer}>
+      <BodyLarge>{title}</BodyLarge>
+      <div className={styles.rateCardValue}>
+        {loadingCurrentPeriod ? (
+          <span>
+            <Spinner purpose="body-text" />
+          </span>
+        ) : (
+          numberFormatter.format(pct) + '%'
+        )}
+      </div>
+      <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
+        <div className={styles.rateCardPrev}>
+          {loadingPrevPeriod ? (
+            <Spinner purpose="body-text" />
+          ) : (
+            numberFormatter.format(prevPct) + '% last period'
+          )}
+        </div>
+        <Box
+          className={styles.rateCardDeltaRow}
+          flex={{direction: 'row', alignItems: 'center', gap: 4}}
+        >
+          {loadingCurrentPeriod || loadingPrevPeriod ? null : (
+            <Icon
+              name={isDown ? 'trending_down' : 'trending_up'}
+              color={Colors.textLight()}
+              size={16}
+            />
+          )}
+          <span className={styles.rateCardDelta}>
+            {loadingCurrentPeriod || loadingPrevPeriod ? (
+              <Spinner purpose="body-text" />
+            ) : (
+              <>{numberFormatter.format(absDelta)}%</>
+            )}
+          </span>
+        </Box>
+      </Box>
+    </div>
+  );
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.module.css
@@ -1,13 +1,15 @@
 .container {
   background-color: var(--color-background-default);
-  border-radius: 12px;
   padding: 20px;
-  color: white;
+  color: var(--color-text-default);
   width: 100%;
   max-width: 800px;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding: 16px 24px;
+  border-radius: 12px;
+  border: 1px solid var(--color-keyline-default);
 }
 
 .table {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -172,26 +172,41 @@ export const AssetCatalogTopAssetsChart = React.memo(
             }}
           >
             <Box
-              flex={{direction: 'row', justifyContent: 'space-between', gap: 12, grow: 1}}
+              flex={{
+                direction: 'row',
+                grow: 1,
+                alignItems: 'flex-end',
+                justifyContent: 'stretch',
+              }}
               border="top"
               padding={{top: 12, horizontal: 8}}
             >
-              <BodySmall>
-                {page + 1} of {totalPages}
-              </BodySmall>
-              <Box flex={{direction: 'row', gap: 4}}>
-                <Button
-                  outlined
-                  onClick={() => setPage(page - 1)}
-                  disabled={page === 0}
-                  icon={<Icon name="arrow_back" />}
-                />
-                <Button
-                  outlined
-                  onClick={() => setPage(page + 1)}
-                  disabled={page === totalPages - 1}
-                  icon={<Icon name="arrow_forward" />}
-                />
+              <Box
+                flex={{
+                  direction: 'row',
+                  gap: 12,
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}
+                style={{width: '100%'}}
+              >
+                <BodySmall>
+                  {page + 1} of {totalPages}
+                </BodySmall>
+                <Box flex={{direction: 'row', gap: 4}}>
+                  <Button
+                    outlined
+                    onClick={() => setPage(page - 1)}
+                    disabled={page === 0}
+                    icon={<Icon name="arrow_back" />}
+                  />
+                  <Button
+                    outlined
+                    onClick={() => setPage(page + 1)}
+                    disabled={page === totalPages - 1}
+                    icon={<Icon name="arrow_forward" />}
+                  />
+                </Box>
               </Box>
             </Box>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   MiddleTruncate,
   Mono,
+  Spinner,
   Subheading,
 } from '@dagster-io/ui-components';
 import {
@@ -40,10 +41,12 @@ export const AssetCatalogTopAssetsChart = React.memo(
     header,
     datasets,
     unitType,
+    loading,
   }: {
     header: string;
     datasets: {labels: string[]; data: number[]};
     unitType: string;
+    loading: boolean;
   }) => {
     const rgbColors = useRGBColorsForTheme();
 
@@ -136,7 +139,10 @@ export const AssetCatalogTopAssetsChart = React.memo(
 
     return (
       <div className={styles.container}>
-        <BodyLarge>{header}</BodyLarge>
+        <Box flex={{direction: 'row', gap: 12, justifyContent: 'space-between'}}>
+          <BodyLarge>{header}</BodyLarge>
+          {loading ? <Spinner purpose="body-text" /> : null}
+        </Box>
         <Box border="bottom" padding={{bottom: 12}} style={{position: 'relative'}}>
           <Bar data={chartConfig} options={options} />
         </Box>
@@ -148,7 +154,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
             padding={{vertical: 8}}
           >
             <BodySmall>Asset</BodySmall>
-            <BodySmall>Count</BodySmall>
+            <BodySmall>{unitType}</BodySmall>
           </Box>
           <div className={styles.table}>
             {currentPageValues.map(({label, value}, i) => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -1,37 +1,39 @@
-import {BodyLarge, BodySmall, Box, Colors, MiddleTruncate} from '@dagster-io/ui-components';
-import {BarElement, CategoryScale, Chart as ChartJS, Legend, LinearScale, Tooltip} from 'chart.js';
-import React from 'react';
+import {
+  Body,
+  BodyLarge,
+  BodySmall,
+  Box,
+  Button,
+  Colors,
+  Icon,
+  MiddleTruncate,
+  Mono,
+  Subheading,
+} from '@dagster-io/ui-components';
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  ChartOptions,
+  Legend,
+  LinearScale,
+  Tooltip,
+} from 'chart.js';
+import React, {useCallback, useMemo, useState} from 'react';
 import {Bar} from 'react-chartjs-2';
 
 import styles from './AssetCatalogTopAssetsChart.module.css';
+import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
+import {TooltipCard} from '../../insights/InsightsChartShared';
+import {
+  RenderTooltipFn,
+  renderInsightsChartTooltip,
+} from '../../insights/renderInsightsChartTooltip';
+import {numberFormatter} from '../../ui/formatters';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
-const assets = [
-  'stitch/salesforce/account',
-  'fivetran/linear/team_project',
-  'purina/staging/product__asset_observations',
-  'purina/staging/cloud_product__teams_users',
-  'fivetran/linear/attachment_metadata',
-  'stitch/elementl_cloud_prod/customer_info',
-  'stitch/elementl_cloud_prod/deployment_settings',
-  'stitch/elementl_cloud_prod/users',
-  'stitch/stripe_prod_v3/plans',
-  'stitch/salesforce/account',
-];
-
-const options = {
-  scales: {
-    y: {
-      beginAtZero: true,
-      grid: {color: '#333', borderDash: [4, 4]},
-    },
-    x: {grid: {display: false}, ticks: {display: false}},
-  },
-  plugins: {
-    legend: {display: false},
-  },
-};
+const PAGE_SIZE = 10;
 
 export const AssetCatalogTopAssetsChart = React.memo(
   ({
@@ -43,22 +45,99 @@ export const AssetCatalogTopAssetsChart = React.memo(
     datasets: {labels: string[]; data: number[]};
     unitType: string;
   }) => {
-    const chartConfig = {
-      labels: datasets.labels,
-      datasets: [
-        {
-          label: unitType,
-          data: datasets.data,
-          backgroundColor: '#b095f9',
-          borderRadius: 0,
+    const rgbColors = useRGBColorsForTheme();
+
+    const [page, setPage] = useState(0);
+
+    const values = useMemo(() => {
+      return datasets.labels
+        .map((label, i) => ({
+          label,
+          value: datasets.data[i]!,
+        }))
+        .filter(({value}) => value !== 0)
+        .sort((a, b) => b.value - a.value);
+    }, [datasets.data, datasets.labels]);
+
+    // Compute the max value from all values for consistent X axis scaling
+    const maxValue = useMemo(() => {
+      return values.length > 0 ? Math.max(...values.map(({value}) => value)) : undefined;
+    }, [values]);
+
+    const totalPages = Math.ceil(values.length / PAGE_SIZE);
+
+    const currentPageValues = useMemo(
+      () => values.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+      [page, values],
+    );
+
+    const renderTooltipFn: RenderTooltipFn = useCallback(
+      ({label, dataPoints}) => {
+        const d = dataPoints[0];
+        return (
+          <TooltipCard>
+            <Box flex={{direction: 'column', gap: 4}} padding={{vertical: 8, horizontal: 12}}>
+              <Box border="bottom" padding={{bottom: 4}} margin={{bottom: 4}}>
+                <Subheading>{d?.label ?? label}</Subheading>
+              </Box>
+              <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                <Mono>{d?.formattedValue}</Mono>
+                <Body>{unitType}</Body>
+              </Box>
+            </Box>
+          </TooltipCard>
+        );
+      },
+      [unitType],
+    );
+
+    const chartConfig = useMemo(
+      () => ({
+        labels: currentPageValues.map(({label}) => label),
+        datasets: [
+          {
+            label: unitType,
+            data: currentPageValues.map(({value}) => value),
+            backgroundColor: rgbColors[Colors.accentBlue()],
+            borderRadius: 0,
+            maxBarThickness: 10,
+          },
+        ],
+      }),
+      [unitType, currentPageValues, rgbColors],
+    );
+
+    const options: ChartOptions<'bar'> = useMemo(
+      () => ({
+        indexAxis: 'y' as const,
+        scales: {
+          x: {
+            beginAtZero: true,
+            max: maxValue,
+            grid: {color: rgbColors[Colors.keylineDefault()], borderDash: [4, 4]},
+          },
+          y: {grid: {display: false}, ticks: {display: false}, beginAtZero: true},
         },
-      ],
-    };
+        plugins: {
+          legend: {display: false},
+          tooltip: {
+            enabled: false,
+            position: 'nearest',
+            external: (context) =>
+              renderInsightsChartTooltip({
+                ...context,
+                renderFn: renderTooltipFn,
+              }),
+          },
+        },
+      }),
+      [maxValue, rgbColors, renderTooltipFn],
+    );
 
     return (
       <div className={styles.container}>
         <BodyLarge>{header}</BodyLarge>
-        <Box border="bottom">
+        <Box border="bottom" padding={{bottom: 12}} style={{position: 'relative'}}>
           <Bar data={chartConfig} options={options} />
         </Box>
         <div>
@@ -72,16 +151,51 @@ export const AssetCatalogTopAssetsChart = React.memo(
             <BodySmall>Count</BodySmall>
           </Box>
           <div className={styles.table}>
-            {assets.map((asset, i) => (
+            {currentPageValues.map(({label, value}, i) => (
               <React.Fragment key={i}>
-                <BodySmall as="div">
-                  <MiddleTruncate text={asset} />
+                <BodySmall as="div" color={Colors.textLight()}>
+                  <MiddleTruncate text={label} />
                 </BodySmall>
-                <BodySmall>190</BodySmall>
+                <BodySmall color={Colors.textDefault()}>
+                  {numberFormatter.format(Math.round(value))}
+                </BodySmall>
               </React.Fragment>
             ))}
           </div>
         </div>
+        {totalPages > 1 && (
+          <Box
+            flex={{
+              alignItems: 'flex-end',
+              grow: 1,
+              direction: 'row',
+            }}
+          >
+            <Box
+              flex={{direction: 'row', justifyContent: 'space-between', gap: 12, grow: 1}}
+              border="top"
+              padding={{top: 12, horizontal: 8}}
+            >
+              <BodySmall>
+                {page + 1} of {totalPages}
+              </BodySmall>
+              <Box flex={{direction: 'row', gap: 4}}>
+                <Button
+                  outlined
+                  onClick={() => setPage(page - 1)}
+                  disabled={page === 0}
+                  icon={<Icon name="arrow_back" />}
+                />
+                <Button
+                  outlined
+                  onClick={() => setPage(page + 1)}
+                  disabled={page === totalPages - 1}
+                  icon={<Icon name="arrow_forward" />}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
       </div>
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/renderInsightsChartTooltip.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/renderInsightsChartTooltip.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui-components';
-import {Chart, TooltipModel} from 'chart.js';
+import {Chart, TooltipItem, TooltipModel} from 'chart.js';
 import {ReactElement} from 'react';
 import {Root, createRoot} from 'react-dom/client';
 
@@ -11,6 +11,8 @@ export type RenderTooltipFn = (config: {
   label: string;
   date: Date;
   formattedValue: string;
+  dataPoints: TooltipItem<'bar' | 'line'>[];
+  chart: Chart;
 }) => ReactElement;
 
 type TooltipContextWithCustomValues = {
@@ -61,21 +63,25 @@ export const renderInsightsChartTooltip = (context: TooltipContextWithCustomValu
   // If this point is at the far left, push the tooltip to the right to prevent overflow.
   // Similarly, if it's at the far right, push it to the left. Otherwise, show it
   // directly above the point.
-  if (dataIndex === 0) {
-    target.style.transform = 'translate(2%, -120%)';
-  } else if (dataIndex === dataset.data.length - 1) {
-    target.style.transform = 'translate(-102%, -120%)';
+  if (chart.options.indexAxis === 'y') {
   } else {
-    target.style.transform = 'translate(-50%, -120%)';
+    if (dataIndex === 0) {
+      target.style.transform = 'translate(2%, -120%)';
+    } else if (dataIndex === dataset.data.length - 1) {
+      target.style.transform = 'translate(-102%, -120%)';
+    } else {
+      target.style.transform = 'translate(-50%, -120%)';
+    }
   }
 
   const date = new Date(parseInt(dataPoint.label, 10));
   const color = (dataset.borderColor as string) || Colors.dataVizBlurpleAlt();
   const label = dataset.label || '';
 
-  root.render(renderFn({color, label, date, formattedValue}));
+  root.render(renderFn({color, label, date, formattedValue, dataPoints, chart}));
 
   const {offsetLeft: positionX, offsetTop: positionY} = chart.canvas;
   target.style.left = positionX + tooltip.caretX + 'px';
   target.style.top = positionY + tooltip.caretY + 'px';
+  target.style.zIndex = '1';
 };


### PR DESCRIPTION
## Summary & Motivation

- Add pagination to the charts at the bottom
- Hook up the correct asset labels to the chart at the bottom
- Use theme colors instead of hardcoded colors
- Add tooltips
- Use the users timezone (still a little weird with the activity charts, need to dig into this more, they need to be offset by the users timezone)
- bypass tooltip positioning logic for charts with indexAxis=y (I tried doing something for it similar but realized the existing logic isn't robust because it checks index=0 instead of checking the actual positioning which means index=1 can overflow and be offscreen, also doesn't seem robust enough for bar charts).
- Format all of the numbers

## How I Tested These Changes
<img width="1410" alt="Screenshot 2025-05-01 at 5 27 47 PM" src="https://github.com/user-attachments/assets/5c568fb5-199d-4119-9547-8ecd48c21c77" />
<img width="892" alt="Screenshot 2025-05-01 at 5 27 40 PM" src="https://github.com/user-attachments/assets/256f97b9-a0b7-4084-beb7-9b1bb2603ec0" />
<img width="983" alt="Screenshot 2025-05-01 at 5 27 35 PM" src="https://github.com/user-attachments/assets/a2cd4271-09cb-42fc-951f-92efde5a2bde" />
<img width="1019" alt="Screenshot 2025-05-01 at 5 27 30 PM" src="https://github.com/user-attachments/assets/4e8868c2-0c56-41f4-bc72-0cdb9516480c" />




## Changelog

> Insert changelog entry or delete this section.
