### PR TITLE
[dg] Change asset_check scaffolder to require an asset key so that it always creates a valid asset check

### DIFF
--- a/python_modules/dagster/dagster/components/lib/shim_components/asset_check.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/asset_check.py
@@ -10,7 +10,9 @@ from dagster.components.scaffold.scaffold import ScaffoldRequest, scaffold_with
 
 
 class AssetCheckScaffoldParams(BaseModel):
-    asset_key: Optional[str] = None
+    """Parameters for the AssetCheckScaffolder."""
+
+    asset_key: str
 
 
 class AssetCheckScaffolder(ShimScaffolder[AssetCheckScaffoldParams]):
@@ -19,29 +21,26 @@ class AssetCheckScaffolder(ShimScaffolder[AssetCheckScaffoldParams]):
         return AssetCheckScaffoldParams
 
     def get_text(self, filename: str, params: Optional[AssetCheckScaffoldParams]) -> str:
-        assert params is not None
-        asset_key_input = params.asset_key
-        asset_key = AssetKey.from_user_string(asset_key_input) if asset_key_input else None
-        if asset_key:
-            return textwrap.dedent(
-                f"""\
-                import dagster as dg
+        """Get the text for an asset check.
+
+        Args:
+            filename: The name of the file to generate
+            params: The parameters for the asset check, which will be validated against AssetCheckScaffoldParams
+
+        Returns:
+            The text for the asset check
+        """
+        assert params
+        asset_key = AssetKey.from_user_string(params.asset_key)
+        return textwrap.dedent(
+            f"""\
+            import dagster as dg
 
 
-                @dg.asset_check(asset=dg.AssetKey({asset_key.path!s}))
-                def {filename}(context: dg.AssetCheckExecutionContext) -> dg.AssetCheckResult: ...
-                """
-            )
-        else:
-            return textwrap.dedent(
-                f"""\
-                # import dagster as dg
-                #
-                #
-                # @dg.asset_check(asset=...)
-                # def {filename}(context: dg.AssetCheckExecutionContext) -> dg.AssetCheckResult: ...
-                """
-            )
+            @dg.asset_check(asset=dg.AssetKey({asset_key.path!s}))
+            def {filename}(context: dg.AssetCheckExecutionContext) -> dg.AssetCheckResult: ...
+            """
+        )
 
     def scaffold(self, request: ScaffoldRequest[AssetCheckScaffoldParams]) -> None:
         return scaffold_text(self, request)

--- a/python_modules/dagster/dagster/components/lib/shim_components/job.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/job.py
@@ -1,13 +1,13 @@
 import textwrap
-from typing import Any
+from typing import Optional
 
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster.components.lib.shim_components.base import ShimScaffolder
-from dagster.components.scaffold.scaffold import scaffold_with
+from dagster.components.scaffold.scaffold import NoParams, scaffold_with
 
 
 class JobScaffolder(ShimScaffolder):
-    def get_text(self, filename: str, params: Any) -> str:
+    def get_text(self, filename: str, params: Optional[NoParams]) -> str:
         return textwrap.dedent(
             f"""\
             import dagster as dg

--- a/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/multi_asset.py
@@ -21,7 +21,7 @@ class MultiAssetScaffolder(ShimScaffolder[MultiAssetScaffoldParams]):
     def get_text(self, filename: str, params: Optional[MultiAssetScaffoldParams]) -> str:
         asset_keys = (
             params.asset_key
-            if isinstance(params, MultiAssetScaffoldParams) and params.asset_key
+            if params and params.asset_key
             # Default to two sample assets based on the filename
             else [
                 f"{filename}/first_asset",

--- a/python_modules/dagster/dagster_tests/component_tests/shim_components/shim_test_utils.py
+++ b/python_modules/dagster/dagster_tests/component_tests/shim_components/shim_test_utils.py
@@ -34,7 +34,7 @@ def execute_ruff_compliance_test(code: str) -> None:
 
 
 def execute_scaffolder_and_get_symbol(
-    scaffolder: ShimScaffolder[TModel],
+    scaffolder: ShimScaffolder[Any],
     symbol_name: str,
     params: Optional[TModel] = None,
 ) -> Any:

--- a/python_modules/dagster/dagster_tests/component_tests/shim_components/test_asset_check.py
+++ b/python_modules/dagster/dagster_tests/component_tests/shim_components/test_asset_check.py
@@ -1,4 +1,7 @@
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey
+from dagster._core.definitions.decorators.asset_check_decorator import asset_check
+from dagster.components.component_scaffolding import parse_params_model
 from dagster.components.lib.shim_components.asset_check import (
     AssetCheckScaffolder,
     AssetCheckScaffoldParams,
@@ -13,7 +16,7 @@ def test_asset_check_scaffolder():
     """Test that the AssetCheckScaffolder creates valid Python code that evaluates to an asset check."""
     scaffolder = AssetCheckScaffolder()
     # Since the scaffolder returns a commented-out template, we should just verify it's a string
-    code = scaffolder.get_text("my_check", AssetCheckScaffoldParams())
+    code = scaffolder.get_text("my_check", AssetCheckScaffoldParams(asset_key="my_asset"))
     assert isinstance(code, str)
     assert "asset_check" in code
     assert "AssetCheckExecutionContext" in code
@@ -24,14 +27,35 @@ def test_asset_check_scaffolder_with_asset_key():
     """Test that the AssetCheckScaffolder creates valid code when given an asset key."""
     scaffolder = AssetCheckScaffolder()
     params = AssetCheckScaffoldParams(asset_key="my_asset")
-    check_fn = execute_scaffolder_and_get_symbol(scaffolder, "my_check", params)
+    checks_def = execute_scaffolder_and_get_symbol(scaffolder, "my_check", params)
 
     # Verify that the function creates a valid asset check
-    assert isinstance(check_fn, AssetChecksDefinition)
+    assert isinstance(checks_def, AssetChecksDefinition)
+    assert len(checks_def.check_keys) == 1
+    check_key = next(iter(checks_def.check_keys))
+    assert check_key == AssetCheckKey(AssetKey("my_asset"), "my_check")
 
 
 def test_asset_check_scaffolder_ruff_compliance():
     """Test that the generated code passes ruff linting."""
     scaffolder = AssetCheckScaffolder()
-    code = scaffolder.get_text("my_check", AssetCheckScaffoldParams())
+    code = scaffolder.get_text("my_check", AssetCheckScaffoldParams(asset_key="my_asset"))
     execute_ruff_compliance_test(code)
+
+
+def test_asset_check_scaffolder_params_flow():
+    """Test that params flow correctly through the scaffolding process."""
+    # Parse params through the CLI function
+    json_params = '{"asset_key": "my_asset"}'
+
+    params_model = parse_params_model(asset_check, json_params)
+
+    # Use the parsed params to generate code and get the symbol
+    scaffolder = AssetCheckScaffolder()
+    checks_def = execute_scaffolder_and_get_symbol(scaffolder, "my_check", params_model)
+
+    # Verify we got a valid asset check definition
+    assert isinstance(checks_def, AssetChecksDefinition)
+    assert len(checks_def.check_keys) == 1
+    check_key = next(iter(checks_def.check_keys))
+    assert check_key == AssetCheckKey(AssetKey("my_asset"), "my_check")

--- a/python_modules/dagster/dagster_tests/components/test_component_scaffolding.py
+++ b/python_modules/dagster/dagster_tests/components/test_component_scaffolding.py
@@ -1,0 +1,132 @@
+from typing import Optional
+
+import pytest
+from dagster.components.component_scaffolding import parse_params_model
+from dagster.components.scaffold.scaffold import NoParams, Scaffolder, scaffold_with
+from pydantic import BaseModel, ValidationError
+
+
+class TestParamsModelWithDefaults(BaseModel):
+    name: Optional[str] = None
+    age: Optional[int] = None
+
+
+class TestParamsModelWithoutDefaults(BaseModel):
+    name: str
+    age: int
+    is_active: bool
+
+
+class TestScaffolderWithDefaults(Scaffolder[TestParamsModelWithDefaults]):
+    @classmethod
+    def get_scaffold_params(cls) -> type[TestParamsModelWithDefaults]:
+        return TestParamsModelWithDefaults
+
+
+class TestScaffolderWithoutDefaults(Scaffolder[TestParamsModelWithoutDefaults]):
+    @classmethod
+    def get_scaffold_params(cls) -> type[TestParamsModelWithoutDefaults]:
+        return TestParamsModelWithoutDefaults
+
+
+class NoParamsScaffolder(Scaffolder[BaseModel]):
+    @classmethod
+    def get_scaffold_params(cls) -> type[BaseModel]:
+        return NoParams
+
+
+@scaffold_with(TestScaffolderWithDefaults)
+def fn_with_scaffolder_with_defaults() -> None: ...
+
+
+@scaffold_with(TestScaffolderWithoutDefaults)
+def fn_with_scaffolder_without_defaults() -> None: ...
+
+
+@scaffold_with(NoParamsScaffolder)
+def fn_with_no_params_scaffolder() -> None: ...
+
+
+def test_parse_params_model_no_params() -> None:
+    """Test when json_params is None."""
+    assert (
+        parse_params_model(obj=fn_with_scaffolder_with_defaults, json_params=None)
+        == TestParamsModelWithDefaults()
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        assert exc_info
+        assert parse_params_model(obj=fn_with_scaffolder_without_defaults, json_params=None)
+    assert parse_params_model(obj=fn_with_no_params_scaffolder, json_params=None) == NoParams()
+
+
+def test_parse_params_model_no_scaffolder() -> None:
+    """Test when object has no scaffolder."""
+
+    def no_scaffolder_fn() -> None: ...
+
+    with pytest.raises(Exception) as exc_info:
+        parse_params_model(obj=no_scaffolder_fn, json_params='{"name": "test", "age": 30}')
+    assert "must be decorated with @scaffold_with" in str(exc_info.value)
+
+
+def test_parse_params_model_valid_params() -> None:
+    """Test when valid JSON params are provided."""
+    result = parse_params_model(
+        obj=fn_with_scaffolder_with_defaults, json_params='{"name": "test", "age": 30}'
+    )
+    assert isinstance(result, TestParamsModelWithDefaults)
+    assert result.name == "test"
+    assert result.age == 30
+
+
+def test_parse_params_model_empty_params() -> None:
+    """Test when no JSON params are provided but scaffolder accepts params."""
+    result = parse_params_model(obj=fn_with_scaffolder_with_defaults, json_params="{}")
+    assert isinstance(result, TestParamsModelWithDefaults)
+    assert result.name is None
+    assert result.age is None
+
+
+def test_parse_params_model_without_defaults_empty_params() -> None:
+    """Test when no JSON params are provided and model has required fields."""
+    with pytest.raises(ValidationError) as exc_info:
+        parse_params_model(obj=fn_with_scaffolder_without_defaults, json_params="{}")
+    assert "validation error" in str(exc_info.value).lower()
+    assert "field required" in str(exc_info.value).lower()
+
+
+def test_parse_params_model_without_defaults_valid_params() -> None:
+    """Test when valid JSON params are provided for model with required fields."""
+    result = parse_params_model(
+        obj=fn_with_scaffolder_without_defaults,
+        json_params='{"name": "test", "age": 30, "is_active": true}',
+    )
+    assert isinstance(result, TestParamsModelWithoutDefaults)
+    assert result.name == "test"
+    assert result.age == 30
+    assert result.is_active is True
+
+
+def test_parse_params_model_no_params_but_provided() -> None:
+    """Test when scaffolder doesn't accept params but JSON params are provided."""
+    with pytest.raises(Exception) as exc_info:
+        parse_params_model(
+            obj=fn_with_no_params_scaffolder, json_params='{"name": "test", "age": 30}'
+        )
+    assert "Input should be null" in str(exc_info.value)
+
+
+def test_parse_params_model_validation_error() -> None:
+    """Test when JSON params fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        parse_params_model(
+            obj=fn_with_scaffolder_with_defaults, json_params='{"name": "test", "age": "invalid"}'
+        )
+    assert "validation error" in str(exc_info.value).lower()
+
+
+def test_parse_params_model_invalid_json() -> None:
+    """Test when invalid JSON is provided."""
+    with pytest.raises(ValidationError) as exc_info:
+        parse_params_model(obj=fn_with_scaffolder_with_defaults, json_params="invalid json")
+    assert "invalid json" in str(exc_info.value).lower()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -626,33 +626,6 @@ def test_scaffold_asset() -> None:
         assert not Path("src/foo_bar/defs/assets/component.yaml").exists()
 
 
-def test_scaffold_asset_check_no_key() -> None:
-    with (
-        ProxyRunner.test() as runner,
-        isolated_example_project_foo_bar(runner),
-    ):
-        result = runner.invoke("scaffold", "dagster.asset_check", "asset_checks/my_check.py")
-        assert_runner_result(result)
-        assert Path("src/foo_bar/defs/asset_checks/my_check.py").exists()
-        # check is commented since it is not pointed at an asset
-        assert (
-            Path("src/foo_bar/defs/asset_checks/my_check.py")
-            .read_text()
-            .startswith("# import dagster as dg")
-        )
-        assert not Path("src/foo_bar/defs/asset_checks/my_check.py").is_dir()
-        assert not Path("src/foo_bar/defs/asset_checks/component.yaml").exists()
-
-        result = runner.invoke("scaffold", "dagster.asset_check", "asset_checks/my_other_check.py")
-        assert_runner_result(result)
-        assert Path("src/foo_bar/defs/asset_checks/my_other_check.py").exists()
-        assert not Path("src/foo_bar/defs/asset_checks/component.yaml").exists()
-
-        result = runner.invoke("list", "defs")
-        assert_runner_result(result)
-        assert "my_check" not in result.output
-
-
 def test_scaffold_asset_check_with_key() -> None:
     with (
         ProxyRunner.test() as runner,


### PR DESCRIPTION
## Summary & Motivation

This PR proposes changes the pattern of scaffolding our core decorators so that it always creates a valid definition viewable with `dg list defs` after scaffolding. I believe this is important to a smooth DX. However this is a product discussion so worthy of discussion.

## How I Tested These Changes

BK

## Changelog

* Will write if we decide to do this.