### PR TITLE
Fix Issue #28789: Skipped assets show status 'FAILED' when other assets in the same run fail

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -66,27 +66,6 @@ export const fetchFailureEvents = async (runId: string, assetKey: AssetKey) => {
   );
 };
 
-const ASSET_FAILURE_EVENTS_QUERY = gql`
-  query AssetFailureEventsQuery($runId: String!, $assetKey: AssetKeyInput!) {
-    assetFailureEvents(runId: $runId, assetKey: $assetKey) {
-      events {
-        eventType
-        timestamp
-      }
-    }
-  }
-`;
-
-export const fetchFailureEvents = async (runId: string, assetKey: AssetKey) => {
-  const {data} = await useQuery(ASSET_FAILURE_EVENTS_QUERY, {
-    variables: {runId, assetKey},
-  });
-
-  return data?.assetFailureEvents?.events.some(
-    (event: {eventType: string}) => event.eventType === 'ASSET_MATERIALIZATION_FAILURE',
-  );
-};
-
 
 export const AssetPartitionDetailLoader = (props: {assetKey: AssetKey; partitionKey: string}) => {
   const result = useQuery<AssetPartitionDetailQuery, AssetPartitionDetailQueryVariables>(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -45,6 +45,49 @@ import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext/util';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
+const ASSET_FAILURE_EVENTS_QUERY = gql`
+  query AssetFailureEventsQuery($runId: String!, $assetKey: AssetKeyInput!) {
+    assetFailureEvents(runId: $runId, assetKey: $assetKey) {
+      events {
+        eventType
+        timestamp
+      }
+    }
+  }
+`;
+
+export const fetchFailureEvents = async (runId: string, assetKey: AssetKey) => {
+  const {data} = await useQuery(ASSET_FAILURE_EVENTS_QUERY, {
+    variables: {runId, assetKey},
+  });
+
+  return data?.assetFailureEvents?.events.some(
+    (event: {eventType: string}) => event.eventType === 'ASSET_MATERIALIZATION_FAILURE',
+  );
+};
+
+const ASSET_FAILURE_EVENTS_QUERY = gql`
+  query AssetFailureEventsQuery($runId: String!, $assetKey: AssetKeyInput!) {
+    assetFailureEvents(runId: $runId, assetKey: $assetKey) {
+      events {
+        eventType
+        timestamp
+      }
+    }
+  }
+`;
+
+export const fetchFailureEvents = async (runId: string, assetKey: AssetKey) => {
+  const {data} = await useQuery(ASSET_FAILURE_EVENTS_QUERY, {
+    variables: {runId, assetKey},
+  });
+
+  return data?.assetFailureEvents?.events.some(
+    (event: {eventType: string}) => event.eventType === 'ASSET_MATERIALIZATION_FAILURE',
+  );
+};
+
+
 export const AssetPartitionDetailLoader = (props: {assetKey: AssetKey; partitionKey: string}) => {
   const result = useQuery<AssetPartitionDetailQuery, AssetPartitionDetailQueryVariables>(
     ASSET_PARTITION_DETAIL_QUERY,
@@ -98,6 +141,14 @@ export const AssetPartitionDetailLoader = (props: {assetKey: AssetKey; partition
 
   if (result.loading || !result.data) {
     return <AssetPartitionDetailEmpty partitionKey={props.partitionKey} />;
+  }
+
+  const assetFailed = latestRunForPartition?.id
+    ? fetchFailureEvents(latestRunForPartition.id, props.assetKey)
+    : false;
+
+  if (assetFailed) {
+    return <FailedRunSinceMaterializationBanner run={latestRunForPartition} />;
   }
 
   return (

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1421,3 +1421,40 @@ class GrapheneAssetNodeOrError(graphene.Union):
     class Meta:
         types = (GrapheneAssetNode, GrapheneAssetNotFoundError)
         name = "AssetNodeOrError"
+
+class GrapheneAssetFailureEvent(graphene.ObjectType):
+    eventType = graphene.NonNull(graphene.String)
+    timestamp = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "AssetFailureEvent"
+
+class GrapheneAssetFailureEvents(graphene.ObjectType):
+    events = graphene.List(GrapheneAssetFailureEvent)
+
+    class Meta:
+        name = "AssetFailureEvents"
+
+class GrapheneAssetFailureEventsQuery(graphene.ObjectType):
+    assetFailureEvents = graphene.Field(
+        GrapheneAssetFailureEvents,
+        runId=graphene.NonNull(graphene.String),
+        assetKey=graphene.NonNull(GrapheneAssetKey),
+    )
+
+    def resolve_assetFailureEvents(self, info, runId, assetKey):
+        instance = info.context.instance
+        asset_records = instance.get_asset_records(AssetRecordsFilter(asset_key=assetKey))
+
+        failure_events = []
+        for record in asset_records:
+            for event in record.asset_entry.event_log:
+                if event.dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION_FAILURE:
+                    failure_events.append(
+                        GrapheneAssetFailureEvent(
+                            eventType=event.dagster_event_type,
+                            timestamp=str(event.timestamp),
+                        )
+                    )
+
+        return GrapheneAssetFailureEvents(events=failure_events)


### PR DESCRIPTION
## Summary

https://gist.github.com/TiaMarieG/e685ca1ed74092f34b3aa19ce0d1a9e9

## Motivation

CodeDay student open-source contribution.

## How I Tested These Changes

Created test cases to validate the updated logic for various scenarios: 
- A run with both successful and failed materializations.
- A run where assets are skipped due to no upstream changes.
- Edge cases like assets with no prior materializations.