### PR TITLE
Renaming `FreshnessPolicy` to `LegacyFreshnessPolicy`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -27,7 +27,7 @@ class FreshnessMinutes(NamedTuple):
     "auto-materialize, use AutomationCondition.cron() and AutomationCondition.any_downstream_conditions().",
 )
 @whitelist_for_serdes
-class FreshnessPolicy(
+class LegacyFreshnessPolicy(
     NamedTuple(
         "_FreshnessPolicy",
         [
@@ -193,3 +193,11 @@ class FreshnessPolicy(
             lag_minutes=max(0.0, (evaluation_tick - data_time).total_seconds() / 60),
             overdue_minutes=max(0.0, (required_time - data_time).total_seconds() / 60),
         )
+
+
+# Type alias for backward compatibility
+@whitelist_for_serdes
+class FreshnessPolicy(LegacyFreshnessPolicy):
+    """Alias for LegacyFreshnessPolicy for backward compatibility."""
+
+    pass


### PR DESCRIPTION
## Summary & Motivation
Step 1 of migration plan to introduce the new `FreshnessPolicy` api (currently named `InternalFreshnessPolicy`) and properly deprecate existing `FreshnessPolicy` api

## How I Tested These Changes
bk

## Changelog

> Insert changelog entry or delete this section.
