### PR TITLE
[ui] Remove Overview alerts section

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageAlerts.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageAlerts.oss.tsx
@@ -1,1 +1,0 @@
-export const OverviewPageAlerts = () => null;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,6 +1,5 @@
 import {Box, PageHeader} from '@dagster-io/ui-components';
 import React from 'react';
-import {OverviewPageAlerts} from 'shared/overview/OverviewPageAlerts.oss';
 
 import {OverviewTabs} from './OverviewTabs';
 
@@ -16,7 +15,6 @@ export const OverviewPageHeader = ({
       tabs={
         <Box flex={{direction: 'column', gap: 8}}>
           <OverviewTabs tab={tab} queryData={queryData} refreshState={refreshState} />
-          <OverviewPageAlerts />
         </Box>
       }
       {...rest}


### PR DESCRIPTION
## Summary & Motivation

OSS counterpart to https://app.graphite.dev/github/pr/dagster-io/internal/15565, which removes the AMP alert currently shown on Overview. It's the only banner there, so I'm just removing this altogether instead of leaving a couple null-rendering components lying around.

## How I Tested These Changes

TS, lint.