### PR TITLE
[ui] use asset health resolvers on GrapheneAsset instead of GrapheneAssetNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -4,7 +4,7 @@
   "AssetAutomationQuery": "30c89838e2bb20980912b383d35a539fa7a67c6df4f721063f4321892d8ca647",
   "AssetGraphLiveQuery": "870d33b271f68fd3fcd1eb64016904deae5b531e7d82f7b22b8b63e6815a6200",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "2bfc193a28e054e5411f2a33256bcd2db23d81619c70f2e96ae7b757bbaebb4b",
+  "AssetHealthQuery": "06028147f280e256ee35a9e136f706aa3056adcc2f992fddd5739981e2468cb5",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "f96f337caf1763ba5644cc79aead3a1b994ad2d4b53ef847a32a0599a9f76587",
   "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -4,7 +4,7 @@
   "AssetAutomationQuery": "30c89838e2bb20980912b383d35a539fa7a67c6df4f721063f4321892d8ca647",
   "AssetGraphLiveQuery": "870d33b271f68fd3fcd1eb64016904deae5b531e7d82f7b22b8b63e6815a6200",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "06028147f280e256ee35a9e136f706aa3056adcc2f992fddd5739981e2468cb5",
+  "AssetHealthQuery": "993ae9eba6562cadf483266d0590b33f26e0315c9110b4126935886b22adf8a9",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "f96f337caf1763ba5644cc79aead3a1b994ad2d4b53ef847a32a0599a9f76587",
   "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -91,14 +91,18 @@ export function useAssetsHealthData(
 
 export const ASSETS_HEALTH_INFO_QUERY = gql`
   query AssetHealthQuery($assetKeys: [AssetKeyInput!]!) {
-    assetNodes(assetKeys: $assetKeys) {
-      id
-      ...AssetHealthFragment
+    assetsOrError(assetKeys: $assetKeys) {
+      ... on AssetConnection {
+        nodes {
+          id
+          ...AssetHealthFragment
+        }
+      }
     }
   }
 
-  fragment AssetHealthFragment on AssetNode {
-    assetKey {
+  fragment AssetHealthFragment on Asset {
+    key {
       path
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -44,7 +44,7 @@ function init() {
       const assetData = healthResponse.data.assetsOrError;
       if (assetData.__typename === 'PythonError') {
         showCustomAlert({
-          title: 'An error ocurred',
+          title: 'An error occurred',
           body: <PythonErrorInfo error={assetData} />,
         });
         return {};
@@ -69,7 +69,7 @@ function init() {
         return result;
       } else {
         showCustomAlert({
-          title: 'An unknown error ocurred',
+          title: 'An unknown error occurred',
         });
         return {};
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -35,13 +35,13 @@ function init() {
           },
         });
       } else {
-        healthResponse = {data: {assetNodes: [] as AssetHealthFragment[]}};
+        healthResponse = {data: {assetsOrError: {nodes: [] as AssetHealthFragment[]}}};
       }
 
       const {data} = healthResponse;
 
       const result: Record<string, AssetHealthFragment> = Object.fromEntries(
-        data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
+        data.assetsOrError.nodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
       );
 
       // External assets are not included in the health response, so as a workaround we add them with a null assetHealth

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -55,21 +55,6 @@ function init() {
       const result: Record<string, AssetHealthFragment> = Object.fromEntries(
         data.assetsOrError.nodes.map((node) => [tokenForAssetKey(node.key), node]),
       );
-
-      // External assets are not included in the health response, so as a workaround we add them with a null assetHealth
-      keys.forEach((key) => {
-        if (!result[key]) {
-          result[key] = {
-            __typename: 'Asset',
-            key: {
-              __typename: 'AssetKey',
-              ...tokenToAssetKey(key),
-            },
-            assetMaterializations: [],
-            assetHealth: null,
-          };
-        }
-      });
       return result;
     },
     BATCH_SIZE,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -64,7 +64,16 @@ export type AssetHealthQuery = {
           } | null;
         }>;
       }
-    | {__typename: 'PythonError'};
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
 };
 
 export type AssetHealthFragment = {
@@ -158,4 +167,4 @@ export type AssetHealthFreshnessMetaFragment = {
   lastMaterializedTimestamp: number | null;
 };
 
-export const AssetHealthQueryVersion = '06028147f280e256ee35a9e136f706aa3056adcc2f992fddd5739981e2468cb5';
+export const AssetHealthQueryVersion = '993ae9eba6562cadf483266d0590b33f26e0315c9110b4126935886b22adf8a9';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -8,60 +8,68 @@ export type AssetHealthQueryVariables = Types.Exact<{
 
 export type AssetHealthQuery = {
   __typename: 'Query';
-  assetNodes: Array<{
-    __typename: 'AssetNode';
-    id: string;
-    assetKey: {__typename: 'AssetKey'; path: Array<string>};
-    assetMaterializations: Array<{__typename: 'MaterializationEvent'; timestamp: string}>;
-    assetHealth: {
-      __typename: 'AssetHealth';
-      assetHealth: Types.AssetHealthStatus;
-      materializationStatus: Types.AssetHealthStatus;
-      assetChecksStatus: Types.AssetHealthStatus;
-      freshnessStatus: Types.AssetHealthStatus;
-      materializationStatusMetadata:
-        | {__typename: 'AssetHealthMaterializationDegradedNotPartitionedMeta'; failedRunId: string}
-        | {
-            __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
-            numMissingPartitions: number;
-            numFailedPartitions: number;
-            totalNumPartitions: number;
-          }
-        | {
-            __typename: 'AssetHealthMaterializationHealthyPartitionedMeta';
-            numMissingPartitions: number;
-            totalNumPartitions: number;
-          }
-        | null;
-      assetChecksStatusMetadata:
-        | {
-            __typename: 'AssetHealthCheckDegradedMeta';
-            numFailedChecks: number;
-            numWarningChecks: number;
-            totalNumChecks: number;
-          }
-        | {
-            __typename: 'AssetHealthCheckUnknownMeta';
-            numNotExecutedChecks: number;
-            totalNumChecks: number;
-          }
-        | {
-            __typename: 'AssetHealthCheckWarningMeta';
-            numWarningChecks: number;
-            totalNumChecks: number;
-          }
-        | null;
-      freshnessStatusMetadata: {
-        __typename: 'AssetHealthFreshnessMeta';
-        lastMaterializedTimestamp: number | null;
-      } | null;
-    } | null;
-  }>;
+  assetsOrError:
+    | {
+        __typename: 'AssetConnection';
+        nodes: Array<{
+          __typename: 'Asset';
+          id: string;
+          key: {__typename: 'AssetKey'; path: Array<string>};
+          assetMaterializations: Array<{__typename: 'MaterializationEvent'; timestamp: string}>;
+          assetHealth: {
+            __typename: 'AssetHealth';
+            assetHealth: Types.AssetHealthStatus;
+            materializationStatus: Types.AssetHealthStatus;
+            assetChecksStatus: Types.AssetHealthStatus;
+            freshnessStatus: Types.AssetHealthStatus;
+            materializationStatusMetadata:
+              | {
+                  __typename: 'AssetHealthMaterializationDegradedNotPartitionedMeta';
+                  failedRunId: string;
+                }
+              | {
+                  __typename: 'AssetHealthMaterializationDegradedPartitionedMeta';
+                  numMissingPartitions: number;
+                  numFailedPartitions: number;
+                  totalNumPartitions: number;
+                }
+              | {
+                  __typename: 'AssetHealthMaterializationHealthyPartitionedMeta';
+                  numMissingPartitions: number;
+                  totalNumPartitions: number;
+                }
+              | null;
+            assetChecksStatusMetadata:
+              | {
+                  __typename: 'AssetHealthCheckDegradedMeta';
+                  numFailedChecks: number;
+                  numWarningChecks: number;
+                  totalNumChecks: number;
+                }
+              | {
+                  __typename: 'AssetHealthCheckUnknownMeta';
+                  numNotExecutedChecks: number;
+                  totalNumChecks: number;
+                }
+              | {
+                  __typename: 'AssetHealthCheckWarningMeta';
+                  numWarningChecks: number;
+                  totalNumChecks: number;
+                }
+              | null;
+            freshnessStatusMetadata: {
+              __typename: 'AssetHealthFreshnessMeta';
+              lastMaterializedTimestamp: number | null;
+            } | null;
+          } | null;
+        }>;
+      }
+    | {__typename: 'PythonError'};
 };
 
 export type AssetHealthFragment = {
-  __typename: 'AssetNode';
-  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  __typename: 'Asset';
+  key: {__typename: 'AssetKey'; path: Array<string>};
   assetMaterializations: Array<{__typename: 'MaterializationEvent'; timestamp: string}>;
   assetHealth: {
     __typename: 'AssetHealth';
@@ -150,4 +158,4 @@ export type AssetHealthFreshnessMetaFragment = {
   lastMaterializedTimestamp: number | null;
 };
 
-export const AssetHealthQueryVersion = '2bfc193a28e054e5411f2a33256bcd2db23d81619c70f2e96ae7b757bbaebb4b';
+export const AssetHealthQueryVersion = '06028147f280e256ee35a9e136f706aa3056adcc2f992fddd5739981e2468cb5';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -29,7 +29,7 @@ export const useAssetGraphSupplementaryData = (
           value: status,
         });
         acc[supplementaryDataKey] = acc[supplementaryDataKey] || [];
-        acc[supplementaryDataKey].push(liveData.assetKey);
+        acc[supplementaryDataKey].push(liveData.key);
         return acc;
       },
       {} as Record<string, AssetKey[]>,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -33,7 +33,7 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
     latestInfo,
     loading,
     refetch,
-  } = useRecentAssetEvents(shouldQuery ? asset.assetKey : undefined, 5, [
+  } = useRecentAssetEvents(shouldQuery ? asset.key : undefined, 5, [
     AssetEventHistoryEventTypeSelector.MATERIALIZATION,
     AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
     AssetEventHistoryEventTypeSelector.OBSERVATION,
@@ -105,7 +105,7 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
           <div style={{height: 13, width: 1, background: Colors.keylineDefault()}} />
         </>
       )}
-      <AssetHealthSummary assetKey={asset.assetKey} iconOnly />
+      <AssetHealthSummary assetKey={asset.key} iconOnly />
     </Box>
   );
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -16,9 +16,10 @@ import {useAssetSelectionInput} from '../../asset-selection/input/useAssetSelect
 import {
   AssetHealthStatus,
   AssetKey,
+  buildAsset,
+  buildAssetConnection,
   buildAssetHealth,
   buildAssetKey,
-  buildAssetNode,
   buildAssetRecord,
   buildAssetRecordConnection,
 } from '../../graphql/types';
@@ -130,14 +131,16 @@ const getHealthQueryMock = (assetKeys: AssetKey[]) =>
     query: ASSETS_HEALTH_INFO_QUERY,
     variableMatcher: () => true,
     data: {
-      assetNodes: assetKeys.map((assetKey, idx) =>
-        buildAssetNode({
-          assetKey,
-          assetHealth: buildAssetHealth({
-            assetHealth: statuses[idx % statuses.length],
+      assetsOrError: buildAssetConnection({
+        nodes: assetKeys.map((assetKey, idx) =>
+          buildAsset({
+            key: assetKey,
+            assetHealth: buildAssetHealth({
+              assetHealth: statuses[idx % statuses.length],
+            }),
           }),
-        }),
-      ),
+        ),
+      }),
     },
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -157,44 +157,54 @@ describe('AssetCatalogTableV2', () => {
     ];
     const healthQueryMock = getHealthQueryMock(assetKeys);
     const resultFn = getMockResultFn(healthQueryMock);
-    expect(() =>
-      render(
-        <RecoilRoot>
-          <MemoryRouter>
-            <MockedProvider
-              mocks={[
-                assetsMock,
-                healthQueryMock,
-                ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
-                ...workspaceMocks,
-              ]}
-            >
-              <WorkspaceProvider>
-                <AssetLiveDataProvider>
-                  <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
-                </AssetLiveDataProvider>
-              </WorkspaceProvider>
-            </MockedProvider>
-          </MemoryRouter>
-        </RecoilRoot>,
-      ),
-    ).not.toThrow();
+    await waitFor(() => {
+      expect(() =>
+        render(
+          <RecoilRoot>
+            <MemoryRouter>
+              <MockedProvider
+                mocks={[
+                  assetsMock,
+                  healthQueryMock,
+                  ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
+                  ...workspaceMocks,
+                ]}
+              >
+                <WorkspaceProvider>
+                  <AssetLiveDataProvider>
+                    <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+                  </AssetLiveDataProvider>
+                </WorkspaceProvider>
+              </MockedProvider>
+            </MemoryRouter>
+          </RecoilRoot>,
+        ),
+      ).not.toThrow();
+    });
 
     await waitFor(() => {
       expect(screen.getByText('5 assets')).toBeInTheDocument();
       expect(resultFn).toHaveBeenCalled();
     });
     const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
+    await waitFor(() =>
+      expect(calls[calls.length - 1][0]).toEqual(
+        expect.objectContaining({
+          healthDataLoading: false,
+        }),
+      ),
+    );
+
     await waitFor(() => {
       expect(calls[calls.length - 1][0]).toEqual({
         groupedByStatus: {
           Healthy: [
-            expect.objectContaining({assetKey: buildAssetKey({path: ['asset1']})}),
-            expect.objectContaining({assetKey: buildAssetKey({path: ['asset5']})}),
+            expect.objectContaining({key: buildAssetKey({path: ['asset1']})}),
+            expect.objectContaining({key: buildAssetKey({path: ['asset5']})}),
           ],
-          Degraded: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset2']})})],
-          Warning: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset3']})})],
-          Unknown: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset4']})})],
+          Degraded: [expect.objectContaining({key: buildAssetKey({path: ['asset2']})})],
+          Warning: [expect.objectContaining({key: buildAssetKey({path: ['asset3']})})],
+          Unknown: [expect.objectContaining({key: buildAssetKey({path: ['asset4']})})],
         },
         loading: false,
         healthDataLoading: false,
@@ -207,28 +217,30 @@ describe('AssetCatalogTableV2', () => {
     const assetKeys = [buildAssetKey({path: ['asset1']}), buildAssetKey({path: ['asset2']})];
     const healthQueryMock = getHealthQueryMock(assetKeys);
     const resultFn = getMockResultFn(healthQueryMock);
-    expect(() =>
-      render(
-        <RecoilRoot>
-          <MemoryRouter>
-            <MockedProvider
-              mocks={[
-                assetsMock,
-                healthQueryMock,
-                ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
-                ...workspaceMocks,
-              ]}
-            >
-              <WorkspaceProvider>
-                <AssetLiveDataProvider>
-                  <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
-                </AssetLiveDataProvider>
-              </WorkspaceProvider>
-            </MockedProvider>
-          </MemoryRouter>
-        </RecoilRoot>,
-      ),
-    ).not.toThrow();
+    await waitFor(() => {
+      expect(() =>
+        render(
+          <RecoilRoot>
+            <MemoryRouter>
+              <MockedProvider
+                mocks={[
+                  assetsMock,
+                  healthQueryMock,
+                  ...buildMockedAssetGraphLiveQuery(assetKeys, undefined),
+                  ...workspaceMocks,
+                ]}
+              >
+                <WorkspaceProvider>
+                  <AssetLiveDataProvider>
+                    <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+                  </AssetLiveDataProvider>
+                </WorkspaceProvider>
+              </MockedProvider>
+            </MemoryRouter>
+          </RecoilRoot>,
+        ),
+      ).not.toThrow();
+    });
 
     await waitFor(() => {
       expect(screen.getByText('2 assets')).toBeInTheDocument();
@@ -237,8 +249,8 @@ describe('AssetCatalogTableV2', () => {
     expect(AssetCatalogV2VirtualizedTable).toHaveBeenCalledWith(
       {
         groupedByStatus: {
-          Healthy: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset1']})})],
-          Degraded: [expect.objectContaining({assetKey: buildAssetKey({path: ['asset2']})})],
+          Healthy: [expect.objectContaining({key: buildAssetKey({path: ['asset1']})})],
+          Degraded: [expect.objectContaining({key: buildAssetKey({path: ['asset2']})})],
           Warning: [],
           Unknown: [],
         },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -131,11 +131,11 @@ export const AssetCatalogTableV2 = React.memo(
           break;
         case 'key_asc':
           sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            COMMON_COLLATOR.compare(tokenForAssetKey(a.assetKey), tokenForAssetKey(b.assetKey));
+            COMMON_COLLATOR.compare(tokenForAssetKey(a.key), tokenForAssetKey(b.key));
           break;
         case 'key_desc':
           sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            COMMON_COLLATOR.compare(tokenForAssetKey(b.assetKey), tokenForAssetKey(a.assetKey));
+            COMMON_COLLATOR.compare(tokenForAssetKey(b.key), tokenForAssetKey(a.key));
           break;
         default:
           assertUnreachable(sortBy);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
@@ -173,9 +173,9 @@ const StatusHeaderContainer = styled(Box)`
 `;
 
 const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
-  const linkUrl = assetDetailsPathForKey({path: asset.assetKey.path});
+  const linkUrl = assetDetailsPathForKey({path: asset.key.path});
 
-  const {definition: _definition, refresh, cachedDefinition} = useAssetDefinition(asset.assetKey);
+  const {definition: _definition, refresh, cachedDefinition} = useAssetDefinition(asset.key);
   const definition = cachedDefinition || _definition;
 
   const repoAddress = definition?.repository
@@ -189,7 +189,7 @@ const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
           <AssetIconWrapper>
             <Icon name="asset" />
           </AssetIconWrapper>
-          {asset.assetKey.path.join(' / ')}
+          {asset.key.path.join(' / ')}
         </Box>
         {/* Prevent clicks on the trend from propoagating to the row and triggering the link */}
         <Box
@@ -203,7 +203,7 @@ const AssetRow = React.memo(({asset}: {asset: AssetHealthFragment}) => {
           <AssetRecentUpdatesTrend asset={asset} />
           <AssetActionMenu
             unstyledButton
-            path={asset.assetKey.path}
+            path={asset.key.path}
             definition={definition}
             repoAddress={repoAddress}
             onRefresh={refresh}

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -20,6 +20,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsSubset,
     fetch_flattened_time_window_ranges,
 )
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import AssetRecordsFilter, EventLogRecord
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DynamicPartitionsStore
@@ -107,7 +108,7 @@ def get_assets(
         # To make this resolver handle both asset_keys and prefix, we would need to
         # make get_asset_keys handle a list of asset_keys so that we filter down to the asset keys that
         # have materializations in the db and match the prefix.
-        raise Exception(  # TODO - get a better exception class
+        raise DagsterInvariantViolationError(
             "Cannot provide both asset_keys and prefix",
         )
 

--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -140,6 +140,24 @@ def asset_with_freshness_and_warning():
     return 1
 
 
+source_asset = dg.SourceAsset("source_asset")
+
+
+@dg.asset_check(asset=source_asset)
+def source_asset_check():
+    return dg.AssetCheckResult(passed=True)
+
+
+@dg.op
+def insert_source_asset_materializations(context: dg.OpExecutionContext) -> None:
+    context.log_event(dg.AssetMaterialization(source_asset.key))
+
+
+@dg.job
+def insert_source_asset_materializations_job() -> None:
+    insert_source_asset_materializations()
+
+
 def get_assets_and_checks():
     return [
         random_1,
@@ -160,4 +178,7 @@ def get_assets_and_checks():
         observable_source_asset_random_execution_error,
         asset_with_freshness_and_warning,
         observe_random_1_job,
+        source_asset,
+        source_asset_check,
+        insert_source_asset_materializations_job,
     ]

--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -140,6 +140,29 @@ def asset_with_freshness_and_warning():
     return 1
 
 
+# external_asset = dg.AssetSpec(key=["external_asset"])
+
+# @dg.op
+# def report_materialization(context):
+#     context.log_event(dg.AssetMaterialization(
+#         asset_key=external_asset.key,
+#     ))
+
+# @dg.job
+# def report_external_asset_materialization_job():
+#     report_materialization()
+
+
+@dg.op
+def observe_random_1(context):
+    context.log_event(dg.AssetObservation(asset_key="random_1", metadata={"foo": "bar"}))
+
+
+@dg.job
+def observe_random_1_job():
+    observe_random_1()
+
+
 def get_assets_and_checks():
     return [
         random_1,

--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -140,29 +140,6 @@ def asset_with_freshness_and_warning():
     return 1
 
 
-# external_asset = dg.AssetSpec(key=["external_asset"])
-
-# @dg.op
-# def report_materialization(context):
-#     context.log_event(dg.AssetMaterialization(
-#         asset_key=external_asset.key,
-#     ))
-
-# @dg.job
-# def report_external_asset_materialization_job():
-#     report_materialization()
-
-
-@dg.op
-def observe_random_1(context):
-    context.log_event(dg.AssetObservation(asset_key="random_1", metadata={"foo": "bar"}))
-
-
-@dg.job
-def observe_random_1_job():
-    observe_random_1()
-
-
 def get_assets_and_checks():
     return [
         random_1,


### PR DESCRIPTION
## Summary & Motivation
Updates the UI to use the asset health resolver on GrapheneAsset. This allows external assets to display health information since they are returned as GrapheneAssets, but not as GrapheneAssetNodes

After this we could switch the sorting to use the sort key on GrapheneAsset, but will do that in a stacked pr


## How I Tested These Changes
external asset w health status in the UI 
<img width="1089" alt="Screenshot 2025-05-14 at 3 56 18 PM" src="https://github.com/user-attachments/assets/efc8dc5a-30f0-4bf2-a780-a0b8d20ea5de" />

<img width="1089" alt="Screenshot 2025-05-14 at 3 57 20 PM" src="https://github.com/user-attachments/assets/352e15a3-aa3c-41e8-8364-b8827cbc04dc" />

<img width="1089" alt="Screenshot 2025-05-14 at 3 56 47 PM" src="https://github.com/user-attachments/assets/c1a90105-4a4b-4c61-b01d-5e9d3d63789f" />


## Changelog

> Insert changelog entry or delete this section.
