### PR TITLE
Skip health live data machinery completely if flag is off

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -80,7 +80,7 @@ export function useAssetsHealthData(
   assetKeys: AssetKeyInput[],
   thread: LiveDataThreadID = 'AssetHealth', // Use AssetHealth to get 250 batch size
 ) {
-  const keys = memoizedAssetKeys(assetKeys);
+  const keys = memoizedAssetKeys(featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? assetKeys : []);
   const result = AssetHealthData.useLiveData(keys, thread);
   useBlockTraceUntilTrue(
     'useAssetsHealthData',


### PR DESCRIPTION
## Summary & Motivation
Currently even though we don't do the health query when the flag is off we still end up doing a bunch of work that can cause the browser the crash for orgs with large numbers of assets. Pass an empty array to basically turn this into a no-op. 