### PR TITLE
Add default value for DAGSTER_GIT_REPO_DIR env var so local builds don't break

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -16,7 +16,7 @@ passenv =
 allowlist_externals =
   /bin/bash
   make
-install_command = /bin/bash {env:DAGSTER_GIT_REPO_DIR}/scripts/uv-retry-install.sh -b ../python_modules/libraries/dagster-pyspark/build-constraints {opts} {packages}
+install_command = /bin/bash {env:DAGSTER_GIT_REPO_DIR:../../dagster}/scripts/uv-retry-install.sh -b ../python_modules/libraries/dagster-pyspark/build-constraints {opts} {packages}
 deps =
   -r sphinx/requirements.txt
   -e sphinx/_ext/dagster-sphinx


### PR DESCRIPTION
## Summary & Motivation

A new `DAGSTER_GIT_REPO_DIR` env var was introduced in https://github.com/dagster-io/dagster/pull/29725; this PR adds a default value for that env var to the docs tox.ini so local API doc builds continue to work without people needing to set that env var locally.

## How I Tested These Changes

Tested locally.

## Changelog

> Insert changelog entry or delete this section.
