### PR TITLE
Fix components test flake

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -132,7 +132,7 @@ def create_project_from_components(
     """Scaffolds a project with the given components in a temporary directory,
     injecting the provided local component defn into each component's __init__.py.
     """
-    location_name = f"my_location_{str(random.random()).replace('.', '')}"
+    location_name = f"my_location_{random.randint(0, 2**32 - 1)}"
 
     # Using mkdtemp instead of TemporaryDirectory so that the directory is accessible
     # from launched procsses (such as duckdb)


### PR DESCRIPTION
Summary:
Previous code sporadically returns something like '9409213471622824e-05' instead of the desired random integer, causing the test to flakily fail.

## How I Tested These Changes
BK