### PR TITLE
AssetMaterializationHealthState

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -3,9 +3,8 @@ from typing import Optional
 from dagster import _check as check
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsSubset
 from dagster._core.remote_representation.external_data import AssetNodeSnap
+from dagster._core.storage.partition_status_cache import get_partition_subsets
 from dagster._core.workspace.context import WorkspaceRequestContext
-
-from dagster_graphql.implementation.fetch_assets import get_partition_subsets
 
 
 def regenerate_and_check_partition_subsets(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -40,6 +40,7 @@ from dagster._core.remote_representation.external_data import (
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
 from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.partition_status_cache import get_partition_subsets
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.utils import is_valid_email
 from dagster._core.workspace.permissions import Permissions
@@ -53,7 +54,6 @@ from dagster_graphql.implementation.fetch_assets import (
     get_asset_materializations,
     get_asset_observations,
     get_freshness_info,
-    get_partition_subsets,
 )
 from dagster_graphql.implementation.fetch_partition_subsets import (
     regenerate_and_check_partition_subsets,

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -516,3 +516,80 @@ def get_and_update_asset_status_cache_value(
         instance.update_asset_cached_status_data(asset_key, updated_cache_value)
 
     return updated_cache_value
+
+
+def get_partition_subsets(
+    instance: DagsterInstance,
+    loading_context: LoadingContext,
+    asset_key: AssetKey,
+    dynamic_partitions_loader: DynamicPartitionsStore,
+    partitions_def: Optional[PartitionsDefinition] = None,
+) -> tuple[Optional[PartitionsSubset], Optional[PartitionsSubset], Optional[PartitionsSubset]]:
+    """Returns a tuple of PartitionSubset objects: the first is the materialized partitions,
+    the second is the failed partitions, and the third are in progress.
+    """
+    from dagster._core.storage.event_log.base import AssetRecord
+
+    if not partitions_def:
+        return None, None, None
+
+    if instance.can_read_asset_status_cache() and is_cacheable_partition_type(partitions_def):
+        # When the "cached_status_data" column exists in storage, update the column to contain
+        # the latest partition status values
+        updated_cache_value = get_and_update_asset_status_cache_value(
+            instance,
+            asset_key,
+            partitions_def,
+            dynamic_partitions_loader,
+            loading_context,
+        )
+        materialized_subset = (
+            updated_cache_value.deserialize_materialized_partition_subsets(partitions_def)
+            if updated_cache_value
+            else partitions_def.empty_subset()
+        )
+        failed_subset = (
+            updated_cache_value.deserialize_failed_partition_subsets(partitions_def)
+            if updated_cache_value
+            else partitions_def.empty_subset()
+        )
+        in_progress_subset = (
+            updated_cache_value.deserialize_in_progress_partition_subsets(partitions_def)
+            if updated_cache_value
+            else partitions_def.empty_subset()
+        )
+
+        return materialized_subset, failed_subset, in_progress_subset
+
+    else:
+        # If the partition status can't be cached, fetch partition status from storage
+        if isinstance(partitions_def, MultiPartitionsDefinition):
+            materialized_keys = get_materialized_multipartitions(
+                instance, asset_key, partitions_def
+            )
+        else:
+            materialized_keys = instance.get_materialized_partitions(asset_key)
+
+        validated_keys = get_validated_partition_keys(
+            dynamic_partitions_loader, partitions_def, set(materialized_keys)
+        )
+
+        materialized_subset = (
+            partitions_def.empty_subset().with_partition_keys(validated_keys)
+            if validated_keys
+            else partitions_def.empty_subset()
+        )
+
+        asset_record = AssetRecord.blocking_get(loading_context, asset_key)
+
+        failed_subset, in_progress_subset, _ = build_failed_and_in_progress_partition_subset(
+            instance,
+            asset_key,
+            partitions_def,
+            dynamic_partitions_loader,
+            last_planned_materialization_storage_id=get_last_planned_storage_id(
+                instance, asset_key, asset_record
+            ),
+        )
+
+        return materialized_subset, failed_subset, in_progress_subset

--- a/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from dagster_graphql.implementation.fetch_assets import get_partition_subsets
 from dagster_shared import record
 from dagster_shared.serdes import whitelist_for_serdes
 
@@ -12,6 +11,7 @@ from dagster._core.loader import LoadingContext
 from dagster._core.remote_representation.external_data import PartitionsSnap
 from dagster._core.storage.dagster_run import RunRecord
 from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.partition_status_cache import get_partition_subsets
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
@@ -19,7 +19,10 @@ from dagster._core.storage.partition_status_cache import get_partition_subsets
 class AssetMaterializationHealthState:
     """For tracking the materialization health of an asset, we only care about the most recent
     completed materialization attempt for each asset/partition. This record keeps track of the
-    assets/partitions that are currently in a successful state and those that are in a failed state.
+    assets/partitions that have ever been successfully materialized and those that are currently in
+    a failed state. From this information we can derive the subset that is currently in a successfully
+    materialized state.
+
     If an asset/partition is currently being materialized, it will not move to a new state until after
     the materialization attempt is complete.
 
@@ -37,6 +40,10 @@ class AssetMaterializationHealthState:
         if self.partitions_snap is None:
             return None
         return self.partitions_snap.get_partitions_definition()
+
+    @property
+    def currently_materialized_subset(self) -> SerializableEntitySubset[AssetKey]:
+        return self.materialized_subset.compute_difference(self.failed_subset)
 
     @classmethod
     async def compute_for_asset(
@@ -90,12 +97,9 @@ class AssetMaterializationHealthState:
         has_ever_materialized = asset_entry.last_materialization is not None
         is_currently_failed = await _get_is_currently_failed(loading_context, asset_record)
 
-        # it's possible that the asset is not materialized and not failed (ie if it has never been run)
-        is_currently_materialized = has_ever_materialized and not is_currently_failed
-
         return cls(
             materialized_subset=SerializableEntitySubset(
-                key=asset_key, value=is_currently_materialized
+                key=asset_key, value=has_ever_materialized
             ),
             failed_subset=SerializableEntitySubset(key=asset_key, value=is_currently_failed),
             partitions_snap=None,
@@ -114,15 +118,22 @@ async def _get_is_currently_failed(
             ],
             key=lambda record: -1 if record is None else record.storage_id,
         )
-        return latest_record.storage_id == asset_entry.last_failed_to_materialize_storage_id
+        return (
+            latest_record.storage_id == asset_entry.last_failed_to_materialize_storage_id
+            if latest_record
+            else False
+        )
 
     # if failure events are not stored, we usually have to fetch the run record to check if the
     # asset is currently failed. However, if the latest run id is the same as the last materialization run id,
     # then we know the asset is in a successfully materialized state.
-    if asset_entry.last_run_id == asset_entry.last_materialization.run_id:
+    if (
+        asset_entry.last_materialization
+        and asset_entry.last_run_id == asset_entry.last_materialization.run_id
+    ):
         return False
 
-    run_record = await RunRecord.gen(loading_context, asset_entry.last_run_id)
+    run_record = await RunRecord.gen(loading_context, check.not_none(asset_entry.last_run_id))
     if run_record is None or not run_record.dagster_run.is_finished:
         # the run is deleted or in progress. With the information we have available, we cannot know
         # if the asset is in a failed state prior to this run, so we report it as not failed

--- a/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
@@ -1,0 +1,176 @@
+from typing import Optional
+
+from dagster_graphql.implementation.fetch_assets import get_partition_subsets
+from dagster_shared import record
+from dagster_shared.serdes import whitelist_for_serdes
+
+import dagster._check as check
+from dagster import AssetKey
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.loader import LoadingContext
+from dagster._core.remote_representation.external_data import PartitionsSnap
+from dagster._core.storage.dagster_run import RunRecord
+from dagster._core.storage.event_log.base import AssetRecord
+
+
+@whitelist_for_serdes
+@record.record
+class AssetMaterializationHealthState:
+    """For tracking the materialization health of an asset, we only care about the most recent
+    completed materialization attempt for each asset/partition. This record keeps track of the
+    assets/partitions that are currently in a successful state and those that are in a failed state.
+    If an asset/partition is currently being materialized, it will not move to a new state until after
+    the materialization attempt is complete.
+
+    In the future, we may want to expand this to track the last N materialization successes/failures for
+    each asset. We could also maintain a list of in progress materializations, but that requires streamline to be
+    better able to handle runs being deleted.
+    """
+
+    materialized_subset: SerializableEntitySubset[AssetKey]
+    failed_subset: SerializableEntitySubset[AssetKey]
+    partitions_snap: Optional[PartitionsSnap]
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        if self.partitions_snap is None:
+            return None
+        return self.partitions_snap.get_partitions_definition()
+
+    @classmethod
+    def default(cls, asset_key: AssetKey) -> "AssetMaterializationHealthState":
+        return AssetMaterializationHealthState(
+            materialized_subset=SerializableEntitySubset(key=asset_key, value=False),
+            failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+            partitions_snap=None,
+        )
+
+    @classmethod
+    async def compute_for_asset(
+        cls,
+        asset_key: AssetKey,
+        partitions_def: Optional[PartitionsDefinition],
+        loading_context: LoadingContext,
+    ) -> "AssetMaterializationHealthState":
+        if partitions_def is not None:
+            (
+                materialized_partition_subset,
+                failed_partition_subset,
+                _,
+            ) = get_partition_subsets(
+                loading_context.instance,
+                loading_context,
+                asset_key,
+                loading_context.instance,
+                partitions_def,
+            )
+
+            if materialized_partition_subset is None or failed_partition_subset is None:
+                check.failed("Expected partitions subset for a partitioned asset")
+
+            return cls(
+                materialized_subset=SerializableEntitySubset(
+                    key=asset_key, value=materialized_partition_subset
+                ),
+                failed_subset=SerializableEntitySubset(
+                    key=asset_key, value=failed_partition_subset
+                ),
+                partitions_snap=PartitionsSnap.from_def(partitions_def),
+            )
+
+        asset_record = await AssetRecord.gen(loading_context, asset_key)
+        if asset_record is None:
+            return cls.default(asset_key)
+        asset_entry = asset_record.asset_entry
+
+        if loading_context.instance.can_read_failure_events_for_asset(asset_record):
+            # compute the status based on the asset key table
+            if (
+                asset_entry.last_materialization_storage_id is None
+                and asset_entry.last_failed_to_materialize_storage_id is None
+            ):
+                # never materialized
+                return cls.default(asset_key)
+            if asset_entry.last_failed_to_materialize_storage_id is None:
+                # last_materialization_record must be non-null, therefore the asset successfully materialized
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    partitions_snap=None,
+                )
+            elif asset_entry.last_materialization_storage_id is None:
+                # last_failed_to_materialize_record must be non-null, therefore the asset failed to materialize
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    partitions_snap=None,
+                )
+
+            if (
+                asset_entry.last_materialization_storage_id
+                > asset_entry.last_failed_to_materialize_storage_id
+            ):
+                # latest materialization succeeded
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    partitions_snap=None,
+                )
+            # latest materialization failed
+            return cls(
+                materialized_subset=SerializableEntitySubset(key=asset_key, value=False),
+                failed_subset=SerializableEntitySubset(key=asset_key, value=True),
+                partitions_snap=None,
+            )
+        # we are not storing failure events for this asset, so must compute status based on the information we have available
+        # in some cases this results in reporting as asset as HEALTHY or UNKNOWN during an in progress run
+        # even if the asset was previously failed
+        else:
+            # if the asset has been successfully materialized in the past, we fallback to that status
+            # when we don't have the information available to compute status based on the latest run
+            fallback_health_state = (
+                cls.default(asset_key)
+                if asset_entry.last_materialization is None
+                else cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    partitions_snap=None,
+                )
+            )
+            if asset_entry.last_run_id is None:
+                return fallback_health_state
+
+            assert asset_entry.last_run_id is not None
+            if (
+                asset_entry.last_materialization is not None
+                and asset_entry.last_run_id == asset_entry.last_materialization.run_id
+            ):
+                # latest materialization succeeded in the latest run
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    partitions_snap=None,
+                )
+            run_record = await RunRecord.gen(loading_context, asset_entry.last_run_id)
+            if run_record is None or not run_record.dagster_run.is_finished:
+                return fallback_health_state
+            run_end_time = check.not_none(run_record.end_time)
+            if (
+                asset_entry.last_materialization
+                and asset_entry.last_materialization.timestamp > run_end_time
+            ):
+                # latest materialization was reported manually
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    partitions_snap=None,
+                )
+            if run_record.dagster_run.is_failure:
+                return cls(
+                    materialized_subset=SerializableEntitySubset(key=asset_key, value=False),
+                    failed_subset=SerializableEntitySubset(key=asset_key, value=True),
+                    partitions_snap=None,
+                )
+
+            return fallback_health_state


### PR DESCRIPTION
## Summary & Motivation
Moves the `AssetMaterializationHealthState` previously defined in internal to OSS. Adds a `compute_for_asset` class method to instantiate an `AssetMaterializationHealthState` for an asset based on the data stored in the DB. The implementation is based off of how materialization health is computed for asset health https://github.com/dagster-io/dagster/blob/2f869684c2e80fe916227f2d0cab04f99571e31a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py#L124. A stacked PR will clean up the duplication between these two methods

I needed to move `get_partitions_subsets` out of `dagster_graphql` so i could use it to regenerate the partition status cache when making a new `AssetMaterializationHealthState`

## How I Tested These Changes
tests in https://github.com/dagster-io/internal/pull/15478
