### PR TITLE
add latest run id to `AssetMaterializationHealthState`

### DIFF
--- a/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
@@ -81,17 +81,15 @@ class AssetMaterializationHealthState:
 
             last_run_id = None
             if asset_record is not None:
-                storage_id_to_run_id = {
-                    asset_record.asset_entry.last_materialization_storage_id: asset_record.asset_entry.last_materialization_record.run_id
-                    if asset_record.asset_entry.last_materialization_record
-                    else None,
-                    asset_record.asset_entry.last_failed_to_materialize_storage_id: asset_record.asset_entry.last_failed_to_materialize_record.run_id
-                    if asset_record.asset_entry.last_failed_to_materialize_record
-                    else None,
-                }
-                max_storage_id = max(key for key in storage_id_to_run_id.keys() if key is not None)
-                if max_storage_id is not None:
-                    last_run_id = storage_id_to_run_id[max_storage_id]
+                entry = asset_record.asset_entry
+                latest_record = max(
+                    [
+                        entry.last_materialization_record,
+                        entry.last_failed_to_materialize_record,
+                    ],
+                    key=lambda record: -1 if record is None else record.storage_id,
+                )
+                last_run_id = latest_record.storage_id if latest_record else None
 
             return cls(
                 materialized_subset=SerializableEntitySubset(

--- a/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_streamline/asset_materialization_health.py
@@ -33,6 +33,7 @@ class AssetMaterializationHealthState:
     materialized_subset: The subset of the asset that has ever been successfully materialized.
     failed_subset: The subset of the asset that is currently in a failed state.
     partitions_snap: The partitions definition for the asset. None if it is not a partitioned asset.
+    latest_terminal_run_id: The id of the latest run with a successful or failed materialization event for the asset.
     """
 
     materialized_subset: SerializableEntitySubset[AssetKey]
@@ -141,7 +142,7 @@ async def _get_is_currently_failed_and_latest_terminal_run_id(
     """Determines if the asset is currently in a failed state. If we are storing failure events for the
     asset, this can be determined by looking at the AssetRecord. For assets where we are not storing failure
     events, we have to derive the failure state from the latest run record.
-    
+
     Also returns the id of the latest run with a successful or failed materialization event for the asset.
     """
     asset_entry = asset_record.asset_entry


### PR DESCRIPTION
## Summary & Motivation
In the asset health UIs we want to show the latest failed run id for an asset in a failed state. I figured we might as well just store the id of the latest run to either successfully materialize or fail to materialize the asset. So this adds that metadata. I'm not thrilled with the name `latest_terminal_run_id`, i'm worried it implies that canceled or deleted runs may be included, which is not necessarily the case (unless they successfully materialized an asset before canceling/deleting)

## How I Tested These Changes
in https://github.com/dagster-io/internal/pull/15480

