### PR TITLE
Pass DAGSTER_GIT_REPO_DIR through to tox

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
     include:
       - master
       - windows/*
-      - */azure/*
+      - *azure*
 pr: none
 parameters:
   - name: py3_versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ jobs:
             ${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}:
               PACKAGE_ROOT: "python_modules\\dagster"
               PATH_BACK_TO_REPO_ROOT: "..\\.."
-              DAGSTER_GIT_REPO_DIR: "..\\.."
               TOX_ENV: "py${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}"
               PYTHON_VERSION: "${{ py_version }}"
 
@@ -41,7 +40,6 @@ jobs:
           dagster-dg-${{ replace(py_version, '.', '') }}:
             PACKAGE_ROOT: "python_modules\\libraries\\dagster-dg"
             PATH_BACK_TO_REPO_ROOT: "..\\..\\.."
-            DAGSTER_GIT_REPO_DIR: "..\\..\\.."
             TOX_ENV: windows
             PYTHON_VERSION: "${{ py_version }}"
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
     include:
       - master
       - windows/*
+      - */azure/*
 pr: none
 parameters:
   - name: py3_versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
             ${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}:
               PACKAGE_ROOT: "python_modules\\dagster"
               PATH_BACK_TO_REPO_ROOT: "..\\.."
+              DAGSTER_GIT_REPO_DIR: "..\\.."
               TOX_ENV: "py${{ replace(py_version, '.', '') }}-windows-${{ env_suffix }}"
               PYTHON_VERSION: "${{ py_version }}"
 
@@ -37,6 +38,7 @@ jobs:
           dagster-dg-${{ replace(py_version, '.', '') }}:
             PACKAGE_ROOT: "python_modules\\libraries\\dagster-dg"
             PATH_BACK_TO_REPO_ROOT: "..\\..\\.."
+            DAGSTER_GIT_REPO_DIR: "..\\..\\.."
             TOX_ENV: windows
             PYTHON_VERSION: "${{ py_version }}"
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,9 @@ trigger:
     include:
       - master
       - windows/*
-      - *azure*
+  paths:
+    include:
+      - azure-pipelines.yml
 pr: none
 parameters:
   - name: py3_versions


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/29725 regressed our Windows tests because the env var was not set on our Azure runners.