### PR TITLE
[dagster-tableau] Add TableauViewMetadataSet

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -13,8 +13,8 @@ from dagster import (
 
 from dagster_tableau.translator import (
     TableauDataSourceMetadataSet,
-    TableauMetadataSet,
     TableauTagSet,
+    TableauViewMetadataSet,
 )
 
 
@@ -92,7 +92,7 @@ def create_view_asset_event(
     view: TSC.ViewItem, spec: AssetSpec, refreshed_workbook_ids: Set[str]
 ) -> Iterator[Union[ObserveResult, Output]]:
     asset_key = spec.key
-    workbook_id = TableauMetadataSet.extract(spec.metadata).workbook_id
+    workbook_id = TableauViewMetadataSet.extract(spec.metadata).workbook_id
 
     if workbook_id and workbook_id in refreshed_workbook_ids:
         yield from create_asset_output(
@@ -108,7 +108,7 @@ def create_data_source_asset_event(
     data_source: TSC.DatasourceItem, spec: AssetSpec, refreshed_data_source_ids: Set[str]
 ) -> Iterator[Union[ObserveResult, Output]]:
     asset_key = spec.key
-    data_source_id = TableauMetadataSet.extract(spec.metadata).id
+    data_source_id = TableauDataSourceMetadataSet.extract(spec.metadata).id
 
     if data_source_id and data_source_id in refreshed_data_source_ids:
         yield from create_asset_output(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -36,6 +36,7 @@ from dagster_tableau.translator import (
     TableauMetadataSet,
     TableauTagSet,
     TableauTranslatorData,
+    TableauViewMetadataSet,
     TableauWorkspaceData,
 )
 
@@ -179,7 +180,7 @@ class BaseTableauClient:
                         in refreshed_data_source_ids
                     ):
                         refreshed_workbook_ids.add(
-                            TableauMetadataSet.extract(spec.metadata).workbook_id
+                            TableauViewMetadataSet.extract(spec.metadata).workbook_id
                         )
                         break
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -108,11 +108,14 @@ class TableauTagSet(NamespacedTagSet):
 
 class TableauMetadataSet(NamespacedMetadataSet):
     id: Optional[str] = None
-    workbook_id: Optional[str] = None
 
     @classmethod
     def namespace(cls) -> str:
         return "dagster-tableau"
+
+
+class TableauViewMetadataSet(TableauMetadataSet):
+    workbook_id: Optional[str] = None
 
 
 class TableauDataSourceMetadataSet(TableauMetadataSet):
@@ -188,7 +191,7 @@ class DagsterTableauTranslator:
             deps=data_source_keys if data_source_keys else None,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="sheet")},
             metadata={
-                **TableauMetadataSet(
+                **TableauViewMetadataSet(
                     id=data.properties["luid"], workbook_id=data.properties["workbook"]["luid"]
                 )
             },
@@ -230,7 +233,7 @@ class DagsterTableauTranslator:
             deps=sheet_keys if sheet_keys else None,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="dashboard")},
             metadata={
-                **TableauMetadataSet(
+                **TableauViewMetadataSet(
                     id=data.properties["luid"], workbook_id=data.properties["workbook"]["luid"]
                 )
             },


### PR DESCRIPTION
## Summary & Motivation

Create a clear separation between TableauMetadataSet, TableauViewMetadataSet and TableauDataSourceMetadataSet following this [comment/change](https://github.com/dagster-io/dagster/pull/29679#discussion_r2070809869).

A Tableau data source can't have a workbook ID and a Tableau view (sheets and dashboards) can't have extracts.

## How I Tested These Changes

BK