### PR TITLE
Revert "hide evaluations button if shown on evaluations table (#29647)"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationDetailDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationDetailDialog.tsx
@@ -38,7 +38,6 @@ interface Props {
   assetCheckName?: string;
   evaluationID: string;
   initialTab?: Tab;
-  showEvaluationsButton?: boolean;
 }
 
 export const EvaluationDetailDialog = ({
@@ -48,7 +47,6 @@ export const EvaluationDetailDialog = ({
   assetKeyPath,
   assetCheckName,
   initialTab = 'evaluation',
-  showEvaluationsButton = true,
 }: Props) => {
   return (
     <Dialog isOpen={isOpen} onClose={onClose} style={EvaluationDetailDialogStyle}>
@@ -58,7 +56,6 @@ export const EvaluationDetailDialog = ({
         initialAssetCheckName={assetCheckName}
         onClose={onClose}
         initialTab={initialTab}
-        showEvaluationsButton={showEvaluationsButton}
       />
     </Dialog>
   );
@@ -70,7 +67,6 @@ interface ContentProps {
   initialAssetCheckName?: string;
   onClose: () => void;
   initialTab?: Tab;
-  showEvaluationsButton?: boolean;
 }
 
 const EvaluationDetailDialogContents = ({
@@ -79,7 +75,6 @@ const EvaluationDetailDialogContents = ({
   initialAssetCheckName,
   onClose,
   initialTab = 'evaluation',
-  showEvaluationsButton = true,
 }: ContentProps) => {
   const [selectedPartition, setSelectedPartition] = useState<string | null>(null);
   const [tabId, setTabId] = useState<Tab>(initialTab);
@@ -277,12 +272,8 @@ const EvaluationDetailDialogContents = ({
       }
       body={body()}
       viewAllButton={
-        showEvaluationsButton && viewAllPath ? (
-          <AnchorButton
-            to={viewAllPath}
-            icon={<Icon name="automation_condition" />}
-            onClick={(e) => e.stopPropagation()}
-          >
+        viewAllPath ? (
+          <AnchorButton to={viewAllPath} icon={<Icon name="automation_condition" />}>
             View evaluations for this asset
           </AnchorButton>
         ) : null

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationListRow.tsx
@@ -65,7 +65,6 @@ export const EvaluationListRow = ({evaluation, assetKey, assetCheckName, isParti
         assetKeyPath={assetKey.path}
         assetCheckName={assetCheckName}
         initialTab={tab}
-        showEvaluationsButton={false}
       />
     </>
   );


### PR DESCRIPTION
## Summary & Motivation
In order to avoid cross-push issues, reverting all the frontend DA changes until after the graphql changes go out.

## How I Tested These Changes
BK

