### PR TITLE
Fix dagster-cloud-cli log level initialization

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
@@ -52,16 +52,11 @@ from dagster_cloud_cli.utils import DEFAULT_PYTHON_VERSION
 app = Typer(help="Commands for deploying code to Dagster+ from any CI/CD environment")
 
 
-class LogLevel(str, Enum):
-    debug = "DEBUG"
-    info = "INFO"
-    warning = "WARNING"
-    error = "ERROR"
-
-
 @app.callback()
-def main(loglevel: LogLevel = LogLevel.warning):
-    logging.basicConfig(level=logging.getLevelName(loglevel))
+def main():
+    logging.basicConfig(
+        level=logging.getLevelName(os.getenv("DAGSTER_CLOUD_CLI_LOG_LEVEL", "WARNING"))
+    )
 
 
 @app.command(help="Print json information about current CI/CD environment")


### PR DESCRIPTION
Summary:
This codepath started failing with the click 8.2 upgrade - but it doesn't seem like there was any way to set the underlying loglevel argument before. Source it from an env var instead.

Test Plan:
Run `dagster-cloud ci check` and `DAGSTER_CLOUD_CLI_LOG_LEVEL=DEBUG dagster-cloud-ci check`

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
