### PR TITLE
[dagster-fivetran] Handle unavailable schema configs in fetch_fivetran_workspace_data

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -519,16 +519,18 @@ class FivetranClient:
     def _make_connector_request(
         self, method: str, endpoint: str, data: Optional[str] = None
     ) -> Mapping[str, Any]:
-        return self._make_request(method, f"{FIVETRAN_CONNECTOR_ENDPOINT}/{endpoint}", data)
+        return self._make_and_handle_request(
+            method, f"{FIVETRAN_CONNECTOR_ENDPOINT}/{endpoint}", data
+        )
 
-    def _make_request(
+    def _make_and_handle_request(
         self,
         method: str,
         endpoint: str,
         data: Optional[str] = None,
         params: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        """Creates and sends a request to the desired Fivetran API endpoint.
+        """Creates, sends and handles a request to the desired Fivetran API endpoint.
 
         Args:
             method (str): The http method to use for this request (e.g. "POST", "GET", "PATCH").
@@ -538,6 +540,34 @@ class FivetranClient:
 
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request.
+        """
+        response = self._make_request(method=method, endpoint=endpoint, data=data, params=params)
+        try:
+            response.raise_for_status()
+            resp_dict = response.json()
+            return resp_dict["data"] if "data" in resp_dict else resp_dict
+        except RequestException as e:
+            raise Failure(
+                f"Max retries ({self.request_max_retries}) exceeded with url: {response.url}. Caused by {e}"
+            )
+
+    def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> requests.Response:
+        """Creates and sends a request to the desired Fivetran API endpoint.
+
+        Args:
+            method (str): The http method to use for this request (e.g. "POST", "GET", "PATCH").
+            endpoint (str): The Fivetran API endpoint to send this request to.
+            data (Optional[str]): JSON-formatted data string to be included in the request.
+            params (Optional[Dict[str, Any]]): JSON-formatted query params to be included in the request.
+
+        Returns:
+            Optional[requests.Response]: The `requests.Response` object for the request.
         """
         url = f"{self.api_base_url}/{endpoint}"
         headers = {
@@ -558,14 +588,11 @@ class FivetranClient:
                     timeout=int(os.getenv("DAGSTER_FIVETRAN_API_REQUEST_TIMEOUT", "60")),
                 )
                 response.raise_for_status()
-                resp_dict = response.json()
-                return resp_dict["data"] if "data" in resp_dict else resp_dict
+                return response
             except RequestException as e:
                 self._log.error("Request to Fivetran API failed: %s", e)
                 if num_retries == self.request_max_retries:
-                    raise Failure(
-                        f"Max retries ({self.request_max_retries}) exceeded with url: {url}. Caused by {e}"
-                    )
+                    return response  # type: ignore
                 num_retries += 1
                 time.sleep(self.request_retry_delay)
 
@@ -593,7 +620,7 @@ class FivetranClient:
         results = []
         cursor = None
         while True:
-            data = self._make_request(
+            data = self._make_and_handle_request(
                 method="GET",
                 endpoint=f"groups/{group_id}/connectors",
                 params={
@@ -608,16 +635,42 @@ class FivetranClient:
                 break
         return results
 
-    def get_schema_config_for_connector(self, connector_id: str) -> Mapping[str, Any]:
+    def get_schema_config_for_connector(
+        self, connector_id: str, raise_on_not_found_error: bool = True
+    ) -> Mapping[str, Any]:
         """Fetches the connector schema config for a given connector from the Fivetran API.
 
         Args:
             connector_id (str): The Fivetran Connector ID.
+            raise_on_not_found_error (bool):
+                Whether to raise an exception if a 404 error is encountered. Defaults to True.
 
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request.
         """
-        return self._make_request("GET", f"connectors/{connector_id}/schemas")
+        response = self._make_request("GET", f"connectors/{connector_id}/schemas")
+        try:
+            response.raise_for_status()
+            resp_dict = response.json()
+            return resp_dict["data"] if "data" in resp_dict else resp_dict
+        except RequestException as e:
+            # In some cases, the schema config doesn't exist,
+            # even if the connector is connected and the schema status is ready.
+            # The Fivetran API request fails with a 404 error in that case.
+            if (
+                not raise_on_not_found_error
+                and e.response is not None
+                and e.response.status_code == 404
+            ):
+                self._log.warning(
+                    f"Schema config was not found for connector with ID {connector_id}."
+                )
+                return {}
+            else:
+                # If the conditions are not met, we raise the error as we do for other endpoints.
+                raise Failure(
+                    f"Max retries ({self.request_max_retries}) exceeded with url: {response.url}. Caused by {e}"
+                )
 
     def get_destination_details(self, destination_id: str) -> Mapping[str, Any]:
         """Fetches details about a given destination from the Fivetran API.
@@ -628,7 +681,7 @@ class FivetranClient:
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request.
         """
-        return self._make_request("GET", f"destinations/{destination_id}")
+        return self._make_and_handle_request("GET", f"destinations/{destination_id}")
 
     def get_groups(self) -> Mapping[str, Any]:
         """Fetches all groups from the Fivetran API.
@@ -636,7 +689,7 @@ class FivetranClient:
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request.
         """
-        return self._make_request("GET", "groups")
+        return self._make_and_handle_request("GET", "groups")
 
     def update_schedule_type_for_connector(
         self, connector_id: str, schedule_type: str
@@ -950,23 +1003,16 @@ class FivetranWorkspace(ConfigurableResource):
                     )
                     continue
 
-                try:
-                    schema_config_details = client.get_schema_config_for_connector(
-                        connector_id=connector.id
-                    )
-                except Failure as e:
-                    if "404" in e.description:
-                        # In some cases, the schema config doesn't exist,
-                        # even if the connector is connected and the schema status is ready.
-                        # The Fivetran API request fails with a 404 error in that case.
-                        schema_config = None
-                    else:
-                        # If the Fivetran API requests fails for anything else than a 404 error, we raise the error.
-                        raise e
-                else:
-                    schema_config = FivetranSchemaConfig.from_schema_config_details(
+                schema_config_details = client.get_schema_config_for_connector(
+                    connector_id=connector.id, raise_on_not_found_error=False
+                )
+                schema_config = (
+                    FivetranSchemaConfig.from_schema_config_details(
                         schema_config_details=schema_config_details
                     )
+                    if schema_config_details
+                    else None
+                )
 
                 # A connector that has not been synced yet has no `schemas` field in its schema config.
                 # Schemas are required for creating the asset definitions,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
@@ -444,6 +444,11 @@ MISSING_SCHEMAS_SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = get_sample_schema_config_fo
     table_name=TEST_TABLE_NAME, include_schemas=False
 )
 
+NOT_FOUND_SCHEMA_CONFIG_FOR_CONNECTOR = {
+    "code": "NotFound_SchemaConfig",
+    "message": f"Connection with id '{TEST_CONNECTOR_ID}' doesn't have schema config",
+}
+
 SAMPLE_SUCCESS_MESSAGE = {"code": "Success", "message": "Operation performed."}
 
 SAMPLE_SOURCE_TABLE_COLUMNS_CONFIG = {
@@ -599,6 +604,37 @@ def broken_connector_fetch_workspace_data_api_mocks_fixture(
     fetch_workspace_data_api_mocks.remove(
         method_or_response=responses.GET,
         url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
+    )
+    yield fetch_workspace_data_api_mocks
+
+
+@pytest.fixture(
+    name="not_found_schema_config_fetch_workspace_data_api_mocks",
+)
+def not_found_schema_config_fetch_workspace_data_api_mocks_fixture(
+    connector_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.replace(
+        method_or_response=responses.GET,
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
+        json=NOT_FOUND_SCHEMA_CONFIG_FOR_CONNECTOR,
+        status=404,
+    )
+    yield fetch_workspace_data_api_mocks
+
+
+@pytest.fixture(
+    name="other_error_schema_config_fetch_workspace_data_api_mocks",
+)
+def other_error_schema_config_fetch_workspace_data_api_mocks_fixture(
+    connector_id: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.replace(
+        method_or_response=responses.GET,
+        url=f"{get_fivetran_connector_api_url(connector_id)}/schemas",
+        status=401,
     )
     yield fetch_workspace_data_api_mocks
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from dagster import Failure
 from dagster._config.field_utils import EnvVar
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.test_utils import environ
@@ -116,6 +117,30 @@ def test_broken_connector_fivetran_workspace_data(
     # The connector is discarded because it's broken
     assert len(actual_workspace_data.connectors_by_id) == 0
     assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+def test_not_found_schema_config_fivetran_workspace_data(
+    not_found_schema_config_fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    actual_workspace_data = resource.get_or_fetch_workspace_data()
+    # The connector is discarded because it's broken
+    assert len(actual_workspace_data.connectors_by_id) == 0
+    assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+def test_other_error_schema_config_fivetran_workspace_data(
+    other_error_schema_config_fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
+
+    with pytest.raises(Failure):
+        resource.get_or_fetch_workspace_data()
 
 
 def test_translator_spec(


### PR DESCRIPTION
## Summary & Motivation

Fixes AD-1290.

In some cases, the schema config doesn't exist, even if the connector is connected and the schema status is ready. The Fivetran API request fails with a 404 error in that case.

## How I Tested These Changes

New tests with BK.

## Changelog

[dagster-fivetran] An issue causing the Fivetran integration to fail when the schema config does not exist for a connector has been fixed.
