### PR TITLE
Wipe asset check evaluations when wiping assets

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1743,11 +1743,12 @@ class SqlEventLogStorage(EventLogStorage):
                     AssetKeyTable.c.asset_key == asset_key.to_string(),
                 )
             )
-            conn.execute(
-                AssetCheckExecutionsTable.delete().where(
-                    AssetCheckExecutionsTable.c.asset_key == asset_key.to_string()
+            if self.has_table("asset_check_executions"):
+                conn.execute(
+                    AssetCheckExecutionsTable.delete().where(
+                        AssetCheckExecutionsTable.c.asset_key == asset_key.to_string()
+                    )
                 )
-            )
 
     def wipe_asset_partitions(self, asset_key: AssetKey, partition_keys: Sequence[str]) -> None:
         """Remove asset index history from event log for given asset partitions."""

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1743,6 +1743,11 @@ class SqlEventLogStorage(EventLogStorage):
                     AssetKeyTable.c.asset_key == asset_key.to_string(),
                 )
             )
+            conn.execute(
+                AssetCheckExecutionsTable.delete().where(
+                    AssetCheckExecutionsTable.c.asset_key == asset_key.to_string()
+                )
+            )
 
     def wipe_asset_partitions(self, asset_key: AssetKey, partition_keys: Sequence[str]) -> None:
         """Remove asset index history from event log for given asset partitions."""

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5871,6 +5871,11 @@ class TestEventLogStorage:
         assert latest_checks[check_key_2].status == AssetCheckExecutionRecordStatus.PLANNED
         assert latest_checks[check_key_2].run_id == run_id_3
 
+        storage.wipe_asset(AssetKey(["my_asset"]))
+
+        latest_checks = storage.get_latest_asset_check_execution_by_key([check_key_1, check_key_2])
+        assert len(latest_checks) == 0
+
     def test_duplicate_asset_check_planned_events(self, storage: EventLogStorage):
         run_id = make_new_run_id()
         for _ in range(2):


### PR DESCRIPTION
## Summary

Wipes asset check evaluations when an asset is wiped in the SQL event log storage.

## Test Plan

Update asset checks storage unit test.

## Changelog

> Wiping an asset will now wipe associated asset check evaluations.
