### PR TITLE
[dagster-powerbi][dagster-components] Add option to opt-in semantic models for refresh

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -185,7 +185,7 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
     ]
     use_workspace_scan: bool = True
     # Takes a list of semantic model names to enable refresh for, or True to enable for all semantic models
-    enable_semantic_model_refresh: Union[bool, list[str]] = True
+    enable_semantic_model_refresh: Union[bool, list[str]] = False
     translation: Optional[ResolvedMultilayerTranslationFn] = None
 
     @cached_property

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -4,16 +4,19 @@ from typing import Annotated, Any, Callable, Optional, Union
 
 import dagster as dg
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components import Component, ComponentLoadContext, Model, Resolvable, Resolver
 from dagster.components.resolved.base import resolve_fields
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import AssetAttributesModel, AssetSpecUpdateKwargs
 from dagster.components.utils import TranslatorResolvingInfo
+from dagster_shared import check
 from dagster_shared.record import record
 from pydantic import BaseModel
 from typing_extensions import TypeAlias
 
-from dagster_powerbi import build_semantic_model_refresh_asset_definition
 from dagster_powerbi.resource import (
     PowerBIServicePrincipal,
     PowerBIToken,
@@ -23,6 +26,8 @@ from dagster_powerbi.resource import (
 from dagster_powerbi.translator import (
     DagsterPowerBITranslator,
     PowerBIContentType,
+    PowerBIMetadataSet,
+    PowerBITagSet,
     PowerBITranslatorData,
 )
 
@@ -194,33 +199,42 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
             return ProxyDagsterPowerBITranslator(self.translation)
         return DagsterPowerBITranslator()
 
+    def _should_spec_be_refreshable(self, spec: AssetSpec) -> bool:
+        return spec.tags.get("dagster-powerbi/asset_type") == "semantic_model" and (
+            self.enable_semantic_model_refresh is True
+            or (
+                isinstance(self.enable_semantic_model_refresh, list)
+                and spec.metadata.get("dagster-powerbi/name") in self.enable_semantic_model_refresh
+            )
+        )
+
+    def build_semantic_model_refresh_asset_definition(self, spec: AssetSpec) -> AssetsDefinition:
+        """Builds an asset definition for refreshing a PowerBI semantic model, with
+        this component's resource implicitly bound to the asset.
+        """
+        check.invariant(PowerBITagSet.extract(spec.tags).asset_type == "semantic_model")
+        dataset_id = check.not_none(PowerBIMetadataSet.extract(spec.metadata).id)
+
+        @multi_asset(
+            specs=[spec],
+            name="_".join(spec.key.path),
+        )
+        def asset_fn(context: AssetExecutionContext) -> None:
+            self.workspace.trigger_and_poll_refresh(dataset_id)
+
+        return asset_fn
+
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
         specs = load_powerbi_asset_specs(
             workspace=self.workspace,
             dagster_powerbi_translator=self.translator,
             use_workspace_scan=self.use_workspace_scan,
         )
-        workspace_resource_key = (
-            f"power_bi_workspace_{self.workspace.workspace_id.replace('-', '_')}"
-        )
 
         specs_with_refreshable_semantic_models = [
-            build_semantic_model_refresh_asset_definition(
-                resource_key=workspace_resource_key, spec=spec
-            )
-            if spec.tags.get("dagster-powerbi/asset_type") == "semantic_model"
-            and (
-                self.enable_semantic_model_refresh is True
-                or (
-                    isinstance(self.enable_semantic_model_refresh, list)
-                    and spec.metadata.get("dagster-powerbi/name")
-                    in self.enable_semantic_model_refresh
-                )
-            )
+            self.build_semantic_model_refresh_asset_definition(spec)
+            if self._should_spec_be_refreshable(spec)
             else spec
             for spec in specs
         ]
-        return dg.Definitions(
-            assets=specs_with_refreshable_semantic_models,
-            resources={workspace_resource_key: self.workspace},
-        )
+        return dg.Definitions(assets=specs_with_refreshable_semantic_models)

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -200,7 +200,9 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
             dagster_powerbi_translator=self.translator,
             use_workspace_scan=self.use_workspace_scan,
         )
-        workspace_resource_key = f"power_bi_workspace_{self.workspace.workspace_id}"
+        workspace_resource_key = (
+            f"power_bi_workspace_{self.workspace.workspace_id.replace('-', '_')}"
+        )
 
         specs_with_refreshable_semantic_models = [
             build_semantic_model_refresh_asset_definition(

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -13,6 +13,7 @@ from dagster_shared.record import record
 from pydantic import BaseModel
 from typing_extensions import TypeAlias
 
+from dagster_powerbi import build_semantic_model_refresh_asset_definition
 from dagster_powerbi.resource import (
     PowerBIServicePrincipal,
     PowerBIToken,
@@ -183,6 +184,8 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
         ),
     ]
     use_workspace_scan: bool = True
+    # Takes a list of semantic model names to enable refresh for, or True to enable for all semantic models
+    enable_semantic_model_refresh: Union[bool, list[str]] = True
     translation: Optional[ResolvedMultilayerTranslationFn] = None
 
     @cached_property
@@ -197,4 +200,25 @@ class PowerBIWorkspaceComponent(Component, Resolvable):
             dagster_powerbi_translator=self.translator,
             use_workspace_scan=self.use_workspace_scan,
         )
-        return dg.Definitions(assets=specs)
+        workspace_resource_key = f"power_bi_workspace_{self.workspace.workspace_id}"
+
+        specs_with_refreshable_semantic_models = [
+            build_semantic_model_refresh_asset_definition(
+                resource_key=workspace_resource_key, spec=spec
+            )
+            if spec.tags.get("dagster-powerbi/asset_type") == "semantic_model"
+            and (
+                self.enable_semantic_model_refresh is True
+                or (
+                    isinstance(self.enable_semantic_model_refresh, list)
+                    and spec.metadata.get("dagster-powerbi/name")
+                    in self.enable_semantic_model_refresh
+                )
+            )
+            else spec
+            for spec in specs
+        ]
+        return dg.Definitions(
+            assets=specs_with_refreshable_semantic_models,
+            resources={workspace_resource_key: self.workspace},
+        )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -150,6 +150,7 @@ class PowerBITagSet(NamespacedTagSet):
 class PowerBIMetadataSet(NamespacedMetadataSet):
     web_url: Optional[UrlMetadataValue] = None
     id: Optional[str] = None
+    name: Optional[str] = None
 
     @classmethod
     def namespace(cls) -> str:
@@ -222,7 +223,12 @@ class DagsterPowerBITranslator:
                 ]
             ),
             deps=report_keys,
-            metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
+            metadata={
+                **PowerBIMetadataSet(
+                    web_url=MetadataValue.url(url) if url else None,
+                    name=data.properties.get("displayName"),
+                )
+            },
             tags={**PowerBITagSet(asset_type="dashboard")},
             kinds={"powerbi", "dashboard"},
         )
@@ -262,7 +268,12 @@ class DagsterPowerBITranslator:
         return AssetSpec(
             key=AssetKey(["report", _clean_asset_name(data.properties["name"])]),
             deps=[dataset_key] if dataset_key else None,
-            metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
+            metadata={
+                **PowerBIMetadataSet(
+                    web_url=MetadataValue.url(url) if url else None,
+                    name=data.properties.get("name"),
+                )
+            },
             tags={**PowerBITagSet(asset_type="report")},
             kinds={"powerbi", "report"},
             owners=[owner] if owner and is_valid_asset_owner(owner) else None,
@@ -320,7 +331,9 @@ class DagsterPowerBITranslator:
             deps=source_keys,
             metadata={
                 **PowerBIMetadataSet(
-                    web_url=MetadataValue.url(url) if url else None, id=data.properties["id"]
+                    web_url=MetadataValue.url(url) if url else None,
+                    id=data.properties["id"],
+                    name=data.properties.get("name"),
                 ),
                 **table_meta,
             },

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import pytest
 from dagster import AssetKey
@@ -44,7 +44,22 @@ def setup_powerbi_component(
             yield component, defs
 
 
-def test_basic_component_load(workspace_data_api_mocks, workspace_id: str) -> None:
+@pytest.mark.parametrize(
+    "enable_semantic_model_refresh, should_be_executable",
+    [
+        (True, True),
+        (False, False),
+        (["Sales & Returns Sample v201912"], True),
+        (["Sales & Returns Sample v201911", "Sales & Returns Sample v201912"], True),
+        (["Does not exist"], False),
+    ],
+)
+def test_basic_component_load(
+    workspace_data_api_mocks,
+    workspace_id: str,
+    enable_semantic_model_refresh: Union[bool, list[str]],
+    should_be_executable: bool,
+) -> None:
     with (
         setup_powerbi_component(
             component_body={
@@ -57,6 +72,7 @@ def test_basic_component_load(workspace_data_api_mocks, workspace_id: str) -> No
                         "workspace_id": workspace_id,
                     },
                     "use_workspace_scan": False,
+                    "enable_semantic_model_refresh": enable_semantic_model_refresh,
                 },
             }
         ) as (
@@ -71,6 +87,13 @@ def test_basic_component_load(workspace_data_api_mocks, workspace_id: str) -> No
             AssetKey(["sales_marketing_datas_xlsx"]),
             AssetKey(["report", "Sales_Returns_Sample_v201912"]),
         }
+
+        assert (
+            defs.get_assets_def(
+                AssetKey(["semantic_model", "Sales_Returns_Sample_v201912"])
+            ).is_executable
+            == should_be_executable
+        )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -31,7 +31,8 @@ def test_translator_dashboard_spec(workspace_data: PowerBIWorkspaceData) -> None
     assert asset_spec.metadata == {
         "dagster-powerbi/web_url": MetadataValue.url(
             "https://app.powerbi.com/groups/a2122b8f-d7e1-42e8-be2b-a5e636ca3221/dashboards/efee0b80-4511-42e1-8ee0-2544fd44e122"
-        )
+        ),
+        "dagster-powerbi/name": "Sales & Returns Sample v201912.pbix",
     }
     assert asset_spec.tags == {
         "dagster-powerbi/asset_type": "dashboard",
@@ -58,7 +59,8 @@ def test_translator_report_spec(workspace_data: PowerBIWorkspaceData) -> None:
     assert asset_spec.metadata == {
         "dagster-powerbi/web_url": MetadataValue.url(
             "https://app.powerbi.com/groups/a2122b8f-d7e1-42e8-be2b-a5e636ca3221/reports/8b7f815d-4e64-40dd-993c-cfa4fb12edee"
-        )
+        ),
+        "dagster-powerbi/name": "Sales & Returns Sample v201912",
     }
     assert asset_spec.tags == {
         "dagster-powerbi/asset_type": "report",
@@ -99,6 +101,7 @@ def test_translator_semantic_model(workspace_data: PowerBIWorkspaceData) -> None
                 TableColumn(name="order_date", type="DateTime"),
             ]
         ),
+        "dagster-powerbi/name": "Sales & Returns Sample v201912",
     }
     assert asset_spec.tags == {
         "dagster-powerbi/asset_type": "semantic_model",
@@ -123,6 +126,7 @@ def test_translator_semantic_model_many_tables(second_workspace_data: PowerBIWor
             "https://app.powerbi.com/groups/a2122b8f-d7e1-42e8-be2b-a5e636ca3221/datasets/8e9c85a1-7b33-4223-9590-76bde70f9a20"
         ),
         "dagster-powerbi/id": "ae9c85a1-7b33-4223-9590-76bde70f9a20",
+        "dagster-powerbi/name": "Second Workspace Sample",
         "sales_column_schema": TableSchema(
             columns=[
                 TableColumn(name="order_id", type="Int64"),


### PR DESCRIPTION
## Summary

Adds a component-level setting which can be used to boolean toggle whether PowerBI Semantic Models should be refreshable from Dagster (making the asset executable) or to opt in a subset of the semantic models by name.

```yaml
type: dagster_powerbi.PowerBIWorkspaceComponent

attributes:
  workspace:
    credentials: 
      token: {{ env('POWERBI_TOKEN') }}
    workspace_id: abcd-1234-abcd-1234
  translation:
    owners:
      - team:analytics
  enable_semantic_model_refresh: true
```


```yaml
type: dagster_powerbi.PowerBIWorkspaceComponent

attributes:
  workspace:
    credentials:
      token: {{ env('POWERBI_TOKEN') }}
    workspace_id: abcd-1234-abcd-1234
  translation:
    owners:
      - team:analytics
  enable_semantic_model_refresh:
    - my model 1
    - my model 2
```

## Test Plan

Update unit tests.

