### PR TITLE
[components] Automatically enable code references for dbt component

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -24,7 +24,11 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import get_asset_key_for_model, get_node
 from dagster_dbt.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
 from dagster_dbt.core.resource import DbtCliResource
-from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
+from dagster_dbt.dagster_dbt_translator import (
+    DagsterDbtComponentsTranslatorSettings,
+    DagsterDbtTranslator,
+    DagsterDbtTranslatorSettings,
+)
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
 from dagster_dbt.dbt_project import DbtProject
 
@@ -132,7 +136,7 @@ class DbtProjectComponent(Component, Resolvable):
     translation: Optional[ResolvedTranslationFn] = None
     select: str = "fqn:*"
     exclude: Optional[str] = None
-    translation_settings: Optional[DagsterDbtTranslatorSettings] = None
+    translation_settings: Optional[DagsterDbtComponentsTranslatorSettings] = None
 
     @cached_property
     def translator(self):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -70,11 +70,6 @@ class DagsterDbtTranslatorSettings(Resolvable):
     enable_source_tests_as_checks: bool = False
 
 
-@dataclass(frozen=True)
-class DagsterDbtComponentsTranslatorSettings(DagsterDbtTranslatorSettings):
-    enable_code_references: bool = True
-
-
 class DagsterDbtTranslator:
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
     of a dbt resource (models, tests, sources, etc).

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -70,6 +70,11 @@ class DagsterDbtTranslatorSettings(Resolvable):
     enable_source_tests_as_checks: bool = False
 
 
+@dataclass(frozen=True)
+class DagsterDbtComponentsTranslatorSettings(DagsterDbtTranslatorSettings):
+    enable_code_references: bool = True
+
+
 class DagsterDbtTranslator:
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
     of a dbt resource (models, tests, sources, etc).

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -11,6 +11,10 @@ import pytest
 from click.testing import CliRunner
 from dagster import AssetKey, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
+from dagster._core.definitions.metadata.source_code import (
+    CodeReferencesMetadataValue,
+    LocalFileCodeReference,
+)
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils.env import environ
 from dagster.components.core.context import ComponentLoadContext
@@ -20,6 +24,7 @@ from dagster.components.resolved.errors import ResolutionException
 from dagster_dbt import DbtProject, DbtProjectComponent
 from dagster_dbt.cli.app import project_app_typer_click_object
 from dagster_dbt.components.dbt_project.component import get_projects_from_dbt_component
+from dagster_shared import check
 
 ensure_dagster_tests_import()
 from dagster_tests.components_tests.integration_tests.component_loader import (
@@ -85,6 +90,15 @@ def test_python_params(dbt_path: Path, backfill_policy: Optional[str]) -> None:
     assets_def = defs.get_assets_def("stg_customers")
     assert assets_def.op.name == "some_op"
     assert assets_def.op.tags["tag1"] == "value"
+
+    # Ensure dbt code references are automatically added to the asset
+    refs = check.inst(
+        assets_def.metadata_by_key[AssetKey("stg_customers")]["dagster/code_references"],
+        CodeReferencesMetadataValue,
+    )
+    assert len(refs.code_references) == 1
+    assert isinstance(refs.code_references[0], LocalFileCodeReference)
+    assert refs.code_references[0].file_path.endswith("models/staging/stg_customers.sql")
 
     if backfill_policy is None:
         assert assets_def.backfill_policy is None


### PR DESCRIPTION
## Summary

Enables code references to underlying SQL files, by default, for the DBT component.

## Test Plan

Unit test.