### PR TITLE
Update asset breadcrumb links for new observe UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -4,6 +4,7 @@ import {Box, Colors, Heading, Icon, MiddleTruncate, PageHeader} from '@dagster-i
 import * as React from 'react';
 import {useContext} from 'react';
 import {Link, useHistory, useLocation} from 'react-router-dom';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {
   getAssetSelectionQueryString,
   useAssetSelectionState,
@@ -12,6 +13,7 @@ import styled from 'styled-components';
 
 import {globalAssetGraphPathToString} from './globalAssetGraphPathToString';
 import {AppContext} from '../app/AppContext';
+import {featureEnabled} from '../app/Flags';
 import {AnchorButton} from '../ui/AnchorButton';
 import {CopyIconButton} from '../ui/CopyButton';
 
@@ -42,10 +44,14 @@ export const AssetPageHeader = ({
   const breadcrumbs = React.useMemo(() => {
     const keyPathItems: BreadcrumbProps[] = [];
     assetKey.path.reduce((accum: string, elem: string) => {
-      const href = `${accum}/${encodeURIComponent(elem)}`;
+      const nextAccum = `${accum ? `${accum}/` : ''}${encodeURIComponent(elem)}`;
+      let href = `/assets/${nextAccum}?view=folder`;
+      if (featureEnabled(FeatureFlag.flagUseNewObserveUIs)) {
+        href = `/assets?asset-selection=key:"${nextAccum}*"`;
+      }
       keyPathItems.push({text: elem, href});
-      return href;
-    }, '/assets');
+      return nextAccum;
+    }, '');
 
     // Use createHref to prepend the basePath on all items. We don't have control over the
     // breadcrumb overflow rendering, and Blueprint renders the overflow items with no awareness

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -4,6 +4,7 @@ import {Alert, Box, ErrorBoundary, Spinner, Tag} from '@dagster-io/ui-components
 import React, {useContext, useEffect, useMemo} from 'react';
 import {Link, Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {getAssetSelectionQueryString} from 'shared/asset-selection/useAssetSelectionState.oss';
 import {AssetPageHeader} from 'shared/assets/AssetPageHeader.oss';
 
@@ -33,6 +34,7 @@ import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDial
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 import {useReportEventsDialog} from './useReportEventsDialog';
 import {useWipeDialog} from './useWipeDialog';
+import {featureEnabled} from '../app/Flags';
 import {currentPageAtom} from '../app/analytics';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetLiveDataRefreshButton, useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
@@ -277,12 +279,13 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
   );
 
   if (definitionQueryResult.data?.assetOrError.__typename === 'AssetNotFoundError') {
+    let nextPath = `/assets/${currentPath.join('/')}?view=folder${getAssetSelectionQueryString()}`;
+    if (featureEnabled(FeatureFlag.flagUseNewObserveUIs)) {
+      // The new UI doesn't have folders. So instead set the asset selection to filter to assets prefixed with the current path.
+      nextPath = `/assets?asset-selection=key:"${currentPath.join('/')}*"`;
+    }
     // Redirect to the asset catalog
-    return (
-      <Redirect
-        to={`/assets/${currentPath.join('/')}?view=folder${getAssetSelectionQueryString()}`}
-      />
-    );
+    return <Redirect to={nextPath} />;
   }
 
   return (


### PR DESCRIPTION
## Summary & Motivation

With the new observe UI we no longer have "folders" and so the folder linking doesn't work. Update the links to instead use the asset selection syntax to scope the catalog to the "folder".

## How I Tested These Changes


https://github.com/user-attachments/assets/1222cfc9-79a2-42bd-a2f8-e3cad6267bfa


