### PR TITLE
Catalog v2 perf + loading improvements

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -601,7 +601,7 @@ describe('AssetLiveDataProvider', () => {
     expect(resultFn).toHaveBeenCalled();
     await waitFor(() => {
       expect(hookResult.mock.calls[1][0]!).toEqual({});
-      expect(hookResult.mock.calls[2][0]!).toEqual({
+      expect(hookResult.mock.calls[1][0]!).toEqual({
         ['key1']: expect.any(Object),
         ['key2']: expect.any(Object),
       });
@@ -617,8 +617,7 @@ describe('AssetLiveDataProvider', () => {
       jest.runOnlyPendingTimers();
     });
     expect(hookResult.mock.calls[1][0]!).toEqual({});
-
-    expect(hookResult2.mock.calls[2][0]).toEqual({
+    expect(hookResult2.mock.calls[1][0]).toEqual({
       ['key1']: expect.any(Object),
     });
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -601,7 +601,7 @@ describe('AssetLiveDataProvider', () => {
     expect(resultFn).toHaveBeenCalled();
     await waitFor(() => {
       expect(hookResult.mock.calls[1][0]!).toEqual({});
-      expect(hookResult.mock.calls[1][0]!).toEqual({
+      expect(hookResult.mock.calls[2][0]!).toEqual({
         ['key1']: expect.any(Object),
         ['key2']: expect.any(Object),
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -15,6 +15,7 @@ export const useAssetGraphSupplementaryData = (
 ): {loading: boolean; data: SupplementaryInformation} => {
   const {liveDataByNode} = useAssetsHealthData(
     useMemo(() => nodes.map((node) => node.assetKey), [nodes]),
+    'AssetGraphSupplementaryData', // Separate thread to avoid starving UI
   );
 
   const loading = Object.keys(liveDataByNode).length !== nodes.length;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -6,6 +6,7 @@ import {tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {AssetNode} from '../graphql/types';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | null;
@@ -20,6 +21,8 @@ export type FilterableAssetDefinition = Nullable<
     }
   >
 >;
+
+const EMPTY_ARRAY: any[] = [];
 
 export const useAssetSelectionFiltering = <
   T extends {
@@ -41,10 +44,10 @@ export const useAssetSelectionFiltering = <
   useWorker?: boolean;
   includeExternalAssets?: boolean;
 }) => {
-  const assetsByKey = getAssetsByKey(assets ?? []);
+  const assetsByKey = getAssetsByKey(assets ?? EMPTY_ARRAY);
 
   const externalAssets = useMemo(
-    () => (includeExternalAssets ? assets?.filter((asset) => !asset.definition) : undefined),
+    () => (includeExternalAssets ? getExternalAssets(assets ?? EMPTY_ARRAY) : undefined),
     [assets, includeExternalAssets],
   );
 
@@ -84,3 +87,7 @@ export const useAssetSelectionFiltering = <
 
   return {filtered, filteredByKey, loading, graphAssetKeys, graphQueryItems};
 };
+
+const getExternalAssets = weakMapMemoize(<T extends {definition?: any}>(assets: T[]) => {
+  return assets.filter((asset) => !asset.definition);
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -194,6 +194,7 @@ describe('AssetCatalogTableV2', () => {
           Unknown: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset4']})})],
         },
         loading: false,
+        healthDataLoading: false,
       });
     });
   });
@@ -239,6 +240,7 @@ describe('AssetCatalogTableV2', () => {
           Unknown: [],
         },
         loading: false,
+        healthDataLoading: false,
       },
       {},
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -82,10 +82,6 @@ export const AssetCatalogTableV2 = React.memo(
       return Object.values(liveDataByNode).length !== filtered.length;
     }, [liveDataByNode, filtered]);
 
-    useMemo(() => {
-      console.log({healthDataLoading}, Object.keys(liveDataByNode).length, filtered.length);
-    }, [healthDataLoading]);
-
     const groupedByStatus = useMemo(() => {
       const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
         Degraded: [],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -72,10 +72,7 @@ export const AssetCatalogTableV2 = React.memo(
     const loading = selectionLoading && !filtered.length;
 
     const {liveDataByNode} = useAssetsHealthData(
-      useMemo(() => {
-        console.log('calculating filtered asset keys', filtered.length);
-        return filtered.map((asset) => asAssetKeyInput(asset.key));
-      }, [filtered]),
+      useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
     );
 
     const healthDataLoading = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -26,7 +26,6 @@ import {IndeterminateLoadingBar} from '../../ui/IndeterminateLoadingBar';
 import {numberFormatter} from '../../ui/formatters';
 import {AssetHealthStatusString, statusToIconAndColor} from '../AssetHealthSummary';
 import {AssetsEmptyState} from '../AssetsEmptyState';
-import {LaunchAssetExecutionButton} from '../LaunchAssetExecutionButton';
 import {asAssetKeyInput} from '../asInput';
 import {AssetTableFragment} from '../types/AssetTableFragment.types';
 
@@ -39,6 +38,7 @@ export const AssetCatalogTableV2 = React.memo(
     useBlockTraceUntilTrue('useAllAssets', !!assets?.length && !assetsLoading);
 
     const {favorites, loading: favoritesLoading} = useFavoriteAssets();
+
     const penultimateAssets = useMemo(() => {
       if (!favorites) {
         return assets ?? [];
@@ -72,12 +72,19 @@ export const AssetCatalogTableV2 = React.memo(
     const loading = selectionLoading && !filtered.length;
 
     const {liveDataByNode} = useAssetsHealthData(
-      useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
+      useMemo(() => {
+        console.log('calculating filtered asset keys', filtered.length);
+        return filtered.map((asset) => asAssetKeyInput(asset.key));
+      }, [filtered]),
     );
 
     const healthDataLoading = useMemo(() => {
       return Object.values(liveDataByNode).length !== filtered.length;
     }, [liveDataByNode, filtered]);
+
+    useMemo(() => {
+      console.log({healthDataLoading}, Object.keys(liveDataByNode).length, filtered.length);
+    }, [healthDataLoading]);
 
     const groupedByStatus = useMemo(() => {
       const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
@@ -136,7 +143,14 @@ export const AssetCatalogTableV2 = React.memo(
         case 'insights':
           return <AssetCatalogInsights assets={filtered} selection={assetSelection} />;
         default:
-          return <Table assets={filtered} groupedByStatus={groupedByStatus} loading={loading} />;
+          return (
+            <Table
+              assets={filtered}
+              groupedByStatus={groupedByStatus}
+              loading={loading}
+              healthDataLoading={healthDataLoading}
+            />
+          );
       }
     }, [
       error,
@@ -149,6 +163,7 @@ export const AssetCatalogTableV2 = React.memo(
       toggleFullScreen,
       filtered,
       groupedByStatus,
+      healthDataLoading,
     ]);
 
     const extraStyles =
@@ -192,25 +207,20 @@ export const AssetCatalogTableV2 = React.memo(
   },
 );
 
+AssetCatalogTableV2.displayName = 'AssetCatalogTableV2';
+
 const Table = React.memo(
   ({
     assets,
     groupedByStatus,
     loading,
+    healthDataLoading,
   }: {
     assets: AssetTableFragment[] | undefined;
     groupedByStatus: Record<AssetHealthStatusString, AssetHealthFragment[]>;
     loading: boolean;
+    healthDataLoading: boolean;
   }) => {
-    const scope = useMemo(
-      () => ({
-        all: (assets ?? [])
-          .filter((a): a is AssetWithDefinition => !!a.definition)
-          .map((a) => ({...a.definition, assetKey: a.key})),
-      }),
-      [assets],
-    );
-
     return (
       <div
         style={{
@@ -249,13 +259,12 @@ const Table = React.memo(
                   </>
                 )}
               </Subtitle1>
-              {loading ? (
-                <Skeleton $width={300} $height={21} />
-              ) : (
-                <LaunchAssetExecutionButton scope={scope} />
-              )}
             </Box>
-            <AssetCatalogV2VirtualizedTable groupedByStatus={groupedByStatus} loading={loading} />
+            <AssetCatalogV2VirtualizedTable
+              groupedByStatus={groupedByStatus}
+              loading={loading}
+              healthDataLoading={healthDataLoading}
+            />
           </div>
           {/* <Box border="left" padding={{vertical: 24, horizontal: 12}}>
             Sidebar
@@ -265,7 +274,4 @@ const Table = React.memo(
     );
   },
 );
-
-type AssetWithDefinition = AssetTableFragment & {
-  definition: NonNullable<AssetTableFragment['definition']>;
-};
+Table.displayName = 'Table';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
@@ -33,9 +33,11 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
   ({
     groupedByStatus,
     loading,
+    healthDataLoading,
   }: {
     groupedByStatus: Record<AssetHealthStatusString, AssetHealthFragment[]>;
     loading: boolean;
+    healthDataLoading: boolean;
   }) => {
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -56,7 +58,15 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
       });
     }, [groupedByStatus, openStatuses]);
 
-    const rowItems = loading ? shimmerRows : unGroupedRowItems;
+    const rowItems = useMemo(() => {
+      if (loading) {
+        return shimmerRows;
+      }
+      if (healthDataLoading) {
+        return [...unGroupedRowItems, ...shimmerRows];
+      }
+      return unGroupedRowItems;
+    }, [healthDataLoading, loading, unGroupedRowItems]);
 
     const rowVirtualizer = useVirtualizer({
       count: rowItems.length,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
@@ -1,5 +1,6 @@
 import {BodySmall, Box, Colors, Icon, MiddleTruncate, Spinner} from '@dagster-io/ui-components';
-import React, {useMemo} from 'react';
+import uniqueId from 'lodash/uniqueId';
+import React, {useEffect, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
 import {statusToIconAndColor} from '../AssetHealthSummary';
@@ -10,39 +11,54 @@ import {AssetHealthStatus} from '../../graphql/types';
 import {numberFormatter} from '../../ui/formatters';
 import {AssetTableFragment} from '../types/AssetTableFragment.types';
 import {useAllAssets} from '../useAllAssets';
+import {ViewType} from './util';
 
 export const TILE_WIDTH = 230;
 export const TILE_HEIGHT = 108;
 export const TILE_GAP = 8;
 
+// An in memory cache to side step slow asset selection filtering when revisiting the page.
+// To fix this properly we need to add more caches within useAssetSelectionFiltering and useAssetGraphData but it is difficult to do so
+// since the array of nodes they receive aren't the same when you visit the page again since they're the result of `.filter` calls.
+const memoryCache = new Map<string, {assets: any[]}>();
+
 export const AssetSelectionSummaryTileFromSelection = React.memo(
   ({
     icon,
-    label,
     selection,
-    link,
   }: {
     icon: React.ReactNode;
-    label: string;
-    selection: string;
-    link: string;
+    selection: Extract<ViewType, {__typename: 'CatalogView'}>;
   }) => {
-    const {assets, loading} = useAllAssets();
-    const {filtered} = useAssetSelectionFiltering({
-      assets,
-      assetSelection: selection,
-      loading,
+    const assetSelection = selection.selection.querySelection ?? '';
+    const {assets: allAssets, loading: allAssetsLoading} = useAllAssets();
+
+    const {filtered, loading: filteredLoading} = useAssetSelectionFiltering({
+      assets: allAssets,
+      assetSelection,
+      loading: allAssetsLoading,
       useWorker: false,
       includeExternalAssets: true,
     });
 
+    useEffect(() => {
+      if (filtered.length > 0) {
+        memoryCache.set(assetSelection, {assets: filtered});
+      }
+    }, [filtered, assetSelection]);
+
+    const assets = filtered.length ? filtered : (memoryCache.get(assetSelection)?.assets ?? []);
+
+    const loading = filteredLoading && assets.length === 0;
+
     return (
       <AssetSelectionSummaryTile
         icon={icon}
-        label={label}
-        assets={filtered}
-        link={link}
+        label={selection.name}
+        assets={assets}
+        link={selection.link}
         loading={loading}
+        threadId={useMemo(() => uniqueId('health-thread-'), [])}
       />
     );
   },
@@ -55,19 +71,22 @@ export const AssetSelectionSummaryTile = React.memo(
     assets,
     link,
     loading: assetsLoading,
+    threadId,
   }: {
     icon: React.ReactNode;
     label: string;
     assets: AssetTableFragment[];
     link: string;
     loading?: boolean;
+    threadId?: string;
   }) => {
     const assetCount = assets.length;
     const {liveDataByNode} = useAssetsHealthData(
       useMemo(() => assets.map((asset) => asset.key), [assets]),
+      threadId,
     );
 
-    const loading = assetsLoading || assets.length !== Object.keys(liveDataByNode).length;
+    const loading = assetsLoading || assets.length > Object.keys(liveDataByNode).length;
 
     const statusCounts = useMemo(() => {
       return Object.values(liveDataByNode).reduce(
@@ -86,13 +105,13 @@ export const AssetSelectionSummaryTile = React.memo(
       );
     }, [liveDataByNode]);
 
+    const degradedMeta = statusToIconAndColor[AssetHealthStatus.DEGRADED];
+    const warningMeta = statusToIconAndColor[AssetHealthStatus.WARNING];
+
     const degradedJsx = statusCounts[AssetHealthStatus.DEGRADED] && (
       <Box className={styles.statusCountItem}>
-        <Icon
-          name={statusToIconAndColor[AssetHealthStatus.DEGRADED].iconName}
-          color={statusToIconAndColor[AssetHealthStatus.DEGRADED].iconColor}
-        />
-        <BodySmall color={statusToIconAndColor[AssetHealthStatus.DEGRADED].textColor}>
+        <Icon name={degradedMeta.iconName} color={degradedMeta.iconColor} />
+        <BodySmall color={degradedMeta.textColor}>
           {numberFormatter.format(statusCounts[AssetHealthStatus.DEGRADED])}
         </BodySmall>
       </Box>
@@ -100,11 +119,8 @@ export const AssetSelectionSummaryTile = React.memo(
 
     const warningJsx = statusCounts[AssetHealthStatus.WARNING] && (
       <Box className={styles.statusCountItem}>
-        <Icon
-          name={statusToIconAndColor[AssetHealthStatus.WARNING].iconName}
-          color={statusToIconAndColor[AssetHealthStatus.WARNING].iconColor}
-        />
-        <BodySmall color={statusToIconAndColor[AssetHealthStatus.WARNING].textColor}>
+        <Icon name={warningMeta.iconName} color={warningMeta.iconColor} />
+        <BodySmall color={warningMeta.textColor}>
           {numberFormatter.format(statusCounts[AssetHealthStatus.WARNING])}
         </BodySmall>
       </Box>
@@ -129,9 +145,16 @@ export const AssetSelectionSummaryTile = React.memo(
           <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
             <Box className={styles.assetCount} style={{color: Colors.textLight()}}>
               <Icon name="asset" color={Colors.textLight()} />
-              <BodySmall color={Colors.textLight()}>{assetCount.toLocaleString()} assets</BodySmall>
+              {assetsLoading ? (
+                <Spinner purpose="caption-text" />
+              ) : (
+                <BodySmall color={Colors.textLight()}>
+                  {numberFormatter.format(assetCount)} assets
+                </BodySmall>
+              )}
             </Box>
-            {loading ? (
+
+            {assetsLoading ? null : loading ? (
               <Spinner purpose="caption-text" />
             ) : (
               <>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
@@ -431,9 +431,7 @@ const SelectionTile = React.memo(
     ) : (
       <AssetSelectionSummaryTileFromSelection
         icon={<InsightsIcon name={item.icon as IconName} size={24} />}
-        label={item.name}
-        selection={item.selection.querySelection ?? ''}
-        link={item.link}
+        selection={item}
       />
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
@@ -144,11 +144,7 @@ export const AssetsGroupedView = ({assets}: {assets: AssetTableFragment[]}) => {
       return <SectionedGrid sections={sections} tileGap={TILE_GAP} tileWidth={TILE_WIDTH} />;
     }
 
-    return (
-      <Box padding={{horizontal: 24, vertical: 24}}>
-        <Grid tiles={tiles} tileGap={TILE_GAP} tileWidth={TILE_WIDTH} />
-      </Box>
-    );
+    return <Grid tiles={tiles} tileGap={TILE_GAP} tileWidth={TILE_WIDTH} />;
   }
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/ListGridViews.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/ListGridViews.tsx
@@ -163,7 +163,10 @@ export function getTilesPerRow(viewport: Viewport, tileGap: number, tileWidth: n
   if (!viewport.width) {
     return 0;
   }
-  return Math.floor((viewport.width + tileGap - PADDING_HORIZONTAL * 2) / (tileWidth + tileGap));
+  return Math.max(
+    Math.floor((viewport.width + tileGap - PADDING_HORIZONTAL * 2) / (tileWidth + tileGap)),
+    1,
+  );
 }
 
 export const List = ({rows}: {rows: React.ReactNode[]}) => {


### PR DESCRIPTION
## Summary & Motivation
1. More memoization
2. Add shimmer rows when health data is still loading to avoid going from showing shimmer rows to no rows / 1 row when we have partial data
3. Add an in memory cache for asset selection resolution similar to what we had in the cloud version of the catalog view tiles.
4. Use a separate live data thread for fetching health data in useAssetGraphSupplementaryData in order to avoid starving the rest of the UI out making the catalog load much faster.
5. Use JSON.stringify on keys in LiveData to avoid unsubscribing/resubscribing to the same set of keys when references change.
6. Process live data updates immediately when cache data is available during subscription to avoid an artificial delay on page load.

## How I Tested These Changes

App-proxy. Existing tests for LiveDataProvider