### PR TITLE
delegate dynamic partitions id caching hash id to dynamic partitions store

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -636,6 +636,18 @@ class DynamicPartitionsDefinition(
                 partitions_def_name=self._validated_name()
             )
 
+    def get_serializable_unique_identifier(
+        self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
+    ) -> str:
+        if not dynamic_partitions_store:
+            return super().get_serializable_unique_identifier(
+                dynamic_partitions_store=dynamic_partitions_store
+            )
+        else:
+            return dynamic_partitions_store.get_dynamic_partitions_definition_id(
+                self._validated_name()
+            )
+
     def get_paginated_partition_keys(
         self,
         context: PartitionLoadingContext,

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -156,6 +156,10 @@ class ScheduleType(Enum):
         return self.ordinal < other.ordinal
 
 
+def generate_partition_key_based_definition_id(partition_keys: Sequence[str]) -> str:
+    return hashlib.sha1(json.dumps(partition_keys).encode("utf-8")).hexdigest()
+
+
 class PartitionsDefinition(ABC, Generic[T_str]):
     """Defines a set of partitions, which can be attached to a software-defined asset or job.
 
@@ -310,11 +314,8 @@ class PartitionsDefinition(ABC, Generic[T_str]):
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
     ) -> str:
-        return hashlib.sha1(
-            json.dumps(
-                self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
-            ).encode("utf-8")
-        ).hexdigest()
+        partition_keys = self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
+        return generate_partition_key_based_definition_id(partition_keys)
 
     def get_tags_for_partition_key(self, partition_key: str) -> Mapping[str, str]:
         tags = {PARTITION_NAME_TAG: partition_key}
@@ -639,9 +640,13 @@ class DynamicPartitionsDefinition(
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
     ) -> str:
-        if not dynamic_partitions_store:
-            return super().get_serializable_unique_identifier(
-                dynamic_partitions_store=dynamic_partitions_store
+        if dynamic_partitions_store is None:
+            check.failed(
+                "The instance is not available to load partitions. You may be seeing this error"
+                " when using dynamic partitions with a version of dagster-webserver or"
+                " dagster-cloud that is older than 1.1.18. The other possibility is that an"
+                " internal framework error where a dynamic partitions store was not properly"
+                " threaded down a call stack."
             )
         else:
             return dynamic_partitions_store.get_dynamic_partitions_definition_id(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import logging
 import logging.config
 import os
@@ -358,6 +360,11 @@ class DynamicPartitionsStore(Protocol):
 
     @abstractmethod
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool: ...
+
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        # matches the base implementation of the get_serializable_unique_identifier on PartitionsDefinition
+        partition_keys = self.get_dynamic_partitions(partitions_def_name)
+        return hashlib.sha1(json.dumps(partition_keys).encode("utf-8")).hexdigest()
 
 
 class DagsterInstance(DynamicPartitionsStore):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 import logging
 import logging.config
 import os
@@ -362,9 +360,11 @@ class DynamicPartitionsStore(Protocol):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool: ...
 
     def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        from dagster._core.definitions.partition import generate_partition_key_based_definition_id
+
         # matches the base implementation of the get_serializable_unique_identifier on PartitionsDefinition
         partition_keys = self.get_dynamic_partitions(partitions_def_name)
-        return hashlib.sha1(json.dumps(partition_keys).encode("utf-8")).hexdigest()
+        return generate_partition_key_based_definition_id(partition_keys)
 
 
 class DagsterInstance(DynamicPartitionsStore):


### PR DESCRIPTION
## Summary & Motivation
We should have the flexibility to change the hashing scheme for dynamic partitions definitions to be less volatile.

To do that we need to selectively change the hash when there are mutations to the dynamic partitions definition that affect the partitions cache (e.g. deletions)

This enables us to start tracking partition deletions in the storage layer and invalidate the cache.

The default implementation at the storage layer should match the implementation on the definition.

## How I Tested These Changes
BK

