### PR TITLE
[dagster-databricks] Skip tests reliant on external infrastructure

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
@@ -40,7 +40,6 @@ def upload_dagster_pipes_whl(databricks_client: WorkspaceClient) -> Iterator[str
     with dbfs_tempdir(dbfs_client) as tempdir:
         path = os.path.join(f"dbfs:{tempdir}", DAGSTER_PIPES_WHL_FILENAME)
         subprocess.check_call(
-            # ["dbfs", "cp", "--overwrite", f"dist/{DAGSTER_PIPES_WHL_FILENAME}", DAGSTER_PIPES_WHL_PATH]
             ["dbfs", "cp", "--overwrite", f"dist/{DAGSTER_PIPES_WHL_FILENAME}", path]
         )
         os.chdir(orig_wd)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -111,7 +111,7 @@ def make_submit_task_dict(
 
 def make_new_cluster_spec(forward_logs: bool, use_inner_objects: bool = False) -> Any:
     cluster_spec = CLUSTER_DEFAULTS.copy()
-    databricks_host = os.getenv("DATABRICKS_HOST")
+    databricks_host = os.getenv("DATABRICKS_HOST", "")
     if "azuredatabricks.net" in databricks_host:
         cluster_spec["node_type_id"] = "Standard_DS3_v2"
     else:  # Assume AWS


### PR DESCRIPTION
## Summary & Motivation

Addresses https://github.com/dagster-io/dagster/issues/29526, by adding a pytest `skipif` condition on the presence of the `DATABRICKS_HOST` environment variable. It appears these tests were built assuming AWS infrastructure, so some basic parsing of the URL was done to set the `node_type_id` to Azure equivalents, with a fallback to the previous default.

Some basic cleaning for typos and unused code was done elsewhere in the module.

## How I Tested These Changes

Locally targeting the `dagster-databricks` library path. 
