### PR TITLE
Make create_temp_workspace_file in dagster-dg match the temporary workspace file creation path that dagster dev uses

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/index/34-dg-component-check-defs.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/34-dg-component-check-defs.txt
@@ -1,7 +1,7 @@
 dg check defs
 
 All components validated successfully.
-dagster definitions validate --log-level warning --log-format colored --workspace /tmp/workspace
+dagster definitions validate --log-level warning --log-format colored --workspace /tmp/workspace.yaml
 
 INFO:dagster.builtin:Running dbt command: `dbt parse --quiet`.
 INFO:dagster.builtin:Finished dbt command: `dbt parse --quiet`.

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/utils.py
@@ -21,8 +21,8 @@ MASK_SLING_DOWNLOAD_DUCKDB = (r".*downloading duckdb.*\n", "")
 MASK_EDITABLE_DAGSTER = (r" --use-editable-dagster", "")
 MASK_USING_ENVIRONMENT = (r"\nUsing[\s\S]*", "\n...")
 MASK_TMP_WORKSPACE = (
-    r"--workspace (/var/folders/.+|/tmp/tmp\w+)",
-    "--workspace /tmp/workspace",
+    r"--workspace (/var/folders/.+|/tmp/.+)",
+    "--workspace /tmp/workspace.yaml",
 )
 MASK_PLUGIN_CACHE_REBUILD = (r"Plugin object cache is invalidated or empty.*\n", "")
 # Kind of a hack, "Running `uv sync` ..." appears after you enter "y" at the prompt, but when we
@@ -61,6 +61,7 @@ SNIPPET_ENV = {
     "VIRTUAL_ENV": "",
     "HOME": "/tmp",
     "DAGSTER_GIT_REPO_DIR": str(DAGSTER_ROOT),
+    "UV_PYTHON": "3.12",
 }
 
 


### PR DESCRIPTION
## Summary & Motivation
The previous implementation has windows-specific problems. Use the same method that we use without issue for `dagster dev` currently instead. Addresses https://github.com/dagster-io/dagster/issues/28681.

## How I Tested These Changes
Run dg dev in windows CI, no more file permissions errors

## Changelog
[dg] Fixed an issue where `dg dev` failed with a temporarily file permissions error when running on Windows. Thanks [@polivbr](https://github.com/polivbr)!
