### PR TITLE
[components] Component.from_yaml_path

### DIFF
--- a/python_modules/dagster-test/dagster_test/components/simple_asset.py
+++ b/python_modules/dagster-test/dagster_test/components/simple_asset.py
@@ -1,19 +1,15 @@
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components import Component, ComponentLoadContext, ComponentTypeSpec, Model, Resolvable
+from dagster.components.resolved.core_models import ResolvedAssetKey
 
 
 class SimpleAssetComponent(Component, Resolvable, Model):
     """A simple asset that returns a constant string value."""
 
-    asset_key: str
+    asset_key: ResolvedAssetKey
     value: str
-
-    def __init__(self, asset_key: AssetKey, value: str):
-        self._asset_key = asset_key
-        self._value = value
 
     @classmethod
     def get_spec(cls):
@@ -23,8 +19,8 @@ class SimpleAssetComponent(Component, Resolvable, Model):
         )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        @asset(key=self._asset_key)
+        @asset(key=self.asset_key)
         def dummy(context: AssetExecutionContext):
-            return self._value
+            return self.value
 
         return Definitions(assets=[dummy])

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -170,11 +170,29 @@ class Component(ABC):
         Returns:
             A Component instance.
         """
+        from dagster.components.core.context import ComponentLoadContext
+
         model_cls = cls.get_model_cls()
         assert model_cls
         model = TypeAdapter(model_cls).validate_python(attributes)
-        if not context:
-            from dagster.components.core.context import ComponentLoadContext
+        return cls.load(model, context if context else ComponentLoadContext.for_test())
 
-            context = ComponentLoadContext.for_test()
-        return cls.load(model, context)
+    @classmethod
+    def from_yaml_path(
+        cls, yaml_path: Path, context: Optional["ComponentLoadContext"] = None
+    ) -> "Component":
+        """Load a Component from a yaml file.
+
+        Args:
+            yaml_path (Path): The path to the yaml file.
+            context (Optional[ComponentLoadContext]): The context to load the Component from. Defaults to a test context.
+
+        Returns:
+            A Component instance.
+        """
+        from dagster.components.core.context import ComponentLoadContext
+        from dagster.components.core.defs_module import load_yaml_component_from_path
+
+        return load_yaml_component_from_path(
+            context=context or ComponentLoadContext.for_test(), component_def_path=yaml_path
+        )

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -290,6 +290,10 @@ def load_pythonic_component(context: ComponentLoadContext) -> Component:
 def load_yaml_component(context: ComponentLoadContext) -> Component:
     # parse the yaml file
     component_def_path = check.not_none(_find_defs_or_component_yaml(context.path))
+    return load_yaml_component_from_path(context, component_def_path)
+
+
+def load_yaml_component_from_path(context: ComponentLoadContext, component_def_path: Path):
     source_trees = parse_yamls_with_source_position(
         component_def_path.read_text(), str(component_def_path)
     )

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -1,11 +1,13 @@
 """Testing utilities for components."""
 
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, Optional
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
+from dagster.components.core.defs_module import load_yaml_component_from_path
 
 
 def component_defs(
@@ -41,3 +43,14 @@ def component_defs(
     """
     context = context or ComponentLoadContext.for_test()
     return component.build_defs(context).with_resources(resources)
+
+
+def defs_from_component_yaml_path(
+    *,
+    component_yaml: Path,
+    context: Optional[ComponentLoadContext] = None,
+    resources: Optional[dict[str, Any]] = None,
+):
+    context = context or ComponentLoadContext.for_test()
+    component = load_yaml_component_from_path(context=context, component_def_path=component_yaml)
+    return component_defs(component=component, resources=resources, context=context)

--- a/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
+++ b/python_modules/dagster/dagster_tests/components_tests/cli_tests/test_commands.py
@@ -60,7 +60,11 @@ def test_list_plugins_from_module():
                 schema={
                     "additionalProperties": False,
                     "properties": {
-                        "asset_key": {"title": "Asset Key", "type": "string"},
+                        "asset_key": {
+                            "description": "A unique identifier for the asset.",
+                            "title": "Asset Key",
+                            "type": "string",
+                        },
                         "value": {"title": "Value", "type": "string"},
                     },
                     "required": ["asset_key", "value"],

--- a/python_modules/dagster/dagster_tests/testing_tests/basic_tests.py
+++ b/python_modules/dagster/dagster_tests/testing_tests/basic_tests.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster._core.execution.context.invocation import build_asset_context
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.base import Resolvable
@@ -133,3 +135,9 @@ def test_components_with_declaration():
         ).get_assets_def("an_asset")()
         == "foobar"
     )
+
+
+def test_component_on_disk():
+    path = Path(__file__).parent / "some_value_simple_asset_component.yaml"
+    assets_def = component_defs(component=Component.from_yaml_path(path)).get_assets_def("an_asset")
+    assert assets_def(context=build_asset_context()) == "some_value"

--- a/python_modules/dagster/dagster_tests/testing_tests/some_value_simple_asset_component.yaml
+++ b/python_modules/dagster/dagster_tests/testing_tests/some_value_simple_asset_component.yaml
@@ -1,0 +1,4 @@
+type: dagster_test.components.simple_asset.SimpleAssetComponent
+attributes:
+  asset_key: an_asset
+  value: some_value


### PR DESCRIPTION
## Summary & Motivation

Add `Component.from_yaml_path` where you can point directly to a yaml path and load a component instance into memory. Useful for test cases where you have a test per yaml file.

## How I Tested These Changes

BK

## Changelog

* Added `Component.from_yaml_path` which is useful for testing.