### PR TITLE
feat: support seperation of SA in user_deployment chart

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
     spec:
       imagePullSecrets: {{ $.Values.imagePullSecrets | toYaml | nindent 8 }}
-      serviceAccountName: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
+      serviceAccountName: {{ if and $deployment.serviceAccount (hasKey $deployment.serviceAccount "name") }}{{ $deployment.serviceAccount.name }}{{ else }}{{ include "dagsterUserDeployments.serviceAccountName" $ }}{{ end }}
       automountServiceAccountToken: true
       securityContext: {{ $deployment.podSecurityContext | toYaml | nindent 8 }}
       {{- if $deployment.initContainers }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
@@ -4,12 +4,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "dagster.fullname" . }}-rolebinding
   labels: {{ include "dagster.labels" . | nindent 4 }}
-
 subjects:
 - kind: ServiceAccount
   name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
+{{- range $deployment := .Values.deployments }}
+{{- if and $deployment.serviceAccount (hasKey $deployment.serviceAccount "name") }}
+- kind: ServiceAccount
+  name: {{ $deployment.serviceAccount.name }}
+{{- end }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "dagster.fullname" . }}-role
-{{- end -}}
+{{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount_deployments.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount_deployments.yaml
@@ -1,0 +1,13 @@
+{{ range $deployment := .Values.deployments }}
+{{ if and $deployment.serviceAccount (hasKey $deployment.serviceAccount "name") }}
+{{ if and $deployment.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $deployment.serviceAccount.name }}
+  labels: {{ include "dagster.labels" $ | nindent 4 }}
+  annotations: {{- $deployment.serviceAccount.annotations | toYaml | nindent 4 }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -537,6 +537,17 @@
                         }
                     ],
                     "default": null
+                },
+                "serviceAccount": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ServiceAccount"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
                 }
             },
             "required": [

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -158,6 +158,12 @@ deployments:
 
     service:
       annotations: {}
+    
+    # Specify a deployments serviceAccount to use. This will override the global serviceAccount for the individual deployment.
+    serviceAccount:
+      create: false
+      name: "example-deployment-sa"
+      annotations: {}
 
 # Specify secrets to run containers based on images in private registries. See:
 # https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, create_model
 
+from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.utils import kubernetes
 
 
@@ -42,6 +43,7 @@ class UserDeployment(BaseModel):
     initContainers: Optional[list[kubernetes.Container]] = None
     sidecarContainers: Optional[list[kubernetes.Container]] = None
     deploymentStrategy: Optional[kubernetes.DeploymentStrategy] = None
+    serviceAccount: Optional[ServiceAccount] = None
 
 
 class UserDeployments(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_rolebinding.py
+++ b/helm/dagster/schema/schema_tests/test_rolebinding.py
@@ -1,0 +1,35 @@
+import pytest
+from kubernetes.client import models
+from schema.charts.dagster.values import DagsterHelmValues
+from schema.utils.helm_template import HelmTemplate
+
+
+@pytest.fixture(name="template")
+def rolebinding_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="templates/rolebinding.yaml",
+        model=models.V1RoleBinding,
+    )
+
+
+def test_rolebinding_renders_correctly(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        rbacEnabled=True,
+        serviceAccount={"name": "custom-service-account"},
+    )
+
+    [rolebinding] = template.render(helm_values)
+
+    assert rolebinding.metadata.name == "release-name-dagster-rolebinding"
+    assert rolebinding.metadata.labels["app"] == "dagster"
+
+    assert len(rolebinding.subjects) == 1
+    subject = rolebinding.subjects[0]
+    assert subject.kind == "ServiceAccount"
+    assert subject.name == "custom-service-account"
+
+    assert rolebinding.role_ref.api_group == "rbac.authorization.k8s.io"
+    assert rolebinding.role_ref.kind == "Role"
+    assert rolebinding.role_ref.name == "release-name-dagster-role"

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -164,3 +164,37 @@ def test_standalone_subchart_service_account_annotations(
 
     assert service_account_template.metadata.name == service_account_name
     assert service_account_template.metadata.annotations == service_account_annotations
+
+
+def test_custom_and_default_service_accounts(template: HelmTemplate):
+    custom_service_account_name = "custom-service-account"
+    custom_service_account_annotations = {"custom-key": "custom-value"}
+    custom_service_account_values = DagsterHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(
+            name=custom_service_account_name,
+            create=True,
+            annotations=kubernetes.Annotations.parse_obj(custom_service_account_annotations),
+        )
+    )
+
+    default_service_account_name = "default-service-account"
+    default_service_account_values = DagsterHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(
+            name=default_service_account_name,
+            create=True,
+        )
+    )
+
+    custom_service_account_templates = template.render(custom_service_account_values)
+    default_service_account_templates = template.render(default_service_account_values)
+
+    assert len(custom_service_account_templates) == 1
+    custom_service_account_template = custom_service_account_templates[0]
+    assert custom_service_account_template.metadata.name == custom_service_account_name
+    assert (
+        custom_service_account_template.metadata.annotations == custom_service_account_annotations
+    )
+
+    assert len(default_service_account_templates) == 1
+    default_service_account_template = default_service_account_templates[0]
+    assert default_service_account_template.metadata.name == default_service_account_name


### PR DESCRIPTION
## Summary & Motivation

Currently the subchart `dagster-user-deployments` support a single serviceAccount shared amongst all deployments referenced by it. This is done via values: `.Values.serviceAccountName` or `.Values.serviceAccount.name`.

While this is fine for a single domain where the bounded context of permission on this serviceAccount is shared amongst the deployments of dagster, then for segregation of responsiblity it would be nice to allow a deployment to specify its own serviceAccount.

The changes does not include any changes to allow the serviceAccount a custom role through this helm chart, but it allows the creation of the serviceAccount outside of the chart, which then can have a custom role and rolebinding, plus in relation to identity management through fx. AKS or EKS it can be used to work with a [workload managed identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet).

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: workload-identity-service-a
  annotations:
    azure.workload.identity/client-id: "someid"
```

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: dagster
spec:
  ...
  values:
    ...
    dagster-user-deployments:
      deployments:
        - name: "workload-example" # set to the name of your deployment
          image:
            repository: "something"
            tag: "latest"
            pullPolicy: Always
          dagsterApiGrpcArgs:
            - -m
            - quickstart
          port: 5000
        - name: "serviceA"
          image:
            repository: "serviceA"
            tag: "latest"
            pullPolicy: Always
          dagsterApiGrpcArgs:
            - m
            - quickstart
          port: 5000
          labels:
            azure.workload.identity/use: "true"
          serviceAccount:
            create: false
            name: workload-identity-service-a
```

With the proposed feature the above configuration is possible, making the `serviceA` allowed to access what the Azure `client-id` have access to through the ServiceAccount `workload-identity-service-a`.

## How I Tested These Changes

I added schema unit tests for the resources:

chore: added test cases for SA
chore: added test cases for deployment
chore: added test case for rolebinding

I added a localized run of the templated resource of a dagster deployment:

```yaml
serviceAccount:
  create: true
  name: ""
  annotations: {}

postgresql:
  enabled: false
  secretName: "test"

deployments:
  - name: deployment-one
    image:
      repository: "test"
      tag: "latest"
      pullPolicy: "IfNotPresent"
    port: 80
    serviceAccount:
      create: true
      name: "deployment-one-sa"
      annotations: {}
  - name: deployment-two
    image:
      repository: "test"
      tag: "latest"
      pullPolicy: "IfNotPresent"
    port: 80
```

## Changelog

feat: allowed support for seperation of serviceAccounts in user_deployment chart for each deployment by `.Values.deployments.serviceAccount`

## Improvements

I wanted to make `serviceaccount.yaml` dynamic by creating a list of serviceAccounts to create by implementation through helpers.tpl,  but I did not manage to do it without breaking implementation. So I settled on a new template `serviceaccount_deployments.yaml` that iterates deployments for serviceAccounts to create.

Let me know if you have input on how I can achieve the removal of `serviceaccount_deployments.yaml`.
