### PR TITLE
[asset health] use streamline data when available to get materialization health

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -7,11 +7,13 @@ from dagster._core.storage.event_log.base import AssetRecord
 from dagster._streamline.asset_check_health import AssetCheckHealthState
 from dagster._streamline.asset_freshness_health import AssetFreshnessHealthState
 from dagster._streamline.asset_health import AssetHealthStatus
+from dagster._streamline.asset_materialization_health import AssetMaterializationHealthState
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.asset_health import (
         GrapheneAssetHealthCheckMeta,
         GrapheneAssetHealthFreshnessMeta,
+        GrapheneAssetHealthMaterializationMeta,
     )
     from dagster_graphql.schema.util import ResolveInfo
 
@@ -139,3 +141,95 @@ async def get_freshness_status_and_metadata(
 
     else:
         check.failed(f"Unexpected freshness state: {asset_freshness_health_state.freshness_state}")
+
+
+async def get_materialization_status_and_metadata(
+    graphene_info: "ResolveInfo", asset_key: AssetKey
+) -> tuple[str, Optional["GrapheneAssetHealthMaterializationMeta"]]:
+    """Gets an AssetMaterializationHealthState object for an asset, either via streamline or by computing
+    it based on the state of the DB. Then converts it to a GrapheneAssetHealthStatus and the metdata
+    needed to power the UIs. Metadata is fetched from the AssetLatestMaterializationState object, again
+    either via streamline or by computing it based on the state of the DB.
+    """
+    from dagster_graphql.schema.asset_health import (
+        GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta,
+        GrapheneAssetHealthMaterializationDegradedPartitionedMeta,
+        GrapheneAssetHealthMaterializationHealthyPartitionedMeta,
+        GrapheneAssetHealthStatus,
+    )
+
+    asset_materialization_health_state = None
+    if graphene_info.context.instance.streamline_read_asset_health_supported():
+        asset_materialization_health_state = (
+            graphene_info.context.instance.get_asset_materialization_health_state_for_asset(
+                asset_key
+            )
+        )
+    # captures streamline disabled or consumer state doesn't exist (because it's an observable source asset)
+    if asset_materialization_health_state is None:
+        node_snap = graphene_info.context.asset_graph.get(asset_key)
+        if node_snap.is_observable and not node_snap.is_materializable:  # observable source asset
+            # get the asset record to see if there is an observation event
+            asset_record = await AssetRecord.gen(graphene_info.context, asset_key)
+            if asset_record and asset_record.asset_entry.last_observation is not None:
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            return GrapheneAssetHealthStatus.UNKNOWN, None
+
+        asset_materialization_health_state = (
+            await AssetMaterializationHealthState.compute_for_asset(
+                asset_key,
+                node_snap.partitions_def,
+                graphene_info.context,
+            )
+        )
+
+    if asset_materialization_health_state.health_status == AssetHealthStatus.HEALTHY:
+        num_missing = 0
+        if asset_materialization_health_state.partitions_def is not None:
+            total_num_partitions = (
+                asset_materialization_health_state.partitions_def.get_num_partitions(
+                    dynamic_partitions_store=graphene_info.context.instance
+                )
+            )
+            # asset is health, so no partitions are failed
+            num_materialized = len(
+                asset_materialization_health_state.materialized_subset.subset_value
+            )
+            num_missing = total_num_partitions - num_materialized
+        if num_missing > 0:
+            meta = GrapheneAssetHealthMaterializationHealthyPartitionedMeta(
+                numMissingPartitions=num_missing,
+                totalNumPartitions=total_num_partitions,
+            )
+        else:
+            # captures the case when asset is not partitioned, or the asset is partitioned and all partitions are materialized
+            meta = None
+        return GrapheneAssetHealthStatus.HEALTHY, meta
+    elif asset_materialization_health_state.health_status == AssetHealthStatus.DEGRADED:
+        if asset_materialization_health_state.partitions_def is not None:
+            total_num_partitions = (
+                asset_materialization_health_state.partitions_def.get_num_partitions(
+                    dynamic_partitions_store=graphene_info.context.instance
+                )
+            )
+            num_failed = len(asset_materialization_health_state.failed_subset.subset_value)
+            num_materialized = len(
+                asset_materialization_health_state.currently_materialized_subset.subset_value
+            )
+            num_missing = total_num_partitions - num_materialized - num_failed
+            meta = GrapheneAssetHealthMaterializationDegradedPartitionedMeta(
+                numFailedPartitions=num_failed,
+                numMissingPartitions=num_missing,
+                totalNumPartitions=total_num_partitions,
+            )
+        else:
+            meta = GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
+                failedRunId=asset_materialization_health_state.latest_terminal_run_id,
+            )
+        return GrapheneAssetHealthStatus.DEGRADED, meta
+    elif asset_materialization_health_state.health_status == AssetHealthStatus.UNKNOWN:
+        return GrapheneAssetHealthStatus.UNKNOWN, None
+    else:
+        check.failed(
+            f"Unexpected materialization health status: {asset_materialization_health_state.health_status}"
+        )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -185,6 +185,7 @@ async def get_materialization_status_and_metadata(
 
     if asset_materialization_health_state.health_status == AssetHealthStatus.HEALTHY:
         num_missing = 0
+        total_num_partitions = 0
         if asset_materialization_health_state.partitions_def is not None:
             total_num_partitions = (
                 asset_materialization_health_state.partitions_def.get_num_partitions(
@@ -196,7 +197,7 @@ async def get_materialization_status_and_metadata(
                 asset_materialization_health_state.materialized_subset.subset_value
             )
             num_missing = total_num_partitions - num_materialized
-        if num_missing > 0:
+        if num_missing > 0 and total_num_partitions > 0:
             meta = GrapheneAssetHealthMaterializationHealthyPartitionedMeta(
                 numMissingPartitions=num_missing,
                 totalNumPartitions=total_num_partitions,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -22,7 +22,7 @@ async def get_asset_check_status_and_metadata(
     graphene_info: "ResolveInfo",
     asset_key: AssetKey,
 ) -> tuple[str, Optional["GrapheneAssetHealthCheckMeta"]]:
-    """Converts an AssetCheckHealthState object to a GrapheneAssetHealthStatus and the metdata
+    """Converts an AssetCheckHealthState object to a GrapheneAssetHealthStatus and the metadata
     needed to power the UIs.
     """
     from dagster_graphql.schema.asset_health import (
@@ -88,7 +88,7 @@ async def get_freshness_status_and_metadata(
     graphene_info: "ResolveInfo", asset_key: AssetKey
 ) -> tuple[str, Optional["GrapheneAssetHealthFreshnessMeta"]]:
     """Gets an AssetFreshnessHealthState object for an asset, either via streamline or by computing
-    it based on the state of the DB. Then converts it to a GrapheneAssetHealthStatus and the metdata
+    it based on the state of the DB. Then converts it to a GrapheneAssetHealthStatus and the metadata
     needed to power the UIs. Metadata is fetched from the AssetLatestMaterializationState object, again
     either via streamline or by computing it based on the state of the DB.
     """
@@ -147,7 +147,7 @@ async def get_materialization_status_and_metadata(
     graphene_info: "ResolveInfo", asset_key: AssetKey
 ) -> tuple[str, Optional["GrapheneAssetHealthMaterializationMeta"]]:
     """Gets an AssetMaterializationHealthState object for an asset, either via streamline or by computing
-    it based on the state of the DB. Then converts it to a GrapheneAssetHealthStatus and the metdata
+    it based on the state of the DB. Then converts it to a GrapheneAssetHealthStatus and the metadata
     needed to power the UIs. Metadata is fetched from the AssetLatestMaterializationState object, again
     either via streamline or by computing it based on the state of the DB.
     """

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -1,17 +1,11 @@
 import asyncio
-from typing import Optional
 
 import graphene
-from dagster import _check as check
-from dagster._core.storage.dagster_run import RunRecord
-from dagster._core.storage.event_log.base import AssetRecord
 
 from dagster_graphql.implementation.fetch_asset_health import (
     get_asset_check_status_and_metadata,
     get_freshness_status_and_metadata,
-)
-from dagster_graphql.implementation.fetch_partition_subsets import (
-    regenerate_and_check_partition_subsets,
+    get_materialization_status_and_metadata,
 )
 from dagster_graphql.schema.util import ResolveInfo
 
@@ -123,154 +117,12 @@ class GrapheneAssetHealth(graphene.ObjectType):
         self.asset_check_status_task = None
         self.freshness_status_task = None
 
-    async def get_materialization_status_for_asset_health(
-        self, graphene_info: ResolveInfo
-    ) -> tuple[str, Optional[GrapheneAssetHealthMaterializationMeta]]:
-        """Computes the health indicator for the asset materialization status. Follows these rules:
-        If the asset is partitioned:
-            - HEALTHY - all partitions successfully materialized.
-            - WARNING - some partitions are successful but any number of partitions are missing (but no failed partitions).
-            - DEGRADED - any number of partitions are failed.
-            - UNKNOWN - all partitions are missing.
-        If the asset is not partitioned:
-            - HEALTHY - the latest materialization of an asset was successfully materialized.
-            - WARNING - no conditions lead to a warning status.
-            - DEGRADED - latest materialization of an asset failed.
-            - UNKNOWN - asset has never had a materialization attempt.
-        """
-        partitions_snap = self._asset_node_snap.partitions
-        asset_key = self._asset_node_snap.asset_key
-        if partitions_snap is not None:  # isPartitioned
-            (
-                materialized_partition_subset,
-                failed_partition_subset,
-                _,
-            ) = regenerate_and_check_partition_subsets(
-                graphene_info.context, self._asset_node_snap, self._dynamic_partitions_loader
-            )
-            total_num_partitions = partitions_snap.get_partitions_definition().get_num_partitions(
-                dynamic_partitions_store=self._dynamic_partitions_loader
-            )
-            currently_materialized_subset = materialized_partition_subset - failed_partition_subset
-            num_materialized = len(currently_materialized_subset)
-            num_failed = len(failed_partition_subset)
-            if num_materialized == 0 and num_failed == 0:
-                # asset has never been materialized
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-            num_missing = total_num_partitions - num_materialized - num_failed
-            if num_failed > 0:
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedPartitionedMeta(
-                        numFailedPartitions=num_failed,
-                        numMissingPartitions=num_missing,
-                        totalNumPartitions=total_num_partitions,
-                    ),
-                )
-            # missing partitions are ok as long as some partitions are successfully materialized (and no failures)
-            # but we want to show the number of missing partitions in the metadata
-            return (
-                GrapheneAssetHealthStatus.HEALTHY,
-                GrapheneAssetHealthMaterializationHealthyPartitionedMeta(
-                    numMissingPartitions=num_missing,
-                    totalNumPartitions=total_num_partitions,
-                )
-                if num_missing > 0
-                else None,
-            )
-
-        asset_record = await AssetRecord.gen(graphene_info.context, asset_key)
-        if asset_record is None:
-            return GrapheneAssetHealthStatus.UNKNOWN, None
-        asset_entry = asset_record.asset_entry
-
-        if self._asset_node_snap.is_observable and not self._asset_node_snap.is_materializable:
-            # for observable assets, if there is an observation event then the asset is healthy
-            if asset_entry.last_observation is not None:
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            else:
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-
-        if graphene_info.context.instance.can_read_failure_events_for_asset(asset_record):
-            # compute the status based on the asset key table
-            if (
-                asset_entry.last_materialization_storage_id is None
-                and asset_entry.last_failed_to_materialize_storage_id is None
-            ):
-                # never materialized
-                return GrapheneAssetHealthStatus.UNKNOWN, None
-            if asset_entry.last_failed_to_materialize_storage_id is None:
-                # last_materialization_record must be non-null, therefore the asset successfully materialized
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            elif asset_entry.last_materialization_storage_id is None:
-                # last_failed_to_materialize_record must be non-null, therefore the asset failed to materialize
-                last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                        failedRunId=last_failed_record.run_id,
-                    ),
-                )
-
-            if (
-                asset_entry.last_materialization_storage_id
-                > asset_entry.last_failed_to_materialize_storage_id
-            ):
-                # latest materialization succeeded
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            # latest materialization failed
-            last_failed_record = check.not_none(asset_entry.last_failed_to_materialize_record)
-            return (
-                GrapheneAssetHealthStatus.DEGRADED,
-                GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                    failedRunId=last_failed_record.run_id,
-                ),
-            )
-        # we are not storing failure events for this asset, so must compute status based on the information we have available
-        # in some cases this results in reporting as asset as HEALTHY or UNKNOWN during an in progress run
-        # even if the asset was previously failed
-        else:
-            # if the asset has been successfully materialized in the past, we fallback to that status
-            # when we don't have the information available to compute status based on the latest run
-            fallback_status_and_meta = (
-                (GrapheneAssetHealthStatus.UNKNOWN, None)
-                if asset_entry.last_materialization is None
-                else (GrapheneAssetHealthStatus.HEALTHY, None)
-            )
-            if asset_entry.last_run_id is None:
-                return fallback_status_and_meta
-
-            assert asset_entry.last_run_id is not None
-            if (
-                asset_entry.last_materialization is not None
-                and asset_entry.last_run_id == asset_entry.last_materialization.run_id
-            ):
-                # latest materialization succeeded in the latest run
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            run_record = await RunRecord.gen(graphene_info.context, asset_entry.last_run_id)
-            if run_record is None or not run_record.dagster_run.is_finished:
-                return fallback_status_and_meta
-            run_end_time = check.not_none(run_record.end_time)
-            if (
-                asset_entry.last_materialization
-                and asset_entry.last_materialization.timestamp > run_end_time
-            ):
-                # latest materialization was reported manually
-                return GrapheneAssetHealthStatus.HEALTHY, None
-            if run_record.dagster_run.is_failure:
-                return (
-                    GrapheneAssetHealthStatus.DEGRADED,
-                    GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
-                        failedRunId=run_record.dagster_run.run_id,
-                    ),
-                )
-
-            return fallback_status_and_meta
-
     async def resolve_materializationStatus(self, graphene_info: ResolveInfo) -> str:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                self.get_materialization_status_for_asset_health(graphene_info)
+                get_materialization_status_and_metadata(
+                    graphene_info, self._asset_node_snap.asset_key
+                )
             )
         materialization_status, _ = await self.materialization_status_task
         return materialization_status
@@ -280,7 +132,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
     ) -> GrapheneAssetHealthMaterializationMeta:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                self.get_materialization_status_for_asset_health(graphene_info)
+                get_materialization_status_and_metadata(
+                    graphene_info, self._asset_node_snap.asset_key
+                )
             )
         _, materialization_status_metadata = await self.materialization_status_task
         return materialization_status_metadata
@@ -330,7 +184,9 @@ class GrapheneAssetHealth(graphene.ObjectType):
             return GrapheneAssetHealthStatus.UNKNOWN
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                self.get_materialization_status_for_asset_health(graphene_info)
+                get_materialization_status_and_metadata(
+                    graphene_info, self._asset_node_snap.asset_key
+                )
             )
         materialization_status, _ = await self.materialization_status_task
         if self.asset_check_status_task is None:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -194,6 +194,7 @@ if TYPE_CHECKING:
     from dagster._core.storage.sql import AlembicVersion
     from dagster._core.workspace.context import BaseWorkspaceRequestContext
     from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
+    from dagster._streamline.asset_materialization_health import AssetMaterializationHealthState
 
 
 DagsterInstanceOverrides: TypeAlias = Mapping[str, Any]
@@ -3593,4 +3594,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def get_asset_freshness_health_state_for_asset(
         self, asset_key: AssetKey
     ) -> Optional[AssetFreshnessHealthState]:
+        return None
+
+    def get_asset_materialization_health_state_for_asset(
+        self, asset_key: AssetKey
+    ) -> Optional["AssetMaterializationHealthState"]:
         return None


### PR DESCRIPTION
## Summary & Motivation
Updates the GQL resolver for asset health to use streamline data when available

## How I Tested These Changes
tests in https://github.com/dagster-io/internal/pull/15492

