### PR TITLE
validate partition mappings more comprehensively to avoid runtime errors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -345,7 +345,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
 
     def validate_partition_mappings(self):
         for node in self.asset_nodes:
-            if node.partitions_def is None or node.is_external:
+            if node.is_external:
                 continue
 
             parents = self.get_parents(node)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -174,16 +174,17 @@ class TimeWindowPartitionMapping(
     def validate_partition_mapping(
         self,
         upstream_partitions_def: PartitionsDefinition,
-        downstream_partitions_def: PartitionsDefinition,
+        downstream_partitions_def: Optional[PartitionsDefinition],
     ):
-        check.invariant(
-            isinstance(upstream_partitions_def, TimeWindowPartitionsDefinition),
-            "Upstream partitions definition must be a TimeWindowPartitionsDefinition",
-        )
-        check.invariant(
-            isinstance(downstream_partitions_def, TimeWindowPartitionsDefinition),
-            "Downstream partitions definition must be a TimeWindowPartitionsDefinition",
-        )
+        if not isinstance(downstream_partitions_def, TimeWindowPartitionsDefinition):
+            raise DagsterInvalidDefinitionError(
+                "Downstream partitions definition must be a TimeWindowPartitionsDefinition",
+            )
+
+        if not isinstance(upstream_partitions_def, TimeWindowPartitionsDefinition):
+            raise DagsterInvalidDefinitionError(
+                "Upstream partitions definition must be a TimeWindowPartitionsDefinition",
+            )
 
         upstream_partitions_def = cast("TimeWindowPartitionsDefinition", upstream_partitions_def)
         downstream_partitions_def = cast(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -270,7 +270,7 @@ def test_custom_unsupported_partition_mapping():
         def validate_partition_mapping(
             self,
             upstream_partitions_def: PartitionsDefinition,
-            downstream_partitions_def: PartitionsDefinition,
+            downstream_partitions_def: Optional[PartitionsDefinition],
         ):
             pass
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -278,7 +278,7 @@ def test_fs_io_manager_partitioned_no_partitions():
             def validate_partition_mapping(
                 self,
                 upstream_partitions_def: PartitionsDefinition,
-                downstream_partitions_def: PartitionsDefinition,
+                downstream_partitions_def: Optional[PartitionsDefinition],
             ):
                 pass
 


### PR DESCRIPTION
## Summary & Motivation
Seeing some runtime errors querying status for assets with invalid partition mappings

## How I Tested These Changes
BK

## Changelog
Expanded definition time validation for partition mappings to avoid runtime errors querying asset status.
