### PR TITLE
[k8s executor] Option to add `ownerReferences`s to k8s executor step jobs

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -229,6 +229,7 @@ def build_k8s_suite_steps() -> List[BuildkiteTopLevelStep]:
         pytest_tox_factors,
         always_run_if=has_helm_changes,
         pytest_extra_cmds=k8s_integration_suite_pytest_extra_cmds,
+        queue=BuildkiteQueue.DOCKER,
     )
 
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import dagster._check as check
+import kubernetes
 import pytest
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance
@@ -373,6 +374,320 @@ def test_k8s_executor_resource_requirements(
 
     updated_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
+
+
+def _does_namespaced_job_exist(job_name: str, namespace: str) -> bool:
+    try:
+        DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
+            name=job_name, namespace=namespace
+        )
+        return True
+    except kubernetes.client.rest.ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+
+
+def _does_namespaced_pod_exist(pod_name: str, namespace: str) -> bool:
+    try:
+        DagsterKubernetesClient.production_client().core_api.read_namespaced_pod(
+            name=pod_name, namespace=namespace
+        )
+        return True
+    except kubernetes.client.rest.ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+
+
+@pytest.mark.integration
+def test_k8s_executor_owner_references_garbage_collection(
+    dagster_instance_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
+    dagster_docker_image,
+    webserver_url_for_k8s_run_launcher,
+):
+    """Test that owner references are properly set when enable_owner_references is True, and that owner references properly
+    allow for garbage collection of the step job and step pod when a run pod is deleted.
+    """
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),  # pyright: ignore[reportArgumentType]
+        {
+            "execution": {
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "job_image": dagster_docker_image,
+                    "image_pull_policy": image_pull_policy(),
+                    "enable_owner_references": True,
+                }
+            },
+        },
+    )
+
+    # Job in question runs indefinitely, but we'll clean up the step once the run pod is deleted
+    run_id = launch_run_over_graphql(
+        webserver_url_for_k8s_run_launcher,
+        run_config=run_config,
+        job_name="spin_forever_job_k8s",
+    )
+
+    run_job_name = f"dagster-run-{run_id}"
+    DagsterKubernetesClient.production_client().wait_for_job(
+        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    run_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(run_pods) == 1
+    run_pod = run_pods[0]
+
+    # Wait a bit for the step job to be created
+    time.sleep(10)
+    step_job_key = get_k8s_job_name(run_id, "spin_forever_op")
+    step_job_name = f"dagster-step-{step_job_key}"
+
+    step_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(step_pods) == 1
+    step_pod = step_pods[0]
+
+    step_job = DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
+        name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    # Verify that the step job has an owner reference to the run pod
+    step_job_owner_references = step_job.metadata.owner_references
+    assert step_job_owner_references is not None
+
+    pod_owner_ref = next((ref for ref in step_job_owner_references if ref.kind == "Pod"), None)
+    assert pod_owner_ref is not None, "Step job should have an owner reference to a Pod"
+    assert pod_owner_ref.name == run_pod.metadata.name, (
+        f"Step job owner reference should point to run pod {run_pod.metadata.name}, but points to {pod_owner_ref.name}"
+    )
+    assert pod_owner_ref.uid == run_pod.metadata.uid, (
+        "Step job owner reference UID should match run pod UID"
+    )
+
+    # Kill the run pod and wait for it to be deleted
+    DagsterKubernetesClient.production_client().core_api.delete_namespaced_pod(
+        name=run_pod.metadata.name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    timeout = datetime.timedelta(0, 30)
+    start_time = datetime.datetime.now()
+    while True:
+        assert datetime.datetime.now() < start_time + timeout, (
+            "Timed out waiting for run pod deletion"
+        )
+        if not _does_namespaced_pod_exist(
+            run_pod.metadata.name, user_code_namespace_for_k8s_run_launcher
+        ):
+            break
+        time.sleep(1)
+
+    # Wait for the step job and pod to be garbage collected
+    timeout = datetime.timedelta(0, 60)
+    start_time = datetime.datetime.now()
+    while True:
+        assert datetime.datetime.now() < start_time + timeout, (
+            "Timed out waiting for step job garbage collection"
+        )
+        if not _does_namespaced_job_exist(
+            step_job_name, user_code_namespace_for_k8s_run_launcher
+        ) and not _does_namespaced_pod_exist(
+            step_pod.metadata.name, user_code_namespace_for_k8s_run_launcher
+        ):
+            break
+        time.sleep(1)
+
+
+@pytest.mark.integration
+def test_k8s_executor_owner_references_disabled(
+    dagster_instance_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
+    dagster_docker_image,
+    webserver_url_for_k8s_run_launcher,
+):
+    """Test that owner references are NOT set when enable_owner_references is False, and that garbage collection does NOT happen when the run pod is deleted."""
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),  # pyright: ignore[reportArgumentType]
+        {
+            "execution": {
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "job_image": dagster_docker_image,
+                    "image_pull_policy": image_pull_policy(),
+                    "enable_owner_references": False,
+                }
+            },
+        },
+    )
+
+    # Job in question runs indefinitely, but we'll verify that step resources persist when run pod is deleted
+    run_id = launch_run_over_graphql(
+        webserver_url_for_k8s_run_launcher,
+        run_config=run_config,
+        job_name="spin_forever_job_k8s",
+    )
+
+    run_job_name = f"dagster-run-{run_id}"
+    DagsterKubernetesClient.production_client().wait_for_job(
+        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    run_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(run_pods) == 1
+    run_pod = run_pods[0]
+    time.sleep(10)
+    step_job_key = get_k8s_job_name(run_id, "spin_forever_op")
+    step_job_name = f"dagster-step-{step_job_key}"
+    step_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(step_pods) == 1
+    step_pod = step_pods[0]
+
+    step_job = DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
+        name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    # Verify that the step job does NOT have owner references
+    step_job_owner_references = step_job.metadata.owner_references
+    assert step_job_owner_references is None or len(step_job_owner_references) == 0
+
+    # Kill the run pod and wait for it to be deleted
+    DagsterKubernetesClient.production_client().core_api.delete_namespaced_pod(
+        name=run_pod.metadata.name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    timeout = datetime.timedelta(0, 30)
+    start_time = datetime.datetime.now()
+    while True:
+        assert datetime.datetime.now() < start_time + timeout, (
+            "Timed out waiting for run pod deletion"
+        )
+        if not _does_namespaced_pod_exist(
+            run_pod.metadata.name, user_code_namespace_for_k8s_run_launcher
+        ):
+            break
+        time.sleep(1)
+
+    # Wait a bit and verify that the step job and pod are NOT garbage collected
+    time.sleep(10)
+    assert _does_namespaced_job_exist(step_job_name, user_code_namespace_for_k8s_run_launcher), (
+        "Step job should NOT be garbage collected when owner references are disabled"
+    )
+    assert _does_namespaced_pod_exist(
+        step_pod.metadata.name, user_code_namespace_for_k8s_run_launcher
+    ), "Step pod should NOT be garbage collected when owner references are disabled"
+
+
+@pytest.mark.integration
+def test_k8s_executor_owner_references(
+    dagster_instance_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
+    dagster_docker_image,
+    webserver_url_for_k8s_run_launcher,
+):
+    """Test that owner references are properly set when enable_owner_references is True."""
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml")),  # pyright: ignore[reportArgumentType]
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),  # pyright: ignore[reportArgumentType]
+        {
+            "execution": {
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "job_image": dagster_docker_image,
+                    "image_pull_policy": image_pull_policy(),
+                    "enable_owner_references": True,
+                }
+            },
+        },
+    )
+
+    run_id = _launch_executor_run(
+        webserver_url_for_k8s_run_launcher,
+        run_config,
+        dagster_instance_for_k8s_run_launcher,
+        user_code_namespace_for_k8s_run_launcher,
+    )
+
+    step_job_key = get_k8s_job_name(run_id, "count_letters")
+    step_job_name = f"dagster-step-{step_job_key}"
+    step_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(step_pods) == 1
+    step_job = DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
+        name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    # Check that the Job has an owner reference
+    step_job_owner_references = step_job.metadata.owner_references
+    assert step_job_owner_references is not None
+
+    # Locate the run pod to check that the owner reference points to it
+    run_job_name = f"dagster-run-{run_id}"
+    run_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(run_pods) == 1
+    run_pod = run_pods[0]
+
+    pod_owner_ref = next((ref for ref in step_job_owner_references if ref.kind == "Pod"), None)
+    assert pod_owner_ref is not None, "Step job should have an owner reference to a Pod"
+    assert pod_owner_ref.name == run_pod.metadata.name, (
+        f"Step job owner reference should point to run pod {run_pod.metadata.name}, but points to {pod_owner_ref.name}"
+    )
+    assert pod_owner_ref.uid == run_pod.metadata.uid, (
+        "Step job owner reference UID should match run pod UID"
+    )
+
+
+@pytest.mark.integration
+def test_k8s_executor_owner_references_disabled(
+    dagster_instance_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
+    dagster_docker_image,
+    webserver_url_for_k8s_run_launcher,
+):
+    """Test that owner references are NOT set when enable_owner_references is False."""
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml")),  # pyright: ignore[reportArgumentType]
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),  # pyright: ignore[reportArgumentType]
+        {
+            "execution": {
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "job_image": dagster_docker_image,
+                    "image_pull_policy": image_pull_policy(),
+                    "enable_owner_references": False,
+                }
+            },
+        },
+    )
+
+    run_id = _launch_executor_run(
+        webserver_url_for_k8s_run_launcher,
+        run_config,
+        dagster_instance_for_k8s_run_launcher,
+        user_code_namespace_for_k8s_run_launcher,
+    )
+
+    step_job_key = get_k8s_job_name(run_id, "count_letters")
+    step_job_name = f"dagster-step-{step_job_key}"
+    step_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
+        job_name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+    assert len(step_pods) == 1
+    step_job = DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
+        name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
+    )
+
+    step_job_owner_references = step_job.metadata.owner_references
+    assert step_job_owner_references is None or len(step_job_owner_references) == 0
 
 
 @pytest.mark.integration

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -585,68 +585,6 @@ def test_k8s_executor_owner_references_disabled(
 
 
 @pytest.mark.integration
-def test_k8s_executor_owner_references(
-    dagster_instance_for_k8s_run_launcher,
-    user_code_namespace_for_k8s_run_launcher,
-    dagster_docker_image,
-    webserver_url_for_k8s_run_launcher,
-):
-    """Test that owner references are properly set when enable_owner_references is True."""
-    run_config = merge_dicts(
-        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml")),  # pyright: ignore[reportArgumentType]
-        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),  # pyright: ignore[reportArgumentType]
-        {
-            "execution": {
-                "config": {
-                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
-                    "job_image": dagster_docker_image,
-                    "image_pull_policy": image_pull_policy(),
-                    "enable_owner_references": True,
-                }
-            },
-        },
-    )
-
-    run_id = _launch_executor_run(
-        webserver_url_for_k8s_run_launcher,
-        run_config,
-        dagster_instance_for_k8s_run_launcher,
-        user_code_namespace_for_k8s_run_launcher,
-    )
-
-    step_job_key = get_k8s_job_name(run_id, "count_letters")
-    step_job_name = f"dagster-step-{step_job_key}"
-    step_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
-        job_name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
-    )
-    assert len(step_pods) == 1
-    step_job = DagsterKubernetesClient.production_client().batch_api.read_namespaced_job(
-        name=step_job_name, namespace=user_code_namespace_for_k8s_run_launcher
-    )
-
-    # Check that the Job has an owner reference
-    step_job_owner_references = step_job.metadata.owner_references
-    assert step_job_owner_references is not None
-
-    # Locate the run pod to check that the owner reference points to it
-    run_job_name = f"dagster-run-{run_id}"
-    run_pods = DagsterKubernetesClient.production_client().get_pods_in_job(
-        job_name=run_job_name, namespace=user_code_namespace_for_k8s_run_launcher
-    )
-    assert len(run_pods) == 1
-    run_pod = run_pods[0]
-
-    pod_owner_ref = next((ref for ref in step_job_owner_references if ref.kind == "Pod"), None)
-    assert pod_owner_ref is not None, "Step job should have an owner reference to a Pod"
-    assert pod_owner_ref.name == run_pod.metadata.name, (
-        f"Step job owner reference should point to run pod {run_pod.metadata.name}, but points to {pod_owner_ref.name}"
-    )
-    assert pod_owner_ref.uid == run_pod.metadata.uid, (
-        "Step job owner reference UID should match run pod UID"
-    )
-
-
-@pytest.mark.integration
 def test_execute_on_k8s_retry_job(
     dagster_instance_for_k8s_run_launcher,
     user_code_namespace_for_k8s_run_launcher,

--- a/python_modules/dagster-test/dagster_test/test_project/build.sh
+++ b/python_modules/dagster-test/dagster_test/test_project/build.sh
@@ -36,16 +36,19 @@ mkdir -p modules
 cp $GOOGLE_APPLICATION_CREDENTIALS ./modules/gac.json
 
 echo -e "--- \033[32m:truck: Copying files...\033[0m"
-alias copy_py="rsync -av \
-      --progress \
-      --exclude *.egginfo \
-      --exclude *.tox \
-      --exclude dist \
-      --exclude __pycache__ \
-      --exclude *.pyc \
-      --exclude .coverage"
 
-copy_py $ROOT/python_modules/dagster \
+echo "ROOT IS $ROOT"
+
+rsync \
+        -av \
+        --progress \
+        --exclude *.egginfo \
+        --exclude *.tox \
+        --exclude dist \
+        --exclude __pycache__ \
+        --exclude *.pyc \
+        --exclude .coverage \
+        $ROOT/python_modules/dagster \
         $ROOT/python_modules/dagster-webserver \
         $ROOT/python_modules/dagster-graphql \
         $ROOT/python_modules/dagster-pipes \

--- a/python_modules/dagster-test/dagster_test/test_project/build.sh
+++ b/python_modules/dagster-test/dagster_test/test_project/build.sh
@@ -37,8 +37,6 @@ cp $GOOGLE_APPLICATION_CREDENTIALS ./modules/gac.json
 
 echo -e "--- \033[32m:truck: Copying files...\033[0m"
 
-echo "ROOT IS $ROOT"
-
 rsync \
         -av \
         --progress \

--- a/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
@@ -392,6 +392,17 @@ def slow_graph():
 
 
 @op
+def spin_forever_op(_):
+    while True:
+        time.sleep(10)
+
+
+@graph
+def spin_forever_graph():
+    spin_forever_op()
+
+
+@op
 def slow_execute_k8s_op(context):
     # lazily import, since this repo is used in docker-tests and we can avoid the k8s import
     from dagster_k8s import execute_k8s_job
@@ -563,6 +574,7 @@ def define_demo_execution_repo():
                 "demo_slow_job_docker": define_job(demo_slow_graph, "docker"),
                 "demo_job_gcs": define_job(demo_graph, "gcs"),
                 "demo_job_k8s": define_job(demo_graph, "k8s"),
+                "spin_forever_job_k8s": define_job(spin_forever_graph, "k8s"),
                 "docker_celery_job": define_job(
                     demo_resource_output_graph,
                     "celery_docker",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -549,6 +549,18 @@ class DagsterKubernetesClient:
 
     ### Pod operations ###
 
+    def get_pod_by_name(self, pod_name: str, namespace: str):
+        """Get a pod by name.
+
+        Args:
+            pod_name (str): Name of the pod to get.
+            namespace (str): Namespace in which the pod is located.
+        """
+        check.str_param(pod_name, "pod_name")
+        check.str_param(namespace, "namespace")
+
+        return self.core_api.read_namespaced_pod(pod_name, namespace=namespace)
+
     def get_pods_in_job(self, job_name, namespace):
         """Get the pods launched by the job ``job_name``.
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -25,6 +25,7 @@ from dagster._core.executor.step_delegating import (
     StepHandler,
     StepHandlerContext,
 )
+from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 
 from dagster_k8s.client import DagsterKubernetesClient
@@ -88,7 +89,9 @@ _K8S_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
             bool,
             is_required=False,
             default_value=False,
-            description="Whether to insert Kubernetes owner references on step jobs to their parent run pod.",
+            description="Whether to insert Kubernetes owner references on step jobs to their parent run pod."
+            " This ensures that step jobs and step pods are garbage collected when the run pod is deleted."
+            " For more information, see https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/",
         ),
     },
 )
@@ -280,6 +283,7 @@ class K8sStepHandler(StepHandler):
 
         return f"dagster-step-{name_key}"
 
+    @cached_method
     def _detect_current_name_and_uid(
         self,
     ) -> Optional[tuple[str, str]]:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Iterator
 from typing import Optional, cast
 
@@ -31,6 +32,7 @@ from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import (
     USER_DEFINED_K8S_JOB_CONFIG_SCHEMA,
     DagsterK8sJobConfig,
+    OwnerReference,
     UserDefinedDagsterK8sConfig,
     construct_dagster_k8s_job,
     get_k8s_job_name,
@@ -81,6 +83,12 @@ _K8S_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
             is_required=False,
             default_value={},
             description="Per op k8s configuration overrides.",
+        ),
+        "enable_owner_references": Field(
+            bool,
+            is_required=False,
+            default_value=False,
+            description="Whether to insert Kubernetes owner references on step jobs to their parent run pod.",
         ),
     },
 )
@@ -171,6 +179,9 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
             load_incluster_config=load_incluster_config,
             kubeconfig_file=kubeconfig_file,
             per_step_k8s_config=exc_cfg.get("per_step_k8s_config", {}),
+            enable_owner_references=check.opt_bool_param(
+                exc_cfg.get("enable_owner_references"), "enable_owner_references", False
+            ),
         ),
         retries=RetryMode.from_config(exc_cfg["retries"]),  # type: ignore
         max_concurrent=check.opt_int_elem(exc_cfg, "max_concurrent"),
@@ -191,7 +202,9 @@ class K8sStepHandler(StepHandler):
         load_incluster_config: bool,
         kubeconfig_file: Optional[str],
         k8s_client_batch_api=None,
+        k8s_client_core_api=None,
         per_step_k8s_config=None,
+        enable_owner_references=False,
     ):
         super().__init__()
 
@@ -199,7 +212,7 @@ class K8sStepHandler(StepHandler):
         self._executor_container_context = check.inst_param(
             container_context, "container_context", K8sContainerContext
         )
-
+        self._kubeconfig_file = None
         if load_incluster_config:
             check.invariant(
                 kubeconfig_file is None,
@@ -209,13 +222,16 @@ class K8sStepHandler(StepHandler):
         else:
             check.opt_str_param(kubeconfig_file, "kubeconfig_file")
             kubernetes.config.load_kube_config(kubeconfig_file)
+            self._kubeconfig_file = kubeconfig_file
 
         self._api_client = DagsterKubernetesClient.production_client(
-            batch_api_override=k8s_client_batch_api
+            batch_api_override=k8s_client_batch_api,
+            core_api_override=k8s_client_core_api,
         )
         self._per_step_k8s_config = check.opt_dict_param(
             per_step_k8s_config, "per_step_k8s_config", key_type=str, value_type=dict
         )
+        self._enable_owner_references = enable_owner_references
 
     def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
         step_keys_to_execute = cast(
@@ -264,6 +280,24 @@ class K8sStepHandler(StepHandler):
 
         return f"dagster-step-{name_key}"
 
+    def _detect_current_name_and_uid(
+        self,
+    ) -> Optional[tuple[str, str]]:
+        """Get the current pod's pod name and uid, if available."""
+        from dagster_k8s.utils import detect_current_namespace
+
+        hostname = os.getenv("HOSTNAME")
+        if not hostname:
+            return None
+
+        namespace = detect_current_namespace(self._kubeconfig_file)
+        if not namespace:
+            return None
+
+        pod = self._api_client.get_pod_by_name(pod_name=hostname, namespace=namespace)
+
+        return pod.metadata.name, pod.metadata.uid
+
     def launch_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:
         step_key = self._get_step_key(step_handler_context)
 
@@ -301,6 +335,13 @@ class K8sStepHandler(StepHandler):
         deployment_name_env_var = get_deployment_id_label(container_context.run_k8s_config)
         if deployment_name_env_var:
             labels["dagster/deployment-name"] = deployment_name_env_var
+
+        owner_references = []
+        if self._enable_owner_references:
+            my_pod = self._detect_current_name_and_uid()
+            if my_pod:
+                owner_references = [OwnerReference(kind="Pod", name=my_pod[0], uid=my_pod[1])]
+
         job = construct_dagster_k8s_job(
             job_config=job_config,
             args=args,
@@ -317,6 +358,7 @@ class K8sStepHandler(StepHandler):
                 },
                 {"name": "DAGSTER_RUN_STEP_KEY", "value": step_key},
             ],
+            owner_references=owner_references,
         )
 
         yield DagsterEvent.step_worker_starting(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,6 +1,8 @@
 import re
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
+import kubernetes
 from dagster import __version__ as dagster_version
 
 if TYPE_CHECKING:
@@ -32,3 +34,29 @@ def get_deployment_id_label(user_defined_k8s_config: "UserDefinedDagsterK8sConfi
         else None
     )
     return deployment_name_env_var["value"] if deployment_name_env_var else None
+
+
+_NAMESPACE_SECRET_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+
+
+def detect_current_namespace(
+    kubeconfig_file: Optional[str], namespace_secret_path: Path = _NAMESPACE_SECRET_PATH
+) -> Optional[str]:
+    """Get the current in-cluster namespace when operating within the cluster.
+
+    First attempt to read it from the `serviceaccount` secret or get it from the kubeconfig_file if it is possible.
+    It will attempt to take from the active context if it exists and returns None if it does not exist.
+    """
+    if namespace_secret_path.exists():
+        with namespace_secret_path.open() as f:
+            # We only need to read the first line, this guards us against bad input.
+            return f.read().strip()
+
+    if not kubeconfig_file:
+        return None
+
+    try:
+        _, active_context = kubernetes.config.list_kube_config_contexts(kubeconfig_file)
+        return active_context["context"]["namespace"]
+    except KeyError:
+        return None

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
@@ -5,12 +5,8 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.utils import make_new_run_id
 from dagster.components.core.tree import ComponentTree
 from dagster_k8s.component import PipesK8sComponent
-from dagster_k8s.pipes import (
-    _DEV_NULL_MESSAGE_WRITER,
-    _detect_current_namespace,
-    build_pod_body,
-    get_pod_name,
-)
+from dagster_k8s.pipes import _DEV_NULL_MESSAGE_WRITER, build_pod_body, get_pod_name
+from dagster_k8s.utils import detect_current_namespace
 from dagster_pipes import DAGSTER_PIPES_CONTEXT_ENV_VAR, DAGSTER_PIPES_MESSAGES_ENV_VAR
 
 
@@ -440,19 +436,19 @@ def kubeconfig_with_namespace(tmpdir) -> str:
 
 
 def test_namespace_autodetect_fails(kubeconfig_dummy):
-    got = _detect_current_namespace(kubeconfig_dummy)
+    got = detect_current_namespace(kubeconfig_dummy)
     assert got is None
 
 
 def test_namespace_autodetect_from_kubeconfig_active_context(kubeconfig_with_namespace):
-    got = _detect_current_namespace(kubeconfig_with_namespace)
+    got = detect_current_namespace(kubeconfig_with_namespace)
     assert got == "my-namespace"
 
 
 def test_pipes_client_namespace_autodetection_from_secret(tmpdir, kubeconfig_dummy):
     namespace_secret_path = Path(tmpdir) / "namespace_secret"
     namespace_secret_path.write_text("my-namespace-from-secret")
-    got = _detect_current_namespace(kubeconfig_with_namespace, namespace_secret_path)  # pyright: ignore[reportArgumentType]
+    got = detect_current_namespace(kubeconfig_with_namespace, namespace_secret_path)  # type: ignore
     assert got == "my-namespace-from-secret"
 
 


### PR DESCRIPTION
## Summary

Adds a new configuration option to the k8s executor which sets a Kubernetes Owner references [\(ref\)](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#System) to step jobs, pointing at the originating run pod. This lets users more easily trace back a step to the run pod which spawned it.

## Test Plan

New unit, integration tests.