### PR TITLE
Add async loaders for RemoteJob and RemoteExecutionPlan

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterable, Mapping, Sequence
 from typing import AbstractSet, Any, Optional  # noqa: UP035
 
+from dagster_shared.utils.hash import make_hashable
+
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
@@ -72,6 +74,11 @@ class JobSubsetSelector(IHaveNew):
             location_name=self.location_name,
             repository_name=self.repository_name,
         )
+
+    def __hash__(self) -> int:
+        if not hasattr(self, "_hash"):
+            self._hash = hash(make_hashable(self))
+        return self._hash
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from datetime import datetime
@@ -36,6 +37,7 @@ from dagster._core.definitions.sensor_definition import (
 from dagster._core.definitions.utils import get_default_automation_condition_sensor_selection
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster._core.instance import DagsterInstance
+from dagster._core.loader import LoadableBy
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation.external_data import (
     DEFAULT_MODE_NAME,
@@ -83,6 +85,8 @@ if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteRepositoryAssetGraph
     from dagster._core.scheduler.instigation import InstigatorState
     from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
+    from dagster._core.workspace.context import BaseWorkspaceRequestContext
+
 
 _empty_set = frozenset()
 
@@ -477,7 +481,7 @@ class RemoteRepository:
         return schedules
 
 
-class RemoteJob(RepresentedJob):
+class RemoteJob(RepresentedJob, LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestContext"]):
     """RemoteJob is a object that represents a loaded job definition that
     is resident in another process or container. Host processes such as dagster-webserver use
     objects such as these to interact with user-defined artifacts.
@@ -519,6 +523,23 @@ class RemoteJob(RepresentedJob):
             job_name=self._name,
             repository_handle=repository_handle,
         )
+
+    @classmethod
+    async def _batch_load(
+        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+    ) -> Iterable[Optional["RemoteJob"]]:
+        unique_keys = {key for key in keys}
+        tasks = [context.gen_job(unique_key) for unique_key in unique_keys]
+        results = await asyncio.gather(*tasks)
+
+        results_by_key = {unique_key: result for unique_key, result in zip(unique_keys, results)}
+        return [results_by_key[key] for key in keys]
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+    ) -> Iterable[Optional["RemoteJob"]]:
+        raise NotImplementedError
 
     @property
     def _job_index(self) -> JobIndex:
@@ -685,7 +706,7 @@ class RemoteJob(RepresentedJob):
         )
 
 
-class RemoteExecutionPlan:
+class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestContext"]):
     """RemoteExecutionPlan is a object that represents an execution plan that
     was compiled in another process or persisted in an instance.
     """
@@ -708,6 +729,39 @@ class RemoteExecutionPlan:
         self._deps = None
         self._topological_steps = None
         self._topological_step_levels = None
+
+    @classmethod
+    async def _batch_load(
+        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+    ) -> Iterable[Optional["RemoteExecutionPlan"]]:
+        remote_jobs = await RemoteJob.gen_many(context, keys)
+        remote_jobs_by_key = {key: job for key, job in zip(keys, remote_jobs)}
+        unique_keys = {key for key in keys}
+
+        tasks = [
+            context.gen_execution_plan(
+                check.not_none(remote_jobs_by_key[key]),
+                run_config={},
+                step_keys_to_execute=None,
+                known_state=None,
+            )
+            for key in unique_keys
+            if remote_jobs_by_key[key] is not None
+        ]
+
+        if tasks:
+            results = await asyncio.gather(*tasks)
+        else:
+            results = []
+        results_by_key = {unique_key: result for unique_key, result in zip(unique_keys, results)}
+
+        return [results_by_key[key] for key in keys]
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+    ) -> Iterable[Optional["RemoteExecutionPlan"]]:
+        raise NotImplementedError
 
     @property
     def step_keys_in_plan(self) -> Sequence[str]:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -284,6 +284,12 @@ class BaseWorkspaceRequestContext(LoadingContext):
             .get_full_job(selector.job_name)
         )
 
+    async def gen_job(
+        self,
+        selector: JobSubsetSelector,
+    ) -> RemoteJob:
+        return await self.get_code_location(selector.location_name).gen_job(selector)
+
     def get_execution_plan(
         self,
         remote_job: RemoteJob,
@@ -292,6 +298,21 @@ class BaseWorkspaceRequestContext(LoadingContext):
         known_state: Optional[KnownExecutionState],
     ) -> RemoteExecutionPlan:
         return self.get_code_location(remote_job.handle.location_name).get_execution_plan(
+            remote_job=remote_job,
+            run_config=run_config,
+            step_keys_to_execute=step_keys_to_execute,
+            known_state=known_state,
+            instance=self.instance,
+        )
+
+    async def gen_execution_plan(
+        self,
+        remote_job: RemoteJob,
+        run_config: Mapping[str, object],
+        step_keys_to_execute: Optional[Sequence[str]],
+        known_state: Optional[KnownExecutionState],
+    ) -> RemoteExecutionPlan:
+        return await self.get_code_location(remote_job.handle.location_name).gen_execution_plan(
             remote_job=remote_job,
             run_config=run_config,
             step_keys_to_execute=step_keys_to_execute,

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/hash.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/hash.py
@@ -22,7 +22,7 @@ def hash_collection(
 
             def __hash__(self):
                 if not hasattr(self, '_hash'):
-                    self._hash = hash_named_tuple(self)
+                    self._hash = hash_collection(self)
                 return self._hash
     """
     assert isinstance(collection, (list, dict, set, tuple)), (


### PR DESCRIPTION
## Summary & Motivation
To unblock parallelizing IO/bound grpc/agent calls in DA.

One new thing about these is that I think they are our first loader that depends on something other than the instance.

## How I Tested These Changes
New unit test cases, used for real in downstream PR
