### PR TITLE
Show asset health on collapsed group node

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -185,10 +185,10 @@ const GroupNodeAssetStatusCountsAssetHealth = ({
           </>
           {statuses[AssetHealthStatus.WARNING] ? (
             <Tooltip
-              content={`${statuses[AssetHealthStatus.WARNING].length} asset${ifPlural(
+              content={`${statuses[AssetHealthStatus.WARNING].length} ${ifPlural(
                 statuses[AssetHealthStatus.WARNING].length,
-                ' has',
-                's have',
+                'asset has',
+                'assets have',
               )} a warning`}
             >
               <Tag icon={statusToIconAndColor[AssetHealthStatus.WARNING].iconName} intent="warning">
@@ -252,10 +252,10 @@ const GroupNodeAssetStatusCountsNonAssetHealth = ({
           </>
           {statuses.missing.length ? (
             <Tooltip
-              content={`${statuses.missing.length} asset${ifPlural(
+              content={`${statuses.missing.length} ${ifPlural(
                 statuses.missing.length,
-                ' has',
-                's have',
+                'asset has',
+                'assets have',
               )} never been materialized`}
             >
               <Tag icon="dot_filled" intent="warning">
@@ -373,7 +373,7 @@ const DegradedStatusTooltip = ({
     return acc;
   }, 0);
 
-  const parittionsFailed = statuses.reduce((acc, status) => {
+  const partitionsFailed = statuses.reduce((acc, status) => {
     if (
       status.materializationStatusMetadata?.__typename ===
       'AssetHealthMaterializationDegradedPartitionedMeta'
@@ -422,9 +422,9 @@ const DegradedStatusTooltip = ({
           {ifPlural(materializationsFailed, '', 's')} failed
         </div>
       ) : null}
-      {parittionsFailed ? (
+      {partitionsFailed ? (
         <div>
-          {numberFormatter.format(parittionsFailed)} partition{ifPlural(parittionsFailed, '', 's')}{' '}
+          {numberFormatter.format(partitionsFailed)} partition{ifPlural(partitionsFailed, '', 's')}{' '}
           failed
         </div>
       ) : null}


### PR DESCRIPTION
## Summary & Motivation

One thing we're losing atm is in the in progress indicator on the group node.... I'll look into fetching that in a follow up in a way that is more performance than querying AssetGraphLiveQuery for it.

## How I Tested These Changes
<img width="464" alt="Screenshot 2025-05-05 at 2 13 33 AM" src="https://github.com/user-attachments/assets/b4acd894-a224-4dc7-b2a0-167069aabdcd" />
<img width="341" alt="Screenshot 2025-05-05 at 2 13 08 AM" src="https://github.com/user-attachments/assets/98b63306-849a-4707-847e-e6772bd04738" />
<img width="335" alt="Screenshot 2025-05-05 at 2 13 06 AM" src="https://github.com/user-attachments/assets/b07b22d0-285c-4698-b228-69e8591dcd68" />
<img width="344" alt="Screenshot 2025-05-05 at 2 12 44 AM" src="https://github.com/user-attachments/assets/ca2523cc-799b-45bc-8001-d0eaa9e8ad14" />
<img width="424" alt="Screenshot 2025-05-05 at 2 12 40 AM" src="https://github.com/user-attachments/assets/a404000e-b425-4fc6-ab42-363e94736c86" />
