### PR TITLE
[dagster-airbyte] Raise custom exception on conflicting group_name in Airbyte asset decorator

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -23,7 +23,7 @@ def airbyte_assets(
         workspace (AirbyteCloudWorkspace): The Airbyte workspace to fetch assets from.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
-            If set, this value will be used for all assets in the asset group. Defaults to None.
+            If set, this value will be used as the group name for all assets in the asset group. Defaults to None.
         dagster_airbyte_translator (Optional[DagsterAirbyteTranslator], optional): The translator to use
             to convert Airbyte content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterAirbyteTranslator`.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -101,10 +101,9 @@ def airbyte_assets(
 
     return multi_asset(
         name=name,
-        group_name=group_name,
         can_subset=True,
         specs=[
-            spec
+            spec.replace_attributes(group_name=group_name if group_name else ...)
             for spec in workspace.load_asset_specs(
                 dagster_airbyte_translator=dagster_airbyte_translator
             )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -117,7 +117,7 @@ def airbyte_assets(
 
     return multi_asset(
         name=name,
-        group_name=name,
+        group_name=group_name,
         can_subset=True,
         specs=specs,
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -24,7 +24,6 @@ def airbyte_assets(
         workspace (AirbyteCloudWorkspace): The Airbyte workspace to fetch assets from.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
-            If set, this value will be used as the group name for all assets in the asset group. Defaults to None.
         dagster_airbyte_translator (Optional[DagsterAirbyteTranslator], optional): The translator to use
             to convert Airbyte content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterAirbyteTranslator`.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -112,7 +112,7 @@ def airbyte_assets(
     if any([spec for spec in specs if spec.group_name]) and group_name:
         raise DagsterInvariantViolationError(
             "Cannot set group_name parameter on airbyte_assets if one or more of the "
-            "airbyte asset specs have a group_name defined."
+            "Airbyte asset specs have a group_name defined."
         )
 
     return multi_asset(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -23,6 +23,7 @@ def airbyte_assets(
         workspace (AirbyteCloudWorkspace): The Airbyte workspace to fetch assets from.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
+            If set, this value will be used for all assets in the asset group. Defaults to None.
         dagster_airbyte_translator (Optional[DagsterAirbyteTranslator], optional): The translator to use
             to convert Airbyte content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterAirbyteTranslator`.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
@@ -1,10 +1,13 @@
+from typing import Optional
+
+import pytest
 import responses
-from dagster._config.field_utils import EnvVar
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster import AssetExecutionContext, AssetSpec, EnvVar
 from dagster._core.definitions.tags import has_kind
 from dagster._core.test_utils import environ
 from dagster_airbyte import (
     AirbyteCloudWorkspace,
+    airbyte_assets,
     build_airbyte_assets_definitions,
     load_airbyte_cloud_asset_specs,
 )
@@ -164,7 +167,7 @@ def test_translator_custom_metadata(
         assert has_kind(asset_spec.tags, TEST_DESTINATION_TYPE)
 
 
-class MyAssetFactoryCustomTranslator(DagsterAirbyteTranslator):
+class MyCustomTranslatorWithGroupName(DagsterAirbyteTranslator):
     def get_asset_spec(self, data: AirbyteConnectionTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
         default_spec = super().get_asset_spec(data)
         return default_spec.replace_attributes(group_name="my_group_name")
@@ -183,9 +186,47 @@ def test_translator_custom_group_name_with_asset_factory(
         )
 
         my_airbyte_assets = build_airbyte_assets_definitions(
-            workspace=workspace, dagster_airbyte_translator=MyAssetFactoryCustomTranslator()
+            workspace=workspace, dagster_airbyte_translator=MyCustomTranslatorWithGroupName()
         )
 
         first_assets_def = next(assets_def for assets_def in my_airbyte_assets)
         first_asset_spec = next(asset_spec for asset_spec in first_assets_def.specs)
         assert first_asset_spec.group_name == "my_group_name"
+
+
+@pytest.mark.parametrize(
+    "asset_decorator_group_name, expected_group_name",
+    [
+        (None, "my_group_name"),
+        ("my_asset_decorator_group_name", "my_asset_decorator_group_name"),
+    ],
+    ids=[
+        "custom_group_name_translator",
+        "custom_group_name_asset_decorator",
+    ],
+)
+def test_translator_custom_group_name_with_asset_decorator(
+    asset_decorator_group_name: Optional[str],
+    expected_group_name: str,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ(
+        {"AIRBYTE_CLIENT_ID": TEST_CLIENT_ID, "AIRBYTE_CLIENT_SECRET": TEST_CLIENT_SECRET}
+    ):
+        workspace = AirbyteCloudWorkspace(
+            workspace_id=TEST_WORKSPACE_ID,
+            client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+            client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
+        )
+
+        @airbyte_assets(
+            connection_id=TEST_CONNECTION_ID,
+            workspace=workspace,
+            group_name=asset_decorator_group_name,
+            dagster_airbyte_translator=MyCustomTranslatorWithGroupName(),
+        )
+        def my_airbyte_assets(context: AssetExecutionContext, airbyte: AirbyteCloudWorkspace):
+            yield from airbyte.sync_and_poll(context=context)
+
+        first_asset_spec = next(asset_spec for asset_spec in my_airbyte_assets.specs)
+        assert first_asset_spec.group_name == expected_group_name

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
@@ -1,6 +1,6 @@
 import pytest
 import responses
-from dagster import AssetExecutionContext, AssetSpec, EnvVar
+from dagster import AssetSpec, EnvVar
 from dagster._core.definitions.tags import has_kind
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.test_utils import environ
@@ -216,6 +216,4 @@ def test_translator_invariant_group_name_with_asset_decorator(
                 group_name="my_asset_decorator_group_name",
                 dagster_airbyte_translator=MyCustomTranslatorWithGroupName(),
             )
-            def my_airbyte_assets(
-                context: AssetExecutionContext, airbyte: AirbyteCloudWorkspace
-            ): ...
+            def my_airbyte_assets(): ...


### PR DESCRIPTION
## Summary & Motivation

Following changes made in https://github.com/dagster-io/dagster/pull/29968.

~~This PR sets the `group_name` using `replace_attributes(group_name=...)` in the Airbyte asset decorator instead of passing the group name to the multi-asset definitions. This allows users to either set the `group_name` at the spec level in the translator or the asset decorator level without raising an exception.~~

~~Note that if a `group_name` is passed to the asset decorator, it overrides the group name set in the spec.~~

Edit:

After discussion with @benpankow, we will explicitly disallow setting a group name on the asset decorator and in the translator by raising a custom exception.

## How I Tested These Changes

Additional tests with BK
