### PR TITLE
[dg] Resource Scaffolding

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/19-dg-list-plugins.txt
@@ -53,6 +53,10 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ same             │                 │ │
 │               │ │                                                             │ upstream assets. │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.resources                                           │ Symbol for dg    │ [scaffold-targ… │ │
+│               │ │                                                             │ scaffold to      │                 │ │
+│               │ │                                                             │ target.          │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
 │               │ │                                                             │ schedule         │                 │ │
 │               │ │                                                             │ following the    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/22-project-jdbt-incorrect.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/22-project-jdbt-incorrect.yaml
@@ -1,6 +1,6 @@
 type: dagster_dt.dbt_project
 
 attributes:
-  project: ../../../../dbt/jdbt
+  project: "{{ project_root }}/dbt/jdbt"
   translation:
     key: "target/main/{{ node.name }}

--- a/examples/docs_snippets/docs_snippets/guides/components/index/24-project-jdbt.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/24-project-jdbt.yaml
@@ -1,6 +1,6 @@
 type: dagster_dbt.DbtProjectComponent
 
 attributes:
-  project: ../../../../dbt/jdbt
+  project: "{{ project_root }}/dbt/jdbt"
   translation:
     key: "target/main/{{ node.name }}"

--- a/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/28-dg-list-plugins.txt
@@ -58,6 +58,10 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │                  │ │                                                             │ upstream       │                │ │
 │                  │ │                                                             │ assets.        │                │ │
 │                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
+│                  │ │ dagster.resources                                           │ Symbol for dg  │ [scaffold-tar… │ │
+│                  │ │                                                             │ scaffold to    │                │ │
+│                  │ │                                                             │ target.        │                │ │
+│                  │ ├─────────────────────────────────────────────────────────────┼────────────────┼────────────────┤ │
 │                  │ │ dagster.schedule                                            │ Creates a      │ [scaffold-tar… │ │
 │                  │ │                                                             │ schedule       │                │ │
 │                  │ │                                                             │ following the  │                │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/7-dg-list-plugins.txt
@@ -49,6 +49,10 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │         │ │                                                             │ and same           │                     │ │
 │         │ │                                                             │ upstream assets.   │                     │ │
 │         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
+│         │ │ dagster.resources                                           │ Symbol for dg      │ [scaffold-target]   │ │
+│         │ │                                                             │ scaffold to        │                     │ │
+│         │ │                                                             │ target.            │                     │ │
+│         │ ├─────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────┤ │
 │         │ │ dagster.schedule                                            │ Creates a schedule │ [scaffold-target]   │ │
 │         │ │                                                             │ following the      │                     │ │
 │         │ │                                                             │ provided cron      │                     │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/9-dg-list-plugins.txt
@@ -53,6 +53,10 @@ Using /.../jaffle-platform/.venv/bin/dagster-components
 │               │ │                                                             │ same             │                 │ │
 │               │ │                                                             │ upstream assets. │                 │ │
 │               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
+│               │ │ dagster.resources                                           │ Symbol for dg    │ [scaffold-targ… │ │
+│               │ │                                                             │ scaffold to      │                 │ │
+│               │ │                                                             │ target.          │                 │ │
+│               │ ├─────────────────────────────────────────────────────────────┼──────────────────┼─────────────────┤ │
 │               │ │ dagster.schedule                                            │ Creates a        │ [scaffold-targ… │ │
 │               │ │                                                             │ schedule         │                 │ │
 │               │ │                                                             │ following the    │                 │ │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-plugins.txt
@@ -63,6 +63,10 @@ Using /.../my-component-library/.venv/bin/dagster-components
 │                      │ │                                                             │ upstream     │              │ │
 │                      │ │                                                             │ assets.      │              │ │
 │                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
+│                      │ │ dagster.resources                                           │ Symbol for   │ [scaffold-t… │ │
+│                      │ │                                                             │ dg scaffold  │              │ │
+│                      │ │                                                             │ to target.   │              │ │
+│                      │ ├─────────────────────────────────────────────────────────────┼──────────────┼──────────────┤ │
 │                      │ │ dagster.schedule                                            │ Creates a    │ [scaffold-t… │ │
 │                      │ │                                                             │ schedule     │              │ │
 │                      │ │                                                             │ following    │              │ │

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-list-plugins.txt
@@ -62,6 +62,10 @@ dg list plugins
 │                     │ │                                                             │ upstream     │               │ │
 │                     │ │                                                             │ assets.      │               │ │
 │                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
+│                     │ │ dagster.resources                                           │ Symbol for   │ [scaffold-ta… │ │
+│                     │ │                                                             │ dg scaffold  │               │ │
+│                     │ │                                                             │ to target.   │               │ │
+│                     │ ├─────────────────────────────────────────────────────────────┼──────────────┼───────────────┤ │
 │                     │ │ dagster.schedule                                            │ Creates a    │ [scaffold-ta… │ │
 │                     │ │                                                             │ schedule     │               │ │
 │                     │ │                                                             │ following    │               │ │

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -639,6 +639,7 @@ from dagster._utils.warnings import (
     PreviewWarning as PreviewWarning,
     SupersessionWarning as SupersessionWarning,
 )
+from dagster.components.lib.shim_components.resources import resources as resources
 from dagster.version import __version__ as __version__
 
 DagsterLibraryRegistry.register("dagster", __version__)

--- a/python_modules/dagster/dagster/components/lib/shim_components/resources.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/resources.py
@@ -1,0 +1,22 @@
+from dagster.components.lib.shim_components.base import ShimScaffolder
+from dagster.components.scaffold.scaffold import scaffold_with
+
+
+class ResourcesScaffolder(ShimScaffolder):
+    def get_text(self, filename: str, params: None) -> str:
+        return """import dagster as dg
+from dagster.components import definitions
+
+
+@definitions
+def resources() -> dg.Definitions:
+    return dg.Definitions(resources={})
+"""
+
+
+def resources() -> None:
+    """Symbol for dg scaffold to target."""
+    ...
+
+
+scaffold_with(ResourcesScaffolder)(resources)

--- a/python_modules/dagster/dagster_tests/component_tests/shim_components/test_resources.py
+++ b/python_modules/dagster/dagster_tests/component_tests/shim_components/test_resources.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import tempfile
+
+from dagster import Definitions
+from dagster.components.lib.shim_components.resources import ResourcesScaffolder
+
+
+def test_resources_scaffolder():
+    """Test that the ResourcesScaffolder creates valid Python code that evaluates to a Definitions object."""
+    # Get the code from the scaffolder
+    scaffolder = ResourcesScaffolder()
+    code = scaffolder.get_text("resources", None)
+
+    # Create a namespace to execute the code in
+    namespace = {}
+    exec(code, namespace)
+
+    # Verify that defs was created and is a Definitions object
+    assert "resources" in namespace
+    defs_fn = namespace["resources"]
+    defs = defs_fn()
+    assert isinstance(defs, Definitions)
+    assert defs.resources == {}
+
+
+def test_resources_scaffolder_ruff_compliance():
+    """Test that the generated code passes ruff linting."""
+    # Get the code from the scaffolder
+    scaffolder = ResourcesScaffolder()
+    code = scaffolder.get_text("resources", None)
+
+    # Create a temporary file to run ruff on
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+        temp_file.write(code.encode())
+        temp_file_path = temp_file.name
+
+    try:
+        # Run ruff check on the temporary file
+        result = subprocess.run(
+            ["ruff", "check", temp_file_path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        # Assert that ruff found no issues
+        assert result.returncode == 0, f"Ruff found issues: {result.stdout}\n{result.stderr}"
+    finally:
+        # Clean up the temporary file
+        os.unlink(temp_file_path)


### PR DESCRIPTION
## Summary & Motivation

Enables the command `dg scaffold dagster.resources path/to/resources.py`

This generates a file:

```python
import dagster as dg
from dagster.components import definitions


@definitions
def resources() -> dg.Definitions:
    return dg.Definitions(resources={})
```

If you do require the `ComponentLoadContext` for this invocation, you can add it:

```python
import dagster as dg
from dagster.components import definitions, ComponentLoadContext


@definitions(has_context_arg=True)
def resources(context: ComponentLoadContext) -> dg.Definitions:
    return dg.Definitions(resources={})
```

No matter where you are in the component hierarchy, these resource keys apply globally to the entire location, something we may have to improve at a later date.

## How I Tested These Changes

Unit tests and manual testing in a standalone project

## Changelog

* Add support for scaffolding resources via `dg scaffold dagster.resources path/to/resources.py`