### PR TITLE
Add new states to asset catalog rate card

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.module.css
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
   gap: 12px;
 }
 
@@ -44,3 +44,28 @@
   font-size: 14px;
   color: var(--color-text-light);
 } 
+
+.spinner {
+  display: flex;
+  flex-grow: 1;
+}
+
+.rateCardNoDataContainer {
+  background-color: var(--color-background-default-hover);
+  display: flex;
+  flex-direction: row;
+  padding: 8px;
+  border-radius: 4px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-disabled);
+}
+
+.rateCardNoDataPercentContainer {
+  background-color: var(--color-background-gray);
+  display: flex;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 20px;
+  font-weight: 800;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -8,57 +8,83 @@ export interface AssetCatalogRateCardProps {
   title: string;
   value: number | null; // e.g., 0.981 for 98.1%
   prevValue: number | null; // e.g., 1 for 100%
+  loading: boolean;
 }
 
-export function AssetCatalogRateCard({title, value, prevValue}: AssetCatalogRateCardProps) {
+export function AssetCatalogRateCard({
+  title,
+  value,
+  prevValue,
+  loading,
+}: AssetCatalogRateCardProps) {
   const pct = value ? Math.round(value * 1000) / 10 : 0;
   const prevPct = prevValue ? Math.round(prevValue * 1000) / 10 : 0;
   const delta = pct - prevPct;
   const isDown = delta < 0;
   const absDelta = Math.abs(delta);
 
-  const loadingCurrentPeriod = !value;
-  const loadingPrevPeriod = !prevValue;
+  const noDataAvailableCard = (
+    <div className={styles.rateCardNoDataContainer}>
+      <div className={styles.rateCardNoDataPercentContainer}>%</div>
+      No data available
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className={styles.rateCardContainer}>
+        <BodyLarge>{title}</BodyLarge>
+        <div className={styles.spinner}>
+          <span>
+            <Spinner purpose="body-text" />
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.rateCardContainer}>
       <BodyLarge>{title}</BodyLarge>
-      <div className={styles.rateCardValue}>
-        {loadingCurrentPeriod ? (
-          <span>
-            <Spinner purpose="body-text" />
-          </span>
-        ) : (
-          numberFormatter.format(pct) + '%'
-        )}
-      </div>
+      {value !== null ? (
+        <div className={styles.rateCardValue}>{numberFormatter.format(pct) + '%'}</div>
+      ) : (
+        noDataAvailableCard
+      )}
       <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
-        <div className={styles.rateCardPrev}>
-          {loadingPrevPeriod ? (
-            <Spinner purpose="body-text" />
-          ) : (
-            numberFormatter.format(prevPct) + '% last period'
-          )}
-        </div>
-        <Box
-          className={styles.rateCardDeltaRow}
-          flex={{direction: 'row', alignItems: 'center', gap: 4}}
-        >
-          {loadingCurrentPeriod || loadingPrevPeriod ? null : (
-            <Icon
-              name={isDown ? 'trending_down' : 'trending_up'}
-              color={Colors.textLight()}
-              size={16}
-            />
-          )}
-          <span className={styles.rateCardDelta}>
-            {loadingCurrentPeriod || loadingPrevPeriod ? (
-              <Spinner purpose="body-text" />
-            ) : (
-              <>{numberFormatter.format(absDelta)}%</>
-            )}
-          </span>
-        </Box>
+        {value !== null && prevValue === null ? (
+          <Box
+            className={styles.rateCardDeltaRow}
+            flex={{direction: 'row', alignItems: 'center', gap: 4}}
+          >
+            <Icon name="trending_up" color={Colors.textLight()} size={16} />
+            <span className={styles.rateCardDelta}>
+              <>New this period</>
+            </span>
+          </Box>
+        ) : (
+          prevValue !== null &&
+          value !== null && (
+            <>
+              <div className={styles.rateCardPrev}>
+                {numberFormatter.format(prevPct) + '% last period'}
+              </div>
+              <Box
+                className={styles.rateCardDeltaRow}
+                flex={{direction: 'row', alignItems: 'center', gap: 4}}
+              >
+                <Icon
+                  name={isDown ? 'trending_down' : 'trending_up'}
+                  color={Colors.textLight()}
+                  size={16}
+                />
+                <span className={styles.rateCardDelta}>
+                  <>{numberFormatter.format(absDelta)}%</>
+                </span>
+              </Box>
+            </>
+          )
+        )}
       </Box>
     </div>
   );


### PR DESCRIPTION
## Summary & Motivation
Instead of displaying infinite loading spinner when there is no data, let's show an empty state

Companion internal PR: https://github.com/dagster-io/internal/pull/15575

## How I Tested These Changes
Locally viewed:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/ea941615-af2d-4dd4-92d1-1baecf939729" />
Loading states:
<img width="707" alt="image" src="https://github.com/user-attachments/assets/36cc80f8-179b-4ef6-a25c-0d767e766788" />

## Changelog
NOCHANGELOG
