### PR TITLE
Use asyncio/ loaders to speed up code server access parallelism in DA

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import time
@@ -271,8 +272,10 @@ def _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id):
     """Executes an asset backfill iteration with side effects (i.e. updates run status and bulk action status)."""
     with get_workspace_process_context(graphql_context.instance) as context:
         backfill = graphql_context.instance.get_backfill(backfill_id)
-        execute_asset_backfill_iteration(
-            backfill, logging.getLogger("fake_logger"), context, graphql_context.instance
+        asyncio.run(
+            execute_asset_backfill_iteration(
+                backfill, logging.getLogger("fake_logger"), context, graphql_context.instance
+            )
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -55,7 +55,7 @@ def _evaluate(sensor_def: "AutomationConditionSensorDefinition", context: Sensor
     )
     if evaluation_context.total_keys > MAX_ENTITIES:
         raise DagsterInvalidInvocationError(
-            f'AutomationConditionSensorDefintion "{sensor_def.name}" targets {evaluation_context.total_keys} '
+            f'AutomationConditionSensorDefinition "{sensor_def.name}" targets {evaluation_context.total_keys} '
             f"assets or checks, which is more than the limit of {MAX_ENTITIES}. Either set `use_user_code_server` to `False`, "
             "or split this sensor into multiple AutomationConditionSensorDefinitions with AssetSelections that target fewer "
             "assets or checks."

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -165,6 +165,20 @@ class AutomationTickEvaluationContext:
                 updated_evaluations.append(result.serializable_evaluation)
         return updated_evaluations
 
+    async def async_evaluate(
+        self,
+    ) -> tuple[
+        Sequence[RunRequest], AssetDaemonCursor, Sequence[AutomationConditionEvaluation[EntityKey]]
+    ]:
+        observe_run_requests = self._legacy_build_auto_observe_run_requests()
+        results, entity_subsets = await self._evaluator.async_evaluate()
+
+        return (
+            [*self._build_run_requests(entity_subsets), *observe_run_requests],
+            self._get_updated_cursor(results, observe_run_requests),
+            self._get_updated_evaluations(results),
+        )
+
     def evaluate(
         self,
     ) -> tuple[

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -715,7 +715,7 @@ def _write_updated_backfill_data(
     return updated_backfill
 
 
-def _submit_runs_and_update_backfill_in_chunks(
+async def _submit_runs_and_update_backfill_in_chunks(
     asset_graph_view: AssetGraphView,
     workspace_process_context: IWorkspaceProcessContext,
     backfill_id: str,
@@ -751,7 +751,7 @@ def _submit_runs_and_update_backfill_in_chunks(
             # create a new request context for each run in case the code location server
             # is swapped out in the middle of the submission process
             workspace = workspace_process_context.create_request_context()
-            submit_asset_run(
+            await submit_asset_run(
                 run_id,
                 run_request._replace(
                     tags={
@@ -981,7 +981,7 @@ def backfill_is_complete(
     return True
 
 
-def execute_asset_backfill_iteration(
+async def execute_asset_backfill_iteration(
     backfill: "PartitionBackfill",
     logger: logging.Logger,
     workspace_process_context: IWorkspaceProcessContext,
@@ -1072,7 +1072,7 @@ def execute_asset_backfill_iteration(
             instance.update_backfill(updated_backfill)
 
         if result.run_requests:
-            _submit_runs_and_update_backfill_in_chunks(
+            await _submit_runs_and_update_backfill_in_chunks(
                 asset_graph_view,
                 workspace_process_context,
                 updated_backfill.backfill_id,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -755,7 +755,7 @@ class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestCon
             results = []
         results_by_key = {unique_key: result for unique_key, result in zip(unique_keys, results)}
 
-        return [results_by_key[key] for key in keys]
+        return [results_by_key.get(key) for key in keys]
 
     @classmethod
     def _blocking_batch_load(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import dataclasses
 import datetime
@@ -419,21 +420,12 @@ class AssetDaemon(DagsterDaemon):
 
         amp_tick_futures: dict[Optional[str], Future] = {}
         threadpool_executor = None
-        submit_threadpool_executor = None
         with ExitStack() as stack:
             if self._settings.get("use_threads"):
                 threadpool_executor = stack.enter_context(
                     InheritContextThreadPoolExecutor(
                         max_workers=self._settings.get("num_workers"),
                         thread_name_prefix="asset_daemon_worker",
-                    )
-                )
-            num_submit_workers = self._settings.get("num_submit_workers")
-            if num_submit_workers:
-                submit_threadpool_executor = stack.enter_context(
-                    InheritContextThreadPoolExecutor(
-                        max_workers=num_submit_workers,
-                        thread_name_prefix="asset_daemon_submit_worker",
                     )
                 )
 
@@ -444,7 +436,6 @@ class AssetDaemon(DagsterDaemon):
                     self._run_iteration_impl(
                         workspace_process_context,
                         threadpool_executor=threadpool_executor,
-                        submit_threadpool_executor=submit_threadpool_executor,
                         amp_tick_futures=amp_tick_futures,
                         debug_crash_flags={},
                     )
@@ -466,7 +457,6 @@ class AssetDaemon(DagsterDaemon):
         self,
         workspace_process_context: IWorkspaceProcessContext,
         threadpool_executor: Optional[ThreadPoolExecutor],
-        submit_threadpool_executor: Optional[ThreadPoolExecutor],
         amp_tick_futures: dict[Optional[str], Future],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,
     ):
@@ -609,7 +599,6 @@ class AssetDaemon(DagsterDaemon):
                     repo,
                     sensor,
                     debug_crash_flags,
-                    submit_threadpool_executor,
                 )
                 amp_tick_futures[selector_id] = future
             else:
@@ -618,7 +607,6 @@ class AssetDaemon(DagsterDaemon):
                     repo,
                     sensor,
                     debug_crash_flags,
-                    submit_threadpool_executor,
                 )
 
     def _create_initial_sensor_cursors_from_raw_cursor(
@@ -705,7 +693,22 @@ class AssetDaemon(DagsterDaemon):
         repository: Optional[RemoteRepository],
         sensor: Optional[RemoteSensor],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,  # TODO No longer single instigator
-        submit_threadpool_executor: Optional[ThreadPoolExecutor],
+    ):
+        asyncio.run(
+            self._async_process_auto_materialize_tick(
+                workspace_process_context,
+                repository,
+                sensor,
+                debug_crash_flags,
+            )
+        )
+
+    async def _async_process_auto_materialize_tick(
+        self,
+        workspace_process_context: IWorkspaceProcessContext,
+        repository: Optional[RemoteRepository],
+        sensor: Optional[RemoteSensor],
+        debug_crash_flags: SingleInstigatorDebugCrashFlags,  # TODO No longer single instigator
     ):
         evaluation_time = get_current_datetime()
 
@@ -903,7 +906,7 @@ class AssetDaemon(DagsterDaemon):
                 self._logger,
                 tick_retention_settings,
             ) as tick_context:
-                self._evaluate_auto_materialize_tick(
+                await self._evaluate_auto_materialize_tick(
                     tick_context,
                     tick,
                     sensor,
@@ -914,7 +917,6 @@ class AssetDaemon(DagsterDaemon):
                     auto_observe_asset_keys,
                     debug_crash_flags,
                     is_retry=(retry_tick is not None),
-                    submit_threadpool_executor=submit_threadpool_executor,
                 )
         except Exception:
             DaemonErrorCapture.process_exception(
@@ -923,7 +925,7 @@ class AssetDaemon(DagsterDaemon):
                 log_message="Automation condition daemon caught an error",
             )
 
-    def _evaluate_auto_materialize_tick(
+    async def _evaluate_auto_materialize_tick(
         self,
         tick_context: AutoMaterializeLaunchContext,
         tick: InstigatorTick,
@@ -935,7 +937,6 @@ class AssetDaemon(DagsterDaemon):
         auto_observe_asset_keys: set[AssetKey],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,
         is_retry: bool,
-        submit_threadpool_executor: Optional[ThreadPoolExecutor],
     ):
         evaluation_id = tick.automation_condition_evaluation_id
 
@@ -986,7 +987,7 @@ class AssetDaemon(DagsterDaemon):
                 *{key for key in auto_materialize_entity_keys if isinstance(key, AssetCheckKey)}
             )
 
-            run_requests, new_cursor, evaluations = AutomationTickEvaluationContext(
+            run_requests, new_cursor, evaluations = await AutomationTickEvaluationContext(
                 evaluation_id=evaluation_id,
                 asset_graph=asset_graph,
                 asset_selection=asset_selection,
@@ -1008,7 +1009,7 @@ class AssetDaemon(DagsterDaemon):
                 ),
                 auto_observe_asset_keys=auto_observe_asset_keys,
                 logger=self._logger,
-            ).evaluate()
+            ).async_evaluate()
 
             check.invariant(new_cursor.evaluation_id == evaluation_id)
 
@@ -1043,19 +1044,32 @@ class AssetDaemon(DagsterDaemon):
             # the chances that changes to code servers after the cursor is written (e.g. a
             # code server moving into an error state or an asset being renamed) causes problems
             workspace = workspace_process_context.create_request_context()
+            async_code_server_tasks = []
             for run_request_index, run_request in enumerate(run_requests):
                 if not run_request.requires_backfill_daemon():
-                    get_job_execution_data_from_run_request(
-                        workspace.asset_graph,
-                        run_request,
-                        instance,
-                        workspace=workspace,
-                        run_request_execution_data_cache=run_request_execution_data_cache,
+                    async_code_server_tasks.append(
+                        get_job_execution_data_from_run_request(
+                            workspace.asset_graph,
+                            run_request,
+                            instance,
+                            workspace=workspace,
+                            run_request_execution_data_cache=run_request_execution_data_cache,
+                        )
                     )
                     check_for_debug_crash(debug_crash_flags, "EXECUTION_PLAN_CACHED")
                     check_for_debug_crash(
                         debug_crash_flags, f"EXECUTION_PLAN_CACHED_{run_request_index}"
                     )
+
+            # Use semaphore to limit concurrency to ensure code servers don't get overloaded
+            batch_size = int(os.getenv("DAGSTER_ASSET_DAEMON_CODE_SERVER_CONCURRENCY", "4"))
+            code_server_semaphore = asyncio.Semaphore(batch_size)
+
+            async def run_with_semaphore(task):
+                async with code_server_semaphore:
+                    return await task
+
+            await asyncio.gather(*[run_with_semaphore(task) for task in async_code_server_tasks])
 
             # Write out the in-progress tick data, which ensures that if the tick crashes or raises an exception, it will retry
             tick = tick_context.set_run_requests(
@@ -1090,7 +1104,7 @@ class AssetDaemon(DagsterDaemon):
             check_for_debug_crash(debug_crash_flags, "CURSOR_UPDATED")
 
         check.invariant(len(run_requests) == len(reserved_run_ids))
-        self._submit_run_requests_and_update_evaluations(
+        await self._submit_run_requests_and_update_evaluations(
             instance=instance,
             tick_context=tick_context,
             workspace_process_context=workspace_process_context,
@@ -1100,7 +1114,6 @@ class AssetDaemon(DagsterDaemon):
             run_requests=run_requests,
             reserved_run_ids=reserved_run_ids,
             debug_crash_flags=debug_crash_flags,
-            submit_threadpool_executor=submit_threadpool_executor,
             remote_sensor=sensor,
             run_request_execution_data_cache=run_request_execution_data_cache,
         )
@@ -1114,7 +1127,7 @@ class AssetDaemon(DagsterDaemon):
 
         self._logger.info(f"Finished auto-materialization tick{print_group_name}")
 
-    def _submit_run_request(
+    async def _submit_run_request(
         self,
         i: int,
         instance: DagsterInstance,
@@ -1153,7 +1166,7 @@ class AssetDaemon(DagsterDaemon):
                 )
             return reserved_run_id, check.not_none(asset_graph_subset.asset_keys)
         else:
-            submitted_run = submit_asset_run(
+            submitted_run = await submit_asset_run(
                 run_id=reserved_run_id,
                 run_request=run_request._replace(
                     tags={
@@ -1177,7 +1190,7 @@ class AssetDaemon(DagsterDaemon):
             }
             return submitted_run.run_id, entity_keys
 
-    def _submit_run_requests_and_update_evaluations(
+    async def _submit_run_requests_and_update_evaluations(
         self,
         instance: DagsterInstance,
         tick_context: AutoMaterializeLaunchContext,
@@ -1188,7 +1201,6 @@ class AssetDaemon(DagsterDaemon):
         run_requests: Sequence[RunRequest],
         reserved_run_ids: Sequence[str],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,
-        submit_threadpool_executor: Optional[ThreadPoolExecutor],
         remote_sensor: Optional[RemoteSensor],
         run_request_execution_data_cache: dict[JobSubsetSelector, RunRequestExecutionData],
     ):
@@ -1198,11 +1210,11 @@ class AssetDaemon(DagsterDaemon):
         check.invariant(len(run_requests) == len(reserved_run_ids))
         to_submit = enumerate(tick_context.tick.reserved_run_ids_with_requests)
 
-        def submit_run_request(
+        async def submit_run_request(
             run_id_with_run_request: tuple[int, tuple[str, RunRequest]],
         ) -> tuple[str, AbstractSet[EntityKey]]:
             i, (run_id, run_request) = run_id_with_run_request
-            return self._submit_run_request(
+            return await self._submit_run_request(
                 i=i,
                 instance=instance,
                 run_request=run_request,
@@ -1214,12 +1226,11 @@ class AssetDaemon(DagsterDaemon):
                 debug_crash_flags=debug_crash_flags,
             )
 
-        if submit_threadpool_executor:
-            gen_run_request_results = submit_threadpool_executor.map(submit_run_request, to_submit)
-        else:
-            gen_run_request_results = map(submit_run_request, to_submit)
+        gen_run_request_results = [submit_run_request(item) for item in to_submit]
 
-        for i, (submitted_run_id, entity_keys) in enumerate(gen_run_request_results):
+        for i, generator in enumerate(gen_run_request_results):
+            submitted_run_id, entity_keys = await generator
+
             tick_context.add_run_info(run_id=submitted_run_id)
 
             # write the submitted run ID to any evaluations

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -156,7 +157,7 @@ def execute_backfill_iteration_with_instigation_logger(
     instance: "DagsterInstance",
     submit_threadpool_executor: Optional[ThreadPoolExecutor] = None,
     debug_crash_flags: Optional[Mapping[str, int]] = None,
-) -> Iterable:
+) -> Iterable[Optional[SerializableErrorInfo]]:
     with _get_instigation_logger_if_log_storage_enabled(instance, backfill, logger) as _logger:
         # create a logger that will always include the backfill_id as an `extra`
         backfill_logger = cast(
@@ -165,11 +166,13 @@ def execute_backfill_iteration_with_instigation_logger(
         )
         try:
             if backfill.is_asset_backfill:
-                execute_asset_backfill_iteration(
-                    backfill,
-                    backfill_logger,
-                    workspace_process_context,
-                    instance,
+                asyncio.run(
+                    execute_asset_backfill_iteration(
+                        backfill,
+                        backfill_logger,
+                        workspace_process_context,
+                        instance,
+                    )
                 )
             else:
                 execute_job_backfill_iteration(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1903,11 +1903,11 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     # submitted.
     counter = 0
 
-    def raise_code_unreachable_error_on_second_call(*args, **kwargs):
+    async def raise_code_unreachable_error_on_second_call(*args, **kwargs):
         nonlocal counter
         if counter == 0:
             counter += 1
-            return get_job_execution_data_from_run_request(*args, **kwargs)
+            return await get_job_execution_data_from_run_request(*args, **kwargs)
         elif counter == 1:
             counter += 1
             raise DagsterUserCodeUnreachableError()
@@ -2105,11 +2105,11 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
     # submitted.
     counter = 0
 
-    def raise_code_unreachable_error_on_second_call(*args, **kwargs):
+    async def raise_code_unreachable_error_on_second_call(*args, **kwargs):
         nonlocal counter
         if counter == 0:
             counter += 1
-            return get_job_execution_data_from_run_request(*args, **kwargs)
+            return await get_job_execution_data_from_run_request(*args, **kwargs)
         elif counter == 1:
             counter += 1
             raise DagsterUserCodeUnreachableError()

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -150,7 +150,6 @@ def get_threadpool_executor():
 def _execute_ticks(
     context: WorkspaceProcessContext,
     threadpool_executor: InheritContextThreadPoolExecutor,
-    submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None,
     debug_crash_flags=None,
 ) -> None:
     """Evaluates a single tick for all automation condition sensors across the workspace.
@@ -163,7 +162,6 @@ def _execute_ticks(
         threadpool_executor=threadpool_executor,
         amp_tick_futures=asset_daemon_futures,
         debug_crash_flags=debug_crash_flags or {},
-        submit_threadpool_executor=submit_threadpool_executor,
     )
 
     sensor_daemon_futures = {}
@@ -490,11 +488,10 @@ def test_non_subsettable_check() -> None:
     with (
         get_grpc_workspace_request_context("check_not_subsettable") as context,
         get_threadpool_executor() as executor,
-        InheritContextThreadPoolExecutor(max_workers=5) as submit_executor,
     ):
         time = datetime.datetime(2024, 8, 17, 1, 35)
         with freeze_time(time):
-            _execute_ticks(context, executor, submit_executor)  # pyright: ignore[reportArgumentType]
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
 
             # eager asset materializes
             runs = _get_runs_for_latest_ticks(context)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_failure_recovery.py
@@ -8,7 +8,6 @@ from dagster._core.instance.ref import InstanceRef
 from dagster._core.instance_for_test import cleanup_test_instance
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.test_utils import freeze_time
-from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._utils import get_terminate_signal
 
 from dagster_tests.declarative_automation_tests.daemon_tests.test_e2e import (
@@ -30,17 +29,12 @@ def _execute(
             "five_runs_required", instance_ref=instance_ref
         ) as context,
         get_threadpool_executor() as executor,
-        InheritContextThreadPoolExecutor(
-            # fewer workers than runs
-            max_workers=3
-        ) as submit_executor,
     ):
         try:
             with freeze_time(evaluation_time):
                 _execute_ticks(
                     context,
                     executor,  # pyright: ignore[reportArgumentType]
-                    submit_executor,
                     {
                         crash_location: get_terminate_signal() if terminate else Exception("Oops!"),
                     },

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -215,7 +215,6 @@ class AssetDaemonScenarioState(ScenarioState):
                     threadpool_executor=self.threadpool_executor,
                     amp_tick_futures=amp_tick_futures,
                     debug_crash_flags={},
-                    submit_threadpool_executor=None,
                 )
 
                 wait_for_futures(amp_tick_futures)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -502,7 +502,6 @@ class AssetReconciliationScenario(
                         threadpool_executor=None,
                         amp_tick_futures={},
                         debug_crash_flags=(debug_crash_flags or {}),
-                        submit_threadpool_executor=None,
                     )
 
                     if self.expected_error_message:


### PR DESCRIPTION
Add asyncio callsites to the DA daemon when it fetches remote jobs and execution plans. This ended up being much more involved than I had been imagining, particularly when the daemon is already using threadpools.

Test Plan: BK, run DA locally with and without submit threadpool enabled