### PR TITLE
[dagster-sling][components] Use translation pattern for SlingReplicationCollectionComponent

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location/defs/ingest/component.yaml
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location/defs/ingest/component.yaml
@@ -3,7 +3,7 @@ type: dagster_sling.SlingReplicationCollectionComponent
 attributes:
   replications:
     - path: ./replication.yaml
-      asset_attributes:
+      translation:
         key: "foo/{{ stream_definition.config.meta.dagster.asset_key }}"
   sling:
     connections:

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -184,7 +184,11 @@ def test_sling_subclass() -> None:
     "attributes, assertion, should_error",
     [
         ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
-        ({"owners": ["team:analytics"]}, None, True),
+        (
+            {"owners": ["team:analytics"]},
+            lambda asset_spec: asset_spec.owners == ["team:analytics"],
+            False,
+        ),
         ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
         ({"kinds": ["snowflake"]}, lambda asset_spec: "snowflake" in asset_spec.kinds, False),
         (
@@ -193,7 +197,7 @@ def test_sling_subclass() -> None:
             and asset_spec.tags.get("foo") == "bar",
             False,
         ),
-        ({"code_version": "1"}, None, True),
+        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
         (
             {"description": "some description"},
             lambda asset_spec: asset_spec.description == "some description",
@@ -241,7 +245,7 @@ def test_sling_subclass() -> None:
         "key_prefix",
     ],
 )
-def test_asset_attributes(
+def test_translation(
     attributes: Mapping[str, Any],
     assertion: Optional[Callable[[AssetSpec], bool]],
     should_error: bool,
@@ -250,7 +254,7 @@ def test_asset_attributes(
     with (
         wrapper,
         temp_sling_component_instance(
-            [{"path": "./replication.yaml", "asset_attributes": attributes}]
+            [{"path": "./replication.yaml", "translation": attributes}]
         ) as (component, defs),
     ):
         key = AssetKey(attributes.get("key", "input_duckdb"))
@@ -265,16 +269,16 @@ def test_asset_attributes(
 IGNORED_KEYS = {"skippable"}
 
 
-def test_asset_attributes_is_comprehensive():
+def test_translation_is_comprehensive():
     all_asset_attribute_keys = []
-    for test_arg in test_asset_attributes.pytestmark[0].args[1]:  # pyright: ignore[reportFunctionMemberAccess]
+    for test_arg in test_translation.pytestmark[0].args[1]:  # pyright: ignore[reportFunctionMemberAccess]
         all_asset_attribute_keys.extend(test_arg[0].keys())
     from dagster.components.resolved.core_models import AssetAttributesModel
 
     assert set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS == set(
         all_asset_attribute_keys
     ), (
-        f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
+        f"The test_translation test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
     )
 
 
@@ -303,7 +307,7 @@ def test_spec_is_available_in_scope() -> None:
         [
             {
                 "path": "./replication.yaml",
-                "asset_attributes": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
+                "translation": {"metadata": {"asset_key": "{{ spec.key.path }}"}},
             }
         ]
     ) as (_, defs):
@@ -337,7 +341,7 @@ def test_udf_map_spec(map_fn: Callable[[AssetSpec], Any]) -> None:
         {
             "sling": {},
             "replications": [
-                {"path": str(REPLICATION_PATH), "asset_attributes": "{{ map_spec(spec) }}"}
+                {"path": str(REPLICATION_PATH), "translation": "{{ map_spec(spec) }}"}
             ],
         },
     )


### PR DESCRIPTION
## Summary

Use the translation pattern for the `SlingReplicationCollectionComponent`, modeled after our DBT component.

## How I Tested These Changes

Updated unit tests.

## Changelog

> [dagster-sling] When using the SlingReplicationCollectionComponent, the `asset_attributes` parameter has been updated to `translation` to match our other integration components.
