### PR TITLE
catch all errors in SerializableEntitySubset.try_from_coercible

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -67,7 +67,9 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
             return cls(key=key, value=True)
         if isinstance(value, str):
             partitions_def = check.not_none(partitions_def)
-            if not isinstance(partitions_def.partitions_subset_class, DefaultPartitionsSubset):
+            if partitions_def.partitions_subset_class is not DefaultPartitionsSubset:
+                # DefaultPartitionsSubset just adds partition keys to a set, but other subsets
+                # may require partition keys be part of the partition, so validate the key
                 partitions_def.validate_partition_key(
                     value, dynamic_partitions_store=dynamic_partitions_store
                 )
@@ -84,6 +86,9 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
             check.list_param(value, "value", of_type=str)
             partitions_def = check.not_none(partitions_def)
             if partitions_def.partitions_subset_class is not DefaultPartitionsSubset:
+                # DefaultPartitionsSubset just adds partition keys to a set, but other subsets
+                # may require partition keys be part of the partition, so validate the keys and only
+                # include the valid keys in the subset
                 valid_keys = [
                     key
                     for key in value

--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import (
     AllPartitionsSubset,
+    DefaultPartitionsSubset,
     PartitionsDefinition,
     PartitionsSubset,
 )
@@ -66,9 +67,10 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
             return cls(key=key, value=True)
         if isinstance(value, str):
             partitions_def = check.not_none(partitions_def)
-            partitions_def.validate_partition_key(
-                value, dynamic_partitions_store=dynamic_partitions_store
-            )
+            if not isinstance(partitions_def.partitions_subset_class, DefaultPartitionsSubset):
+                partitions_def.validate_partition_key(
+                    value, dynamic_partitions_store=dynamic_partitions_store
+                )
             partitions_subset = partitions_def.subset_with_partition_keys([value])
         elif isinstance(value, PartitionsSubset):
             if partitions_def is not None:
@@ -81,13 +83,16 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
         else:
             check.list_param(value, "value", of_type=str)
             partitions_def = check.not_none(partitions_def)
-            valid_keys = [
-                key
-                for key in value
-                if partitions_def.has_partition_key(
-                    key, dynamic_partitions_store=dynamic_partitions_store
-                )
-            ]
+            if partitions_def.partitions_subset_class is not DefaultPartitionsSubset:
+                valid_keys = [
+                    key
+                    for key in value
+                    if partitions_def.has_partition_key(
+                        key, dynamic_partitions_store=dynamic_partitions_store
+                    )
+                ]
+            else:
+                valid_keys = value
             partitions_subset = partitions_def.subset_with_partition_keys(valid_keys)
         return cls(key=key, value=partitions_subset)
 

--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -84,7 +84,7 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
         """
         try:
             return cls.from_coercible_value(key, value, partitions_def)
-        except check.CheckError:
+        except:
             return None
 
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -102,12 +102,14 @@ def test_from_coercible_value():
         key=a,
         value=None,
         partitions_def=None,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(key=AssetKey("a"), value=True)
 
     assert SerializableEntitySubset.from_coercible_value(
         key=a,
         value="1",
         partitions_def=partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -117,6 +119,7 @@ def test_from_coercible_value():
         key=a,
         value=["1", "2"],
         partitions_def=partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1", "2"]),
@@ -125,7 +128,18 @@ def test_from_coercible_value():
     assert SerializableEntitySubset.from_coercible_value(
         key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
+        partitions_def=None,
+        dynamic_partitions_store=None,
+    ) == SerializableEntitySubset(
+        key=AssetKey("a"),
+        value=partitions_def.subset_with_partition_keys(["1"]),
+    )
+
+    assert SerializableEntitySubset.from_coercible_value(
+        key=a,
+        value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -134,8 +148,17 @@ def test_from_coercible_value():
     with pytest.raises(CheckError):
         SerializableEntitySubset.from_coercible_value(
             key=a,
+            value=partitions_def.subset_with_partition_keys(["1"]),
+            partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
+            dynamic_partitions_store=None,
+        )
+
+    with pytest.raises(CheckError):
+        SerializableEntitySubset.from_coercible_value(
+            key=a,
             value="1",
             partitions_def=None,
+            dynamic_partitions_store=None,
         )
 
     with pytest.raises(CheckError):
@@ -143,6 +166,7 @@ def test_from_coercible_value():
             key=a,
             value=None,
             partitions_def=partitions_def,
+            dynamic_partitions_store=None,
         )
 
 
@@ -154,12 +178,14 @@ def test_try_from_coercible_value():
         key=a,
         value=None,
         partitions_def=None,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(key=AssetKey("a"), value=True)
 
     assert SerializableEntitySubset.try_from_coercible_value(
         key=a,
         value="1",
         partitions_def=partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -169,6 +195,7 @@ def test_try_from_coercible_value():
         key=a,
         value=["1", "2"],
         partitions_def=partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1", "2"]),
@@ -177,7 +204,8 @@ def test_try_from_coercible_value():
     assert SerializableEntitySubset.try_from_coercible_value(
         key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
-        partitions_def=partitions_def,
+        partitions_def=None,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -188,6 +216,7 @@ def test_try_from_coercible_value():
             key=a,
             value="1",
             partitions_def=None,
+            dynamic_partitions_store=None,
         )
         is None
     )
@@ -197,16 +226,21 @@ def test_try_from_coercible_value():
             key=a,
             value=None,
             partitions_def=partitions_def,
+            dynamic_partitions_store=None,
         )
         is None
     )
 
+
+def test_from_coercible_time_partitions():
     time_window_partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")
+    a = AssetKey("a")
 
     assert SerializableEntitySubset.try_from_coercible_value(
         key=a,
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
         partitions_def=time_window_partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
@@ -216,25 +250,54 @@ def test_try_from_coercible_value():
         key=a,
         value="2024-01-01",
         partitions_def=time_window_partitions_def,
+        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
     )
+
+    with pytest.raises(Exception):
+        SerializableEntitySubset.from_coercible_value(
+            key=a,
+            value="invalid_value",
+            partitions_def=time_window_partitions_def,
+            dynamic_partitions_store=None,
+        )
 
     assert (
         SerializableEntitySubset.try_from_coercible_value(
             key=a,
             value="invalid_value",
             partitions_def=time_window_partitions_def,
+            dynamic_partitions_store=None,
         )
         is None
     )
+
+    with pytest.raises(Exception):
+        SerializableEntitySubset.from_coercible_value(
+            key=a,
+            value="2024-01-01 12:45:45",
+            partitions_def=time_window_partitions_def,
+            dynamic_partitions_store=None,
+        )
 
     assert (
         SerializableEntitySubset.try_from_coercible_value(
             key=a,
             value="2024-01-01 12:45:45",
             partitions_def=time_window_partitions_def,
+            dynamic_partitions_store=None,
         )
         is None
+    )
+
+    assert SerializableEntitySubset.from_coercible_value(
+        key=a,
+        value=["2024-01-01 12:45:45", "2024-01-02"],
+        partitions_def=time_window_partitions_def,
+        dynamic_partitions_store=None,
+    ) == SerializableEntitySubset(
+        key=AssetKey("a"),
+        value=time_window_partitions_def.subset_with_partition_keys(["2024-01-02"]),
     )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, StaticPartitionsDefinition
+from dagster import AssetKey, DailyPartitionsDefinition, StaticPartitionsDefinition
 from dagster._check import CheckError
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 
@@ -197,6 +197,44 @@ def test_try_from_coercible_value():
             key=a,
             value=None,
             partitions_def=partitions_def,
+        )
+        is None
+    )
+
+    time_window_partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")
+
+    assert SerializableEntitySubset.try_from_coercible_value(
+        key=a,
+        value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
+        partitions_def=time_window_partitions_def,
+    ) == SerializableEntitySubset(
+        key=AssetKey("a"),
+        value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
+    )
+
+    assert SerializableEntitySubset.try_from_coercible_value(
+        key=a,
+        value="2024-01-01",
+        partitions_def=time_window_partitions_def,
+    ) == SerializableEntitySubset(
+        key=AssetKey("a"),
+        value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
+    )
+
+    assert (
+        SerializableEntitySubset.try_from_coercible_value(
+            key=a,
+            value="invalid_value",
+            partitions_def=time_window_partitions_def,
+        )
+        is None
+    )
+
+    assert (
+        SerializableEntitySubset.try_from_coercible_value(
+            key=a,
+            value="2024-01-01 12:45:45",
+            partitions_def=time_window_partitions_def,
         )
         is None
     )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -108,14 +108,12 @@ def test_from_coercible_value():
         key=a,
         value=None,
         partitions_def=None,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(key=AssetKey("a"), value=True)
 
     assert SerializableEntitySubset.from_coercible_value(
         key=a,
         value="1",
         partitions_def=partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -125,7 +123,6 @@ def test_from_coercible_value():
         key=a,
         value=["1", "2"],
         partitions_def=partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1", "2"]),
@@ -135,7 +132,6 @@ def test_from_coercible_value():
         key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=None,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -145,7 +141,6 @@ def test_from_coercible_value():
         key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -156,7 +151,6 @@ def test_from_coercible_value():
             key=a,
             value=partitions_def.subset_with_partition_keys(["1"]),
             partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
-            dynamic_partitions_store=None,
         )
 
     with pytest.raises(CheckError):
@@ -164,7 +158,6 @@ def test_from_coercible_value():
             key=a,
             value="1",
             partitions_def=None,
-            dynamic_partitions_store=None,
         )
 
     with pytest.raises(CheckError):
@@ -172,7 +165,6 @@ def test_from_coercible_value():
             key=a,
             value=None,
             partitions_def=partitions_def,
-            dynamic_partitions_store=None,
         )
 
 
@@ -184,14 +176,12 @@ def test_try_from_coercible_value():
         key=a,
         value=None,
         partitions_def=None,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(key=AssetKey("a"), value=True)
 
     assert SerializableEntitySubset.try_from_coercible_value(
         key=a,
         value="1",
         partitions_def=partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -201,7 +191,6 @@ def test_try_from_coercible_value():
         key=a,
         value=["1", "2"],
         partitions_def=partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1", "2"]),
@@ -211,7 +200,6 @@ def test_try_from_coercible_value():
         key=a,
         value=partitions_def.subset_with_partition_keys(["1"]),
         partitions_def=None,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=partitions_def.subset_with_partition_keys(["1"]),
@@ -222,7 +210,6 @@ def test_try_from_coercible_value():
             key=a,
             value="1",
             partitions_def=None,
-            dynamic_partitions_store=None,
         )
         is None
     )
@@ -232,7 +219,6 @@ def test_try_from_coercible_value():
             key=a,
             value=None,
             partitions_def=partitions_def,
-            dynamic_partitions_store=None,
         )
         is None
     )
@@ -246,7 +232,6 @@ def test_from_coercible_time_partitions():
         key=a,
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
         partitions_def=time_window_partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
@@ -256,7 +241,6 @@ def test_from_coercible_time_partitions():
         key=a,
         value="2024-01-01",
         partitions_def=time_window_partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-01"]),
@@ -267,7 +251,6 @@ def test_from_coercible_time_partitions():
             key=a,
             value="invalid_value",
             partitions_def=time_window_partitions_def,
-            dynamic_partitions_store=None,
         )
 
     assert (
@@ -275,7 +258,6 @@ def test_from_coercible_time_partitions():
             key=a,
             value="invalid_value",
             partitions_def=time_window_partitions_def,
-            dynamic_partitions_store=None,
         )
         is None
     )
@@ -285,7 +267,6 @@ def test_from_coercible_time_partitions():
             key=a,
             value="2024-01-01 12:45:45",
             partitions_def=time_window_partitions_def,
-            dynamic_partitions_store=None,
         )
 
     assert (
@@ -293,7 +274,6 @@ def test_from_coercible_time_partitions():
             key=a,
             value="2024-01-01 12:45:45",
             partitions_def=time_window_partitions_def,
-            dynamic_partitions_store=None,
         )
         is None
     )
@@ -302,7 +282,6 @@ def test_from_coercible_time_partitions():
         key=a,
         value=["2024-01-01 12:45:45", "2024-01-02"],
         partitions_def=time_window_partitions_def,
-        dynamic_partitions_store=None,
     ) == SerializableEntitySubset(
         key=AssetKey("a"),
         value=time_window_partitions_def.subset_with_partition_keys(["2024-01-02"]),
@@ -320,7 +299,6 @@ def test_from_coercible_value_dynamic_partitions():
             key=a,
             value=["1"],
             partitions_def=partitions_def,
-            dynamic_partitions_store=instance,
         ) == SerializableEntitySubset(
             key=a,
             value=partitions_def.subset_with_partition_keys(["1"]),
@@ -332,7 +310,6 @@ def test_from_coercible_value_dynamic_partitions():
             key=a,
             value=["1"],
             partitions_def=partitions_def,
-            dynamic_partitions_store=None,
         ) == SerializableEntitySubset(
             key=a,
             value=partitions_def.subset_with_partition_keys(["1"]),
@@ -342,7 +319,6 @@ def test_from_coercible_value_dynamic_partitions():
             key=a,
             value=["3"],
             partitions_def=partitions_def,
-            dynamic_partitions_store=None,
         ) == SerializableEntitySubset(
             key=a,
             value=partitions_def.subset_with_partition_keys(["3"]),


### PR DESCRIPTION
1. Don't just catch check errors, we might timestamp keys in the wrong format for the partitions definitions, for example
2. Validate partition keys when the subset type is not Default. For now we just allow all keys in the DefaultPartitionSubset, but we may want to add validation eventually. Right now, validating that an asset is in a dynamic partition subset can be expensive, so we won't do it for now