### PR TITLE
[1/2] Update link to code location in asset search to go to catalog with code location asset selection syntax filter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.ts
@@ -6,9 +6,9 @@ import {
   linkToAssetTableWithGroupFilter,
   linkToAssetTableWithKindFilter,
   linkToAssetTableWithTagFilter,
-  linkToCodeLocation,
+  linkToCodeLocationInCatalog,
 } from '../../search/links';
-import {buildRepoAddress, buildRepoPathForHuman} from '../../workspace/buildRepoAddress';
+import {buildRepoPathForHuman} from '../../workspace/buildRepoAddress';
 import {AssetTableFragment} from '../types/AssetTableFragment.types';
 
 export type ViewType =
@@ -66,7 +66,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
         acc.repository[name] = acc.repository[name] || {
           assets: [],
           label: name,
-          link: linkToCodeLocation(buildRepoAddress(repository.name, repository.location.name)),
+          link: linkToCodeLocationInCatalog(repository.name, repository.location.name),
         };
         acc.repository[name]!.assets.push(asset);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
@@ -46,6 +46,15 @@ export const linkToCodeLocation = (repoAddress: RepoAddress) => {
   return `/locations/${repoAddressAsURLString(repoAddress)}/assets`;
 };
 
+export const linkToCodeLocationInCatalog = (
+  repositoryName: string,
+  repositoryLocationName: string,
+) => {
+  return `/assets?${qs.stringify({
+    'asset-selection': `code_location:"${buildRepoPathForHuman(repositoryName, repositoryLocationName)}"`,
+  })}`;
+};
+
 export const linkToAssetTableWithTableNameFilter = (tableName: string) => {
   return `/assets?${qs.stringify({
     'asset-selection': `table_name:"${tableName}"`,


### PR DESCRIPTION
## Summary & Motivation

as titled.


## How I Tested These Changes
Click the link and saw it went to the catalog.
<img width="1168" alt="Screenshot 2025-05-08 at 2 17 29 PM" src="https://github.com/user-attachments/assets/8222aa56-76b9-4eaa-942d-31605e434300" />
