### PR TITLE
[dg] Support @definitions in the defs hierarchy

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -30,6 +30,7 @@ from dagster.components.component.component import Component
 from dagster.components.component.component_loader import is_component_loader
 from dagster.components.core.context import ComponentLoadContext, use_component_load_context
 from dagster.components.core.package_entry import load_package_object
+from dagster.components.definitions import LazyDefinitions
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.core_models import AssetPostProcessor
 
@@ -234,16 +235,40 @@ class DagsterDefsComponent(Component):
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         module = context.load_defs_relative_python_module(self.path)
-        definitions_objects = list(find_objects_in_module_of_types(module, Definitions))
-        if len(definitions_objects) == 0:
-            return load_definitions_from_module(module)
-        elif len(definitions_objects) == 1:
-            return next(iter(definitions_objects))
-        else:
+
+        def_objects = check.is_list(
+            list(find_objects_in_module_of_types(module, Definitions)), Definitions
+        )
+        lazy_def_objects = check.is_list(
+            list(find_objects_in_module_of_types(module, LazyDefinitions)), LazyDefinitions
+        )
+
+        if lazy_def_objects and def_objects:
+            raise DagsterInvalidDefinitionError(
+                f"Found both @definitions-decorated functions and Definitions objects in {self.path}. "
+                "At most one may be specified per module."
+            )
+
+        if len(def_objects) == 1:
+            return next(iter(def_objects))
+
+        if len(def_objects) > 1:
             raise DagsterInvalidDefinitionError(
                 f"Found multiple Definitions objects in {self.path}. At most one Definitions object "
                 "may be specified per module."
             )
+
+        if len(lazy_def_objects) == 1:
+            lazy_def = next(iter(lazy_def_objects))
+            return lazy_def(context)
+
+        if len(lazy_def_objects) > 1:
+            raise DagsterInvalidDefinitionError(
+                f"Found multiple @definitions-decorated functions in {self.path}. At most one "
+                "@definitions-decorated function may be specified per module."
+            )
+
+        return load_definitions_from_module(module)
 
 
 def load_pythonic_component(context: ComponentLoadContext) -> Component:

--- a/python_modules/dagster/dagster/components/definitions.py
+++ b/python_modules/dagster/dagster/components/definitions.py
@@ -103,3 +103,12 @@ def definitions(
 
     lazy_defs = LazyDefinitions[Definitions](load_fn=fn, has_context_arg=has_context_arg)
     return cast("Callable[..., Definitions]", lazy_defs)
+
+
+def lazy_repository(
+    fn: Union[
+        Callable[[], RepositoryDefinition], Callable[[ComponentLoadContext], RepositoryDefinition]
+    ],
+) -> Callable[..., RepositoryDefinition]:
+    lazy_defs = LazyDefinitions[RepositoryDefinition](load_fn=fn, has_context_arg=False)
+    return cast("Callable[..., RepositoryDefinition]", lazy_defs)

--- a/python_modules/dagster/dagster/components/definitions.py
+++ b/python_modules/dagster/dagster/components/definitions.py
@@ -1,4 +1,5 @@
-from typing import Callable, Generic, TypeVar
+import inspect
+from typing import Callable, Generic, Optional, TypeVar, Union, cast
 
 from dagster._annotations import preview, public
 from dagster._core.definitions.definitions_class import Definitions
@@ -7,6 +8,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._record import record
+from dagster.components.core.context import ComponentLoadContext
 
 T_Defs = TypeVar("T_Defs", Definitions, RepositoryDefinition)
 
@@ -15,86 +17,85 @@ T_Defs = TypeVar("T_Defs", Definitions, RepositoryDefinition)
 class LazyDefinitions(Generic[T_Defs]):
     """An object that can be invoked to load a set of definitions. Useful in tests when you want to regenerate the same definitions in multiple contexts."""
 
-    load_fn: Callable[[], T_Defs]
+    load_fn: Callable[..., T_Defs]
+    has_context_arg: bool
 
-    def __call__(self) -> T_Defs:
+    def __call__(self, context: Optional[ComponentLoadContext] = None) -> T_Defs:
         """Load a set of definitions using the load_fn provided at construction time.
 
+        Args:
+            context (Optional[ComponentLoadContext]): Optional context for loading definitions.
+
         Returns:
-            Union[Definitions, RepositoryDefinition]: The loaded definitions.
+            T: The loaded definitions.
         """
-        result = self.load_fn()
-        if not isinstance(result, (Definitions, RepositoryDefinition)):
-            raise DagsterInvariantViolationError(
-                "DefinitionsLoader must return a Definitions or RepositoryDefinition object"
-            )
+        if self.has_context_arg:
+            if context is None:
+                raise DagsterInvariantViolationError(
+                    "Function requires a ComponentLoadContext but none was provided"
+                )
+            result = self.load_fn(context)
+        else:
+            result = self.load_fn()
+
         return result
 
 
 @public
 @preview(emit_runtime_warning=False)
-def definitions(fn: Callable[[], T_Defs]) -> LazyDefinitions[T_Defs]:
-    """Marks a function as an entry point for loading a set of Dagster definitions. Useful as a test
-    utility to define definitions that you wish to load multiple times with different contexts.
+def definitions(
+    fn: Union[Callable[[], Definitions], Callable[[ComponentLoadContext], Definitions]],
+) -> Callable[..., Definitions]:
+    """Marks a function as an entry point for loading a set of Dagster definitions. It is an alternative
+    to directly instantiating a Definitions object and assigning it to a local variable. This enables
+    a user to import a python module that contains a loadable definitions object without having
+    to create it at import time.
 
-    As with plain `Definitions` objects, there can be only one `@definitions`-decorated function per
-    module if that module is being loaded as a Dagster code location.
+    The function can optionally accept a ComponentLoadContext parameter. If it does, the context will be
+    passed to the function when it is called. If it doesn't, the function will be called without any
+    parameters.
 
     Returns:
-        LazyDefinitions: A callable that will load a set of definitions when invoked.
+        Callable[..., Definitions]: A callable that will load a set of definitions when invoked.
+            The callable accepts an optional ComponentLoadContext parameter that defaults to None.
 
     Examples:
         .. code-block:: python
 
-            from dagster import (
-                AssetSpec,
-                Definitions,
-                DefinitionsLoadContext,
-                DefinitionsLoadType,
-                asset,
-                definitions,
-                external_assets_from_specs,
-            )
+            import dagster as dg
 
-            WORKSPACE_ID = "my_workspace"
-            FOO_METADATA_KEY_PREFIX = "foo"
-
-
-            # Simple model of an external service foo
-            def fetch_foo_defs_metadata(workspace_id: str):
-                if workspace_id == WORKSPACE_ID:
-                    return [{"id": "alpha"}, {"id": "beta"}]
-                else:
-                    raise Exception("Unknown workspace")
-
-
-            def get_foo_defs(context: DefinitionsLoadContext, workspace_id: str) -> Definitions:
-                metadata_key = f"{FOO_METADATA_KEY_PREFIX}/{workspace_id}"
-                if (
-                    context.load_type == DefinitionsLoadType.RECONSTRUCTION
-                    and metadata_key in context.reconstruction_metadata
-                ):
-                    payload = context.reconstruction_metadata[metadata_key]
-                else:
-                    payload = fetch_foo_defs_metadata(workspace_id)
-                asset_specs = [AssetSpec(item["id"]) for item in payload]
-                assets = external_assets_from_specs(asset_specs)
-                return Definitions(
-                    assets=assets,
-                ).with_reconstruction_metadata({metadata_key: payload})
-
-
-            @definitions
-            def defs():
+            # Example with context parameter
+            @dg.definitions
+            def defs_with_context(context: ComponentLoadContext):
                 @asset
                 def regular_asset(): ...
 
-                context = DefinitionsLoadContext.get()
+                return Definitions(assets=[regular_asset])
 
-                return Definitions.merge(
-                    get_foo_defs(context, WORKSPACE_ID),
-                    Definitions(assets=[regular_asset]),
-                )
+            # Example without context parameter
+            @dg.definitions
+            def defs_without_context():
+                @asset
+                def regular_asset(): ...
+
+                return Definitions(assets=[regular_asset])
 
     """
-    return LazyDefinitions(load_fn=fn)
+    sig = inspect.signature(fn)
+    has_context_arg = False
+
+    if len(sig.parameters) > 0:
+        first_param = next(iter(sig.parameters.values()))
+        if first_param.annotation == ComponentLoadContext:
+            has_context_arg = True
+            if len(sig.parameters) > 1:
+                raise DagsterInvariantViolationError(
+                    "Function must accept either no parameters or exactly one ComponentLoadContext parameter"
+                )
+        else:
+            raise DagsterInvariantViolationError(
+                "Function must accept either no parameters or exactly one ComponentLoadContext parameter"
+            )
+
+    lazy_defs = LazyDefinitions[Definitions](load_fn=fn, has_context_arg=has_context_arg)
+    return cast("Callable[..., Definitions]", lazy_defs)

--- a/python_modules/dagster/dagster/components/definitions.py
+++ b/python_modules/dagster/dagster/components/definitions.py
@@ -27,7 +27,7 @@ class LazyDefinitions(Generic[T_Defs]):
             context (Optional[ComponentLoadContext]): Optional context for loading definitions.
 
         Returns:
-            T: The loaded definitions.
+            T_Defs: The loaded definitions.
         """
         if self.has_context_arg:
             if context is None:
@@ -38,6 +38,10 @@ class LazyDefinitions(Generic[T_Defs]):
         else:
             result = self.load_fn()
 
+        if not isinstance(result, (Definitions, RepositoryDefinition)):
+            raise DagsterInvariantViolationError(
+                "Function must return a Definitions or RepositoryDefinition object"
+            )
         return result
 
 

--- a/python_modules/dagster/dagster/components/definitions.py
+++ b/python_modules/dagster/dagster/components/definitions.py
@@ -105,10 +105,7 @@ def definitions(
     return cast("Callable[..., Definitions]", lazy_defs)
 
 
-def lazy_repository(
-    fn: Union[
-        Callable[[], RepositoryDefinition], Callable[[ComponentLoadContext], RepositoryDefinition]
-    ],
-) -> Callable[..., RepositoryDefinition]:
+# For backwards compatibility with existing test cases
+def lazy_repository(fn: Callable[[], RepositoryDefinition]) -> Callable[[], RepositoryDefinition]:
     lazy_defs = LazyDefinitions[RepositoryDefinition](load_fn=fn, has_context_arg=False)
-    return cast("Callable[..., RepositoryDefinition]", lazy_defs)
+    return cast("Callable[[],RepositoryDefinition]", lazy_defs)

--- a/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
@@ -1,0 +1,93 @@
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from dagster import AssetSpec, Definitions
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster.components import ComponentLoadContext
+from dagster.components.definitions import definitions
+from dagster_shared import check
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+
+
+def test_definitions_decorator_without_context():
+    """Test the basic usage of @definitions without context."""
+
+    @definitions
+    def my_defs():
+        return Definitions(assets=[AssetSpec(key="asset1")])
+
+    result = my_defs()
+    assert isinstance(result, Definitions)
+    assets = list(result.assets or [])
+    assert len(assets) == 1
+    asset_def = cast("AssetsDefinition", assets[0])
+    assert asset_def.key.path[0] == "asset1"
+
+
+def test_definitions_decorator_with_context():
+    """Test the usage of @definitions with context."""
+
+    @definitions
+    def my_defs_with_context(context: ComponentLoadContext):
+        assert isinstance(context, ComponentLoadContext)
+        return Definitions(assets=[AssetSpec(key="asset1")])
+
+    context = ComponentLoadContext.for_test()
+    result = my_defs_with_context(context)
+    assert isinstance(result, Definitions)
+    assets = list(result.assets or [])
+    assert len(assets) == 1
+    asset_def = cast("AssetsDefinition", assets[0])
+    assert asset_def.key.path[0] == "asset1"
+
+
+def test_definitions_decorator_invalid_signature():
+    """Test that the decorator enforces correct function signatures."""
+    # Test invalid signature with multiple parameters
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Function must accept either no parameters or exactly one ComponentLoadContext parameter",
+    ):
+
+        @definitions  # type: ignore
+        def invalid_defs(context: ComponentLoadContext, extra_param: str):
+            return Definitions()
+
+
+def test_definitions_decorator_return_type():
+    """Test that the decorator enforces correct return types."""
+
+    @definitions  # type: ignore
+    def invalid_return():
+        return "not a definitions object"
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="DefinitionsLoader must return a Definitions or RepositoryDefinition object",
+    ):
+        invalid_return()
+
+
+def test_definitions_decorator_with_context_using_context():
+    """Test that the decorator works when the context is actually used in the function."""
+
+    @definitions
+    def my_defs_with_context(context: ComponentLoadContext):
+        assert isinstance(context, ComponentLoadContext)
+        return Definitions(
+            assets=[
+                AssetSpec(
+                    key="asset1",
+                )
+            ]
+        )
+
+    context = ComponentLoadContext.for_test()
+    result = my_defs_with_context(context)
+    assert isinstance(result, Definitions)
+    assets = list(result.assets or [])
+    assert len(assets) == 1
+
+    assert check.inst(next(iter(assets)), AssetSpec).key.path[0] == "asset1"

--- a/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
@@ -65,7 +65,7 @@ def test_definitions_decorator_return_type():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="DefinitionsLoader must return a Definitions or RepositoryDefinition object",
+        match="Function must return a Definitions or RepositoryDefinition object",
     ):
         invalid_return()
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -36,7 +36,7 @@ from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance import DagsterInstance
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
-from dagster._utils.test.definitions import definitions
+from dagster.components.definitions import lazy_repository
 
 
 def define_inty_job(using_file_system=False):
@@ -354,7 +354,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         ]
 
 
-@definitions
+@lazy_repository
 def cacheable_asset_defs():
     @asset
     def bar(foo):

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -34,7 +34,8 @@ from dagster._core.executor.step_delegating import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._utils.merger import merge_dicts
-from dagster._utils.test.definitions import definitions, scoped_definitions_load_context
+from dagster._utils.test.definitions import scoped_definitions_load_context
+from dagster.components.definitions import lazy_repository
 
 from dagster_tests.execution_tests.engine_tests.retry_jobs import (
     assert_expected_failure_behavior,
@@ -453,7 +454,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         ]
 
 
-@definitions
+@lazy_repository
 def cacheable_asset_defs():
     @asset
     def bar(foo):

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -61,7 +61,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import safe_tempfile_path, send_interrupt
 from dagster._utils.merger import deep_merge_dicts, merge_dicts
-from dagster._utils.test.definitions import definitions
+from dagster.components.definitions import lazy_repository
 
 RUN_CONFIG_BASE = {"ops": {"return_two": {"config": {"a": "b"}}}}
 
@@ -724,7 +724,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         )
 
 
-@definitions
+@lazy_repository
 def cacheable_asset_defs():
     @asset
     def bar(foo):

--- a/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_cacheable_assets_defs.py
@@ -30,7 +30,8 @@ from dagster._core.definitions.reconstruct import ReconstructableRepository
 from dagster._core.definitions.repository_definition import RepositoryLoadData
 from dagster._core.definitions.resource_definition import resource
 from dagster._core.execution.with_resources import with_resources
-from dagster._utils.test.definitions import definitions, scoped_definitions_load_context
+from dagster._utils.test.definitions import scoped_definitions_load_context
+from dagster.components.definitions import lazy_repository
 
 from dagster_tests.general_tests.test_repository import (
     define_empty_job,
@@ -74,7 +75,7 @@ def define_cacheable_and_uncacheable_assets():
     return [MyCacheableAssets("a"), MyCacheableAssets("b"), upstream, downstream]
 
 
-@definitions
+@lazy_repository
 def cacheable_asset_repo():
     @repository
     def cacheable_asset_repo():


### PR DESCRIPTION
## Summary & Motivation

This adds support for `@definitions` in the `defs` hierarchy. Current we support it at code location entry points, and this mirrors that support in the defs module component. I believe we should default all scaffolding to use this mechanism in order to avoid import-based side effects.

So instead of 

```python
import dagster as dg

defs = dg.Definitions(resources={'some_resource': 'value'})
```

you can write

```python
from dagster.components import definitions

@definitions
def resources():
   return dg.Definitions({'some_resource': 'value'})
```

## How I Tested These Changes

BK. Also manual tests in standalone projects.

## Changelog

* Support the usage of `@definitions` in the `defs` hierarchy.