### PR TITLE
Pin onnx

### DIFF
--- a/examples/with_wandb/setup.py
+++ b/examples/with_wandb/setup.py
@@ -8,7 +8,7 @@ setup(
         "dagster-wandb",
         "onnxruntime",
         "skl2onnx",
-        "onnx>=1.13.0",  # Ensure a version is installed that is protobuf 4 compatible
+        "onnx>=1.13.0,<1.18.0",  # Ensure a version is installed that is protobuf 4 compatible
         "joblib",
         "torch",
         "torchvision",


### PR DESCRIPTION
https://buildkite.com/dagster/dagster-dagster/builds/122390#0196ca05-6e98-422d-98e1-9146922c2ec2/451-507

```
E   ImportError: cannot import name 'split_complex_to_pairs' from 'onnx.helper'
```

Looks like 1.18.0 introduced a breaking change. Pinning around it for now.