### PR TITLE
fix word breaking for evaluation links

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
@@ -234,18 +234,18 @@ const NewPolicyEvaluationTable = ({
                   });
                 }}
               >
-                <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                <div style={{whiteSpace: 'nowrap'}}>
                   View evaluation
                   {lastEvaluationForEntityKey.evaluationId !== evaluationId ? (
                     <>
-                      {' @'}
+                      {' @ '}
                       <TimestampDisplay
                         timestamp={lastEvaluationForEntityKey.timestamp}
                         timeFormat={{...DEFAULT_TIME_FORMAT, showSeconds: true}}
                       />
                     </>
                   ) : null}
-                </Box>
+                </div>
               </a>
             </Tooltip>
           ) : null;


### PR DESCRIPTION
## Summary & Motivation
When the automation condition description is long, the word breaks are ugly:

![Screenshot 2025-05-14 at 2 52 04 PM](https://github.com/user-attachments/assets/d64e1741-b015-4ddb-a4cf-7ea7b2d772f3)

## How I Tested These Changes
Viewed page
