### PR TITLE
Improved ergonomics for setting internal freshness policies

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -160,18 +160,14 @@ def test_apply_internal_freshness_policy_skip_unsupported() -> None:
         fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
     )
 
-    # Test with skip_unsupported=True
     mapped_assets = apply_internal_freshness_policy(freshness_policy, assets, skip_unsupported=True)
 
-    # Verify we got all assets back
     assert len(mapped_assets) == len(assets)
 
-    # Verify policy was applied to supported assets
     for asset_or_spec in mapped_assets:
         if isinstance(asset_or_spec, (AssetsDefinition, AssetSpec)):
             assert_time_window_policy_on_asset(freshness_policy, asset_or_spec)
         else:
-            # Verify unsupported assets are returned unchanged
             assert isinstance(asset_or_spec, SourceAsset)
             assert asset_or_spec.key == AssetKey("foo_source_asset")
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -100,6 +100,30 @@ def test_apply_internal_freshness_policy_multiple_assets() -> None:
     assert_time_window_policy_on_assets(freshness_policy, mapped_assets)
 
 
+def apply_internal_freshness_policy_to_definitions() -> None:
+    """Can we apply internal freshness policy to a Definitions object?"""
+
+    @asset
+    def foo_asset():
+        pass
+
+    @asset
+    def bar_asset():
+        pass
+
+    spec_def = AssetSpec(key="spec_def")
+
+    defs = Definitions(assets=[foo_asset, bar_asset, spec_def])
+
+    freshness_policy = TimeWindowFreshnessPolicy.from_timedeltas(
+        fail_window=timedelta(hours=24), warn_window=timedelta(hours=12)
+    )
+
+    defs.map_asset_specs(lambda s: s.replace_attributes(internal_freshness_policy=freshness_policy))
+
+    assert_time_window_policy_on_assets(freshness_policy, defs.assets)
+
+
 def test_apply_internal_freshness_policy_unsupported_types() -> None:
     """Applying freshness policy to unsupported types should raise ValueError by default."""
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -100,30 +100,6 @@ def test_apply_internal_freshness_policy_multiple_assets() -> None:
     assert_time_window_policy_on_assets(freshness_policy, mapped_assets)
 
 
-def apply_internal_freshness_policy_to_definitions() -> None:
-    """Can we apply internal freshness policy to a Definitions object?"""
-
-    @asset
-    def foo_asset():
-        pass
-
-    @asset
-    def bar_asset():
-        pass
-
-    spec_def = AssetSpec(key="spec_def")
-
-    defs = Definitions(assets=[foo_asset, bar_asset, spec_def])
-
-    freshness_policy = TimeWindowFreshnessPolicy.from_timedeltas(
-        fail_window=timedelta(hours=24), warn_window=timedelta(hours=12)
-    )
-
-    defs.map_asset_specs(lambda s: s.replace_attributes(internal_freshness_policy=freshness_policy))
-
-    assert_time_window_policy_on_assets(freshness_policy, defs.assets)
-
-
 def test_apply_internal_freshness_policy_unsupported_types() -> None:
     """Applying freshness policy to unsupported types should raise ValueError by default."""
 


### PR DESCRIPTION
## Summary & Motivation
Improves the ergonomics of setting internal freshness policies on large numbers of assets.


Adds helper method `apply_internal_freshness_policy` to set freshness policy directly on a list of assets and specs:

```
@asset
def asset_1: ...

asset_2 = AssetSpec(...)

policy = InternalFreshnessPolicy.time_window(
  fail_window=timedelta(hours=24)
)
assets = [asset_1, asset_2]
return apply_internal_freshness_policy(policy, assets)
```

## How I Tested These Changes
unit tests