### PR TITLE
RFC: remove cache invalidation for dynamic partitions definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -592,6 +592,13 @@ class DynamicPartitionsDefinition(
         else:
             return super().__str__()
 
+    def get_serializable_unique_identifier(
+        self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
+    ) -> str:
+        return hashlib.sha1(
+            f"DynamicPartitionsDefinition({self._validated_name()})".encode()
+        ).hexdigest()
+
     @public
     def get_partition_keys(
         self,

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -107,7 +107,7 @@ def test_unique_identifier():
             dynamic_partitions_store=instance
         )
         instance.add_dynamic_partitions(dynamic_def.name, ["bar"])  # pyright: ignore[reportArgumentType]
-        assert identifier1 != dynamic_def.get_serializable_unique_identifier(
+        assert identifier1 == dynamic_def.get_serializable_unique_identifier(
             dynamic_partitions_store=instance
         )
 
@@ -117,7 +117,7 @@ def test_unique_identifier():
         )
         serializable_unique_id = multipartitions_def.get_serializable_unique_identifier(instance)
         instance.add_dynamic_partitions(dynamic_dimension_def.name, ["apple"])  # pyright: ignore[reportArgumentType]
-        assert serializable_unique_id != multipartitions_def.get_serializable_unique_identifier(
+        assert serializable_unique_id == multipartitions_def.get_serializable_unique_identifier(
             instance
         )
 


### PR DESCRIPTION
## Summary & Motivation
For dynamic partitions definitions with a large partition key count, recalculating partition status can be very expensive, and is  usually unnecessary.

I think by allowing cached values for additions/removals, we could wind up in a scenario where we get inconsistent values (depending on cached state) for the following:

1. add partition A
2. materialize asset with partition A
3. remove partition A
4. materialize asset with partition not-A
5. add partition A

If the partition status was cached after (2), we would return A as materialized after (5).
If the partition status was not cached until after (3), we would return A as not materialized after (5).

One strategy to avoid this would be to delete cached status values for assets that match the partition def id on the asset record.  This would be easiest to do if we had a column in the asset record that identified which assets would be affected by a particular dynamic partitions definition (without reaching into the serialized cache value).

We should consider the following strategies:
1) land this PR as is and ignore the cache inconsistency issue outlined above
2) pull out the partitions def name into the asset records, so that we can blow away the asset cache on dynamic partition deletions
3) add a `deleted` / `deleted_timestamp` column to the dynamic partitions table and change the reads to filter by `deleted` status.  This allows us to get the max deleted timestamp and put that into the serializable hash, instead of just using the partitions def name.

## How I Tested These Changes
BK

