### PR TITLE
[dagster-fivetran] Support setting group names on per-asset basis thru translator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -181,7 +181,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 "node_def is None, so keys_by_output_name must be empty",
             )
             check.invariant(
-                backfill_policy is None, "node_def is None, so backfill_policy must be None"
+                backfill_policy is None,
+                "node_def is None, so backfill_policy must be None",
             )
             check.invariant(not can_subset, "node_def is None, so can_subset must be False")
             self._computation = None
@@ -243,7 +244,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
 
         else:
             computation_not_none = check.not_none(
-                self._computation, "If specs are not provided, a node_def must be provided"
+                self._computation,
+                "If specs are not provided, a node_def must be provided",
             )
             all_asset_keys = set(computation_not_none.keys_by_output_name.values())
 
@@ -653,7 +655,10 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         keys_by_input_name = _infer_keys_by_input_names(
             node_def,
             check.opt_mapping_param(
-                keys_by_input_name, "keys_by_input_name", key_type=str, value_type=AssetKey
+                keys_by_input_name,
+                "keys_by_input_name",
+                key_type=str,
+                value_type=AssetKey,
             ),
         )
         keys_by_output_name = check.opt_mapping_param(
@@ -973,7 +978,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         }
 
     @property
-    def auto_materialize_policies_by_key(self) -> Mapping[AssetKey, AutoMaterializePolicy]:
+    def auto_materialize_policies_by_key(
+        self,
+    ) -> Mapping[AssetKey, AutoMaterializePolicy]:
         return {
             key: spec.auto_materialize_policy
             for key, spec in self._specs_by_key.items()
@@ -1395,7 +1402,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         if key is not None:
             resolved_key = AssetKey.from_coercible(key)
             check.invariant(
-                resolved_key in self.keys, f"Key {resolved_key} not found in AssetsDefinition"
+                resolved_key in self.keys,
+                f"Key {resolved_key} not found in AssetsDefinition",
             )
         else:
             resolved_key = self.key
@@ -1831,7 +1839,8 @@ def _validate_self_deps(specs: Iterable[AssetSpec]) -> None:
 
 
 def get_self_dep_time_window_partition_mapping(
-    partition_mapping: Optional[PartitionMapping], partitions_def: Optional[PartitionsDefinition]
+    partition_mapping: Optional[PartitionMapping],
+    partitions_def: Optional[PartitionsDefinition],
 ) -> Optional[TimeWindowPartitionMapping]:
     """Returns a time window partition mapping dimension of the provided partition mapping,
     if exists.
@@ -1856,7 +1865,9 @@ def get_self_dep_time_window_partition_mapping(
 
 
 def get_partition_mappings_from_deps(
-    partition_mappings: dict[AssetKey, PartitionMapping], deps: Iterable[AssetDep], asset_name: str
+    partition_mappings: dict[AssetKey, PartitionMapping],
+    deps: Iterable[AssetDep],
+    asset_name: str,
 ) -> Mapping[AssetKey, PartitionMapping]:
     # Add PartitionMappings specified via AssetDeps to partition_mappings dictionary. Error on duplicates
     for dep in deps:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -146,7 +146,6 @@ def _build_fivetran_assets(
     @multi_asset(
         name=f"fivetran_sync_{connector_id}",
         resource_defs=resource_defs,
-        group_name=group_name,
         op_tags=op_tags,
         specs=[
             AssetSpec(
@@ -159,6 +158,7 @@ def _build_fivetran_assets(
                     **build_kind_tag("fivetran"),
                     **(asset_tags or {}),
                 },
+                group_name=group_name,
             )
             if not translator_instance or not connection_metadata
             else translator_instance.get_asset_spec(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -9,6 +9,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
 from dagster._record import as_dict, record
 from dagster._utils.cached_method import cached_method
+from dagster._utils.names import clean_name_lower
 from dagster._vendored.dateutil import parser
 from dagster_shared.serdes import whitelist_for_serdes
 from typing_extensions import TypeAlias
@@ -337,4 +338,5 @@ class DagsterFivetranTranslator:
             key=AssetKey(props.table.split(".")),
             metadata=augmented_metadata,
             kinds={"fivetran", *({props.service} if props.service else set())},
+            group_name=clean_name_lower(props.name),
         )


### PR DESCRIPTION
## Summary

Right now, the Fivetran multi-asset is still built setting a group name on the `multi_asset` itself. This errors if you try to return an `AssetSpec` from the translator with a group name attached. This PR moves the group name to specs, and tests that a translator can properly alter the group name of an asset.