### PR TITLE
Skip starlift-demo for real

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -36,7 +36,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
                 "examples/experimental", custom_example_pkg_roots
             )
         )
-        if pkg != "examples/deploy_ecs"
+        if pkg not in ("examples/deploy_ecs", "examples/starlift-demo")
     ]
 
     example_packages = (


### PR DESCRIPTION
Companion to https://github.com/dagster-io/dagster/pull/29729

Once I removed the custom PackageSpec, it started falling back to the generic PackageSpec discovery.

https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/a1ec44fc-cc1c-89a4-ad62-52eca6871d7b