### PR TITLE
[dagster-airlift] Sensor changes for historical runs

### DIFF
--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -95,6 +95,21 @@ def get_automatically_retried_run_if_exists(
         return child_run
 
 
+def run_was_successfully_retried(run: DagsterRun, instance: DagsterInstance) -> bool:
+    """Returns True if the run was successfully retried.
+    This includes the following cases:
+    - The run initially succeeds
+    - The run succeeds on automatic retry
+    - The run succeeds on a manual retry.
+    """
+    run_group = instance.get_run_group(run.run_id)
+    if run_group is None:
+        return run.status == DagsterRunStatus.SUCCESS
+    else:
+        runs_in_group = run_group[1]
+        return any(r.status == DagsterRunStatus.SUCCESS for r in runs_in_group)
+
+
 def get_reexecution_strategy(
     run: DagsterRun, instance: DagsterInstance
 ) -> Optional[ReexecutionStrategy]:

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
@@ -18,6 +18,7 @@ from dagster._core.definitions.sensor_definition import (
 )
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
+from dagster._daemon.auto_run_reexecution.auto_run_reexecution import run_was_successfully_retried
 from dagster._grpc.client import DEFAULT_SENSOR_GRPC_TIMEOUT
 from dagster._record import record
 from dagster._serdes import deserialize_value, serialize_value
@@ -32,7 +33,7 @@ from pydantic import Field
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 30
-START_LOOKBACK_SECONDS = 60  # Lookback one minute in time for the initial setting of the cursor.
+NO_CURSOR_LOOKBACK_DELTA = datetime.timedelta(days=1)
 
 
 @whitelist_for_serdes
@@ -101,18 +102,22 @@ def build_monitoring_sensor(
         effective_timestamp = get_current_datetime()
         if context.cursor is None:
             cursor = AirflowMonitoringJobSensorCursor(
-                range_start=(get_current_datetime() - datetime.timedelta(seconds=30)).isoformat(),
+                range_start=(get_current_datetime() - NO_CURSOR_LOOKBACK_DELTA).isoformat(),
                 range_end=effective_timestamp.isoformat(),
             )
         else:
             cursor = deserialize_value(context.cursor, AirflowMonitoringJobSensorCursor)
 
         run = _get_run_for_cursor(context, airflow_instance, cursor)
+        # We only advance the cursor if the run has finished successfully.
         if run and not run.is_finished:
             return SkipReason(
                 f"Monitoring job is still running for range {cursor.range_start} to {cursor.range_end}. Waiting to advance."
             )
-        # We only advance the cursor if the run has finished.
+        if run and not run.is_success and not run_was_successfully_retried(run, context.instance):
+            raise Exception(
+                f"Monitoring job failed for range {cursor.range_start} to {cursor.range_end} with run {run.run_id}. Dagster currently expects runs to be inserted in time-increasing order. To avoid unexpected side effects, the sensor will wait until this range has been successfully executed before advancing. To rectify this, you can either wait for automatic retries to succeed, or you can manually re-execute the failed run once the issue is resolved."
+            )
         cursor = cursor if not run else cursor.advance(effective_timestamp)
         context.update_cursor(serialize_value(cursor))
 


### PR DESCRIPTION
## Summary & Motivation
We've realized that allowing for "arbitrary history import" is a trickier problem than we initially thought. Dagster currently synonymizes increasing "storage id" in the event log with increasing "event order", but Airlift V2 currently breaks this by potentially inserting runs which occur in the "middle" of history - IE if I run the airflow monitoring job on a time range which is not the most recently processed one, I can insert runs in the middle of the timeline. This can have weird operational affects on downstream event processors which will pick up those runs in the middle of the timeline and kick off side effects, like declarative automation and alerts

Instead of playing a game of "whack-a-mole" to make sure every callsite properly handles "historical runs", we want to try to avoid the problematic case in general by making it _impossible_ to insert runs in the middle of the range. This has a few implications:
- Make the sensor hard fail if any kicked off monitoring job run fails; so we can guarantee we only move "forward" in time.
- Since this makes it tricky to schedule a true "historical" run of the monitoring job, start the sensor at the previous day when there is no cursor. This still makes the initial "historical import" possible.

I'm making the explicit decision not to "hard fail" the monitoring job for two reasons:
- It's not easy to query the monitoring job for a "later range" that works in all cases; you can check the last run, but checking arbitrarily far in the past gets tricky.
- There may be cases that come up where we _do_ want to rectify some historical range, because we've decided that the downstream side effects are acceptable. It's advantageous to be able to do that manually.


This is not a full solution. Eventually, we're going to need to figure out how to separate "new to dagster" from "newly occurring", as this will be broadly important for all federation-type integrations. We're also going to want to track all the places that currently synonymize "new to dagster" with "newly occurring" (basically all the things that tail the event log).

Downstream tasks tracked here: https://linear.app/dagster-labs/issue/BCOR-178/fully-native-historical-runs

## How I Tested These Changes
- New tests for failure cases.
