### PR TITLE
[resolvable] error on nested parent object resoler use

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -363,6 +363,12 @@ def _dig_for_resolver(annotation, path: Sequence[_TypeContainer]) -> Optional[Re
                 f"Nested resolver must define model_field_type {args[0]} is not model compliant.",
             )
             # need to ensure nested resolvers set their model type
+            if resolver.resolves_from_parent_object and path:
+                raise ResolutionException(
+                    f"Resolver.from_model found nested within {list(p.name for p in path)}. "
+                    "Resolver.from_model can only be used on the outer most Annotated wrapper."
+                )
+
             return Resolver(
                 resolver.fn.__class__(
                     partial(

--- a/python_modules/dagster/dagster/components/resolved/model.py
+++ b/python_modules/dagster/dagster/components/resolved/model.py
@@ -129,8 +129,13 @@ class Resolver:
 
         raise ValueError(f"Unsupported Resolver type: {self.fn}")
 
+    @property
     def is_default(self):
         return self.fn is default_resolver
+
+    @property
+    def resolves_from_parent_object(self) -> bool:
+        return isinstance(self.fn, ParentFn)
 
     def with_outer_resolver(self, outer: "Resolver"):
         description = outer.description or self.description


### PR DESCRIPTION
Using whole parent object resolvers and nested annotations is effectively incompatible so raise an error on it explicitly 

## How I Tested These Changes

added test