### PR TITLE
Attempt to handle `SourceAssets` in `map_asset_specs`

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -13,6 +13,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from pydantic import BaseModel, TypeAdapter
 
@@ -411,3 +412,12 @@ def test_pydantic_spec() -> None:
 
     holder = SpecHolder(spec=AssetSpec(key="foo"), spec_list=[AssetSpec(key="bar")])
     assert TypeAdapter(SpecHolder).validate_python(holder)
+
+
+def test_source_asset_map_asset_specs() -> None:
+    source_asset = SourceAsset(key="foo")
+    result = dg.map_asset_specs(
+        lambda spec: spec.replace_attributes(owners=["daggy@dagsterlabs.com"]), [source_asset]
+    )
+
+    assert result[0].owners == ["daggy@dagsterlabs.com"]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -1141,11 +1141,11 @@ def test_map_asset_specs() -> None:
     with pytest.raises(DagsterInvalidSubsetError):
         mapped_defs = defs.map_asset_specs(func=spec_lambda, selection="asset3")
 
-    # attempt to map with source asset
     source_asset = SourceAsset("source_asset")
     defs = Definitions(assets=[source_asset])
-    with pytest.raises(DagsterInvariantViolationError):
-        defs.map_asset_specs(func=spec_lambda)
+    mapped_defs = defs.map_asset_specs(func=spec_lambda)
+    assert len(mapped_defs.assets) == 1
+    assert isinstance(mapped_defs.assets[0], SourceAsset)
 
     class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         def compute_cacheable_data(self):


### PR DESCRIPTION
## Summary & Motivation


To allow using `map_asset_specs` over lists of assets, `Definitions` or `AssetSelection`s within a `Definitions` that contain a mix of `AssetSpec`, `AssetsDefinition` and `SourceAssets`.

We use `create_external_asset_from_source_asset` to go from `SourceAsset` to an `AssetsDefinition`, which lets us map over it with `map_asset_specs`.

Just stuck on converting back to a `SourceAsset`

## How I Tested These Changes
unit tests

## Changelog

> Insert changelog entry or delete this section.
