### PR TITLE
Make `TimeFromNow` component re-render every 5seconds + use it in more spots

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -13,7 +13,6 @@ import {
   UnstyledButton,
   ifPlural,
 } from '@dagster-io/ui-components';
-import dayjs from 'dayjs';
 import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
@@ -33,6 +32,7 @@ import {
   AssetHealthMaterializationHealthyPartitionedMetaFragment,
 } from '../asset-data/types/AssetHealthDataProvider.types';
 import {AssetHealthStatus, AssetKeyInput} from '../graphql/types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 import {numberFormatter} from '../ui/formatters';
 
 export const AssetHealthSummary = React.memo(
@@ -247,7 +247,8 @@ const Criteria = React.memo(
 
           return (
             <Body>
-              Last materialized {dayjs(Number(metadata.lastMaterializedTimestamp * 1000)).fromNow()}{' '}
+              Last materialized{' '}
+              <TimeFromNow unixTimestamp={Number(metadata.lastMaterializedTimestamp)} />
             </Body>
           );
         case undefined:

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -16,6 +16,7 @@ import {
 import {Timestamp} from '../app/time/Timestamp';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 dayjs.extend(relativeTime);
 
@@ -187,7 +188,7 @@ export const TimeSinceWithOverdueColor = ({
 
   return relativeTo === 'now' ? (
     <span style={{color: isOverdue ? Colors.textRed() : Colors.textLight()}}>
-      ({dayjs(timestamp).fromNow()})
+      <TimeFromNow unixTimestamp={timestamp / 1000} />
     </span>
   ) : (
     <span style={{color: isOverdue ? Colors.textRed() : Colors.textLight()}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -7,8 +7,7 @@ import {
   Skeleton,
   useDelayedState,
 } from '@dagster-io/ui-components';
-import dayjs from 'dayjs';
-import React, {useLayoutEffect, useMemo, useState} from 'react';
+import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -24,6 +23,7 @@ import {Timestamp} from '../app/time/Timestamp';
 import {AssetLatestInfoFragment} from '../asset-data/types/AssetBaseDataProvider.types';
 import {AssetHealthFragment} from '../asset-data/types/AssetHealthDataProvider.types';
 import {MaterializationHistoryEventTypeSelector} from '../graphql/types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 
 export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthFragment}) => {
   // Wait 100ms to avoid querying during fast scrolling of the table
@@ -94,7 +94,13 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
       ) : (
         <>
           <EventPopover event={lastEvent}>
-            {lastEvent ? <TimeAgo timestamp={Number(lastEvent.timestamp)} /> : ' - '}
+            {lastEvent ? (
+              <Body color={Colors.textLight()}>
+                <TimeFromNow unixTimestamp={Number(lastEvent.timestamp) / 1000} />
+              </Body>
+            ) : (
+              ' - '
+            )}
           </EventPopover>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>{states}</Box>
           <div style={{height: 13, width: 1, background: Colors.keylineDefault()}} />
@@ -104,17 +110,6 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
     </Box>
   );
 });
-
-function TimeAgo({timestamp}: {timestamp: number}) {
-  const [timeAgo, setTimeAgo] = useState(() => dayjs(timestamp).fromNow());
-  useLayoutEffect(() => {
-    const interval = setInterval(() => {
-      setTimeAgo(dayjs(timestamp).fromNow());
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [timestamp]);
-  return <Body color={Colors.textLight()}>{timeAgo}</Body>;
-}
 
 const Pill = styled.div<{$index: number; $color: string}>`
   border-radius: 2px;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -96,7 +96,10 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
           <EventPopover event={lastEvent}>
             {lastEvent ? (
               <Body color={Colors.textLight()}>
-                <TimeFromNow unixTimestamp={Number(lastEvent.timestamp) / 1000} />
+                <TimeFromNow
+                  unixTimestamp={Number(lastEvent.timestamp) / 1000}
+                  showTooltip={false}
+                />
               </Body>
             ) : (
               ' - '

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
@@ -7,11 +7,11 @@ import {
   MiddleTruncate,
   Tag,
 } from '@dagster-io/ui-components';
-import dayjs from 'dayjs';
 import {Link} from 'react-router-dom';
 import {UserDisplay} from 'shared/runs/UserDisplay.oss';
 import styled from 'styled-components';
 
+import {TimeFromNow} from '../../ui/TimeFromNow';
 import {AssetDefinedInMultipleReposNotice} from '../AssetDefinedInMultipleReposNotice';
 import {AttributeAndValue} from './Common';
 import {CodeLink, getCodeReferenceKey} from '../../code-links/CodeLink';
@@ -78,7 +78,7 @@ export const DefinitionSection = ({
           <RepositoryLink repoAddress={repoAddress!} />
           {location && (
             <Caption color={Colors.textLighter()}>
-              Loaded {dayjs.unix(location.updatedTimestamp).fromNow()}
+              Loaded <TimeFromNow unixTimestamp={location.updatedTimestamp} />
             </Caption>
           )}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/FreshnessPolicySection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/FreshnessPolicySection.tsx
@@ -2,6 +2,7 @@ import {BodySmall, Box, Colors, Popover, Skeleton, Tag} from '@dagster-io/ui-com
 import dayjs from 'dayjs';
 
 import {useAssetHealthData} from '../../asset-data/AssetHealthDataProvider';
+import {TimeFromNow} from '../../ui/TimeFromNow';
 import {statusToIconAndColor} from '../AssetHealthSummary';
 import {AssetKey} from '../types';
 import {AssetTableDefinitionFragment} from '../types/AssetTableFragment.types';
@@ -44,7 +45,7 @@ export const FreshnessPolicySection = ({
         </div>
         {lastMaterializedTimestamp ? (
           <BodySmall color={Colors.textLight()}>
-            Last materialized {dayjs(Number(lastMaterializedTimestamp * 1000)).fromNow()}
+            Last materialized <TimeFromNow unixTimestamp={lastMaterializedTimestamp} />
           </BodySmall>
         ) : (
           <BodySmall color={Colors.textLight()}>No materializations</BodySmall>
@@ -96,7 +97,7 @@ export const FreshnessTag = ({
             <Box padding={{vertical: 8, horizontal: 12}}>
               {lastMaterializedTimestamp ? (
                 <BodySmall>
-                  Last materialized {dayjs(Number(lastMaterializedTimestamp * 1000)).fromNow()}
+                  Last materialized <TimeFromNow unixTimestamp={lastMaterializedTimestamp} />
                 </BodySmall>
               ) : (
                 <BodySmall>No materializations</BodySmall>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TimeFromNow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TimeFromNow.tsx
@@ -1,7 +1,7 @@
 import {Tooltip} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import {memo} from 'react';
+import {memo, useLayoutEffect, useState} from 'react';
 
 import {Timestamp} from '../app/time/Timestamp';
 
@@ -14,15 +14,21 @@ interface Props {
 }
 
 export const TimeFromNow = memo(({unixTimestamp, showTooltip = true}: Props) => {
-  const value = dayjs(unixTimestamp * 1000).fromNow();
+  const [timeAgo, setTimeAgo] = useState(() => dayjs(unixTimestamp * 1000).fromNow());
+  useLayoutEffect(() => {
+    const interval = setInterval(() => {
+      setTimeAgo(dayjs(unixTimestamp * 1000).fromNow());
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [unixTimestamp]);
   return showTooltip ? (
     <Tooltip
       placement="top"
       content={<Timestamp timestamp={{unix: unixTimestamp}} timeFormat={TIME_FORMAT} />}
     >
-      {value}
+      {timeAgo}
     </Tooltip>
   ) : (
-    <span>{value}</span>
+    <span>{timeAgo}</span>
   );
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TimeFromNow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TimeFromNow.tsx
@@ -1,7 +1,7 @@
 import {Tooltip} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import {memo, useLayoutEffect, useState} from 'react';
+import {memo, useLayoutEffect, useRef, useState} from 'react';
 
 import {Timestamp} from '../app/time/Timestamp';
 
@@ -13,14 +13,78 @@ interface Props {
   showTooltip?: boolean;
 }
 
+// Helper: returns ms until the next fromNow breakpoint for a given timestamp
+function getNextFromNowUpdateMs(unixTimestamp: number): number {
+  const now = dayjs();
+  const then = dayjs(unixTimestamp * 1000);
+  const diffSec = Math.abs(now.diff(then, 'second'));
+  const diffMin = Math.abs(now.diff(then, 'minute'));
+  const diffHour = Math.abs(now.diff(then, 'hour'));
+  const diffDay = Math.abs(now.diff(then, 'day'));
+  const diffMonth = Math.abs(now.diff(then, 'month'));
+  const diffYear = Math.abs(now.diff(then, 'year'));
+
+  // See: https://day.js.org/docs/en/display/from-now#list-of-breakdown-range
+  if (diffSec < 45) {
+    // Next change at 45s
+    return (45 - diffSec) * 1000;
+  } else if (diffSec < 90) {
+    // Next change at 90s
+    return (90 - diffSec) * 1000;
+  } else if (diffMin < 45) {
+    // Next change at next minute
+    const nextMin = then.add(diffMin + 1, 'minute');
+    return Math.abs(nextMin.diff(now, 'millisecond'));
+  } else if (diffMin < 90) {
+    // Next change at 90min
+    return (90 * 60 - diffSec) * 1000;
+  } else if (diffHour < 22) {
+    // Next change at next hour
+    const nextHour = then.add(diffHour + 1, 'hour');
+    return Math.abs(nextHour.diff(now, 'millisecond'));
+  } else if (diffHour < 36) {
+    // Next change at 36h
+    return (36 * 60 * 60 - diffSec) * 1000;
+  } else if (diffDay < 25) {
+    // Next change at next day
+    const nextDay = then.add(diffDay + 1, 'day');
+    return Math.abs(nextDay.diff(now, 'millisecond'));
+  } else if (diffDay < 45) {
+    // Next change at 46d
+    return (46 * 24 * 60 * 60 - diffSec) * 1000;
+  } else if (diffMonth < 11) {
+    // Next change at next month
+    const nextMonth = then.add(diffMonth + 1, 'month');
+    return Math.abs(nextMonth.diff(now, 'millisecond'));
+  } else if (diffYear < 1.5) {
+    // Next change at 1.5y (18 months)
+    const nextYear = then.add(1.5, 'year');
+    return Math.abs(nextYear.diff(now, 'millisecond'));
+  } else {
+    // Next change at next year
+    const nextYear = then.add(diffYear + 1, 'year');
+    return Math.abs(nextYear.diff(now, 'millisecond'));
+  }
+}
+
 export const TimeFromNow = memo(({unixTimestamp, showTooltip = true}: Props) => {
   const [timeAgo, setTimeAgo] = useState(() => dayjs(unixTimestamp * 1000).fromNow());
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
   useLayoutEffect(() => {
-    const interval = setInterval(() => {
+    function scheduleUpdate() {
       setTimeAgo(dayjs(unixTimestamp * 1000).fromNow());
-    }, 5000);
-    return () => clearInterval(interval);
+      const nextMs = Math.max(1000, getNextFromNowUpdateMs(unixTimestamp));
+      timeoutRef.current = setTimeout(scheduleUpdate, nextMs);
+    }
+    scheduleUpdate();
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
   }, [unixTimestamp]);
+
   return showTooltip ? (
     <Tooltip
       placement="top"

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedObserveJobRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedObserveJobRow.tsx
@@ -17,6 +17,7 @@ import {forwardRef, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
 import {SINGLE_JOB_QUERY} from './SingleJobQuery';
+import {TimeFromNow} from '../ui/TimeFromNow';
 import {SingleJobQuery, SingleJobQueryVariables} from './types/SingleJobQuery.types';
 import {JobMenu} from '../instance/JobMenu';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
@@ -102,7 +103,7 @@ export const VirtualizedObserveJobRow = forwardRef(
                   <HoverButton>
                     <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
                       <RunStatusIndicator status={latestRuns[0].status} />
-                      {dayjs(latestRuns[0].startTime * 1000).fromNow()}
+                      <TimeFromNow unixTimestamp={latestRuns[0].startTime} />
                     </Box>
                   </HoverButton>
                 </Popover>


### PR DESCRIPTION
## Summary & Motivation

Makes the TimeFromNow component re-render every 5 seconds so that the time updates. Also uses it in more spots since the tooltip functionality is useful generally

## How I Tested These Changes

<img width="293" alt="Screenshot 2025-05-13 at 11 48 29 AM" src="https://github.com/user-attachments/assets/bd6bbf5f-f4a5-4879-a8ce-df9322e88c75" />
<img width="325" alt="Screenshot 2025-05-13 at 11 48 26 AM" src="https://github.com/user-attachments/assets/74e3596a-01ef-4f53-9cfa-25d6833df7be" />
<img width="329" alt="Screenshot 2025-05-13 at 11 57 00 AM" src="https://github.com/user-attachments/assets/8976b83d-218d-4128-8e8e-6ff742e3686b" />
<img width="496" alt="Screenshot 2025-05-13 at 11 48 24 AM" src="https://github.com/user-attachments/assets/24866498-4558-490d-b942-92a19fd45b25" />

<img width="335" alt="Screenshot 2025-05-13 at 11 57 19 AM" src="https://github.com/user-attachments/assets/23cb8878-6f65-4d9d-a6ad-47c848a4f60f" />

