### PR TITLE
[components][dagster-sling] Add code refs to sling files

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -80,9 +80,9 @@ def local_source_path_from_fn(fn: Callable[..., Any]) -> Optional[LocalFileCodeR
 
 
 def merge_code_references(
-    asset_spec: AssetSpec,
+    asset_spec: "AssetSpec",
     new_code_references: Sequence[CodeReference],
-) -> AssetSpec:
+) -> "AssetSpec":
     existing_references_meta = CodeReferencesMetadataSet.extract(asset_spec.metadata)
     references = (
         existing_references_meta.code_references.code_references

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -79,6 +79,32 @@ def local_source_path_from_fn(fn: Callable[..., Any]) -> Optional[LocalFileCodeR
     return LocalFileCodeReference(file_path=origin_file, line_number=origin_line)
 
 
+def merge_code_references(
+    asset_spec: AssetSpec,
+    new_code_references: Sequence[CodeReference],
+) -> AssetSpec:
+    existing_references_meta = CodeReferencesMetadataSet.extract(asset_spec.metadata)
+    references = (
+        existing_references_meta.code_references.code_references
+        if existing_references_meta.code_references
+        else []
+    )
+
+    return asset_spec.replace_attributes(
+        metadata={
+            **asset_spec.metadata,
+            **CodeReferencesMetadataSet(
+                code_references=CodeReferencesMetadataValue(
+                    code_references=[
+                        *references,
+                        *new_code_references,
+                    ],
+                )
+            ),
+        }
+    )
+
+
 class CodeReferencesMetadataSet(NamespacedMetadataSet):
     """Metadata entries that apply to asset definitions and which specify the location where
     source code for the asset can be found.

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -119,13 +119,13 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         op_spec = replication_spec_model.op or OpSpec()
 
         class ReplicationTranslatorWithCodeReferences(DagsterSlingTranslator):
-            def get_asset_spec(self, obj: Any) -> AssetSpec:
-                asset_spec = replication_spec_model.translator.get_asset_spec(obj)
+            def get_asset_spec(self, stream_definition: Mapping[str, Any]) -> AssetSpec:
+                asset_spec = replication_spec_model.translator.get_asset_spec(stream_definition)
                 return merge_code_references(
                     asset_spec,
                     [
                         LocalFileCodeReference(
-                            file_path=str(context.path / replication_spec_model.path),
+                            file_path=str(context.path / replication_spec_model.path)
                         )
                     ],
                 )

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -122,7 +122,12 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
             def get_asset_spec(self, obj: Any) -> AssetSpec:
                 asset_spec = replication_spec_model.translator.get_asset_spec(obj)
                 return merge_code_references(
-                    asset_spec, [LocalFileCodeReference(file_path=replication_spec_model.path)]
+                    asset_spec,
+                    [
+                        LocalFileCodeReference(
+                            file_path=str(context.path / replication_spec_model.path),
+                        )
+                    ],
                 )
 
         @sling_assets(

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -361,7 +361,17 @@ class DagsterSlingTranslator:
         Returns:
             Mapping[str, Any]: A dictionary containing the stream configuration as JSON metadata.
         """
-        return {"stream_config": MetadataValue.json(stream_definition.get("config", {}))}
+        return {
+            "stream_config": MetadataValue.json(stream_definition.get("config", {})),
+            **CodeReferencesMetadataSet(
+                code_references=CodeReferencesMetadataValue(
+                    code_references=[
+                        *references,
+                        LocalFileCodeReference(file_path=os.fspath(abs_path)),
+                    ],
+                )
+            ),
+        }
 
     @superseded(
         additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).tags` instead.",

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -361,9 +361,7 @@ class DagsterSlingTranslator:
         Returns:
             Mapping[str, Any]: A dictionary containing the stream configuration as JSON metadata.
         """
-        return {
-            "stream_config": MetadataValue.json(stream_definition.get("config", {})),
-        }
+        return {"stream_config": MetadataValue.json(stream_definition.get("config", {}))}
 
     @superseded(
         additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).tags` instead.",

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -363,14 +363,6 @@ class DagsterSlingTranslator:
         """
         return {
             "stream_config": MetadataValue.json(stream_definition.get("config", {})),
-            **CodeReferencesMetadataSet(
-                code_references=CodeReferencesMetadataValue(
-                    code_references=[
-                        *references,
-                        LocalFileCodeReference(file_path=os.fspath(abs_path)),
-                    ],
-                )
-            ),
         }
 
     @superseded(


### PR DESCRIPTION
## Summary

Enables code references to replication file for Sling components.


## Test Plan

Unit test.