### PR TITLE
Add virtual env folder to PATH when using a venv executable_path in dagster dev

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -112,6 +112,7 @@ from dagster._utils.container import (
 )
 from dagster._utils.env import use_verbose, using_dagster_dev
 from dagster._utils.error import serializable_error_info_from_exc_info, unwrap_user_code_error
+from dagster._utils.path import is_likely_venv_executable
 from dagster._utils.typed_dict import init_optional_typeddict
 
 if TYPE_CHECKING:
@@ -1420,7 +1421,6 @@ def open_server_process(
     startup_timeout: int = 20,
     cwd: Optional[str] = None,
     log_level: str = "INFO",
-    env: Optional[dict[str, str]] = None,
     inject_env_vars_from_instance: bool = True,
     container_image: Optional[str] = None,
     container_context: Optional[dict[str, Any]] = None,
@@ -1458,8 +1458,20 @@ def open_server_process(
         subprocess_args += loadable_target_origin.get_cli_args()
 
     env = {
-        **(env or os.environ),
+        **os.environ,
     }
+
+    if (
+        executable_path
+        and is_likely_venv_executable(executable_path)
+        and executable_path != sys.executable
+    ):
+        # ensure that if a venv is being used as an executable path that the same PATH
+        # that would be set if the venv was activated is also set in the launched
+        # subprocess
+        current_path = os.environ.get("PATH")
+        added_path = os.path.dirname(executable_path)
+        env["PATH"] = f"{added_path}{os.pathsep}{current_path}" if current_path else added_path
 
     # Unset click environment variables in the current environment
     # that might conflict with arguments that we're using
@@ -1533,7 +1545,6 @@ class GrpcServerProcess:
         startup_timeout: int = 20,
         cwd: Optional[str] = None,
         log_level: str = "INFO",
-        env: Optional[dict[str, str]] = None,
         wait_on_exit=False,
         inject_env_vars_from_instance: bool = True,
         container_image: Optional[str] = None,
@@ -1575,7 +1586,6 @@ class GrpcServerProcess:
         self._startup_timeout = startup_timeout
         self._cwd = cwd
         self._log_level = log_level
-        self._env = env
         self._inject_env_vars_from_instance = inject_env_vars_from_instance
         self._container_image = container_image
         self._container_context = container_context
@@ -1597,7 +1607,6 @@ class GrpcServerProcess:
             startup_timeout=self._startup_timeout,
             cwd=self._cwd,
             log_level=self._log_level,
-            env=self._env,
             inject_env_vars_from_instance=self._inject_env_vars_from_instance,
             container_image=self._container_image,
             container_context=self._container_context,

--- a/python_modules/dagster/dagster/_utils/path.py
+++ b/python_modules/dagster/dagster/_utils/path.py
@@ -1,0 +1,6 @@
+import os
+
+
+def is_likely_venv_executable(executable_path: str) -> bool:
+    # venvs have a file called activate in the same bin directory as the Python executable
+    return os.path.exists(os.path.join(os.path.dirname(executable_path), "activate"))

--- a/python_modules/dagster/dagster_tests/utils_tests/test_path.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_path.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from dagster._utils.path import is_likely_venv_executable
+
+
+@pytest.fixture
+def temp_venv():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_venv = Path(temp_dir) / "venv"
+        try:
+            # Check if uv is installed
+            subprocess.run(["uv", "--version"], check=True, capture_output=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            raise Exception("uv is not installed or not in PATH")
+
+        # Create a new virtual environment using uv
+        result = subprocess.run(
+            ["uv", "venv", temp_dir_venv, "--seed"], check=True, capture_output=True, text=True
+        )
+        assert result.returncode == 0, f"Failed to create virtual environment: {result.stderr}"
+
+        python_executable = temp_dir_venv / "bin" / "python"
+        yield python_executable
+
+
+def test_is_likely_venv_executable(temp_venv):
+    assert is_likely_venv_executable(temp_venv)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        assert not is_likely_venv_executable(os.path.join(temp_dir, "python"))


### PR DESCRIPTION
## Summary & Motivation
Fix an issue where running `dg` in a workspace that depends on executables in the constituent projects wasn't actually referencing those
 
## How I Tested These Changes
New test case, run dg dev in a workspace against a project with dbt installed and verify that it is referencing the one in the project now

## Changelog
Fixed an issue where specifying `executable_path` in a workspace.yaml file to run code locations in a different virtual environment would not correctly inherit the PATH of that virtual environment in the code location.
