### PR TITLE
Fetch all code server data in DA before writing the initial tick cursor

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -748,6 +748,9 @@ def _submit_runs_and_update_backfill_in_chunks(
     for run_request_idx, run_request in enumerate(run_requests):
         run_id = reserved_run_ids[run_request_idx] if reserved_run_ids else None
         try:
+            # create a new request context for each run in case the code location server
+            # is swapped out in the middle of the submission process
+            workspace = workspace_process_context.create_request_context()
             submit_asset_run(
                 run_id,
                 run_request._replace(
@@ -760,6 +763,7 @@ def _submit_runs_and_update_backfill_in_chunks(
                 run_request_idx,
                 instance,
                 workspace_process_context,
+                workspace,
                 run_request_execution_data_cache,
                 {},
                 logger,

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -54,7 +54,7 @@ def _get_execution_plan_entity_keys(
     return output_entity_keys
 
 
-def _get_job_execution_data_from_run_request(
+def get_job_execution_data_from_run_request(
     asset_graph: RemoteWorkspaceAssetGraph,
     run_request: RunRequest,
     instance: DagsterInstance,
@@ -116,6 +116,7 @@ def _create_asset_run(
     instance: DagsterInstance,
     run_request_execution_data_cache: dict[JobSubsetSelector, RunRequestExecutionData],
     workspace_process_context: IWorkspaceProcessContext,
+    workspace: BaseWorkspaceRequestContext,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
 ) -> DagsterRun:
@@ -134,11 +135,8 @@ def _create_asset_run(
 
         # retry until the execution plan targets the asset selection
         try:
-            # create a new request context for each run in case the code location server
-            # is swapped out in the middle of the submission process
-            workspace = workspace_process_context.create_request_context()
             asset_graph = workspace.asset_graph
-            execution_data = _get_job_execution_data_from_run_request(
+            execution_data = get_job_execution_data_from_run_request(
                 asset_graph,
                 run_request,
                 instance,
@@ -244,6 +242,7 @@ def submit_asset_run(
     run_request_index: int,
     instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
+    workspace: BaseWorkspaceRequestContext,
     run_request_execution_data_cache: dict[JobSubsetSelector, RunRequestExecutionData],
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
@@ -285,6 +284,7 @@ def submit_asset_run(
             instance,
             run_request_execution_data_cache,
             workspace_process_context,
+            workspace,
             debug_crash_flags,
             logger,
         )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1279,14 +1279,14 @@ def test_asset_backfill_retryable_error(instance, workspace_context):
     assert backfill.status == BulkActionStatus.REQUESTED
 
     # The following backfill iteration will attempt to submit run requests for asset_f's two partitions.
-    # The first call to _get_job_execution_data_from_run_request will succeed, but the second call will
+    # The first call to get_job_execution_data_from_run_request will succeed, but the second call will
     # raise a DagsterUserCodeUnreachableError. Subsequently only the first partition will be successfully
     # submitted.
     def raise_retryable_error(*args, **kwargs):
         raise Exception("This is transient because it is not a DagsterError or a CheckError")
 
     with mock.patch(
-        "dagster._core.execution.submit_asset_runs._get_job_execution_data_from_run_request",
+        "dagster._core.execution.submit_asset_runs.get_job_execution_data_from_run_request",
         side_effect=raise_retryable_error,
     ):
         with environ({"DAGSTER_MAX_ASSET_BACKFILL_RETRIES": "2"}):
@@ -1888,7 +1888,7 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
 def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
-    from dagster._core.execution.submit_asset_runs import _get_job_execution_data_from_run_request
+    from dagster._core.execution.submit_asset_runs import get_job_execution_data_from_run_request
 
     asset_selection = [AssetKey("asset_a"), AssetKey("asset_e")]
     asset_graph = workspace_context.create_request_context().asset_graph
@@ -1933,7 +1933,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     assert instance.get_runs_count() == 1
 
     # The following backfill iteration will attempt to submit run requests for asset_e's three partitions.
-    # The first call to _get_job_execution_data_from_run_request will succeed, but the second call will
+    # The first call to get_job_execution_data_from_run_request will succeed, but the second call will
     # raise a DagsterUserCodeUnreachableError. Subsequently only the first partition will be successfully
     # submitted.
     counter = 0
@@ -1942,7 +1942,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
         nonlocal counter
         if counter == 0:
             counter += 1
-            return _get_job_execution_data_from_run_request(*args, **kwargs)
+            return get_job_execution_data_from_run_request(*args, **kwargs)
         elif counter == 1:
             counter += 1
             raise DagsterUserCodeUnreachableError()
@@ -1952,7 +1952,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
             raise Exception("Should not reach")
 
     with mock.patch(
-        "dagster._core.execution.submit_asset_runs._get_job_execution_data_from_run_request",
+        "dagster._core.execution.submit_asset_runs.get_job_execution_data_from_run_request",
         side_effect=raise_code_unreachable_error_on_second_call,
     ):
         errors = [
@@ -2053,7 +2053,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_no_runs_
         raise DagsterUserCodeUnreachableError()
 
     with mock.patch(
-        "dagster._core.execution.submit_asset_runs._get_job_execution_data_from_run_request",
+        "dagster._core.execution.submit_asset_runs.get_job_execution_data_from_run_request",
         side_effect=raise_code_unreachable_error,
     ):
         errors = [
@@ -2108,7 +2108,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
 ):
     # tests that we can recover from unreachable code location error during the first tick when
     # we are requesting the root assets
-    from dagster._core.execution.submit_asset_runs import _get_job_execution_data_from_run_request
+    from dagster._core.execution.submit_asset_runs import get_job_execution_data_from_run_request
 
     asset_selection = [AssetKey("asset_f"), AssetKey("asset_g")]
     asset_graph = workspace_context.create_request_context().asset_graph
@@ -2135,7 +2135,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
     assert backfill.status == BulkActionStatus.REQUESTED
 
     # The following backfill iteration will attempt to submit run requests for asset_f's two partitions.
-    # The first call to _get_job_execution_data_from_run_request will succeed, but the second call will
+    # The first call to get_job_execution_data_from_run_request will succeed, but the second call will
     # raise a DagsterUserCodeUnreachableError. Subsequently only the first partition will be successfully
     # submitted.
     counter = 0
@@ -2144,7 +2144,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
         nonlocal counter
         if counter == 0:
             counter += 1
-            return _get_job_execution_data_from_run_request(*args, **kwargs)
+            return get_job_execution_data_from_run_request(*args, **kwargs)
         elif counter == 1:
             counter += 1
             raise DagsterUserCodeUnreachableError()
@@ -2154,7 +2154,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
             raise Exception("Should not reach")
 
     with mock.patch(
-        "dagster._core.execution.submit_asset_runs._get_job_execution_data_from_run_request",
+        "dagster._core.execution.submit_asset_runs.get_job_execution_data_from_run_request",
         side_effect=raise_code_unreachable_error_on_second_call,
     ):
         errors = [

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
@@ -149,6 +149,8 @@ def test_old_tick_not_resumed(daemon_not_paused_instance):
     [
         "EVALUATIONS_FINISHED",
         "RUN_REQUESTS_CREATED",
+        "EXECUTION_PLAN_CACHED",
+        "EXECUTION_PLAN_CACHED_1",
     ],
 )
 def test_error_loop_before_cursor_written(daemon_not_paused_instance, crash_location):


### PR DESCRIPTION
## Summary
The way that DA attempts to ensure that each run is launched exactly once is as follows:

1) DA calculations figure out what runs to be requested, reserves a bunch of run IDs
2) A cursor is written with those run requests and run IDs
3) DA attempts to launch each run in succession, hitting the code server to generate job and execution plan snapshots for each one. It checks that a run does not already exist with the reserved run ID before launching.

If there is a failure during step 1, the tick can just retry from scrach - nothing has been written, so there's no risk of duplicated work.
If there is a failure during step 3, things are trickier. We don't want DA to get stuck in a loop where it can't proceed if the failure is permanent, but if it proceeds without launching everything it was supposed to, since the cursor is already written, work might get skipped.

The most common issue that causes a problem during step 3 is a change in the underlying workspace or code servers. For example, if a code location moves into an error state, the ideal behavior would be to not launch anything for that code location and not update the cursor and just wait, so that when the code location is back up and running again it can pick up where it left off.

But if an asset was renamed, for example, it's find to just ignore the cursor for the old asset, since it no longer exists at all.

In both of these cases, the best thing would be for the cursor to just not be written and for the tick to start over from scratch.

This PR attempts to bring us closer to that reality by doing all the reads that require code server access before writing the DA cursor, ensuring that as many failures as possible happen in step 1 where it is safe to retry and guarantee exactly-once semantics, vs. retrying in 3) where it is more dicery.

The main downside here is likely increased latency before any runs actually get submitted - since now all the snapshots need to be generated before a single run is actually created. The total amount of work that needs to happen is unchanged though, it's just the ordering of the steps that gets moved around.

## Test Plan
TBD based on initial feedback
