### PR TITLE
[dg list env] Show plus env var state when running dg list env

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/list.py
@@ -448,7 +448,7 @@ def list_env_command(path: Path, **global_options: object) -> None:
     env_var_keys = env.values.keys() | used_env_vars.keys()
     plus_keys = _get_dagster_plus_keys(dg_context.project_name, env_var_keys)
 
-    table = Table(border_style="dim")
+    table = DagsterOuterTable([])
     table.add_column("Env Var")
     table.add_column("Value")
     table.add_column("Components")

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql.py
@@ -61,7 +61,7 @@ CREATE_OR_UPDATE_SECRET_FOR_SCOPES_MUTATION = """
 """
 
 GET_SECRETS_FOR_SCOPES_QUERY = """
-query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, $secretName: String!) {
+query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, $secretName: String) {
     secretsOrError(locationName: $locationName, scopes: $scopes, secretName: $secretName) {
         __typename
         ... on Secrets {
@@ -69,6 +69,38 @@ query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, 
                 id
                 secretName
                 secretValue
+                updatedBy {
+                    email
+                }
+                updateTimestamp
+                locationNames
+                fullDeploymentScope
+                allBranchDeploymentsScope
+                specificBranchDeploymentScope
+                localDeploymentScope
+                canViewSecretValue
+                canEditSecret
+            }
+        }
+        ...on UnauthorizedError {
+            message
+        }
+        ... on PythonError {
+            message
+            stack
+        }
+    }
+}
+"""
+
+GET_SECRETS_FOR_SCOPES_QUERY_NO_VALUE = """
+query SecretsForScopesQuery($locationName: String, $scopes: SecretScopesInput!, $secretName: String) {
+    secretsOrError(locationName: $locationName, scopes: $scopes, secretName: $secretName) {
+        __typename
+        ... on Secrets {
+            secrets {
+                id
+                secretName
                 updatedBy {
                     email
                 }

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_list_env_plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_list_env_plus.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
+import textwrap
+
+import responses
+from dagster_dg.utils import ensure_dagster_dg_tests_import
+from dagster_dg.utils.plus import gql
+
+from dagster_dg_tests.cli_tests.plus_tests.utils import mock_gql_response
+from dagster_dg_tests.utils import (
+    ProxyRunner,
+    assert_runner_result,
+    isolated_example_project_foo_bar,
+)
+
+# ###############################################################
+# ##### TEST LIST COMMANDS WITH PLUS CONFIGURED ENV VARS
+# ###############################################################
+
+
+@responses.activate
+def test_list_env_succeeds(dg_plus_cli_config):
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False),
+    ):
+        result = runner.invoke("list", "env")
+        assert_runner_result(result)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+            No environment variables are defined for this project.
+        """).strip()
+        )
+
+        mock_gql_response(
+            query=gql.GET_SECRETS_FOR_SCOPES_QUERY_NO_VALUE,
+            json_data={"data": {"secretsOrError": {"secrets": []}}},
+            expected_variables={
+                "scopes": {
+                    "localDeploymentScope": True,
+                    "fullDeploymentScope": True,
+                    "allBranchDeploymentsScope": True,
+                },
+                "locationName": "foo-bar",
+            },
+        )
+        Path(".env").write_text("FOO=bar")
+        result = runner.invoke("list", "env")
+        assert_runner_result(result)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components ┃ Dev ┃ Branch ┃ Full ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━┩
+               │ FOO     │ ✓     │            │     │        │      │
+               └─────────┴───────┴────────────┴─────┴────────┴──────┘
+        """).strip()
+        )
+
+        mock_gql_response(
+            query=gql.GET_SECRETS_FOR_SCOPES_QUERY_NO_VALUE,
+            json_data={
+                "data": {
+                    "secretsOrError": {
+                        "secrets": [
+                            {
+                                "secretName": "FOO",
+                                "locationNames": ["foo-bar"],
+                                "localDeploymentScope": True,
+                                "fullDeploymentScope": True,
+                                "allBranchDeploymentsScope": False,
+                            },
+                        ]
+                    }
+                }
+            },
+            expected_variables={
+                "scopes": {
+                    "localDeploymentScope": True,
+                    "fullDeploymentScope": True,
+                    "allBranchDeploymentsScope": True,
+                },
+                "locationName": "foo-bar",
+            },
+        )
+        Path(".env").write_text("FOO=bar")
+        result = runner.invoke("list", "env")
+        assert_runner_result(result)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components ┃ Dev ┃ Branch ┃ Full ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━┩
+               │ FOO     │ ✓     │            │ ✓   │        │ ✓    │
+               └─────────┴───────┴────────────┴─────┴────────┴──────┘
+        """).strip()
+        )
+
+        result = runner.invoke(
+            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "subfolder/mydefs"
+        )
+        assert_runner_result(result)
+        Path("src/foo_bar/defs/subfolder/mydefs/component.yaml").write_text(
+            textwrap.dedent("""
+                type: dagster_test.components.AllMetadataEmptyComponent
+
+                requirements:
+                    env:
+                        - BAZ
+            """)
+        )
+
+        mock_gql_response(
+            query=gql.GET_SECRETS_FOR_SCOPES_QUERY_NO_VALUE,
+            json_data={
+                "data": {
+                    "secretsOrError": {
+                        "secrets": [
+                            {
+                                "secretName": "FOO",
+                                "locationNames": ["foo-bar"],
+                                "localDeploymentScope": True,
+                                "fullDeploymentScope": True,
+                                "allBranchDeploymentsScope": False,
+                            },
+                            {
+                                "secretName": "BAZ",
+                                "locationNames": [],
+                                "localDeploymentScope": True,
+                                "fullDeploymentScope": False,
+                                "allBranchDeploymentsScope": False,
+                            },
+                        ]
+                    }
+                }
+            },
+            expected_variables={
+                "scopes": {
+                    "localDeploymentScope": True,
+                    "fullDeploymentScope": True,
+                    "allBranchDeploymentsScope": True,
+                },
+                "locationName": "foo-bar",
+            },
+        )
+        Path(".env").write_text("FOO=bar")
+        result = runner.invoke("list", "env")
+        assert_runner_result(result)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+               ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━┓
+               ┃ Env Var ┃ Value ┃ Components       ┃ Dev ┃ Branch ┃ Full ┃
+               ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━┩
+               │ BAZ     │       │ subfolder/mydefs │ ✓   │        │      │
+               │ FOO     │ ✓     │                  │ ✓   │        │ ✓    │
+               └─────────┴───────┴──────────────────┴─────┴────────┴──────┘
+        """).strip()
+        )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -1,6 +1,7 @@
 import inspect
 import re
 import shutil
+import tempfile
 import textwrap
 from pathlib import Path
 from typing import Any, Union
@@ -571,11 +572,14 @@ def _sample_failed_defs():
 # ########################
 
 
-def test_list_env_succeeds():
+def test_list_env_succeeds(monkeypatch):
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace=False, uv_sync=False),
+        tempfile.TemporaryDirectory() as cloud_config_dir,
     ):
+        monkeypatch.setenv("DG_CLI_CONFIG", str(Path(cloud_config_dir) / "dg.toml"))
+        monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", str(Path(cloud_config_dir) / "config"))
         result = runner.invoke("list", "env")
         assert_runner_result(result)
         assert (
@@ -594,7 +598,7 @@ def test_list_env_succeeds():
                ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
                ┃ Env Var ┃ Value ┃ Components ┃
                ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
-               │ FOO     │ bar   │            │
+               │ FOO     │ ✓     │            │
                └─────────┴───────┴────────────┘
         """).strip()
         )
@@ -621,7 +625,7 @@ def test_list_env_succeeds():
                ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
                ┃ Env Var ┃ Value ┃ Components       ┃
                ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
-               │ FOO     │ bar   │ subfolder/mydefs │
+               │ FOO     │ ✓     │ subfolder/mydefs │
                └─────────┴───────┴──────────────────┘
         """).strip()
         )


### PR DESCRIPTION
## Summary

When logged into Dagster Plus, makes `dg list env` output whether an env var is configured for each plus scope.
This segment of the env demo never made it into a standalone PR.

```sh
$ dg list env

┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━┓
┃ Env Var ┃ Value ┃ Components       ┃ Dev ┃ Branch ┃ Full ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━┩
│ BAZ     │       │ subfolder/mydefs │ ✓   │        │      │
│ FOO     │ ✓     │                  │ ✓   │        │ ✓    │
└─────────┴───────┴──────────────────┴─────┴────────┴──────┘
```

## Test Plan

New unit tests.

## Changelog

> [components] `dg list env` now displays whether env vars are configured in each Dagster Plus scope.