### PR TITLE
New freshness policies - docs for private preview

### DIFF
--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -13,7 +13,7 @@ Freshness policies help you understand which of your assets have materialized re
 
 For example, freshness policies can help identify stale assets caused by:
 
-- Misconfigured `AutomationCondition`s
+- Misconfigured <PyObject section="assets" module="dagster" object="AutomationCondition" pluralize />
 - Runs not being scheduled due to an upstream failure
 - Runs taking longer than expected to complete
 

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Asset Freshness'
 sidebar_position: 10
+unlisted: True
 ---
 import Preview from '@site/docs/partials/\_Preview.md';
 

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -17,10 +17,10 @@ For example, freshness policies can help identify stale assets caused by:
 - Runs not being scheduled due to an upstream failure
 - Runs taking longer than expected to complete
 
-### Wait ... isn't there already a `FreshnessPolicy`?
-Yes, there is an existing `FreshnessPolicy` API that has been deprecated for some time. We're opting to reuse the name for the new freshness APIs, which requires us to migrate off the legacy API.
+### Wait, isn't there already a `FreshnessPolicy`?
+Yes, there is an existing `FreshnessPolicy` API that has been deprecated for quite some time. We're opting to reuse the name for the new freshness APIs, which requires us to migrate off the legacy API.
 
-To avoid naming conflicts during this migration, we've prefixed the new APIs, class/variable names and function args with "internal" (for example, `InternalFreshnessPolicy` and `internal_freshness_policy` arg on the `@asset` decorator). Once the migration is complete, the "internal" prefix will be removed and `FreshnessPolicy` will be the name of the new APIs.
+To avoid naming conflicts with the legacy API during this migration, we've prefixed the new APIs, class names and method args with "internal" (for example, `InternalFreshnessPolicy` and the `internal_freshness_policy` arg on the `@asset` decorator). Once the migration is complete and the new APIs exit preview mode, the "internal" prefix will be removed and `FreshnessPolicy` will be the name of the new APIs.
 
 ## Types of Freshness Policies
 

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -54,9 +54,11 @@ You can also use `map_asset_specs` directly on the asset specs before creating a
 
 <CodeExample path="docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py" language="python" />
 
-<aside>
-⚠️ Note that applying a freshness policy in this way to an asset with an existing freshness policy (for example, if it was defined in the `@asset` decorator) will overwrite the existing policy.
-</aside>
+:::caution
+
+Applying a freshness policy in this way to an asset with an existing freshness policy (for example, if it was defined in the `@asset` decorator) will overwrite the existing policy.
+
+:::
 
 ### Limitations
 

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -3,9 +3,9 @@ title: 'Freshness policies'
 sidebar_position: 100
 unlisted: True
 ---
-import Preview from '@site/docs/partials/\_Preview.md';
+import FreshnessPoliciesPreview from '@site/docs/partials/\_FreshnessPoliciesPreview.md';
 
-<Preview />
+<FreshnessPoliciesPreview />
 
 ## Overview
 
@@ -63,7 +63,7 @@ Applying a freshness policy in this way to an asset with an existing freshness p
 
 ### Limitations
 
-Freshness policies are not currently supported for source observable assets (`SourceAssets`) and cacheable assets (`CacheableAssetsDefinition`).
+Freshness policies are not currently supported for source observable assets (<PyObject section="assets" module="dagster" object="SourceAsset" pluralize />) and cacheable assets (`CacheableAssetsDefinition`).
 
 ## Future enhancements
 

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -1,0 +1,138 @@
+---
+title: 'Asset Freshness'
+sidebar_position: 10
+---
+import Preview from '@site/docs/partials/\_Preview.md';
+
+<Preview />
+
+## Overview
+
+Freshness policies help you understand which of your assets have materialized recently and which ones are running behind - a key component of asset health. Freshness policies also communicate expectations for data freshness, allowing downstream asset consumers to determine how often assets are expected to be updated.
+
+For example, freshness policies can help identify stale assets caused by:
+
+- Misconfigured `AutomationCondition`s
+- Runs not being scheduled due to an upstream failure
+- Runs taking longer than expected to complete
+
+## Types of Freshness Policies
+
+Currently, we support time window-based freshness policies, which are suitable for most use cases. We plan to add more policy types in the future.
+
+### Time Window Policy
+
+A time window freshness policy is useful when you expect an asset to have new data or be recalculated with some frequency.
+
+```python
+from datetime import timedelta
+from dagster._core.definitions.freshness import InternalFreshnessPolicy, TimeWindowFreshnessPolicy
+
+# Create a policy that requires updates every 24 hours
+policy = TimeWindowFreshnessPolicy.from_timedeltas(
+    fail_window=timedelta(hours=24),
+    warn_window=timedelta(hours=12)  # optional, must be less than fail_window
+)
+
+# Or, equivalently, from the base class
+policy = InternalFreshnessPolicy.time_window(
+    fail_window=timedelta(hours=24),
+    warn_window=timedelta(hours=12)
+)
+```
+
+The above policy states that there should be a successful materialization of the asset at least every 24 hours for it to be considered fresh. An asset that does not meet this condition will be considered failing its freshness policy.
+
+There is an optional warning window (in this case, 12 hours). If the asset does not successfully materialize within this window, it will enter a `warning` freshness state.
+
+## Setting Freshness Policies
+
+### On Individual Assets
+
+You can configure a freshness policy directly on an asset:
+
+```python
+from datetime import timedelta
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.asset_spec import AssetSpec
+
+policy = InternalFreshnessPolicy.time_window(
+    fail_window=timedelta(hours=24)
+)
+
+@asset(internal_freshness_policy=policy)
+def my_asset(): ...
+
+# Or on an asset spec
+spec = AssetSpec(..., internal_freshness_policy=policy)
+```
+
+### Across Multiple Assets
+
+To apply freshness policies to many or all assets in your deployment, you can use `map_asset_specs`:
+
+```python
+from dagster import asset, AssetsDefinition
+from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from datetime import timedelta
+
+@asset
+def asset_1(): ...
+
+@asset
+def asset_2(): ...
+
+policy = InternalFreshnessPolicy.time_window(
+    fail_window=timedelta(hours=24)
+)
+
+defs = Definitions(assets=[asset_1, asset_2])
+defs.map_asset_specs(
+    func=lambda spec: attach_internal_freshness_policy(spec, freshness_policy)
+)
+
+# Or, you can optionally provide an asset selection string
+defs.map_asset_specs(
+    func=lambda spec: attach_internal_freshness_policy(spec, freshness_policy),
+    selection="asset_1" # will only apply policy to asset_1
+)
+```
+
+You can also use `map_asset_specs` directly on the asset specs before creating a `Definitions` object:
+```python
+from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from datetime import timedelta
+
+
+@asset
+def asset_1(): ...
+
+@asset
+def asset_2(): ...
+
+policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+
+assets = [asset_1, asset_2]
+assets_with_policies = map_asset_specs(func=lambda spec: attach_internal_freshness_policy(spec, freshness_policy))
+
+defs = Definitions(assets=assets_with_policies)
+```
+
+<aside>
+⚠️ Note that applying a freshness policy in this way to an asset with an existing freshness policy (for example, if it was defined in the `@asset` decorator) will overwrite the existing policy.
+</aside>
+
+### Limitations
+
+Freshness policies are not currently supported for source observable assets (`SourceAssets`) and cacheable assets (`CacheableAssetsDefinition`).
+
+## Future Enhancements
+
+- More types of freshness policies, including:
+    - Cron-based
+    - Anomaly detection-based
+    - Custom (user-defined) freshness
+- Support for source observable assets

--- a/docs/docs/guides/labs/freshness/index.md
+++ b/docs/docs/guides/labs/freshness/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Freshness Policies'
+title: 'Freshness policies'
 sidebar_position: 100
 unlisted: True
 ---
@@ -17,36 +17,37 @@ For example, freshness policies can help identify stale assets caused by:
 - Runs not being scheduled due to an upstream failure
 - Runs taking longer than expected to complete
 
-### Wait, isn't there already a `FreshnessPolicy`?
-Yes, there is an existing `FreshnessPolicy` API that has been deprecated for quite some time. We're opting to reuse the name for the new freshness APIs, which requires us to migrate off the legacy API.
+### Relationship to existing `FreshnessPolicy`
 
-To avoid naming conflicts with the legacy API during this migration, we've prefixed the new APIs, class names and method args with "internal" (for example, `InternalFreshnessPolicy` and the `internal_freshness_policy` arg on the `@asset` decorator). Once the migration is complete and the new APIs exit preview mode, the "internal" prefix will be removed and `FreshnessPolicy` will be the name of the new APIs.
+There is an existing `FreshnessPolicy` API that has been deprecated for quite some time. We're opting to reuse the name for the new freshness APIs, which requires us to migrate off the legacy API.
 
-## Types of Freshness Policies
+To avoid naming conflicts with the legacy API during this migration, we've prefixed the new APIs, class names, and method arguments with "internal", for example, `InternalFreshnessPolicy` and the `internal_freshness_policy` argument on the `@asset` decorator. Once the migration is complete and the new APIs exit preview mode, the "internal" prefix will be removed and `FreshnessPolicy` will be the name of the new APIs.
+
+## Freshness policy types
 
 Currently, we support time window-based freshness policies, which are suitable for most use cases. We plan to add more policy types in the future.
 
-### Time Window Policy
+### Time window policy
 
-A time window freshness policy is useful when you expect an asset to have new data or be recalculated with some frequency.
+A time window freshness policy is useful when you expect an asset to have new data, or be recalculated with some frequency. An asset that does not meet this condition will be considered failing its freshness policy. You can set an optional warning window on a freshness policy; if the asset does not successfully materialize within this window, it will enter a `warning` freshness state.
+
+For example, the policy below states that there should be a successful materialization of the asset at least every 24 hours for it to be considered fresh, with a warning window of 12 hours:
 
 <CodeExample path="docs_snippets/docs_snippets/guides/freshness/time_window_policy.py" language="python" />
 
-The above policy states that there should be a successful materialization of the asset at least every 24 hours for it to be considered fresh. An asset that does not meet this condition will be considered failing its freshness policy.
 
-There is an optional warning window (in this case, 12 hours). If the asset does not successfully materialize within this window, it will enter a `warning` freshness state.
 
-## Setting Freshness Policies
+## Setting freshness policies
 
-### On Individual Assets
+### On individual assets
 
 You can configure a freshness policy directly on an asset:
 
 <CodeExample path="docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py" language="python" />
 
-### Across Multiple Assets
+### Across multiple assets
 
-To apply freshness policies to many or all assets in your deployment, you can use `map_asset_specs`:
+To apply freshness policies to multiple or all assets in your deployment, you can use `map_asset_specs`:
 
 <CodeExample path="docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py" language="python" />
 
@@ -64,9 +65,9 @@ Applying a freshness policy in this way to an asset with an existing freshness p
 
 Freshness policies are not currently supported for source observable assets (`SourceAssets`) and cacheable assets (`CacheableAssetsDefinition`).
 
-## Future Enhancements
+## Future enhancements
 
-- More types of freshness policies, including:
+- More freshness policy types, including:
     - Cron-based
     - Anomaly detection-based
     - Custom (user-defined) freshness

--- a/docs/docs/guides/labs/index.md
+++ b/docs/docs/guides/labs/index.md
@@ -8,4 +8,3 @@ The features in this section are under active development. You may encounter fea
 
 - [`dg` CLI](/guides/labs/dg/)
 - [Components](/guides/labs/components/)
-- [Freshness](/guides/labs/freshness/)

--- a/docs/docs/guides/labs/index.md
+++ b/docs/docs/guides/labs/index.md
@@ -8,3 +8,4 @@ The features in this section are under active development. You may encounter fea
 
 - [`dg` CLI](/guides/labs/dg/)
 - [Components](/guides/labs/components/)
+- [Freshness](/guides/labs/freshness/)

--- a/docs/docs/partials/_FreshnessPoliciesPreview.md
+++ b/docs/docs/partials/_FreshnessPoliciesPreview.md
@@ -1,0 +1,5 @@
+:::info
+
+Freshness policies are under active development. You may encounter feature gaps, and the APIs may change. To report issues or give feedback, please reach out to your CSM.
+
+:::

--- a/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
@@ -1,0 +1,14 @@
+from datetime import timedelta
+
+from dagster import AssetSpec, asset
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+
+policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+
+
+@asset(internal_freshness_policy=policy)
+def my_asset(): ...
+
+
+# Or on an asset spec
+spec = AssetSpec(..., internal_freshness_policy=policy)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
@@ -7,8 +7,9 @@ policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 
 @asset(internal_freshness_policy=policy)
-def my_asset(): ...
+def my_asset():
+    pass
 
 
 # Or on an asset spec
-spec = AssetSpec(..., internal_freshness_policy=policy)
+spec = AssetSpec("my_asset", internal_freshness_policy=policy)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
@@ -6,16 +6,18 @@ from dagster._core.definitions.freshness import InternalFreshnessPolicy
 
 
 @asset
-def asset_1(): ...
+def asset_1():
+    pass
 
 
 @asset
-def asset_2(): ...
+def asset_2():
+    pass
 
 
 policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 assets = [asset_1, asset_2]
 assets_with_policies = map_asset_specs(
-    func=lambda spec: attach_internal_freshness_policy(spec, policy)
+    func=lambda spec: attach_internal_freshness_policy(spec, policy), iterable=assets
 )

--- a/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
@@ -1,0 +1,21 @@
+from datetime import timedelta
+
+from dagster import asset, map_asset_specs
+from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+
+
+@asset
+def asset_1(): ...
+
+
+@asset
+def asset_2(): ...
+
+
+policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+
+assets = [asset_1, asset_2]
+assets_with_policies = map_asset_specs(
+    func=lambda spec: attach_internal_freshness_policy(spec, policy)
+)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
@@ -1,0 +1,25 @@
+from datetime import timedelta
+
+from dagster import Definitions, asset
+from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
+
+
+@asset
+def asset_1(): ...
+
+
+@asset
+def asset_2(): ...
+
+
+policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+
+defs = Definitions(assets=[asset_1, asset_2])
+defs.map_asset_specs(func=lambda spec: attach_internal_freshness_policy(spec, policy))
+
+# Or, you can optionally provide an asset selection string
+defs.map_asset_specs(
+    func=lambda spec: attach_internal_freshness_policy(spec, policy),
+    selection="asset_1",  # will only apply policy to asset_1
+)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
@@ -6,11 +6,13 @@ from dagster._core.definitions.freshness import InternalFreshnessPolicy
 
 
 @asset
-def asset_1(): ...
+def asset_1():
+    pass
 
 
 @asset
-def asset_2(): ...
+def asset_2():
+    pass
 
 
 policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))

--- a/examples/docs_snippets/docs_snippets/guides/freshness/time_window_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/time_window_policy.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+
+from dagster._core.definitions.freshness import (
+    InternalFreshnessPolicy,
+    TimeWindowFreshnessPolicy,
+)
+
+# Create a policy that requires updates every 24 hours
+policy = TimeWindowFreshnessPolicy.from_timedeltas(
+    fail_window=timedelta(hours=24),
+    warn_window=timedelta(hours=12),  # optional, must be less than fail_window
+)
+
+# Or, equivalently, from the base class
+policy = InternalFreshnessPolicy.time_window(
+    fail_window=timedelta(hours=24), warn_window=timedelta(hours=12)
+)


### PR DESCRIPTION
## Summary & Motivation
Unlisted docs for new freshness policies, intended to ship to design partners for a private preview. 

## How I Tested These Changes
Ran docs site on local

## Changelog

> Insert changelog entry or delete this section.
