### PR TITLE
Retry docker daemon exit code 125

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -41,6 +41,7 @@ class CommandStepBuilder:
             "retry": {
                 "automatic": [
                     {"exit_status": -1, "limit": 2},  # agent lost
+                    {"exit_status": 125, "limit": 2},  # docker daemon error
                     {"exit_status": 143, "limit": 2},  # agent lost
                     {"exit_status": 2, "limit": 2},  # often a uv read timeout
                     {"exit_status": 255, "limit": 2},  # agent forced shut down


### PR DESCRIPTION
We're seeing intermittent failures with:

https://docs.docker.com/engine/containers/run/#125

For example:

https://buildkite.com/dagster/dagster-dagster/builds/121996#0196b037-f82b-486d-a2dc-047d4315615b/306-312

I think the exit code is sufficiently narrowly scoped that we can retry on it for now.