### PR TITLE
Update mechanism for re-execute from asset failure

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -69,6 +69,7 @@ class AssetCheckEvaluation(
             ),
             ("severity", AssetCheckSeverity),
             ("description", Optional[str]),
+            ("blocking", Optional[bool]),
         ],
     )
 ):
@@ -91,6 +92,8 @@ class AssetCheckEvaluation(
             Severity of the check result.
         description (Optional[str]):
             A text description of the result of the check evaluation.
+        blocking (Optional[bool]):
+            Whether the check is blocking.
     """
 
     def __new__(
@@ -102,6 +105,7 @@ class AssetCheckEvaluation(
         target_materialization_data: Optional[AssetCheckEvaluationTargetMaterializationData] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
         description: Optional[str] = None,
+        blocking: Optional[bool] = None,
     ):
         normed_metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
@@ -120,6 +124,7 @@ class AssetCheckEvaluation(
             ),
             severity=check.inst_param(severity, "severity", AssetCheckSeverity),
             description=check.opt_str_param(description, "description"),
+            blocking=check.opt_bool_param(blocking, "blocking"),
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -176,6 +176,7 @@ class AssetCheckResult(
             target_materialization_data=target_materialization_data,
             severity=self.severity,
             description=self.description,
+            blocking=assets_def_for_check.get_spec_for_check_key(check_key).blocking,
         )
 
     def with_metadata(self, metadata: Mapping[str, RawMetadataValue]) -> "AssetCheckResult":  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -116,6 +116,7 @@ RUNLESS_JOB_NAME = ""
 if TYPE_CHECKING:
     from dagster._core.debug import DebugRunPayload
     from dagster._core.definitions.asset_check_spec import AssetCheckKey
+    from dagster._core.definitions.asset_key import EntityKey
     from dagster._core.definitions.base_asset_graph import BaseAssetGraph
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.partition import PartitionsDefinition
@@ -1694,49 +1695,68 @@ class DagsterInstance(DynamicPartitionsStore):
 
         return dagster_run
 
-    def _get_skipped_entity_keys(
-        self, run_id: str
+    def _get_keys_to_reexecute(
+        self, run_id: str, execution_plan_snapshot: "ExecutionPlanSnapshot"
     ) -> tuple[AbstractSet["AssetKey"], AbstractSet["AssetCheckKey"]]:
-        """For a given run_id, return the set of asset keys and asset check keys that were planned but
-        not executed.
+        """For a given run_id, return the subset of asset keys and asset check keys that should be
+        re-executed for a run when in the `FROM_ASSET_FAILURE` mode.
+
+        An asset key will be included if it was planned but not materialized in the original run,
+        or if any of its planned blocking asset checks were planned but not executed, or failed.
+
+        An asset check key will be included if it was planned but not executed in the original run,
+        or if it was associated with an asset that will be re-executed.
         """
+        from dagster._core.definitions.asset_check_spec import AssetCheckKey
         from dagster._core.events import (
             AssetCheckEvaluation,
-            AssetCheckEvaluationPlanned,
-            AssetMaterializationPlannedData,
             DagsterEventType,
             StepMaterializationData,
         )
 
+        # figure out the set of assets that were materialized and checks that successfully executed
         logs = self.all_logs(
             run_id=run_id,
             of_type={
-                DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
                 DagsterEventType.ASSET_MATERIALIZATION,
-                DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
                 DagsterEventType.ASSET_CHECK_EVALUATION,
             },
         )
-        planned_asset_keys: set[AssetKey] = set()
-        executed_asset_keys: set[AssetKey] = set()
-        planned_asset_check_keys: set[AssetCheckKey] = set()
-        executed_asset_check_keys: set[AssetCheckKey] = set()
+        executed_keys: set[EntityKey] = set()
+        blocking_failure_keys: set[AssetKey] = set()
         for log in logs:
             event_data = log.dagster_event.event_specific_data if log.dagster_event else None
-            if isinstance(event_data, AssetMaterializationPlannedData):
-                planned_asset_keys.add(event_data.asset_key)
-            elif isinstance(event_data, StepMaterializationData):
-                executed_asset_keys.add(event_data.materialization.asset_key)
-            elif isinstance(event_data, AssetCheckEvaluationPlanned):
-                planned_asset_check_keys.add(event_data.asset_check_key)
+            if isinstance(event_data, StepMaterializationData):
+                executed_keys.add(event_data.materialization.asset_key)
             elif isinstance(event_data, AssetCheckEvaluation):
-                executed_asset_check_keys.add(event_data.asset_check_key)
+                # blocking asset checks did not "successfully execute", so we keep track
+                # of them and their associated assets
+                if event_data.blocking and not event_data.passed:
+                    blocking_failure_keys.add(event_data.asset_check_key.asset_key)
+                else:
+                    executed_keys.add(event_data.asset_check_key)
+
+        # handled_keys is the set of keys that do not need to be re-executed
+        to_not_reexecute = executed_keys - blocking_failure_keys
+
+        # find the set of planned assets and checks
+        to_reexecute: set[EntityKey] = set()
+        for step in execution_plan_snapshot.steps:
+            to_reexecute_for_step = {
+                key
+                for key in step.entity_keys
+                if key not in to_not_reexecute
+                # we need to re-execute any asset check keys (blocking or otherwise) if the asset
+                # has a failed blocking check.
+                or (isinstance(key, AssetCheckKey) and key.asset_key in blocking_failure_keys)
+            }
+            if to_reexecute_for_step:
+                # we need to include all keys that were marked as required on the step
+                to_reexecute.update(to_reexecute_for_step | step.required_entity_keys)
 
         return (
-            # skipped assets
-            planned_asset_keys - executed_asset_keys,
-            # skipped checks
-            planned_asset_check_keys - executed_asset_check_keys,
+            {key for key in to_reexecute if isinstance(key, AssetKey)},
+            {key for key in to_reexecute if isinstance(key, AssetCheckKey)},
         )
 
     def create_reexecuted_run(
@@ -1808,9 +1828,12 @@ class DagsterInstance(DynamicPartitionsStore):
             )
             tags[RESUME_RETRY_TAG] = "true"
         elif strategy == ReexecutionStrategy.FROM_ASSET_FAILURE:
-            skipped_asset_keys, skipped_asset_check_keys = self._get_skipped_entity_keys(
-                parent_run_id
+            parent_snapshot_id = check.not_none(parent_run.execution_plan_snapshot_id)
+            snapshot = self.get_execution_plan_snapshot(parent_snapshot_id)
+            skipped_asset_keys, skipped_asset_check_keys = self._get_keys_to_reexecute(
+                parent_run_id, snapshot
             )
+
             remote_job = code_location.get_job(
                 remote_job.get_subset_selector(
                     asset_selection=skipped_asset_keys,


### PR DESCRIPTION
## Summary & Motivation

This changes the logic for determining which keys to execute to solve two issues:

We did not handle non-subsettable multi assets at all, so this process could have resulted in errors when generating the execution plan
When a blocking asset check fails, we should re-execute it (as this is the source of the run failure, we need to re-execute as part of the process), and we weren't doing that before
Potentially controversially, I have this re-executing both the blocking asset check AND the asset that the check targets, with the logic being that the code of the asset itself is more likely to be the issue than the code of the check. So the workflow you'd want would be to update the code of the asset, then execute "re-execute from asset failure", and have your asset re-executed.

Also moved some of the logic from using the event log scan to using the execution plan snapshot as suggest by Daniel, which might help perf somewhat.

## How I Tested These Changes

