### PR TITLE
Remove single extraneous blank line at end of file

### DIFF
--- a/docs/static/assets/iris.csv
+++ b/docs/static/assets/iris.csv
@@ -148,4 +148,3 @@
 6.5,3.0,5.2,2.0,Iris-virginica
 6.2,3.4,5.4,2.3,Iris-virginica
 5.9,3.0,5.1,1.8,Iris-virginica
-


### PR DESCRIPTION
## Summary & Motivation

The blank line is unnecessary and at times annoying (e.g. when reading using Polars):

```pycon
>>> pl.read_csv("https://docs.dagster.io/assets/iris.csv", has_header=False, new_columns=["sepal_length_cm", "sepal_width_cm", "petal_length_cm", "petal_width_cm", "species"])
shape: (151, 5)
┌─────────────────┬────────────────┬─────────────────┬────────────────┬────────────────┐
│ sepal_length_cm ┆ sepal_width_cm ┆ petal_length_cm ┆ petal_width_cm ┆ species        │
│ ---             ┆ ---            ┆ ---             ┆ ---            ┆ ---            │
│ f64             ┆ f64            ┆ f64             ┆ f64            ┆ str            │
╞═════════════════╪════════════════╪═════════════════╪════════════════╪════════════════╡
│ 5.1             ┆ 3.5            ┆ 1.4             ┆ 0.2            ┆ Iris-setosa    │
│ 4.9             ┆ 3.0            ┆ 1.4             ┆ 0.2            ┆ Iris-setosa    │
│ 4.7             ┆ 3.2            ┆ 1.3             ┆ 0.2            ┆ Iris-setosa    │
│ 4.6             ┆ 3.1            ┆ 1.5             ┆ 0.2            ┆ Iris-setosa    │
│ 5.0             ┆ 3.6            ┆ 1.4             ┆ 0.2            ┆ Iris-setosa    │
│ …               ┆ …              ┆ …               ┆ …              ┆ …              │
│ 6.3             ┆ 2.5            ┆ 5.0             ┆ 1.9            ┆ Iris-virginica │
│ 6.5             ┆ 3.0            ┆ 5.2             ┆ 2.0            ┆ Iris-virginica │
│ 6.2             ┆ 3.4            ┆ 5.4             ┆ 2.3            ┆ Iris-virginica │
│ 5.9             ┆ 3.0            ┆ 5.1             ┆ 1.8            ┆ Iris-virginica │
│ null            ┆ null           ┆ null            ┆ null           ┆ null           │
└─────────────────┴────────────────┴─────────────────┴────────────────┴────────────────┘
```
