### PR TITLE
docs: Add missing type hint

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/run_status_run_requests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/run_status_run_requests.py
@@ -27,7 +27,7 @@ def report_status_sensor(context: dg.RunStatusSensorContext):
 
 
 @dg.run_failure_sensor(request_job=status_reporting_job)
-def report_failure_sensor(context: dg.RunStatusSensorContext):
+def report_failure_sensor(context: dg.RunFailureSensorContext):
     run_config = {
         "ops": {"status_report": {"config": {"job_name": context.dagster_run.job_name}}}
     }

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/run_status_run_requests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/run_status_run_requests.py
@@ -8,7 +8,7 @@ status_reporting_job = None
     run_status=dg.DagsterRunStatus.SUCCESS,
     request_job=status_reporting_job,
 )
-def report_status_sensor(context):
+def report_status_sensor(context: dg.RunStatusSensorContext):
     # this condition prevents the sensor from triggering status_reporting_job again after it succeeds
     if context.dagster_run.job_name != status_reporting_job.name:
         run_config = {
@@ -27,7 +27,7 @@ def report_status_sensor(context):
 
 
 @dg.run_failure_sensor(request_job=status_reporting_job)
-def report_failure_sensor(context):
+def report_failure_sensor(context: dg.RunStatusSensorContext):
     run_config = {
         "ops": {"status_report": {"config": {"job_name": context.dagster_run.job_name}}}
     }


### PR DESCRIPTION
The type hint for `context` was missing.