### PR TITLE
[da] validate cron string in `cron_tick_passed` condition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.partition import AllPartitionsSubset
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
 from dagster._record import copy, record
 from dagster._time import get_current_timestamp
+from dagster._utils.schedules import is_valid_cron_schedule
 from dagster._utils.security import non_secure_md5_hash_str
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -576,6 +577,11 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
             CronTickPassedCondition,
         )
 
+        check.param_invariant(
+            is_valid_cron_schedule(cron_schedule),
+            "cron_schedule",
+            f"Invalid cron schedule: {cron_schedule}",
+        )
         return CronTickPassedCondition(cron_schedule=cron_schedule, cron_timezone=cron_timezone)
 
     @public

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
@@ -17,6 +17,7 @@ from dagster import (
     observable_source_asset,
 )
 from dagster._time import datetime_from_timestamp
+from dagster_shared.check.functions import ParameterCheckError
 
 from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
     AutomationConditionScenarioState,
@@ -308,3 +309,26 @@ def test_asset_order_change_doesnt_reset_cursor_state() -> None:
         evaluation_time=datetime_from_timestamp(start_time),
     )
     assert result.total_requested == 1
+
+
+@pytest.mark.parametrize(
+    "schedule, should_fail",
+    [
+        ("0 0 * * *", False),
+        ("0 */5 * * *", False),
+        ("@daily", False),
+        ("@hourly", False),
+        ("*/15 * * * 1-6", False),
+        ("* /15 * * * 1-6", True),
+        ("totally-invalid", True),
+    ],
+)
+def test_invalid_schedules(schedule: str, should_fail: bool) -> None:
+    if should_fail:
+        with pytest.raises(
+            ParameterCheckError,
+            match="Invalid cron schedule",
+        ):
+            AutomationCondition.on_cron(cron_schedule=schedule)
+    else:
+        AutomationCondition.on_cron(cron_schedule=schedule)


### PR DESCRIPTION
## Summary & Motivation

Make sure people don't make invalid conditions that will fail when evaluated

## How I Tested These Changes

