### PR TITLE
[dagster-fivetran] mark legacy Fivetran integration as deprecated

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -13,7 +13,7 @@ from dagster import (
     _check as check,
     multi_asset,
 )
-from dagster._annotations import superseded
+from dagster._annotations import deprecated
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -240,7 +240,7 @@ def _build_fivetran_assets(
     return [_assets]
 
 
-@superseded(additional_warn_text="Use the `fivetran_assets` decorator instead.")
+@deprecated(breaking_version="1.12", additional_warn_text="Use the `fivetran_assets` decorator instead.")
 def build_fivetran_assets(
     connector_id: str,
     destination_tables: Sequence[str],
@@ -600,7 +600,8 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
 _clean_name = clean_name_lower
 
 
-@superseded(
+@deprecated(
+    breaking_version="1.12",
     additional_warn_text="Use the `build_fivetran_assets_definitions` factory instead.",
 )
 def load_assets_from_fivetran_instance(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -240,7 +240,9 @@ def _build_fivetran_assets(
     return [_assets]
 
 
-@deprecated(breaking_version="1.12", additional_warn_text="Use the `fivetran_assets` decorator instead.")
+@deprecated(
+    breaking_version="1.12", additional_warn_text="Use the `fivetran_assets` decorator instead."
+)
 def build_fivetran_assets(
     connector_id: str,
     destination_tables: Sequence[str],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -241,7 +241,7 @@ def _build_fivetran_assets(
 
 
 @deprecated(
-    breaking_version="1.12", additional_warn_text="Use the `fivetran_assets` decorator instead."
+    breaking_version="0.30", additional_warn_text="Use the `fivetran_assets` decorator instead."
 )
 def build_fivetran_assets(
     connector_id: str,
@@ -603,7 +603,7 @@ _clean_name = clean_name_lower
 
 
 @deprecated(
-    breaking_version="1.12",
+    breaking_version="0.30",
     additional_warn_text="Use the `build_fivetran_assets_definitions` factory instead.",
 )
 def load_assets_from_fivetran_instance(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -58,7 +58,7 @@ class SyncConfig(Config):
     tags={COMPUTE_KIND_TAG: "fivetran"},
 )
 @deprecated(
-    breaking_version="1.12",
+    breaking_version="0.30",
     additional_warn_text=(
         "Fivetran ops are no longer best practice and will soon be removed. "
         "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."
@@ -134,7 +134,7 @@ class FivetranResyncConfig(SyncConfig):
     tags={COMPUTE_KIND_TAG: "fivetran"},
 )
 @deprecated(
-    breaking_version="1.12",
+    breaking_version="0.30",
     additional_warn_text=(
         "Fivetran ops are no longer best practice and will soon be removed. "
         "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from dagster import AssetKey, Config, In, Nothing, Out, Output, op
-from dagster._annotations import superseded
+from dagster._annotations import deprecated
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from pydantic import Field
 
@@ -57,9 +57,10 @@ class SyncConfig(Config):
     ),
     tags={COMPUTE_KIND_TAG: "fivetran"},
 )
-@superseded(
+@deprecated(
+    breaking_version="1.12",
     additional_warn_text=(
-        "Fivetran ops are no longer best practice. "
+        "Fivetran ops are no longer best practice and will soon be removed. "
         "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."
     ),
 )
@@ -132,9 +133,10 @@ class FivetranResyncConfig(SyncConfig):
     ),
     tags={COMPUTE_KIND_TAG: "fivetran"},
 )
-@superseded(
+@deprecated(
+    breaking_version="1.12",
     additional_warn_text=(
-        "Fivetran ops are no longer best practice. "
+        "Fivetran ops are no longer best practice and will soon be removed. "
         "Use `FivetranWorkspace` resource and `@fivetran_asset` decorator instead."
     ),
 )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -22,7 +22,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import public, superseded
+from dagster._annotations import public, deprecated
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
@@ -68,7 +68,7 @@ DEFAULT_POLL_INTERVAL = 10
 FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX = "dagster-fivetran/reconstruction_metadata"
 
 
-@superseded(additional_warn_text="Use `FivetranWorkspace` instead.")
+@deprecated(breaking_version="1.12", additional_warn_text="Use `FivetranWorkspace` instead.")
 class FivetranResource(ConfigurableResource):
     """This class exposes methods on top of the Fivetran REST API."""
 
@@ -435,7 +435,7 @@ class FivetranResource(ConfigurableResource):
         return self.make_request("GET", f"destinations/{destination_id}")
 
 
-@superseded(additional_warn_text="Use `FivetranWorkspace` instead.")
+@deprecated(breaking_version="1.12", additional_warn_text="Use `FivetranWorkspace` instead.")
 @dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -22,7 +22,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import public, deprecated
+from dagster._annotations import deprecated, public
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -68,7 +68,7 @@ DEFAULT_POLL_INTERVAL = 10
 FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX = "dagster-fivetran/reconstruction_metadata"
 
 
-@deprecated(breaking_version="1.12", additional_warn_text="Use `FivetranWorkspace` instead.")
+@deprecated(breaking_version="0.30", additional_warn_text="Use `FivetranWorkspace` instead.")
 class FivetranResource(ConfigurableResource):
     """This class exposes methods on top of the Fivetran REST API."""
 
@@ -435,7 +435,7 @@ class FivetranResource(ConfigurableResource):
         return self.make_request("GET", f"destinations/{destination_id}")
 
 
-@deprecated(breaking_version="1.12", additional_warn_text="Use `FivetranWorkspace` instead.")
+@deprecated(breaking_version="0.30", additional_warn_text="Use `FivetranWorkspace` instead.")
 @dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:


### PR DESCRIPTION
## Summary & Motivation

Now that the new Fivetran resource is GA, the legacy resource should be deprecated.

## Changelog

[dagster-fivetran] the `FivetranResource` resource is now deprecated.
