### PR TITLE
add config tests, guard against unconfigured threadpool worker

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -365,6 +365,14 @@ def backfills_daemon_config() -> Field:
                 is_required=False,
                 description="How many threads to use to process multiple backfills in parallel",
             ),
+            "num_submit_workers": Field(
+                int,
+                is_required=False,
+                description=(
+                    "How many threads to use to submit runs from backfills. Can be used to"
+                    " decrease latency for backfill run submission."
+                ),
+            ),
         },
         is_required=False,
     )

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -355,12 +355,14 @@ class BackfillDaemon(DagsterDaemon):
         self._submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
 
         if settings.get("use_threads"):
-            self._threadpool_executor = self._exit_stack.enter_context(
-                InheritContextThreadPoolExecutor(
-                    max_workers=settings.get("num_workers"),
-                    thread_name_prefix="backfill_daemon_worker",
+            num_workers = settings.get("num_workers")
+            if num_workers:
+                self._threadpool_executor = self._exit_stack.enter_context(
+                    InheritContextThreadPoolExecutor(
+                        max_workers=settings.get("num_workers"),
+                        thread_name_prefix="backfill_daemon_worker",
+                    )
                 )
-            )
 
             num_submit_workers = settings.get("num_submit_workers")
             if num_submit_workers:


### PR DESCRIPTION
## Summary & Motivation
Adds instance config to configure submit threadpool workers for backfill runs

## How I Tested These Changes
BK

## Changelog
Added a config section to enable submitting backfill runs in a threadpool