### PR TITLE
[ui] Update the behavior of "view lineage" on the runs view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/globalAssetGraphPathToString.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/globalAssetGraphPathToString.test.tsx
@@ -20,17 +20,17 @@ describe('Global Graph URLs', () => {
   describe('globalAssetGraphPathForAssetsAndDescendants', () => {
     it('should return a valid path for a single asset', async () => {
       const url = globalAssetGraphPathForAssetsAndDescendants([{path: ['asset_0']}]);
-      expect(url).toEqual(`/asset-groups~${encodeURIComponent('key:"asset_0"+')}/asset_0`);
+      expect(url).toEqual(`/asset-groups~(${encodeURIComponent('key:"asset_0"')})%2B/asset_0`);
     });
 
     it('should avoid exceeding a 32k character URL', async () => {
       const keysLarge = new Array(800).fill(0).map((_, idx) => ({path: [`asset_${idx}`]}));
       const urlLarge = globalAssetGraphPathForAssetsAndDescendants(keysLarge);
-      expect(urlLarge.length).toEqual(34984);
+      expect(urlLarge.length).toEqual(32589);
 
       const keysHuge = new Array(900).fill(0).map((_, idx) => ({path: [`asset_${idx}`]}));
       const urlHuge = globalAssetGraphPathForAssetsAndDescendants(keysHuge);
-      expect(urlHuge.length).toEqual(28697); // smaller because the selection is not passed
+      expect(urlHuge.length).toEqual(26002); // smaller because the selection is not passed
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
@@ -19,10 +19,17 @@ export function globalAssetGraphPathFromString(pathName: string) {
   return explorerPathFromString(__GLOBAL__ + pathName || '/');
 }
 
-export function globalAssetGraphPathForAssetsAndDescendants(assetKeys: AssetKeyInput[]) {
-  const opsQuery = assetKeys.map((a) => `key:"${tokenForAssetKey(a)}"+`).join(' or ');
+export function globalAssetGraphPathForAssets(
+  assetKeys: AssetKeyInput[],
+  include_descendants: boolean = false,
+) {
+  const rawAssetsQuery = assetKeys.map((a) => `key:"${tokenForAssetKey(a)}"`).join(' or ');
+  const opsQuery = `(${rawAssetsQuery})` + (include_descendants ? '+' : '');
   const opNames =
     opsQuery.length > URL_MAX_LENGTH / 2 ? [] : [assetKeys.map(tokenForAssetKey).join(',')];
 
   return globalAssetGraphPathToString({opNames, opsQuery});
+}
+export function globalAssetGraphPathForAssetsAndDescendants(assetKeys: AssetKeyInput[]) {
+  return globalAssetGraphPathForAssets(assetKeys, true);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -25,7 +25,7 @@ import {
   assetDetailsPathForAssetCheck,
   assetDetailsPathForKey,
 } from '../assets/assetDetailsPathForKey';
-import {globalAssetGraphPathForAssetsAndDescendants} from '../assets/globalAssetGraphPathToString';
+import {globalAssetGraphPathForAssets} from '../assets/globalAssetGraphPathToString';
 import {AssetKey} from '../assets/types';
 import {TagActionsPopover} from '../ui/TagActions';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
@@ -229,7 +229,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
               },
               {
                 label: 'View lineage',
-                to: globalAssetGraphPathForAssetsAndDescendants(sortedAssetKeys),
+                to: globalAssetGraphPathForAssets(sortedAssetKeys),
               },
             ]}
           >


### PR DESCRIPTION
## Summary & Motivation

https://dagsterlabs.slack.com/archives/C03CCE471E0/p1746749043149529

Previously, we would include the downstreams of each key on the run when you clicked the "View lineage" button.

I found this unintuitive, as the "view list" button only shows the keys directly on the run. I also added parens to the wider expression to make it easier to add further clauses (e.g. (<big expression>) and status:degraded))

## How I Tested These Changes



