### PR TITLE
[dagster-powerbi][components] Per-content-type translation layer

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -71,13 +71,12 @@ def resolve_translation(context: ResolutionContext, model):
     )
 
 
-resolver = Resolver(
-    resolve_translation,
-    model_field_type=Union[str, AssetAttributesModel],
-)
 ResolvedTranslationFn: TypeAlias = Annotated[
     TranslationFn,
-    resolver,
+    Resolver(
+        resolve_translation,
+        model_field_type=Union[str, AssetAttributesModel],
+    ),
 ]
 
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -7,8 +7,9 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster.components import Component, ComponentLoadContext, Model, Resolvable, Resolver
 from dagster.components.resolved.base import resolve_fields
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.core_models import AssetAttributesModel
+from dagster.components.resolved.core_models import AssetAttributesModel, AssetSpecUpdateKwargs
 from dagster.components.utils import TranslatorResolvingInfo
+from dagster_shared.record import record
 from pydantic import BaseModel
 from typing_extensions import TypeAlias
 
@@ -18,7 +19,11 @@ from dagster_powerbi.resource import (
     PowerBIWorkspace,
     load_powerbi_asset_specs,
 )
-from dagster_powerbi.translator import DagsterPowerBITranslator, PowerBITranslatorData
+from dagster_powerbi.translator import (
+    DagsterPowerBITranslator,
+    PowerBIContentType,
+    PowerBITranslatorData,
+)
 
 
 class PowerBITokenModel(Model):
@@ -47,6 +52,9 @@ def resolve_powerbi_credentials(
     )
 
 
+TranslationFn: TypeAlias = Callable[[AssetSpec, PowerBITranslatorData], AssetSpec]
+
+
 def resolve_translation(context: ResolutionContext, model):
     info = TranslatorResolvingInfo(
         "data",
@@ -63,13 +71,75 @@ def resolve_translation(context: ResolutionContext, model):
     )
 
 
-TranslationFn: TypeAlias = Callable[[AssetSpec, PowerBITranslatorData], AssetSpec]
-
+resolver = Resolver(
+    resolve_translation,
+    model_field_type=Union[str, AssetAttributesModel],
+)
 ResolvedTranslationFn: TypeAlias = Annotated[
     TranslationFn,
+    resolver,
+]
+
+
+@record
+class PowerBIAssetArgs(AssetSpecUpdateKwargs, Resolvable):
+    for_dashboard: Optional[ResolvedTranslationFn] = None
+    for_report: Optional[ResolvedTranslationFn] = None
+    for_semantic_model: Optional[ResolvedTranslationFn] = None
+
+
+def resolve_multilayer_translation(context: ResolutionContext, model):
+    """The PowerBI translation schema supports defining global transforms
+    as well as per-content-type transforms. This resolver composes the
+    per-content-type transforms with the global transforms.
+    """
+    info = TranslatorResolvingInfo(
+        "data",
+        asset_attributes=model,
+        resolution_context=context,
+        model_key="translation",
+    )
+
+    def _translation_fn(base_asset_spec: AssetSpec, data: PowerBITranslatorData):
+        processed_spec = info.get_asset_spec(
+            base_asset_spec,
+            {
+                "data": data,
+                "spec": base_asset_spec,
+            },
+        )
+
+        nested_translation_fns = resolve_fields(
+            model=model,
+            resolved_cls=PowerBIAssetArgs,
+            context=context.with_scope(
+                **{
+                    "data": data,
+                    "spec": processed_spec,
+                }
+            ),
+        )
+        for_semantic_model = nested_translation_fns.get("for_semantic_model")
+        for_dashboard = nested_translation_fns.get("for_dashboard")
+        for_report = nested_translation_fns.get("for_report")
+
+        if data.content_type == PowerBIContentType.SEMANTIC_MODEL and for_semantic_model:
+            return for_semantic_model(processed_spec, data)
+        if data.content_type == PowerBIContentType.DASHBOARD and for_dashboard:
+            return for_dashboard(processed_spec, data)
+        if data.content_type == PowerBIContentType.REPORT and for_report:
+            return for_report(processed_spec, data)
+
+        return processed_spec
+
+    return _translation_fn
+
+
+ResolvedMultilayerTranslationFn: TypeAlias = Annotated[
+    TranslationFn,
     Resolver(
-        resolve_translation,
-        model_field_type=Union[str, AssetAttributesModel],
+        resolve_multilayer_translation,
+        model_field_type=Union[str, PowerBIAssetArgs.model()],
     ),
 ]
 
@@ -114,7 +184,7 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
         ),
     ]
     use_workspace_scan: bool = True
-    translation: Optional[ResolvedTranslationFn] = None
+    translation: Optional[ResolvedMultilayerTranslationFn] = None
 
     @cached_property
     def translator(self) -> DagsterPowerBITranslator:

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -191,7 +191,7 @@ def test_per_content_type_translation(
     workspace_data_api_mocks,
 ) -> None:
     body = {
-        "type": "dagster_powerbi.PowerBiWorkspaceComponent",
+        "type": "dagster_powerbi.PowerBIWorkspaceComponent",
         "attributes": {
             "credentials": {
                 "token": uuid.uuid4().hex,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -11,7 +11,6 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
-from dagster._utils.env import environ
 from dagster.components.testing import scaffold_defs_sandbox
 from dagster_dg_core.utils import ensure_dagster_dg_tests_import
 from dagster_powerbi import PowerBIWorkspaceComponent
@@ -168,7 +167,6 @@ def test_translation(
         }
         body["attributes"]["translation"] = attributes
         with (
-            environ({"SOURCES__ACCESS_TOKEN": "fake"}),
             setup_powerbi_component(
                 component_body=body,
             ) as (
@@ -186,3 +184,60 @@ def test_translation(
             assets_def = defs.get_assets_def(key)
             if assertion:
                 assert assertion(assets_def.get_asset_spec(key))
+
+
+def test_per_content_type_translation(
+    workspace_id: str,
+    workspace_data_api_mocks,
+) -> None:
+    body = {
+        "type": "dagster_powerbi.PowerBiWorkspaceComponent",
+        "attributes": {
+            "credentials": {
+                "token": uuid.uuid4().hex,
+            },
+            "workspace_id": workspace_id,
+            "use_workspace_scan": False,
+            "translation": {
+                "tags": {"custom_tag": "custom_value"},
+                "for_semantic_model": {
+                    "tags": {"is_semantic_model": "true"},
+                },
+                "for_dashboard": {
+                    "tags": {"is_dashboard": "true"},
+                    "metadata": {"id": "{{ data.properties.id }}"},
+                },
+                "for_report": {
+                    "tags": {"is_report": "true"},
+                    "metadata": {"base_key": "{{ spec.key.to_user_string() }}"},
+                },
+            },
+        },
+    }
+    with (
+        setup_powerbi_component(
+            component_body=body,
+        ) as (
+            component,
+            defs,
+        ),
+    ):
+        semantic_model_spec = defs.get_assets_def(
+            AssetKey(["semantic_model", "Sales_Returns_Sample_v201912"])
+        ).get_asset_spec(AssetKey(["semantic_model", "Sales_Returns_Sample_v201912"]))
+        assert semantic_model_spec.tags.get("custom_tag") == "custom_value"
+        assert semantic_model_spec.tags.get("is_semantic_model") == "true"
+
+        dashboard_spec = defs.get_assets_def(
+            AssetKey(["dashboard", "Sales_Returns_Sample_v201912"])
+        ).get_asset_spec(AssetKey(["dashboard", "Sales_Returns_Sample_v201912"]))
+        assert dashboard_spec.tags.get("custom_tag") == "custom_value"
+        assert dashboard_spec.tags.get("is_dashboard") == "true"
+        assert dashboard_spec.metadata.get("id") == "efee0b80-4511-42e1-8ee0-2544fd44e122"
+
+        report_spec = defs.get_assets_def(
+            AssetKey(["report", "Sales_Returns_Sample_v201912"])
+        ).get_asset_spec(AssetKey(["report", "Sales_Returns_Sample_v201912"]))
+        assert report_spec.tags.get("custom_tag") == "custom_value"
+        assert report_spec.tags.get("is_report") == "true"
+        assert report_spec.metadata.get("base_key") == "report/Sales_Returns_Sample_v201912"

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -193,10 +193,12 @@ def test_per_content_type_translation(
     body = {
         "type": "dagster_powerbi.PowerBIWorkspaceComponent",
         "attributes": {
-            "credentials": {
-                "token": uuid.uuid4().hex,
+            "workspace": {
+                "credentials": {
+                    "token": uuid.uuid4().hex,
+                },
+                "workspace_id": workspace_id,
             },
-            "workspace_id": workspace_id,
             "use_workspace_scan": False,
             "translation": {
                 "tags": {"custom_tag": "custom_value"},


### PR DESCRIPTION
## Summary

Power BI is distinct from other translator-enabled component types (dbt, dlt, sling) in that the translated objects are fairly heterogenous; datasets have very different properties from reports which are very different from data sets. This PR introduces the ability to specify per-object-type translators, which are applied after (and merge with, in most cases) the global translation logic:

```yaml
type: dagster_powerbi.PowerBIWorkspaceComponent

attributes:
  workspace:
    credentials: 
      token: {{ env('POWERBI_TOKEN') }}
    workspace_id: abcd-1234-abcd-1234
  translation:
    tags:
      - foo: bar
    for_datasets:
      tags:
       - dataset_id: {{ data.properties.id }}
    for_reports:
      tags:
       - report_name: {{ data.properties.name }}
```

## Test Plan

New unit tests.