### PR TITLE
Enforce lower limit of 1 minute for time window freshness parameters

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/freshness.py
+++ b/python_modules/dagster-test/dagster_test/toys/freshness.py
@@ -29,7 +29,7 @@ def asset_with_time_window_freshness_and_warning():
 
 @dg.asset(
     internal_freshness_policy=InternalFreshnessPolicy.time_window(
-        fail_window=timedelta(seconds=60), warn_window=timedelta(seconds=30)
+        fail_window=timedelta(seconds=120), warn_window=timedelta(seconds=60)
     )
 )
 def asset_with_time_window_freshness_fast_fail():

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -68,11 +68,13 @@ class TimeWindowFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
     @classmethod
     def from_timedeltas(cls, fail_window: timedelta, warn_window: Optional[timedelta] = None):
         check.invariant(
-            fail_window.total_seconds() >= 60, "fail_window cannot be less than 1 minute"
+            fail_window.total_seconds() >= 60,
+            "Due to Dagster system constraints, fail_window cannot be less than 1 minute",
         )
         if warn_window:
             check.invariant(
-                warn_window.total_seconds() >= 60, "warn_window cannot be less than 1 minute"
+                warn_window.total_seconds() >= 60,
+                "Due to Dagster system constraints, warn_window cannot be less than 1 minute",
             )
             check.invariant(warn_window < fail_window, "warn_window must be less than fail_window")
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -67,7 +67,13 @@ class TimeWindowFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
 
     @classmethod
     def from_timedeltas(cls, fail_window: timedelta, warn_window: Optional[timedelta] = None):
+        check.invariant(
+            fail_window.total_seconds() >= 60, "fail_window cannot be less than 1 minute"
+        )
         if warn_window:
+            check.invariant(
+                warn_window.total_seconds() >= 60, "warn_window cannot be less than 1 minute"
+            )
             check.invariant(warn_window < fail_window, "warn_window must be less than fail_window")
 
         return cls(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -164,6 +164,7 @@ def test_internal_freshness_policy_fail_window_validation() -> None:
         )
 
     # exactly 1 minute is ok
+    InternalFreshnessPolicy.time_window(fail_window=timedelta(seconds=60))
     InternalFreshnessPolicy.time_window(
         fail_window=timedelta(seconds=61), warn_window=timedelta(minutes=1)
     )


### PR DESCRIPTION
## Summary & Motivation

As discussed in https://dagsterlabs.slack.com/archives/C08F6TSCFCJ/p1746226913600029, it does not make sense to have time window freshness policies with fail or warn windows shorter than 1 minute. This PR adds validation to enforce this limit.

Technically a breaking change but should be safe since we don't have any external users creating the new freshness policies yet. We'll advise the freshness design partners of these limits ahead of launch. Will also add to the new freshness docs in a stacked PR.

## How I Tested These Changes
bk

## Changelog

> Insert changelog entry or delete this section.
