### PR TITLE
[docs] add explainer for modifying max­­­_concurrent­­­_branch­­­_deployment­­­_runs setting

### DIFF
--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -143,7 +143,7 @@ dagster_cloud_api:
 
 ### How can I set the concurrency limit for runs across all branch deployments?
 
-There is an organization-scoped setting ​​`max­­_concurrent­­_branch­­_deployment­­_runs`​​ that controls concurrency across all branch deployments. By default its value is 50.
+There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
 Modifying organization-scoped settings can only be done using the [​​dagster-cloud​​ CLI](dagster-plus/deployment/management/dagster-cloud-cli/).
 

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -145,7 +145,7 @@ dagster_cloud_api:
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
-Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](dagster-plus/deployment/management/dagster-cloud-cli/).
+Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](dagster-plus/deployment/management/dagster-cloud-cli/). The CLI must be authenticated with a user token for a user that has the [Organization Admin role](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
 
 To view the organization settings in the terminal:
 

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -141,6 +141,30 @@ dagster_cloud_api:
   branch_deployments: true
 ```
 
+### How can I set the concurrency limit for runs across all branch deployments?
+
+There is an organization-scoped setting ​​`max­­_concurrent­­_branch­­_deployment­­_runs`​​ that controls concurrency across all branch deployments. By default its value is 50.
+
+Modifying organization-scoped settings can only be done using the [​​dagster-cloud​​ CLI](dagster-plus/deployment/management/dagster-cloud-cli/).
+
+To view the organization settings in the terminal:
+
+```bash
+dagster-cloud organization settings get # max_concurrent_branch_deployment_runs: 50
+```
+
+To modify organization settings, first save the settings to a `YAML` file on your local system:
+
+```bash
+dagster-cloud organization settings get > org-settings.yaml
+```
+
+Edit the contents of this `YAML` file and save it. Then run the below command to sync the changes:
+
+```bash
+dagster-cloud organization settings set-from-file org-settings.yaml
+```
+
 ## Troubleshooting
 
 ### No agent is serving my branch deployment

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -145,7 +145,7 @@ dagster_cloud_api:
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
-Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](dagster-plus/deployment/management/dagster-cloud-cli/). The CLI must be authenticated with a user token for a user that has the [Organization Admin role](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
+Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](/dagster-plus/deployment/management/dagster-cloud-cli/). The CLI must be authenticated with a user token for a user that has the [Organization Admin role](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
 
 To view the organization settings in the terminal:
 

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -141,7 +141,7 @@ dagster_cloud_api:
   branch_deployments: true
 ```
 
-### How can I set the concurrency limit for runs across all branch deployments?
+### Setting the concurrency limit for runs across all branch deployments
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -145,7 +145,7 @@ dagster_cloud_api:
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
-Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](/dagster-plus/deployment/management/dagster-cloud-cli/). The CLI must be authenticated with a user token for a user that has the [Organization Admin role](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
+Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](/dagster-plus/deployment/management/dagster-cloud-cli/). The CLI must be [authenticated](/dagster-plus/deployment/management/dagster-cloud-cli/installing-and-configuring#setting-up-the-configuration-file) with a user token for a user that has the [Organization Admin role](/dagster-plus/features/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
 
 To view the organization settings in the terminal:
 

--- a/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/dagster-plus/features/ci-cd/branch-deployments/multiple-deployments.md
@@ -145,7 +145,7 @@ dagster_cloud_api:
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
-Modifying organization-scoped settings can only be done using the [​​dagster-cloud​​ CLI](dagster-plus/deployment/management/dagster-cloud-cli/).
+Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](dagster-plus/deployment/management/dagster-cloud-cli/).
 
 To view the organization settings in the terminal:
 


### PR DESCRIPTION
## Summary & Motivation
There is an organization-scoped setting ​​`max­­_concurrent­­_branch­­_deployment­­_runs​​` that controls concurrency across all branch deployments.

We unfortunately do not yet have a good UI for modifying organization-scoped (as opposed to deployment-scoped) settings, but it can be done from the ​​dagster-cloud​​ CLI. This documents how to do that.

## How I Tested These Changes
👀