### PR TITLE
[dbt component] fix project args resolution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -76,7 +76,7 @@ def resolve_dbt_project(context: ResolutionContext, model) -> DbtProject:
     if isinstance(model, str):
         return DbtProject(context.resolve_source_relative_path(model))
 
-    args: DbtProjectArgs = context.resolve_value(model)
+    args = DbtProjectArgs.resolve_from_model(context, model)
 
     kwargs = {}  # use optionally splatted kwargs to avoid redefining default value
     if args.target_path:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from dagster import AssetKey, AssetSpec, BackfillPolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicyType
 from dagster._core.test_utils import ensure_dagster_tests_import
+from dagster._utils.env import environ
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.load_defs import build_component_defs
 from dagster.components.resolved.core_models import AssetAttributesModel
@@ -393,3 +394,14 @@ translation_settings:
     enable_source_tests_as_checks: True
     """)
     assert c.translator.settings.enable_source_tests_as_checks
+
+
+def test_resolution(dbt_path: Path):
+    with environ({"DBT_TARGET": "prod"}):
+        target = """target: "{{ env('DBT_TARGET') }}" """
+        c = DbtProjectComponent.resolve_from_yaml(f"""
+project:
+  project_dir: {dbt_path!s}
+  {target}
+        """)
+    assert c.project.target == "prod"


### PR DESCRIPTION
`context.resolve_value` currently does not implicitly handle model resolution so do it manually 

## How I Tested These Changes

added test

## Changelog

[bugfix][components][dbt] `DbtProjectComponent` fields now properly evaluate templates