### PR TITLE
[components] component_defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -884,6 +884,9 @@ class Definitions(IHaveNew):
             asset_selection=frozenset(asset_selection),
         )
 
+    def with_resources(self, resources: Optional[Mapping[str, Any]]) -> "Definitions":
+        return Definitions.merge(self, Definitions(resources=resources)) if resources else self
+
 
 def get_job_from_defs(
     name: str, defs: Definitions

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -1,0 +1,43 @@
+"""Testing utilities for components."""
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentLoadContext
+
+
+def component_defs(
+    *,
+    component: Component,
+    resources: Optional[Mapping[str, Any]] = None,
+    context: Optional[ComponentLoadContext] = None,
+) -> Definitions:
+    """Builds a Definitions object from a Component.
+
+
+    Args:
+        component (Component): The Component to build the Definitions from.
+        resources (Optional[Mapping[str, Any]]): A dictionary of resources to pass to the Component.
+        context (Optional[ComponentLoadContext]): A ComponentLoadContext to pass to the Component. Defaults to a test context.
+
+    Examples:
+
+        .. code-block:: python
+
+            # SimpleComponent produces an asset "an_asset"
+            an_asset = component_defs(component=SimpleComponent()).get_assets_def("an_asset")
+            assert an_asset.key == AssetKey("an_asset")
+
+        .. code-block:: python
+
+            # RequiresResoureComponent produces an asset "an_asset" and requires a resource "my_resource"
+            an_asset = component_defs(
+                component=SimpleComponent(),
+                resources={"my_resource": MyResource()},
+            ).get_assets_def("an_asset")
+            assert an_asset.key == AssetKey("an_asset")
+    """
+    context = context or ComponentLoadContext.for_test()
+    return component.build_defs(context).with_resources(resources)

--- a/python_modules/dagster/dagster_tests/testing_tests/basic_tests.py
+++ b/python_modules/dagster/dagster_tests/testing_tests/basic_tests.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentLoadContext
+from dagster.components.testing import component_defs
+
+
+def test_basic_test() -> None:
+    class SimpleComponent(Component):
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            @asset
+            def an_asset() -> int:
+                return 1
+
+            return Definitions([an_asset])
+
+    an_asset = component_defs(component=SimpleComponent()).get_assets_def("an_asset")
+
+    assert an_asset.key == AssetKey("an_asset")
+    assert an_asset() == 1
+
+
+def test_asset_with_resources() -> None:
+    @dataclass
+    class AResource:
+        value: str
+
+    class ComponentWithUnfulfilledResource(Component):
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            @asset
+            def asset_with_resource(a_resource: ResourceParam[AResource]) -> str:
+                return a_resource.value
+
+            return Definitions([asset_with_resource])
+
+    an_asset = component_defs(
+        component=ComponentWithUnfulfilledResource(),
+        resources={"a_resource": AResource(value="foo")},
+    ).get_assets_def("asset_with_resource")
+
+    assert isinstance(an_asset, AssetsDefinition)
+    assert an_asset() == "foo"


### PR DESCRIPTION
## Summary & Motivation

Add `component_defs`, a helper function for creating a `Definitiions` object from a component instance. This enables scenarios of easily utilizing the Pythonic interface for a component and getting a `Definitions` object out of it.

## How I Tested These Changes

BK

## Changelog

* Added `dagster.components.testing.component_defs` utility to help with testing components.