### PR TITLE
RFC: Enable pytest-xdist in Buildkite

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -120,7 +120,7 @@ setup(
             "objgraph",
             "pytest-cov==5.0.0",
             "pytest-mock==3.14.0",
-            "pytest-xdist==3.6.1",
+            "pytest-xdist[psutil]==3.6.1",
             "pytest>=8",
             "pytest-asyncio",
             "pytest-timeout",

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -42,32 +42,32 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
 
-  api_tests: pytest -vv ./dagster_tests/api_tests --durations 10 {posargs}
-  asset_defs_tests: pytest -vv ./dagster_tests/asset_defs_tests --durations 10 {posargs}
-  cli_tests: pytest -vv ./dagster_tests/cli_tests --durations 10 {posargs}
-  components_tests: pytest -vv ./dagster_tests/components_tests --durations 10 {posargs}
-  core_tests: pytest -vv ./dagster_tests/core_tests --durations 10 {posargs}
-  daemon_sensor_tests: pytest -vv ./dagster_tests/daemon_sensor_tests --durations 10 {posargs}
-  daemon_tests: pytest -vv ./dagster_tests/daemon_tests --durations 10 {posargs}
-  declarative_automation_tests: pytest -vv ./dagster_tests/declarative_automation_tests --durations 10 {posargs}
-  definitions_tests: pytest -vv ./dagster_tests/definitions_tests --durations 10 {posargs}
-  execution_tests__context_tests: pytest -vv ./dagster_tests/execution_tests/context_tests --durations 10  {posargs}
-  execution_tests__dynamic_tests: pytest -vv ./dagster_tests/execution_tests/dynamic_tests --durations 10  {posargs}
-  execution_tests__engine_tests: pytest -vv ./dagster_tests/execution_tests/engine_tests --durations 10  {posargs}
-  execution_tests__execute_job_tests: pytest -vv ./dagster_tests/execution_tests/execute_job_tests --durations 10  {posargs}
-  execution_tests__execution_plan_tests: pytest -vv ./dagster_tests/execution_tests/execution_plan_tests --durations 10  {posargs}
-  execution_tests__misc_execution_tests: pytest -vv ./dagster_tests/execution_tests/misc_execution_tests --durations 10  {posargs}
-  execution_tests__pipes_tests: pytest -vv ./dagster_tests/execution_tests/pipes_tests --durations 10  {posargs}
-  execution_tests__versioning_tests: pytest -vv ./dagster_tests/execution_tests/versioning_tests --durations 10  {posargs}
-  general_tests: pytest -vv ./dagster_tests/general_tests --durations 10  {posargs}
-  general_tests_old_protobuf: pytest -vv ./dagster_tests/general_tests --durations 10  {posargs}
-  launcher_tests: pytest -vv ./dagster_tests/launcher_tests --durations 10 {posargs}
-  logging_tests: pytest -vv ./dagster_tests/logging_tests --durations 10 {posargs}
-  model_tests: pytest -vv ./dagster_tests/model_tests --durations 10 {posargs}
-  scheduler_tests: pytest -vv ./dagster_tests/scheduler_tests --durations 10 {posargs}
-  scheduler_tests_pendulum_1: pytest -vv ./dagster_tests/scheduler_tests --durations 10  {posargs}
-  scheduler_tests_pendulum_2: pytest -vv ./dagster_tests/scheduler_tests --durations 10  {posargs}
-  storage_tests: pytest -vv ./dagster_tests/storage_tests --durations 10 {posargs}
-  storage_tests_sqlalchemy_1_3: pytest -vv ./dagster_tests/storage_tests --durations 10 {posargs}
-  storage_tests_sqlalchemy_1_4: pytest -vv ./dagster_tests/storage_tests --durations 10 {posargs}
-  type_signature_tests: pytest -vv ./dagster_tests/core_tests --durations 10 {posargs} -m 'typesignature'
+  api_tests: pytest -vv ./dagster_tests/api_tests --durations 10 -n logical {posargs}
+  asset_defs_tests: pytest -vv ./dagster_tests/asset_defs_tests --durations 10 -n logical {posargs}
+  cli_tests: pytest -vv ./dagster_tests/cli_tests --durations 10 -n logical {posargs}
+  components_tests: pytest -vv ./dagster_tests/components_tests --durations 10 -n logical {posargs}
+  core_tests: pytest -vv ./dagster_tests/core_tests --durations 10 -n logical {posargs}
+  daemon_sensor_tests: pytest -vv ./dagster_tests/daemon_sensor_tests --durations 10 -n logical {posargs}
+  daemon_tests: pytest -vv ./dagster_tests/daemon_tests --durations 10 -n logical {posargs}
+  declarative_automation_tests: pytest -vv ./dagster_tests/declarative_automation_tests --durations 10 -n logical {posargs}
+  definitions_tests: pytest -vv ./dagster_tests/definitions_tests --durations 10 -n logical {posargs}
+  execution_tests__context_tests: pytest -vv ./dagster_tests/execution_tests/context_tests --durations 10 -n logical  {posargs}
+  execution_tests__dynamic_tests: pytest -vv ./dagster_tests/execution_tests/dynamic_tests --durations 10 -n logical  {posargs}
+  execution_tests__engine_tests: pytest -vv ./dagster_tests/execution_tests/engine_tests --durations 10 -n logical  {posargs}
+  execution_tests__execute_job_tests: pytest -vv ./dagster_tests/execution_tests/execute_job_tests --durations 10 -n logical  {posargs}
+  execution_tests__execution_plan_tests: pytest -vv ./dagster_tests/execution_tests/execution_plan_tests --durations 10 -n logical  {posargs}
+  execution_tests__misc_execution_tests: pytest -vv ./dagster_tests/execution_tests/misc_execution_tests --durations 10 -n logical  {posargs}
+  execution_tests__pipes_tests: pytest -vv ./dagster_tests/execution_tests/pipes_tests --durations 10 -n logical  {posargs}
+  execution_tests__versioning_tests: pytest -vv ./dagster_tests/execution_tests/versioning_tests --durations 10 -n logical  {posargs}
+  general_tests: pytest -vv ./dagster_tests/general_tests --durations 10 -n logical  {posargs}
+  general_tests_old_protobuf: pytest -vv ./dagster_tests/general_tests --durations 10 -n logical  {posargs}
+  launcher_tests: pytest -vv ./dagster_tests/launcher_tests --durations 10 -n logical {posargs}
+  logging_tests: pytest -vv ./dagster_tests/logging_tests --durations 10 -n logical {posargs}
+  model_tests: pytest -vv ./dagster_tests/model_tests --durations 10 -n logical {posargs}
+  scheduler_tests: pytest -vv ./dagster_tests/scheduler_tests --durations 10 -n logical {posargs}
+  scheduler_tests_pendulum_1: pytest -vv ./dagster_tests/scheduler_tests --durations 10 -n logical  {posargs}
+  scheduler_tests_pendulum_2: pytest -vv ./dagster_tests/scheduler_tests --durations 10 -n logical  {posargs}
+  storage_tests: pytest -vv ./dagster_tests/storage_tests --durations 10 -n logical {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -vv ./dagster_tests/storage_tests --durations 10 -n logical {posargs}
+  storage_tests_sqlalchemy_1_4: pytest -vv ./dagster_tests/storage_tests --durations 10 -n logical {posargs}
+  type_signature_tests: pytest -vv ./dagster_tests/core_tests --durations 10 -n logical {posargs} -m 'typesignature'


### PR DESCRIPTION
Most of our Buildkite runners have 2 vCPU. Some have 4. So we might be able to get some pretty cheap improvements just by running more in parallel. And we might find that there's a sufficient enough tradeoff here that we can begin running larger Builkite runners.

I think we've made several half-hearted attempts at this in the past. My guess is that we'll:

- unearth certain kinds of fixtures that cannot safely use this strategy (for example, ones that rely heavily on docker compose or already do their own crazy multi-process stuff). But I suspect once identified, we can split these into their own variant that don't parallelize.
- unearth non-determinism in test collection that prevents the initial distribution from happening. But I suspect once identified, we can pretty quickly burn this list down.
- make our logs kind of impossible to read. But they already are. We might be able to do something fun with Buildkite artifacts to log per test or something.

Anyway, putting this up to see what happens and for comment.

Some initial highlights on Buildkite with baseline vs. 2 vCPU:

Baseline: https://buildkite.com/dagster/dagster-dagster/builds/121620
2 vCPU: https://buildkite.com/dagster/dagster-dagster/builds/121622

- dagster cli tests: 17:08 -> 10:15
- dagster core tests: 15:23 -> 10:27
- dagster general tests: 8:13 -> 6:19
- dagster storage tests: 11:57 -> 6:45

With presumably more benefit to be had if we move these onto runners with more vCPUs.

But of course, not everything is sunshine and roses yet.

If we generally like this direction, I'll spend some time generalizing this across the test suite, playing whack-a-mole, and pricing out our upsizing our Buildkite runners.