### PR TITLE
[components] Add Component.from_attributes_dict

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -158,7 +158,7 @@ class Component(ABC):
 
             assert (
                 component_defs(
-                    component=ModelComponentWithDeclaration.from_dict(attributes={"value": "foobar"}),
+                    component=ModelComponentWithDeclaration.from_attributes_dict(attributes={"value": "foobar"}),
                 ).get_assets_def("an_asset")()
                 == "foobar"
             )

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from dagster_shared.record import IHaveNew, record_custom
 from dagster_shared.yaml_utils.source_position import SourcePosition
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 from typing_extensions import Self
 
 import dagster._check as check
@@ -139,3 +139,42 @@ class Component(ABC):
     @classmethod
     def get_description(cls) -> Optional[str]:
         return cls.get_spec().description or inspect.getdoc(cls)
+
+    @classmethod
+    def from_attributes_dict(
+        cls, *, attributes: dict, context: Optional["ComponentLoadContext"] = None
+    ) -> Self:
+        """Load a Component from a dictionary. The dictionary is what would exist in the component.yaml file
+        under the "attributes" key.
+
+        Examples:
+
+        .. code-block:: python
+
+            class ModelComponentWithDeclaration(Component, Model, Resolvable):
+                value: str
+
+                def build_defs(self, context: ComponentLoadContext) -> Definitions: ...
+
+            assert (
+                component_defs(
+                    component=ModelComponentWithDeclaration.from_dict(attributes={"value": "foobar"}),
+                ).get_assets_def("an_asset")()
+                == "foobar"
+            )
+
+        Args:
+            attributes (dict): The attributes to load the Component from.
+            context (Optional[ComponentLoadContext]): The context to load the Component from.
+
+        Returns:
+            A Component instance.
+        """
+        model_cls = cls.get_model_cls()
+        assert model_cls
+        model = TypeAdapter(model_cls).validate_python(attributes)
+        if not context:
+            from dagster.components.core.context import ComponentLoadContext
+
+            context = ComponentLoadContext.for_test()
+        return cls.load(model, context)


### PR DESCRIPTION
## Summary & Motivation

For cases when you want to directly test the templating logic using a dictionary rather than a yaml file. This dictionary is what would be passed to `attributes` key of the yaml file.

## How I Tested These Changes

BK

## Changelog

* Added Component.from_attributes_dict