### PR TITLE
[docs] Fixed typo in aws.md

### DIFF
--- a/docs/docs/guides/deploy/deployment-options/aws.md
+++ b/docs/docs/guides/deploy/deployment-options/aws.md
@@ -78,7 +78,7 @@ run_launcher:
 
 :::note
 
-Fargate tasks only support [certain combinations of CPU and memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) and values of ephemeral storage between 21 and 200 GiB (the default is set to 20 GiB).
+Fargate tasks only support [certain combinations of CPU and memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) and values of ephemeral storage between 20 and 200 GiB (the default is set to 20 GiB).
 
 :::
 


### PR DESCRIPTION
Fargate storage warning stated the values of ephemeral storage are between 21 and 200 GiB (actual values are between 20 and 200 GiB).

## Summary & Motivation

While reading the [Deploying Dagster to Amazon Web Services](https://docs.dagster.io/guides/deploy/deployment-options/aws) page, I noticed a typo in a warning about Fargate ephemeral storage.

## How I Tested These Changes

These changes were not tested, as a single character was changed to fix the typo.
