### PR TITLE
[dagster-cloud-cli] Add `--wait` to `job launch` command

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/job/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/job/__init__.py
@@ -54,6 +54,15 @@ def launch(
             " finished."
         ),
     ),
+    interval: int = typer.Option(
+        30,
+        "-i",
+        "--interval",
+        help=(
+            "Interval in seconds to wait between checking the status of the run. Only used if"
+            " --wait is specified."
+        ),
+    ),
 ):
     """Launch a run for a job."""
     loaded_tags: dict[str, Any] = json.loads(tags) if tags else {}
@@ -86,7 +95,7 @@ def launch(
         status = None
         with gql.graphql_client_from_url(url, api_token, deployment_name=deployment) as client:
             while True:
-                time.sleep(30)
+                time.sleep(interval)
                 try:
                     status = gql.run_status(client, run_id)
                     if not status:

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/job/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/job/__init__.py
@@ -98,10 +98,6 @@ def launch(
                 time.sleep(interval)
                 try:
                     status = gql.run_status(client, run_id)
-                    if not status:
-                        ui.error(
-                            f"Failed to get status for run {run_id}. Check the Dagster Cloud UI for more details."
-                        )
                 except Exception as e:
                     ui.error(f"Failed to get status for run {run_id}: {e}.")
 

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/run/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/run/__init__.py
@@ -23,4 +23,7 @@ def status(
         raise ui.error("No run_id provided")
 
     with gql.graphql_client_from_url(url, api_token, deployment_name=deployment) as client:
-        ui.print(gql.run_status(client, run_id))
+        try:
+            ui.print(gql.run_status(client, run_id))
+        except Exception as e:
+            ui.error(f"Failed to get status for run {run_id}: {e}.")

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
@@ -721,14 +721,14 @@ query CliGetRunStatus($runId: ID!) {
 
 
 def run_status(client: DagsterCloudGraphQLClient, run_id: str) -> Any:
-    data = client.execute(
+    result = client.execute(
         GET_RUN_STATUS_QUERY,
         variable_values={"runId": run_id},
     )["data"]
-    if data["runOrError"]["__typename"] != "Run":
-        return None
+    if result["runOrError"]["__typename"] != "Run" or result["runOrError"]["status"] is None:
+        raise Exception(f"Unable to fetch run status: {result}")
 
-    return data["runOrError"]["status"]
+    return result["runOrError"]["status"]
 
 
 MARK_CLI_EVENT_MUTATION = """
@@ -754,7 +754,7 @@ def mark_cli_event(
     message: Optional[str] = None,
 ) -> Any:
     with suppress(Exception):
-        res = client.execute(
+        result = client.execute(
             MARK_CLI_EVENT_MUTATION,
             variable_values={
                 "eventType": event_type.name,
@@ -764,7 +764,7 @@ def mark_cli_event(
                 "message": message,
             },
         )
-        return res["data"]["markCliEvent"] == "ok"
+        return result["data"]["markCliEvent"] == "ok"
 
 
 GET_DEPLOYMENT_BY_NAME_QUERY = """


### PR DESCRIPTION
## Summary & Motivation

Adding the `--wait` flag to `dagster-cloud job launch` is particularly useful in CI pipelines where you're wanting to launch a job to test changes and ensure the dagster run succeeds before merging.

## How I Tested These Changes

Local manual testing

## Changelog

> [dagster-cloud-cli] Add `--wait` to `job launch` command
