### PR TITLE
only show failed to materialize events in run logs reading failure events is enabled

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -37,6 +37,7 @@ from dagster._core.events import (
     StepExpectationResultData,
 )
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.event_log.base import EventLogConnection
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluationPlanned
@@ -516,6 +517,21 @@ def from_event_record(event_record: EventLogEntry, pipeline_name: str) -> Any:
         return from_dagster_event_record(event_record, pipeline_name)
     else:
         return GrapheneLogMessageEvent(**construct_basic_params(event_record))
+
+
+def get_graphene_events_from_records_connection(
+    instance, connection: EventLogConnection, job_name: str
+):
+    show_failed_to_materialize = instance.can_read_asset_failure_events()
+    events = []
+    for el_record in connection.records:
+        if (
+            show_failed_to_materialize
+            or el_record.event_type != DagsterEventType.ASSET_FAILED_TO_MATERIALIZE
+        ):
+            events.append(from_event_record(el_record.event_log_entry, job_name))
+
+    return events
 
 
 def construct_basic_params(event_record: EventLogEntry) -> Any:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -527,7 +527,8 @@ def get_graphene_events_from_records_connection(
     for el_record in connection.records:
         if (
             show_failed_to_materialize
-            or el_record.event_type != DagsterEventType.ASSET_FAILED_TO_MATERIALIZE
+            or el_record.event_log_entry.dagster_event_type
+            != DagsterEventType.ASSET_FAILED_TO_MATERIALIZE
         ):
             events.append(from_event_record(el_record.event_log_entry, job_name))
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -301,7 +301,8 @@ async def gen_events_for_run(
             event, cursor = await queue.get()
             if (
                 show_failed_to_materialize
-                or event.event_type != DagsterEventType.ASSET_FAILED_TO_MATERIALIZE
+                or event.event_log_entry.dagster_event_type
+                != DagsterEventType.ASSET_FAILED_TO_MATERIALIZE
             ):
                 yield GraphenePipelineRunLogsSubscriptionSuccess(
                     run=GrapheneRun(record),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3611,6 +3611,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def can_read_failure_events_for_asset(self, asset_record: "AssetRecord") -> bool:
         return False
 
+    def can_read_asset_failure_events(self) -> bool:
+        return False
+
     def internal_asset_freshness_enabled(self) -> bool:
         return False
 


### PR DESCRIPTION
## Summary & Motivation
only shows asset materialization failure events if the `read_asset_materialization_failures` feature is enabled. Does some lite refactoring to make this repeatable  

## How I Tested These Changes
manually tested, see https://github.com/dagster-io/internal/pull/15561 for before and after in the UI
