### PR TITLE
[dagster-dbt] Fix `DagsterDbtTranslatorSettings.enable_source_tests_as_checks` returning duplicate asset checks

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -734,7 +734,7 @@ def build_dbt_specs(
     )
 
     specs: list[AssetSpec] = []
-    check_specs: list[AssetCheckSpec] = []
+    check_specs: dict[str, AssetCheckSpec] = {}
     key_by_unique_id: dict[str, AssetKey] = {}
     for unique_id in selected_unique_ids:
         resource_props = get_node(manifest, unique_id)
@@ -772,7 +772,7 @@ def build_dbt_specs(
                 project,
             )
             if check_spec:
-                check_specs.append(check_spec)
+                check_specs[check_spec.get_python_identifier()] = check_spec
 
         # update the keys_by_unqiue_id dictionary to include keys created for upstream
         # assets. note that this step may need to change once the translator is updated
@@ -798,10 +798,10 @@ def build_dbt_specs(
                         project=project,
                     )
                     if check_spec:
-                        check_specs.append(check_spec)
+                        check_specs[check_spec.get_python_identifier()] = check_spec
 
     _validate_asset_keys(translator, manifest, key_by_unique_id)
-    return specs, check_specs
+    return specs, list(check_specs.values())
 
 
 def _validate_asset_keys(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -30,6 +30,7 @@ ALL_ASSET_KEYS = {
         "raw_orders",
         "raw_payments",
         "stg_customers",
+        "stg_customers_again",
         "stg_orders",
         "stg_payments",
         "raw_fail_tests_model",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -298,7 +298,7 @@ def test_materialize_no_selection(
     )
     assert not result.success  # fail_tests_model fails
     # raw_customers is a source, and thus does not receive an asset materialization.
-    assert len(result.get_asset_materialization_events()) == 9
+    assert len(result.get_asset_materialization_events()) == 10
     assert len(result.get_asset_check_evaluations()) == 26
     assert len(result.get_asset_observation_events()) == 4
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/staging/stg_customers_again.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/staging/stg_customers_again.sql
@@ -1,0 +1,22 @@
+with source as (
+
+    {#-
+    Normally we would select from the table here, but we are using seeds to load
+    our data in this project
+    #}
+    select * from {{ source('jaffle_shop', 'raw_customers') }}
+
+),
+
+renamed as (
+
+    select
+        cast(id as int) as customer_id,
+        first_name,
+        last_name
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
## Summary & Motivation

When generating asset checks for sources, we encounter the source in the manifest as many times as it is referenced downstream. This meant the existing implementation of `build_dbt_specs` would generate duplicate asset checks.

This PR switches the `asset_checks` list to a dict of `AssetCheckSpec.get_python_identifier()` -> `AssetCheckSpec`

Closes [#29746](https://github.com/dagster-io/dagster/issues/29746)

## How I Tested These Changes

Added an extra dbt model to existing test project that references the dbt source.

## Changelog

> [dagster-dbt] Fix `DagsterDbtTranslatorSettings.enable_source_tests_as_checks` returning duplicate asset checks
