### PR TITLE
[ui] Fix bug in automation condition sensor display when only a single asset check exists in a code location

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTargetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTargetList.tsx
@@ -126,7 +126,7 @@ const AssetSelectionTag = ({
   const assetSelectionString = assetSelection.assetSelectionString || '';
   const isAllAssets = assetSelectionString === ALL_ASSETS_STRING;
 
-  if (assets.length === 1 && assets[0]) {
+  if (checks.length === 0 && assets.length === 1 && assets[0]) {
     return (
       <Tag icon="asset">
         <Link to={assetDetailsPathForKey(assets[0])}>{displayNameForAssetKey(assets[0])}</Link>
@@ -134,7 +134,7 @@ const AssetSelectionTag = ({
     );
   }
 
-  if (checks.length === 1 && checks[0]) {
+  if (assets.length === 0 && checks.length === 1 && checks[0]) {
     return (
       <Tag icon="asset_check">
         <Link to={assetDetailsPathForAssetCheck(checks[0])}>{labelForAssetCheck(checks[0])}</Link>


### PR DESCRIPTION
## Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/29708

Previously, the logic for this UI would the following in cases where there were multiple assets defined and a single check:

![Screenshot 2025-05-02 at 8.14.41 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/ccf1e344-d0e3-4df1-a934-8f5af43059da.png)

The previous logic first checked if there was exactly one asset defined, and if that was not the case (and exactly one check was defined), then it would render in the "single check" style. This means that if there were multiple assets and one check, we'd get the "single check" case, which is not what we want.

## How I Tested These Changes

## Changelog

[ui] Fixed an issue which could cause the "Target" field of AutomationConditionSensorDefinitions to render incorrectly when exactly one asset check was defined in a code location.
