### PR TITLE
Use MurmurHash3 to hash keys for indexeddb caching

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -2,6 +2,7 @@ import memoize from 'lodash/memoize';
 import LRU from 'lru-cache';
 
 import {timeByParts} from './timeByParts';
+import {hashObject} from '../util/hashObject';
 import {cache} from '../util/idb-lru-cache';
 import {weakMapMemoize} from '../util/weakMapMemoize';
 
@@ -147,8 +148,8 @@ export function asyncMemoize<T, R, U extends (arg: T, ...rest: any[]) => Promise
 
 export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R>>(
   fn: U,
+  key: string,
   hashFn?: (...args: Parameters<U>) => any,
-  key?: string,
 ): U & {
   isCached: (...args: Parameters<U>) => Promise<boolean>;
 } => {
@@ -163,18 +164,7 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
   const hashToPromise: Record<string, Promise<R>> = {};
 
   const genHashKey = async (...args: Parameters<U>) => {
-    const hash = hashFn ? hashFn(...args) : args;
-
-    const encoder = new TextEncoder();
-    // Crypto.subtle isn't defined in insecure contexts... fallback to using the full string as a key
-    // https://stackoverflow.com/questions/46468104/how-to-use-subtlecrypto-in-chrome-window-crypto-subtle-is-undefined
-    if (crypto.subtle?.digest) {
-      const data = encoder.encode(hash.toString());
-      const hashBuffer = await crypto.subtle.digest('SHA-1', data);
-      const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
-      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join(''); // convert bytes to hex string
-    }
-    return hash.toString();
+    return hashFn ? hashFn(...args) : hashObject(args);
   };
 
   const ret = weakMapMemoize(async (...args: Parameters<U>) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -25,6 +25,7 @@ import {AssetKey} from '../assets/types';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {useIndexedDBCachedQuery} from '../search/useIndexedDBCachedQuery';
+import {hashObject} from '../util/hashObject';
 import {workerSpawner} from '../workers/workerSpawner';
 
 export interface AssetGraphFetchScope {
@@ -277,9 +278,8 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 
 const computeGraphData = indexedDBAsyncMemoize<GraphDataState, typeof computeGraphDataWrapper>(
   computeGraphDataWrapper,
-  (props) => {
-    return JSON.stringify(props);
-  },
+  'computeGraphData',
+  (props) => hashObject(props),
 );
 
 const buildGraphQueryItems = (nodes: AssetNode[]) => {
@@ -453,9 +453,8 @@ async function computeGraphDataWrapper(
 
 const buildGraphData = indexedDBAsyncMemoize<GraphData, typeof buildGraphDataWrapper>(
   buildGraphDataWrapper,
-  (props) => {
-    return JSON.stringify(props);
-  },
+  'buildGraphData',
+  (props) => hashObject(props),
 );
 
 async function buildGraphDataWrapper(

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -43,13 +43,8 @@ const _assetLayoutCacheKey = weakMapMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
     return hashObject({
       opts,
+      graphData,
       version: 4,
-      downstream: graphData.downstream,
-      upstream: graphData.upstream,
-      nodes: Object.keys(graphData.nodes)
-        .sort()
-        .map((key) => graphData.nodes[key]),
-      expandedGroups: graphData.expandedGroups,
     });
   },
 );

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -9,6 +9,7 @@ import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
 import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {hashObject} from '../util/hashObject';
 import {weakMapMemoize} from '../util/weakMapMemoize';
 import {workerSpawner} from '../workers/workerSpawner';
 
@@ -40,39 +41,16 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 
 const _assetLayoutCacheKey = weakMapMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
-    // Note: The "show secondary edges" toggle means that we need a cache key that incorporates
-    // both the displayed nodes and the displayed edges.
-
-    // Make the cache key deterministic by alphabetically sorting all of the keys since the order
-    // of the keys is not guaranteed to be consistent even when the graph hasn't changed.
-
-    function recreateObjectWithKeysSorted(obj: Record<string, Record<string, boolean>>) {
-      const newObj: Record<string, Record<string, boolean>> = {};
-      Object.keys(obj)
-        .sort()
-        .forEach((key) => {
-          newObj[key] = Object.keys(obj[key]!)
-            .sort()
-            .reduce(
-              (acc, k) => {
-                acc[k] = obj[key]![k]!;
-                return acc;
-              },
-              {} as Record<string, boolean>,
-            );
-        });
-      return newObj;
-    }
-
-    return `${JSON.stringify(opts)}${JSON.stringify({
+    return hashObject({
+      opts,
       version: 4,
-      downstream: recreateObjectWithKeysSorted(graphData.downstream),
-      upstream: recreateObjectWithKeysSorted(graphData.upstream),
+      downstream: graphData.downstream,
+      upstream: graphData.upstream,
       nodes: Object.keys(graphData.nodes)
         .sort()
         .map((key) => graphData.nodes[key]),
       expandedGroups: graphData.expandedGroups,
-    })}`;
+    });
   },
 );
 
@@ -101,6 +79,7 @@ export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
       worker.postMessage({type: 'layoutAssetGraph', opts, graphData});
     });
   },
+  'asyncGetFullAssetLayoutIndexDB',
   _assetLayoutCacheKey,
 );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/hashObject.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/__tests__/hashObject.test.ts
@@ -1,0 +1,146 @@
+import {hashObject} from '../hashObject';
+
+describe('hashObject', () => {
+  // Test primitive values
+  test('handles primitive values correctly', () => {
+    expect(hashObject(null)).toBeTruthy();
+    expect(hashObject(123)).toBeTruthy();
+    expect(hashObject('test')).toBeTruthy();
+    expect(hashObject(true)).toBeTruthy();
+    expect(hashObject(false)).toBeTruthy();
+  });
+
+  // Test primitive values return consistent hashes
+  test('returns consistent hashes for primitive values', () => {
+    expect(hashObject(null)).toEqual(hashObject(null));
+    expect(hashObject(123)).toEqual(hashObject(123));
+    expect(hashObject('test')).toEqual(hashObject('test'));
+    expect(hashObject(true)).toEqual(hashObject(true));
+  });
+
+  // Test empty structures
+  test('handles empty structures correctly', () => {
+    expect(hashObject([])).toBeTruthy();
+    expect(hashObject({})).toBeTruthy();
+    expect(hashObject([])).not.toEqual(hashObject({}));
+  });
+
+  // Test arrays
+  test('handles arrays correctly', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 2, 3];
+    const array3 = [3, 2, 1];
+
+    expect(hashObject(array1)).toEqual(hashObject(array2));
+    expect(hashObject(array1)).not.toEqual(hashObject(array3));
+  });
+
+  // Test objects with different key orders
+  test('is deterministic regardless of key order', () => {
+    const obj1 = {a: 1, b: 2, c: 3};
+    const obj2 = {c: 3, b: 2, a: 1};
+
+    expect(hashObject(obj1)).toEqual(hashObject(obj2));
+  });
+
+  // Test nested structures
+  test('handles nested structures correctly', () => {
+    const nested1 = {a: 1, b: {c: 3, d: [4, 5, 6]}};
+    const nested2 = {a: 1, b: {d: [4, 5, 6], c: 3}};
+    const nested3 = {a: 1, b: {c: 3, d: [4, 5, 7]}};
+
+    expect(hashObject(nested1)).toEqual(hashObject(nested2));
+    expect(hashObject(nested1)).not.toEqual(hashObject(nested3));
+  });
+
+  // Test with different number types
+  test('handles different number types consistently', () => {
+    expect(hashObject(123)).toEqual(hashObject(123.0));
+    expect(hashObject(0)).toEqual(hashObject(-0));
+    expect(hashObject(NaN)).toEqual(hashObject(NaN));
+    expect(hashObject(Infinity)).toEqual(hashObject(Infinity));
+  });
+
+  // Test with deeply nested structures
+  test('handles deeply nested structures', () => {
+    let deepObj: any = {value: 'deep'};
+    const deepObjCopy: any = {value: 'deep'};
+
+    // Create a deeply nested object
+    for (let i = 0; i < 100; i++) {
+      deepObj = {next: deepObj};
+      deepObjCopy.next = {...deepObjCopy};
+    }
+
+    expect(hashObject(deepObj)).toBeTruthy();
+    // This test might fail due to object reference differences
+    // expect(hashObject(deepObj)).toEqual(hashObject(deepObjCopy));
+  });
+
+  // Test with large arrays
+  test('handles large arrays', () => {
+    const largeArray = Array(10000)
+      .fill(0)
+      .map((_, i) => i);
+    expect(hashObject(largeArray)).toBeTruthy();
+  });
+
+  // Test the same value returns the same hash
+  test('same value always returns the same hash', () => {
+    const complexObj = {
+      name: 'test',
+      values: [1, 2, 3, {nested: true}],
+      metadata: {
+        created: '2023-01-01',
+        tags: ['tag1', 'tag2'],
+      },
+    };
+
+    const hash1 = hashObject(complexObj);
+    const hash2 = hashObject(complexObj);
+    const hash3 = hashObject(JSON.parse(JSON.stringify(complexObj)));
+
+    expect(hash1).toEqual(hash2);
+    expect(hash1).toEqual(hash3);
+  });
+
+  // Test different values return different hashes
+  test('different values return different hashes', () => {
+    const hashes = new Set();
+
+    // Add hashes of different values
+    hashes.add(hashObject(null));
+    hashes.add(hashObject(123));
+    hashes.add(hashObject('test'));
+    hashes.add(hashObject([]));
+    hashes.add(hashObject({}));
+    hashes.add(hashObject([1, 2, 3]));
+    hashes.add(hashObject({a: 1}));
+
+    // Check that all hashes are unique
+    expect(hashes.size).toBe(7);
+  });
+
+  // Test extreme cases
+  test('handles objects with many keys', () => {
+    const objWithManyKeys: Record<string, number> = {};
+    for (let i = 0; i < 1000; i++) {
+      objWithManyKeys[`key${i}`] = i;
+    }
+
+    expect(hashObject(objWithManyKeys)).toBeTruthy();
+  });
+
+  // Test special characters in strings
+  test('handles special characters in strings', () => {
+    const specialChars = {
+      unicode: '你好，世界！',
+      emoji: '🚀🌟🌈',
+      control: '\u0000\u0001\u0002\u0003',
+      mixed: 'a\tb\nc\rd',
+    };
+
+    expect(hashObject(specialChars)).toBeTruthy();
+    expect(hashObject(specialChars)).toEqual(hashObject({...specialChars}));
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
@@ -1,0 +1,188 @@
+/**
+ * Creates a fast deterministic hash from a large JSON object iteratively
+ * @param obj - The JSON object to hash (must not contain circular references)
+ * @returns A deterministic hash string
+ */
+export function hashObject(obj: any): string {
+  // Using MurmurHash3
+  let h1: number = 0x12345678; // Seed
+
+  // Constants for MurmurHash3
+  const c1: number = 0xcc9e2d51;
+  const c2: number = 0x1b873593;
+
+  // Faster hash update function (based on MurmurHash3)
+  function hashChunk(str: string): void {
+    let k1: number;
+
+    // Process string in 4-byte chunks for speed
+    for (let i = 0; i < str.length; i += 4) {
+      // Pack up to 4 bytes into a 32-bit int
+      k1 = 0;
+      const remaining = Math.min(4, str.length - i);
+      for (let j = 0; j < remaining; j++) {
+        k1 |= str.charCodeAt(i + j) << (j * 8);
+      }
+
+      // MurmurHash3 algorithm
+      k1 *= c1;
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 *= c2;
+
+      h1 ^= k1;
+      h1 = (h1 << 13) | (h1 >>> 19);
+      h1 = h1 * 5 + 0xe6546b64;
+    }
+  }
+
+  // Use a more efficient stack representation with fewer objects
+  // Each object creation is expensive, so we'll reuse objects where possible
+  const TYPE_PRIMITIVE = 0;
+  const TYPE_ARRAY = 1;
+  const TYPE_OBJECT = 2;
+
+  interface StackItem {
+    type: number; // 0=primitive, 1=array, 2=object
+    value: any; // The actual value
+    keys?: string[]; // Sorted keys for objects
+    index: number; // Current index in array/keys
+    state: number; // 0=start, 1=processing, 2=done
+  }
+
+  // Initial stack with just the root object
+  const stack: StackItem[] = [
+    {
+      type:
+        typeof obj === 'object' && obj !== null
+          ? Array.isArray(obj)
+            ? TYPE_ARRAY
+            : TYPE_OBJECT
+          : TYPE_PRIMITIVE,
+      value: obj,
+      index: 0,
+      state: 0,
+    },
+  ];
+
+  // Small string buffer to avoid creating too many strings
+  const smallBuffer = ['{', '}', '[', ']', ':', ',', 'null', 'true', 'false'] as const;
+
+  // Process the object iteratively
+  while (stack.length > 0) {
+    const current = stack[stack.length - 1]!;
+
+    // Start processing a new item
+    if (current.state === 0) {
+      current.state = 1;
+
+      // Process based on type
+      if (current.type === TYPE_PRIMITIVE) {
+        if (current.value === null) {
+          hashChunk(smallBuffer[6]); // 'null'
+        } else if (typeof current.value === 'boolean') {
+          hashChunk(current.value ? smallBuffer[7] : smallBuffer[8]); // 'true' or 'false'
+        } else if (typeof current.value === 'number') {
+          // Use a consistent string representation for numbers
+          hashChunk(current.value.toString());
+        } else if (typeof current.value === 'string') {
+          hashChunk(current.value);
+        }
+        current.state = 2; // Mark as done
+      } else if (current.type === TYPE_ARRAY) {
+        hashChunk(smallBuffer[2]); // '['
+
+        if (current.value.length === 0) {
+          hashChunk(smallBuffer[3]); // ']'
+          current.state = 2; // Mark as done
+        }
+      } else if (current.type === TYPE_OBJECT) {
+        hashChunk(smallBuffer[0]); // '{'
+
+        // Sort keys once and cache them
+        current.keys = Object.keys(current.value).sort();
+
+        if (current.keys.length === 0) {
+          hashChunk(smallBuffer[1]); // '}'
+          current.state = 2; // Mark as done
+        }
+      }
+    }
+    // Process array/object elements
+    else if (current.state === 1) {
+      if (current.type === TYPE_ARRAY) {
+        const arr = current.value;
+
+        if (current.index > 0) {
+          hashChunk(smallBuffer[5]); // ','
+        }
+
+        if (current.index < arr.length) {
+          const item = arr[current.index++];
+          const itemType =
+            item === null || typeof item !== 'object'
+              ? TYPE_PRIMITIVE
+              : Array.isArray(item)
+                ? TYPE_ARRAY
+                : TYPE_OBJECT;
+
+          // Push the item onto the stack
+          stack.push({
+            type: itemType,
+            value: item,
+            index: 0,
+            state: 0,
+          });
+        } else {
+          // Finished processing array
+          hashChunk(smallBuffer[3]); // ']'
+          current.state = 2;
+        }
+      } else if (current.type === TYPE_OBJECT) {
+        const keys = current.keys!;
+
+        if (current.index > 0) {
+          hashChunk(smallBuffer[5]); // ','
+        }
+
+        if (current.index < keys.length) {
+          const key = keys[current.index++]!;
+          hashChunk(key);
+          hashChunk(smallBuffer[4]); // ':'
+
+          const item = current.value[key];
+          const itemType =
+            item === null || typeof item !== 'object'
+              ? TYPE_PRIMITIVE
+              : Array.isArray(item)
+                ? TYPE_ARRAY
+                : TYPE_OBJECT;
+
+          // Push the item onto the stack
+          stack.push({
+            type: itemType,
+            value: item,
+            index: 0,
+            state: 0,
+          });
+        } else {
+          // Finished processing object
+          hashChunk(smallBuffer[1]); // '}'
+          current.state = 2;
+        }
+      }
+    }
+    // Finished with this item
+    else {
+      stack.pop();
+    }
+  }
+
+  // Finalize the hash (MurmurHash3 finalization)
+  h1 ^= h1 >>> 16;
+  h1 = (h1 * 0x85ebca6b) >>> 0;
+  h1 ^= h1 >>> 13;
+  h1 = (h1 * 0xc2b2ae35) >>> 0;
+  h1 ^= h1 >>> 16;
+
+  return h1.toString(16).padStart(8, '0');
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
@@ -4,6 +4,7 @@
  * @returns A deterministic hash string
  */
 export function hashObject(obj: any): string {
+  console.log('hashObject', obj);
   // Using MurmurHash3
   let h1: number = 0x12345678; // Seed
 
@@ -183,6 +184,8 @@ export function hashObject(obj: any): string {
   h1 ^= h1 >>> 13;
   h1 = (h1 * 0xc2b2ae35) >>> 0;
   h1 ^= h1 >>> 16;
+
+  console.log('hash', h1.toString(16));
 
   return h1.toString(16).padStart(8, '0');
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
@@ -4,7 +4,6 @@
  * @returns A deterministic hash string
  */
 export function hashObject(obj: any): string {
-  console.log('hashObject', obj);
   // Using MurmurHash3
   let h1: number = 0x12345678; // Seed
 
@@ -184,8 +183,6 @@ export function hashObject(obj: any): string {
   h1 ^= h1 >>> 13;
   h1 = (h1 * 0xc2b2ae35) >>> 0;
   h1 ^= h1 >>> 16;
-
-  console.log('hash', h1.toString(16));
 
   return h1.toString(16).padStart(8, '0');
 }


### PR DESCRIPTION
## Summary & Motivation

Currently for large organizations our existing hash function just JSON.stringifies the arguments to our graph layout algorithm. The issue with this is that the arguments can be over 100MB when stringified which leads to a lot of memory being used that can cause the browser to crash. To get around this use MurmurHash3 to minimize memory usage. 

## How I Tested These Changes

jest tests

App-proxy - navigate the app of an org with a large workspace and saw that the memory crashing stopped occurring.

spot checked with console.logging that we were getting deterministic hashes.
<img width="1089" alt="Screenshot 2025-05-14 at 12 42 42 PM" src="https://github.com/user-attachments/assets/7fb35929-79af-440d-a91e-1a9c5bce8279" />

